### PR TITLE
mutation_partition_view: do_accept_gently: keep clustering_row key on stack

### DIFF
--- a/mutation_fragment_v2.hh
+++ b/mutation_fragment_v2.hh
@@ -40,6 +40,10 @@ public:
         : _pos(pos)
         , _tomb(tomb)
     { }
+    range_tombstone_change(clustering_key_prefix&& ckp, bound_weight weight, tombstone tomb)
+        : _pos(partition_region::clustered, weight, std::move(ckp))
+        , _tomb(tomb)
+    { }
     const position_in_partition& position() const & {
         return _pos;
     }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1296,10 +1296,18 @@ public:
     deletable_row& clustered_row(const schema& s, clustering_key&& key);
     deletable_row& clustered_row(const schema& s, clustering_key_view key);
     deletable_row& clustered_row(const schema& s, position_in_partition_view pos, is_dummy, is_continuous);
+    deletable_row& clustered_row(const schema& s, clustering_key&& key_, is_dummy dummy, is_continuous continuous) {
+        auto key = std::move(key_);
+        return clustered_row(s, key, dummy, continuous);
+    }
     // Throws if the row already exists or if the row was not inserted to the
     // last position (one or more greater row already exists).
     // Weak exception guarantees.
     deletable_row& append_clustered_row(const schema& s, position_in_partition_view pos, is_dummy, is_continuous);
+    deletable_row& append_clustered_row(const schema& s, clustering_key&& key_, is_dummy dummy, is_continuous continuous) {
+        auto key = std::move(key_);
+        return append_clustered_row(s, key, dummy, continuous);
+    }
 public:
     tombstone partition_tombstone() const { return _tombstone; }
     lazy_row& static_row() { return _static_row; }

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -266,7 +266,12 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
 
     for (auto&& cr : mpv.rows()) {
         auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-        visitor.accept_row(position_in_partition_view::for_key(cr.key()), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
+        // Keep the row's key on the stack
+        // so `position_in_partition_view::for_key` can safely refernce it.
+        // Otherwise we observed it get lost after resuming the coroutine on aarch64.
+        // See https://github.com/scylladb/scylla/issues/10555
+        auto key = cr.key();
+        visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
 
         struct cell_visitor {
             Visitor& _visitor;

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -447,6 +447,13 @@ public:
         return no_clustering_row_between(_schema, lower_bound, position());
     }
 
+    bool advance_to(clustering_key_prefix&& lower_bound_ckp) {
+        auto ckp = std::move(lower_bound_ckp);
+        auto lower_bound = position_in_partition_view(ckp);
+        maybe_advance_to(lower_bound);
+        return no_clustering_row_between(_schema, lower_bound, position());
+    }
+
     // Call only when valid.
     // Returns true iff the cursor is pointing at a row.
     bool at_a_row() const { return !_current_row.empty(); }

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -802,8 +802,9 @@ SEASTAR_TEST_CASE(test_partition_snapshot_row_cursor) {
 
             {
                 logalloc::reclaim_lock rl(r);
-                BOOST_REQUIRE(cur.advance_to(table.make_ckey(0)));
-                BOOST_REQUIRE(eq(cur.position(), table.make_ckey(0)));
+                auto ck = table.make_ckey(0);
+                BOOST_REQUIRE(cur.advance_to(ck));
+                BOOST_REQUIRE(eq(cur.position(), ck));
                 BOOST_REQUIRE(!cur.continuous());
             }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -737,8 +737,8 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
 
             for (auto idx : boost::irange(1, 1024 * 128, 3)) {
                 r.produces_row(to_full_ck(idx, idx), to_expected(idx))
-                .produces_range_tombstone_change({{to_non_full_ck(idx + 1), bound_weight::before_all_prefixed}, tomb})
-                .produces_range_tombstone_change({{to_non_full_ck(idx + 2), bound_weight::after_all_prefixed}, {}});
+                .produces_range_tombstone_change({to_non_full_ck(idx + 1), bound_weight::before_all_prefixed, tomb})
+                .produces_range_tombstone_change({to_non_full_ck(idx + 2), bound_weight::after_all_prefixed, {}});
             }
             r.produces_partition_end();
         }
@@ -761,11 +761,11 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
             r.fast_forward_to(to_full_ck(4471, 4471), to_full_ck(4653, 4653));
             for (const auto idx : boost::irange(4471, 4652, 3)) {
                 r.produces_row(to_full_ck(idx, idx), to_expected(idx))
-                .produces_range_tombstone_change({{to_non_full_ck(idx + 1), bound_weight::before_all_prefixed}, tomb});
+                .produces_range_tombstone_change({to_non_full_ck(idx + 1), bound_weight::before_all_prefixed, tomb});
                 if (idx == 4651) {
-                    r.produces_range_tombstone_change({{to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed, {}});
                 } else {
-                    r.produces_range_tombstone_change({{to_non_full_ck(idx + 2), bound_weight::after_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_non_full_ck(idx + 2), bound_weight::after_all_prefixed, {}});
                 }
             }
             r.produces_end_of_stream();
@@ -773,17 +773,17 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
             // We have a range tombstone start read, now make sure we reset it properly
             // when we fast-forward to a block that doesn't have an end open marker.
             r.fast_forward_to(to_full_ck(13413, 13413), to_non_full_ck(13417));
-            r.produces_range_tombstone_change({{to_full_ck(13413, 13413), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13413), bound_weight::after_all_prefixed}, {}})
+            r.produces_range_tombstone_change({to_full_ck(13413, 13413), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13413), bound_weight::after_all_prefixed, {}})
             .produces_row(to_full_ck(13414, 13414), to_expected(13414))
-            .produces_range_tombstone_change({{to_non_full_ck(13415), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13416), bound_weight::after_all_prefixed}, {}})
+            .produces_range_tombstone_change({to_non_full_ck(13415), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13416), bound_weight::after_all_prefixed, {}})
             .produces_end_of_stream();
 
             r.fast_forward_to(to_non_full_ck(13417), to_non_full_ck(13420));
             r.produces_row(to_full_ck(13417, 13417), to_expected(13417))
