### PR TITLE
Move pending ranges functions into effective_replication_map 

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1283,7 +1283,10 @@ future<> mutate_MV(
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto& keyspace_name = mut.s->ks_name();
         auto target_endpoint = get_view_natural_endpoint(keyspace_name, base_token, view_token);
-        auto remote_endpoints = service::get_local_storage_proxy().get_token_metadata_ptr()->pending_endpoints_for(view_token, keyspace_name);
+        const auto& db = service::get_local_storage_proxy().local_db();
+        const auto& ks = db.find_keyspace(keyspace_name);
+        auto erm = ks.get_effective_replication_map();
+        auto remote_endpoints = erm->pending_endpoints_for(view_token);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());
 
         // First, find the local endpoint and ensure that if it exists,

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -135,14 +135,14 @@ private:
      * Get a map of all ranges and their respective sources that are candidates for streaming the given ranges
      * to us. For each range, the list of sources is sorted by proximity relative to the given destAddress.
      */
-    std::unordered_map<dht::token_range, std::vector<inet_address>>
+    future<std::unordered_map<dht::token_range, std::vector<inet_address>>>
     get_all_ranges_with_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges);
     /**
      * Get a map of all ranges and the source that will be cleaned up once this bootstrapped node is added for the given ranges.
      * For each range, the list should only contain a single source. This allows us to consistently migrate data without violating
      * consistency.
      */
