### PR TITLE
scrub: make ABORT a validate mode

### DIFF
--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -64,6 +64,7 @@ namespace sstables {
         uint64_t total_partitions = 0;
         uint64_t total_keys_written = 0;
         int64_t ended_at;
+        size_t invalid_sstables;
         std::vector<shared_sstable> new_sstables;
         sstring stop_requested;
         bool tracking = true;

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -115,5 +115,5 @@ namespace sstables {
     flat_mutation_reader make_scrubbing_reader(flat_mutation_reader rd, compaction_options::scrub::mode scrub_mode);
 
     // For tests, can drop after we virtualize sstables.
-    future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader rd, const compaction_info& info);
+    future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader rd, const compaction_info& info, compaction_options::scrub::mode operation_mode);
 }

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -80,6 +80,17 @@ public:
             validate, // validate data, printing all errors found (sstables are only read, not rewritten)
         };
         mode operation_mode = mode::abort;
+
+        static bool is_validate_mode(mode m) {
+            switch (m) {
+            case mode::abort:
+            case mode::validate:
+                return true;
+            case mode::skip:
+            case mode::segregate:
+                return false;
+            }
+        }
     };
     struct reshard {
     };

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -548,7 +548,9 @@ inline bool compaction_manager::maybe_stop_on_error(future<> f, stop_iteration w
         // case we won't retry.
         retry = e.retry();
         decision_msg = !retry ? stop_msg : decision_msg;
-        cmlog.info("compaction info: {}: {}", e.what(), decision_msg);
+        auto error_msg = sstring(e.what());
+        logging::log_level level = error_msg.find("failed") == sstring::npos ? logging::log_level::info : logging::log_level::error;
+        cmlog.log(level, "compaction info: {}: {}", error_msg, decision_msg);
     } catch (storage_io_error& e) {
         cmlog.error("compaction failed due to storage io error: {}: stopping", e.what());
         retry = false;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -907,7 +907,7 @@ future<> compaction_manager::perform_sstable_upgrade(database& db, column_family
 
 // Submit a column family to be scrubbed and wait for its termination.
 future<> compaction_manager::perform_sstable_scrub(column_family* cf, sstables::compaction_options::scrub::mode scrub_mode) {
-    if (scrub_mode == sstables::compaction_options::scrub::mode::validate) {
+    if (sstables::compaction_options::scrub::is_validate_mode(scrub_mode)) {
         return perform_sstable_scrub_validate_mode(cf);
     }
     return rewrite_sstables(cf, sstables::compaction_options::make_scrub(scrub_mode), [this] (const table& cf) {


### PR DESCRIPTION
ABORT doesn't fix any issues it finds, but rather it aborts scrubbing on the first error.
There is no point in it re-writing all the valid SSTables it scrubs.
Instead, it can just re-use scrub/validate mode and abort on the first
error, without rewriting the valid sstables.

Fixes #9288

Test: unit(dev)

DTest: nodetool_additional_test.py:TestNodetool.{
    scrub_sstable_with_invalid_fragment_test, scrub_ks_sstable_with_invalid_fragment_test, scrub_with_multi_nodes_expect_data_rebuild_test, scrub_with_one_node_expect_data_loss_test,
    scrub_segregate_sstable_with_invalid_fragment_test, scrub_segregate_ks_sstable_with_invalid_fragment_test,
    validate_with_one_node_expect_data_loss_test, validate_sstable_with_invalid_fragment_test, validate_ks_sstable_with_invalid_fragment_test
} (dev, w/ https://github.com/scylladb/scylla-dtest/pull/2265)