-            .produces_range_tombstone_change({{to_non_full_ck(13418), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13419), bound_weight::after_all_prefixed}, {}})
+            .produces_range_tombstone_change({to_non_full_ck(13418), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13419), bound_weight::after_all_prefixed, {}})
             .produces_end_of_stream();
 
             r.fast_forward_to(to_non_full_ck(13420), to_full_ck(13420, 13421));
@@ -795,8 +795,8 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
                     .produces_end_of_stream();
 
             r.fast_forward_to(to_non_full_ck(13425), to_non_full_ck(13426));
-            r.produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::after_all_prefixed}, {}})
+            r.produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::after_all_prefixed, {}})
             .produces_end_of_stream();
 
             r.fast_forward_to(to_full_ck(13429, 13428), to_full_ck(13429, 13429));
@@ -827,28 +827,28 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
             .produces_static_row({{st_cdef, int32_type->decompose(static_row_values[pkey - 1])}});
             for (const auto idx : boost::irange(4471, 4652, 3)) {
                 r.produces_row(to_full_ck(idx, idx), to_expected(idx))
-                .produces_range_tombstone_change({{to_non_full_ck(idx + 1), bound_weight::before_all_prefixed}, tomb});
+                .produces_range_tombstone_change({to_non_full_ck(idx + 1), bound_weight::before_all_prefixed, tomb});
                 if (idx == 4651) {
-                    r.produces_range_tombstone_change({{to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed, {}});
                 } else {
-                    r.produces_range_tombstone_change({{to_non_full_ck(idx + 2), bound_weight::after_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_non_full_ck(idx + 2), bound_weight::after_all_prefixed, {}});
                 }
             }
 
-            r.produces_range_tombstone_change({{to_full_ck(13413, 13413), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13413), bound_weight::after_all_prefixed}, {}})
+            r.produces_range_tombstone_change({to_full_ck(13413, 13413), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13413), bound_weight::after_all_prefixed, {}})
             .produces_row(to_full_ck(13414, 13414), to_expected(13414))
-            .produces_range_tombstone_change({{to_non_full_ck(13415), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13416), bound_weight::after_all_prefixed}, {}});
+            .produces_range_tombstone_change({to_non_full_ck(13415), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13416), bound_weight::after_all_prefixed, {}});
 
             r.produces_row(to_full_ck(13417, 13417), to_expected(13417))
-            .produces_range_tombstone_change({{to_non_full_ck(13418), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13419), bound_weight::after_all_prefixed}, {}})
+            .produces_range_tombstone_change({to_non_full_ck(13418), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13419), bound_weight::after_all_prefixed, {}})
             .produces_row(to_full_ck(13420, 13420), to_expected(13420))
             .produces_row(to_full_ck(13423, 13423), to_expected(13423));
 
