### PR TITLE
Move pending ranges functions into effective_replication_map: part 1

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1255,7 +1255,10 @@ future<> mutate_MV(
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto& keyspace_name = mut.s->ks_name();
         auto target_endpoint = get_view_natural_endpoint(keyspace_name, base_token, view_token);
-        auto remote_endpoints = service::get_local_storage_proxy().get_token_metadata_ptr()->pending_endpoints_for(view_token, keyspace_name);
+        const auto& db = service::get_local_storage_proxy().local_db();
+        const auto& ks = db.find_keyspace(keyspace_name);
+        auto erm = ks.get_effective_replication_map();
+        auto remote_endpoints = erm->pending_endpoints_for(view_token);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());
 
         // First, find the local endpoint and ensure that if it exists,

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -216,22 +216,6 @@ effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
 }
 
 future<std::unordered_multimap<inet_address, dht::token_range>>
-abstract_replication_strategy::get_address_ranges(const token_metadata& tm) const {
-    std::unordered_multimap<inet_address, dht::token_range> ret;
-    for (auto& t : tm.sorted_tokens()) {
-        dht::token_range_vector r = tm.get_primary_ranges_for(t);
-        auto eps = co_await calculate_natural_endpoints(t, tm);
-        rslogger.debug("token={}, primary_range={}, address={}", t, r, eps);
-        for (auto ep : eps) {
-            for (auto&& rng : r) {
-                ret.emplace(ep, rng);
-            }
-        }
-    }
-    co_return ret;
-}
-
-future<std::unordered_multimap<inet_address, dht::token_range>>
 abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet_address endpoint) const {
     std::unordered_multimap<inet_address, dht::token_range> ret;
     for (auto& t : tm.sorted_tokens()) {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -117,14 +117,15 @@ public:
     // Note: must be called with initialized, non-empty token_metadata.
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
 
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
-
     // Caller must ensure that token_metadata will not change throughout the call.
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_addresses(const token_metadata& tm) const;
 
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, token pending_token, inet_address pending_address) const;
 
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address) const;
+
+private:
+    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 };
 
 // Holds the full replication_map resulting from applying the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -11,6 +11,10 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
+
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
+
 #include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
 #include "dht/i_partitioner.hh"
@@ -149,10 +153,15 @@ public:
     };
 
 private:
+    using address_ranges = std::unordered_multimap<inet_address, dht::token_range>;
+    using pending_ranges = std::unordered_multimap<range<token>, inet_address>;
+    using pending_ranges_interval_map = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
+
     abstract_replication_strategy::ptr_type _rs;
     token_metadata_ptr _tmptr;
     replication_map _replication_map;
     size_t _replication_factor;
+    pending_ranges_interval_map _pending_ranges_interval_map;
     std::optional<factory_key> _factory_key = std::nullopt;
     effective_replication_map_factory* _factory = nullptr;
 
@@ -216,9 +225,58 @@ public:
     std::unordered_map<dht::token_range, inet_address_vector_replica_set>
     get_range_addresses() const;
 
+    // returns empty vector if token not found.
+    inet_address_vector_topology_change pending_endpoints_for(const token& token) const;
+
+    bool has_pending_ranges(inet_address endpoint) const noexcept;
+
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<bool(inet_address_vector_replica_set)> should_add_range) const;
 
+    future<address_ranges> calculate_address_ranges() const;
+
+    future<> calculate_pending_ranges_for_replacing(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const std::unordered_map<inet_address, inet_address>& replacing_endpoints) const;
+    future<> calculate_pending_ranges_for_leaving(
+        const address_ranges& address_ranges,
+        pending_ranges& new_pending_ranges,
+        const token_metadata& all_left_metadata,
+        const std::unordered_set<inet_address>& leaving_endpoints) const;
+    future<> calculate_pending_ranges_for_bootstrap(
+        pending_ranges& new_pending_ranges,
+        token_metadata& all_left_metadata,
+        const std::unordered_map<token, inet_address>& bootstrap_tokens) const;
+
+    future<> set_pending_ranges(pending_ranges new_pending_ranges);
+
+     /**
+      * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
+      *
+      * (1) When in doubt, it is better to write too much to a node than too little. That is, if
+      * there are multiple nodes moving, calculate the biggest ranges a node could have. Cleaning
+      * up unneeded data afterwards is better than missing writes during movement.
+      * (2) When a node leaves, ranges for other nodes can only grow (a node might get additional
+      * ranges, but it will not lose any of its current ranges as a result of a leave). Therefore
+      * we will first remove _all_ leaving tokens for the sake of calculation and then check what
+      * ranges would go where if all nodes are to leave. This way we get the biggest possible
+      * ranges with regard current leave operations, covering all subsets of possible final range
+      * values.
+      * (3) When a node bootstraps, ranges of other nodes can only get smaller. Without doing
+      * complex calculations to see if multiple bootstraps overlap, we simply base calculations
+      * on the same token ring used before (reflecting situation after all leave operations have
+      * completed). Bootstrapping nodes will be added and removed one by one to that metadata and
+      * checked what their ranges would be. This will give us the biggest possible ranges the
+      * node could have. It might be that other bootstraps make our actual final ranges smaller,
+      * but it does not matter as we can clean up the data afterwards.
+      *
+      * NOTE: This is heavy and ineffective operation. This will be done only once when a node
+      * changes state in the cluster, so it should be manageable.
+      */
+    future<> update_pending_ranges();
+
+    friend future<lw_shared_ptr<effective_replication_map>> calculate_effective_replication_map(abstract_replication_strategy::ptr_type rs, token_metadata_ptr tmptr);
 public:
     static factory_key make_factory_key(const abstract_replication_strategy::ptr_type& rs, const token_metadata_ptr& tmptr);
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -117,8 +117,6 @@ public:
     // Note: must be called with initialized, non-empty token_metadata.
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
 
