### PR TITLE
SCYLLA-VERSION-GEN: rm unnecessary Bashism

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -31,7 +31,7 @@ using '-o PATH' option.
 END
 )
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
 	opt="$1"
 	case $opt in
 		-h|--help)


### PR DESCRIPTION
Make Debian's dash happy