### PR TITLE
unified: move unified package contents to sub-directory

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -114,11 +114,11 @@ have_gnutls = any([lib.startswith('libgnutls.so')
 gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.PIPE)
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
-# relocatable package format version = 2.2
+# relocatable package format version = 3.0
 shutil.rmtree(f'build/{SCYLLA_DIR}', ignore_errors=True)
 os.makedirs(f'build/{SCYLLA_DIR}')
 with open(f'build/{SCYLLA_DIR}/.relocatable_package_version', 'w') as f:
-    f.write('2.2\n')
+    f.write('3.0\n')
 ar.add(f'build/{SCYLLA_DIR}/.relocatable_package_version', arcname='.relocatable_package_version')
 
 for exe in executables_scylla:

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -51,9 +51,10 @@ done
 
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
 PKGS="build/$MODE/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz build/$MODE/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz build/$MODE/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz build/$MODE/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz"
+BASEDIR="build/$MODE/unified/$PRODUCT-$VERSION"
 
 rm -rf build/"$MODE"/unified/
-mkdir -p build/"$MODE"/unified/
+mkdir -p "$BASEDIR"
 for pkg in $PKGS; do
     if [ ! -e "$pkg" ]; then
         echo "$pkg not found."
@@ -61,17 +62,17 @@ for pkg in $PKGS; do
         exit 1
     fi
     pkg="$(readlink -f $pkg)"
-    tar -C build/"$MODE"/unified/ -xpf "$pkg"
+    tar -C "$BASEDIR" -xpf "$pkg"
     dirname=$(basename "$pkg"| sed -e "s/-$VERSION_ESC-$RELEASE_ESC\.[^.]*\.tar\.gz//")
     dirname=${dirname/#$PRODUCT/scylla}
-    if [ ! -d build/"$MODE"/unified/"$dirname" ]; then
+    if [ ! -d "$BASEDIR/$dirname" ]; then
         echo "Directory $dirname not found in $pkg, the pacakge may corrupted."
         exit 1
     fi
 done
-ln -f unified/install.sh build/"$MODE"/unified/
-ln -f unified/uninstall.sh build/"$MODE"/unified/
-# relocatable package format version = 2.2
-echo "2.2" > build/"$MODE"/unified/.relocatable_package_version
+ln -f unified/install.sh "$BASEDIR"
+ln -f unified/uninstall.sh "$BASEDIR"
+# relocatable package format version = 3.0
+echo "3.0" > "$BASEDIR"/.relocatable_package_version
 cd build/"$MODE"/unified
-tar cpf "$UNIFIED_PKG" --use-compress-program=pigz * .relocatable_package_version
+tar cpf "$UNIFIED_PKG" --use-compress-program=pigz "$PRODUCT-$VERSION"


### PR DESCRIPTION
On most of the software distribution tar.gz, it has sub-directory to contain
everything, to prevent extract contents to current directory.
We should follow this style on our unified package too.

To do this we need to increment relocatable package version to '3'.

Fixes #8349