### PR TITLE
Commit log refactoring - first iteration - message loop

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -137,7 +137,6 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     c.commitlog_sync_period_in_ms = cfg.commitlog_sync_period_in_ms();
     c.mode = cfg.commitlog_sync() == "batch" ? sync_mode::BATCH : sync_mode::PERIODIC;
     c.extensions = &cfg.extensions();
-    c.reuse_segments = cfg.commitlog_reuse_segments();
     c.use_o_dsync = cfg.commitlog_use_o_dsync();
     c.allow_going_over_size_limit = !cfg.commitlog_use_hard_size_limit();
 
@@ -298,7 +297,6 @@ public:
     using request_controller_type = basic_semaphore<timeout_exception_factory, db::timeout_clock>;
     using request_controller_units = semaphore_units<timeout_exception_factory, db::timeout_clock>;
     request_controller_type _request_controller;
-    shared_promise<> _disk_deletions;
 
     std::optional<shared_future<with_clock<db::timeout_clock>>> _segment_allocating;
     std::unordered_map<sstring, descriptor> _files_to_delete;
@@ -519,7 +517,6 @@ private:
 
     future<> clear_reserve_segments();
     void abort_recycled_list(std::exception_ptr);
-    void abort_deletion_promise(std::exception_ptr);
 
     future<> message_loop();
     void wakeup();
