### PR TITLE
gossip: Make boot process faster and safer

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2173,6 +2173,15 @@ future<> gossiper::wait_for_range_setup() {
     return wait_for_gossip(ring_delay);
 }
 
+void gossiper::set_node_to_be_replaced(gms::inet_address node) {
+    logger.info("Set node to be replaced = {}", node);
+    _node_to_be_replaced = node;
+}
+
+std::optional<gms::inet_address> gossiper::get_node_to_be_replaced() {
+    return _node_to_be_replaced;
+}
+
 bool gossiper::is_safe_for_bootstrap(inet_address endpoint) {
     auto* eps = get_endpoint_state_for_endpoint_ptr(endpoint);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -61,6 +61,7 @@
 #include <algorithm>
 #include <chrono>
 #include <set>
+#include <map>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/abort_source.hh>
@@ -83,6 +84,45 @@ class inet_address;
 class i_endpoint_state_change_subscriber;
 
 class feature_service;
+
+class cluster_ring_status_response {
+public:
+    // The keys can be:
+    // - nr_known_nodes : Number of nodes this node knows about
+    // - status_token_hash: The hash of the gossip status and tokens for nodes
+    // - normal_token_hash: The hash of the tokens for nodes in NORMAL status
+    // - bootstrap_token_hash: The hash of the tokens for nodes in BOOTSTRAPPING status
+    // - leaving_nodes_hash: The hash of the nodes that are leaving the cluster
+    // - pending_ranges_hash: The hash of pending ranges
+    // - same_on_all_shards: If all the shards have the same hashes
+    static constexpr const char* nr_known_nodes = "nr_known_nodes";
+    static constexpr const char* status_token_hash = "status_token_hash";
+    static constexpr const char* normal_token_hash = "normal_token_hash";
+    static constexpr const char* bootstrap_token_hash = "bootstrap_token_hash";
+    static constexpr const char* leaving_nodes_hash = "leaving_nodes_hash";
+    static constexpr const char* pending_ranges_hash = "pending_ranges_hash";
+    static constexpr const char* same_on_all_shards = "same_on_all_shards";
+
+    // The values for same_on_all_shard
+    static constexpr const char* same_on_all_shards_yes = "yes";
+    static constexpr const char* same_on_all_shards_no = "no";
+
+    std::map<sstring, sstring> status;
+
+    bool operator!=(const cluster_ring_status_response& x) const {
+        return x.status != status;
+    }
+    bool operator==(const cluster_ring_status_response& x) const {
+        return x.status == status;
+    }
+    bool is_same_on_all_shards() const {
+        auto it = status.find(same_on_all_shards);
+        if (it != status.end()) {
+            return it->second == same_on_all_shards_yes;
+        }
+        return false;
+    }
+};
 
 struct bind_messaging_port_tag {};
 using bind_messaging_port = bool_class<bind_messaging_port_tag>;
@@ -553,6 +593,7 @@ public:
 public:
     sstring get_gossip_status(const endpoint_state& ep_state) const;
     sstring get_gossip_status(const inet_address& endpoint) const;
+    uint64_t get_gossip_status_token_hash() const;
 public:
     future<> wait_for_gossip_to_settle();
     future<> wait_for_range_setup();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -556,6 +556,10 @@ public:
 public:
     future<> wait_for_gossip_to_settle();
     future<> wait_for_range_setup();
+public:
+    void set_node_to_be_replaced(gms::inet_address node);
+    std::optional<gms::inet_address> get_node_to_be_replaced();
+
 private:
     future<> wait_for_gossip(std::chrono::milliseconds, std::optional<int32_t> = {});
 
@@ -564,6 +568,7 @@ private:
     bool _ms_registered = false;
     bool _gossiped_to_seed = false;
     bool _gossip_settled = false;
+    std::optional<gms::inet_address> _node_to_be_replaced;
 
     class msg_proc_guard;
 private:

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -74,4 +74,8 @@ class gossip_digest_ack2 {
     std::map<gms::inet_address, gms::endpoint_state> get_endpoint_state_map();
 };
 
+class cluster_ring_status_response {
+    std::map<sstring, sstring> status;
+};
+
 }

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -30,6 +30,14 @@
 #include <algorithm>
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
+#include "xx_hasher.hh"
+#include "bytes_ostream.hh"
+#include "gms/inet_address_serializer.hh"
+#include "serializer_impl.hh"
+#include "idl/token.dist.hh"
+#include "idl/token.dist.impl.hh"
+#include "idl/range.dist.hh"
+#include "idl/range.dist.impl.hh"
 
 namespace locator {
 
@@ -862,6 +870,93 @@ public:
     void invalidate_cached_rings() {
         ++_ring_version;
         //cachedTokenMap.set(null);
+    }
+
+private:
+    // Must run inside a seastar thread
+    uint64_t get_hash_for_map(const std::unordered_map<dht::token, gms::inet_address>& unordered) {
+        if (unordered.empty()) {
+            return 0;
+        }
+        std::map<dht::token, gms::inet_address> map(unordered.begin(), unordered.end());
+        xx_hasher h;
+        bytes_ostream out;
+        for (auto& x : map) {
+            thread::maybe_yield();
+            out.clear();
+            ser::serialize(out, x.first);
+            ser::serialize(out, x.second);
+            feed_hash(h, out.linearize());
+        }
+        return h.finalize_uint64();
+    }
+
+    // Must run inside a seastar thread
+    uint64_t get_hash_for_set(const std::unordered_set<gms::inet_address>& unordered) {
+        if (unordered.empty()) {
+            return 0;
+        }
+        std::set<gms::inet_address> nodes(unordered.begin(), unordered.end());
+        xx_hasher h;
+        bytes_ostream out;
+        for (auto& node: nodes) {
+            thread::maybe_yield();
+            out.clear();
+            ser::serialize(out, node);
+            feed_hash(h, out.linearize());
+        }
+        return h.finalize_uint64();
+    }
+
+public:
+    // Must run inside a seastar thread
+    uint64_t get_normal_token_hash() {
+        return get_hash_for_map(get_token_to_endpoint());
+    }
+
+    // Must run inside a seastar thread
+    uint64_t get_bootstrap_token_hash() {
+        return get_hash_for_map(get_bootstrap_tokens());
+    }
+
+    // Must run inside a seastar thread
+    uint64_t get_leaving_endpoints_hash() {
+        return get_hash_for_set(get_leaving_endpoints());
+    }
+
+    // Must run inside a seastar thread
+    uint64_t get_pending_ranges_hash() {
+        if (_pending_ranges_map.empty()) {
+            return 0;
+        }
+        std::map<sstring, uint64_t> keyspace_hash_map;
+        bytes_ostream out;
+        for (auto& x : _pending_ranges_map) {
+            struct less {
+                bool operator()(const range<token>& l, const range<token>& r) const {
+                    return format("{}", l) < format("{}", r);
+                }
+            };
+            std::map<range<token>, std::unordered_set<inet_address>, less> map(x.second.begin(), x.second.end());
+            xx_hasher h;
+            for (auto& y : map) {
+                thread::maybe_yield();
+                out.clear();
+                ser::serialize(out, y.first);
+                ser::serialize(out, get_hash_for_set(y.second));
+                feed_hash(h, out.linearize());
+            }
+            keyspace_hash_map[x.first] = h.finalize_uint64();
+        }
+        xx_hasher h;
+        for (auto& x : keyspace_hash_map) {
+            thread::maybe_yield();
+            out.clear();
+            ser::serialize(out, x.first);
+            ser::serialize(out, x.second);
+            feed_hash(h, out.linearize());
+        }
+        return h.finalize_uint64();
     }
 
     friend class token_metadata;
@@ -1870,6 +1965,26 @@ token_metadata::get_ring_version() const {
 void
 token_metadata::invalidate_cached_rings() {
     _impl->invalidate_cached_rings();
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_normal_token_hash() {
+    return _impl->get_normal_token_hash();
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_bootstrap_token_hash() {
+    return _impl->get_bootstrap_token_hash();
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_leaving_endpoints_hash() {
+    return _impl->get_leaving_endpoints_hash();
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_pending_ranges_hash() {
+    return _impl->get_pending_ranges_hash();
 }
 
 /////////////////// class topology /////////////////////////////////////////////

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -313,6 +313,11 @@ public:
     long get_ring_version() const;
     void invalidate_cached_rings();
 
+    uint64_t get_normal_token_hash();
+    uint64_t get_bootstrap_token_hash();
+    uint64_t get_leaving_endpoints_hash();
+    uint64_t get_pending_ranges_hash();
+
     friend class token_metadata_impl;
 };
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -54,6 +54,7 @@ namespace gms {
     class gossip_digest_syn;
     class gossip_digest_ack;
     class gossip_digest_ack2;
+    class cluster_ring_status_response;
 }
 
 namespace utils {
@@ -139,7 +140,8 @@ enum class messaging_verb : int32_t {
     PAXOS_ACCEPT = 40,
     PAXOS_LEARN = 41,
     HINT_MUTATION = 42,
-    LAST = 43,
+    CLUSTER_RING_STATUS = 43,
+    LAST = 44,
 };
 
 } // namespace netw
@@ -369,6 +371,11 @@ public:
     void register_gossip_echo(std::function<future<> ()>&& func);
     future<> unregister_gossip_echo();
     future<> send_gossip_echo(msg_addr id);
+
+    // Wrapper for CLUSTER_RING_STATUS verb
+    void register_cluster_ring_status(std::function<future<gms::cluster_ring_status_response> (const rpc::client_info& cinfo)>&& func);
+    future<> unregister_cluster_ring_status();
+    future<gms::cluster_ring_status_response> send_cluster_ring_status(msg_addr id);
 
     // Wrapper for GOSSIP_SHUTDOWN
     void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from)>&& func);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -278,6 +278,8 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
     if (get_replace_tokens().size() > 0 || get_replace_node()) {
          throw std::runtime_error("Replace method removed; use replace_address instead");
     }
+    bool replacing_a_node_with_same_ip = false;
+    bool replacing_a_node_with_diff_ip = false;
     if (db().local().is_replacing()) {
         if (db::system_keyspace::bootstrap_complete()) {
             throw std::runtime_error("Cannot replace address with a node that is already bootstrapped");
@@ -292,6 +294,9 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
         app_states.emplace(gms::application_state::TOKENS, value_factory.tokens(_bootstrap_tokens));
         app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(_cdc_streams_ts));
         app_states.emplace(gms::application_state::STATUS, value_factory.hibernate(true));
+        auto replace_address = db().local().get_replace_address();
+        replacing_a_node_with_same_ip = replace_address && *replace_address == get_broadcast_address();
+        replacing_a_node_with_diff_ip = replace_address && *replace_address != get_broadcast_address();
     } else if (should_bootstrap()) {
         check_for_endpoint_collision(loaded_peer_features).get();
     } else {
@@ -363,6 +368,26 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
                     "Restarting node in NORMAL status with CDC enabled, but no streams timestamp was proposed"
                     " by this node according to its local tables. Are we upgrading from a non-CDC supported version?");
         }
+    }
+
+    if (replacing_a_node_with_same_ip) {
+        slogger.info("Replacing a node with same IP address, my address={}, node being replaced={}",
+                    get_broadcast_address(), get_broadcast_address());
+        slogger.info("Update tokens for replacing node early, replacing node has the same IP address of the node being replaced");
+        // We want the replacing node and the rest of the cluster has the same view of the normal tokens.
+        _token_metadata.update_normal_tokens(_bootstrap_tokens, get_broadcast_address());
+    }
+
+    if (replacing_a_node_with_diff_ip) {
+        // replacing_a_node_with_diff_ip guarantees replace_address contains a value
+        auto replace_address = db().local().get_replace_address();
+        // Unlike replacing_a_node_with_same_ip case above, we do not update
+        // the normal tokens for the replacing node in token_metadata because
+        // the rest of the cluster updates the tokens for the replacing node
+        // only after the replace operaiton is finished.
+        slogger.info("Replacing a node with different IP address, my address={}, node to being replaced={}",
+                get_broadcast_address(), *replace_address);
+        _gossiper.set_node_to_be_replaced(*replace_address);
     }
 
     // have to start the gossip service before we can see any info on other nodes.  this is necessary


### PR DESCRIPTION
gossip: Make boot process faster and safer

During boot up, we need to wait for gossip in multiple places:

1) Wait for gossip to settle to enable features. See commit
71bf757b2c8fb372bfd115ed00bf56069331d7cc ("gossiper: Enable features
only after gossip is settled").

2) Wait until local node knows tokens of peer nodes before announcing
join status. To make sure when the writes sent by the other nodes for
pending token range arrives, the local node knows all the tokens of the
cluster. See commit 89b769a073da1a1727b913159d85b97fe911676c.

