### PR TITLE
commitlog: Make flush threshold a config parameter

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -138,6 +138,10 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     c.use_o_dsync = cfg.commitlog_use_o_dsync();
     c.allow_going_over_size_limit = !cfg.commitlog_use_hard_size_limit();
 
+    if (cfg.commitlog_flush_threshold_in_mb() >= 0) {
+        c.commitlog_flush_threshold_in_mb = cfg.commitlog_flush_threshold_in_mb();
+    }
+
     return c;
 }
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -384,6 +384,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
         "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
         "Related information: Configuring memtable throughput")
+    , commitlog_flush_threshold_in_mb(this, "commitlog_flush_threshold_in_mb", value_status::Used, -1,
+        "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency.")
     , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Used, true,
         "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -172,6 +172,7 @@ public:
     named_value<uint32_t> commitlog_sync_period_in_ms;
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;
+    named_value<int64_t> commitlog_flush_threshold_in_mb;
     named_value<bool> commitlog_reuse_segments;
     named_value<bool> commitlog_use_o_dsync;
     named_value<bool> commitlog_use_hard_size_limit;


### PR DESCRIPTION
Perhaps useful for problem tracking.