### PR TITLE
repair: Add ranges_parallelism option

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -917,6 +917,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"ranges_parallelism",
+                     "description":"An integer specifying the number of ranges to repair in parallel.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             },

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -376,7 +376,7 @@ void set_storage_service(http_context& ctx, routes& r) {
     ss::repair_async.set(r, [&ctx](std::unique_ptr<request> req) {
         static std::vector<sstring> options = {"primaryRange", "parallelism", "incremental",
                 "jobThreads", "ranges", "columnFamilies", "dataCenters", "hosts", "trace",
-                "startToken", "endToken" };
+                "startToken", "endToken", "ranges_parallelism" };
         std::unordered_map<sstring, sstring> options_map;
         for (auto o : options) {
             auto s = req->get_query_param(o);

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -159,6 +159,8 @@ public:
     shard_id shard;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
+    int ranges_parallelism;
+    std::optional<semaphore> ranges_parallelism_semaphore;
     size_t nr_failed_ranges = 0;
     bool aborted = false;
     // Map of peer -> <cf, ranges>
@@ -188,7 +190,8 @@ public:
             const std::vector<sstring>& cfs_,
             int id_,
             const std::vector<sstring>& data_centers_,
-            const std::vector<sstring>& hosts_);
+            const std::vector<sstring>& hosts_,
+            int ranges_parallelism);
     future<> do_streaming();
     void check_failed_ranges();
     future<> request_transfer_ranges(const sstring& cf,


### PR DESCRIPTION
In commit 131acc09cc1d568f994059736c8500adf5d05d88 (repair: Adjust
parallelism according to memory size), we choose the ranges to repair in
parallel according to the memory size automatically.

However, this automatic number might not the optimal one. For example,
user wants repair to have minimal impact on the user cql reads and
writes, or user wants to repair at full speed allowing more cpu and
memory resources.

This patch introduces a ranges_parallelism option that controls number
of ranges that we repair in parallel, so that the advanced
user can control the parallelism.

Here is an example:

In a cluster with high network latency, e.g., multiple DCs with high
latency link, user can increase ranges_parallelism to compensate.

For example in two DCs cluster with 7 nodes + 60ms round trip time + RF
(dc1:3, dc2:4) + a keyspace with 3 empty tables:

2019-04-10 11:00:03.303549 Repair with ks ranges_parallelism=1 on node 1 started ...
2019-04-10 11:32:32.673043 Repair with ks on node 1 finished ...

2019-04-10 11:32:32.673292 Repair with ks ranges_parallelism=16 on node 1 started ...
2019-04-10 11:36:49.475977 Repair with ks on node 1 finished ...

2019-04-10 11:36:49.476145 Repair with ks ranges_parallelism=256 on node 1 started ...
2019-04-10 11:38:04.242553 Repair with ks on node 1 finished ...

That is 1949s vs 257s vs 75s to complete repair respectively, which
gives 7X and 25X difference.

Fixes #4847