-            r.produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::after_all_prefixed}, {}});
+            r.produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::after_all_prefixed, {}});
 
             r.next_partition();
         }
@@ -884,30 +884,30 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
             r.fast_forward_to(to_non_full_ck(3000), to_non_full_ck(6000));
             for (const auto idx : boost::irange(4471, 4652, 3)) {
                 r.produces_row(to_full_ck(idx, idx), to_expected(idx))
-                .produces_range_tombstone_change({{to_non_full_ck(idx + 1), bound_weight::before_all_prefixed}, tomb});
+                .produces_range_tombstone_change({to_non_full_ck(idx + 1), bound_weight::before_all_prefixed, tomb});
                 if (idx == 4651) {
-                    r.produces_range_tombstone_change({{to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_full_ck(idx + 2, idx + 2), bound_weight::before_all_prefixed, {}});
                 } else {
-                    r.produces_range_tombstone_change({{to_non_full_ck(idx + 2), bound_weight::after_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_non_full_ck(idx + 2), bound_weight::after_all_prefixed, {}});
                 }
             }
             r.produces_end_of_stream();
 
             r.fast_forward_to(to_non_full_ck(13000), to_non_full_ck(15000));
-            r.produces_range_tombstone_change({{to_full_ck(13413, 13413), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13413), bound_weight::after_all_prefixed}, {}})
+            r.produces_range_tombstone_change({to_full_ck(13413, 13413), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13413), bound_weight::after_all_prefixed, {}})
             .produces_row(to_full_ck(13414, 13414), to_expected(13414))
-            .produces_range_tombstone_change({{to_non_full_ck(13415), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13416), bound_weight::after_all_prefixed}, {}});
+            .produces_range_tombstone_change({to_non_full_ck(13415), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13416), bound_weight::after_all_prefixed, {}});
 
             r.produces_row(to_full_ck(13417, 13417), to_expected(13417))
-            .produces_range_tombstone_change({{to_non_full_ck(13418), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13419), bound_weight::after_all_prefixed}, {}})
+            .produces_range_tombstone_change({to_non_full_ck(13418), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13419), bound_weight::after_all_prefixed, {}})
             .produces_row(to_full_ck(13420, 13420), to_expected(13420))
             .produces_row(to_full_ck(13423, 13423), to_expected(13423));
 
-            r.produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(13425), bound_weight::after_all_prefixed}, {}});
+            r.produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(13425), bound_weight::after_all_prefixed, {}});
 
             r.produces_end_of_stream();
             r.next_partition();
@@ -1033,9 +1033,9 @@ SEASTAR_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
         .produces_static_row({{st_cdef, int32_type->decompose(int32_t(555))}});
 
         for (auto idx : boost::irange(1, 1024 * 128, 5)) {
-            r.produces_range_tombstone_change({{to_non_full_ck(idx), bound_weight::before_all_prefixed}, tomb})
+            r.produces_range_tombstone_change({to_non_full_ck(idx), bound_weight::before_all_prefixed, tomb})
             .produces_row(to_full_ck(idx + 3, idx + 3), to_expected(idx + 3))
-            .produces_range_tombstone_change({{to_non_full_ck(idx + 4), bound_weight::after_all_prefixed}, {}});
+            .produces_range_tombstone_change({to_non_full_ck(idx + 4), bound_weight::after_all_prefixed, {}});
         }
         r.produces_partition_end()
         .produces_end_of_stream();
