### PR TITLE
Add enable_auto_compaction option

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1118,6 +1118,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.enable_cache = _config.enable_cache;
     cfg.enable_dangerous_direct_import_of_cassandra_counters = _config.enable_dangerous_direct_import_of_cassandra_counters;
     cfg.compaction_enforce_min_threshold = _config.compaction_enforce_min_threshold;
+    cfg.enable_auto_compaction = _config.enable_auto_compaction;
     cfg.dirty_memory_manager = _config.dirty_memory_manager;
     cfg.streaming_read_concurrency_semaphore = _config.streaming_read_concurrency_semaphore;
     cfg.compaction_concurrency_semaphore = _config.compaction_concurrency_semaphore;
@@ -1955,6 +1956,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
     }
     cfg.enable_dangerous_direct_import_of_cassandra_counters = _cfg.enable_dangerous_direct_import_of_cassandra_counters();
     cfg.compaction_enforce_min_threshold = _cfg.compaction_enforce_min_threshold;
+    cfg.enable_auto_compaction = _cfg.enable_auto_compaction;
     cfg.dirty_memory_manager = &_dirty_memory_manager;
     cfg.streaming_read_concurrency_semaphore = &_streaming_concurrency_sem;
     cfg.compaction_concurrency_semaphore = &_compaction_concurrency_sem;

--- a/database.hh
+++ b/database.hh
@@ -447,7 +447,6 @@ private:
     compaction_manager& _compaction_manager;
     secondary_index::secondary_index_manager _index_manager;
     int _compaction_disabled = 0;
-    bool _compaction_disabled_by_user = false;
     utils::phased_barrier _flush_barrier;
     std::vector<view_ptr> _views;
 
@@ -938,7 +937,7 @@ public:
     void enable_auto_compaction();
     void disable_auto_compaction();
     bool is_auto_compaction_disabled_by_user() const {
-      return _compaction_disabled_by_user;
+        return !_config.enable_auto_compaction;
     }
 
     utils::phased_barrier::operation write_in_progress() {

--- a/database.hh
+++ b/database.hh
@@ -364,6 +364,7 @@ public:
         bool enable_commitlog = true;
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
+        utils::updateable_value<bool> enable_auto_compaction{true};
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
         ::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
@@ -1148,6 +1149,7 @@ public:
         bool enable_cache = true;
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
+        utils::updateable_value<bool> enable_auto_compaction{true};
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
         ::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;

--- a/db/config.cc
+++ b/db/config.cc
@@ -242,6 +242,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "If set to higher than 0, ignore the controller's output and set the compaction shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity")
     , compaction_enforce_min_threshold(this, "compaction_enforce_min_threshold", liveness::LiveUpdate, value_status::Used, false,
         "If set to true, enforce the min_threshold option for compactions strictly. If false (default), Scylla may decide to compact even if below min_threshold")
+    , enable_auto_compaction(this, "enable_auto_compaction", liveness::LiveUpdate, value_status::Used, true,
+        "If set to true (default), enable automatic compaction on all tables. If false, autocompaction is disabled by default and can be re-enabled by reloading this flag or using `nodetool enableautocompaction`")
     /* Initialization properties */
     /* The minimal properties needed for configuring a cluster. */
     , cluster_name(this, "cluster_name", value_status::Used, "",

--- a/db/config.hh
+++ b/db/config.hh
@@ -137,6 +137,7 @@ public:
     named_value<float> memtable_flush_static_shares;
     named_value<float> compaction_static_shares;
     named_value<bool> compaction_enforce_min_threshold;
+    named_value<bool> enable_auto_compaction;
     named_value<sstring> cluster_name;
     named_value<sstring> listen_address;
     named_value<sstring> listen_interface;

--- a/main.cc
+++ b/main.cc
@@ -1076,12 +1076,16 @@ int main(int ac, char** av) {
                 }
             }
 
-            db.invoke_on_all([] (database& db) {
+            if (cfg->enable_auto_compaction()) {
+              db.invoke_on_all([] (database& db) {
                 for (auto& x : db.get_column_families()) {
                     table& t = *(x.second);
                     t.enable_auto_compaction();
                 }
-            }).get();
+              }).get();
+            } else {
+              supervisor::notify("autocompaction disabled by configuration option (enable_auto_compaction = false)");
+            }
 
             // If the same sstable is shared by several shards, it cannot be
             // deleted until all shards decide to compact it. So we want to

--- a/table.cc
+++ b/table.cc
@@ -1168,6 +1168,7 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
     , _durable_writes(true)
     , _compaction_manager(compaction_manager)
     , _index_manager(*this)
+    , _compaction_disabled_by_user(!config.enable_auto_compaction)
     , _counter_cell_locks(_schema->is_counter() ? std::make_unique<cell_locker>(_schema, cl_stats) : nullptr)
     , _row_locker(_schema)
     , _off_strategy_trigger([this] { trigger_offstrategy_compaction(); })

--- a/table.cc
+++ b/table.cc
@@ -1168,7 +1168,6 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
     , _durable_writes(true)
     , _compaction_manager(compaction_manager)
     , _index_manager(*this)
-    , _compaction_disabled_by_user(!config.enable_auto_compaction)
     , _counter_cell_locks(_schema->is_counter() ? std::make_unique<cell_locker>(_schema, cl_stats) : nullptr)
     , _row_locker(_schema)
     , _off_strategy_trigger([this] { trigger_offstrategy_compaction(); })
@@ -2115,7 +2114,7 @@ void
 table::enable_auto_compaction() {
     // XXX: unmute backlog. turn table backlog back on.
     //      see table::disable_auto_compaction() notes.
-    _compaction_disabled_by_user = false;
+    _config.enable_auto_compaction = true;
 }
 
 void
@@ -2146,7 +2145,7 @@ table::disable_auto_compaction() {
     //   option
     // - it will break computation of major compaction descriptor
     //   for new submissions
-    _compaction_disabled_by_user = true;
+    _config.enable_auto_compaction = false;
 }
 
 flat_mutation_reader


### PR DESCRIPTION
Support configuring automatic compaction on startup.
    
Log a global message when auto-compaction is disabled.
    
Auto-compaction can be reenabled using `nodetool enableautocompaction`
or dynamically when reloading the configuration.
    
The motivation for providing this option is to disable
auto-compaction, e.g. before running scrub/validation compaction
since sstables that fail validation race with regular compaction
that might compact them away and spread the possible corruption
to new sstables before the admin has a chance to handle them.

Fixes #9186