3) Wait until peer nodes know the bootstrap tokens of local node before
streaming. To make sure all peer nodes knows the pending token range
before the streaming starts, so that all writes after streaming starts
that belong to the pending token range will be forwarded to the new node.

4) Wait until gossip is settled before start the cql server. See commit
8c909122a6a6b90ddb50ea8be250829c199616ab.

Before this patch, we sleep ring_delay which is 30 seconds by default
and wait for the size of endpoint_state_map does not change over some
time. The time out based approach does not guarantee the above
conditions are met. It can wait foo much or wait too few.

This patch introduces a new method. Instead of waiting for some
arbitrary time, we ask peer nodes to return the number of nodes it
knows, the checksum of normal tokens, the checksum of bootstrap tokens
and the checksum of gossip status (e.g., NORMAL), the checksum of nodes
leaving the cluster. If the checksums between local node and all remote
nodes are identical, it is guaranteed all nodes have the same view of
tokens and nodes status.

A new RPC verb GOSSIP_QUERY_TOKEN_STATUS is introduced for this new
method. If any of the nodes in the cluster does not support this new
verb, or a node is down and can not respond the new verb, it will
fallback to the old timeout based method. A nice thing is that we do not
need to negotiate between nodes if GOSSIP_QUERY_TOKEN_STATUS is
supported. When the node that supports GOSSIP_QUERY_TOKEN_STATUS send
this verb to node that does not support it during boot process, the
sender will get rpc::unknown_verb_error then it will fallback.

With this patch, we observed significant improvement in scylla boot time.

To bootstrap a single node with the default 30s ring_delay:
Before: 88 seconds
After: 4 seconds

To run update_cluster_layout_tests.py:TestUpdateClusterLayout.simple_add_node_1_test
Before: 141 seconds
After: 25 seconds

To run update_cluster_layout_tests.py:TestLargeScaleCluster.add_50_nodes_test
to increase a cluster from 3 nodes to 12 nodes
Before: 866 seconds
After: 111 seconds

Fixes: #4755
Refs: #4632
Tests: update_cluster_layout_tests.py + replace_address_test.py  + manual test