@@ -1056,16 +1056,16 @@ SEASTAR_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
         {
             auto clustering_range = make_clustering_range(to_full_ck(7460, 7461), to_full_ck(7500, 7501));
 
-            r.produces_range_tombstone_change({{to_full_ck(7460, 7461), bound_weight::before_all_prefixed}, tomb})
-            .produces_range_tombstone_change({{to_non_full_ck(7460), bound_weight::after_all_prefixed}, {}});
+            r.produces_range_tombstone_change({to_full_ck(7460, 7461), bound_weight::before_all_prefixed, tomb})
+            .produces_range_tombstone_change({to_non_full_ck(7460), bound_weight::after_all_prefixed, {}});
 
             for (auto idx : boost::irange(7461, 7501, 5)) {
-                r.produces_range_tombstone_change({{to_non_full_ck(idx), bound_weight::before_all_prefixed}, tomb})
+                r.produces_range_tombstone_change({to_non_full_ck(idx), bound_weight::before_all_prefixed, tomb})
                 .produces_row(to_full_ck(idx + 3, idx + 3), to_expected(idx + 3));
                 if (idx == 7496) {
-                    r.produces_range_tombstone_change({{to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed, {}});
                 } else {
-                    r.produces_range_tombstone_change({{to_non_full_ck(idx + 4), bound_weight::after_all_prefixed}, {}});
+                    r.produces_range_tombstone_change({to_non_full_ck(idx + 4), bound_weight::after_all_prefixed, {}});
                 }
             }
             r.produces_end_of_stream();
@@ -1084,16 +1084,16 @@ SEASTAR_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
         r.produces_partition_start(to_pkey(1))
         .produces_static_row({{st_cdef, int32_type->decompose(int32_t(555))}});
 
-        r.produces_range_tombstone_change({{to_full_ck(7460, 7461), bound_weight::before_all_prefixed}, tomb})
-        .produces_range_tombstone_change({{to_non_full_ck(7460), bound_weight::after_all_prefixed}, {}});
+        r.produces_range_tombstone_change({to_full_ck(7460, 7461), bound_weight::before_all_prefixed, tomb})
+        .produces_range_tombstone_change({to_non_full_ck(7460), bound_weight::after_all_prefixed, {}});
 
         for (auto idx : boost::irange(7461, 7501, 5)) {
-            r.produces_range_tombstone_change({{to_non_full_ck(idx), bound_weight::before_all_prefixed}, tomb})
+            r.produces_range_tombstone_change({to_non_full_ck(idx), bound_weight::before_all_prefixed, tomb})
             .produces_row(to_full_ck(idx + 3, idx + 3), to_expected(idx + 3));
             if (idx == 7496) {
-                r.produces_range_tombstone_change({{to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed}, {}});
+                r.produces_range_tombstone_change({to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed, {}});
             } else {
-                r.produces_range_tombstone_change({{to_non_full_ck(idx + 4), bound_weight::after_all_prefixed}, {}});
+                r.produces_range_tombstone_change({to_non_full_ck(idx + 4), bound_weight::after_all_prefixed, {}});
             }
         }
         r.produces_partition_end()
@@ -1118,16 +1118,16 @@ SEASTAR_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
 
         auto clustering_range = make_clustering_range(to_full_ck(7470, 7471), to_full_ck(7500, 7501));
 
-        r.produces_range_tombstone_change({{to_full_ck(7470, 7471), bound_weight::before_all_prefixed}, tomb});
-        r.produces_range_tombstone_change({{to_non_full_ck(7470), bound_weight::after_all_prefixed}, {}});
+        r.produces_range_tombstone_change({to_full_ck(7470, 7471), bound_weight::before_all_prefixed, tomb});
+        r.produces_range_tombstone_change({to_non_full_ck(7470), bound_weight::after_all_prefixed, {}});
 
         for (auto idx : boost::irange(7471, 7501, 5)) {
-            r.produces_range_tombstone_change({{to_non_full_ck(idx), bound_weight::before_all_prefixed}, tomb})
+            r.produces_range_tombstone_change({to_non_full_ck(idx), bound_weight::before_all_prefixed, tomb})
             .produces_row(to_full_ck(idx + 3, idx + 3), to_expected(idx + 3));
             if (idx == 7496) {
-                r.produces_range_tombstone_change({{to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed}, {}});
+                r.produces_range_tombstone_change({to_full_ck(idx + 4, idx + 5), bound_weight::before_all_prefixed, {}});
             } else {
-                r.produces_range_tombstone_change({{to_non_full_ck(idx + 4), bound_weight::after_all_prefixed}, {}});
+                r.produces_range_tombstone_change({to_non_full_ck(idx + 4), bound_weight::after_all_prefixed, {}});
             }
         }
         r.produces_end_of_stream();
@@ -2544,20 +2544,20 @@ SEASTAR_TEST_CASE(test_uncompressed_range_tombstones_simple_read) {
     assert_that(sst.make_reader())
     .produces_partition_start(to_key(1))
     .produces_row(to_ck(101), {{int_cdef, int32_type->decompose(1001)}})
-    .produces_range_tombstone_change({{to_ck(101), bound_weight::after_all_prefixed},
+    .produces_range_tombstone_change({to_ck(101), bound_weight::after_all_prefixed,
             tombstone(api::timestamp_type{1529519641211958},
                       gc_clock::time_point(gc_clock::duration(1529519641)))})
-    .produces_range_tombstone_change({{to_ck(104), bound_weight::before_all_prefixed},
+    .produces_range_tombstone_change({to_ck(104), bound_weight::before_all_prefixed,
             tombstone(api::timestamp_type{1529519641215380},
                       gc_clock::time_point(gc_clock::duration(1529519641)))})
-    .produces_range_tombstone_change({{to_ck(105), bound_weight::before_all_prefixed}, {}})
+    .produces_range_tombstone_change({to_ck(105), bound_weight::before_all_prefixed, {}})
     .produces_row(to_ck(105), {{int_cdef, int32_type->decompose(1005)}})
     .produces_row(to_ck(106), {{int_cdef, int32_type->decompose(1006)}})
     .produces_row(to_ck(107), {{int_cdef, int32_type->decompose(1007)}})
     .produces_row(to_ck(108), {{int_cdef, int32_type->decompose(1008)}})
-    .produces_range_tombstone_change({{to_ck(108), bound_weight::after_all_prefixed}, tombstone(api::timestamp_type{1529519643267068},
+    .produces_range_tombstone_change({to_ck(108), bound_weight::after_all_prefixed, tombstone(api::timestamp_type{1529519643267068},
                                                                                                 gc_clock::time_point(gc_clock::duration(1529519643)))})
-    .produces_range_tombstone_change({{clustering_key_prefix::make_empty(), bound_weight::after_all_prefixed}, {}})
+    .produces_range_tombstone_change({clustering_key_prefix::make_empty(), bound_weight::after_all_prefixed, {}})
     .produces_partition_end()
     .produces_end_of_stream();
   });
@@ -2607,18 +2607,18 @@ SEASTAR_TEST_CASE(test_uncompressed_range_tombstones_partial_read) {
 
     assert_that(sst.make_reader())
     .produces_partition_start(to_key(1))
-    .produces_range_tombstone_change({{to_ck(1), bound_weight::after_all_prefixed},
+    .produces_range_tombstone_change({to_ck(1), bound_weight::after_all_prefixed,
             tombstone(api::timestamp_type{1530543711595401},
                       gc_clock::time_point(gc_clock::duration(1530543711)))})
     .produces_row_with_key(clustering_key::from_exploded(*UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA, {
                                                             int32_type->decompose(2),
                                                             int32_type->decompose(13)
             }))
-    .produces_range_tombstone_change({{to_ck(3), bound_weight::before_all_prefixed}, {}})
-    .produces_range_tombstone_change({{to_ck(3), bound_weight::after_all_prefixed},
+    .produces_range_tombstone_change({to_ck(3), bound_weight::before_all_prefixed, {}})
+    .produces_range_tombstone_change({to_ck(3), bound_weight::after_all_prefixed,
             tombstone(api::timestamp_type{1530543761322213},
                       gc_clock::time_point(gc_clock::duration(1530543761)))})
-    .produces_range_tombstone_change({{clustering_key_prefix::make_empty(), bound_weight::after_all_prefixed}, {}})
+    .produces_range_tombstone_change({clustering_key_prefix::make_empty(), bound_weight::after_all_prefixed, {}})
     .produces_partition_end()
     .produces_end_of_stream();
   });

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -751,6 +751,11 @@ public:
         return *this;
     }
 
+    flat_reader_assertions_v2& produces_range_tombstone_change(range_tombstone_change&& rt_) {
+        auto rt = std::move(rt_);
+        return produces_range_tombstone_change(rt);
+    }
+
     flat_reader_assertions_v2& produces_partition_end() {
         testlog.trace("Expecting partition end");
         auto mfopt = read_next();


### PR DESCRIPTION
We're hitting a unit test failure as in
https://jenkins.scylladb.com/view/master/job/scylla-master/job/build/1010/artifact/testlog/aarch64_dev/frozen_mutation_test.test_writing_and_reading_gently.918.log
```
unknown location(0): fatal error: in "test_writing_and_reading_gently": std::_Nested_exception<std::runtime_error>: frozen_mutation::unfreeze_gently(): failed unfreezing mutation pk{00801806000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000} of ks.cf
```

on aarch64 clang 12.0.1, in release and dev modes (but not debug).

This turned out to be a miscompilation
in `position_in_partition_view::for_key(cr.key())`
that returns a position_in_partition_view of the
clustering_key_prefix rvalue that cr.key() returns.

The latter is lost on aarch64 in release mode.
Keeping the key on the stack allows to safely pass
a view to it.

Fixes #10555

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>