### PR TITLE
malformed_sstable_exception: log error

### DIFF
--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -26,18 +26,27 @@
 
 #include "seastarx.hh"
 
+namespace seastar { class logger; }
+
 namespace sstables {
+
+class sstable;
+
 class malformed_sstable_exception : public std::exception {
     sstring _msg;
 public:
     malformed_sstable_exception(sstring msg, sstring filename)
         : malformed_sstable_exception{format("{} in sstable {}", msg, filename)}
     {}
+    malformed_sstable_exception(const sstable& sst, sstring msg, const sstring& filename);
     malformed_sstable_exception(sstring s) : _msg(s) {}
     const char *what() const noexcept {
         return _msg.c_str();
     }
 };
+
+[[noreturn]] void throw_malformed_sstable_exception(seastar::logger& log, const sstable& sst, sstring msg);
+[[noreturn]] void throw_malformed_sstable_exception(seastar::logger& log, const sstable& sst, sstring msg, const sstring& filename);
 
 struct bufsize_mismatch_exception : malformed_sstable_exception {
     bufsize_mismatch_exception(size_t size, size_t expected) :

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -546,7 +546,7 @@ private:
             bound.current_index_idx = 0;
             bound.current_pi_idx = 0;
             if (bound.current_list->empty()) {
-                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->filename(component_type::Index));
+                throw_malformed_sstable_exception(sstlog, *_sstable, format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->filename(component_type::Index));
             }
             bound.data_file_position = bound.current_list->_entries[0]->position();
             bound.element = indexable_element::partition;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -803,7 +803,7 @@ public:
         _sst._components->filter = utils::i_filter::get_filter(estimated_partitions, _schema.bloom_filter_fp_chance(), utils::filter_format::m_format);
         _pi_write_m.desired_block_size = cfg.promoted_index_block_size;
         _index_sampling_state.summary_byte_cost = _cfg.summary_byte_cost;
-        prepare_summary(_sst._components->summary, estimated_partitions, _schema.min_index_interval());
+        prepare_summary(_sst, _sst._components->summary, estimated_partitions, _schema.min_index_interval());
 
         // Initialize at the end of the constructor body, so we can delay making
         // the semaphore used until we know that no more exceptions can be thrown.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1419,7 +1419,7 @@ future<foreign_sstable_open_info> sstable::get_open_info() & {
     });
 }
 
