### PR TITLE
db,docs: set alternator default write policy

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -865,7 +865,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")
     , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforce checking the authorization header for every request in Alternator")
-    , alternator_write_isolation(this, "alternator_write_isolation", value_status::Used, "", "Default write isolation policy for Alternator")
+    , alternator_write_isolation(this, "alternator_write_isolation", value_status::Used, "always_use_lwt", "Default write isolation policy for Alternator")
     , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", value_status::Used, 10000,
         "The server-side timeout for completing Alternator API requests.")

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -75,10 +75,10 @@ So Alternator supports four _write isolation policies_, which can be chosen
 on a per-table basis and may make sense for certain workloads as explained
 below.
 
-A default write isolation policy **must** be chosen using the
-`--alternator-write-isolation` configuration option. Additionally, the write
-isolation policy for a specific table can be overridden by tagging the table
-(at CreateTable time, or any time later with TagResource) with the key
+A default write isolation policy is `always_use_lwt`, and it can be overwritten
+using the `--alternator-write-isolation` configuration option. Additionally,
+the write isolation policy for a specific table can be overridden by tagging
+the table (at CreateTable time, or any time later with TagResource) with the key
 `system:write_isolation`, and one of the following values:
 
   * `a`, `always`, or `always_use_lwt` - This mode performs every write

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -46,13 +46,14 @@ non-LWT write. Furthermore, if Alternator is told that a certain workload
 does have do both write-only and read-modify-write, but to *different* items,
 it could use LWT only for the read-modify-write operations.
 
-Therefore, Alternator must be explicitly configured to tell it which of the
+Therefore, Alternator can be explicitly configured to tell it which of the
 above assumptions it may make on the write workload. This configuration is
-mandatory, and described in the "Write isolation policies" section of
-alternator.md. One of the options, `always_use_lwt`, is always safe, but the
-other options result in significantly better write performance and should be
-considered when the workload involves pure writes (e.g., ingestion of new
-data) or if pure writes and read-modify-writes go to distinct items.
+optional, defaults to `always_use_lwt`, and is described in the
+"Write isolation policies" section of alternator.md. One of the options,
+`always_use_lwt`, is always safe, but the other options result in significantly
+better write performance and should be considered when the workload involves
+pure writes (e.g., ingestion of new data) or if pure writes and read-modify-writes
+go to distinct items.
 
 ## Authorization
 


### PR DESCRIPTION
This commit sets the default isolation policy for alternator.
Previously, users were required to explicitly choose their isolation
policy, but that adds another step to the quickstart process
and can slow the actual adoption, as users might find the choice
to be too complicated to bother. 