-    std::unordered_map<dht::token_range, std::vector<inet_address>>
+    future<std::unordered_map<dht::token_range, std::vector<inet_address>>>
     get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges, gms::gossiper& gossiper);
 private:
     /**

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -229,22 +229,6 @@ effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
 }
 
 future<std::unordered_multimap<inet_address, dht::token_range>>
-abstract_replication_strategy::get_address_ranges(const token_metadata& tm) const {
-    std::unordered_multimap<inet_address, dht::token_range> ret;
-    for (auto& t : tm.sorted_tokens()) {
-        dht::token_range_vector r = tm.get_primary_ranges_for(t);
-        auto eps = co_await calculate_natural_endpoints(t, tm);
-        rslogger.debug("token={}, primary_range={}, address={}", t, r, eps);
-        for (auto ep : eps) {
-            for (auto&& rng : r) {
-                ret.emplace(ep, rng);
-            }
-        }
-    }
-    co_return ret;
-}
-
-future<std::unordered_multimap<inet_address, dht::token_range>>
 abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet_address endpoint) const {
     std::unordered_multimap<inet_address, dht::token_range> ret;
     for (auto& t : tm.sorted_tokens()) {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -322,7 +322,9 @@ future<mutable_effective_replication_map_ptr> calculate_effective_replication_ma
     }
 
     auto rf = rs->get_replication_factor(*tmptr);
-    co_return make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(replication_map), rf);
+    auto erm = make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(replication_map), rf);
+    co_await erm->update_pending_ranges();
+    co_return std::move(erm);
 }
 
 future<replication_map> effective_replication_map::clone_endpoints_gently() const {
@@ -341,8 +343,193 @@ inet_address_vector_replica_set effective_replication_map::get_natural_endpoints
 }
 
 future<> effective_replication_map::clear_gently() noexcept {
+    for (auto& [range, eps] : _pending_ranges_interval_map) {
+        eps.clear();
+        co_await coroutine::maybe_yield();
+    }
     co_await utils::clear_gently(_replication_map);
     co_await utils::clear_gently(_tmptr);
+}
+
+inet_address_vector_topology_change effective_replication_map::pending_endpoints_for(const token& token) const {
+    // Fast path: empty pending ranges for this replication map
+    const auto& ks_map = _pending_ranges_interval_map;
+    if (ks_map.empty()) {
+        return {};
+    }
+
+    // Slow path: lookup pending ranges
+    auto interval = token_metadata::range_to_interval(range<dht::token>(token));
+    const auto it = ks_map.find(interval);
+    if (it != ks_map.end()) {
+        // interval_map does not work with std::vector, convert to std::vector of ips
+        return inet_address_vector_topology_change(it->second.begin(), it->second.end());
+    }
+    return inet_address_vector_topology_change{};
+}
+
+bool effective_replication_map::has_pending_ranges(inet_address endpoint) const noexcept {
+    for (const auto& item : _pending_ranges_interval_map) {
+        const auto& nodes = item.second;
+        if (nodes.contains(endpoint)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+future<effective_replication_map::address_ranges>
+effective_replication_map::calculate_address_ranges() const {
+    const token_metadata& tm = *_tmptr;
+    address_ranges ret;
+    for (auto& t : tm.sorted_tokens()) {
+        dht::token_range_vector r = tm.get_primary_ranges_for(t);
+        auto eps = get_natural_endpoints(t);
+        rslogger.debug("effective_replication_map: calculate_address_ranges: token={} primary_range={} endpoints={}", t, r, eps);
+        for (auto ep : eps) {
+            for (auto&& rng : r) {
+                ret.emplace(ep, rng);
+            }
+        }
+        co_await coroutine::maybe_yield();
+    }
+    co_return ret;
+}
+
+future<> effective_replication_map::calculate_pending_ranges_for_replacing(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const std::unordered_map<inet_address, inet_address>& replacing_endpoints) const {
+    if (replacing_endpoints.empty()) {
+        co_return;
+    }
+    for (const auto& node : replacing_endpoints) {
+        auto existing_node = node.first;
+        auto replacing_node = node.second;
+        for (const auto& x : address_ranges) {
+            if (x.first == existing_node) {
+                rslogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x.second);
+                new_pending_ranges.emplace(x.second, replacing_node);
+            }
+            co_await coroutine::maybe_yield();
+        }
+    }
+}
+
+future<> effective_replication_map::calculate_pending_ranges_for_leaving(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const token_metadata& all_left_metadata,
+        const std::unordered_set<inet_address>& leaving_endpoints) const {
+    // get all ranges that will be affected by leaving nodes
+    std::unordered_set<range<token>> affected_ranges;
+    for (auto endpoint : leaving_endpoints) {
+        auto r = address_ranges.equal_range(endpoint);
+        for (auto x = r.first; x != r.second; x++) {
+            affected_ranges.emplace(x->second);
+        }
+        co_await coroutine::maybe_yield();
+    }
+    // for each of those ranges, find what new nodes will be responsible for the range when
+    // all leaving nodes are gone.
+    auto metadata = co_await _tmptr->clone_only_token_map();
+    auto affected_ranges_size = affected_ranges.size();
+    rslogger.debug("In calculate_pending_ranges: affected_ranges.size={} starts", affected_ranges_size);
+    for (const auto& r : affected_ranges) {
+        auto t = r.end() ? r.end()->value() : dht::maximum_token();
+        auto current_endpoints = co_await _rs->calculate_natural_endpoints(t, metadata);
+        auto new_endpoints = co_await _rs->calculate_natural_endpoints(t, all_left_metadata);
+        std::vector<inet_address> diff;
+        std::sort(current_endpoints.begin(), current_endpoints.end());
+        std::sort(new_endpoints.begin(), new_endpoints.end());
+        std::set_difference(new_endpoints.begin(), new_endpoints.end(),
+            current_endpoints.begin(), current_endpoints.end(), std::back_inserter(diff));
+        for (auto& ep : diff) {
+            new_pending_ranges.emplace(r, ep);
+        }
+    }
+    co_await metadata.clear_gently();
+    rslogger.debug("In calculate_pending_ranges: affected_ranges.size={} ends", affected_ranges_size);
+}
+
+future<> effective_replication_map::calculate_pending_ranges_for_bootstrap(
+        pending_ranges& new_pending_ranges,
+        token_metadata& all_left_metadata,
+        const std::unordered_map<token, inet_address>& bootstrap_tokens) const {
+    // For each of the bootstrapping nodes, simply add and remove them one by one to
+    // all_left_metadata and check in between what their ranges would be.
+    std::unordered_multimap<inet_address, token> bootstrap_addresses;
+    for (auto& x : bootstrap_tokens) {
+        bootstrap_addresses.emplace(x.second, x.first);
+    }
+
+    std::unordered_map<inet_address, std::unordered_set<token>> tmp;
+    for (auto& x : bootstrap_addresses) {
+        auto& addr = x.first;
+        auto& t = x.second;
+        tmp[addr].insert(t);
+    }
+    for (auto& x : tmp) {
+        auto& endpoint = x.first;
+        auto& tokens = x.second;
+        co_await all_left_metadata.update_normal_tokens(tokens, endpoint);
+        auto all_left_address_ranges = co_await _rs->get_address_ranges(all_left_metadata, endpoint);
+        for (auto& x : all_left_address_ranges) {
+            new_pending_ranges.emplace(x.second, endpoint);
+        }
+        all_left_metadata.remove_endpoint(endpoint);
+    }
+}
+
+future<> effective_replication_map::set_pending_ranges(pending_ranges new_pending_ranges) {
+    _pending_ranges_interval_map = {};
+
+    if (new_pending_ranges.empty()) {
+        co_return;
+    }
+
+    std::unordered_map<range<token>, std::unordered_set<inet_address>> map;
+    for (const auto& x : new_pending_ranges) {
+        map[x.first].emplace(x.second);
+        co_await coroutine::maybe_yield();
+    }
+
+    // construct a interval map to speed up the search
+    pending_ranges_interval_map interval_map;
+    for (auto& m : map) {
+        interval_map +=
+                std::make_pair(token_metadata::range_to_interval(m.first), std::move(m.second));
+        co_await coroutine::maybe_yield();
+    }
+    _pending_ranges_interval_map = std::move(interval_map);
+}
+
+future<> effective_replication_map::update_pending_ranges() {
+    const auto& bootstrap_tokens = _tmptr->get_bootstrap_tokens();
+    const auto& leaving_endpoints = _tmptr->get_leaving_endpoints();
+    const auto& replacing_endpoints = _tmptr->get_replacing_endpoints();
+    if (bootstrap_tokens.empty() && leaving_endpoints.empty() && replacing_endpoints.empty()) {
+        rslogger.debug("No bootstrapping, leaving nodes, replacing nodes -> empty pending ranges");
+        co_return co_await set_pending_ranges(pending_ranges());
+    }
+
+    rslogger.debug("update_pending_ranges: bootstrap_tokens={}, leaving nodes={}, replacing_endpoints={}",
+            bootstrap_tokens, leaving_endpoints, replacing_endpoints);
+
+    auto address_ranges = co_await calculate_address_ranges();
+    pending_ranges new_pending_ranges;
+    co_await calculate_pending_ranges_for_replacing(address_ranges, new_pending_ranges, replacing_endpoints);
+    // Copy of metadata reflecting the situation after all leave operations are finished.
+    auto all_left_metadata = co_await _tmptr->clone_after_all_left();
+    co_await calculate_pending_ranges_for_leaving(address_ranges, new_pending_ranges, all_left_metadata, leaving_endpoints);
+    // At this stage newPendingRanges has been updated according to leave operations. We can
+    // now continue the calculation by checking bootstrapping nodes.
+    co_await calculate_pending_ranges_for_bootstrap(new_pending_ranges, all_left_metadata, bootstrap_tokens);
+    co_await all_left_metadata.clear_gently();
+    co_await utils::clear_gently(address_ranges);
+
+    // At this stage newPendingRanges has been updated according to leaving and bootstrapping nodes.
+    co_await set_pending_ranges(std::move(new_pending_ranges));
 }
 
 effective_replication_map::~effective_replication_map() {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -24,6 +24,10 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
+
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
+
 #include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
 #include "dht/i_partitioner.hh"
@@ -162,10 +166,15 @@ public:
     };
 
 private:
+    using address_ranges = std::unordered_multimap<inet_address, dht::token_range>;
+    using pending_ranges = std::unordered_multimap<range<token>, inet_address>;
+    using pending_ranges_interval_map = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
+
     abstract_replication_strategy::ptr_type _rs;
     token_metadata_ptr _tmptr;
     replication_map _replication_map;
     size_t _replication_factor;
+    pending_ranges_interval_map _pending_ranges_interval_map;
     std::optional<factory_key> _factory_key = std::nullopt;
     effective_replication_map_factory* _factory = nullptr;
 
@@ -229,9 +238,58 @@ public:
     std::unordered_map<dht::token_range, inet_address_vector_replica_set>
     get_range_addresses() const;
 
+    // returns empty vector if token not found.
+    inet_address_vector_topology_change pending_endpoints_for(const token& token) const;
+
+    bool has_pending_ranges(inet_address endpoint) const noexcept;
+
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<bool(inet_address_vector_replica_set)> should_add_range) const;
 
+    future<address_ranges> calculate_address_ranges() const;
+
+    future<> calculate_pending_ranges_for_replacing(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const std::unordered_map<inet_address, inet_address>& replacing_endpoints) const;
+    future<> calculate_pending_ranges_for_leaving(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const token_metadata& all_left_metadata,
+        const std::unordered_set<inet_address>& leaving_endpoints) const;
+    future<> calculate_pending_ranges_for_bootstrap(
+        pending_ranges& new_pending_ranges,
+        token_metadata& all_left_metadata,
+        const std::unordered_map<token, inet_address>& bootstrap_tokens) const;
+
+    future<> set_pending_ranges(pending_ranges new_pending_ranges);
+
+     /**
+      * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
+      *
+      * (1) When in doubt, it is better to write too much to a node than too little. That is, if
+      * there are multiple nodes moving, calculate the biggest ranges a node could have. Cleaning
+      * up unneeded data afterwards is better than missing writes during movement.
+      * (2) When a node leaves, ranges for other nodes can only grow (a node might get additional
+      * ranges, but it will not lose any of its current ranges as a result of a leave). Therefore
+      * we will first remove _all_ leaving tokens for the sake of calculation and then check what
+      * ranges would go where if all nodes are to leave. This way we get the biggest possible
+      * ranges with regard current leave operations, covering all subsets of possible final range
+      * values.
+      * (3) When a node bootstraps, ranges of other nodes can only get smaller. Without doing
+      * complex calculations to see if multiple bootstraps overlap, we simply base calculations
+      * on the same token ring used before (reflecting situation after all leave operations have
+      * completed). Bootstrapping nodes will be added and removed one by one to that metadata and
+      * checked what their ranges would be. This will give us the biggest possible ranges the
+      * node could have. It might be that other bootstraps make our actual final ranges smaller,
+      * but it does not matter as we can clean up the data afterwards.
+      *
+      * NOTE: This is heavy and ineffective operation. This will be done only once when a node
+      * changes state in the cluster, so it should be manageable.
+      */
+    future<> update_pending_ranges();
+
+    friend future<lw_shared_ptr<effective_replication_map>> calculate_effective_replication_map(abstract_replication_strategy::ptr_type rs, token_metadata_ptr tmptr);
 public:
     static factory_key make_factory_key(const abstract_replication_strategy::ptr_type& rs, const token_metadata_ptr& tmptr);
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -168,7 +168,7 @@ public:
 
 private:
     using address_ranges = std::unordered_map<inet_address, dht::token_range_vector>;
