### PR TITLE
Accelerate lister::rmdir

### DIFF
--- a/test/boost/lister_test.cc
+++ b/test/boost/lister_test.cc
@@ -9,6 +9,8 @@
 #include <unordered_set>
 #include <fmt/format.h>
 
+#include <boost/range/irange.hpp>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/file.hh>

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -1,7 +1,11 @@
+#include <dirent.h>
+
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/defer.hh>
 #include "utils/lister.hh"
 #include "checked-file-impl.hh"
 
@@ -61,23 +65,112 @@ future<> lister::scan_dir(fs::path dir, lister::dir_entry_types type, lister::sh
     });
 }
 
+static std::vector<directory_entry> list_directory(int fd) {
+    std::vector<directory_entry> ret;
+    static constexpr size_t buffer_size = 8192;
+    char buffer[buffer_size];
+
+    // From getdents(2):
+    struct linux_dirent64 {
+        ino64_t        d_ino;    /* 64-bit inode number */
+        off64_t        d_off;    /* 64-bit offset to next structure */
+        unsigned short d_reclen; /* Size of this dirent */
+        unsigned char  d_type;   /* File type */
+        char           d_name[]; /* Filename (null-terminated) */
+    };
+
+    long count = ::syscall(__NR_getdents64, fd, reinterpret_cast<linux_dirent64*>(buffer), buffer_size);
+    if (count == -1) {
+        if (errno == ENOENT) {
+            return ret;
+        }
+        throw std::system_error(std::error_code(errno, std::system_category()));
+    }
+
+    for (long next = 0; next < count; ) {
+        auto de = reinterpret_cast<linux_dirent64*>(buffer + next);
+        next += de->d_reclen;
+        std::optional<directory_entry_type> type;
+        switch (de->d_type) {
+        case DT_BLK:
+            type = directory_entry_type::block_device;
+            break;
+        case DT_CHR:
+            type = directory_entry_type::char_device;
+            break;
+        case DT_DIR:
+            type = directory_entry_type::directory;
+            break;
+        case DT_FIFO:
+            type = directory_entry_type::fifo;
+            break;
+        case DT_REG:
+            type = directory_entry_type::regular;
+            break;
+        case DT_LNK:
+            type = directory_entry_type::link;
+            break;
+        case DT_SOCK:
+            type = directory_entry_type::socket;
+            break;
+        default:
+            // unknown, ignore
+            ;
+        }
+        sstring name = de->d_name;
+        if (name == "." || name == "..") {
+            continue;
+        }
+        ret.emplace_back(directory_entry{std::move(name), type});
+    }
+
+    return ret;
+}
+
 future<> lister::rmdir(fs::path dir) {
     // first, kill the contents of the directory
     llogger.debug("rmdir: {}", dir);
-    return lister::scan_dir(dir, {}, show_hidden::yes, [] (fs::path parent_dir, directory_entry de) mutable {
-        fs::path current_entry_path(parent_dir / de.name.c_str());
 
-        if (de.type.value() == directory_entry_type::directory) {
-            return rmdir(std::move(current_entry_path));
-        } else {
-            llogger.debug("rmdir: remove_file {}", current_entry_path);
-            return remove_file(current_entry_path.native());
+    int dirfd = ::open(dir.native().c_str(), O_DIRECTORY | O_CLOEXEC | O_RDONLY);
+    if (dirfd == -1) {
+        if (errno == ENOENT) {
+            co_return;
         }
-    }).then([dir] {
-        // ...then kill the directory itself
-        llogger.debug("rmdir: {}: done", dir);
-        return remove_file(dir.native());
+        co_await coroutine::return_exception(std::system_error(std::error_code(errno, std::system_category()), dir.native()));
+    }
+    auto close_fd = defer([dirfd] {
+        ::close(dirfd);
     });
+
+    while (true) {
+        auto ents = list_directory(dirfd);
+        if (ents.empty()) {
+            break;
+        }
+        for (auto& de : ents) {
+            if (de.type != directory_entry_type::directory) {
+                llogger.debug("rmdir: unlinking {} from {}", de.name, dir);
+                auto res = ::unlinkat(dirfd, de.name.c_str(), 0);
+                if (res == -1) {
+                    if (errno != ENOENT) {
+                        co_await coroutine::return_exception(std::system_error(std::error_code(errno, std::system_category()), (dir / de.name).native()));
+                    }
+                }
+                co_await coroutine::maybe_yield();
+            }
+        }
+        for (auto& de : ents) {
+            if (de.type == directory_entry_type::directory) {
+                co_await rmdir(dir / de.name);
+            }
+        }
+    }
+    // ...then kill the directory itself
+    llogger.debug("rmdir: removing {}", dir);
+    auto res = ::rmdir(dir.native().c_str());
+    if (res == -1 && errno != ENOENT) {
+        co_await coroutine::return_exception(std::system_error(std::error_code(errno, std::system_category()), dir.native()));
+    }
 }
 
 directory_lister::~directory_lister() {

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -63,16 +63,19 @@ future<> lister::scan_dir(fs::path dir, lister::dir_entry_types type, lister::sh
 
 future<> lister::rmdir(fs::path dir) {
     // first, kill the contents of the directory
+    llogger.debug("rmdir: {}", dir);
     return lister::scan_dir(dir, {}, show_hidden::yes, [] (fs::path parent_dir, directory_entry de) mutable {
         fs::path current_entry_path(parent_dir / de.name.c_str());
 
         if (de.type.value() == directory_entry_type::directory) {
             return rmdir(std::move(current_entry_path));
         } else {
+            llogger.debug("rmdir: remove_file {}", current_entry_path);
             return remove_file(current_entry_path.native());
         }
     }).then([dir] {
         // ...then kill the directory itself
+        llogger.debug("rmdir: {}: done", dir);
         return remove_file(dir.native());
     });
 }


### PR DESCRIPTION
Calling remove_file for each entry is slow
since it requires to do a full path lookup for each entry.

This series adds a unit test to exercise lister::tmdir
and adds lister's own implementation
of synchronous list_directory (allowing yielding
in between buffers), and then uses `unlinkat` to
unlink each file, reusing the open directory
file handle.

Fixes #10484