### PR TITLE
RFC: Commitlog refactor: message loop v2

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1902,6 +1902,12 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
 
         sm::make_gauge("active_allocations", totals.active_allocations,
                        sm::description("Current number of active allocations.")),
+                       
+        sm::make_gauge("message_queue_length", [this] { return _message_queue.size(); },
+                       sm::description("Pending, unprocessed messages in commitlog action queue")),
+
+        sm::make_gauge("write_queue_length", [this] { return _write_queue.size(); },
+                       sm::description("Pending, unprocessed write commands in commitlog IO queue")),
     });
 }
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -301,7 +301,7 @@ SEASTAR_TEST_CASE(test_commitlog_delete_when_over_disk_limit) {
     constexpr auto max_size_mb = 2;
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 1;
-    cfg.commitlog_sync_period_in_ms = 1;
+    cfg.commitlog_sync_period_in_ms = 1000;
     return cl_test(cfg, [](commitlog& log) {
             auto sem = make_lw_shared<semaphore>(0);
             auto segments = make_lw_shared<std::set<sstring>>();
@@ -761,7 +761,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_in_recycle) {
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
-    cfg.commitlog_sync_period_in_ms = 10;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -836,7 +835,6 @@ SEASTAR_TEST_CASE(test_commitlog_shutdown_during_wait) {
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
-    cfg.commitlog_sync_period_in_ms = 10;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -903,7 +901,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
 
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
-    cfg.commitlog_sync_period_in_ms = 10;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -952,7 +949,6 @@ static future<> do_test_exception_in_allocate_ex(bool do_file_delete) {
 
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
-    cfg.commitlog_sync_period_in_ms = 10;
     cfg.allow_going_over_size_limit = false; // #9348 - now can enforce size limit always
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -289,7 +289,7 @@ SEASTAR_TEST_CASE(test_commitlog_closed) {
             return log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [tmp](db::commitlog::output& dst) {
                 dst.write(tmp.data(), tmp.size());
             }).then_wrapped([] (future<db::rp_handle> f) {
-                BOOST_REQUIRE_EXCEPTION(f.get(), gate_closed_exception, exception_predicate::message_equals("gate closed"));
+                BOOST_REQUIRE_EXCEPTION(f.get(), std::runtime_error, exception_predicate::message_equals("Commitlog has been shut down. Cannot add data"));
             });
         });
     });

--- a/utils/waitable_counter.hh
+++ b/utils/waitable_counter.hh
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <map>
+#include <iosfwd>
+#include <exception>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/condition-variable.hh>
+
+#include "seastarx.hh"
+
+namespace utils {
+
+/**
+ * Simple counter type wrapper, that allows
+ * waiting for it to reach a given value.
+ * 
+ * Actual content must be monotonically 
+ * increasing. 
+ * 
+ * Waiting using future<> wait routines
+ * is less efficient than using coroutine
+ * when(..) calls, as the former can cause
+ * spurious wakeups wheras the latter will 
+ * not.
+ */
+template<typename T, typename Cmp = std::less<T>>
+class waitable_counter {
+private:
+    T _value;
+    condition_variable _cond;
+    Cmp _cmp;
+
+    template<std::invocable<> Func>
+    waitable_counter& set(T v, Func&& f) {
+        if (_cmp(v, _value)) {
+            throw std::invalid_argument("Values must be monotonically increasing");
+        }
+        _value = std::move(v);
+        f();
+        return *this;
+    }
+
+public:
+    waitable_counter(T&& t = {}, Cmp cmp = {})
+        : _value(t)
+        , _cmp(std::move(cmp))
+    {}
+
+    /**
+     * Waits for the counter to reach pos, or timeout
+     */
+    template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration>
+    future<> wait(const T& pos, std::chrono::time_point<Clock, Duration> timeout) {
+        return _cond.wait(timeout, [this, pos] { return !_cmp(_value, pos); });
+    }
+
+    /**
+     * Waits for the counter to reach pos
+     */
+    future<> wait(const T& pos) {
+        return _cond.wait([this, pos] { return !_cmp(_value, pos); });
+    }
+
+    /**
+     * Waits for the counter to reach pos, or timeout (co-routine only)
+     * Note: the coroutine versions are supoerior in every sense, since 
+     * they are immune to suprious wakeups (go condition-var::when).
+     */
+    template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration>
+    auto when(const T& pos, std::chrono::time_point<Clock, Duration> timeout) {
+        return _cond.when(timeout, [this, pos] { return !_cmp(_value, pos); });
+    }
+
+    /**
+     * Waits for the counter to reach pos (co-routine only)
+     */
+    auto when(const T& pos) {
+        return _cond.when([this, pos] { return !_cmp(_value, pos); });
+    }
+
+    /**
+     * Sets the new counter value, notifying
+     * any waiting entities (for values <= v)
+     * 
+     * v must be >= current value.
+     */
+    waitable_counter& set(T v) {
+        return set(std::move(v), [&] {
+            _cond.broadcast();
+        });
+    }
+
+    /**
+     * Signals all waiters at v or below
+     * with exception. Current value is updated 
+     * to v, thus waits after this will pass
+     * as if successful.
+     */
+    waitable_counter& set_exception(T v, std::exception_ptr e) {
+        return set(std::move(v), [&] {
+            _cond.broken(e);
+        });
+    }
+
+    operator const T&() const {
+        return _value;
+    }
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const waitable_counter<T>& t) {
+    const T& v = t;
+    return os << v;
+}
+
+}


### PR DESCRIPTION
A new take on trying to move operations in commit log into a "message loop" construct, i.e. "requests/tasks", but now split into two distinct execution fibers: "controller" and "writing". Also, now all operations (except shutdown) are executed fully serialized. I.e. we finish message A before getting to message B. 

This means theoretically that we could utilize slightly less bandwidth for write than existing code, but semi-relevant experiments/observations show that we only really have parallel write executions on segment spin-up and close/termination. 
Thus this part of IO (which is less latency sensitive) is handled by the "main" loop, not the dedicated IO one, which only deals with low-latency write/flush stuff. 

Note this is RFC. Needs rebasing, as it is based on previous refactor branch, and can probably do with a little cleanup. 
The idea is to enable further simplification due to the now more serialized nature of the ops. 

See #9222 for the first version/discussion. 
Requires seastar patch "Add basic_condition_variable templated on clock type"

Significant differences: 
* "message queue" is now just a seastar::circular_buffer + condition variable.
* two "queues": one for latency-sensistive writing, one for periodic flushing, segment managemen, alloc, close, terminate etc.
* All ops fully serialized, except shutdown which is partially parallel, and replenish, which is a "background" fiber still.