### PR TITLE
scylla_io_setup: reconfig by iotune if there is no experience disk properties

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     if not is_developer_mode():
         if args.ami:
             idata = aws_instance()
+            reconfig_by_iotune = False
 
             disk_properties = {}
             disk_properties["mountpoint"] = datadir()
@@ -81,60 +82,66 @@ if __name__ == "__main__":
                 disk_properties["read_bandwidth"] = 507338935 * nr_disks
                 disk_properties["write_iops"] = 57100 * nr_disks
                 disk_properties["write_bandwidth"] = 483141731 * nr_disks
-            properties_file = open(etcdir() + "/scylla.d/io_properties.yaml", "w")
-            yaml.dump({ "disks": [ disk_properties ] }, properties_file,  default_flow_style=False)
-            ioconf = open(etcdir() + "/scylla.d/io.conf", "w")
-            ioconf.write("SEASTAR_IO=\"--io-properties-file={}\"\n".format(properties_file.name))
-        else:
-            if "SCYLLA_CONF" in os.environ:
-                conf_dir = os.environ["SCYLLA_CONF"]
             else:
-                conf_dir = etcdir() + "/scylla"
-            cfg = yaml.safe_load(open(os.path.join(conf_dir, "scylla.yaml")))
-            default_path = cfg.get('workdir') or datadir()
-            if not "data_file_directories" in cfg:
-                cfg["data_file_directories"] = [os.path.join(default_path, 'data')]
-            data_dirs = cfg["data_file_directories"]
+                reconfig_by_iotune = True
+                logging.error("There is not experience disk properties, will get the properities by running iotune.\n")
 
-            for t in [ "commitlog", "hints", "view_hints", "saved_caches" ]:
-                key = "%s_directory" % t
-                if key in cfg:
-                    data_dirs += [ cfg[key] ]
-                elif os.path.isdir(os.path.join(default_path, t)):
-                    data_dirs += [ os.path.join(default_path, t) ]
+            if not reconfig_by_iotune:
+                properties_file = open(etcdir() + "/scylla.d/io_properties.yaml", "w")
+                yaml.dump({ "disks": [ disk_properties ] }, properties_file,  default_flow_style=False)
+                ioconf = open(etcdir() + "/scylla.d/io.conf", "w")
+                ioconf.write("SEASTAR_IO=\"--io-properties-file={}\"\n".format(properties_file.name))
+                sys.exit(0)
 
-            iotune_args = []
-            for data_dir in data_dirs:
-                if os.path.exists(data_dir) == False:
-                    logging.error("%s was not found. Please check the configuration and run scylla_io_setup again.\n", data_dir)
-                    sys.exit(1)
-                if os.path.isdir(data_dir) == False:
-                    logging.error("%s is not a directory. Please check the configuration and run scylla_io_setup again.\n", data_dir)
-                    sys.exit(1)
-                st = os.statvfs(data_dir)
-                avail = st.f_bavail * st.f_frsize
-                rec = 10000000000
-                if avail < rec:
-                    logging.error("Filesystem at %s has only %d bytes available; that is less than the recommended 10 GB. Please free up space and run scylla_io_setup again.\n", data_dir, avail)
-                    sys.exit(1)
-                blocktune.tune_fs(data_dir, '2')
-                iotune_args += [ "--evaluation-directory", data_dir ]
+        if "SCYLLA_CONF" in os.environ:
+            conf_dir = os.environ["SCYLLA_CONF"]
+        else:
+            conf_dir = etcdir() + "/scylla"
+        cfg = yaml.safe_load(open(os.path.join(conf_dir, "scylla.yaml")))
+        default_path = cfg.get('workdir') or datadir()
+        if not "data_file_directories" in cfg:
+            cfg["data_file_directories"] = [os.path.join(default_path, 'data')]
+        data_dirs = cfg["data_file_directories"]
 
-            if cpudata.cpuset():
-                iotune_args += [ "--cpuset", ",".join(map(str, cpudata.cpuset())) ]
-            elif cpudata.smp():
-                iotune_args += [ "--smp", str(cpudata.smp()) ]
+        for t in [ "commitlog", "hints", "view_hints", "saved_caches" ]:
+            key = "%s_directory" % t
+            if key in cfg:
+                data_dirs += [ cfg[key] ]
+            elif os.path.isdir(os.path.join(default_path, t)):
+                data_dirs += [ os.path.join(default_path, t) ]
 
-            try:
-                subprocess.check_call([bindir() + "/iotune",
-                                       "--format", "envfile",
-                                       "--options-file", etcdir() + "/scylla.d/io.conf",
-                                       "--properties-file", etcdir() + "/scylla.d/io_properties.yaml"] + iotune_args)
-            except Exception:
-                logging.error("%s did not pass validation tests, it may not be on XFS and/or has limited disk space.\n"
-                              "This is a non-supported setup, and performance is expected to be very bad.\n"
-                              "For better performance, placing your data on XFS-formatted directories is required.\n"
-                              "To override this error, enable developer mode as follow:\n"
-                              "sudo %s/scylla_dev_mode_setup --developer-mode 1", data_dirs, scriptsdir())
+        iotune_args = []
+        for data_dir in data_dirs:
+            if os.path.exists(data_dir) == False:
+                logging.error("%s was not found. Please check the configuration and run scylla_io_setup again.\n", data_dir)
                 sys.exit(1)
+            if os.path.isdir(data_dir) == False:
+                logging.error("%s is not a directory. Please check the configuration and run scylla_io_setup again.\n", data_dir)
+                sys.exit(1)
+            st = os.statvfs(data_dir)
+            avail = st.f_bavail * st.f_frsize
+            rec = 10000000000
+            if avail < rec:
+                logging.error("Filesystem at %s has only %d bytes available; that is less than the recommended 10 GB. Please free up space and run scylla_io_setup again.\n", data_dir, avail)
+                sys.exit(1)
+            blocktune.tune_fs(data_dir, '2')
+            iotune_args += [ "--evaluation-directory", data_dir ]
+
+        if cpudata.cpuset():
+            iotune_args += [ "--cpuset", ",".join(map(str, cpudata.cpuset())) ]
+        elif cpudata.smp():
+            iotune_args += [ "--smp", str(cpudata.smp()) ]
+
+        try:
+            subprocess.check_call([bindir() + "/iotune",
+                                   "--format", "envfile",
+                                   "--options-file", etcdir() + "/scylla.d/io.conf",
+                                   "--properties-file", etcdir() + "/scylla.d/io_properties.yaml"] + iotune_args)
+        except Exception:
+            logging.error("%s did not pass validation tests, it may not be on XFS and/or has limited disk space.\n"
+                          "This is a non-supported setup, and performance is expected to be very bad.\n"
+                          "For better performance, placing your data on XFS-formatted directories is required.\n"
+                          "To override this error, enable developer mode as follow:\n"
+                          "sudo %s/scylla_dev_mode_setup --developer-mode 1", data_dirs, scriptsdir())
+            sys.exit(1)
 


### PR DESCRIPTION
Currently we have some experience disk properties for some kinds of instance
types (eg: i3, i3en, i2), no disk properties will be set if there is no
experience disk properties for the instance type, then scylla-server won't
start successfully because of the following error:

Could not initialize seastar: YAML::InvalidNode (invalid node; first invalid key: "read_bandwidth")

This patch changed scylla_io_setup to run iotune to reconfig io.conf and
io_properties.yaml for the instance types, which doesn't have experience disk
properties.

Fixes #5438

/CC @glommer 