### PR TITLE
database, storage_proxy: Reconcile pages with dead rows and partitions incrementally

### DIFF
--- a/cql3/result_generator.hh
+++ b/cql3/result_generator.hh
@@ -33,6 +33,7 @@ class result_generator {
     lw_shared_ptr<const query::read_command> _command;
     shared_ptr<const selection::selection> _selection;
     cql_stats* _stats;
+    bool _empty;
 private:
     friend class untyped_result_set;
     template<typename Visitor>
@@ -122,12 +123,13 @@ public:
     result_generator() = default;
 
     result_generator(schema_ptr s, foreign_ptr<lw_shared_ptr<query::result>> result, lw_shared_ptr<const query::read_command> cmd,
-                     ::shared_ptr<const selection::selection> select, cql_stats& stats)
+                     ::shared_ptr<const selection::selection> select, cql_stats& stats, bool empty)
         : _schema(std::move(s))
         , _result(std::move(result))
         , _command(std::move(cmd))
         , _selection(std::move(select))
         , _stats(&stats)
+        , _empty(empty)
     { }
 
     template<typename Visitor>
@@ -135,6 +137,10 @@ public:
         query_result_visitor<Visitor> v(*_schema, visitor, *_selection);
         query::result_view::consume(*_result, _command->slice, v);
         _stats->rows_read += v.rows_read();
+    }
+
+    bool empty() const {
+        return _empty;
     }
 };
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -772,8 +772,10 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
     const bool restrictions_need_filtering = _restrictions->need_filtering();
     const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !restrictions_need_filtering;
     if (fast_path) {
+        results->ensure_counts(); // Should be no-op since 2.1
+        bool empty = results->row_count() == 0;
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(make_shared<cql_transport::messages::result_message::rows>(result(
-            result_generator(_schema, std::move(results), std::move(cmd), _selection, _stats),
+            result_generator(_schema, std::move(results), std::move(cmd), _selection, _stats, empty),
             ::make_shared<metadata>(*_selection->get_result_metadata()))
         ));
     }

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2038,13 +2038,63 @@ reconcilable_result reconcilable_result_builder::consume_end_of_stream() {
                                std::move(_memory_accounter).done());
 }
 
+template<FlattenedConsumer Delegate>
+class position_recording_consumer {
+    Delegate _delegate;
+    std::optional<dht::decorated_key> _pkey;
+    std::optional<clustering_key> _ckey;
+public:
+    position_recording_consumer(Delegate delegate)
+        : _delegate(std::move(delegate))
+    { }
+
+    void consume_new_partition(const dht::decorated_key& dk) {
+        _pkey = dk;
+        _ckey = std::nullopt;
+        _delegate.consume_new_partition(dk);
+    }
+
+    void consume(tombstone t) {
+        _delegate.consume(std::move(t));
+    }
+
+    stop_iteration consume(static_row&& sr) {
+        return _delegate.consume(std::move(sr));
+    }
+
+    stop_iteration consume(clustering_row&& cr) {
+        _ckey = cr.key();
+        return _delegate.consume(std::move(cr));
+    }
+
+    stop_iteration consume(range_tombstone&& rt) {
+        return _delegate.consume(std::move(rt));
+    }
+
+    stop_iteration consume_end_of_partition() {
+        return _delegate.consume_end_of_partition();
+    }
+
+    auto consume_end_of_stream() {
+        return _delegate.consume_end_of_stream();
+    }
+
+    std::optional<query::result::primary_key> last_key() const {
+        if (!_pkey) {
+            return std::nullopt;
+        }
+        return std::make_tuple(_pkey->key(), std::move(_ckey));
+    }
+};
+
 query::result
 to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::partition_slice& slice, uint64_t max_rows, uint32_t max_partitions,
         query::result_options opts) {
     // This result was already built with a limit, don't apply another one.
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
-    auto consumer = compact_for_query<emit_only_live_rows::yes, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
-            max_partitions, query_result_builder(*s, builder));
+    auto consumer = position_recording_consumer(
+        compact_for_query<emit_only_live_rows::yes, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
+            max_partitions, query_result_builder(*s, builder)));
     const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
 
     for (const partition& p : r.partitions()) {
@@ -2056,7 +2106,17 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     if (r.is_short_read()) {
         builder.mark_as_short_read();
     }
-    return builder.build();
+
+    auto qr = builder.build();
+
+    if (r.is_short_read()) {
+        auto pk = consumer.last_key();
+        if (pk) {
+            qr.set_short_read_pos(std::move(*pk));
+        }
+    }
+
+    return qr;
 }
 
 query::result

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2000,7 +2000,7 @@ stop_iteration reconcilable_result_builder::consume(static_row&& sr, tombstone, 
 stop_iteration reconcilable_result_builder::consume(clustering_row&& cr, row_tombstone, bool is_alive) {
     _live_rows += is_alive;
     auto stop = _memory_accounter.update_and_check(cr.memory_usage(_schema));
-    if (is_alive) {
+    if (is_alive || _slice.options.contains<query::partition_slice::option::allow_empty_pages>()) {
         // We are considering finishing current read only after consuming a
         // live clustering row. While sending a single live row is enough to
         // guarantee progress, not ending the result on a live row would

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -148,6 +148,7 @@ class reconcilable_result_builder {
     uint64_t _live_rows{};
     // make this the last member so it is destroyed first. #7240
     utils::chunked_vector<partition> _result;
+    size_t _used_at_entry;
 public:
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept

--- a/query-request.hh
+++ b/query-request.hh
@@ -146,6 +146,11 @@ public:
         // directly, bypassing the intermediate reconcilable_result format used
         // in pre 4.5 range scans.
         range_scan_data_variant,
+        // When set, mutation query can end a page even if there is no live row in the
+        // final reconcilable_result. This prevents exchanging large pages when there
+        // is a lot of dead rows. This flag is needed during rolling upgrades to support
+        // old coordinators which do not tolerate pages with no live rows.
+        allow_empty_pages,
     };
     using option_set = enum_set<super_enum<option,
         option::send_clustering_key,
@@ -160,7 +165,8 @@ public:
         option::with_digest,
         option::bypass_cache,
         option::always_return_static_content,
-        option::range_scan_data_variant>>;
+        option::range_scan_data_variant,
+        option::allow_empty_pages>>;
     clustering_row_ranges _row_ranges;
 public:
     column_id_vector static_columns; // TODO: consider using bitmap

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -210,6 +210,10 @@ public:
         auto rs = p.rows();
         return { p.key().value(), !rs.empty() ? rs.back().key() : std::optional<clustering_key>() };
     }
+
+    bool empty() const {
+        return _v.partitions().empty();
+    }
 };
 
 }

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -82,6 +82,7 @@ protected:
     // remember if we use clustering. if not, each partition == one row
     const bool _has_clustering_keys;
     bool _exhausted = false;
+    uint64_t _row_count;
     uint64_t _max;
     uint64_t _per_partition_limit;
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3617,8 +3617,10 @@ protected:
                                || rr_opt->row_count() >= original_row_limit()
                                || data_resolver->live_partition_count() >= original_partition_limit())
                         && !data_resolver->any_partition_short_read()) {
+                    mlogger.trace("reconciled: {}", rr_opt->pretty_printer(_schema));
                     auto result = ::make_foreign(::make_lw_shared<query::result>(
                             to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit)));