@@ -1571,11 +1568,9 @@ void db::commitlog::segment_manager::handle_shutdowns(messages& msgs, pending_ta
                 discard_unused_segments();
                 co_await do_pending_deletes();
 
-                auto ep = std::make_exception_ptr(shutdown_marker{});
                 if (_recycled_segments.empty()) {
-                    abort_recycled_list(ep);
+                    abort_recycled_list(std::make_exception_ptr(shutdown_marker{}));
                 }
-                abort_deletion_promise(ep);
 
                 co_await shutdown_all_segments();
                 co_await clear_reserve_segments();
@@ -1972,7 +1967,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
 
         if (!cfg.allow_going_over_size_limit && max_disk_size != 0 && totals.total_size_on_disk >= max_disk_size) {
             clogger.debug("Disk usage ({} MB) exceeds maximum ({} MB) - allocation will wait...", totals.total_size_on_disk/(1024*1024), max_disk_size/(1024*1024));
-            auto f = cfg.reuse_segments ? _recycled_segments.not_empty() :  _disk_deletions.get_shared_future();
+            auto f = _recycled_segments.not_empty();
             if (!f.available()) {
                 _new_counter = 0; // zero this so timer task does not duplicate the below flush
                 flush_segments(0); // force memtable flush already
@@ -2185,8 +2180,6 @@ future<> db::commitlog::segment_manager::delete_file(const sstring& filename) {
         co_await seastar::remove_file(filename);
         clogger.trace("Reclaimed {} MB", size/(1024*1024));
         totals.total_size_on_disk -= size;
-        auto p = std::exchange(_disk_deletions, {});
-        p.set_value();
     } catch (...) {
         commit_error_handler(std::current_exception());
         throw;
@@ -2215,7 +2208,7 @@ future<> db::commitlog::segment_manager::delete_segments(std::vector<sstring> fi
             }
 
             // We allow reuse of the segment if the current disk size is less than shard max.
-            if (cfg.reuse_segments) {
+            {
                 auto usage = totals.total_size_on_disk;
                 auto recycle = usage <= max_disk_size;
 
@@ -2250,6 +2243,7 @@ future<> db::commitlog::segment_manager::delete_segments(std::vector<sstring> fi
                     }
                 }
             }
+            // last resort.
             co_await delete_file(filename);
         } catch (...) {
             clogger.error("Could not delete segment {}: {}", filename, std::current_exception());
@@ -2273,10 +2267,6 @@ void db::commitlog::segment_manager::abort_recycled_list(std::exception_ptr ep) 
     _recycled_segments.abort(ep);
     // and ensure next lap(s) still has a queue
     _recycled_segments = queue<sstring>(std::numeric_limits<size_t>::max());
-}
-
-void db::commitlog::segment_manager::abort_deletion_promise(std::exception_ptr ep) {
-    std::exchange(_disk_deletions, {}).set_exception(ep);
 }
 
 future<> db::commitlog::segment_manager::do_pending_deletes() {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -139,6 +139,10 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     c.use_o_dsync = cfg.commitlog_use_o_dsync();
     c.allow_going_over_size_limit = !cfg.commitlog_use_hard_size_limit();
 
+    if (cfg.commitlog_flush_threshold_in_mb() >= 0) {
+        c.commitlog_flush_threshold_in_mb = cfg.commitlog_flush_threshold_in_mb();
+    }
+
     return c;
 }
 

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -137,7 +137,6 @@ public:
         sync_mode mode = sync_mode::PERIODIC;
         std::string fname_prefix = descriptor::FILENAME_PREFIX;
 
-        bool reuse_segments = true;
         bool use_o_dsync = false;
         bool warn_about_segments_left_on_disk_after_shutdown = true;
         bool allow_going_over_size_limit = true;

--- a/db/config.cc
+++ b/db/config.cc
@@ -386,8 +386,6 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Related information: Configuring memtable throughput")
     , commitlog_flush_threshold_in_mb(this, "commitlog_flush_threshold_in_mb", value_status::Used, -1,
         "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency.")
-    , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Used, true,
-        "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
         "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, false,

--- a/db/config.cc
+++ b/db/config.cc
@@ -384,6 +384,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
         "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
         "Related information: Configuring memtable throughput")
+    , commitlog_flush_threshold_in_mb(this, "commitlog_flush_threshold_in_mb", value_status::Used, -1,
+        "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency.")
     , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Used, true,
         "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -175,7 +175,6 @@ public:
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;
     named_value<int64_t> commitlog_flush_threshold_in_mb;
-    named_value<bool> commitlog_reuse_segments;
     named_value<bool> commitlog_use_o_dsync;
     named_value<bool> commitlog_use_hard_size_limit;
     named_value<bool> compaction_preheat_key_cache;

--- a/db/config.hh
+++ b/db/config.hh
@@ -174,6 +174,7 @@ public:
     named_value<uint32_t> commitlog_sync_period_in_ms;
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;
+    named_value<int64_t> commitlog_flush_threshold_in_mb;
     named_value<bool> commitlog_reuse_segments;
     named_value<bool> commitlog_use_o_dsync;
     named_value<bool> commitlog_use_hard_size_limit;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -399,9 +399,6 @@ future<db::commitlog> manager::end_point_hints_manager::add_store() noexcept {
             cfg.fname_prefix = manager::FILENAME_PREFIX;
             cfg.extensions = &_shard_manager.local_db().extensions();
 
-            // HH doesn't utilize the flow that benefits from reusing segments.
-            // Therefore let's simply disable it to avoid any possible confusion.
-            cfg.reuse_segments = false;
             // HH leaves segments on disk after commitlog shutdown, and later reads
             // them when commitlog is re-created. This is expected to happen regularly
             // during standard HH workload, so no need to print a warning about it.

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -295,7 +295,7 @@ SEASTAR_TEST_CASE(test_commitlog_closed) {
             return log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [tmp](db::commitlog::output& dst) {
                 dst.write(tmp.data(), tmp.size());
             }).then_wrapped([] (future<db::rp_handle> f) {
-                BOOST_REQUIRE_EXCEPTION(f.get(), gate_closed_exception, exception_predicate::message_equals("gate closed"));
+                BOOST_REQUIRE_EXCEPTION(f.get(), std::runtime_error, exception_predicate::message_equals("Commitlog has been shut down. Cannot add data"));
             });
         });
     });

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -763,7 +763,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_in_recycle) {
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -834,7 +833,6 @@ SEASTAR_TEST_CASE(test_commitlog_shutdown_during_wait) {
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -902,7 +900,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 

--- a/utils/waitable_counter.hh
+++ b/utils/waitable_counter.hh
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <map>
+#include <iosfwd>
+#include <exception>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+
+namespace utils {
+
+/**
+ * Simple counter type wrapper, that allows
+ * waiting for it to reach a given value.
+ * 
+ * Actual content must be monotonically 
+ * increasing, and unless you want a lot
+ * of entries, waiting should be either
+ * sparse, or at least quantized to "typical"
+ * values (like disk blocks or similar, hint hint)
+ */
+template<typename T, typename Cmp = std::less<T>>
+class waitable_counter {
+private:
+    using shared_promise_type = seastar::shared_promise<>;
+
+    T _value;
+    std::map<T, shared_promise_type, Cmp> _waiters;
+
+    using value_type = typename decltype(_waiters)::value_type;
+
+    template<std::invocable<value_type&> Func>
+    waitable_counter& set(T v, Func&& f) {
+        if (_waiters.key_comp()(v, _value)) {
+            throw std::invalid_argument("Values must be monotonically increasing");
+        }
+        _value = std::move(v);
+        auto i = _waiters.upper_bound(_value);
+        std::for_each(_waiters.begin(), i, f);
+        _waiters.erase(_waiters.begin(), i);
+        return *this;
+    }
+
+public:
+    using clock = typename shared_promise_type::clock;
+    using time_point = typename shared_promise_type::time_point;
+
+    waitable_counter(T&& t = {}, Cmp cmp = {})
+        : _value(t)
+        , _waiters(std::move(cmp))
+    {}
+    /**
+     * Waits for the counter to reach pos
+     */
+    future<> wait(const T& pos, time_point timeout = time_point::max()) {
+        // if value held is already greater or 
+        // equal, just go ahead.
+        if (!_waiters.key_comp()(_value, pos)) {
+            return make_ready_future<>();
+        }
+        // else create/use the shared_promise
+        // at this pos.
+        auto& p = _waiters[pos];
+        return p.get_shared_future(timeout);
+    }
+    /**
+     * Sets the new counter value, notifying
+     * any waiting entities (for values <= v)
+     * 
+     * v must be >= current value.
+     */
+    waitable_counter& set(T v) {
+        return set(std::move(v), [](value_type& p) {
+            p.second.set_value();
+        });
+    }
+
+    /**
+     * Signals all waiters at v or below
+     * with exception. Current value is updated 
+     * to v, thus waits after this will pass
+     * as if successful.
+     */
+    waitable_counter& set_exception(T v, std::exception_ptr e) {
+        return set(std::move(v), [&](value_type& p) {
+            p.second.set_exception(e);
+        });
+    }
+
+    future<> wait_and_set_range(const T& s, T v) {
+        co_await wait(s);
+        set(std::move(v));
+    }
+
+    future<> wait_and_set_range_exception(const T& s, T v, std::exception_ptr e) {
+        co_await wait(s);
+        set_exception(std::move(v), std::move(e));
+    }
+
+    operator const T&() const {
+        return _value;
+    }
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const waitable_counter<T>& t) {
+    const T& v = t;
+    return os << v;
+}
+
+}


### PR DESCRIPTION
Changes the commitlog execution mechanism, adding a "message loop" to the commitlog instance. This replaces the old timer task, but also allows dispatching "messages" (i.e. requests/operations) to.

All actual disk IO/operations are now done in message loop, thus when an allocating continuation wishes to write a buffer, he makes a write request, sends to message loop, and then optionally waits for it to finish. The main benefits here are that no futures are any longer "discarded"/left hanging. While actual IO etc will still be async tasks started from the message loop, we at least keep track of all from there (loosely, but...). It also means that we avoid "promoting" "external" fibers to IO workers.

Partially because of this, since we can control write/flush a little more, this code is simplified a bit, using waitable counters instead of the old rp_queue. We also explicitly serialize write completion/flush completion, potentially delaying tasks a bit, but actual IO is still fully parallel.

We also simplify shutdown/state tracking a bit (not fully, but...), since we know our task chain is the only place where things happen. This is far from perfect, but a little better perhaps. 

More to the point, it allows us to trigger "loop actions" (pruning recycling, delete, cleanup) consistently without doing side effects in callbacks (I am looking at you discard_completed_segments()). 

The implementation is prepared for "delayed" messages, even though right now at least it does not really use them. A little overkill.

It also kills the non-recycling usage of commitlog, since the only place that does not really use it is hints, and in that case it is simply because it does not delete things anyway. So we can simplify a little. 

This patch set does _not_ yet deal with making flush callbacks return future<> (i.e. waitable). This is a job for the next set.

This is only performance tested with micro benchmarks, which does not say  much, since this does _not_ touch fast paths at all really. Macro behaviour is tested with cassandra-stress, though only lightly at the point of this writing. As such, it should probably be treated with caution and more of a RFC/opportunity for discussion.

v2:
* Removed unused message timeouts
* Added abstraction types to hide plumbing in actual handler routines, making it hopefully easier to read intent separated from impl.