### PR TITLE
commitlog_replayer: Add exception type for truncation case and throw+handle

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2693,6 +2693,9 @@ db::commitlog::read_log_file(sstring filename, sstring pfx, seastar::io_priority
                 if (corrupt_size > 0) {
                     throw segment_data_corruption_error("Data corruption", corrupt_size);
                 }
+            } catch (std::out_of_range&) {
+                // if we get an underflow, the file is somehow truncated/not fully created
+                p = std::make_exception_ptr(file_truncated_error{});
             } catch (...) {
                 p = std::current_exception();
             }

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -391,6 +391,14 @@ public:
         }
     };
 
+    class file_truncated_error : public segment_error {
+        static constexpr const char* _msg = "File truncated";
+    public:
+        virtual const char* what() const noexcept {
+            return _msg;
+        }
+    };
+
     static future<> read_log_file(sstring filename, sstring prefix, seastar::io_priority_class read_io_prio_class, commit_load_reader_func, position_type = 0, const db::extensions* = nullptr);
 private:
     commitlog(config);


### PR DESCRIPTION
Fixes #6653
    
If a file is either externally truncated or somehow not preallocated fully (not odsync?), such that when we replay we hit a buffer underflow in entry read, we should signal this wrapped, instead of just underlying out_of_range, then handle this as a recoverable/ignorable (but warned) exception in replayer, same as data corruption, not terminate server. Yes, there is possible data loss, but again, same as file corruption...

Does some partial co-routinization of replayer to make exception handling more sane, and adds test.