### PR TITLE
large_data_handler: Add metrics for large cells and rows

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -534,7 +534,12 @@ database::setup_metrics() {
         sm::make_counter("large_partition_exceeding_threshold", [this] { return _large_data_handler->stats().partitions_bigger_than_threshold; },
             sm::description("Number of large partitions exceeding compaction_large_partition_warning_threshold_mb. "
                 "Large partitions have performance impact and should be avoided, check the documentation for details.")),
-
+        sm::make_counter("large_row_exceeding_threshold", [this] { return _large_data_handler->stats().rows_bigger_than_threshold; },
+            sm::description("Number of large rows exceeding compaction_large_row_warning_threshold_mb. "
+                "Large rows have performance impact and should be avoided, check the documentation for details.")),
+        sm::make_counter("large_cell_exceeding_threshold", [this] { return _large_data_handler->stats().cells_bigger_than_threshold; },
+            sm::description("Number of large cells exceeding compaction_large_cell_warning_threshold_mb. "
+                "Large cells have performance impact and should be avoided, check the documentation for details.")),
         sm::make_total_operations("total_view_updates_pushed_local", _cf_stats.total_view_updates_pushed_local,
                 sm::description("Total number of view updates generated for tables and applied locally.")),
 

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -36,6 +36,8 @@ class large_data_handler {
 public:
     struct stats {
         int64_t partitions_bigger_than_threshold = 0; // number of large partition updates exceeding threshold_bytes
+        int64_t rows_bigger_than_threshold = 0; // number of large row updates exceeding threshold_bytes
+        int64_t cells_bigger_than_threshold = 0; // number of large cell updates exceeding threshold_bytes
     };
 
 private:
@@ -91,6 +93,7 @@ public:
             const clustering_key_prefix* clustering_key, uint64_t row_size) {
         assert(running());
         if (__builtin_expect(row_size > _row_threshold_bytes, false)) {
+            ++_stats.rows_bigger_than_threshold;
             return with_sem([&sst, &partition_key, clustering_key, row_size, this] {
                 return record_large_rows(sst, partition_key, clustering_key, row_size);
             });
@@ -104,6 +107,7 @@ public:
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size) {
         assert(running());
         if (__builtin_expect(cell_size > _cell_threshold_bytes, false)) {
+            ++_stats.cells_bigger_than_threshold;
             return with_sem([&sst, &partition_key, clustering_key, &cdef, cell_size, this] {
                 return record_large_cells(sst, partition_key, clustering_key, cdef, cell_size);
             });


### PR DESCRIPTION
This patch adds counter and metrics for large cells and large rows.
Similar to large partitions, those counters will be updated whenever a
large cell or large rows will be identified.

This allows monitoring big rows and cells.

After this path large rows will look like that in the monitor:
 HELP scylla_database_large_row_exceeding_threshold Number of large rows exceeding compaction_large_row_warning_threshold_mb. Large rows have performance impact and should be avoided, check the documentation for details.
scylla_database_large_row_exceeding_threshold{shard="0"} 0
scylla_database_large_row_exceeding_threshold{shard="1"} 0
scylla_database_large_row_exceeding_threshold{shard="2"} 1

And large cells will look like that:
scylla_database_large_cell_exceeding_threshold{shard="0"} 0
scylla_database_large_cell_exceeding_threshold{shard="1"} 0
scylla_database_large_cell_exceeding_threshold{shard="2"} 1

Fixes #7353

Signed-off-by: Amnon Heiman <amnon@scylladb.com>