### PR TITLE
[RFC] utils: managed_bytes: rewrite to save 16 bytes in the last fragment

### DIFF
--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -25,12 +25,16 @@
 
 std::unique_ptr<bytes_view::value_type[]>
 managed_bytes::do_linearize_pure() const {
-    auto b = _u.ptr;
-    auto data = std::unique_ptr<bytes_view::value_type[]>(new bytes_view::value_type[b->size]);
-    auto e = data.get();
-    while (b) {
-        e = std::copy_n(b->data, b->frag_size, e);
-        b = b->next;
+    size_t s = external_size();
+    auto data = std::unique_ptr<bytes_view::value_type[]>(new bytes_view::value_type[s]);
+    const blob_storage::ref_type* b = &first_fragment();
+    bytes_view::value_type* out = data.get();
+    while (s) {
+        size_t frag_size = b->frag_size();
+        memcpy(out, b->data(), frag_size);
+        out += frag_size;
+        s -= frag_size;
+        b = &b->next();
     }
     return data;
 }


### PR DESCRIPTION
When the contents of managed_bytes are bigger than 15 bytes, they are allocated
externally in a linked list of blob_storage. Each blob storage stores a
backref (to allow moving it), the size of itself, the size of all fragments after it,
and the pointer to the next fragment. This is fairly wasteful, because
in the most common case, when there is only one fragment, the pointer is unused,
and managed_bytes has 63 unused bits which can be used to store the sizes.
In other words, for every value bigger than 15B, there are 16 bytes which can be saved.

Note that live cells have a flag byte and 8B for the timestamp, so only
6B values fit inside the internal storage, so even cells with 8B values are
allocated externally and incur the 16B of overhead.

This patch rewrites the internals of managed_bytes and blob_storage (and
consequently, managed_bytes_view), to:
1. Cut out the next-pointer from the last fragment.
2. Move the size of a fragment from the fragment itself to its backreference,
which will allow us to move the size from the first fragment directly into
managed_bytes.
3. Not store the total size in fragments, (because it's useless there),
but only in managed_bytes.

This is accomplished as follows:
managed_bytes and every non-last fragment stores a blob_storage::ref_type
at its first 12 bytes. This is the type which backreferences point to.
This type contains the pointer to the next fragment (8B), the size of that
fragment (31 bits), and a bit marking whether this is the last fragment or not.
When blob_storage is being moved, it updates the pointer under the
backreference (which is how it always was), and also reads its own size (to know
how much to move) from there (this is a change; it used to store the size in
itself). In other words, this patch moves all fragment sizes one node back.

The remaining thing to deal with is the total size, which is stored as 31 bits
at the last 4 bytes of managed_bytes (as a big-endian integer shifted by 1).
The least significant bit in the last byte differentiates between external
and internal storage.

To sum up, this patch moves the fragment sizes one node up in the linked list
of fragments, avoids allocating the pointer to next fragment in the last
fragment, and moves the total size directly to managed_bytes. This saves 16B
for typical uses of managed_bytes, but results in more work for the CPU
(bit shifts, byte swaps), more complicated code, and reduces the size of
supported blobs from 4GiB to 2GiB.