-void prepare_summary(summary& s, uint64_t expected_partition_count, uint32_t min_index_interval) {
+void prepare_summary(const sstable& sst, summary& s, uint64_t expected_partition_count, uint32_t min_index_interval) {
     assert(expected_partition_count >= 1);
 
     s.header.min_index_interval = min_index_interval;
@@ -1724,7 +1724,7 @@ future<> sstable::generate_summary(const io_priority_class& pc) {
         auto index_size = co_await index_file.size();
         // an upper bound. Surely to be less than this.
         auto estimated_partitions = std::max<uint64_t>(index_size / sizeof(uint64_t), 1);
-        prepare_summary(_components->summary, estimated_partitions, _schema->min_index_interval());
+        prepare_summary(*this, _components->summary, estimated_partitions, _schema->min_index_interval());
 
         file_input_stream_options options;
         options.buffer_size = sstable_buffer_size;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -832,7 +832,7 @@ future<> sstable::read_toc() noexcept {
             f.get();
         } catch (std::system_error& e) {
             if (e.code() == std::error_code(ENOENT, std::system_category())) {
-                throw malformed_sstable_exception(filename(component_type::TOC) + ": file not found");
+                throw malformed_sstable_exception(format("{}", std::current_exception()), filename(component_type::TOC));
             }
             throw;
         }
@@ -1016,7 +1016,7 @@ future<> sstable::read_simple(T& component, const io_priority_class& pc) {
             f.get();
         } catch (std::system_error& e) {
             if (e.code() == std::error_code(ENOENT, std::system_category())) {
-                throw malformed_sstable_exception(file_path + ": file not found");
+                throw malformed_sstable_exception(format("{}", std::current_exception()), file_path);
             }
             throw;
         } catch (malformed_sstable_exception &e) {

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -603,7 +603,7 @@ void maybe_add_summary_entry(summary&, const dht::token&, bytes_view key, uint64
 // case none has been loaded (this happens, for example, in unit tests).
 const db::config& get_config();
 
-void prepare_summary(summary& s, uint64_t expected_partition_count, uint32_t min_index_interval);
+void prepare_summary(const sstable& sst, summary& s, uint64_t expected_partition_count, uint32_t min_index_interval);
 
 future<> seal_summary(summary& s,
     std::optional<key>&& first_key,

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -51,7 +51,9 @@ static future<> broken_sst(sstring dir, unsigned long generation, schema_ptr s, 
         BOOST_FAIL("expecting exception");
     } catch (malformed_sstable_exception& e) {
         auto ex_what = sstring(e.what());
-        BOOST_REQUIRE(ex_what.find(msg) != sstring::npos);
+        if (ex_what.find(msg) == sstring::npos) {
+            BOOST_FAIL(format("Expected message '{}' not found in error message: '{}'", msg, ex_what));
+        }
         if (sst_name) {
             BOOST_REQUIRE(ex_what.find(*sst_name) != sstring::npos);
         }

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -232,25 +232,25 @@ SEASTAR_TEST_CASE(empty_toc) {
 
 SEASTAR_TEST_CASE(alien_toc) {
     return broken_sst("test/resource/sstables/badtoc", 2,
-               "test/resource/sstables/badtoc/la-2-big-Statistics.db: file not found");
+               "open failed: No such file or directory [test/resource/sstables/badtoc/la-2-big-Statistics.db]");
 }
 
 SEASTAR_TEST_CASE(truncated_toc) {
     return broken_sst("test/resource/sstables/badtoc", 3,
-               "test/resource/sstables/badtoc/la-3-big-Statistics.db: file not found");
+               "open failed: No such file or directory [test/resource/sstables/badtoc/la-3-big-Statistics.db]");
 }
 
 SEASTAR_TEST_CASE(wrong_format_toc) {
     return broken_sst("test/resource/sstables/badtoc", 4,
-               "test/resource/sstables/badtoc/la-4-big-TOC.txt: file not found");
+               "open failed: No such file or directory [test/resource/sstables/badtoc/la-4-big-TOC.txt]");
 }
 
 SEASTAR_TEST_CASE(compression_truncated) {
     return broken_sst("test/resource/sstables/badcompression", 1,
-               "test/resource/sstables/badcompression/la-1-big-Statistics.db: file not found");
+               "open failed: No such file or directory [test/resource/sstables/badcompression/la-1-big-Statistics.db]");
 }
 
 SEASTAR_TEST_CASE(compression_bytes_flipped) {
     return broken_sst("test/resource/sstables/badcompression", 2,
-               "test/resource/sstables/badcompression/la-2-big-Statistics.db: file not found");
+               "open failed: No such file or directory [test/resource/sstables/badcompression/la-2-big-Statistics.db]");
 }


### PR DESCRIPTION
log an error meassage whenever a malformed_sstable_exception is generated to make them more visible so they won't go unnoticed.

For example, as seen in https://jenkins.scylladb.com/view/master/job/scylla-master/job/next/4318/artifact/logs-gating.release.2/1640145203194_update_cluster_layout_tests.py%3A%3ATestUpdateClusterLayout%3A%3Atest_simple_kill_streaming_node_while_bootstrapping/node3.log
```
WARN  2021-12-22 03:53:22,082 [shard 0] stream_session - [Stream #b5002180-62da-11ec-9d9b-4e2d269411e2] stream_transfer_task: Fail to send to 127.0.74.4:0: sstables::malformed_sstable_exception (missing index entry for summary index 45 (bound 0x60000106c8f0) in sstable /jenkins/workspace/scylla-master/next/scylla/.dtest/dtest-ek7636zz/test/node3/data/ks3/standard1-92df8f0062da11ecb1ba221c1df2a2ea/md-2-big-Index.db)
WARN  2021-12-22 03:53:22,082 [shard 0] stream_session - [Stream #b5002180-62da-11ec-9d9b-4e2d269411e2] Failed to send: sstables::malformed_sstable_exception (missing index entry for summary index 45 (bound 0x60000106c8f0) in sstable /jenkins/workspace/scylla-master/next/scylla/.dtest/dtest-ek7636zz/test/node3/data/ks3/standard1-92df8f0062da11ecb1ba221c1df2a2ea/md-2-big-Index.db)
```
    
The malformed_sstable_exception may be printed only at a WARN level or might be swallawed as a whole.
