### PR TITLE
cql3: deprecate and start replacing cql3::util::maybe_quote

### DIFF
--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -63,11 +63,11 @@ sstring column_identifier::to_string() const {
 }
 
 sstring column_identifier::to_cql_string() const {
-    return util::maybe_quote(_text);
+    return util::quote(_text);
 }
 
 sstring column_identifier_raw::to_cql_string() const {
-    return util::maybe_quote(_text);
+    return util::quote(_text);
 }
 
 column_identifier_raw::column_identifier_raw(sstring raw_text, bool keep_case)

--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -463,6 +463,27 @@ sstring maybe_quote(const sstring& identifier) {
     return result;
 }
 
+sstring quote(const sstring& identifier) {
+    // quote empty string
+    if (identifier.empty()) {
+        return "\"\"";
+    }
+    size_t num_quotes = 0;
+    for (char c : identifier) {
+        num_quotes += (c == '"');
+    }
+    if (num_quotes == 0) {
+        return make_sstring("\"", identifier, "\"");
+    }
+    static const std::regex double_quote_re("\"");
+    std::string result;
+    result.reserve(2 + identifier.size() + num_quotes);
+    result.push_back('"');
+    std::regex_replace(std::back_inserter(result), identifier.begin(), identifier.end(), double_quote_re, "\"\"");
+    result.push_back('"');
+    return result;
+}
+
 }
 
 }

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -87,7 +87,25 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
 /// forbids non-alpha-numeric characters in identifier names.
 /// Quoting involves wrapping the string in double-quotes ("). A double-quote
 /// character itself is quoted by doubling it.
+/// Using maybe_quote() is not recommended, because while usually avoiding
+/// quotes for lowercase names is recommended, it can not be avoided if the
+/// name is a CQL keyword - and this function is not aware of the full list
+/// of keywords. So always quoting - with quote() - is recommended.
+[[deprecated("use quote instead")]]
 sstring maybe_quote(const sstring& s);
+
+/// quote() takes an identifier - the name of a column, table or keyspace -
+/// and transforms it to a string which can be safely used in CQL commands.
+/// Quoting involves wrapping the name in double-quotes ("). A double-quote
+/// character itself is quoted by doubling it.
+/// Quoting is necessary when the identifier contains non-alpha-numeric
+/// characters, when it contains uppercase letters (which will be folded to
+/// lowercase if not quoted), or when the identifier is one of many CQL
+/// keywords. But it's allowed - and easier - to just unconditionally
+/// quote the identifier name in CQL, so that is what we'll do.
+/// Unconditionally quoting the identifier name is useful so we don't need
+/// to keep track of which names are CQL keywords (see issue #9450).
+sstring quote(const sstring& s);
 
 // Check whether timestamp is not too far in the future as this probably
 // indicates its incorrectness (for example using other units than microseconds).

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -98,3 +98,41 @@ def test_mv_empty_string_partition_key(cql, test_keyspace):
             # because Cassandra forbids an empty partition key on select
             with pytest.raises(InvalidRequest, match='Key may not be empty'):
                 cql.execute(f"SELECT * FROM {mv} WHERE v=''")
+
+# Reproducer for issue #9450 - when a view's key column name is a (quoted)
+# keyword, writes used to fail because they generated internally broken CQL
+# with the column name not quoted.
+def test_mv_quoted_column_names(cql, test_keyspace):
+    # check the following column names, all with double-quotes which the
+    # CQL syntax allows for specifying case-sensitive or reserved names.
+    for colname in ['"dog"', '"Dog"', 'DOG', '"to"']:
+        print(f'Trying {colname}')
+        with new_test_table(cql, test_keyspace, f'p int primary key, {colname} int') as table:
+            with new_materialized_view(cql, table, '*', f'{colname}, p', f'{colname} is not null and p is not null') as mv:
+                cql.execute(f'INSERT INTO {table} (p, {colname}) values (1, 2)')
+                # Validate that not only the write didn't fail, it actually
+                # write the right thing to the view. NOTE: on a single-node
+                # Scylla, view update is synchronous so we can just read and
+                # don't need to wait or retry.
+                assert list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]
+
+# Same as test_mv_quoted_column_names above (reproducing issue #9450), just
+# check *view building* - i.e., pre-existing data in the base table that
+# needs to be copied to the view. The view building cannot return an error
+# to the user, but can fail to write the desired data into the view.
+def test_mv_quoted_column_names_build(cql, test_keyspace):
+    for colname in ['"dog"', '"Dog"', 'DOG', '"to"']:
+        print(f'Trying {colname}')
+        with new_test_table(cql, test_keyspace, f'p int primary key, {colname} int') as table:
+            cql.execute(f'INSERT INTO {table} (p, {colname}) values (1, 2)')
+            with new_materialized_view(cql, table, '*', f'{colname}, p', f'{colname} is not null and p is not null') as mv:
+                # When Scylla's view builder fails as it did in issue #9450,
+                # there is no way to tell this state apart from a view build
+                # that simply hasn't completed (besides looking at the logs,
+                # which we don't). This means, unfortunately, that a failure
+                # of this test is slow - it needs to wait for a timeout.
+                start_time = time.time()
+                while time.time() < start_time + 30:
+                    if list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]:
+                        break
+                assert list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]


### PR DESCRIPTION
cql3::util::maybe_quote() is a utility function formatting an identifier
name (table name, column name, etc.) that needs to be embedded in a CQL
statement - and might require quoting if it contains non-alphanumeric
characters, uppercase characters, or a CQL keyword.

maybe_quote() made a valiant effort to only quote the identifier name
if neccessary - e.g., a lowercase name does not need quoting. Or, so
we thought. I now consider that effort to be misdirected: It turns out
that even lowercase names sometimes need to be quoted - when they are
CQL keywords they cannot be used without quoting. This can cause
problems for code that wants to generate CQL statements, such as the
materialized-view problem in issue #9450.

So this patch concedes that maybe_quote() is problematic - it doesn't
always quote when necessary - and deprecates it. Instead it adds a new
function - quote() - which unconditionally quotes an identifier name.
It is always legal to add quotes even when not necessary.

I did not want to replace all uses of maybe_quote() with quote() because
I am not sure how to test all the places it is used. So I changed only
the one place in the code which is needed to fix issue #9450 - the
column identifier's to_cql_string() function. Probably eventually all
other calls to maybe_quote() should be reviewed, tests added for the
CQL-keyword case, and the call to maybe_quote() should be replaced by
quote().

Fixes #9450

Signed-off-by: Nadav Har'El <nyh@scylladb.com>