### PR TITLE
Prevent queries from running after storage_proxy and batchlog_manager shutdown

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -140,7 +140,13 @@ future<> db::batchlog_manager::stop() {
     }
     _stop = true;
     _timer.cancel();
+    // Synchronize with do_batch_log_replay.
+    // Although _sem might be held only on shard 0
+    // it is safe to wait for it on all shards.
+    return _sem.wait().then([this] {
+    // FIXME: indentation
     return _gate.close();
+    });
 }
 
 future<size_t> db::batchlog_manager::count_all_batches() const {

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -123,7 +123,9 @@ future<> db::batchlog_manager::start() {
             (void)do_batch_log_replay().handle_exception([] (auto ep) {
                 blogger.error("Exception in batch replay: {}", ep);
             }).finally([this] {
+              if (!_stop) {
                 _timer.arm(lowres_clock::now() + std::chrono::milliseconds(replay_interval));
+              }
             });
         });
 

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -144,8 +144,7 @@ future<> db::batchlog_manager::stop() {
     // Although _sem might be held only on shard 0
     // it is safe to wait for it on all shards.
     return _sem.wait().then([this] {
-    // FIXME: indentation
-    return _gate.close();
+        return _gate.close();
     });
 }
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -315,6 +315,8 @@ private:
     cdc_stats _cdc_stats;
 
     std::unordered_set<utils::UUID> _hint_queue_checkpoints;
+
+    gate _query_gate;
 private:
     future<coordinator_query_result> query_singular(lw_shared_ptr<query::read_command> cmd,
             dht::partition_range_vector&& partition_ranges,

--- a/service_permit.hh
+++ b/service_permit.hh
@@ -23,14 +23,19 @@
 
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/gate.hh>
 
 class service_permit {
     seastar::lw_shared_ptr<seastar::semaphore_units<>> _permit;
+    gate::holder _gh; // for holding the storage_proxy query_gate until the query completes
     service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<seastar::semaphore_units<>>(std::move(u))) {}
     friend service_permit make_service_permit(seastar::semaphore_units<>&& permit);
     friend service_permit empty_service_permit();
 public:
     size_t count() const { return _permit ? _permit->count() : 0; };
+    gate::holder& gate_holder() noexcept {
+        return _gh;
+    }
 };
 
 inline service_permit make_service_permit(seastar::semaphore_units<>&& permit) {


### PR DESCRIPTION
This series hardnes both `storage_proxy::drain_on_shutdown()`
and `db::batchlog_manager::stop()` to make sure no queries run after they complete.

For the storage_proxy, a `_query_gate` is added, and is held by queries using a newly introduced `gate::holder` that was added to the `service_permit`.

db::batchlog_manager::stop() and its timer rearming logic were hardened to prevent `do_batch_log_replay` from running after the batchlog_manager was stopped.

Fixes #8995

Test: unit(dev)
DTest: compact_storage_tests.py:TestCompactStorage.wide_row_test,
           update_cluster_layout_tests:TestUpdateClusterLayout.simple_add_new_node_while_adding_info_{1,2}_test (dev)
