### PR TITLE
repair: Introduce bandwidth limiter

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -834,6 +834,38 @@
          ]
       },
       {
+         "path":"/storage_service/repair_limit/",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Set the bandwidth limiter for repair",
+               "type":"void",
+               "nickname":"repair_set_limiter",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"rate",
+                     "description":"Limit on sustained bytes per second for repair",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"long",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"burst",
+                     "description":"Limit on max number of bytes per request for repair",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"long",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/repair_status/",
          "operations":[
             {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -55,3 +55,5 @@ future<> repair_cf_range_row_level(repair_info& ri,
         const std::vector<gms::inet_address>& all_peer_nodes);
 
 future<> shutdown_all_row_level_repair();
+
+future<> repair_set_limiter(size_t rate, size_t burst);


### PR DESCRIPTION
This patch introduces a bandwidth limiter at the repair level. It limits
the number of sstable reads from a reader and writes to sstable per
second. Users can use this limiter to make repair and node operations
which are based on repair less aggressive than default. This limiter is
disabled by default.

For example:

1) To set the limiter to 1000000 bytes per second:

curl -X POST "http://127.0.0.1:10000/storage_service/repair_set_limiter/?rate=1000000&burst=1000000"

The burst is the maximum bytes per read or write. It should be larger
than maximum row size. If a row is larger than the burst size, the
limiter is skipped to prevent deadlock.

2) To disable the limiter

curl -X POST "http://127.0.0.1:10000/storage_service/repair_set_limiter/?rate=0&burst=0"

Fixes #7255