### PR TITLE
hints: implement adaptive limit of hint sending concurrency

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -852,7 +852,7 @@ future<> manager::end_point_hints_manager::sender::send_one_mutation(frozen_muta
 
 future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, gc_clock::duration secs_since_file_mod, const sstring& fname) {
     return _concurrency_limiter.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] (auto local_units) mutable {
-    return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr, local_units = std::move(local_units)] (auto global_units) mutable {
+      return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr, local_units = std::move(local_units)] (auto global_units) mutable {
         const size_t mutation_size = buf.size_bytes();
         ctx_ptr->mark_hint_as_in_progress(rp);
 
@@ -911,10 +911,10 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
             }
             f.ignore_ready_future();
         });
-    }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
-        manager_logger.trace("send_one_file(): Hmmm. Something bad had happend: {}", eptr);
-        ctx_ptr->on_hint_send_failure(rp);
-    });
+      }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
+          manager_logger.trace("send_one_file(): Hmmm. Something bad had happend: {}", eptr);
+          ctx_ptr->on_hint_send_failure(rp);
+      });
     });
 }
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -84,6 +84,8 @@ class manager {
 private:
     struct stats {
         uint64_t size_of_hints_in_progress = 0;
+        uint64_t size_of_sent_hints_in_progress = 0;
+        uint64_t count_of_sent_hints_in_progress = 0;
         uint64_t written = 0;
         uint64_t errors = 0;
         uint64_t dropped = 0;

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -71,6 +71,10 @@ size_t resource_manager::sending_queue_length() const {
     return _send_limiter.waiters();
 }
 
+size_t resource_manager::get_max_send_in_flight_memory() const {
+    return _max_send_in_flight_memory;
+}
+
 const std::chrono::seconds space_watchdog::_watchdog_period = std::chrono::seconds(1);
 
 space_watchdog::space_watchdog(shard_managers_set& managers, per_device_limits_map& per_device_limits_map)

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -188,6 +188,7 @@ public:
 
     future<semaphore_units<named_semaphore::exception_factory>> get_send_units_for(size_t buf_size);
     size_t sending_queue_length() const;
+    size_t get_max_send_in_flight_memory() const;
 
     future<> start(shared_ptr<service::storage_proxy> proxy_ptr, shared_ptr<gms::gossiper> gossiper_ptr);
     future<> stop() noexcept;


### PR DESCRIPTION
Currently, hinted handoff uses a fixed (but configurable) per-node
concurrency limit - the memory hints being sent may take up cannot
exceed 10% of node's memory and their count is bounded by the
`max_hinted_handoff_concurrency` option. Because hints reuse the
mutation sending framework and use the same timeout as regular writes,
if the hints concurrency is too much for the receiving node to handle,
hint writes will start to time out. In an event of a failed hint, the
sender waits for a second and retries sending after that delay. Due to
the relentlessness of this logic, sending hints might generate lots of
timeouts - which is wasted effort - or even get stuck in extreme cases.

In order to make current logic less aggressive and reduce the number
of timeouts, an adaptive strategy based on the concept of AIMD
(additive increase, multiplicative decrease) is introduced. Apart from
the current global limit, each hint queue gets an additional, dynamic
memory limit. The limit, similarly to the current one, allows to send
one hint at a time if a hint larger than the limit is encountered.

1. The limit starts with 1 byte.
2. Every second, the limit is increased by 10% of the size of an
   average hint. The average is calculated based on the hints sent
   since the last update.
3. In case of a timeout, the concurrency is cut in half, and the next
   update described in point 2 is scheduled to happen after 10 seconds.

The backoff behavior in case of a timeout is also changed in order to
further reduce the load if hints keep on timing out:

1. If the concurrency == 1 byte, the next sending attempt is scheduled
   after a random delay between 1 and 120 seconds,
2. Otherwise the next sending attempt is scheduled after 1 second.

In addition to this, two new metrics are introduced which describe
the count and size of hints being currently sent.

Fixes: https://github.com/scylladb/scylla/issues/7886