### PR TITLE
WIP: raft: automatically join group0 when upgrading the cluster and switch to raft-based schema changes

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -145,6 +145,11 @@ this:
   groups, hence failure detection RPC could run once on network peer level,
   not sepately for each Raft instance. The library expects an accurate
   `failure_detector` instance from a complying implementation.
+- Since Raft leader no longer sends RPC every  0.1 second there can be a
+  situation when a follower may not know who the leader is for a long time
+  (if the leader is idle). Add an extension that allows a follower to actively
+  search for a leader by sending specially crafted append reply RPC to all voters.
+  A leader will reply with an empty append message to such a message.
 
 ### Pre-voting and protection against disruptive leaders
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -337,6 +337,7 @@ future<> server_impl::wait_for_leader(seastar::abort_source* as) {
     }
 
     logger.trace("[{}] the leader is unknown, waiting through uncertainty", id());
+    _fsm->ping_leader();
     if (!_leader_promise) {
         _leader_promise.emplace();
     }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -140,7 +140,7 @@ void migration_manager::init_messaging_service()
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
-        if (self._raft_gr.is_enabled() && options->group0_snapshot_transfer) {
+        if (self.is_raft_enabled() && options->group0_snapshot_transfer) {
             // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
             // (`group0_snapshot_transfer` was added more recently).
             if (!cm_retval_supported) {
@@ -1077,7 +1077,7 @@ future<> migration_manager::announce_without_raft(std::vector<mutation> schema) 
 
 // Returns a future on the local application of the schema
 future<> migration_manager::announce(std::vector<mutation> schema, group0_guard guard, std::string_view description) {
-    if (_raft_gr.is_enabled()) {
+    if (is_raft_enabled()) {
         if (this_shard_id() != 0) {
             // This should not happen since all places which construct `group0_guard` also check that they are on shard 0.
             // Note: `group0_guard::impl` is private to this module, making this easy to verify.
@@ -1109,7 +1109,7 @@ static utils::UUID generate_group0_state_id(utils::UUID prev_state_id) {
 }
 
 future<group0_guard> migration_manager::start_group0_operation() {
-    if (_raft_gr.is_enabled()) {
+    if (is_raft_enabled()) {
         if (this_shard_id() != 0) {
             on_internal_error(mlogger, "start_group0_operation: must run on shard 0");
         }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -193,7 +193,7 @@ public:
     future<group0_guard> start_group0_operation();
 
     // used to check if raft is enabled on the cluster
-    bool is_raft_enabled() { return _raft_gr.is_enabled(); }
+    bool is_raft_enabled() { return _raft_gr.joined_group0(); }
 
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -177,7 +177,7 @@ future<> raft_group0::join_group0() {
     // do nothing either if raft group registry is not enabled or we've already
     // finished joining some existing group0, so that subsequent calls
     // to the function are safe.
-    if (!_raft_gr.is_enabled() || std::holds_alternative<raft::group_id>(_group0)) {
+    if (!_raft_gr.is_enabled() || joined_group0()) {
         co_return;
     }
     auto my_addr = co_await load_or_create_my_addr();
@@ -326,6 +326,10 @@ future<group0_peer_exchange> raft_group0::peer_exchange(discovery::peer_list pee
             }};
         }
     }, _group0);
+}
+
+bool raft_group0::joined_group0() const {
+    return std::holds_alternative<raft::group_id>(_group0);
 }
 
 static constexpr auto DISCOVERY_KEY = "peers";

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -114,6 +114,8 @@ public:
 
     // Handle peer_exchange RPC
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
+
+    bool joined_group0() const;
 };
 
 } // end of namespace service

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -24,23 +24,8 @@ raft_group_registry::raft_group_registry(bool is_enabled, netw::messaging_servic
     : _is_enabled(is_enabled)
     , _ms(ms)
     , _fd(make_shared<raft_gossip_failure_detector>(gossiper, _srv_address_mappings))
-    , _raft_support_listener(feat.cluster_supports_raft_cluster_mgmt().when_enabled([this, &feat, &gossiper] {
-        // If the `USES_RAFT_CLUSTER_MANAGEMENT` feature was already enabled, do nothing.
-        //
-        // This can happen if the current node is either a fresh node in an empty cluster
-        // or a restarting node, which is already part of an existing group0.
-        if (!_is_enabled || feat.cluster_uses_raft_cluster_mgmt()) {
-            return;
-        }
-        // When the cluster fully supports raft-based cluster management,
-        // we can re-enable support for the second gossip feature to trigger
-        // actual use of raft-based cluster management procedures.
-        feat.support(gms::features::USES_RAFT_CLUSTER_MANAGEMENT).get();
-        if (this_shard_id() == 0) {
-            // When the supported feature set is dynamically extended, re-advertise it through the gossip.
-            gossiper.add_local_application_state(gms::application_state::SUPPORTED_FEATURES,
-                gms::versioned_value::supported_features(feat.supported_feature_set())).get();
-        }
+    , _raft_support_listener(feat.cluster_supports_raft_cluster_mgmt().when_enabled([] {
+        // TODO: join group 0 on upgrade
     }))
 {
 }

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -8,6 +8,7 @@
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/raft_rpc.hh"
 #include "service/raft/raft_gossip_failure_detector.hh"
+#include "service/raft/raft_group0.hh"
 #include "message/messaging_service.hh"
 #include "serializer_impl.hh"
 #include "idl/raft.dist.hh"
@@ -24,8 +25,10 @@ raft_group_registry::raft_group_registry(bool is_enabled, netw::messaging_servic
     : _is_enabled(is_enabled)
     , _ms(ms)
     , _fd(make_shared<raft_gossip_failure_detector>(gossiper, _srv_address_mappings))
-    , _raft_support_listener(feat.cluster_supports_raft_cluster_mgmt().when_enabled([] {
-        // TODO: join group 0 on upgrade
+    , _raft_support_listener(feat.cluster_supports_raft_cluster_mgmt().when_enabled([this] {
+        if (_group0) {
+            _group0->join_group0().get();
+        }
     }))
 {
 }

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -249,4 +249,8 @@ unsigned raft_group_registry::shard_for_group(const raft::group_id& gid) const {
     return 0; // schema raft server is always owned by shard 0
 }
 
+bool raft_group_registry::joined_group0() const {
+    return _group0 && _group0->joined_group0();
+}
+
 } // end of namespace service

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -106,6 +106,8 @@ public:
     bool is_enabled() const { return _is_enabled; }
 
     void bind_group0_discovery_impl(service::raft_group0& gr0) { _group0 = &gr0; }
+
+    bool joined_group0() const;
 };
 
 } // end of namespace service

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -24,6 +24,7 @@ namespace service {
 class raft_rpc;
 class raft_sys_table_storage;
 class raft_gossip_failure_detector;
+class raft_group0;
 
 struct raft_group_not_found: public raft::error {
     raft::group_id gid;
@@ -68,6 +69,9 @@ private:
     // Group 0 id, valid only on shard 0 after boot is over
     std::optional<raft::group_id> _group0_id;
 
+    // Is set in `storage_service::init_server()`
+    service::raft_group0* _group0 = nullptr;
+
     gms::feature::listener_registration _raft_support_listener;
 
 public:
@@ -100,6 +104,8 @@ public:
     raft_address_map<>& address_map() { return _srv_address_mappings; }
 
     bool is_enabled() const { return _is_enabled; }
+
+    void bind_group0_discovery_impl(service::raft_group0& gr0) { _group0 = &gr0; }
 };
 
 } // end of namespace service

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1319,6 +1319,8 @@ future<> storage_service::init_server(cql3::query_processor& qp) {
         _group0 = std::make_unique<raft_group0>(_abort_source, _raft_gr, _messaging.local(),
             _gossiper, qp, _migration_manager.local());
 
+        _raft_gr.bind_group0_discovery_impl(*_group0);
+
         std::unordered_set<inet_address> loaded_endpoints;
         if (_db.local().get_config().load_ring_state()) {
             slogger.info("Loading persisted ring state");


### PR DESCRIPTION
Wire in `join_group0()` to be called when enabling `SUPPORTS_RAFT_CLUSTER_MANAGEMENT` feature.

Also, fix the check for migration manager to properly switch to using raft-based schema changes: it should check that the current node is a part of group0 instead of just checking that `raft_group_registry::is_enabled()` returns `true` (which can be so even if group0 is not formed yet). 

This PR is draft, since it is dependent on https://github.com/scylladb/scylla/pull/10380