### PR TITLE
commitlog_test: Add unit test for footprint + ensure disk limit >= 2 segments (per shard)

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1499,7 +1499,7 @@ db::commitlog::segment_manager::segment_manager(config c)
     }())
     , max_size(std::min<size_t>(std::numeric_limits<position_type>::max() / (1024 * 1024), std::max<size_t>(cfg.commitlog_segment_size_in_mb, 1)) * 1024 * 1024)
     , max_mutation_size(max_size >> 1)
-    , max_disk_size(size_t(std::ceil(cfg.commitlog_total_space_in_mb / double(smp::count))) * 1024 * 1024)
+    , max_disk_size(std::max(2 * max_size, size_t(std::ceil(cfg.commitlog_total_space_in_mb / double(smp::count))) * 1024 * 1024))
     // our threshold for trying to force a flush. needs heristics, for now max - segment_size/2.
     , disk_usage_threshold([&] {
         if (cfg.commitlog_flush_threshold_in_mb.has_value()) {


### PR DESCRIPTION
Refs /scylladb/scylla-dtest#2277
Fixes #9369    

A better place to verify we adhere to disk limits (as such as we do) is in a unit test, where we can get the actual per-shard limits and current actual footprint (as CL sees it).

Included is a small sanity change for commitlog init that makes disk limit max(2*segment_size, cfg.per_shard_disk_limit) to ensure 
we get workable ranges even if a user (or more likely - in this case and always - a clumsy test writer).
Not making this a check + throw for one single reason: It is potentially difficult for a user to put in a value that is sanity checked for different configs, since we need to verify this per-shard, not the actual input values.
