### PR TITLE
Revamp exception handling in compaction manager

### DIFF
--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -316,6 +316,7 @@ future<> compaction_manager::run_custom_job(column_family* cf, sstring name, non
         } catch (sstables::compaction_stop_exception& e) {
             cmlog.info("{} was abruptly stopped, reason: {}", name, e.what());
             _stats.errors++;
+            throw;
         } catch (...) {
             cmlog.error("{} failed: {}", name, std::current_exception());
             _stats.errors++;

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -662,6 +662,7 @@ void compaction_manager::submit_offstrategy(column_family* cf) {
                         f.get();
                         _stats.completed_tasks++;
                     } catch (sstables::compaction_stop_exception& e) {
+                        _stats.errors++;
                         cmlog.info("off-strategy compaction was abruptly stopped, reason: {}", e.what());
                         return put_task_to_sleep(task).then([] {
                             return make_ready_future<stop_iteration>(stop_iteration::no);

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -207,6 +207,7 @@ void compaction_manager::register_compacting_sstables(const std::vector<sstables
         _compacting_sstables.merge(sstables_to_merge);
     } catch (...) {
         cmlog.error("Unexpected error when registering compacting SSTables: {}. Ignored...", std::current_exception());
+        throw;
     }
 }
 

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -276,9 +276,11 @@ future<> compaction_manager::submit_major_compaction(column_family* cf) {
         } catch (sstables::compaction_stop_exception& e) {
             cmlog.info("major compaction stopped, reason: {}", e.what());
             _stats.errors++;
+            throw;
         } catch (...) {
             cmlog.error("major compaction failed, reason: {}", std::current_exception());
             _stats.errors++;
+            throw;
         }
     });
     return task->compaction_done.get_future().then([task] {});

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -315,8 +315,10 @@ future<> compaction_manager::run_custom_job(column_family* cf, sstring name, non
             f.get();
         } catch (sstables::compaction_stop_exception& e) {
             cmlog.info("{} was abruptly stopped, reason: {}", name, e.what());
+            _stats.errors++;
         } catch (...) {
             cmlog.error("{} failed: {}", name, std::current_exception());
+            _stats.errors++;
             throw;
         }
     });

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -396,6 +396,10 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of compaction tasks waiting for an opportunity to run.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
+        sm::make_gauge("errors", [this] { return _stats.errors; },
+                       sm::description("Holds the number of compaction tasks that failed.")),
+        sm::make_gauge("completed", [this] { return _stats.completed_tasks; },
+                       sm::description("Holds the number of compaction tasks that completed successfully.")),
     });
 }
 

--- a/sstables/compaction_manager.hh
+++ b/sstables/compaction_manager.hh
@@ -144,11 +144,6 @@ private:
 
     inline future<> put_task_to_sleep(lw_shared_ptr<task>& task);
 
-    // Compaction manager stop itself if it finds an storage I/O error which results in
-    // stop of transportation services. It cannot make progress anyway.
-    // Returns true if error is judged not fatal, and compaction can be retried.
-    inline bool maybe_stop_on_error(future<> f, stop_iteration will_stop = stop_iteration::no);
-
     void postponed_compactions_reevaluation();
     void reevaluate_postponed_compactions();
     // Postpone compaction for a column family that couldn't be executed due to ongoing


### PR DESCRIPTION
This series is revamping exception handling in the manager for improving maintainability, and also fixing a couple of missing stats updates and also problems like major compaction not propagating the failure back to the caller, and some exceptions being incorrectly swallowed.