-    using pending_ranges = std::unordered_multimap<range<token>, inet_address>;
+    using pending_ranges = std::unordered_map<range<token>, std::unordered_set<inet_address>>;
     using pending_ranges_interval_map = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
 
     abstract_replication_strategy::ptr_type _rs;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -130,14 +130,15 @@ public:
     // Note: must be called with initialized, non-empty token_metadata.
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
 
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
-
     // Caller must ensure that token_metadata will not change throughout the call.
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_addresses(const token_metadata& tm) const;
 
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, token pending_token, inet_address pending_address) const;
 
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address) const;
+
+private:
+    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 };
 
 // Holds the full replication_map resulting from applying the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -169,7 +169,7 @@ public:
 private:
     using address_ranges = std::unordered_map<inet_address, dht::token_range_vector>;
     using pending_ranges = std::unordered_map<range<token>, std::unordered_set<inet_address>>;
-    using pending_ranges_interval_map = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
+    using pending_ranges_interval_map = boost::icl::interval_map<token, inet_address_vector_topology_change>;
 
     abstract_replication_strategy::ptr_type _rs;
     token_metadata_ptr _tmptr;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -130,8 +130,6 @@ public:
     // Note: must be called with initialized, non-empty token_metadata.
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
 
-public:
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm) const;
     future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 
     // Caller must ensure that token_metadata will not change throughout the call.

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -167,7 +167,7 @@ public:
     };
 
 private:
