### PR TITLE
reloc: add support stripped binary installation for relocatable package

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1825,8 +1825,14 @@ with open(buildfile, 'w') as f:
         rule copy
             command = cp --reflink=auto $in $out
             description = COPY $out
+        rule strip
+            command = scripts/strip.sh $in
         rule package
             command = scripts/create-relocatable-package.py --mode $mode $out
+        rule stripped_package
+            command = scripts/create-relocatable-package.py --stripped --mode $mode $out
+        rule debuginfo_package
+            command = dist/debuginfo/scripts/create-relocatable-package.py --mode $mode $out
         rule rpmbuild
             command = reloc/build_rpm.sh --reloc-pkg $in --builddir $out
         rule debbuild
@@ -1971,6 +1977,8 @@ with open(buildfile, 'w') as f:
                     f.write('build $builddir/{}/{}: {}.{} {} | {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), seastar_dep))
                     if has_thrift:
                         f.write('   libs =  {} {} $seastar_libs_{} $libs\n'.format(thrift_libs, maybe_static(args.staticboost, '-lboost_system'), mode))
+                    f.write(f'build $builddir/{mode}/{binary}.stripped: strip $builddir/{mode}/{binary}\n')
+                    f.write(f'build $builddir/{mode}/{binary}.debug: phony $builddir/{mode}/{binary}.stripped\n')
             for src in srcs:
                 if src.endswith('.cc'):
                     obj = '$builddir/' + mode + '/' + src.replace('.cc', '.o')
@@ -2105,22 +2113,36 @@ with open(buildfile, 'w') as f:
         f.write('  target = iotune\n'.format(**locals()))
         f.write(textwrap.dedent('''\
             build $builddir/{mode}/iotune: copy $builddir/{mode}/seastar/apps/iotune/iotune
+            build $builddir/{mode}/iotune.stripped: strip $builddir/{mode}/iotune
+            build $builddir/{mode}/iotune.debug: phony $builddir/{mode}/iotune.stripped
             ''').format(**locals()))
-        include_scylla_and_iotune = f'$builddir/{mode}/scylla $builddir/{mode}/iotune' if not args.dist_only else ''
-        f.write('build $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz: package {include_scylla_and_iotune} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter | always\n'.format(**locals()))
+        if args.dist_only:
+            include_scylla_and_iotune = ''
+            include_scylla_and_iotune_stripped = ''
+            include_scylla_and_iotune_debug = ''
+        else:
+            include_scylla_and_iotune = f'$builddir/{mode}/scylla $builddir/{mode}/iotune'
+            include_scylla_and_iotune_stripped = f'$builddir/{mode}/scylla.stripped $builddir/{mode}/iotune.stripped'
+            include_scylla_and_iotune_debug = f'$builddir/{mode}/scylla.debug $builddir/{mode}/iotune.debug'
+        f.write('build $builddir/{mode}/dist/tar/{scylla_product}-unstripped-{scylla_version}-{scylla_release}.{arch}.tar.gz: package {include_scylla_and_iotune} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter | always\n'.format(**locals()))
+        f.write('  mode = {mode}\n'.format(**locals()))
+        f.write('build $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz: stripped_package {include_scylla_and_iotune_stripped} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter.stripped | always\n'.format(**locals()))
+        f.write('  mode = {mode}\n'.format(**locals()))
+        f.write('build $builddir/{mode}/dist/tar/{scylla_product}-debuginfo-{scylla_version}-{scylla_release}.{arch}.tar.gz: debuginfo_package {include_scylla_and_iotune_debug} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter.debug | always\n'.format(**locals()))
         f.write('  mode = {mode}\n'.format(**locals()))
         f.write('build $builddir/{mode}/dist/tar/{scylla_product}-package.tar.gz: copy $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz\n'.format(**locals()))
         f.write('  mode = {mode}\n'.format(**locals()))
         f.write('build $builddir/{mode}/dist/tar/{scylla_product}-{arch}-package.tar.gz: copy $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz\n'.format(**locals()))
         f.write('  mode = {mode}\n'.format(**locals()))
 
-        f.write(f'build $builddir/dist/{mode}/redhat: rpmbuild $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
+        f.write(f'build $builddir/dist/{mode}/redhat: rpmbuild $builddir/{mode}/dist/tar/{scylla_product}-unstripped-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
         f.write(f'  mode = {mode}\n')
-        f.write(f'build $builddir/dist/{mode}/debian: debbuild $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
+        f.write(f'build $builddir/dist/{mode}/debian: debbuild $builddir/{mode}/dist/tar/{scylla_product}-unstripped-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
         f.write(f'  mode = {mode}\n')
         f.write(f'build dist-server-{mode}: phony $builddir/dist/{mode}/redhat $builddir/dist/{mode}/debian dist-server-compat-{mode} dist-server-compat-arch-{mode}\n')
         f.write(f'build dist-server-compat-{mode}: phony $builddir/{mode}/dist/tar/{scylla_product}-package.tar.gz\n')
         f.write(f'build dist-server-compat-arch-{mode}: phony $builddir/{mode}/dist/tar/{scylla_product}-{arch}-package.tar.gz\n')
+        f.write(f'build dist-server-debuginfo-{mode}: phony $builddir/{mode}/dist/tar/{scylla_product}-debuginfo-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
         f.write(f'build dist-jmx-{mode}: phony $builddir/{mode}/dist/tar/{scylla_product}-jmx-{scylla_version}-{scylla_release}.noarch.tar.gz dist-jmx-rpm dist-jmx-deb dist-jmx-compat\n')
         f.write(f'build dist-tools-{mode}: phony $builddir/{mode}/dist/tar/{scylla_product}-tools-{scylla_version}-{scylla_release}.noarch.tar.gz dist-tools-rpm dist-tools-deb dist-tools-compat\n')
         f.write(f'build dist-python3-{mode}: phony dist-python3-tar dist-python3-rpm dist-python3-deb dist-python3-compat dist-python3-compat-arch\n')
@@ -2164,9 +2186,10 @@ with open(buildfile, 'w') as f:
         build dist-server-deb: phony {' '.join(['$builddir/dist/{mode}/debian'.format(mode=mode) for mode in build_modes])}
         build dist-server-rpm: phony {' '.join(['$builddir/dist/{mode}/redhat'.format(mode=mode) for mode in build_modes])}
         build dist-server-tar: phony {' '.join(['$builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz'.format(mode=mode, scylla_product=scylla_product, arch=arch, scylla_version=scylla_version, scylla_release=scylla_release) for mode in default_modes])}
+        build dist-server-debuginfo: phony {' '.join(['$builddir/{mode}/dist/tar/{scylla_product}-debuginfo-{scylla_version}-{scylla_release}.{arch}.tar.gz'.format(mode=mode, scylla_product=scylla_product, arch=arch, scylla_version=scylla_version, scylla_release=scylla_release) for mode in default_modes])}
         build dist-server-compat: phony {' '.join(['$builddir/{mode}/dist/tar/{scylla_product}-package.tar.gz'.format(mode=mode, scylla_product=scylla_product, arch=arch) for mode in default_modes])}
         build dist-server-compat-arch: phony {' '.join(['$builddir/{mode}/dist/tar/{scylla_product}-{arch}-package.tar.gz'.format(mode=mode, scylla_product=scylla_product, arch=arch) for mode in default_modes])}
-        build dist-server: phony dist-server-tar dist-server-compat dist-server-compat-arch dist-server-rpm dist-server-deb
+        build dist-server: phony dist-server-tar dist-server-debuginfo dist-server-compat dist-server-compat-arch dist-server-rpm dist-server-deb
 
         rule build-submodule-reloc
           command = cd $reloc_dir && ./reloc/build_reloc.sh --version $$(<../../build/SCYLLA-PRODUCT-FILE)-$$(sed 's/-/~/' <../../build/SCYLLA-VERSION-FILE)-$$(<../../build/SCYLLA-RELEASE-FILE) --nodeps $args
@@ -2236,7 +2259,7 @@ with open(buildfile, 'w') as f:
         build $builddir/{mode}/dist/tar/{scylla_product}-jmx-{scylla_version}-{scylla_release}.noarch.tar.gz: copy tools/jmx/build/{scylla_product}-jmx-{scylla_version}-{scylla_release}.noarch.tar.gz
         build $builddir/{mode}/dist/tar/{scylla_product}-jmx-package.tar.gz: copy tools/jmx/build/{scylla_product}-jmx-{scylla_version}-{scylla_release}.noarch.tar.gz
 
-        build {mode}-dist: phony dist-server-{mode} dist-python3-{mode} dist-tools-{mode} dist-jmx-{mode} dist-unified-{mode}
+        build {mode}-dist: phony dist-server-{mode} dist-server-debuginfo-{mode} dist-python3-{mode} dist-tools-{mode} dist-jmx-{mode} dist-unified-{mode}
         build dist-{mode}: phony {mode}-dist
         build dist-check-{mode}: dist-check
           mode = {mode}
@@ -2279,7 +2302,9 @@ with open(buildfile, 'w') as f:
         build $builddir/debian/debian: debian_files_gen | always
         rule extract_node_exporter
             command = tar -C build -xvpf {node_exporter_filename} --no-same-owner && rm -rfv build/node_exporter && mv -v build/{node_exporter_dirname} build/node_exporter
-        build $builddir/node_exporter: extract_node_exporter | always
+        build $builddir/node_exporter/node_exporter: extract_node_exporter | always
+        build $builddir/node_exporter/node_exporter.stripped: strip $builddir/node_exporter/node_exporter
+        build $builddir/node_exporter/node_exporter.debug: phony $builddir/node_exporter/node_exporter.stripped
         rule print_help
              command = ./scripts/build-help.sh
         build help: print_help | always

--- a/dist/debuginfo/install.sh
+++ b/dist/debuginfo/install.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+set -e
+
+if [ -z "$BASH_VERSION" ]; then
+    echo "Unsupported shell, please run this script on bash."
+    exit 1
+fi
+
+print_usage() {
+    cat <<EOF
+Usage: install.sh [options]
+
+Options:
+  --root /path/to/root     alternative install root (default /)
+  --prefix /prefix         directory prefix (default /usr)
+  --nonroot                install Scylla without required root priviledge
+  --help                   this helpful message
+EOF
+    exit 1
+}
+
+# Some words about pathnames in this script.
+#
+# A pathname has three components: "$root/$prefix/$rest".
+#
+# $root is used to point at the entire installed hierarchy, so you can perform
+# an install to a temporary directory without modifying your system, with the intent
+# that the files are copied later to the real /. So, if "$root"="/tmp/xyz", you'd get
+# a standard hierarchy under /tmp/xyz: /tmp/xyz/etc, /tmp/xyz/var, and 
+# /tmp/xyz/opt/scylladb/bin/scylla. This is used by rpmbuild --root to create a filesystem
+# image to package.
+#
+# When this script creates a file, it must use "$root" to refer to the file. When this
+# script inserts a file name into a file, it must not use "$root", because in the installed
+# system "$root" is stripped out. Example:
+#
+#    echo "This file's name is /a/b/c. > "$root/a/b/c"
+#
+# The second component is "$prefix". It is used by non-root install to place files into
+# a directory of the user's choice (typically somewhere under their home directory). In theory
+# all files should be always under "$prefix", but in practice /etc files are not under "$prefix"
+# for standard installs (we use /etc not /usr/etc) and are under "$prefix" for non-root installs.
+# Another exception is files that go under /opt/scylladb in a standard install go under "$prefix"
+# for a non-root install.
+#
+# The last component is the rest of the file name, which doesn't matter for this script and
+# isn't changed by it.
+
+root=/
+nonroot=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "--root")
+            root="$(realpath "$2")"
+            shift 2
+            ;;
+        "--prefix")
+            prefix="$2"
+            shift 2
+            ;;
+        "--nonroot")
+            nonroot=true
+            shift 1
+            ;;
+        "--help")
+            shift 1
+	    print_usage
+            ;;
+        *)
+            print_usage
+            ;;
+    esac
+done
+
+# change directory to the package's root directory
+cd "$(dirname "$0")"
+
+if [ -z "$prefix" ]; then
+    if $nonroot; then
+        prefix=~/scylladb
+    else
+        prefix=/opt/scylladb
+    fi
+fi
+
+rprefix=$(realpath -m "$root/$prefix")
+
+install -d -m755 "$rprefix"/libexec/.debug
+cp -r ./libexec/.debug/* "$rprefix"/libexec/.debug
+install -d -m755 "$rprefix"/node_exporter/.debug
+cp -r ./node_exporter/.debug/* "$rprefix"/node_exporter/.debug

--- a/dist/debuginfo/scripts/create-relocatable-package.py
+++ b/dist/debuginfo/scripts/create-relocatable-package.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import argparse
+import io
+import os
+import subprocess
+import tarfile
+import pathlib
+import shutil
+
+
+RELOC_PREFIX='scylla-debuginfo'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname),
+                        filter=filter)
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name),
+                        filter=filter)
+
+tarfile.TarFile.reloc_add = reloc_add
+
+SCYLLA_DIR='scylla-debuginfo-package'
+def reloc_add(ar, name, arcname=None):
+    ar.add(name, arcname="{}/{}".format(SCYLLA_DIR, arcname if arcname else name))
+
+ap = argparse.ArgumentParser(description='Create a relocatable scylla-debuginfo package.')
+ap.add_argument('dest',
+                help='Destination file (tar format)')
+ap.add_argument('--mode', dest='mode', default='release',
+                help='Build mode (debug/release) to use')
+
+args = ap.parse_args()
+
+executables_scylla = [
+                'build/{}/scylla'.format(args.mode),
+                'build/{}/iotune'.format(args.mode)]
+
+output = args.dest
+
+# Although tarfile.open() can write directly to a compressed tar by using
+# the "w|gz" mode, it does so using a slow Python implementation. It is as
+# much as 3 times faster (!) to output to a pipe running the external gzip
+# command. We can complete the compression even faster by using the pigz
+# command - a parallel implementation of gzip utilizing all processors
+# instead of just one.
+gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.PIPE)
+
+ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
+# relocatable package format version = 2.1
+shutil.rmtree(f'build/{SCYLLA_DIR}', ignore_errors=True)
+os.makedirs(f'build/{SCYLLA_DIR}')
+with open(f'build/{SCYLLA_DIR}/.relocatable_package_version', 'w') as f:
+    f.write('2.1\n')
+ar.add(f'build/{SCYLLA_DIR}/.relocatable_package_version', arcname='.relocatable_package_version')
+
+for exe in executables_scylla:
+    basename = os.path.basename(exe)
+    ar.reloc_add(f'{exe}.debug', arcname=f'libexec/.debug/{basename}.debug')
+ar.reloc_add('build/node_exporter/node_exporter.debug', arcname='node_exporter/.debug/node_exporter.debug')
+ar.reloc_add('dist/debuginfo/install.sh', arcname='install.sh')
+
+# Complete the tar output, and wait for the gzip process to complete
+ar.close()
+gzip_process.communicate()

--- a/scripts/strip.sh
+++ b/scripts/strip.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+orig="$1"
+stripped="$orig.stripped"
+debuginfo="$orig.debug"
+
+# generate stripped binary and debuginfo
+cp -a "$orig" "$stripped"
+gdb-add-index "$stripped"
+objcopy --merge-notes "$stripped"
+eu-strip --remove-comment -f "$debuginfo" "$stripped"
+
+# generate minidebug (minisymtab)
+dynsyms="$orig.dynsyms"
+funcsyms="$orig.funcsyms"
+keep_symbols="$orig.keep_symbols"
+mini_debuginfo="$orig.minidebug"
+remove_sections=`readelf -W -S "$debuginfo" | awk '{ if (index($2,".debug_") != 1 && ($3 == "PROGBITS" || $3 == "NOTE" || $3 == "NOBITS") && index($8,"A") == 0) printf "--remove-section "$2" " }'`
+nm -D "$stripped" --format=posix --defined-only | awk '{ print $1 }' | sort > "$dynsyms"
+nm "$debuginfo" --format=sysv --defined-only | awk -F \| '{ if ($4 ~ "FUNC") print $1 }' | sort > "$funcsyms"
+comm -13 "$dynsyms" "$funcsyms" > "$keep_symbols"
+objcopy -S $remove_sections --keep-symbols="$keep_symbols" "$debuginfo" "$mini_debuginfo"
+xz -f --threads=0 "$mini_debuginfo"
+objcopy --add-section .gnu_debugdata="$mini_debuginfo".xz "$stripped"

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -28,6 +28,7 @@ Options:
   --supervisor             enable supervisor to manage scylla processes
   --supervisor-log-to-stdout logging to stdout on supervisor
   --without-systemd         skip installing systemd units
+  --debuginfo               install debuginfo
   --help                   this helpful message
 EOF
     exit 1
@@ -44,6 +45,7 @@ nonroot=false
 supervisor=false
 supervisor_log_to_stdout=false
 without_systemd=false
+debuginfo=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -81,6 +83,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--without-systemd")
             without_systemd=true
+            shift 1
+            ;;
+        "--debuginfo")
+            debuginfo=true
             shift 1
             ;;
         "--help")
@@ -158,6 +164,9 @@ fi
 if $without_systemd; then
     scylla_args+=(--without-systemd)
     jmx_args+=(--without-systemd)
+fi
+if $debuginfo; then
+    scylla_args+=(--debuginfo)
 fi
 
 (cd $(readlink -f scylla); ./install.sh --root "$root" --prefix "$prefix" --python3 "$python3" --sysconfdir "$sysconfdir" ${scylla_args[@]})


### PR DESCRIPTION
This add support stripped binary installation for relocatable package.
After this change, we will install stripped binary by default, and also
install debug symbol optionally (./install.sh --debuginfo).
When the option specified to install.sh, the script will extract debug symbol
at /opt/scylladb/\<dir\>/.debug.

Note that we need to keep unstripped version of relocatable package for rpm/deb,
otherwise rpmbuild/debuild fails to create debug symbol package.
This version is renamed to scylla-unstripped-$(arch)-package.tar.gz.

scylla-$(arch)-package.tar.gz changed to stripped binary + debug symbol,
will use for unified pacakge.

See #8918