### PR TITLE
Type listener interface for extensions/configurables

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -37,6 +37,8 @@
 
 namespace seastar { class file; struct logging_settings; }
 
+class cql_test_config;
+
 namespace db {
 
 namespace fs = std::filesystem;
@@ -347,6 +349,9 @@ public:
 
     static const sstring default_tls_priority;
 private:
+    // for testing
+    friend class ::cql_test_config;
+
     template<typename T>
     struct log_legacy_value : public named_value<T> {
         using MyBase = named_value<T>;

--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -67,3 +67,23 @@ void db::extensions::add_commitlog_file_extension(sstring n, commitlog_file_exte
 void db::extensions::add_extension_to_schema(schema_ptr s, const sstring& name, shared_ptr<schema_extension> ext) {
     const_cast<schema *>(s.get())->extensions()[name] = std::move(ext);
 }
+
+db::extensions::type_release::type_release(std::function<void()> f)
+    : func(std::move(f))
+{}
+
+db::extensions::type_release::type_release(type_release&&) = default;
+db::extensions::type_release& db::extensions::type_release::operator=(type_release&&) = default;
+
+db::extensions::type_release::~type_release() {
+    if (func) {
+        try {
+            func();
+        } catch (...) {
+        }
+    }
+}
+
+void db::extensions::type_release::release() {
+    func = {};
+}

--- a/init.hh
+++ b/init.hh
@@ -57,13 +57,8 @@ void init_gossiper(sharded<gms::gossiper>& gossiper
  */
 class configurable {
 public:
-    configurable() {
-        // We auto register. Not that like cycle is assumed to be forever
-        // and scope should be managed elsewhere.
-        register_configurable(*this);
-    }
-    virtual ~configurable()
-    {}
+    configurable();
+    virtual ~configurable();
     // Hook to add command line options and/or add main config options
     virtual void append_options(db::config&, boost::program_options::options_description_easy_init&)
     {};
@@ -81,6 +76,4 @@ public:
     static future<> init_all(const boost::program_options::variables_map&, const db::config&, db::extensions&);
     static future<> init_all(const db::config&, db::extensions&);
     static void append_all(db::config&, boost::program_options::options_description_easy_init&);
-private:
-    static void register_configurable(configurable &);
 };

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -71,6 +71,8 @@ public:
     cql_test_config(const cql_test_config&);
     cql_test_config(shared_ptr<db::config>);
     ~cql_test_config();
+
+    db::extensions& extensions() const;
 };
 
 class cql_test_env {


### PR DESCRIPTION
Loosly coupled listen-notify injection of types to extensions and whatnot, to avoid both tangled type knowledge in main (i.e. be able to have loosly coupled extensions), and yet avoid globals for certain high-demand services. 

This poc just publishes query_processor, migration_manger, storage_service and database, but should obviously be extended. 
Note: this combo of services allows de-coupling a certain enterprise feature from globals. 

Update 2021-03-08: 
* Rebased on master
* Now with RAII-result for object init, I.e. "destroys" listened objects when returned "handle" goes out of scope.
* Supports "qualifiers" to object listeners, making it possible to distinguish instances of same object type

Basically, object flow would be:

* Extension function registers static callback in config listeners. 
* Main init calls each of these object with config + extensions registry. 
* Extension creates an instance of itself, then registers listeners for all service and whatnot objects it require. 
* Main init calls "notify" for its service objects created, keeping the returned handles on stack. 
* Scylla runs.
* Main exists, RAII objects die, calls notifications to clear out dependent objects. 
* Extension objects die.