-    using address_ranges = std::unordered_multimap<inet_address, dht::token_range>;
+    using address_ranges = std::unordered_map<inet_address, dht::token_range_vector>;
     using pending_ranges = std::unordered_multimap<range<token>, inet_address>;
     using pending_ranges_interval_map = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -265,6 +265,8 @@ private:
 
     future<> set_pending_ranges(pending_ranges new_pending_ranges);
 
+    future<> clear_pending_ranges_gently() noexcept;
+
      /**
       * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
       *

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -176,6 +176,7 @@ private:
     replication_map _replication_map;
     size_t _replication_factor;
     pending_ranges_interval_map _pending_ranges_interval_map;
+    std::unordered_set<inet_address> _pending_nodes;
     std::optional<factory_key> _factory_key = std::nullopt;
     effective_replication_map_factory* _factory = nullptr;
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -123,6 +123,10 @@ public:
     // returns the node itself as the natural_endpoints and the node will not
     // appear in the pending_endpoints.
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const = 0;
+    virtual bool is_symmetric() const noexcept {
+        return false;
+    }
+
     replication_strategy_type get_type() const noexcept { return _my_type; }
     const replication_strategy_config_options get_config_options() const noexcept { return _config_options; }
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -138,7 +138,7 @@ public:
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address) const;
 
 private:
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
+    future<dht::token_range_vector> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 };
 
 // Holds the full replication_map resulting from applying the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -28,6 +28,8 @@
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 
+#include <seastar/core/coroutine.hh>
+
 #include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
 #include "dht/i_partitioner.hh"
@@ -401,6 +403,13 @@ public:
         return _stopped;
     }
 
+    // Note that func is called with a const effective_replication_map&
+    // If it yields, it must keep erm.shared_from_this() to extend its lifetime
+    future<> do_for_each(std::invocable<const effective_replication_map&> auto func) const noexcept {
+        for (const auto& [key, p] : _effective_replication_maps) {
+            co_await futurize_invoke(func, *p);
+        }
+    }
 private:
     effective_replication_map_ptr find_effective_replication_map(const effective_replication_map::factory_key& key) const;
     effective_replication_map_ptr insert_effective_replication_map(mutable_effective_replication_map_ptr erm, effective_replication_map::factory_key key);

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -61,6 +61,10 @@ public:
         return true;
     }
 
+    virtual bool is_symmetric() const noexcept override {
+        return true;
+    }
+
     /**
      * We need to override this because the default implementation depends
      * on token calculations but everywhere_replication_strategy may be used before tokens are set up.

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -50,6 +50,10 @@ public:
         return false;
     }
 
+    virtual bool is_symmetric() const noexcept override {
+        return true;
+    }
+
     /**
      * We need to override this because the default implementation depends
      * on token calculations but LocalStrategy may be used before tokens are set up.

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -51,7 +51,7 @@ snitch_base::get_endpoint_info(inet_address endpoint,
 
 inet_address_vector_replica_set snitch_base::get_sorted_list_by_proximity(
     inet_address address,
-    inet_address_vector_replica_set& unsorted_address) {
+    const inet_address_vector_replica_set& unsorted_address) {
 
     inet_address_vector_replica_set
         preferred(unsorted_address.begin(), unsorted_address.end());

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -99,7 +99,7 @@ public:
      */
     virtual inet_address_vector_replica_set get_sorted_list_by_proximity(
         inet_address address,
-        inet_address_vector_replica_set& unsorted_address) = 0;
+        const inet_address_vector_replica_set& unsorted_address) = 0;
 
     /**
      * This method will sort the <tt>List</tt> by proximity to the given
@@ -435,7 +435,7 @@ public:
 
     virtual inet_address_vector_replica_set get_sorted_list_by_proximity(
         inet_address address,
-        inet_address_vector_replica_set& unsorted_address) override;
+        const inet_address_vector_replica_set& unsorted_address) override;
 
     virtual void sort_by_proximity(
         inet_address address, inet_address_vector_replica_set& addresses) override;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -189,6 +189,7 @@ public:
     std::vector<token> get_tokens(const inet_address& addr) const;
     const std::unordered_map<token, inet_address>& get_token_to_endpoint() const;
     const std::unordered_set<inet_address>& get_leaving_endpoints() const;
+    const std::unordered_map<inet_address, inet_address>& get_replacing_endpoints() const noexcept;
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
     void update_topology(inet_address ep);
     /**
@@ -295,32 +296,6 @@ public:
     static boost::icl::interval<token>::interval_type range_to_interval(range<dht::token> r);
     static range<dht::token> interval_to_range(boost::icl::interval<token>::interval_type i);
 
-    bool has_pending_ranges(sstring keyspace_name, inet_address endpoint) const;
-     /**
-     * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
-     *
-     * (1) When in doubt, it is better to write too much to a node than too little. That is, if
-     * there are multiple nodes moving, calculate the biggest ranges a node could have. Cleaning
-     * up unneeded data afterwards is better than missing writes during movement.
-     * (2) When a node leaves, ranges for other nodes can only grow (a node might get additional
-     * ranges, but it will not lose any of its current ranges as a result of a leave). Therefore
-     * we will first remove _all_ leaving tokens for the sake of calculation and then check what
-     * ranges would go where if all nodes are to leave. This way we get the biggest possible
-     * ranges with regard current leave operations, covering all subsets of possible final range
-     * values.
-     * (3) When a node bootstraps, ranges of other nodes can only get smaller. Without doing
-     * complex calculations to see if multiple bootstraps overlap, we simply base calculations
-     * on the same token ring used before (reflecting situation after all leave operations have
-     * completed). Bootstrapping nodes will be added and removed one by one to that metadata and
-     * checked what their ranges would be. This will give us the biggest possible ranges the
-     * node could have. It might be that other bootstraps make our actual final ranges smaller,
-     * but it does not matter as we can clean up the data afterwards.
-     *
-     * NOTE: This is heavy and ineffective operation. This will be done only once when a node
-     * changes state in the cluster, so it should be manageable.
-     */
-    future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name);
-
     token get_predecessor(token t) const;
 
     std::vector<inet_address> get_all_endpoints() const;
