### PR TITLE
scylla_setup: support yaml config file

### DIFF
--- a/conf/scylla_setup.yaml.example
+++ b/conf/scylla_setup.yaml.example
@@ -1,0 +1,89 @@
+# scylla_setup config file
+
+########################
+# parameters for setup #
+########################
+# specify disks for RAID
+disks: /dev/sda,/dev/sdb
+
+# specify NIC
+nic: eth0
+
+# specify subdomain of pool.ntp.org (ex: centos, fedora or amazon)
+ntp_domain:
+
+# specify swap directory
+swap_directory:
+
+# specify swapfile size in GB
+swap_size:
+
+# enable developer mode
+developer_mode: false
+
+# specify rsyslog server address
+rsyslog_server:
+
+########################
+# enable/disable setup #
+########################
+
+# raid setup
+raid_setup: true
+
+# setup AMI instance
+ami: false
+
+# optimize NIC and disks
+setup_nic_and_disks: false
+
+# EC2 configuration check
+ec2_check: true
+
+# kernel version check
+kernel_check: true
+
+# verifying packages
+verify_package: true
+
+# enabling service
+enable_service: true
+
+# selinux setup
+selinux_setup: true
+
+# bootparam setup
+bootparam_setup: true
+
+# ntp setup
+ntp_setup: true
+
+# coredump setup
+coredump_setup: true
+
+# sysconfig setup
+sysconfig_setup: true
+
+# IO configuration setup
+io_setup: true
+
+# daily version check
+version_check: true
+
+# install the node exporter
+node_exporter: true
+
+# cpu scaling setup
+cpuscaling_setup: true
+
+# fstrim setup
+fstrim_setup: true
+
+# memory setup
+memory_setup: true
+
+# swap setup
+swap_setup: true
+
+# rsyslog setup
+rsyslog_setup: true

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -28,6 +28,8 @@ import shutil
 import io
 import stat
 import distro
+import yaml
+from cerberus import validator
 from scylla_util import *
 from subprocess import run, DEVNULL
 
@@ -176,7 +178,80 @@ def warn_offline(setup):
 def warn_offline_missing_pkg(setup, pkg):
     colorprint('{red}{setup} disabled by default, since {pkg} not available.{nocolor}', setup=setup, pkg=pkg)
 
+def current_umask():
+    current = os.umask(0)
+    os.umask(current)
+    return current
+
+class ConfModeArgumentParserError(Exception):
+    pass
+
+class ConfModeArgumentParser(argparse.ArgumentParser):
+    def __init__(self):
+        super().__init__(add_help=False)
+
+    def error(self, message):
+        raise ConfModeArgumentParserError(message)
+
+class ConfModeValidator(validator.Validator):
+    def _validate_negative(self, negative, field, value):
+        """ Dummy validator for negative field.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
+        pass
+
+
 if __name__ == '__main__':
+    schema_file = scriptsdir_p() / 'scylla_setup_schema.yaml'
+    schema = yaml.safe_load(open(schema_file))
+    parser = ConfModeArgumentParser()
+    parser.add_argument('--conf')
+    try:
+        args = parser.parse_args()
+        with open(args.conf, 'r') as f:
+            conf = yaml.safe_load(f)
+        if conf == None:
+            conf = {}
+        v = ConfModeValidator(schema)
+        if not v.validate(conf):
+            print('config file {} failed to validate'.format(args.conf))
+            for k in v.errors:
+                for e in v.errors[k]:
+                    print(f"  field '{k}': {e}")
+            sys.exit(1)
+
+        dargs = {}
+        conf = v.normalized(conf)
+        for k in schema:
+            if not k in conf:
+                continue
+            v = conf[k]
+            # XXX: fixup for args.io_setup
+            if k == 'io_setup':
+                dargs[k] = '1' if v else '0'
+                continue
+            if 'negative' in schema[k]:
+                k = f'no_{k}'
+                v = not v
+            dargs[k] = v
+        args = argparse.Namespace(**dargs)
+    except ConfModeArgumentParserError:
+        pass
+    except OSError as e:
+        print('config file {} does not able to access'.format(args.conf))
+        print(e)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print('config file {} does not able to load'.format(args.conf))
+        print(e)
+        sys.exit(1)
+    except Exception as e:
+        print('unknown error:')
+        print(e)
+        sys.exit(1)
+
     if not is_nonroot() and os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
@@ -283,7 +358,8 @@ if __name__ == '__main__':
         interactive = True
         group.required = False # interactive mode: no option is required.
 
-    args = parser.parse_args()
+    if not args:
+        args = parser.parse_args()
 
     if not interactive:
         if not args.no_sysconfig_setup or (is_ec2() and not args.no_ec2_check):

--- a/dist/common/scripts/scylla_setup_schema.yaml
+++ b/dist/common/scripts/scylla_setup_schema.yaml
@@ -1,0 +1,103 @@
+disks:
+    type: string
+    nullable: true
+nic:
+    type: string
+    nullable: true
+ntp_domain:
+    type: string
+    nullable: true
+swap_directory:
+    type: string
+    nullable: true
+swap_size:
+    type: integer
+    nullable: true
+rsyslog_server:
+    type: string
+    nullable: true
+developer_mode:
+    type: boolean
+    default: false
+raid_setup:
+    type: boolean
+    dependencies:
+      - disks
+    default: true
+    negative: true
+ami:
+    type: boolean
+    default: false
+setup_nic_and_disks:
+    type: boolean
+    dependencies:
+      - nic
+    default: false
+ec2_check:
+    type: boolean
+    default: true
+    negative: true
+kernel_check:
+    type: boolean
+    default: true
+    negative: true
+verify_package:
+    type: boolean
+    default: true
+    negative: true
+enable_service:
+    type: boolean
+    default: true
+    negative: true
+selinux_setup:
+    type: boolean
+    default: true
+    negative: true
+bootparam_setup:
+    type: boolean
+    default: true
+    negative: true
+ntp_setup:
+    type: boolean
+    default: true
+    negative: true
+coredump_setup:
+    type: boolean
+    default: true
+    negative: true
+sysconfig_setup:
+    type: boolean
+    default: true
+    negative: true
+io_setup:
+    type: boolean
+    default: true
+    negative: true
+version_check:
+    type: boolean
+    default: true
+    negative: true
+node_exporter:
+    type: boolean
+    default: true
+    negative: true
+cpuscaling_setup:
+    type: boolean
+    default: true
+    negative: true
+fstrim_setup:
+    type: boolean
+    default: true
+    negative: true
+memory_setup:
+    type: boolean
+    default: true
+    negative: true
+swap_setup:
+    type: boolean
+    default: true
+    negative: true
+rsyslog_setup:
+    type: boolean
+    default: true
+    nagative: true

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -103,6 +103,7 @@ fedora_python3_packages=(
     python3-setuptools
     python3-psutil
     python3-distro
+    python3-cerberus
 )
 
 centos_packages=(


### PR DESCRIPTION
Introduce supporting yaml config file, to reuse scylla_setup parameters
for multiple nodes.

closes #6683