+                    qlogger.trace("reconciled: {}", result->pretty_printer(_schema, _cmd->slice));
                     // wait for write to complete before returning result to prevent multiple concurrent read requests to
                     // trigger repair multiple times and to prevent quorum read to return an old value, even after a quorum
                     // another read had returned a newer value (but the newer value had not yet been sent to the other replicas)

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3597,6 +3597,8 @@ protected:
         data_resolver_ptr data_resolver = ::make_shared<data_read_resolver>(_schema, cl, _targets.size(), timeout);
         auto exec = shared_from_this();
 
+        cmd->slice.options.set<query::partition_slice::option::allow_empty_pages>();
+
         // Waited on indirectly.
         make_mutation_data_requests(cmd, data_resolver, _targets.begin(), _targets.end(), timeout);
 
@@ -3608,9 +3610,11 @@ protected:
 
                 // We generate a retry if at least one node reply with count live columns but after merge we have less
                 // than the total number of column we are interested in (which may be < count on a retry).
-                // So in particular, if no host returned count live columns, we know it's not a short read.
-                bool can_send_short_read = rr_opt && rr_opt->is_short_read() && rr_opt->row_count() > 0;
-                if (rr_opt && (can_send_short_read || data_resolver->all_reached_end() || rr_opt->row_count() >= original_row_limit()
+                // So in particular, if no host returned count live columns, we know it's not a short read due to
+                // row or partition limits being exhausted and retry is not needed.
+                if (rr_opt && (rr_opt->is_short_read()
+                               || data_resolver->all_reached_end()
+                               || rr_opt->row_count() >= original_row_limit()
                                || data_resolver->live_partition_count() >= original_partition_limit())
                         && !data_resolver->any_partition_short_read()) {
                     auto result = ::make_foreign(::make_lw_shared<query::result>(


### PR DESCRIPTION

Currently, mutation query on replica side will not respond with a
result which doesn't have at least one live row. This causes problems
if there is a lot of dead rows or partitions before we reach a live row, which stem
from the fact that resulting reconcilable_result will be large:

1) Large allocations:

  Serialization of reconcilable_result causes large allocations for storing result rows in std::deque

2) Reactor stalls:

  Serialization of reconcilable_result on the replica side and on the
  coordinator side causes reactor stalls. This impacts not only the
  query at hand.

  For 1M dead rows, freezing takes 130ms, unfreezing takes 500ms.

  Coordinator does multiple freezes and unfreezes. The reactor stall on the coordinator side is >5s

3) Too large repair mutations

  If reconciliation works on large pages, repair may fail due to too large mutation size.
  1M dead rows is already too much: Refs #9111

This patch fixes all of the above by making mutation reads respect the
memory accounter's limit for the page size, even for dead rows. Range
tombstones are not handled yet, they will be still accumulated (TODO).
Fixing range tombstones requires more extensive changes to the format of
paging state and associated algorithms to handle positions which are not
full keys.

The coordinator needs to be prepared for this. Select statement execution
will request the next page if it doesn't contain any live row
automatically, like is already done for aggregate queries.

This patch doesn't address the problem of client-side timeouts during
paging. It is an orthogonal problem. Query pager could periodically
send empty pages to the client, or use some other keep-alive
mechanism.

My testing shows that this solution significantly reduces efficiency.
I tested 1M dead rows, which takes 80MB as a single frozen mutation.

  cl=one, no reconciliation, hot cache: 460 ms
  cl=two, reconciling, no paging (before the patch), hot cache: 6.2 s
  cl=two, reconciling, coordinator-side paging (after the patch), hot cache: 24.3 s

The number of page requests in that test was about 80.

Refs #7929 (range tombstone case is not fixed yet)
Refs #3672 (client may still time-out, we should send empty pages)
Refs #7933 (partition tombstone case not fixed yet, see next patch)
           (also, client-side timeout is not solved)
Fixes #9111

