### PR TITLE
RFC: commitlog data segregation based on expected source behaviour

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -119,6 +119,7 @@ class extensions;
 class rp_handle;
 class data_listeners;
 class large_data_handler;
+enum class data_class;
 
 future<> system_keyspace_make(database& db, service::storage_service& ss);
 
@@ -488,7 +489,13 @@ private:
     db_clock::time_point _truncated_at = db_clock::time_point::min();
 
     bool _is_bootstrap_or_replace = false;
+
+    db::data_class _data_class;
 public:
+    db::data_class get_data_class() const {
+        return _data_class;
+    }
+
     future<> add_sstable_and_update_cache(sstables::shared_sstable sst,
                                           sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2054,7 +2054,7 @@ db::commitlog::segment_manager::buffer_type db::commitlog::segment_manager::acqu
  * Add mutation.
  */
 future<db::rp_handle> db::commitlog::add(const cf_id_type& id,
-        size_t size, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync, serializer_func func) {
+        size_t size, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync, serializer_func func, data_class dc) {
     class serializer_func_entry_writer final : public entry_writer {
         cf_id_type _id;
         serializer_func _func;
@@ -2085,7 +2085,7 @@ future<db::rp_handle> db::commitlog::add(const cf_id_type& id,
     return _segment_manager->allocate_when_possible(serializer_func_entry_writer(id, size, std::move(func), sync), timeout);
 }
 
-future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commitlog_entry_writer& cew, timeout_clock::time_point timeout)
+future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commitlog_entry_writer& cew, timeout_clock::time_point timeout, data_class dc)
 {
     assert(id == cew.schema()->id());
 
@@ -2129,7 +2129,7 @@ future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commi
 }
 
 future<std::vector<db::rp_handle>> 
-db::commitlog::add_entries(std::vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout) {
+db::commitlog::add_entries(std::vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout, data_class dc) {
     class cl_entries_writer final : public entry_writer {
         std::vector<commitlog_entry_writer> _writers;
         std::unordered_set<table_schema_version> _known;

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1628,7 +1628,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
             auto f = cfg.reuse_segments ? _recycled_segments.not_empty() :  _disk_deletions.get_shared_future();
             if (!f.available()) {
                 _new_counter = 0; // zero this so timer task does not duplicate the below flush
-                flush_segments(0); // force memtable flush already
+                flush_segments(max_size); // force memtable flush already
             }
             try {
                 co_await std::move(f);


### PR DESCRIPTION
Do not merge. RFC.
A somewhat coarse, but at least partially functional version of segregation of data in CL based on source "class" (determined by caller).
Basically divides CL segment queues into two: "normal" and "low freq/volume". The idea being that we can limit the amount of forward flush request calls we generate for the low frequency set while still maintaining a somewhat healthy flow of segments in the more heavy queue. The idea being to try to reduce flushing of memtables with very low utilization (near empty), and the subsequent tiny sstables. All in the search for less compaction issues eventually. 

This test implementation only distinguishes system.paxos, based on recent LWT woes. And in local, probably not very representative runs of the C-S lwt test from #9331, the amount of flushes for this table does go down by ~75% or so. 
If this has any impact whatsoever on actual end performance is yet to be determined. 

Some other improvements, such as keeping track of which segments we've flush requested for, are in here to, and shoudl probably eventually make it to master regardless of if we decide this segmented approach is meaningful or not. 