@@ -328,9 +303,6 @@ public:
     /* Returns the number of different endpoints that own tokens in the ring.
      * Bootstrapping tokens are not taken into account. */
     size_t count_normal_token_owners() const;
-
-    // returns empty vector if keyspace_name not found.
-    inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
 
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
     std::multimap<inet_address, token> get_endpoint_to_token_map_for_reading() const;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1342,12 +1342,12 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                     seastar::thread::maybe_yield();
                     if (src_range.contains(desired_range, dht::tri_compare)) {
                         std::vector<inet_address> old_endpoints(x.second.begin(), x.second.end());
-                        auto it = pending_range_addresses.find(desired_range);
-                        if (it == pending_range_addresses.end()) {
+                        auto opt_replica_set = pending_range_addresses.find(desired_range);
+                        if (!opt_replica_set) {
                             throw std::runtime_error(format("Can not find desired_range = {} in pending_range_addresses", desired_range));
                         }
 
-                        std::unordered_set<inet_address> new_endpoints(it->second.begin(), it->second.end());
+                        std::unordered_set<inet_address> new_endpoints(opt_replica_set->begin(), opt_replica_set->end());
                         rlogger.debug("bootstrap_with_repair: keyspace={}, range={}, old_endpoints={}, new_endpoints={}",
                                 keyspace_name, desired_range, old_endpoints, new_endpoints);
                         // Due to CASSANDRA-5953 we can have a higher RF then we have endpoints.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1967,7 +1967,7 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
     replica::keyspace& ks = _db.local().find_keyspace(keyspace_name);
     auto erm = ks.get_effective_replication_map();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm->get_token_metadata_ptr()->pending_endpoints_for(token, keyspace_name);
+    inet_address_vector_topology_change pending_endpoints = erm->pending_endpoints_for(token);
 
     slogger.trace("creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints, pending_endpoints);
     tracing::trace(tr_state, "Creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints ,pending_endpoints);
@@ -2292,7 +2292,7 @@ storage_proxy::get_paxos_participants(const sstring& ks_name, const dht::token &
     replica::keyspace& ks = _db.local().find_keyspace(ks_name);
     auto erm = ks.get_effective_replication_map();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm->get_token_metadata_ptr()->pending_endpoints_for(token, ks_name);
+    inet_address_vector_topology_change pending_endpoints = erm->pending_endpoints_for(token);
 
     if (cl_for_paxos == db::consistency_level::LOCAL_SERIAL) {
         auto itend = boost::range::remove_if(natural_endpoints, std::not_fn(std::cref(db::is_local)));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -414,10 +414,6 @@ void storage_service::join_token_ring(int delay) {
             sleep_abortable(std::chrono::seconds(1), _abort_source).get();
         }
         set_mode(mode::JOINING, "schema complete, ready to bootstrap", true);
-        set_mode(mode::JOINING, "waiting for pending range calculation", true);
-        update_pending_ranges("joining").get();
-        set_mode(mode::JOINING, "calculation complete, ready to bootstrap", true);
-        slogger.debug("... got ring + schema info");
 
         auto t = gms::gossiper::clk::now();
         auto tmptr = get_token_metadata_ptr();
@@ -441,7 +437,6 @@ void storage_service::join_token_ring(int delay) {
                 set_mode(mode::JOINING, "waiting for schema information to complete", true);
                 sleep_abortable(std::chrono::seconds(1), _abort_source).get();
             }
-            update_pending_ranges("bootstrapping/leaving nodes while joining").get();
             tmptr = get_token_metadata_ptr();
         }
         slogger.info("Checking bootstrapping/leaving nodes: ok");
@@ -660,11 +655,11 @@ void storage_service::bootstrap() {
       if (!bootstrap_rbno) {
         // When is_repair_based_node_ops_enabled is true, the bootstrap node
         // will use node_ops_cmd to bootstrap, node_ops_cmd will update the pending ranges.
-        slogger.debug("bootstrap: update pending ranges: endpoint={} bootstrap_tokens={}", get_broadcast_address(), _bootstrap_tokens);
+        slogger.debug("bootstrap: endpoint={} bootstrap_tokens={}", get_broadcast_address(), _bootstrap_tokens);
         mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
             auto endpoint = get_broadcast_address();
             tmptr->add_bootstrap_tokens(_bootstrap_tokens, endpoint);
-            return update_pending_ranges(std::move(tmptr), format("bootstrapping node {}", endpoint));
+            return make_ready_future<>();
         }).get();
       }
 
@@ -794,7 +789,6 @@ future<> storage_service::handle_state_replacing_update_pending_ranges(mutable_t
                 replacing_node, std::current_exception());
     }
     slogger.info("handle_state_replacing: Update pending ranges for replacing node {}", replacing_node);
-    co_await update_pending_ranges(tmptr, format("handle_state_replacing {}", replacing_node));
 }
 
 future<> storage_service::handle_state_replacing(inet_address replacing_node) {
@@ -855,7 +849,6 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
     }
-    co_await update_pending_ranges(tmptr, format("handle_state_bootstrap {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -944,7 +937,6 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
     // a race where natural endpoint was updated to contain node A, but A was
     // not yet removed from pending endpoints
     co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
-    co_await update_pending_ranges(tmptr, format("handle_state_normal {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -1007,7 +999,6 @@ future<> storage_service::handle_state_leaving(inet_address endpoint) {
     // normally
     tmptr->add_leaving_endpoint(endpoint);
 
-    co_await update_pending_ranges(tmptr, format("handle_state_leaving", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -1064,7 +1055,7 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
                 slogger.debug("Tokens {} removed manually (endpoint was {})", remove_tokens, endpoint);
                 // Note that the endpoint is being removed
                 tmptr->add_leaving_endpoint(endpoint);
-                return update_pending_ranges(std::move(tmptr), format("handle_state_removing {}", endpoint));
+                return make_ready_future<>();
             });
             // find the endpoint coordinating this removal that we need to notify when we're done
             auto* value = _gossiper.get_application_state_ptr(endpoint, application_state::REMOVAL_COORDINATOR);
@@ -1187,7 +1178,6 @@ future<> storage_service::on_remove(gms::inet_address endpoint) {
     auto tmlock = co_await get_token_metadata_lock();
     auto tmptr = co_await get_mutable_token_metadata_ptr();
     tmptr->remove_endpoint(endpoint);
-    co_await update_pending_ranges(tmptr, format("on_remove {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -1875,11 +1865,10 @@ future<> storage_service::decommission() {
                 throw std::runtime_error(format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
             }
 
-            ss.update_pending_ranges(format("decommission {}", endpoint)).get();
-
             auto non_system_keyspaces = db.get_non_system_keyspaces();
             for (const auto& keyspace_name : non_system_keyspaces) {
-                if (ss.get_token_metadata().has_pending_ranges(keyspace_name, ss.get_broadcast_address())) {
+                auto erm = db.find_keyspace(keyspace_name).get_effective_replication_map();
+                if (erm->has_pending_ranges(ss.get_broadcast_address())) {
                     throw std::runtime_error("data is currently moving to this node; unable to leave the ring");
                 }
             }
@@ -2410,21 +2399,23 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("removenode[{}]: adding leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& node : req.leaving_nodes) {
                     slogger.info("removenode[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, format("removenode {}", req.leaving_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("removenode[{}]: removing leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& node : req.leaving_nodes) {
                         slogger.info("removenode[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, format("removenode {}", req.leaving_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
@@ -2459,21 +2450,23 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("decommission[{}]: adding leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& node : req.leaving_nodes) {
                     slogger.info("decommission[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, format("decommission {}", req.leaving_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("decommission[{}]: removing leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& node : req.leaving_nodes) {
                         slogger.info("decommission[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, format("decommission {}", req.leaving_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
@@ -2499,6 +2492,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("replace[{}]: adding replacing_nodes={}", req.ops_uuid, req.replace_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: req.replace_nodes) {
                     auto existing_node = x.first;
@@ -2510,6 +2504,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("replace[{}]: removing replacing_nodes={}", req.ops_uuid, req.replace_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& x: req.replace_nodes) {
                         auto existing_node = x.first;
@@ -2517,7 +2512,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("replace[{}]: Removed replacing_node={} to replace existing_node={}, coordinator={}", req.ops_uuid, replacing_node, existing_node, coordinator);
                         tmptr->del_replacing_endpoint(existing_node);
                     }
-                    return update_pending_ranges(tmptr, format("replace {}", req.replace_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
@@ -2535,9 +2530,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
         } else if (req.cmd == node_ops_cmd::replace_prepare_pending_ranges) {
             // Update the pending_ranges for the replacing node
             slogger.debug("replace[{}]: Updated pending_ranges from coordinator={}", req.ops_uuid, coordinator);
-            mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
-                return update_pending_ranges(tmptr, format("replace {}", req.replace_nodes));
-            }).get();
         } else if (req.cmd == node_ops_cmd::replace_heartbeat) {
             slogger.debug("replace[{}]: Updated heartbeat from coordinator={}", req.ops_uuid, coordinator);
             node_ops_update_heartbeat(ops_uuid);
@@ -2553,6 +2545,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("bootstrap[{}]: adding bootstrap_nodes={}", req.ops_uuid, req.bootstrap_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: req.bootstrap_nodes) {
                     auto& endpoint = x.first;
@@ -2560,10 +2553,11 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     slogger.info("bootstrap[{}]: Added node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
                     tmptr->add_bootstrap_tokens(tokens, endpoint);
                 }
-                return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("bootstrap[{}]: removing bootstrap_nodes={}", req.ops_uuid, req.bootstrap_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& x: req.bootstrap_nodes) {
                         auto& endpoint = x.first;
@@ -2571,7 +2565,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("bootstrap[{}]: Removed node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
                         tmptr->remove_bootstrap_tokens(tokens);
                     }
-                    return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
@@ -2911,7 +2905,6 @@ future<> storage_service::excise(std::unordered_set<token> tokens, inet_address 
     tmptr->remove_endpoint(endpoint);
     tmptr->remove_bootstrap_tokens(tokens);
 
-    co_await update_pending_ranges(tmptr, format("excise {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -2972,7 +2965,7 @@ future<> storage_service::leave_ring() {
     co_await mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
         auto endpoint = get_broadcast_address();
         tmptr->remove_endpoint(endpoint);
-        return update_pending_ranges(std::move(tmptr), format("leave_ring {}", endpoint));
+        return make_ready_future<>();
     });
 
     auto expire_time = _gossiper.compute_expire_time().time_since_epoch().count();
@@ -3012,10 +3005,11 @@ storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multim
 
 future<> storage_service::start_leaving() {
     return _gossiper.add_local_application_state(application_state::STATUS, versioned_value::leaving(db::system_keyspace::get_local_tokens().get0())).then([this] {
-        return mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
-            auto endpoint = get_broadcast_address();
+        auto endpoint = get_broadcast_address();
+        slogger.debug("start_leaving: endpoint={}", endpoint);
+        return mutate_token_metadata([this, endpoint] (mutable_token_metadata_ptr tmptr) {
             tmptr->add_leaving_endpoint(endpoint);
-            return update_pending_ranges(std::move(tmptr), format("start_leaving {}", endpoint));
+            return make_ready_future<>();
         });
     });
 }
@@ -3185,44 +3179,21 @@ future<> storage_service::mutate_token_metadata(std::function<future<> (mutable_
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
-future<> storage_service::update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason) {
-    assert(this_shard_id() == 0);
-
-    // long start = System.currentTimeMillis();
-    return do_with(_db.local().get_non_system_keyspaces(), [this, tmptr = std::move(tmptr)] (auto& keyspaces) mutable {
-        return do_for_each(keyspaces, [this, tmptr = std::move(tmptr)] (auto& keyspace_name) mutable {
-            auto& ks = this->_db.local().find_keyspace(keyspace_name);
-            auto& strategy = ks.get_replication_strategy();
-            slogger.debug("Updating pending ranges for keyspace={} starts", keyspace_name);
-            return tmptr->update_pending_ranges(strategy, keyspace_name).finally([&keyspace_name] {
-                slogger.debug("Updating pending ranges for keyspace={} ends", keyspace_name);
-            });
-        });
-    }).handle_exception([this, reason = std::move(reason)] (std::exception_ptr ep) mutable {
-        slogger.error("Failed to update pending ranges for {}: {}", reason, ep);
-        return make_exception_future<>(std::move(ep));
-    });
-    // slogger.debug("finished calculation for {} keyspaces in {}ms", keyspaces.size(), System.currentTimeMillis() - start);
-}
-
-future<> storage_service::update_pending_ranges(sstring reason, acquire_merge_lock acquire_merge_lock) {
-    return mutate_token_metadata([this, reason = std::move(reason)] (mutable_token_metadata_ptr tmptr) mutable {
-        return update_pending_ranges(std::move(tmptr), std::move(reason));
-    }, acquire_merge_lock);
-}
-
 future<> storage_service::keyspace_changed(const sstring& ks_name) {
     // Update pending ranges since keyspace can be changed after we calculate pending ranges.
-    sstring reason = format("keyspace {}", ks_name);
-    return container().invoke_on(0, [reason = std::move(reason)] (auto& ss) mutable {
-        return ss.update_pending_ranges(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
-            slogger.warn("Failure to update pending ranges for {} ignored", reason);
+    slogger.debug("keyspace {} changed", ks_name);
+    return container().invoke_on(0, [ks_name] (auto& ss) mutable {
+        return ss.mutate_token_metadata([] (mutable_token_metadata_ptr) {
+            return make_ready_future<>();
+        }, acquire_merge_lock::no).handle_exception([ks_name = std::move(ks_name)] (auto ep) {
+            slogger.warn("Failure to update pending ranges for keyspace {} ignored", ks_name);
         });
     });
 }
 
 future<> storage_service::update_topology(inet_address endpoint) {
     return container().invoke_on(0, [endpoint] (auto& ss) {
+        slogger.debug("update_topology: {}", endpoint);
         return ss.mutate_token_metadata([&ss, endpoint] (mutable_token_metadata_ptr tmptr) mutable {
             // re-read local rack and DC info
             tmptr->update_topology(endpoint);
@@ -3552,7 +3523,8 @@ future<> storage_service::notify_cql_change(inet_address endpoint, bool ready) {
 future<bool> storage_service::is_cleanup_allowed(sstring keyspace) {
     return container().invoke_on(0, [keyspace = std::move(keyspace)] (storage_service& ss) {
         auto my_address = ss.get_broadcast_address();
-        auto pending_ranges = ss.get_token_metadata().has_pending_ranges(keyspace, my_address);
+        auto erm = ss._db.local().find_keyspace(keyspace).get_effective_replication_map();
+        auto pending_ranges = erm->has_pending_ranges(my_address);
         bool is_bootstrap_mode = ss._is_bootstrap_mode;
         slogger.debug("is_cleanup_allowed: keyspace={}, is_bootstrap_mode={}, pending_ranges={}",
                 keyspace, is_bootstrap_mode, pending_ranges);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -240,11 +240,6 @@ private:
     // Note: must be called on shard 0.
     future<> mutate_token_metadata(std::function<future<> (mutable_token_metadata_ptr)> func, acquire_merge_lock aml = acquire_merge_lock::yes) noexcept;
 
-    // Update pending ranges locally and then replicate to all cores.
-    // Should be serialized under token_metadata_lock.
-    // Must be called on shard 0.
-    future<> update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason);
-    future<> update_pending_ranges(sstring reason, acquire_merge_lock aml = acquire_merge_lock::yes);
     future<> keyspace_changed(const sstring& ks_name);
     void register_metrics();
     future<> snitch_reconfigured();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -642,6 +642,8 @@ private:
      * @param keyspaceName the keyspace ranges belong to
      * @param ranges the ranges to find sources for
      * @return multimap of addresses to ranges the address is responsible for
+     *
+     * Must run inside seastar::async context
      */
     std::unordered_multimap<inet_address, dht::token_range> get_new_source_ranges(const sstring& keyspaceName, const dht::token_range_vector& ranges) const;
 public:


### PR DESCRIPTION
Currently, the pending ranges are kept in token_metadata in
per-keyspace maps.

However, the pending endpoints aren't really per keyspace
so we shouldn't calculate them over and over again per keyspace.
    
They actually depend on the replication strategy, its configuration and the token_metadata,
hence they should be kept per effective_replication_map and use the precalculated address_ranges.

This series moves the function into e_r_m, and convert them to coroutines.
Also, it uses the e_r_m factory to iterate over all e_r_m:s for calling has_pending_ranges for each.

The main benefit from doing this is reducing memory footprint for the pending ranges and respectively saving cpu cycles that were used for recalculating them for multiple keyspaces that now share a replication map.

Fixes #9667 

Test: unit(dev)
Dtest: update_cluster_layout_tests:TestLargeScaleCluster.add_50_nodes_test update_cluster_layout_tests:TestUpdateClusterLayout.{simple_add_node_1_test,add_new_node_while_add_new_table_after_bootstrapping_test,increment_decrement_counters_in_threads_nodes_restarted_test,iterative_add_3_node_decommission_3_node_rf_2_test,simple_add_new_node_while_adding_info_2_test,simple_kill_new_node_while_bootstrapping_with_parallel_writes_in_multidc_test,verify_latest_copy_decommission_node_test,verify_latest_copy_rebuild_node_test,verify_latest_copy_removenode_node_test,verify_latest_copy_replace_node_test,verify_latest_copy_add_node_test}