-public:
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm) const;
     future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 
     // Caller must ensure that token_metadata will not change throughout the call.

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -15,8 +15,6 @@
 #include "partition_range_compat.hh"
 #include <unordered_map>
 #include <algorithm>
-#include <boost/icl/interval.hpp>
-#include <boost/icl/interval_map.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/adaptors.hpp>
@@ -58,8 +56,6 @@ private:
     // The map between the existing node to be replaced and the replacing node
     std::unordered_map<inet_address, inet_address> _replacing_endpoints;
 
-    std::unordered_map<sstring, boost::icl::interval_map<token, std::unordered_set<inet_address>>> _pending_ranges_interval_map;
-
     std::vector<token> _sorted_tokens;
 
     topology _topology;
@@ -89,6 +85,10 @@ public:
 
     const std::unordered_set<inet_address>& get_leaving_endpoints() const {
         return _leaving_endpoints;
+    }
+
+    const std::unordered_map<inet_address, inet_address>& get_replacing_endpoints() const noexcept {
+        return _replacing_endpoints;
     }
 
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const {
@@ -214,53 +214,7 @@ public:
     static boost::icl::interval<token>::interval_type range_to_interval(range<dht::token> r);
     static range<dht::token> interval_to_range(boost::icl::interval<token>::interval_type i);
 
-private:
-    void set_pending_ranges(const sstring& keyspace_name, std::unordered_multimap<range<token>, inet_address> new_pending_ranges, can_yield);
-
 public:
-    bool has_pending_ranges(sstring keyspace_name, inet_address endpoint) const;
-
-     /**
-     * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
-     *
-     * (1) When in doubt, it is better to write too much to a node than too little. That is, if
-     * there are multiple nodes moving, calculate the biggest ranges a node could have. Cleaning
-     * up unneeded data afterwards is better than missing writes during movement.
-     * (2) When a node leaves, ranges for other nodes can only grow (a node might get additional
-     * ranges, but it will not lose any of its current ranges as a result of a leave). Therefore
-     * we will first remove _all_ leaving tokens for the sake of calculation and then check what
-     * ranges would go where if all nodes are to leave. This way we get the biggest possible
-     * ranges with regard current leave operations, covering all subsets of possible final range
-     * values.
-     * (3) When a node bootstraps, ranges of other nodes can only get smaller. Without doing
-     * complex calculations to see if multiple bootstraps overlap, we simply base calculations
-     * on the same token ring used before (reflecting situation after all leave operations have
-     * completed). Bootstrapping nodes will be added and removed one by one to that metadata and
-     * checked what their ranges would be. This will give us the biggest possible ranges the
-     * node could have. It might be that other bootstraps make our actual final ranges smaller,
-     * but it does not matter as we can clean up the data afterwards.
-     *
-     * NOTE: This is heavy and ineffective operation. This will be done only once when a node
-     * changes state in the cluster, so it should be manageable.
-     */
-    future<> update_pending_ranges(
-            const token_metadata& unpimplified_this,
-            const abstract_replication_strategy& strategy, const sstring& keyspace_name);
-    void calculate_pending_ranges_for_leaving(
-        const token_metadata& unpimplified_this,
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges,
-        mutable_token_metadata_ptr all_left_metadata) const;
-    void calculate_pending_ranges_for_bootstrap(
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges,
-        mutable_token_metadata_ptr all_left_metadata) const;
-    void calculate_pending_ranges_for_replacing(
-        const token_metadata& unpimplified_this,
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges) const;
-public:
-
     token get_predecessor(token t) const;
 
     // Returns nodes that are officially part of the ring. It does not include
@@ -275,10 +229,6 @@ public:
     /* Returns the number of different endpoints that own tokens in the ring.
      * Bootstrapping tokens are not taken into account. */
     size_t count_normal_token_owners() const;
-
-public:
-    // returns empty vector if keyspace_name not found.
-    inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
 
 public:
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
@@ -343,11 +293,6 @@ future<token_metadata_impl> token_metadata_impl::clone_async() const noexcept {
             ret._leaving_endpoints = _leaving_endpoints;
             ret._replacing_endpoints = _replacing_endpoints;
         }).then([this, &ret] {
-            return do_for_each(_pending_ranges_interval_map,
-                    [this, &ret] (const auto& p) {
-                ret._pending_ranges_interval_map.emplace(p);
-            });
-        }).then([this, &ret] {
             ret._ring_version = _ring_version;
             return make_ready_future<token_metadata_impl>(std::move(ret));
         });
