### PR TITLE
dist/docker: return non-zero code when scylla setup fails

### DIFF
--- a/dist/docker/redhat/docker-entrypoint.py
+++ b/dist/docker/redhat/docker-entrypoint.py
@@ -21,6 +21,8 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 try:
     arguments, extra_arguments = commandlineparser.parse()
+
+    logging.info("Setup ScyllaDB")
     setup = scyllasetup.ScyllaSetup(arguments, extra_arguments=extra_arguments)
     setup.developerMode()
     setup.cpuSet()
@@ -28,7 +30,10 @@ try:
     setup.cqlshrc()
     setup.arguments()
     setup.set_housekeeping()
+
+    logging.info("Run ScyllaDB")
     supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
     supervisord.wait()
 except Exception:
-    logging.exception('failed!')
+    logging.exception("Failed to configure or start Scylla", exc_info=True)
+    sys.exit(1)


### PR DESCRIPTION
For the moment running Scylla with docker returns only 0 code
when process finishes it's execution.
It is suitable for the case of correctly setup Scylla and
shutdown/decomission operation, but not Scylla setup failure.

So, make containerized scylla return exit code "1" when
it's setup fails as in the following bug:
- https://github.com/scylladb/scylla/issues/8032

Such behavior is useful for proper handling of the Scylla containers
in such container orchestration systems as 'kubernetes'.
With current approach kubernetes doesn't know about suppressed error.
With the fix it will get to know that something goes wrong.