@@ -379,7 +324,6 @@ future<> token_metadata_impl::clear_gently() noexcept {
     co_await utils::clear_gently(_bootstrap_tokens);
     co_await utils::clear_gently(_leaving_endpoints);
     co_await utils::clear_gently(_replacing_endpoints);
-    co_await utils::clear_gently(_pending_ranges_interval_map);
     co_await utils::clear_gently(_sorted_tokens);
     co_await _topology.clear_gently();
     co_return;
@@ -737,168 +681,6 @@ token_metadata_impl::interval_to_range(boost::icl::interval<token>::interval_typ
     return range<dht::token>({{i.lower(), start_inclusive}}, {{i.upper(), end_inclusive}});
 }
 
-void token_metadata_impl::set_pending_ranges(const sstring& keyspace_name,
-        std::unordered_multimap<range<token>, inet_address> new_pending_ranges,
-        can_yield can_yield) {
-    if (new_pending_ranges.empty()) {
-        _pending_ranges_interval_map.erase(keyspace_name);
-        return;
-    }
-    std::unordered_map<range<token>, std::unordered_set<inet_address>> map;
-    for (const auto& x : new_pending_ranges) {
-        if (can_yield) {
-            seastar::thread::maybe_yield();
-        }
-        map[x.first].emplace(x.second);
-    }
-
-    // construct a interval map to speed up the search
-    boost::icl::interval_map<token, std::unordered_set<inet_address>> interval_map;
-    for (auto& m : map) {
-        if (can_yield) {
-            seastar::thread::maybe_yield();
-        }
-        interval_map +=
-                std::make_pair(range_to_interval(m.first), std::move(m.second));
-    }
-    _pending_ranges_interval_map[keyspace_name] = std::move(interval_map);
-}
-
-
-bool
-token_metadata_impl::has_pending_ranges(sstring keyspace_name, inet_address endpoint) const {
-    const auto it = _pending_ranges_interval_map.find(keyspace_name);
-    if (it == _pending_ranges_interval_map.end()) {
-        return false;
-    }
-    for (const auto& item : it->second) {
-        const auto& nodes = item.second;
-        if (nodes.contains(endpoint)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Called from a seastar thread
-void token_metadata_impl::calculate_pending_ranges_for_leaving(
-        const token_metadata& unpimplified_this,
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges,
-        mutable_token_metadata_ptr all_left_metadata) const {
-    std::unordered_multimap<inet_address, dht::token_range> address_ranges = strategy.get_address_ranges(unpimplified_this).get0();
-    // get all ranges that will be affected by leaving nodes
-    std::unordered_set<range<token>> affected_ranges;
-    for (auto endpoint : _leaving_endpoints) {
-        auto r = address_ranges.equal_range(endpoint);
-        for (auto x = r.first; x != r.second; x++) {
-            affected_ranges.emplace(x->second);
-        }
-    }
-    // for each of those ranges, find what new nodes will be responsible for the range when
-    // all leaving nodes are gone.
-    auto metadata = token_metadata(std::make_unique<token_metadata_impl>(clone_only_token_map().get0()));
-    auto affected_ranges_size = affected_ranges.size();
-    tlogger.debug("In calculate_pending_ranges: affected_ranges.size={} stars", affected_ranges_size);
-    for (const auto& r : affected_ranges) {
-        auto t = r.end() ? r.end()->value() : dht::maximum_token();
-        auto current_endpoints = strategy.calculate_natural_endpoints(t, metadata).get0();
-        auto new_endpoints = strategy.calculate_natural_endpoints(t, *all_left_metadata).get0();
-        std::vector<inet_address> diff;
-        std::sort(current_endpoints.begin(), current_endpoints.end());
-        std::sort(new_endpoints.begin(), new_endpoints.end());
-        std::set_difference(new_endpoints.begin(), new_endpoints.end(),
-            current_endpoints.begin(), current_endpoints.end(), std::back_inserter(diff));
-        for (auto& ep : diff) {
-            new_pending_ranges.emplace(r, ep);
-        }
-        seastar::thread::maybe_yield();
-    }
-    metadata.clear_gently().get();
-    tlogger.debug("In calculate_pending_ranges: affected_ranges.size={} ends", affected_ranges_size);
-}
-
-// Called from a seastar thread
-void token_metadata_impl::calculate_pending_ranges_for_replacing(
-        const token_metadata& unpimplified_this,
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges) const {
-    if (_replacing_endpoints.empty()) {
-        return;
-    }
-    auto address_ranges = strategy.get_address_ranges(unpimplified_this).get0();
-    for (const auto& node : _replacing_endpoints) {
-        auto existing_node = node.first;
-        auto replacing_node = node.second;
-        for (const auto& x : address_ranges) {
-            seastar::thread::maybe_yield();
-            if (x.first == existing_node) {
-                tlogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x.second);
-                new_pending_ranges.emplace(x.second, replacing_node);
-            }
-        }
-    }
-}
-
-// Called from a seastar thread
-void token_metadata_impl::calculate_pending_ranges_for_bootstrap(
-        const abstract_replication_strategy& strategy,
-        std::unordered_multimap<range<token>, inet_address>& new_pending_ranges,
-        mutable_token_metadata_ptr all_left_metadata) const {
-    // For each of the bootstrapping nodes, simply add and remove them one by one to
-    // allLeftMetadata and check in between what their ranges would be.
-    std::unordered_multimap<inet_address, token> bootstrap_addresses;
-    for (auto& x : _bootstrap_tokens) {
-        bootstrap_addresses.emplace(x.second, x.first);
-    }
-
-    // TODO: share code with unordered_multimap_to_unordered_map
-    std::unordered_map<inet_address, std::unordered_set<token>> tmp;
-    for (auto& x : bootstrap_addresses) {
-        auto& addr = x.first;
-        auto& t = x.second;
-        tmp[addr].insert(t);
-    }
-    for (auto& x : tmp) {
-        auto& endpoint = x.first;
-        auto& tokens = x.second;
-        all_left_metadata->update_normal_tokens(tokens, endpoint).get();
-        for (auto& x : strategy.get_address_ranges(*all_left_metadata, endpoint).get0()) {
-            new_pending_ranges.emplace(x.second, endpoint);
-        }
-        all_left_metadata->_impl->remove_endpoint(endpoint);
-    }
-    all_left_metadata->_impl->sort_tokens();
-}
-
-future<> token_metadata_impl::update_pending_ranges(
-        const token_metadata& unpimplified_this,
-        const abstract_replication_strategy& strategy, const sstring& keyspace_name) {
-    tlogger.debug("calculate_pending_ranges: keyspace_name={}, bootstrap_tokens={}, leaving nodes={}, replacing_endpoints={}",
-        keyspace_name, _bootstrap_tokens, _leaving_endpoints, _replacing_endpoints);
-    if (_bootstrap_tokens.empty() && _leaving_endpoints.empty() && _replacing_endpoints.empty()) {
-        tlogger.debug("No bootstrapping, leaving nodes, replacing nodes -> empty pending ranges for {}", keyspace_name);
-        set_pending_ranges(keyspace_name, std::unordered_multimap<range<token>, inet_address>(), can_yield::no);
-        return make_ready_future<>();
-    }
-
-    return async([this, &unpimplified_this, &strategy, keyspace_name] () mutable {
-        std::unordered_multimap<range<token>, inet_address> new_pending_ranges;
-        calculate_pending_ranges_for_replacing(unpimplified_this, strategy, new_pending_ranges);
-        // Copy of metadata reflecting the situation after all leave operations are finished.
-        auto all_left_metadata = make_token_metadata_ptr(std::make_unique<token_metadata_impl>(clone_after_all_left().get0()));
-        calculate_pending_ranges_for_leaving(unpimplified_this, strategy, new_pending_ranges, all_left_metadata);
-        // At this stage newPendingRanges has been updated according to leave operations. We can
-        // now continue the calculation by checking bootstrapping nodes.
-        calculate_pending_ranges_for_bootstrap(strategy, new_pending_ranges, all_left_metadata);
-        all_left_metadata->clear_gently().get();
-
-        // At this stage newPendingRanges has been updated according to leaving and bootstrapping nodes.
-        set_pending_ranges(keyspace_name, std::move(new_pending_ranges), can_yield::yes);
-    });
-
-}
-
 size_t token_metadata_impl::count_normal_token_owners() const {
     std::set<inet_address> eps;
     for (auto [t, ep]: _token_to_endpoint_map) {
@@ -927,30 +709,6 @@ void token_metadata_impl::del_replacing_endpoint(inet_address existing_node) {
                 _replacing_endpoints[existing_node], existing_node);
     }
     _replacing_endpoints.erase(existing_node);
-}
-
-inet_address_vector_topology_change token_metadata_impl::pending_endpoints_for(const token& token, const sstring& keyspace_name) const {
-    // Fast path 0: pending ranges not found for this keyspace_name
-    const auto pr_it = _pending_ranges_interval_map.find(keyspace_name);
-    if (pr_it == _pending_ranges_interval_map.end()) {
-        return {};
-    }
-
-    // Fast path 1: empty pending ranges for this keyspace_name
-    const auto& ks_map = pr_it->second;
-    if (ks_map.empty()) {
-        return {};
-    }
-
-    // Slow path: lookup pending ranges
-    inet_address_vector_topology_change endpoints;
-    auto interval = range_to_interval(range<dht::token>(token));
-    const auto it = ks_map.find(interval);
-    if (it != ks_map.end()) {
-        // interval_map does not work with std::vector, convert to std::vector of ips
-        endpoints = inet_address_vector_topology_change(it->second.begin(), it->second.end());
-    }
-    return endpoints;
 }
 
 std::map<token, inet_address> token_metadata_impl::get_normal_and_bootstrapping_token_to_endpoint_map() const {
@@ -1025,6 +783,11 @@ token_metadata::get_token_to_endpoint() const {
 const std::unordered_set<inet_address>&
 token_metadata::get_leaving_endpoints() const {
     return _impl->get_leaving_endpoints();
+}
+
+const std::unordered_map<inet_address, inet_address>&
+token_metadata::get_replacing_endpoints() const noexcept {
+    return _impl->get_replacing_endpoints();
 }
 
 const std::unordered_map<token, inet_address>&
@@ -1190,16 +953,6 @@ token_metadata::interval_to_range(boost::icl::interval<token>::interval_type i) 
     return token_metadata_impl::interval_to_range(std::move(i));
 }
 
-bool
-token_metadata::has_pending_ranges(sstring keyspace_name, inet_address endpoint) const {
-    return _impl->has_pending_ranges(std::move(keyspace_name), endpoint);
-}
-
-future<>
-token_metadata::update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name) {
-    return _impl->update_pending_ranges(*this, strategy, keyspace_name);
-}
-
 token
 token_metadata::get_predecessor(token t) const {
     return _impl->get_predecessor(t);
@@ -1213,11 +966,6 @@ token_metadata::get_all_endpoints() const {
 size_t
 token_metadata::count_normal_token_owners() const {
     return _impl->count_normal_token_owners();
-}
-
-inet_address_vector_topology_change
-token_metadata::pending_endpoints_for(const token& token, const sstring& keyspace_name) const {
-    return _impl->pending_endpoints_for(token, keyspace_name);
 }
 
 std::multimap<inet_address, token>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1939,7 +1939,7 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
     replica::keyspace& ks = _db.local().find_keyspace(keyspace_name);
     auto erm = ks.get_effective_replication_map();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm->get_token_metadata_ptr()->pending_endpoints_for(token, keyspace_name);
+    inet_address_vector_topology_change pending_endpoints = erm->pending_endpoints_for(token);
 
     slogger.trace("creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints, pending_endpoints);
     tracing::trace(tr_state, "Creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints ,pending_endpoints);
@@ -2264,7 +2264,7 @@ storage_proxy::get_paxos_participants(const sstring& ks_name, const dht::token &
     replica::keyspace& ks = _db.local().find_keyspace(ks_name);
     auto erm = ks.get_effective_replication_map();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm->get_token_metadata_ptr()->pending_endpoints_for(token, ks_name);
+    inet_address_vector_topology_change pending_endpoints = erm->pending_endpoints_for(token);
 
     if (cl_for_paxos == db::consistency_level::LOCAL_SERIAL) {
         auto itend = boost::range::remove_if(natural_endpoints, std::not_fn(std::cref(db::is_local)));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -386,10 +386,6 @@ void storage_service::join_token_ring(int delay) {
             sleep_abortable(std::chrono::seconds(1), _abort_source).get();
         }
         set_mode(mode::JOINING, "schema complete, ready to bootstrap", true);
-        set_mode(mode::JOINING, "waiting for pending range calculation", true);
-        update_pending_ranges("joining").get();
-        set_mode(mode::JOINING, "calculation complete, ready to bootstrap", true);
-        slogger.debug("... got ring + schema info");
 
         auto t = gms::gossiper::clk::now();
         auto tmptr = get_token_metadata_ptr();
@@ -413,7 +409,6 @@ void storage_service::join_token_ring(int delay) {
                 set_mode(mode::JOINING, "waiting for schema information to complete", true);
                 sleep_abortable(std::chrono::seconds(1), _abort_source).get();
             }
-            update_pending_ranges("bootstrapping/leaving nodes while joining").get();
             tmptr = get_token_metadata_ptr();
         }
         slogger.info("Checking bootstrapping/leaving nodes: ok");
@@ -632,11 +627,11 @@ void storage_service::bootstrap() {
       if (!bootstrap_rbno) {
         // When is_repair_based_node_ops_enabled is true, the bootstrap node
         // will use node_ops_cmd to bootstrap, node_ops_cmd will update the pending ranges.
-        slogger.debug("bootstrap: update pending ranges: endpoint={} bootstrap_tokens={}", get_broadcast_address(), _bootstrap_tokens);
+        slogger.debug("bootstrap: endpoint={} bootstrap_tokens={}", get_broadcast_address(), _bootstrap_tokens);
         mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
             auto endpoint = get_broadcast_address();
             tmptr->add_bootstrap_tokens(_bootstrap_tokens, endpoint);
-            return update_pending_ranges(std::move(tmptr), format("bootstrapping node {}", endpoint));
+            return make_ready_future<>();
         }).get();
       }
 
@@ -766,7 +761,6 @@ future<> storage_service::handle_state_replacing_update_pending_ranges(mutable_t
                 replacing_node, std::current_exception());
     }
     slogger.info("handle_state_replacing: Update pending ranges for replacing node {}", replacing_node);
-    co_await update_pending_ranges(tmptr, format("handle_state_replacing {}", replacing_node));
 }
 
 future<> storage_service::handle_state_replacing(inet_address replacing_node) {
@@ -827,7 +821,6 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
     }
-    co_await update_pending_ranges(tmptr, format("handle_state_bootstrap {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -916,7 +909,6 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
     // a race where natural endpoint was updated to contain node A, but A was
     // not yet removed from pending endpoints
     co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
-    co_await update_pending_ranges(tmptr, format("handle_state_normal {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -979,7 +971,6 @@ future<> storage_service::handle_state_leaving(inet_address endpoint) {
     // normally
     tmptr->add_leaving_endpoint(endpoint);
 
-    co_await update_pending_ranges(tmptr, format("handle_state_leaving", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -1036,7 +1027,7 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
                 slogger.debug("Tokens {} removed manually (endpoint was {})", remove_tokens, endpoint);
                 // Note that the endpoint is being removed
                 tmptr->add_leaving_endpoint(endpoint);
-                return update_pending_ranges(std::move(tmptr), format("handle_state_removing {}", endpoint));
+                return make_ready_future<>();
             });
             // find the endpoint coordinating this removal that we need to notify when we're done
             auto* value = _gossiper.get_application_state_ptr(endpoint, application_state::REMOVAL_COORDINATOR);
@@ -1159,7 +1150,6 @@ future<> storage_service::on_remove(gms::inet_address endpoint) {
     auto tmlock = co_await get_token_metadata_lock();
     auto tmptr = co_await get_mutable_token_metadata_ptr();
     tmptr->remove_endpoint(endpoint);
-    co_await update_pending_ranges(tmptr, format("on_remove {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -1847,11 +1837,10 @@ future<> storage_service::decommission() {
                 throw std::runtime_error(format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
             }
 
-            ss.update_pending_ranges(format("decommission {}", endpoint)).get();
-
             auto non_system_keyspaces = db.get_non_system_keyspaces();
             for (const auto& keyspace_name : non_system_keyspaces) {
-                if (ss.get_token_metadata().has_pending_ranges(keyspace_name, ss.get_broadcast_address())) {
+                auto erm = db.find_keyspace(keyspace_name).get_effective_replication_map();
+                if (erm->has_pending_ranges(ss.get_broadcast_address())) {
                     throw std::runtime_error("data is currently moving to this node; unable to leave the ring");
                 }
             }
@@ -2382,21 +2371,23 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("removenode[{}]: adding leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& node : req.leaving_nodes) {
                     slogger.info("removenode[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, format("removenode {}", req.leaving_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("removenode[{}]: removing leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& node : req.leaving_nodes) {
                         slogger.info("removenode[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, format("removenode {}", req.leaving_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
@@ -2431,21 +2422,23 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("decommission[{}]: adding leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& node : req.leaving_nodes) {
                     slogger.info("decommission[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, format("decommission {}", req.leaving_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("decommission[{}]: removing leaving nodes: {}", req.ops_uuid, req.leaving_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& node : req.leaving_nodes) {
                         slogger.info("decommission[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, format("decommission {}", req.leaving_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
@@ -2471,6 +2464,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("replace[{}]: adding replacing_nodes={}", req.ops_uuid, req.replace_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: req.replace_nodes) {
                     auto existing_node = x.first;
@@ -2482,6 +2476,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("replace[{}]: removing replacing_nodes={}", req.ops_uuid, req.replace_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& x: req.replace_nodes) {
                         auto existing_node = x.first;
@@ -2489,7 +2484,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("replace[{}]: Removed replacing_node={} to replace existing_node={}, coordinator={}", req.ops_uuid, replacing_node, existing_node, coordinator);
                         tmptr->del_replacing_endpoint(existing_node);
                     }
-                    return update_pending_ranges(tmptr, format("replace {}", req.replace_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
@@ -2507,9 +2502,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
         } else if (req.cmd == node_ops_cmd::replace_prepare_pending_ranges) {
             // Update the pending_ranges for the replacing node
             slogger.debug("replace[{}]: Updated pending_ranges from coordinator={}", req.ops_uuid, coordinator);
-            mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
-                return update_pending_ranges(tmptr, format("replace {}", req.replace_nodes));
-            }).get();
         } else if (req.cmd == node_ops_cmd::replace_heartbeat) {
             slogger.debug("replace[{}]: Updated heartbeat from coordinator={}", req.ops_uuid, coordinator);
             node_ops_update_heartbeat(ops_uuid);
@@ -2525,6 +2517,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 slogger.warn("{}", msg);
                 throw std::runtime_error(msg);
             }
+            slogger.debug("bootstrap[{}]: adding bootstrap_nodes={}", req.ops_uuid, req.bootstrap_nodes);
             mutate_token_metadata([coordinator, &req, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: req.bootstrap_nodes) {
                     auto& endpoint = x.first;
@@ -2532,10 +2525,11 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     slogger.info("bootstrap[{}]: Added node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
                     tmptr->add_bootstrap_tokens(tokens, endpoint);
                 }
-                return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));
+                return make_ready_future<>();
             }).get();
             auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, false, std::move(req.ignore_nodes)});
             auto meta = node_ops_meta_data(ops_uuid, coordinator, std::move(ops), [this, coordinator, req = std::move(req)] () mutable {
+                slogger.debug("bootstrap[{}]: removing bootstrap_nodes={}", req.ops_uuid, req.bootstrap_nodes);
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& x: req.bootstrap_nodes) {
                         auto& endpoint = x.first;
@@ -2543,7 +2537,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("bootstrap[{}]: Removed node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
                         tmptr->remove_bootstrap_tokens(tokens);
                     }
-                    return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));
+                    return make_ready_future<>();
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
@@ -2883,7 +2877,6 @@ future<> storage_service::excise(std::unordered_set<token> tokens, inet_address 
     tmptr->remove_endpoint(endpoint);
     tmptr->remove_bootstrap_tokens(tokens);
 
-    co_await update_pending_ranges(tmptr, format("excise {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -2944,7 +2937,7 @@ future<> storage_service::leave_ring() {
     co_await mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
         auto endpoint = get_broadcast_address();
         tmptr->remove_endpoint(endpoint);
-        return update_pending_ranges(std::move(tmptr), format("leave_ring {}", endpoint));
+        return make_ready_future<>();
     });
 
     auto expire_time = _gossiper.compute_expire_time().time_since_epoch().count();
@@ -2984,10 +2977,11 @@ storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multim
 
 future<> storage_service::start_leaving() {
     return _gossiper.add_local_application_state(application_state::STATUS, versioned_value::leaving(db::system_keyspace::get_local_tokens().get0())).then([this] {
-        return mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
-            auto endpoint = get_broadcast_address();
+        auto endpoint = get_broadcast_address();
+        slogger.debug("start_leaving: endpoint={}", endpoint);
+        return mutate_token_metadata([this, endpoint] (mutable_token_metadata_ptr tmptr) {
             tmptr->add_leaving_endpoint(endpoint);
-            return update_pending_ranges(std::move(tmptr), format("start_leaving {}", endpoint));
+            return make_ready_future<>();
         });
     });
 }
@@ -3157,44 +3151,21 @@ future<> storage_service::mutate_token_metadata(std::function<future<> (mutable_
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
-future<> storage_service::update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason) {
-    assert(this_shard_id() == 0);
-
-    // long start = System.currentTimeMillis();
-    return do_with(_db.local().get_non_system_keyspaces(), [this, tmptr = std::move(tmptr)] (auto& keyspaces) mutable {
-        return do_for_each(keyspaces, [this, tmptr = std::move(tmptr)] (auto& keyspace_name) mutable {
-            auto& ks = this->_db.local().find_keyspace(keyspace_name);
-            auto& strategy = ks.get_replication_strategy();
-            slogger.debug("Updating pending ranges for keyspace={} starts", keyspace_name);
-            return tmptr->update_pending_ranges(strategy, keyspace_name).finally([&keyspace_name] {
-                slogger.debug("Updating pending ranges for keyspace={} ends", keyspace_name);
-            });
-        });
-    }).handle_exception([this, reason = std::move(reason)] (std::exception_ptr ep) mutable {
-        slogger.error("Failed to update pending ranges for {}: {}", reason, ep);
-        return make_exception_future<>(std::move(ep));
-    });
-    // slogger.debug("finished calculation for {} keyspaces in {}ms", keyspaces.size(), System.currentTimeMillis() - start);
-}
-
-future<> storage_service::update_pending_ranges(sstring reason, acquire_merge_lock acquire_merge_lock) {
-    return mutate_token_metadata([this, reason = std::move(reason)] (mutable_token_metadata_ptr tmptr) mutable {
-        return update_pending_ranges(std::move(tmptr), std::move(reason));
-    }, acquire_merge_lock);
-}
-
 future<> storage_service::keyspace_changed(const sstring& ks_name) {
     // Update pending ranges since keyspace can be changed after we calculate pending ranges.
-    sstring reason = format("keyspace {}", ks_name);
-    return container().invoke_on(0, [reason = std::move(reason)] (auto& ss) mutable {
-        return ss.update_pending_ranges(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
-            slogger.warn("Failure to update pending ranges for {} ignored", reason);
+    slogger.debug("keyspace {} changed", ks_name);
+    return container().invoke_on(0, [ks_name] (auto& ss) mutable {
+        return ss.mutate_token_metadata([] (mutable_token_metadata_ptr) {
+            return make_ready_future<>();
+        }, acquire_merge_lock::no).handle_exception([ks_name = std::move(ks_name)] (auto ep) {
+            slogger.warn("Failure to update pending ranges for keyspace {} ignored", ks_name);
         });
     });
 }
 
 future<> storage_service::update_topology(inet_address endpoint) {
     return container().invoke_on(0, [endpoint] (auto& ss) {
+        slogger.debug("update_topology: {}", endpoint);
         return ss.mutate_token_metadata([&ss, endpoint] (mutable_token_metadata_ptr tmptr) mutable {
             // re-read local rack and DC info
             tmptr->update_topology(endpoint);
@@ -3524,7 +3495,8 @@ future<> storage_service::notify_cql_change(inet_address endpoint, bool ready) {
 future<bool> storage_service::is_cleanup_allowed(sstring keyspace) {
     return container().invoke_on(0, [keyspace = std::move(keyspace)] (storage_service& ss) {
         auto my_address = ss.get_broadcast_address();
-        auto pending_ranges = ss.get_token_metadata().has_pending_ranges(keyspace, my_address);
+        auto erm = ss._db.local().find_keyspace(keyspace).get_effective_replication_map();
+        auto pending_ranges = erm->has_pending_ranges(my_address);
         bool is_bootstrap_mode = ss._is_bootstrap_mode;
         slogger.debug("is_cleanup_allowed: keyspace={}, is_bootstrap_mode={}, pending_ranges={}",
                 keyspace, is_bootstrap_mode, pending_ranges);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1837,13 +1837,11 @@ future<> storage_service::decommission() {
                 throw std::runtime_error(format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
             }
 
-            auto non_system_keyspaces = db.get_non_system_keyspaces();
-            for (const auto& keyspace_name : non_system_keyspaces) {
-                auto erm = db.find_keyspace(keyspace_name).get_effective_replication_map();
-                if (erm->has_pending_ranges(ss.get_broadcast_address())) {
+            ss.get_erm_factory().do_for_each([endpoint] (const locator::effective_replication_map& erm) {
+                if (erm.has_pending_ranges(endpoint)) {
                     throw std::runtime_error("data is currently moving to this node; unable to leave the ring");
                 }
-            }
+            }).get();
 
             slogger.info("DECOMMISSIONING: starts");
             auto leaving_nodes = std::list<gms::inet_address>{endpoint};

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -212,11 +212,6 @@ private:
     // Note: must be called on shard 0.
     future<> mutate_token_metadata(std::function<future<> (mutable_token_metadata_ptr)> func, acquire_merge_lock aml = acquire_merge_lock::yes) noexcept;
 
-    // Update pending ranges locally and then replicate to all cores.
-    // Should be serialized under token_metadata_lock.
-    // Must be called on shard 0.
-    future<> update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason);
-    future<> update_pending_ranges(sstring reason, acquire_merge_lock aml = acquire_merge_lock::yes);
     future<> keyspace_changed(const sstring& ks_name);
     void register_metrics();
     future<> snitch_reconfigured();


### PR DESCRIPTION
This pull request contains the first part of the series requested in #9703 ([effective_replication_map-pending_ranges-v6](https://github.com/bhalevy/scylla/commits/effective_replication_map-pending_ranges-v6))
which was dequeued due to a failure in https://jenkins.scylladb.com/job/scylla-master/job/next/4454/testReport/cdc_test/TestCdc/dtest___test_cluster_expansion_with_cdc/

Part 1 is focused on moving the pending ranges code form the `token_metadata` class into `effective_replication_map` and converting decommission to scan the e_r_m factory for pending ranges rather than inefficiently call `has_pending_ranges` for every keyspace.

Test: unit(dev)
DTest: cdc_test.py::TestCdc::test_cluster_expansion_with_cdc