### PR TITLE
Deglobalize LSA

### DIFF
--- a/api/lsa.cc
+++ b/api/lsa.cc
@@ -22,8 +22,8 @@ static logging::logger alogger("lsa-api");
 void set_lsa(http_context& ctx, routes& r) {
     httpd::lsa_json::lsa_compact.set(r, [&ctx](std::unique_ptr<request> req) {
         alogger.info("Triggering compaction");
-        return ctx.db.invoke_on_all([] (replica::database&) {
-            logalloc::shard_tracker().reclaim(std::numeric_limits<size_t>::max());
+        return ctx.db.invoke_on_all([] (replica::database& db) {
+            db.logalloc_tracker().reclaim(std::numeric_limits<size_t>::max());
         }).then([] {
             return json::json_return_type(json::json_void());
         });

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1464,7 +1464,7 @@ public:
                     [consumer = std::move(end_consumer), this] (flat_mutation_reader_v2 rd) {
                 ++_bucket_count;
                 return consumer(std::move(rd));
-            });
+            }, _options.memtable_factory);
         };
     }
 

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -20,6 +20,10 @@
 #include "dht/i_partitioner.hh"
 #include "compaction_weight_registration.hh"
 
+namespace logalloc {
+class tracker;
+}
+
 namespace sstables {
 
 enum class compaction_type {

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -74,6 +74,8 @@ public:
             only, // scrub only quarantined sstables
         };
         quarantine_mode quarantine_operation_mode = quarantine_mode::include;
+
+        std::function<lw_shared_ptr<replica::memtable>(schema_ptr)> memtable_factory;
     };
     struct reshard {
     };
@@ -110,8 +112,9 @@ public:
         return compaction_type_options(upgrade{std::move(owned_ranges)});
     }
 
-    static compaction_type_options make_scrub(scrub::mode mode) {
-        return compaction_type_options(scrub{mode});
+    // memtable_factory only required for scrub::mode::segregate
+    static compaction_type_options make_scrub(scrub::mode mode, std::function<lw_shared_ptr<replica::memtable>(schema_ptr)> memtable_factory) {
+        return compaction_type_options(scrub{mode, scrub::quarantine_mode::include, memtable_factory});
     }
 
     template <typename... Visitor>

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -399,7 +399,8 @@ public:
     future<> perform_sstable_upgrade(replica::database& db, replica::table* t, bool exclude_current_version);
 
     // Submit a table to be scrubbed and wait for its termination.
-    future<> perform_sstable_scrub(replica::table* t, sstables::compaction_type_options::scrub opts);
+    future<> perform_sstable_scrub(replica::table* t, sstables::compaction_type_options::scrub::mode scrub_mode,
+            sstables::compaction_type_options::scrub::quarantine_mode quarantine_mode = sstables::compaction_type_options::scrub::quarantine_mode::include);
 
     // Submit a table for major compaction.
     future<> perform_major_compaction(replica::table* t);

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -83,8 +83,8 @@ private:
     void setup_metrics();
 public:
     using register_metrics = bool_class<class register_metrics_tag>;
-    cache_tracker(mutation_application_stats&, register_metrics);
-    cache_tracker(register_metrics = register_metrics::no);
+    cache_tracker(logalloc::tracker& tracker, mutation_application_stats&, register_metrics);
+    cache_tracker(logalloc::tracker& tracker, register_metrics = register_metrics::no);
     ~cache_tracker();
     void clear();
     void touch(rows_entry&);

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -54,7 +54,7 @@ mutation_source memtable_filling_virtual_table::as_mutation_source() {
 
         auto units = make_lw_shared<my_units>(permit.consume_memory(0));
 
-        auto populate = [this, mt = make_lw_shared<replica::memtable>(schema()), s, units, range, slice, pc, trace_state, fwd, fwd_mr] () mutable {
+        auto populate = [this, mt = _mt_factory(schema()), s, units, range, slice, pc, trace_state, fwd, fwd_mr] () mutable {
             auto mutation_sink = [units, mt] (mutation m) mutable {
                 mt->apply(m);
                 units->units.add(units->units.permit().consume_memory(mt->occupancy().used_space() - units->memory_used));

--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -38,6 +38,7 @@ public:
     };
 
     explicit virtual_table(schema_ptr s) : _s(std::move(s)) {}
+    virtual ~virtual_table() = default;
 
     const schema_ptr& schema() const { return _s; }
 

--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -10,6 +10,7 @@
 
 #include "readers/filtering.hh"
 #include "replica/memtable.hh"
+#include "dirty_memory_manager.hh"
 #include "schema.hh"
 #include "replica/database_fwd.hh"
 
@@ -51,8 +52,12 @@ public:
 // Produces results by filling a memtable on each read.
 // Use when the amount of data is not significant relative to shard's memory size.
 class memtable_filling_virtual_table : public virtual_table {
+    std::function<lw_shared_ptr<replica::memtable>(schema_ptr)> _mt_factory;
 public:
-    using virtual_table::virtual_table;
+    memtable_filling_virtual_table(schema_ptr s, std::function<lw_shared_ptr<replica::memtable>(schema_ptr)> mt_factory)
+        : db::virtual_table(std::move(s))
+        , _mt_factory(mt_factory)
+    { }
 
     // Override one of these execute() overloads.
     // The handler is always allowed to produce more data than implied by the query_restrictions.

--- a/debug.hh
+++ b/debug.hh
@@ -17,6 +17,7 @@ class database;
 namespace debug {
 
 extern seastar::sharded<replica::database>* the_database;
+extern sharded<logalloc::tracker> *the_logalloc_tracker;
 
 
 }

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -139,10 +139,10 @@ public:
     // We then set the soft limit to 80 % of the virtual dirty hard limit, which is equal to 40 % of
     // the user-supplied threshold.
     dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg);
-    dirty_memory_manager() : logalloc::region_group_reclaimer()
+    explicit dirty_memory_manager(logalloc::tracker& tracker) : logalloc::region_group_reclaimer()
         , _db(nullptr)
-        , _real_region_group("memtable", _real_dirty_reclaimer)
-        , _virtual_region_group("memtable (virtual)", &_real_region_group, *this)
+        , _real_region_group(tracker, "memtable", _real_dirty_reclaimer)
+        , _virtual_region_group(tracker, "memtable (virtual)", &_real_region_group, *this)
         , _flush_serializer(1)
         , _waiting_flush(make_ready_future<>()) {}
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -220,6 +220,3 @@ private:
 
     friend class flush_permit;
 };
-
-extern thread_local dirty_memory_manager default_dirty_memory_manager;
-

--- a/mutation_writer/partition_based_splitting_writer.hh
+++ b/mutation_writer/partition_based_splitting_writer.hh
@@ -31,6 +31,7 @@ struct segregate_config {
 // streams that honor it.
 // This is useful for scrub compaction to split sstables containing out-of-order
 // and/or duplicate partitions into sstables that honor the partition ordering.
-future<> segregate_by_partition(flat_mutation_reader_v2 producer, segregate_config cfg, reader_consumer_v2 consumer);
+future<> segregate_by_partition(flat_mutation_reader_v2 producer, segregate_config cfg, reader_consumer_v2 consumer,
+        std::function<lw_shared_ptr<replica::memtable>(schema_ptr)> mt_factory);
 
 } // namespace mutation_writer

--- a/mutation_writer/partition_based_splitting_writer.hh
+++ b/mutation_writer/partition_based_splitting_writer.hh
@@ -13,6 +13,10 @@
 
 #include "feed_writers.hh"
 
+namespace logalloc {
+class tracker;
+}
+
 namespace mutation_writer {
 
 struct segregate_config {

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -236,7 +236,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader_v2::impl, pub
 
         template<typename Function>
         decltype(auto) with_reserve(Function&& fn) {
-            return _read_section.with_reserve(std::forward<Function>(fn));
+            return _read_section.with_reserve(_region, std::forward<Function>(fn));
         }
 
         tombstone partition_tombstone() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -201,7 +201,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
     memory::set_additional_diagnostics_producer([this] (memory::memory_diagnostics_writer wr) {
         auto writeln = memory_diagnostics_line_writer(std::move(wr));
 
-        const auto lsa_occupancy_stats = logalloc::lsa_global_occupancy_stats();
+        const auto lsa_occupancy_stats = logalloc::shard_tracker().global_occupancy();
         writeln("LSA\n");
         writeln("  allocated: {}\n", utils::to_hr_size(lsa_occupancy_stats.total_space()));
         writeln("  used:      {}\n", utils::to_hr_size(lsa_occupancy_stats.used_space()));

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -75,10 +75,6 @@ using namespace db;
 
 logging::logger dblog("database");
 
-// Used for tests where the CF exists without a database object. We need to pass a valid
-// dirty_memory manager in that case.
-thread_local dirty_memory_manager default_dirty_memory_manager;
-
 namespace replica {
 
 inline

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -313,13 +313,13 @@ public:
     }
 };
 
-database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
+database::database(const db::config& cfg, database_config dbcfg, logalloc::tracker& logalloc_tracker, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
         abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
     , _cl_stats(std::make_unique<cell_locker_stats>())
     , _cfg(cfg)
-    , _logalloc_tracker(logalloc::shard_tracker())
+    , _logalloc_tracker(logalloc_tracker)
     // Allow system tables a pool of 10 MB memory to write, but never block on other regions.
     , _system_dirty_memory_manager(*this, 10 << 20, cfg.virtual_dirty_soft_limit(), default_scheduling_group())
     , _dirty_memory_manager(*this, dbcfg.available_memory * 0.50, cfg.virtual_dirty_soft_limit(), dbcfg.statement_scheduling_group)

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1438,7 +1438,7 @@ public:
     };
 
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
-    database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
+    database(const db::config&, database_config dbcfg, logalloc::tracker& logalloc_tracker, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
             abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -367,7 +367,7 @@ public:
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
-        ::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
+        ::dirty_memory_manager* dirty_memory_manager = nullptr;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
         reader_concurrency_semaphore* compaction_concurrency_semaphore;
         replica::cf_stats* cf_stats = nullptr;
@@ -1126,7 +1126,7 @@ public:
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
-        ::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
+        ::dirty_memory_manager* dirty_memory_manager = nullptr;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
         reader_concurrency_semaphore* compaction_concurrency_semaphore;
         replica::cf_stats* cf_stats = nullptr;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1299,6 +1299,7 @@ private:
 
     dirty_memory_manager _system_dirty_memory_manager;
     dirty_memory_manager _dirty_memory_manager;
+    dirty_memory_manager _misc_dirty_memory_manager;
 
     database_config _dbcfg;
     backlog_controller::scheduling_group _flush_sg;
@@ -1438,6 +1439,11 @@ public:
 
     cache_tracker& row_cache_tracker() { return _row_cache_tracker; }
     future<> drop_caches() const;
+
+    dirty_memory_manager& get_user_dirty_memory_manager() { return _dirty_memory_manager; }
+
+    // Used by miscellaneous source outside of the regular write-path, like virtual tables and scrub compaction.
+    dirty_memory_manager& get_misc_dirty_memory_manager() { return _misc_dirty_memory_manager; }
 
     void update_version(const utils::UUID& version);
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -769,6 +769,10 @@ public:
         return _rate_limiter_label_for_reads;
     }
 
+    logalloc::tracker& logalloc_tracker() {
+        return _cache.get_cache_tracker().region().get_tracker();
+    }
+
     future<std::vector<locked_cell>> lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout);
 
     logalloc::occupancy_stats occupancy() const;
@@ -1297,6 +1301,8 @@ private:
 
     const db::config& _cfg;
 
+    logalloc::tracker& _logalloc_tracker;
+
     dirty_memory_manager _system_dirty_memory_manager;
     dirty_memory_manager _dirty_memory_manager;
     dirty_memory_manager _misc_dirty_memory_manager;
@@ -1436,6 +1442,8 @@ public:
             abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
+
+    logalloc::tracker& logalloc_tracker() const { return _logalloc_tracker; }
 
     cache_tracker& row_cache_tracker() { return _row_cache_tracker; }
     future<> drop_caches() const;

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -126,11 +126,10 @@ memtable::memtable(schema_ptr schema, dirty_memory_manager& dmm, replica::table_
         , _table_stats(table_stats) {
 }
 
-static thread_local dirty_memory_manager mgr_for_tests;
 static thread_local replica::table_stats stats_for_tests;
 
-memtable::memtable(schema_ptr schema)
-        : memtable(std::move(schema), mgr_for_tests, stats_for_tests)
+memtable::memtable(schema_ptr schema, dirty_memory_manager& dmm)
+        : memtable(std::move(schema), dmm, stats_for_tests)
 { }
 
 memtable::~memtable() {

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -175,7 +175,7 @@ public:
     explicit memtable(schema_ptr schema, dirty_memory_manager&, replica::table_stats& table_stats, memtable_list *memtable_list = nullptr,
             seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group());
     // Used for testing that want to control the flush process.
-    explicit memtable(schema_ptr schema);
+    explicit memtable(schema_ptr schema, dirty_memory_manager&);
     ~memtable();
     // Clears this memtable gradually without consuming the whole CPU.
     // Never resolves with a failed future.

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -51,14 +51,15 @@ row_cache::create_underlying_reader(read_context& ctx, mutation_source& src, con
 
 static thread_local mutation_application_stats dummy_app_stats;
 
-cache_tracker::cache_tracker(register_metrics with_metrics)
-    : cache_tracker(dummy_app_stats, with_metrics)
+cache_tracker::cache_tracker(logalloc::tracker& tracker, register_metrics with_metrics)
+    : cache_tracker(tracker, dummy_app_stats, with_metrics)
 {}
 
 static thread_local cache_tracker* current_tracker;
 
-cache_tracker::cache_tracker(mutation_application_stats& app_stats, register_metrics with_metrics)
-    : _garbage(_region, this, app_stats)
+cache_tracker::cache_tracker(logalloc::tracker& tracker, mutation_application_stats& app_stats, register_metrics with_metrics)
+    : _region(tracker)
+    , _garbage(_region, this, app_stats)
     , _memtable_cleaner(_region, nullptr, app_stats)
     , _app_stats(app_stats)
 {

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1091,6 +1091,15 @@ class sharded:
         return self.instance()
 
 
+def get_lsa_segment_pool():
+    try:
+        tracker = gdb.parse_and_eval('\'logalloc::tracker_instance\'')
+        tracker_impl = std_unique_ptr(tracker["_impl"]).get().dereference()
+        return std_unique_ptr(tracker_impl["_segment_pool"]).get().dereference()
+    except gdb.error:
+        return gdb.parse_and_eval('\'logalloc::shard_segment_pool\'')
+
+
 def find_db(shard=None):
     try:
         db = gdb.parse_and_eval('::debug::the_database')
@@ -1926,7 +1935,7 @@ class scylla_memory(gdb.Command):
         gdb.write('Used memory: {used_mem:>13}\nFree memory: {free_mem:>13}\nTotal memory: {total_mem:>12}\n\n'
                   .format(used_mem=total_mem - free_mem, free_mem=free_mem, total_mem=total_mem))
 
-        lsa = gdb.parse_and_eval('\'logalloc::shard_segment_pool\'')
+        lsa = get_lsa_segment_pool()
         segment_size = int(gdb.parse_and_eval('\'logalloc::segment::size\''))
         lsa_free = int(lsa['_free_segments']) * segment_size
         non_lsa_mem = int(lsa['_non_lsa_memory_in_use'])
@@ -2390,11 +2399,11 @@ class scylla_ptr(gdb.Command):
             ptr_meta.offset_in_object = ptr - span.start
 
         # FIXME: handle debug-mode build
-        try:
-            index = gdb.parse_and_eval('(%d - \'logalloc::shard_segment_pool\'._store._segments_base) / \'logalloc::segment\'::size' % (ptr))
-        except gdb.error:
-            index = gdb.parse_and_eval('(%d - \'logalloc::shard_segment_pool\'._segments_base) / \'logalloc::segment\'::size' % (ptr)) # Scylla 3.0 compatibility
-        desc = gdb.parse_and_eval('\'logalloc::shard_segment_pool\'._segments._M_impl._M_start[%d]' % (index))
+        segment_pool = get_lsa_segment_pool()
+        segments_base = int(segment_pool["_store"]["_segments_base"])
+        segment_size = int(gdb.parse_and_eval('\'logalloc::segment\'::size'))
+        index = int((int(ptr) - segments_base) / segment_size)
+        desc = std_vector(segment_pool["_segments"])[index]
         ptr_meta.is_lsa = bool(desc['_region'])
 
         return ptr_meta
@@ -2431,11 +2440,12 @@ class scylla_segment_descs(gdb.Command):
 
     def invoke(self, arg, from_tty):
         segment_size = int(gdb.parse_and_eval('\'logalloc\'::segment::size'))
+        segment_pool = get_lsa_segment_pool()
         try:
-            base = int(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._store._segments_base'))
+            base = int(segment_pool["_store"]["_segments_base"])
         except gdb.error:
             try:
-                base = int(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._segments_base'))
+                base = int(segment_pool["_segments_base"])
             except gdb.error:
                 base = None
 
@@ -2449,15 +2459,15 @@ class scylla_segment_descs(gdb.Command):
                 gdb.write('0x%x: std\n' % (seg_addr))
 
         if base is None: # debug mode build
-            segs = std_vector(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._store._segments'))
-            descs = std_vector(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._segments'))
+            segs = std_vector(segment_pool["_store"]["_segments"])
+            descs = std_vector(segment_pool["_segments"])
 
             for seg, desc_ref in zip(segs, descs):
                 desc = segment_descriptor(desc_ref)
                 print_desc(int(seg), desc)
         else:
             addr = base
-            for desc in std_vector(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._segments')):
+            for desc in std_vector(segment_pool["_segments"]):
                 desc = segment_descriptor(desc)
                 print_desc(addr, desc)
                 addr += segment_size
@@ -2492,10 +2502,11 @@ class scylla_lsa_check(gdb.Command):
         # Scan shard's segment_descriptor:s for anomalies:
         #  - detect segments owned by cache which are not in cache region's _segment_descs
         #  - compute segment occupancy statistics for comparison with region's stored ones
-        base = int(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._store._segments_base'))
+        segment_pool = get_lsa_segment_pool()
+        base = int(segment_pool["_store"]["_segments_base"])
         desc_free_space = 0
         desc_total_space = 0
-        for desc in std_vector(gdb.parse_and_eval('\'logalloc\'::shard_segment_pool._segments')):
+        for desc in std_vector(segment_pool["_segments"]):
             desc = segment_descriptor(desc)
             if desc.is_lsa() and desc.region() == cache_region.impl():
                 if not int(desc.address) in in_buckets:
@@ -2526,7 +2537,7 @@ class scylla_lsa(gdb.Command):
         gdb.Command.__init__(self, 'scylla lsa', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
 
     def invoke(self, arg, from_tty):
-        lsa = gdb.parse_and_eval('\'logalloc::shard_segment_pool\'')
+        lsa = get_lsa_segment_pool()
         segment_size = int(gdb.parse_and_eval('\'logalloc::segment::size\''))
 
         lsa_mem = int(lsa['_segments_in_use']) * segment_size

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -309,7 +309,7 @@ SEASTAR_THREAD_TEST_CASE(test_stress_eviction) {
     auto cached_size = 4'000'000;
 
     cached_file::metrics metrics;
-    tests::logalloc::sharded_tracker logalloc_tracker(memory::stats().total_memory(), 0);
+    tests::logalloc::sharded_tracker logalloc_tracker(::logalloc::tracker::config(memory::stats().total_memory(), 0));
     logalloc::region region(*logalloc_tracker);
 
     auto f = file(make_shared<garbage_file_impl>());

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -28,7 +28,8 @@ using disk_array = lsa::chunked_managed_vector<uint64_t>;
 using deque = std::deque<int>;
 
 SEASTAR_TEST_CASE(test_random_walk) {
-  region region(shard_tracker());
+  logalloc::tracker logalloc_tracker;
+  region region(logalloc_tracker);
   allocating_section as;
   with_allocator(region.allocator(), [&] {
     auto rand = std::default_random_engine();
@@ -166,7 +167,8 @@ public:
 };
 
 SEASTAR_TEST_CASE(tests_constructor_exception_safety) {
-  region region(shard_tracker());
+  logalloc::tracker logalloc_tracker;
+  region region(logalloc_tracker);
   allocating_section as;
   with_allocator(region.allocator(), [&] {
    as(region, [&] {
@@ -186,7 +188,8 @@ SEASTAR_TEST_CASE(tests_constructor_exception_safety) {
 }
 
 SEASTAR_TEST_CASE(tests_reserve_partial) {
-  region region(shard_tracker());
+  logalloc::tracker logalloc_tracker;
+  region region(logalloc_tracker);
   allocating_section as;
   with_allocator(region.allocator(), [&] {
    as(region, [&] {
@@ -208,7 +211,8 @@ SEASTAR_TEST_CASE(tests_reserve_partial) {
 }
 
 SEASTAR_TEST_CASE(test_clear_and_release) {
-    region region(shard_tracker());
+    logalloc::tracker logalloc_tracker;
+    region region(logalloc_tracker);
     allocating_section as;
 
     with_allocator(region.allocator(), [&] {
@@ -227,7 +231,8 @@ SEASTAR_TEST_CASE(test_clear_and_release) {
 }
 
 SEASTAR_TEST_CASE(test_chunk_reserve) {
-    region region(shard_tracker());
+    logalloc::tracker logalloc_tracker;
+    region region(logalloc_tracker);
     allocating_section as;
 
     for (auto conf :
@@ -269,7 +274,8 @@ SEASTAR_TEST_CASE(test_chunk_reserve) {
 }
 
 SEASTAR_TEST_CASE(test_correctness_when_crossing_chunk_boundary) {
-    region region(shard_tracker());
+    logalloc::tracker logalloc_tracker;
+    region region(logalloc_tracker);
     allocating_section as;
     with_allocator(region.allocator(), [&] {
         as(region, [&] {
@@ -292,7 +298,8 @@ SEASTAR_TEST_CASE(test_correctness_when_crossing_chunk_boundary) {
 // Tests the case of make_room() invoked with last_chunk_capacity_deficit but _size not in
 // the last reserved chunk.
 SEASTAR_TEST_CASE(test_shrinking_and_expansion_involving_chunk_boundary) {
-    region region(shard_tracker());
+    logalloc::tracker logalloc_tracker;
+    region region(logalloc_tracker);
     allocating_section as;
 
     with_allocator(region.allocator(), [&] {

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -14,6 +14,7 @@
 #include "utils/lsa/chunked_managed_vector.hh"
 #include "utils/managed_ref.hh"
 #include "test/lib/log.hh"
+#include "test/lib/logalloc.hh"
 
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/equal.hpp>
@@ -27,7 +28,7 @@ using disk_array = lsa::chunked_managed_vector<uint64_t>;
 using deque = std::deque<int>;
 
 SEASTAR_TEST_CASE(test_random_walk) {
-  region region;
+  region region(shard_tracker());
   allocating_section as;
   with_allocator(region.allocator(), [&] {
     auto rand = std::default_random_engine();
@@ -165,7 +166,7 @@ public:
 };
 
 SEASTAR_TEST_CASE(tests_constructor_exception_safety) {
-  region region;
+  region region(shard_tracker());
   allocating_section as;
   with_allocator(region.allocator(), [&] {
    as(region, [&] {
@@ -185,7 +186,7 @@ SEASTAR_TEST_CASE(tests_constructor_exception_safety) {
 }
 
 SEASTAR_TEST_CASE(tests_reserve_partial) {
-  region region;
+  region region(shard_tracker());
   allocating_section as;
   with_allocator(region.allocator(), [&] {
    as(region, [&] {
@@ -207,7 +208,7 @@ SEASTAR_TEST_CASE(tests_reserve_partial) {
 }
 
 SEASTAR_TEST_CASE(test_clear_and_release) {
-    region region;
+    region region(shard_tracker());
     allocating_section as;
 
     with_allocator(region.allocator(), [&] {
@@ -226,7 +227,7 @@ SEASTAR_TEST_CASE(test_clear_and_release) {
 }
 
 SEASTAR_TEST_CASE(test_chunk_reserve) {
-    region region;
+    region region(shard_tracker());
     allocating_section as;
 
     for (auto conf :
@@ -268,7 +269,7 @@ SEASTAR_TEST_CASE(test_chunk_reserve) {
 }
 
 SEASTAR_TEST_CASE(test_correctness_when_crossing_chunk_boundary) {
-    region region;
+    region region(shard_tracker());
     allocating_section as;
     with_allocator(region.allocator(), [&] {
         as(region, [&] {
@@ -291,7 +292,7 @@ SEASTAR_TEST_CASE(test_correctness_when_crossing_chunk_boundary) {
 // Tests the case of make_room() invoked with last_chunk_capacity_deficit but _size not in
 // the last reserved chunk.
 SEASTAR_TEST_CASE(test_shrinking_and_expansion_involving_chunk_boundary) {
-    region region;
+    region region(shard_tracker());
     allocating_section as;
 
     with_allocator(region.allocator(), [&] {

--- a/test/boost/double_decker_test.cc
+++ b/test/boost/double_decker_test.cc
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "utils/double-decker.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/random_utils.hh"
 
 class compound_key {
@@ -303,7 +304,8 @@ SEASTAR_THREAD_TEST_CASE(test_insert_and_erase) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_compaction) {
-    logalloc::region reg;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region reg(*logalloc_tracker);
     with_allocator(reg.allocator(), [&] {
         collection c(compound_key::less_compare{});
         test_data::compare cmp;

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -30,6 +30,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/log.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
@@ -867,8 +868,9 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
 
     std::mt19937 engine(tests::random::get_int<uint32_t>());
 
+    tests::logalloc::sharded_tracker logalloc_tracker;
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    dirty_memory_manager dmm;
+    dirty_memory_manager dmm(*logalloc_tracker);
     auto permit = semaphore.make_permit();
 
     auto rnd_schema_spec = tests::make_random_schema_specification(

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -868,6 +868,7 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
     std::mt19937 engine(tests::random::get_int<uint32_t>());
 
     tests::reader_concurrency_semaphore_wrapper semaphore;
+    dirty_memory_manager dmm;
     auto permit = semaphore.make_permit();
 
     auto rnd_schema_spec = tests::make_random_schema_specification(
@@ -879,8 +880,8 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
     auto forward_schema = rnd_schema.schema();
     auto reverse_schema = forward_schema->make_reversed();
 
-    auto forward_mt = make_lw_shared<replica::memtable>(forward_schema);
-    auto reverse_mt = make_lw_shared<replica::memtable>(reverse_schema);
+    auto forward_mt = make_lw_shared<replica::memtable>(forward_schema, dmm);
+    auto reverse_mt = make_lw_shared<replica::memtable>(reverse_schema, dmm);
 
     for (size_t pk = 0; pk != 8; ++pk) {
         auto mut = rnd_schema.new_mutation(pk);

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -1515,10 +1515,10 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
     std::vector<managed_bytes> std_allocs;
     size_t std_alloc_size = 1000000; // note that managed_bytes fragments these, even in std
     for (int i = 0; i < 50; ++i) {
-        auto compacted_pre = logalloc::memory_compacted();
+        auto compacted_pre = logalloc::shard_tracker().statistics().memory_compacted;
         fmt::print("compacted {} items {} (pre)\n", compacted_pre, evictable_allocs.size());
         std_allocs.emplace_back(managed_bytes::initialized_later(), std_alloc_size);
-        auto compacted_post = logalloc::memory_compacted();
+        auto compacted_post = logalloc::shard_tracker().statistics().memory_compacted;
         fmt::print("compacted {} items {} (post)\n", compacted_post, evictable_allocs.size());
         BOOST_REQUIRE_EQUAL(compacted_pre, compacted_post);
     

--- a/test/boost/managed_vector_test.cc
+++ b/test/boost/managed_vector_test.cc
@@ -9,6 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <seastar/testing/thread_test_case.hh>
 
+#include "test/lib/logalloc.hh"
 #include "utils/managed_vector.hh"
 #include "utils/logalloc.hh"
 
@@ -130,7 +131,8 @@ SEASTAR_THREAD_TEST_CASE(test_resize_down) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_compaction) {
-    logalloc::region reg;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region reg(*logalloc_tracker);
     with_allocator(reg.allocator(), [&] {
         managed_vector<unsigned> vec;
         fill(vec);

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -28,14 +28,16 @@
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/fragment_scatterer.hh"
+#include "test/lib/logalloc.hh"
 
 #include <boost/range/algorithm/transform.hpp>
 #include "readers/from_mutations_v2.hh"
 
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
     return seastar::async([] {
+        tests::logalloc::sharded_tracker logalloc_tracker;
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        dirty_memory_manager dmm(*logalloc_tracker);
         run_mutation_source_tests([&](schema_ptr s, const std::vector<mutation>& partitions) -> mutation_source {
             // We create a mutation source which combines N memtables.
             // The input fragments are spread among the memtables according to some selection logic,

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -35,6 +35,7 @@
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
+        dirty_memory_manager dmm;
         run_mutation_source_tests([&](schema_ptr s, const std::vector<mutation>& partitions) -> mutation_source {
             // We create a mutation source which combines N memtables.
             // The input fragments are spread among the memtables according to some selection logic,
@@ -43,7 +44,7 @@ SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
 
             std::vector<lw_shared_ptr<replica::memtable>> memtables;
             for (int i = 0; i < n; ++i) {
-                memtables.push_back(make_lw_shared<replica::memtable>(s));
+                memtables.push_back(make_lw_shared<replica::memtable>(s, dmm));
             }
 
             for (auto&& m : partitions) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -487,7 +487,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
         {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
 
     auto cf_stats = make_lw_shared<replica::cf_stats>();
-    replica::column_family::config cfg = column_family_test_config(env.semaphore());
+    replica::column_family::config cfg = env.make_table_config();
     cfg.enable_disk_reads = false;
     cfg.enable_disk_writes = false;
     cfg.enable_incremental_backups = false;
@@ -539,7 +539,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
 
     auto cf_stats = make_lw_shared<replica::cf_stats>();
 
-    replica::column_family::config cfg = column_family_test_config(env.semaphore());
+    replica::column_family::config cfg = env.make_table_config();
     cfg.enable_disk_reads = true;
     cfg.enable_disk_writes = true;
     cfg.enable_cache = true;
@@ -621,7 +621,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
 
     auto cf_stats = make_lw_shared<replica::cf_stats>();
 
-    replica::column_family::config cfg = column_family_test_config(env.semaphore());
+    replica::column_family::config cfg = env.make_table_config();
     cfg.enable_disk_reads = false;
     cfg.enable_disk_writes = false;
     cfg.enable_incremental_backups = false;

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -46,6 +46,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/log.hh"
+#include "test/lib/logalloc.hh"
 #include "types/map.hh"
 #include "types/list.hh"
 #include "types/set.hh"
@@ -90,7 +91,7 @@ static mutation_partition get_partition(reader_permit permit, replica::memtable&
 
 future<>
 with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::test_env& env, noncopyable_function<future<> (replica::column_family&)> func) {
-    auto tracker = make_lw_shared<cache_tracker>();
+    auto tracker = make_lw_shared<cache_tracker>(env.logalloc_tracker());
     auto dir = tmpdir();
     cfg.datadir = dir.path().string();
     auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{}, env.get_dirty_memory_manager());
@@ -105,7 +106,8 @@ with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::t
 SEASTAR_TEST_CASE(test_mutation_is_applied) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
 
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
@@ -210,7 +212,8 @@ collection_mutation_description make_collection_mutation(tombstone t, bytes key1
 SEASTAR_TEST_CASE(test_map_mutations) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
 
         auto my_map_type = map_type_impl::get_instance(int32_type, utf8_type, true);
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
@@ -249,7 +252,8 @@ SEASTAR_TEST_CASE(test_map_mutations) {
 SEASTAR_TEST_CASE(test_set_mutations) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
 
         auto my_set_type = set_type_impl::get_instance(int32_type, true);
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
@@ -288,7 +292,8 @@ SEASTAR_TEST_CASE(test_set_mutations) {
 SEASTAR_TEST_CASE(test_list_mutations) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
 
         auto my_list_type = list_type_impl::get_instance(int32_type, true);
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
@@ -327,7 +332,8 @@ SEASTAR_TEST_CASE(test_list_mutations) {
 
 SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
 
     // (a int, b text, c long, d text)
     auto ut = user_type_impl::get_instance("ks", to_bytes("ut"),
@@ -399,7 +405,8 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
 // there are no allocations larger than our usual 128KB buffer size.
 SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
 
     const auto key_type = int32_type;
     const auto value_type = utf8_type;
@@ -1161,7 +1168,8 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
 SEASTAR_TEST_CASE(test_large_blobs) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
 
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {}, {}, {{"s1", bytes_type}}, utf8_type);

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -26,6 +26,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/log.hh"
+#include "test/lib/logalloc.hh"
 
 #include <boost/range/adaptor/map.hpp>
 #include "readers/from_mutations_v2.hh"
@@ -442,8 +443,9 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer_abort) {
 
 // Check that the partition_based_splitting_mutation_writer can fix reordered partitions
 SEASTAR_THREAD_TEST_CASE(test_partition_based_splitting_mutation_writer) {
+    tests::logalloc::sharded_tracker logalloc_tracker;
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    dirty_memory_manager dmm;
+    dirty_memory_manager dmm(*logalloc_tracker);
     auto random_spec = tests::make_random_schema_specification(
             get_name(),
             std::uniform_int_distribution<size_t>(1, 2),

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -1367,7 +1367,8 @@ SEASTAR_TEST_CASE(test_ensure_entry_in_latest_does_not_set_continuity_in_reverse
 
 SEASTAR_TEST_CASE(test_apply_is_atomic) {
     auto do_test = [](auto&& gen) {
-        logalloc::region r(logalloc::shard_tracker());
+        ::logalloc::tracker tracker(tests::logalloc::default_config());
+        logalloc::region r(tracker);
         mutation_cleaner cleaner(r, no_cache_tracker, app_stats_for_tests);
         failure_injecting_allocation_strategy alloc(r.allocator());
         with_allocator(r.allocator(), [&] {

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -12,6 +12,7 @@
 #include "repair/row.hh"
 #include "repair/writer.hh"
 #include "repair/row_level.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
@@ -117,7 +118,8 @@ SEASTAR_TEST_CASE(flush_repair_rows_on_wire_to_sstable) {
     // to disk, they would produce the original stream.
     return seastar::async([&] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        dirty_memory_manager dmm;
+        tests::logalloc::sharded_tracker logalloc_tracker;
+        dirty_memory_manager dmm(*logalloc_tracker);
         reader_permit permit = semaphore.make_permit();
         random_mutation_generator gen{random_mutation_generator::generate_counters::no};
         schema_ptr s = gen.schema();

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -35,7 +35,7 @@ SEASTAR_TEST_CASE(test_schema_changes) {
             shared_sstable created_with_base_schema;
             shared_sstable created_with_changed_schema;
             if (it == cache.end()) {
-                auto mt = make_lw_shared<replica::memtable>(base);
+                auto mt = env.make_memtable(base);
                 for (auto& m : base_mutations) {
                     mt->apply(m);
                 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3023,7 +3023,7 @@ static flat_mutation_reader_v2 compacted_sstable_reader(test_env& env, schema_pt
     auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto tracker = make_lw_shared<cache_tracker>();
-    auto cf = make_lw_shared<replica::column_family>(s, column_family_test_config(env.semaphore()), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
+    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
     cf->mark_ready_for_writes();
     lw_shared_ptr<replica::memtable> mt = make_lw_shared<replica::memtable>(s);
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2303,10 +2303,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
             testlog.info("Validate");
 
             // No way to really test validation besides observing the log messages.
-            sstables::compaction_type_options::scrub opts = {
-                .operation_mode = sstables::compaction_type_options::scrub::mode::validate,
-            };
-            compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+            compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::validate).get();
 
             BOOST_REQUIRE(sst->is_quarantined());
             BOOST_REQUIRE(table->in_strategy_sstables().empty());
@@ -2502,9 +2499,7 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
             testlog.info("Scrub in abort mode");
 
             // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
-            sstables::compaction_type_options::scrub opts = {};
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+            compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::abort).get();
 
             BOOST_REQUIRE(table->in_strategy_sstables().size() == 1);
             verify_fragments(sst, corrupt_fragments);
@@ -2512,8 +2507,7 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
             testlog.info("Scrub in skip mode");
 
             // We expect the scrub with mode=srub::mode::skip to get rid of all invalid data.
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::skip;
-            compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+            compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::skip).get();
 
             BOOST_REQUIRE(table->in_strategy_sstables().size() == 1);
             BOOST_REQUIRE(table->in_strategy_sstables().front() != sst);
@@ -2599,9 +2593,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
             testlog.info("Scrub in abort mode");
 
             // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
-            sstables::compaction_type_options::scrub opts = {};
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+            compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::abort).get();
 
             BOOST_REQUIRE(table->in_strategy_sstables().size() == 1);
             verify_fragments(sst, corrupt_fragments);
@@ -2609,8 +2601,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
             testlog.info("Scrub in segregate mode");
 
             // We expect the scrub with mode=srub::mode::segregate to fix all out-of-order data.
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
-            compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+            compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::segregate).get();
 
             testlog.info("Scrub resulted in {} sstables", table->in_strategy_sstables().size());
             BOOST_REQUIRE(table->in_strategy_sstables().size() > 1);
@@ -2711,9 +2702,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
                 testlog.info("Scrub in validate mode");
 
                 // We expect the scrub with mode=scrub::mode::validate to quarantine the sstable.
-                sstables::compaction_type_options::scrub opts = {};
-                opts.operation_mode = sstables::compaction_type_options::scrub::mode::validate;
-                compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+                compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::validate).get();
 
                 BOOST_REQUIRE(table->in_strategy_sstables().empty());
                 BOOST_REQUIRE(sst->is_quarantined());
@@ -2722,9 +2711,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
                 testlog.info("Scrub in segregate mode with quarantine_mode {}", qmode);
 
                 // We expect the scrub with mode=scrub::mode::segregate to fix all out-of-order data.
-                opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
-                opts.quarantine_operation_mode = qmode;
-                compaction_manager.perform_sstable_scrub(table.get(), opts).get();
+                compaction_manager.perform_sstable_scrub(table.get(), sstables::compaction_type_options::scrub::mode::segregate, qmode).get();
 
                 switch (qmode) {
                 case sstables::compaction_type_options::scrub::quarantine_mode::include:

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -193,7 +193,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
     auto cm = compaction_manager_for_testing();
 
     auto tmp = tmpdir();
-    replica::column_family::config cfg = column_family_test_config(env.semaphore());
+    replica::column_family::config cfg = env.make_table_config();
     cfg.datadir = tmp.path().string();
     cfg.enable_commitlog = false;
     cfg.enable_incremental_backups = false;
@@ -268,7 +268,7 @@ SEASTAR_TEST_CASE(compact) {
     auto cm = compaction_manager_for_testing();
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto tracker = make_lw_shared<cache_tracker>();
-    auto cf = make_lw_shared<replica::column_family>(s, column_family_test_config(env.semaphore()), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
+    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
     cf->mark_ready_for_writes();
 
     test_setup::do_with_tmp_directory([s, generation, cf, cm] (test_env& env, sstring tmpdir_path) {
@@ -2122,7 +2122,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             auto sst = make_sstable_containing(sst_gen, mutations);
             auto run_identifier = sst->run_identifier();
 
-            auto cf = make_lw_shared<replica::column_family>(s, column_family_test_config(env.semaphore()), replica::column_family::no_commitlog(),
+            auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(),
                 db.get_compaction_manager(), env.manager(), cl_stats, db.row_cache_tracker());
             cf->mark_ready_for_writes();
             cf->start();
@@ -2271,7 +2271,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
-            auto cfg = column_family_test_config(env.semaphore());
+            auto cfg = env.make_table_config();
             cfg.datadir = tmp.path().string();
             auto table = make_lw_shared<replica::column_family>(schema, cfg, replica::column_family::no_commitlog(),
                 db.get_compaction_manager(), env.manager(), cl_stats, db.row_cache_tracker());
@@ -2470,7 +2470,7 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
-            auto cfg = column_family_test_config(env.semaphore());
+            auto cfg = env.make_table_config();
             cfg.datadir = tmp.path().string();
             auto table = make_lw_shared<replica::column_family>(schema, cfg, replica::column_family::no_commitlog(),
                 db.get_compaction_manager(), env.manager(), cl_stats, db.row_cache_tracker());
@@ -2567,7 +2567,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
-            auto cfg = column_family_test_config(env.semaphore());
+            auto cfg = env.make_table_config();
             cfg.datadir = tmp.path().string();
             auto table = make_lw_shared<replica::column_family>(schema, cfg, replica::column_family::no_commitlog(),
                 db.get_compaction_manager(), env.manager(), cl_stats, db.row_cache_tracker());
@@ -2679,7 +2679,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
 
                 testlog.info("Loaded sstable {}", sst->get_filename());
 
-                auto cfg = column_family_test_config(env.semaphore());
+                auto cfg = env.make_table_config();
                 cfg.datadir = tmp.path().string();
                 auto table = make_lw_shared<replica::column_family>(schema, cfg, replica::column_family::no_commitlog(),
                     db.get_compaction_manager(), env.manager(), cl_stats, db.row_cache_tracker());
@@ -3246,7 +3246,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         auto cm = compaction_manager_for_testing();
 
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_commitlog = false;
         cfg.enable_incremental_backups = false;
@@ -3511,7 +3511,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         forward_jump_clocks(std::chrono::seconds(ttl));
 
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = false;
         cfg.enable_commitlog = false;
@@ -3619,7 +3619,7 @@ SEASTAR_TEST_CASE(twcs_major_compaction_test) {
         auto mut4 = make_insert(1ms);
 
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = true;
         cfg.enable_commitlog = false;
@@ -3656,7 +3656,7 @@ SEASTAR_TEST_CASE(autocompaction_control_test) {
                 .build();
 
         auto tmp = tmpdir();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_commitlog = false;
         cfg.enable_disk_writes = true;
@@ -3757,7 +3757,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
         };
 
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmpdir_path;
         cfg.enable_disk_writes = true;
         cfg.enable_commitlog = false;
@@ -3889,7 +3889,7 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
         };
 
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmpdir_path;
         cfg.enable_disk_writes = true;
         cfg.enable_commitlog = false;
@@ -4018,7 +4018,7 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
 
         auto tmp = tmpdir();
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = true;
         cfg.enable_cache = false;
@@ -4126,7 +4126,7 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
 
             auto cm = compaction_manager_for_testing();
 
-            replica::column_family::config cfg = column_family_test_config(env.semaphore());
+            replica::column_family::config cfg = env.make_table_config();
             cfg.datadir = tmp.path().string();
             cfg.enable_disk_writes = true;
             cfg.enable_cache = false;
@@ -4409,7 +4409,7 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         auto dkey = sst1->get_first_decorated_key();
 
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         replica::cf_stats cf_stats{0};
         cfg.cf_stats = &cf_stats;
         cfg.datadir = tmp.path().string();
@@ -4501,7 +4501,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
 
         auto make_table_with_single_fully_expired_sstable = [&] (auto idx) {
             auto s = make_schema(idx);
-            replica::column_family::config cfg = column_family_test_config(env.semaphore());
+            replica::column_family::config cfg = env.make_table_config();
             cfg.datadir = tmp.path().string() + "/" + std::to_string(idx);
             touch_directory(cfg.datadir).get();
             cfg.enable_commitlog = false;
@@ -4702,7 +4702,7 @@ SEASTAR_TEST_CASE(twcs_single_key_reader_through_compound_set_test) {
 
         auto tmp = tmpdir();
         auto cm = compaction_manager_for_testing();
-        replica::column_family::config cfg = column_family_test_config(env.semaphore());
+        replica::column_family::config cfg = env.make_table_config();
         replica::cf_stats cf_stats{0};
         cfg.cf_stats = &cf_stats;
         cfg.datadir = tmp.path().string();
@@ -4834,7 +4834,7 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
             simple_schema ss;
             auto s = ss.schema();
 
-            replica::column_family::config cfg = column_family_test_config(env.semaphore());
+            replica::column_family::config cfg = env.make_table_config();
             cfg.datadir = "";
             cfg.enable_disk_writes = true;
             cfg.enable_cache = false;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -190,7 +190,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
     auto s = make_shared_schema({}, some_keyspace, some_column_family,
         {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", int32_type}}, {}, utf8_type);
 
-    auto cm = compaction_manager_for_testing();
+    auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
 
     auto tmp = tmpdir();
     replica::column_family::config cfg = env.make_table_config();
@@ -208,7 +208,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
     for (auto generation : generations) {
         // create 4 sstables of similar size to be compacted later on.
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
 
@@ -265,7 +265,7 @@ SEASTAR_TEST_CASE(compact) {
     builder.set_comment("Example table for compaction");
     builder.set_gc_grace_seconds(std::numeric_limits<int32_t>::max());
     auto s = builder.build();
-    auto cm = compaction_manager_for_testing();
+    auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto tracker = make_lw_shared<cache_tracker>();
     auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
@@ -387,7 +387,7 @@ static future<std::vector<unsigned long>> compact_sstables(test_env& env, sstrin
             });
         }
         return do_for_each(*generations, [&env, generations, sstables, s, min_sstable_size, tmpdir_path] (unsigned long generation) {
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
 
             const column_definition& r1_col = *s->get_column_definition("r1");
 
@@ -1248,7 +1248,7 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
 
@@ -1314,7 +1314,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time_2) {
                 schema_ptr s = builder.build(schema_builder::compact_storage::no);
                 column_family_for_tests cf(env.manager(), s);
                 auto close_cf = deferred_stop(cf);
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 auto now = gc_clock::now();
                 int32_t last_expiry = 0;
                 auto add_row = [&now, &mt, &s, &last_expiry](mutation &m, bytes column_name, uint32_t ttl) {
@@ -1339,7 +1339,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time_2) {
                 auto sst1 = get_usable_sst(*mt, 54).get0();
                 BOOST_REQUIRE(last_expiry == sst1->get_stats_metadata().max_local_deletion_time);
 
-                mt = make_lw_shared<replica::memtable>(s);
+                mt = env.make_memtable(s);
                 m = mutation(s, partition_key::from_exploded(*s, {to_bytes("deletetest")}));
                 tombstone tomb(api::new_timestamp(), now);
                 m.partition().apply_delete(*s, clustering_key::from_exploded(*s, {to_bytes("todelete")}), tomb);
@@ -1422,7 +1422,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
             return env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
         };
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mutation m(s, key);
         tombstone tomb(api::new_timestamp(), gc_clock::now() - std::chrono::seconds(3600));
         m.partition().apply_delete(*s, c_key, tomb);
@@ -1814,7 +1814,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test_2) {
             column_family_for_tests cf(env.manager(), s);
             auto close_cf = deferred_stop(cf);
             auto tmp = tmpdir();
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
             const column_definition &r1_col = *s->get_column_definition("r1");
 
             for (auto j = 0; j < 8; j++) {
@@ -1831,7 +1831,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test_2) {
             sst = env.reusable_sst(s, tmp.path().string(), 1, version).get0();
             check_min_max_column_names(sst, {"0ck100"}, {"7ck149"});
 
-            mt = make_lw_shared<replica::memtable>(s);
+            mt = env.make_memtable(s);
             auto key = partition_key::from_exploded(*s, {to_bytes("key9")});
             mutation m(s, key);
             for (auto i = 101; i < 299; i++) {
@@ -1879,7 +1879,7 @@ SEASTAR_TEST_CASE(sstable_expired_data_ratio) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         static constexpr float expired = 0.33;
         // we want number of expired keys to be ~ 1.5*sstables::TOMBSTONE_HISTOGRAM_BIN_SIZE so as to
@@ -2254,7 +2254,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
                 return env.make_sstable(schema, tmp.path().string(), (*gen)++);
             };
 
-            auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
+            auto scrubbed_mt = env.make_memtable(schema);
             auto sst = sst_gen();
 
             testlog.info("Writing sstable {}", sst->get_filename());
@@ -2550,7 +2550,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
                 return env.make_sstable(schema, tmp.path().string(), (*gen)++);
             };
 
-            auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
+            auto scrubbed_mt = env.make_memtable(schema);
             auto sst = sst_gen();
 
             testlog.info("Writing sstable {}", sst->get_filename());
@@ -2662,7 +2662,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
                     return env.make_sstable(schema, tmp.path().string(), (*gen)++);
                 };
 
-                auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
+                auto scrubbed_mt = env.make_memtable(schema);
                 auto sst = sst_gen();
 
                 testlog.info("Writing sstable {}", sst->get_filename());
@@ -2761,6 +2761,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
     simple_schema ss;
     auto schema = ss.schema();
     tests::reader_concurrency_semaphore_wrapper semaphore;
+    dirty_memory_manager dmm;
     auto permit = semaphore.make_permit();
 
     struct expected_rows_type {
@@ -2843,6 +2844,10 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
 
     std::list<std::deque<mutation_fragment_v2>> segregated_fragment_streams;
 
+    auto mt_factory = [&dmm] (schema_ptr s) {
+        return make_lw_shared<replica::memtable>(std::move(s), dmm);
+    };
+
     mutation_writer::segregate_by_partition(
             make_scrubbing_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(all_fragments)), sstables::compaction_type_options::scrub::mode::segregate),
             mutation_writer::segregate_config{default_priority_class(), 100000},
@@ -2854,7 +2859,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
                 fragments.emplace_back(*schema, rd.permit(), *mf_opt);
             }
         });
-    }).get();
+    }, mt_factory).get();
 
     testlog.info("Segregation resulted in {} fragment streams", segregated_fragment_streams.size());
 
@@ -3244,7 +3249,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         auto tmp = tmpdir();
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
 
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
@@ -3510,7 +3515,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         // make mut1_deletion gc'able.
         forward_jump_clocks(std::chrono::seconds(ttl));
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = false;
@@ -3618,7 +3623,7 @@ SEASTAR_TEST_CASE(twcs_major_compaction_test) {
         auto mut3 = make_insert(0ms);
         auto mut4 = make_insert(1ms);
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = true;
@@ -3647,7 +3652,7 @@ SEASTAR_TEST_CASE(autocompaction_control_test) {
         cell_locker_stats cl_stats;
         cache_tracker tracker;
 
-        auto cmft = compaction_manager_for_testing();
+        auto cmft = compaction_manager_for_testing(env.get_dirty_memory_manager());
         auto& cm = *cmft;
 
         auto s = schema_builder(some_keyspace, some_column_family)
@@ -3756,7 +3761,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
             return m;
         };
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmpdir_path;
         cfg.enable_disk_writes = true;
@@ -3888,7 +3893,7 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
             return make_sstable_containing(sst_gen, {m});
         };
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmpdir_path;
         cfg.enable_disk_writes = true;
@@ -4017,7 +4022,7 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
         };
 
         auto tmp = tmpdir();
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         cfg.datadir = tmp.path().string();
         cfg.enable_disk_writes = true;
@@ -4031,7 +4036,7 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
         size_t target_windows_span = (split_during_flush) ? 10 : 1;
         constexpr size_t rows_per_window = 10;
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         for (unsigned i = 1; i <= target_windows_span; i++) {
             for (unsigned j = 0; j < rows_per_window; j++) {
                 mt->apply(make_row(std::chrono::hours(i)));
@@ -4124,7 +4129,7 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
             auto mut = mutation(s, pk);
             ss.add_row(mut, ss.make_ckey(0), "val");
 
-            auto cm = compaction_manager_for_testing();
+            auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
 
             replica::column_family::config cfg = env.make_table_config();
             cfg.datadir = tmp.path().string();
@@ -4408,7 +4413,7 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         auto sst2 = make_sstable_containing(sst_gen, {make_row(0, 1)});
         auto dkey = sst1->get_first_decorated_key();
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         replica::cf_stats cf_stats{0};
         cfg.cf_stats = &cf_stats;
@@ -4476,7 +4481,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             return builder.build();
         };
 
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
 
         auto tmp = tmpdir();
         auto cl_stats = make_lw_shared<cell_locker_stats>();
@@ -4701,7 +4706,7 @@ SEASTAR_TEST_CASE(twcs_single_key_reader_through_compound_set_test) {
         };
 
         auto tmp = tmpdir();
-        auto cm = compaction_manager_for_testing();
+        auto cm = compaction_manager_for_testing(env.get_dirty_memory_manager());
         replica::column_family::config cfg = env.make_table_config();
         replica::cf_stats cf_stats{0};
         cfg.cf_stats = &cf_stats;
@@ -4810,6 +4815,7 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
 
         auto as = abort_source();
         compaction_manager::config cfg = {
+            .dmm = env.get_dirty_memory_manager(),
             .compaction_sched_group = { default_scheduling_group(), default_priority_class() },
             .maintenance_sched_group = { default_scheduling_group(), default_priority_class() },
             .available_memory = available_memory,

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -236,7 +236,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
     auto rev_full_slice = native_reverse_slice_to_legacy_reverse_slice(*query_schema, query_schema->full_slice());
     rev_full_slice.options.set(query::partition_slice::option::reversed);
 
-    sstables::test_env::do_with([&, version = writable_sstable_versions[1]] (sstables::test_env& env) {
+    sstables::test_env::do_with_async([&, version = writable_sstable_versions[1]] (sstables::test_env& env) {
 
         std::vector<tmpdir> dirs;
         sstable_writer_config cfg = env.manager().configure_writer();

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -57,7 +57,7 @@ void test_cache_population_with_range_tombstone_adjacent_to_population_range(tes
     s.delete_range(m1, s.make_ckey_range(2, 100));
     cache_mt->apply(m1);
 
-    cache_tracker tracker;
+    cache_tracker tracker(env.logalloc_tracker());
     auto ms = populate(s.schema(), std::vector<mutation>({m1}), gc_clock::now());
     row_cache cache(s.schema(), snapshot_source_from_snapshot(std::move(ms)), tracker);
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -89,7 +89,7 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", int32_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
 
@@ -130,7 +130,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = complex_schema();
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         const column_definition& set_col = *s->get_column_definition("reg_set");
         const column_definition& static_set_col = *s->get_column_definition("static_collection");
@@ -229,7 +229,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = complex_schema();
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto cp = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
@@ -267,7 +267,7 @@ static future<> sstable_compression_test(compressor_ptr c, unsigned generation) 
         builder.set_compressor_params(c);
         auto s = builder.build(schema_builder::compact_storage::no);
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
+        auto mtp = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto cp = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
@@ -314,7 +314,7 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = uncompressed_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
+        auto mtp = env.make_memtable(s);
         // Create a number of keys that is a multiple of the sampling level
         for (int i = 0; i < 0x80; ++i) {
             sstring k = "key" + to_sstring(i);
@@ -350,7 +350,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = compact_simple_dense_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
+        auto mtp = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
@@ -387,7 +387,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = compact_dense_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
+        auto mtp = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
@@ -423,7 +423,7 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         auto s = compact_sparse_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
+        auto mtp = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
@@ -461,7 +461,7 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", int32_type}, {"r2", int32_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto c_key = clustering_key::from_exploded(*s, {to_bytes("c1")});
@@ -496,7 +496,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
 
@@ -534,7 +534,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
                     .with_column("r1", counter_type)
                     .with_column("r2", counter_type)
                     .build();
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
 
             auto& r1_col = *s->get_column_definition("r1");
             auto& r2_col = *s->get_column_definition("r2");
@@ -960,7 +960,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time) {
                 builder.with_column("c1", utf8_type, column_kind::clustering_key);
                 builder.with_column("r1", utf8_type);
                 schema_ptr s = builder.build(schema_builder::compact_storage::no);
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 int32_t last_expiry = 0;
                 for (auto i = 0; i < 10; i++) {
                     auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(i))});
@@ -1056,7 +1056,7 @@ static void check_min_max_column_names(const sstable_ptr& sst, std::vector<bytes
 
 static void test_min_max_clustering_key(test_env& env, schema_ptr s, std::vector<bytes> exploded_pk, std::vector<std::vector<bytes>> exploded_cks,
         std::vector<bytes> min_components, std::vector<bytes> max_components, sstable_version_types version, bool remove = false) {
-    auto mt = make_lw_shared<replica::memtable>(s);
+    auto mt = env.make_memtable(s);
     auto insert_data = [&mt, &s] (std::vector<bytes>& exploded_pk, std::vector<bytes>&& exploded_ck) {
         const column_definition& r1_col = *s->get_column_definition("r1");
         auto key = partition_key::from_exploded(*s, exploded_pk);
@@ -1218,7 +1218,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
@@ -1231,7 +1231,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
@@ -1243,7 +1243,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
@@ -1255,7 +1255,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
 
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1275,7 +1275,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
@@ -1288,7 +1288,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 range_tombstone rt(clustering_key_prefix::from_single_value(*s, bytes(
@@ -1305,7 +1305,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1325,7 +1325,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1345,7 +1345,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1366,7 +1366,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
 
             if (version >= sstable_version_types::mc) {
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1384,7 +1384,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 }
 
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1402,7 +1402,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 }
 
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1436,7 +1436,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
@@ -1449,7 +1449,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
@@ -1461,7 +1461,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
@@ -1473,7 +1473,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
 
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1493,7 +1493,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
@@ -1506,7 +1506,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 range_tombstone rt(
@@ -1525,7 +1525,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1545,7 +1545,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1565,7 +1565,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1586,7 +1586,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
 
             if (version >= sstable_version_types::mc) {
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1604,7 +1604,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 }
 
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1642,7 +1642,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
@@ -1655,7 +1655,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
@@ -1667,7 +1667,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
@@ -1679,7 +1679,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
 
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1699,7 +1699,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
@@ -1712,7 +1712,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 range_tombstone rt(
@@ -1731,7 +1731,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1751,7 +1751,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1771,7 +1771,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             }
 
             {
-                auto mt = make_lw_shared<replica::memtable>(s);
+                auto mt = env.make_memtable(s);
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1792,7 +1792,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
 
             if (version >= sstable_version_types::mc) {
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -1810,7 +1810,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 }
 
                 {
-                    auto mt = make_lw_shared<replica::memtable>(s);
+                    auto mt = env.make_memtable(s);
                     mutation m(s, key);
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
@@ -2971,7 +2971,7 @@ SEASTAR_TEST_CASE(sstable_reader_with_timeout) {
         return async([&env, tmpdir_path] {
             auto s = complex_schema();
 
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
 
             auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
             auto cp = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -78,7 +78,7 @@ make_sstable_for_all_shards(replica::database& db, replica::table& table, fs::pa
     // but the users are usually in a thread, and rewrite_toc_without_scylla_component requires
     // a thread. We could fix that, but deferring that for now.
     auto s = table.schema();
-    auto mt = make_lw_shared<replica::memtable>(s);
+    auto mt = make_lw_shared<replica::memtable>(s, db.get_user_dirty_memory_manager());
     auto msb = db.get_config().murmur3_partitioner_ignore_msb_bits();
     for (shard_id shard = 0; shard < smp::count; ++shard) {
         auto key_token_pair = token_generation_for_shard(1, shard, msb);

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -11,6 +11,7 @@
 #include <seastar/testing/thread_test_case.hh>
 
 #include "utils/lister.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/sstable_test_env.hh"
 #include "sstable_test.hh"
@@ -32,7 +33,8 @@ static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schem
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
     tmpdir tmp;
-    auto env = test_env();
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    auto env = test_env(*logalloc_tracker);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;
@@ -84,7 +86,8 @@ static bool partial_create_links(sstable_ptr sst, fs::path dst_path, int64_t gen
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
     tmpdir tmp;
-    auto env = test_env();
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    auto env = test_env(*logalloc_tracker);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;
@@ -105,7 +108,8 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     tmpdir tmp;
-    auto env = test_env();
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    auto env = test_env(*logalloc_tracker);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -412,7 +412,7 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
         auto ttl = gc_clock::now() + std::chrono::seconds(1);
         m.partition().apply_delete(*s, range_tombstone(c_key_start, bound_kind::excl_start, c_key_end, bound_kind::excl_end, tombstone(9, ttl)));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
 
         auto sst = env.make_sstable(s,
@@ -856,7 +856,7 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
         m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
 
         auto sst = env.make_sstable(s,
@@ -891,7 +891,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
             m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
             mt->apply(std::move(m));
 
             auto sst = env.make_sstable(s,
@@ -954,7 +954,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
@@ -991,7 +991,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_with_auto_scaling) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
@@ -1036,7 +1036,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
@@ -1087,7 +1087,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(std::move(m));
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
@@ -1135,7 +1135,7 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
             auto ck = clustering_key::from_exploded(*s, {bytes_type->decompose(data_value(to_bytes("ck3")))});
             m.set_clustered_cell(ck, *s->get_column_definition("v"), atomic_cell(*int32_type, cell));
 
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = env.make_memtable(s);
             mt->apply(m);
             sstable_writer_config cfg = env.manager().configure_writer();
             cfg.promoted_index_block_size = 1;
@@ -1173,7 +1173,7 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(m);
         sstable_writer_config cfg = env.manager().configure_writer();
 
@@ -1204,7 +1204,7 @@ SEASTAR_TEST_CASE(test_promoted_index_is_absent_for_schemas_without_clustering_k
             auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(v), { });
             m.set_clustered_cell(clustering_key_prefix::make_empty(), *s->get_column_definition("v"), atomic_cell(*int32_type, cell));
         }
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         mt->apply(m);
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
@@ -1240,10 +1240,10 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
         m2.partition().apply_delete(*s, rt2);
         ss.add_row(m2, ss.make_ckey(4), "v2"); // position inside rt2
 
-        auto mt1 = make_lw_shared<replica::memtable>(s);
+        auto mt1 = env.make_memtable(s);
         mt1->apply(m1);
 
-        auto mt2 = make_lw_shared<replica::memtable>(s);
+        auto mt2 = env.make_memtable(s);
         mt2->apply(m2);
         auto combined_permit = env.make_reader_permit();
         auto mr = make_combined_reader(s, combined_permit,
@@ -1402,7 +1402,7 @@ SEASTAR_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) {
 
     seastar::memory::scoped_large_allocation_warning_threshold mtg(logalloc::segment_size);
 
-    auto mt = make_lw_shared<replica::memtable>(s);
+    auto mt = env.make_memtable(s);
     {
         mutation m(s, *large_key);
         ss.add_row(m, ss.make_ckey(0), "v");
@@ -1471,7 +1471,7 @@ SEASTAR_TEST_CASE(test_reading_serialization_header) {
             tests::data_model::mutation_description::atomic_value(random_int32_value(), tests::data_model::data_timestamp, ttl, expiry_time));
     auto m2 = md2.build(s);
 
-    auto mt = make_lw_shared<replica::memtable>(s);
+    auto mt = env.make_memtable(s);
     mt->apply(m1);
     mt->apply(m2);
 
@@ -1574,7 +1574,7 @@ SEASTAR_TEST_CASE(test_counter_header_size) {
     }
     m.set_clustered_cell(ck, col, ccb.build(api::new_timestamp()));
 
-    auto mt = make_lw_shared<replica::memtable>(s);
+    auto mt = env.make_memtable(s);
     mt->apply(m);
 
     for (const auto version : writable_sstable_versions) {

--- a/test/boost/sstable_partition_index_cache_test.cc
+++ b/test/boost/sstable_partition_index_cache_test.cc
@@ -63,7 +63,8 @@ static void has_page0(partition_index_cache::list_ptr ptr) {
 SEASTAR_THREAD_TEST_CASE(test_caching) {
     ::lru lru;
     simple_schema s;
-    logalloc::region r;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region r(*logalloc_tracker);
     partition_index_cache cache(lru, r);
 
     auto page0_loader = [&] (partition_index_cache::key_type k) {
@@ -152,7 +153,8 @@ static future<> ignore_result(future<T>&& f) {
 SEASTAR_THREAD_TEST_CASE(test_exception_while_loading) {
     ::lru lru;
     simple_schema s;
-    logalloc::region r;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region r(*logalloc_tracker);
     partition_index_cache cache(lru, r);
 
     auto clear_lru = defer([&] {
@@ -182,7 +184,8 @@ SEASTAR_THREAD_TEST_CASE(test_exception_while_loading) {
 SEASTAR_THREAD_TEST_CASE(test_auto_clear) {
     ::lru lru;
     simple_schema s;
-    logalloc::region r;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region r(*logalloc_tracker);
 
     partition_index_cache::stats old_stats;
 
@@ -209,7 +212,8 @@ SEASTAR_THREAD_TEST_CASE(test_auto_clear) {
 SEASTAR_THREAD_TEST_CASE(test_destroy) {
     ::lru lru;
     simple_schema s;
-    logalloc::region r;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region r(*logalloc_tracker);
 
     partition_index_cache::stats old_stats;
 
@@ -235,7 +239,8 @@ SEASTAR_THREAD_TEST_CASE(test_destroy) {
 SEASTAR_THREAD_TEST_CASE(test_evict_gently) {
     ::lru lru;
     simple_schema s;
-    logalloc::region r;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    logalloc::region r(*logalloc_tracker);
 
     partition_index_cache::stats old_stats;
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -47,7 +47,7 @@ void run_sstable_resharding_test() {
     auto s = get_schema();
     auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
     auto cl_stats = make_lw_shared<cell_locker_stats>();
-    auto cf = make_lw_shared<replica::column_family>(s, column_family_test_config(env.semaphore()), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, tracker);
+    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, tracker);
     cf->mark_ready_for_writes();
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -45,7 +45,7 @@ void run_sstable_resharding_test() {
   for (const auto version : writable_sstable_versions) {
     auto tmp = tmpdir();
     auto s = get_schema();
-    auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+    auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{}, env.get_dirty_memory_manager());
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, tracker);
     cf->mark_ready_for_writes();
@@ -54,7 +54,7 @@ void run_sstable_resharding_test() {
 
     // create sst shared by all shards
     {
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = env.make_memtable(s);
         auto get_mutation = [mt, s] (sstring key_to_write, auto value) {
             auto key = partition_key::from_exploded(*s, {to_bytes(key_to_write)});
             mutation m(s, key);

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -18,6 +18,7 @@
 #include "test/lib/tmpdir.hh"
 #include "cell_locking.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/sstable_utils.hh"
 #include "service/storage_proxy.hh"
 #include "db/config.hh"
@@ -39,9 +40,10 @@ static schema_ptr get_schema(unsigned shard_count, unsigned sharding_ignore_msb_
 }
 
 void run_sstable_resharding_test() {
-    test_env env;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    test_env env(*logalloc_tracker);
     auto close_env = defer([&] { env.stop().get(); });
-    cache_tracker tracker;
+    cache_tracker tracker(*logalloc_tracker);
   for (const auto version : writable_sstable_versions) {
     auto tmp = tmpdir();
     auto s = get_schema();

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -787,6 +787,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
     };
 
     reader_concurrency_semaphore sem(reader_concurrency_semaphore::for_tests{}, get_name(), 1, replica::new_reader_base_cost);
+    dirty_memory_manager dmm;
     auto stop_sem = deferred_stop(sem);
 
     auto schema = schema_builder("ks", "cf")
@@ -825,7 +826,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
 
         auto permit = sem.obtain_permit(schema.get(), get_name(), replica::new_reader_base_cost, db::no_timeout).get0();
 
-        auto mt = make_lw_shared<replica::memtable>(schema);
+        auto mt = make_lw_shared<replica::memtable>(schema, dmm);
         for (const auto& mut : muts) {
             mt->apply(mut);
         }

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -787,7 +787,8 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
     };
 
     reader_concurrency_semaphore sem(reader_concurrency_semaphore::for_tests{}, get_name(), 1, replica::new_reader_base_cost);
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
     auto stop_sem = deferred_stop(sem);
 
     auto schema = schema_builder("ks", "cf")

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -53,7 +53,8 @@ public:
 };
 
 SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
     std::unique_ptr<memtable_filling_test_vt> table; // Used to prolong table's life
 
     auto mt_factory = [&dmm] (schema_ptr s) {
@@ -67,7 +68,8 @@ SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
     std::unique_ptr<streaming_test_vt> table; // Used to prolong table's life
 
     run_mutation_source_tests([&table, &dmm] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -45,6 +45,7 @@
 #include "db/query_context.hh"
 #include "test/lib/test_services.hh"
 #include "test/lib/log.hh"
+#include "test/lib/logalloc.hh"
 #include "unit_test_service_levels_accessor.hh"
 #include "db/view/view_builder.hh"
 #include "db/view/node_view_update_backlog.hh"
@@ -446,7 +447,8 @@ public:
                 engine().update_blocked_reactor_notify_ms(std::chrono::milliseconds(1000000));
             }).get();
 
-            logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
+            tests::logalloc::sharded_tracker logalloc_tracker;
+
             bool old_active = false;
             if (!active.compare_exchange_strong(old_active, true)) {
                 throw std::runtime_error("Starting more than one cql_test_env at a time not supported due to singletons.");

--- a/test/lib/logalloc.hh
+++ b/test/lib/logalloc.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "utils/logalloc.hh"
+
+#include <seastar/core/sharded.hh>
+
+namespace tests::logalloc {
+
+// Must live in a seastar thread
+class sharded_tracker {
+    bool _need_stop = false;
+public:
+    explicit sharded_tracker(uint64_t available_memory, uint64_t min_free_memory, std::optional<::logalloc::tracker::config> cfg = {}) {
+        ::logalloc::prime_segment_pool(available_memory, min_free_memory).get();
+        if (cfg) {
+            ::logalloc::shard_tracker().configure(*cfg);
+            _need_stop = true;
+        }
+    }
+    explicit sharded_tracker(::logalloc::tracker::config cfg)
+        : sharded_tracker(memory::stats().total_memory(), memory::min_free_memory(), std::move(cfg)) {
+    }
+    sharded_tracker()
+        : sharded_tracker(memory::stats().total_memory(), memory::min_free_memory(), {}) {
+    }
+    ~sharded_tracker() {
+        if (_need_stop) {
+            ::logalloc::shard_tracker().stop().get();
+        }
+    }
+
+    ::logalloc::tracker& operator*() {
+        return ::logalloc::shard_tracker();
+    }
+
+    ::logalloc::tracker* operator->() {
+        return &::logalloc::shard_tracker();
+    }
+};
+
+}

--- a/test/lib/memtable_snapshot_source.hh
+++ b/test/lib/memtable_snapshot_source.hh
@@ -79,8 +79,9 @@ private:
         _memtables.push_back(new_mt);
     }
 public:
-    memtable_snapshot_source(schema_ptr s)
+    memtable_snapshot_source(schema_ptr s, logalloc::tracker& tracker)
         : _s(s)
+        , _dmm(tracker)
         , _compactor(seastar::async([this] () noexcept {
             while (!_closed) {
                 // condition_variable::wait() also allocates memory

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -29,25 +29,32 @@ public:
 };
 
 class test_env {
-    std::unique_ptr<cache_tracker> _cache_tracker;
-    std::unique_ptr<test_env_sstables_manager> _mgr;
-    std::unique_ptr<reader_concurrency_semaphore> _semaphore;
+    struct impl {
+        cache_tracker cache_tracker;
+        test_env_sstables_manager mgr;
+        reader_concurrency_semaphore semaphore;
+
+        impl()
+            : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker)
+            , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
+        { }
+        impl(impl&&) = delete;
+        impl(const impl&) = delete;
+    };
+    std::unique_ptr<impl> _impl;
 public:
-    explicit test_env()
-        : _cache_tracker(std::make_unique<cache_tracker>())
-        , _mgr(std::make_unique<test_env_sstables_manager>(nop_lp_handler, test_db_config, test_feature_service, *_cache_tracker))
-        , _semaphore(std::make_unique<reader_concurrency_semaphore>(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")) { }
+    explicit test_env() : _impl(std::make_unique<impl>()) { }
 
     future<> stop() {
-        return _mgr->close().finally([this] {
-            return _semaphore->stop();
+        return _impl->mgr.close().finally([this] {
+            return _impl->semaphore.stop();
         });
     }
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
-        return _mgr->make_sstable(std::move(schema), dir, generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
+        return _impl->mgr.make_sstable(std::move(schema), dir, generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
     }
 
     struct sst_not_found : public std::runtime_error {
@@ -67,13 +74,13 @@ public:
     // looks up the sstable in the given dir
     future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, unsigned long generation);
 
-    test_env_sstables_manager& manager() { return *_mgr; }
-    reader_concurrency_semaphore& semaphore() { return *_semaphore; }
+    test_env_sstables_manager& manager() { return _impl->mgr; }
+    reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
-        return _semaphore->make_tracking_only_permit(s, n, timeout);
+        return _impl->semaphore.make_tracking_only_permit(s, n, timeout);
     }
     reader_permit make_reader_permit(db::timeout_clock::time_point timeout = db::no_timeout) {
-        return _semaphore->make_tracking_only_permit(nullptr, "test", timeout);
+        return _impl->semaphore.make_tracking_only_permit(nullptr, "test", timeout);
     }
 
     future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -83,6 +83,10 @@ public:
         return _impl->semaphore.make_tracking_only_permit(nullptr, "test", timeout);
     }
 
+    replica::table::config make_table_config() {
+        return replica::table::config{.compaction_concurrency_semaphore = &_impl->semaphore};
+    }
+
     future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {
         return reusable_sst(std::move(schema), dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
     }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -91,6 +91,10 @@ public:
         return replica::table::config{.dirty_memory_manager = &_impl->dmm, .compaction_concurrency_semaphore = &_impl->semaphore};
     }
 
+    lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s) {
+        return make_lw_shared<replica::memtable>(std::move(s), _impl->dmm);
+    }
+
     future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {
         return reusable_sst(std::move(schema), dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
     }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -33,6 +33,7 @@ class test_env {
         cache_tracker cache_tracker;
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
+        dirty_memory_manager dmm;
 
         impl()
             : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker)
@@ -83,8 +84,11 @@ public:
         return _impl->semaphore.make_tracking_only_permit(nullptr, "test", timeout);
     }
 
+    dirty_memory_manager& get_dirty_memory_manager() {
+        return _impl->dmm;
+    }
     replica::table::config make_table_config() {
-        return replica::table::config{.compaction_concurrency_semaphore = &_impl->semaphore};
+        return replica::table::config{.dirty_memory_manager = &_impl->dmm, .compaction_concurrency_semaphore = &_impl->semaphore};
     }
 
     future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -18,6 +18,7 @@
 #include <boost/range/algorithm/sort.hpp>
 #include "sstables/version.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
+#include "test/lib/logalloc.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
@@ -57,7 +58,8 @@ std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_ke
 
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    dirty_memory_manager dmm;
+    tests::logalloc::sharded_tracker logalloc_tracker;
+    dirty_memory_manager dmm(*logalloc_tracker);
 
     auto sst = sst_factory();
     schema_ptr s = muts[0].schema();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -341,14 +341,14 @@ public:
 class compaction_manager_for_testing {
     struct wrapped_compaction_manager {
         compaction_manager cm;
-        explicit wrapped_compaction_manager(bool enabled);
+        explicit wrapped_compaction_manager(dirty_memory_manager& dmm, bool enabled);
         // Must run in a seastar thread
         ~wrapped_compaction_manager();
     };
 
     lw_shared_ptr<wrapped_compaction_manager> _wcm;
 public:
-    explicit compaction_manager_for_testing(bool enabled = true) : _wcm(make_lw_shared<wrapped_compaction_manager>(enabled)) {}
+    explicit compaction_manager_for_testing(dirty_memory_manager& dmm, bool enabled = true) : _wcm(make_lw_shared<wrapped_compaction_manager>(dmm, enabled)) {}
 
     compaction_manager& operator*() noexcept {
         return _wcm->cm;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -35,12 +35,6 @@ db::nop_large_data_handler nop_lp_handler;
 db::config test_db_config;
 gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
 
-replica::column_family::config column_family_test_config(reader_concurrency_semaphore& compaction_semaphore) {
-    replica::column_family::config cfg;
-    cfg.compaction_concurrency_semaphore = &compaction_semaphore;
-    return cfg;
-}
-
 column_family_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
 { }
@@ -58,7 +52,7 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     : _data(make_lw_shared<data>())
 {
     _data->s = s;
-    _data->cfg = column_family_test_config(_data->semaphore);
+    _data->cfg = replica::table::config{.compaction_concurrency_semaphore = &_data->semaphore};
     _data->cfg.enable_disk_writes = bool(datadir);
     _data->cfg.datadir = datadir.value_or(sstring());
     _data->cfg.cf_stats = &_data->cf_stats;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -36,7 +36,8 @@ db::config test_db_config;
 gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
 
 column_family_for_tests::data::data()
-    : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
+    : dmm(logalloc::shard_tracker())
+    , semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
     , cm(compaction_manager::for_testing_tag{}, dmm)
 { }
 
@@ -59,6 +60,6 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     _data->cfg.cf_stats = &_data->cf_stats;
     _data->cfg.enable_commitlog = false;
     _data->cm.enable();
-    _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, replica::column_family::no_commitlog(), _data->cm, sstables_manager, _data->cl_stats, _data->tracker);
+    _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, replica::column_family::no_commitlog(), _data->cm, sstables_manager, _data->cl_stats, sstables_manager.get_cache_tracker());
     _data->cf->mark_ready_for_writes();
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -35,8 +35,8 @@ db::nop_large_data_handler nop_lp_handler;
 db::config test_db_config;
 gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
 
-column_family_for_tests::data::data()
-    : dmm(logalloc::shard_tracker())
+column_family_for_tests::data::data(logalloc::tracker& logalloc_tracker)
+    : dmm(logalloc_tracker)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
     , cm(compaction_manager::for_testing_tag{}, dmm)
 { }
@@ -51,7 +51,7 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
 { }
 
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)
-    : _data(make_lw_shared<data>())
+    : _data(make_lw_shared<data>(sstables_manager.get_cache_tracker().region().get_tracker()))
 {
     _data->s = s;
     _data->cfg = replica::table::config{.dirty_memory_manager = &_data->dmm, .compaction_concurrency_semaphore = &_data->semaphore};

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -37,6 +37,7 @@ gms::feature_service test_feature_service(gms::feature_config_from_db_config(tes
 
 column_family_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
+    , cm(compaction_manager::for_testing_tag{}, dmm)
 { }
 
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager)
@@ -52,7 +53,7 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     : _data(make_lw_shared<data>())
 {
     _data->s = s;
-    _data->cfg = replica::table::config{.compaction_concurrency_semaphore = &_data->semaphore};
+    _data->cfg = replica::table::config{.dirty_memory_manager = &_data->dmm, .compaction_concurrency_semaphore = &_data->semaphore};
     _data->cfg.enable_disk_writes = bool(datadir);
     _data->cfg.datadir = datadir.value_or(sstring());
     _data->cfg.cf_stats = &_data->cf_stats;

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -38,8 +38,6 @@ extern db::nop_large_data_handler nop_lp_handler;
 extern db::config test_db_config;
 extern gms::feature_service test_feature_service;
 
-replica::column_family::config column_family_test_config(reader_concurrency_semaphore& compaction_semaphore);
-
 struct column_family_for_tests {
     struct data {
         schema_ptr s;

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -41,12 +41,13 @@ extern gms::feature_service test_feature_service;
 struct column_family_for_tests {
     struct data {
         schema_ptr s;
+        dirty_memory_manager dmm;
         reader_concurrency_semaphore semaphore;
         cache_tracker tracker;
         replica::cf_stats cf_stats{0};
         replica::column_family::config cfg;
         cell_locker_stats cl_stats;
-        compaction_manager cm{compaction_manager::for_testing_tag{}};
+        compaction_manager cm;
         lw_shared_ptr<replica::column_family> cf;
         data();
     };

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -48,7 +48,7 @@ struct column_family_for_tests {
         cell_locker_stats cl_stats;
         compaction_manager cm;
         lw_shared_ptr<replica::column_family> cf;
-        data();
+        explicit data(logalloc::tracker& tracker);
     };
     lw_shared_ptr<data> _data;
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -43,7 +43,6 @@ struct column_family_for_tests {
         schema_ptr s;
         dirty_memory_manager dmm;
         reader_concurrency_semaphore semaphore;
-        cache_tracker tracker;
         replica::cf_stats cf_stats{0};
         replica::column_family::config cfg;
         cell_locker_stats cl_stats;

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -251,7 +251,7 @@ void test_main_thread(cql_test_env& env) {
     row_cache c(s, snapshot_source([&] { return underlying(); }), tr, is_continuous::yes);
     auto prev_evictions = tr.get_stats().row_evictions;
     while (tr.get_stats().row_evictions == prev_evictions) {
-        auto mt = make_lw_shared<replica::memtable>(s);
+        auto mt = make_lw_shared<replica::memtable>(s, env.local_db().get_user_dirty_memory_manager());
         mt->apply(gen(sstable_size));
         c.update(row_cache::external_updater([] {}), *mt).get();
         thread::maybe_yield();

--- a/test/perf/logalloc.cc
+++ b/test/perf/logalloc.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/util/defer.hh>
 
 #include <fmt/core.h>
 #include <random>
@@ -18,6 +19,7 @@
 #include "utils/allocation_strategy.hh"
 #include "utils/logalloc.hh"
 #include "log.hh"
+#include "test/lib/logalloc.hh"
 #include "test/perf/perf.hh"
 
 class piggie {
@@ -36,8 +38,8 @@ int main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [&app] {
         return seastar::async([&] {
-            logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
-            logalloc::region reg;
+            tests::logalloc::sharded_tracker logalloc_tracker;
+            logalloc::region reg(*logalloc_tracker);
 
             std::array<piggie*, nr_seq_allocations> objects;
             std::array<size_t, nr_sizes> sizes;

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -85,4 +85,14 @@ reader_permit reader_concurrency_semaphore_wrapper::make_permit() {
     return _semaphore->make_tracking_only_permit(nullptr, "perf", db::no_timeout);
 }
 
+logalloc_tracker::logalloc_tracker()
+{ }
+
+logalloc_tracker::~logalloc_tracker() {
+}
+
+logalloc::tracker& logalloc_tracker::tracker() {
+    return logalloc::shard_tracker();
+}
+
 } // namespace perf

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -86,13 +86,15 @@ reader_permit reader_concurrency_semaphore_wrapper::make_permit() {
 }
 
 logalloc_tracker::logalloc_tracker()
+    : _tracker(std::make_unique<logalloc::tracker>(logalloc::tracker::config{memory::stats().total_memory(), memory::min_free_memory()}))
 { }
 
 logalloc_tracker::~logalloc_tracker() {
+    (void)_tracker->stop().finally([t = std::move(_tracker)] {});
 }
 
 logalloc::tracker& logalloc_tracker::tracker() {
-    return logalloc::shard_tracker();
+    return *_tracker;
 }
 
 } // namespace perf

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -284,6 +284,7 @@ public:
 
 // Closes the tracker in the background when destroyed
 class logalloc_tracker {
+    std::unique_ptr<logalloc::tracker> _tracker;
 public:
     explicit logalloc_tracker();
     ~logalloc_tracker();

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -16,6 +16,7 @@
 #include "seastarx.hh"
 #include "utils/extremum_tracking.hh"
 #include "utils/estimated_histogram.hh"
+#include "utils/logalloc.hh"
 #include <seastar/testing/linux_perf_event.hh>
 #include <seastar/util/defer.hh>
 #include "reader_permit.hh"
@@ -279,6 +280,14 @@ public:
     explicit reader_concurrency_semaphore_wrapper(sstring name);
     ~reader_concurrency_semaphore_wrapper();
     reader_permit make_permit();
+};
+
+// Closes the tracker in the background when destroyed
+class logalloc_tracker {
+public:
+    explicit logalloc_tracker();
+    ~logalloc_tracker();
+    logalloc::tracker& tracker();
 };
 
 } // namespace perf

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -87,6 +87,7 @@ int main(int argc, char** argv) {
             utils::estimated_histogram writes_hist;
 
             auto& tracker = env.local_db().row_cache_tracker();
+            auto& logalloc_tracker = tracker.region().get_tracker();
 
             timer<> stats_printer;
             monotonic_counter<uint64_t> reads_ctr([&] { return reads; });
@@ -104,8 +105,8 @@ int main(int argc, char** argv) {
                     miss_ctr.change(),
                     tracker.region().occupancy().used_space() / MB,
                     tracker.region().occupancy().total_space() / MB,
-                    logalloc::shard_tracker().region_occupancy().used_space() / MB,
-                    logalloc::shard_tracker().region_occupancy().total_space() / MB,
+                    logalloc_tracker.region_occupancy().used_space() / MB,
+                    logalloc_tracker.region_occupancy().total_space() / MB,
                     seastar::memory::stats().free_memory() / MB) << "\n\n";
 
                 auto print_percentiles = [] (const utils::estimated_histogram& hist) {

--- a/test/perf/perf_mutation.cc
+++ b/test/perf/perf_mutation.cc
@@ -35,7 +35,8 @@ int main(int argc, char* argv[]) {
         }
 
         auto s = builder.build();
-        replica::memtable mt(s);
+        dirty_memory_manager dmm;
+        replica::memtable mt(s, dmm);
 
         std::cout << "Timing mutation of single column within one row...\n";
 

--- a/test/perf/perf_mutation.cc
+++ b/test/perf/perf_mutation.cc
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
         }
 
         auto s = builder.build();
-        dirty_memory_manager dmm;
+        dirty_memory_manager dmm(logalloc::shard_tracker());
         replica::memtable mt(s, dmm);
 
         std::cout << "Timing mutation of single column within one row...\n";

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -312,6 +312,7 @@ class memtable {
     static constexpr size_t row_count = 50;
     mutable simple_schema _schema;
     perf::reader_concurrency_semaphore_wrapper _semaphore;
+    dirty_memory_manager _dmm;
     reader_permit _permit;
     std::vector<dht::decorated_key> _dkeys;
     lw_shared_ptr<replica::memtable> _single_row;
@@ -323,9 +324,9 @@ public:
         : _semaphore(__FILE__)
         , _permit(_semaphore.make_permit())
         , _dkeys(_schema.make_pkeys(partition_count))
-        , _single_row(make_lw_shared<replica::memtable>(_schema.schema()))
-        , _multi_row(make_lw_shared<replica::memtable>(_schema.schema()))
-        , _large_partition(make_lw_shared<replica::memtable>(_schema.schema()))
+        , _single_row(make_lw_shared<replica::memtable>(_schema.schema(), _dmm))
+        , _multi_row(make_lw_shared<replica::memtable>(_schema.schema(), _dmm))
+        , _large_partition(make_lw_shared<replica::memtable>(_schema.schema(), _dmm))
     {
         boost::for_each(
             _dkeys

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -312,6 +312,7 @@ class memtable {
     static constexpr size_t row_count = 50;
     mutable simple_schema _schema;
     perf::reader_concurrency_semaphore_wrapper _semaphore;
+    perf::logalloc_tracker _tracker;
     dirty_memory_manager _dmm;
     reader_permit _permit;
     std::vector<dht::decorated_key> _dkeys;
@@ -322,6 +323,7 @@ class memtable {
 public:
     memtable()
         : _semaphore(__FILE__)
+        , _dmm(_tracker.tracker())
         , _permit(_semaphore.make_permit())
         , _dkeys(_schema.make_pkeys(partition_count))
         , _single_row(make_lw_shared<replica::memtable>(_schema.schema(), _dmm))

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -40,8 +40,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 
     for (int i = 0; i < update_iterations; ++i) {
         auto MB = 1024 * 1024;
-        auto prefill_compacted = logalloc::memory_compacted();
-        auto prefill_allocated = logalloc::memory_allocated();
+        const auto prefill_stats = logalloc::shard_tracker().statistics();
+        auto prefill_compacted = prefill_stats.memory_compacted;
+        auto prefill_allocated = prefill_stats.memory_allocated;
 
         auto mt = make_lw_shared<replica::memtable>(s);
         auto fill_d = duration_in_seconds([&] {
@@ -62,8 +63,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
         });
         std::cout << format("took {:.6f} [ms]", drain_d.count() * 1000) << std::endl;
 
-        auto prev_compacted = logalloc::memory_compacted();
-        auto prev_allocated = logalloc::memory_allocated();
+        const auto prev_stats = logalloc::shard_tracker().statistics();
+        auto prev_compacted = prev_stats.memory_compacted;
+        auto prev_allocated = prev_stats.memory_allocated;
         auto prev_rows_processed_from_memtable = tracker.get_stats().rows_processed_from_memtable;
         auto prev_rows_merged_from_memtable = tracker.get_stats().rows_merged_from_memtable;
         auto prev_rows_dropped_from_memtable = tracker.get_stats().rows_dropped_from_memtable;
@@ -105,8 +107,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 
         slm.stop();
 
-        auto compacted = logalloc::memory_compacted() - prev_compacted;
-        auto allocated = logalloc::memory_allocated() - prev_allocated;
+        const auto stats = logalloc::shard_tracker().statistics();
+        auto compacted = stats.memory_compacted - prev_compacted;
+        auto allocated = stats.memory_allocated - prev_allocated;
 
         std::cout << format("update: {:.6f} [ms], preemption: {}, cache: {:d}/{:d} [MB], alloc/comp: {:d}/{:d} [MB] (amp: {:.3f}), pr/me/dr {:d}/{:d}/{:d}\n",
             d.count() * 1000,

--- a/test/perf/perf_sstable.cc
+++ b/test/perf/perf_sstable.cc
@@ -18,6 +18,7 @@
 #define BOOST_CHECK_NO_THROW(x) (void)(x)
 
 #include "test/perf/perf_sstable.hh"
+#include "test/lib/logalloc.hh"
 
 using namespace sstables;
 
@@ -108,7 +109,7 @@ int main(int argc, char** argv) {
         }
         cfg.compaction_strategy = sstables::compaction_strategy::type(app.configuration()["compaction-strategy"].as<sstring>());
         cfg.timestamp_range = app.configuration()["timestamp-range"].as<api::timestamp_type>();
-        return test->start(std::move(cfg)).then([mode, dir, test] {
+        return test->start(sharded_parameter([] { return std::ref(logalloc::shard_tracker()); }), std::move(cfg)).then([mode, dir, test] {
             engine().at_exit([test] { return test->stop(); });
             if ((mode == test_modes::index_read) ||
                (mode == test_modes::sequential_read)) {

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -170,7 +170,7 @@ public:
                 cache_tracker tracker;
                 cell_locker_stats cl_stats;
                 auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
-                auto cf = make_lw_shared<replica::column_family>(s, column_family_test_config(env.semaphore()), replica::column_family::no_commitlog(), *cm, env.manager(), cl_stats, tracker);
+                auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), cl_stats, tracker);
 
                 auto start = perf_sstable_test_env::now();
 

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -64,6 +64,7 @@ private:
 
     conf _cfg;
     schema_ptr s;
+    dirty_memory_manager _dmm;
     std::default_random_engine _generator;
     std::uniform_int_distribution<char> _distribution;
     lw_shared_ptr<replica::memtable> _mt;
@@ -98,7 +99,7 @@ public:
     perf_sstable_test_env(conf cfg) : _cfg(std::move(cfg))
            , s(create_schema(cfg.compaction_strategy))
            , _distribution('@', '~')
-           , _mt(make_lw_shared<replica::memtable>(s))
+           , _mt(make_lw_shared<replica::memtable>(s, _dmm))
     {}
 
     future<> stop() {
@@ -169,7 +170,7 @@ public:
 
                 cache_tracker tracker;
                 cell_locker_stats cl_stats;
-                auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+                auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{}, env.get_dirty_memory_manager());
                 auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), cl_stats, tracker);
 
                 auto start = perf_sstable_test_env::now();

--- a/test/unit/bptree_compaction_test.cc
+++ b/test/unit/bptree_compaction_test.cc
@@ -19,6 +19,7 @@ constexpr int TEST_NODE_SIZE = 7;
 #include "utils/bptree.hh"
 #include "bptree_validation.hh"
 #include "collection_stress.hh"
+#include "test/lib/logalloc.hh"
 
 using namespace bplus;
 using namespace seastar;
@@ -51,10 +52,13 @@ int main(int argc, char **argv) {
         auto verb = app.configuration()["verb"].as<bool>();
 
         return seastar::async([count, iter, verb] {
+            tests::logalloc::sharded_tracker logalloc_tracker;
+
             stress_config cfg;
             cfg.count = count;
             cfg.iters = iter;
             cfg.verb = verb;
+            cfg.logalloc_tracker = &*logalloc_tracker;
 
             tree_pointer<test_tree> t(test_key_compare{});
             test_validator tv;

--- a/test/unit/btree_compaction_test.cc
+++ b/test/unit/btree_compaction_test.cc
@@ -20,6 +20,7 @@ constexpr int TEST_LINEAR_THRESHOLD = 19;
 #include "utils/intrusive_btree.hh"
 #include "btree_validation.hh"
 #include "collection_stress.hh"
+#include "test/lib/logalloc.hh"
 
 using namespace intrusive_b;
 using namespace seastar;
@@ -49,10 +50,13 @@ int main(int argc, char **argv) {
         auto verb = app.configuration()["verb"].as<bool>();
 
         return seastar::async([count, rep, verb] {
+            tests::logalloc::sharded_tracker logalloc_tracker;
+
             stress_config cfg;
             cfg.count = count;
             cfg.iters = rep;
             cfg.verb = verb;
+            cfg.logalloc_tracker = &*logalloc_tracker;
 
             tree_pointer<test_tree> t;
             test_validator tv;

--- a/test/unit/collection_stress.hh
+++ b/test/unit/collection_stress.hh
@@ -19,6 +19,7 @@ struct stress_config {
     int iters;
     std::string keys;
     bool verb;
+    logalloc::tracker* logalloc_tracker;
 };
 
 enum class stress_step { before_insert, before_erase, iteration_finished };
@@ -179,7 +180,7 @@ void stress_compact_collection(const stress_config& conf, Insert&& insert, Erase
     std::random_device rd;
     std::mt19937 g(rd());
 
-    logalloc::region mem;
+    logalloc::region mem(*conf.logalloc_tracker);
 
     with_allocator(mem.allocator(), [&] {
         for (auto rep = 0; rep < conf.iters; rep++) {

--- a/test/unit/lsa_sync_eviction_test.cc
+++ b/test/unit/lsa_sync_eviction_test.cc
@@ -10,12 +10,14 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/util/defer.hh>
 
 #include "utils/managed_bytes.hh"
 #include "utils/logalloc.hh"
 #include "utils/managed_ref.hh"
 #include "test/perf/perf.hh"
 #include "log.hh"
+#include "test/lib/logalloc.hh"
 
 #include <random>
 
@@ -38,8 +40,8 @@ int main(int argc, char** argv) {
         }
 
         return seastar::async([reg_obj_size, std_obj_size, obj_count] {
-            logalloc::region r;
-            logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
+            tests::logalloc::sharded_tracker logalloc_tracker;
+            logalloc::region r(*logalloc_tracker);
 
             with_allocator(r.allocator(), [&] {
                 std::deque<managed_bytes> refs;

--- a/test/unit/radix_tree_compaction_test.cc
+++ b/test/unit/radix_tree_compaction_test.cc
@@ -19,6 +19,7 @@
 #include "utils/compact-radix-tree.hh"
 #include "radix_tree_printer.hh"
 #include "collection_stress.hh"
+#include "test/lib/logalloc.hh"
 
 using namespace compact_radix_tree;
 using namespace seastar;
@@ -62,6 +63,8 @@ int main(int argc, char **argv) {
         auto verb = app.configuration()["verb"].as<bool>();
 
         return seastar::async([count, iter, verb] {
+            tests::logalloc::sharded_tracker logalloc_tracker;
+
             tree_pointer<test_tree> t;
 
             stress_config cfg;
@@ -69,6 +72,7 @@ int main(int argc, char **argv) {
             cfg.iters = 1;
             cfg.keys = "rand";
             cfg.verb = verb;
+            cfg.logalloc_tracker = &*logalloc_tracker;
 
             unsigned col_size = 0;
 

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -18,6 +18,7 @@
 #include "log.hh"
 #include "schema_builder.hh"
 #include "replica/memtable.hh"
+#include "dirty_memory_manager.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 
 static
@@ -56,11 +57,12 @@ int main(int argc, char** argv) {
                 .with_column("v", bytes_type, column_kind::regular_column)
                 .build();
             tests::reader_concurrency_semaphore_wrapper semaphore;
+            dirty_memory_manager dmm;
 
             cache_tracker tracker;
             row_cache cache(s, make_empty_snapshot_source(), tracker);
 
-            auto mt = make_lw_shared<replica::memtable>(s);
+            auto mt = make_lw_shared<replica::memtable>(s, dmm);
             std::vector<dht::decorated_key> keys;
 
             size_t cell_size = 1024;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2178,7 +2178,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
 
             db::config dbcfg;
             gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
-            cache_tracker tracker;
+            cache_tracker tracker(logalloc::shard_tracker());
             dbcfg.host_id = ::utils::make_random_uuid();
             sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker);
             auto close_sst_man = deferred_close(sst_man);

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2615,12 +2615,12 @@ void region_group::update(ssize_t delta) {
     }
 }
 
-allocating_section::guard::guard()
-    : _prev(shard_tracker().get_impl().segment_pool().emergency_reserve_max())
+allocating_section::guard::guard(tracker::impl& tracker)
+    : _tracker(tracker), _prev(_tracker.segment_pool().emergency_reserve_max())
 { }
 
 allocating_section::guard::~guard() {
-    shard_tracker().get_impl().segment_pool().set_emergency_reserve_max(_prev);
+    _tracker.segment_pool().set_emergency_reserve_max(_prev);
 }
 
 void allocating_section::maybe_decay_reserve() {
@@ -2651,8 +2651,8 @@ void allocating_section::maybe_decay_reserve() {
     }
 }
 
-void allocating_section::reserve() {
-    auto& pool = shard_tracker().get_impl().segment_pool();
+void allocating_section::reserve(tracker::impl& tracker) {
+    auto& pool = tracker.segment_pool();
   try {
     pool.set_emergency_reserve_max(std::max(_lsa_reserve, _minimum_lsa_emergency_reserve));
     pool.refill_emergency_reserve();
@@ -2662,14 +2662,14 @@ void allocating_section::reserve() {
         if (free >= _std_reserve) {
             break;
         }
-        if (!tracker_instance.reclaim(_std_reserve - free)) {
+        if (!tracker.reclaim(_std_reserve - free, is_preemptible::no)) {
             throw std::bad_alloc();
         }
     }
 
     pool.clear_allocation_failure_flag();
   } catch (const std::bad_alloc&) {
-        if (shard_tracker().should_abort_on_bad_alloc()) {
+        if (tracker.should_abort_on_bad_alloc()) {
             llogger.error("Aborting due to allocation failure");
             abort();
         }
@@ -2679,14 +2679,14 @@ void allocating_section::reserve() {
 
 void allocating_section::on_alloc_failure(logalloc::region& r) {
     r.allocator().invalidate_references();
-    if (shard_tracker().get_impl().segment_pool().allocation_failure_flag()) {
+    if (r.get_tracker().get_impl().segment_pool().allocation_failure_flag()) {
         _lsa_reserve *= 2;
         llogger.debug("LSA allocation failure, increasing reserve in section {} to {} segments", fmt::ptr(this), _lsa_reserve);
     } else {
         _std_reserve *= 2;
         llogger.debug("Standard allocator failure, increasing head-room in section {} to {} [B]", fmt::ptr(this), _std_reserve);
     }
-    reserve();
+    reserve(r.get_tracker().get_impl());
 }
 
 void allocating_section::set_lsa_reserve(size_t reserve) {

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2571,7 +2571,8 @@ region_group::start_releaser(scheduling_group deferred_work_sg) {
 
 region_group::region_group(sstring name, region_group *parent,
         region_group_reclaimer& reclaimer, scheduling_group deferred_work_sg)
-    : _parent(parent)
+    : _tracker(shard_tracker())
+    , _parent(parent)
     , _reclaimer(reclaimer)
     , _blocked_requests(on_request_expiry{std::move(name)})
     , _releaser(reclaimer_can_block() ? start_releaser(deferred_work_sg) : make_ready_future<>())

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1077,7 +1077,10 @@ void segment_pool::prime(size_t available_memory, size_t min_free_memory) {
     size_t min_gap = 1 * 1024 * 1024;
     size_t max_gap = 32 * 1024 * 1024;
     size_t gap = std::min(max_gap, std::max(available_memory / 16, min_gap));
-    _store.non_lsa_reserve = min_free_memory + gap;
+    // If caller requested 0 reserve, respect it.
+    if (min_free_memory) {
+        _store.non_lsa_reserve = min_free_memory + gap;
+    }
     // Since the reclaimer is not yet in place, free some low memory for general use
     reclaim_segments(_store.non_lsa_reserve / segment::size, is_preemptible::no);
 }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1941,12 +1941,12 @@ region_group::region_evictable_occupancy_ascending_less_comparator::operator()(r
     return r1->evictable_occupancy().total_space() < r2->evictable_occupancy().total_space();
 }
 
-region::region()
-    : _impl(make_shared<impl>(shard_tracker(), this))
+region::region(tracker& tracker)
+    : _impl(make_shared<impl>(tracker, this))
 { }
 
 region::region(region_group& group)
-        : _impl(make_shared<impl>(shard_tracker(), this, &group)) {
+        : _impl(make_shared<impl>(group.get_tracker(), this, &group)) {
 }
 
 region_impl& region::get_impl() {
@@ -2572,9 +2572,9 @@ region_group::start_releaser(scheduling_group deferred_work_sg) {
     });
 }
 
-region_group::region_group(sstring name, region_group *parent,
+region_group::region_group(tracker& tracker, sstring name, region_group *parent,
         region_group_reclaimer& reclaimer, scheduling_group deferred_work_sg)
-    : _tracker(shard_tracker())
+    : _tracker(tracker)
     , _parent(parent)
     , _reclaimer(reclaimer)
     , _blocked_requests(on_request_expiry{std::move(name)})

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -748,11 +748,12 @@ class allocating_section {
     int _remaining_lsa_segments_until_decay = s_segments_per_decay;
 private:
     struct guard {
+        tracker::impl& _tracker;
         size_t _prev;
-        guard();
+        explicit guard(tracker::impl& tracker);
         ~guard();
     };
-    void reserve();
+    void reserve(tracker::impl& tracker);
     void maybe_decay_reserve();
     void on_alloc_failure(logalloc::region&);
 public:
@@ -767,13 +768,13 @@ public:
     // Throws std::bad_alloc when reserves can't be increased to a sufficient level.
     //
     template<typename Func>
-    decltype(auto) with_reserve(Func&& fn) {
+    decltype(auto) with_reserve(region& r, Func&& fn) {
         auto prev_lsa_reserve = _lsa_reserve;
         auto prev_std_reserve = _std_reserve;
         try {
-            guard g;
+            guard g(r.get_tracker().get_impl());
             _minimum_lsa_emergency_reserve = g._prev;
-            reserve();
+            reserve(r.get_tracker().get_impl());
             return fn();
         } catch (const std::bad_alloc&) {
             // roll-back limits to protect against pathological requests
@@ -824,7 +825,7 @@ public:
     //
     template<typename Func>
     decltype(auto) operator()(logalloc::region& r, Func&& func) {
-        return with_reserve([this, &r, &func] {
+        return with_reserve(r, [this, &r, &func] {
             return with_reclaiming_disabled(r, func);
         });
     }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -424,6 +424,15 @@ public:
         scheduling_group background_reclaim_sched_group;
     };
 
+    struct stats {
+        size_t segments_compacted;
+        size_t lsa_buffer_segments;
+        uint64_t memory_allocated;
+        uint64_t memory_freed;
+        uint64_t memory_compacted;
+        uint64_t memory_evicted;
+    };
+
     void configure(const config& cfg);
     future<> stop();
 
@@ -437,6 +446,8 @@ private:
 public:
     tracker();
     ~tracker();
+
+    stats statistics() const;
 
     //
     // Tries to reclaim given amount of bytes in total using all compactible
@@ -454,6 +465,8 @@ public:
     void full_compaction();
 
     void reclaim_all_free_segments();
+
+    occupancy_stats global_occupancy();
 
     // Returns aggregate statistics for all pools.
     occupancy_stats region_occupancy();
@@ -832,12 +845,5 @@ public:
 };
 
 future<> prime_segment_pool(size_t available_memory, size_t min_free_memory);
-
-uint64_t memory_allocated();
-uint64_t memory_freed();
-uint64_t memory_compacted();
-uint64_t memory_evicted();
-
-occupancy_stats lsa_global_occupancy_stats();
 
 }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -847,6 +847,8 @@ public:
     }
 };
 
+/// LSA may reserve more memory then requested via \p min_free_memory.
+/// A request for 0 reserves will be honored however.
 future<> prime_segment_pool(size_t available_memory, size_t min_free_memory);
 
 }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -24,6 +24,7 @@
 namespace logalloc {
 
 struct occupancy_stats;
+class tracker;
 class region;
 class region_impl;
 class allocating_section;
@@ -158,6 +159,7 @@ class region_group {
           //constant_time_size<true> causes corruption with boost < 1.60
           boost::heap::constant_time_size<false>>;
 
+    tracker& _tracker;
     region_group* _parent = nullptr;
     size_t _total_memory = 0;
     region_group_reclaimer& _reclaimer;
@@ -263,6 +265,7 @@ public:
     }
     region_group& operator=(const region_group&) = delete;
     region_group& operator=(region_group&&) = delete;
+    tracker& get_tracker() const { return _tracker; }
     size_t memory_used() const {
         return _total_memory;
     }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -245,11 +245,11 @@ public:
     // The deferred_work_sg parameter specifies a scheduling group in which to run allocations
     // (given to run_when_memory_available()) when they must be deferred due to lack of memory
     // at the time the call to run_when_memory_available() was made.
-    region_group(sstring name = "(unnamed region_group)",
+    region_group(tracker& tracker, sstring name = "(unnamed region_group)",
             region_group_reclaimer& reclaimer = no_reclaimer,
             scheduling_group deferred_work_sg = default_scheduling_group())
-        : region_group(name, nullptr, reclaimer, deferred_work_sg) {}
-    region_group(sstring name, region_group* parent, region_group_reclaimer& reclaimer = no_reclaimer,
+        : region_group(tracker, name, nullptr, reclaimer, deferred_work_sg) {}
+    region_group(tracker& tracker, sstring name, region_group* parent, region_group_reclaimer& reclaimer = no_reclaimer,
             scheduling_group deferred_work_sg = default_scheduling_group());
     region_group(region_group&& o) = delete;
     region_group(const region_group&) = delete;
@@ -660,7 +660,7 @@ private:
     region_impl& get_impl();
     const region_impl& get_impl() const;
 public:
-    region();
+    region(tracker& tracker);
     explicit region(region_group& group);
     ~region();
     region(region&& other);

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -601,9 +601,15 @@ public:
 
 class basic_region_impl : public allocation_strategy {
 protected:
+    tracker& _tracker;
     bool _reclaiming_enabled = true;
     seastar::shard_id _cpu = this_shard_id();
 public:
+    basic_region_impl(tracker& tracker) : _tracker(tracker)
+    { }
+
+    tracker& get_tracker() { return _tracker; }
+
     void set_reclaiming_enabled(bool enabled) {
         assert(this_shard_id() == _cpu);
         _reclaiming_enabled = enabled;
@@ -644,6 +650,10 @@ public:
     region(region&& other);
     region& operator=(region&& other);
     region(const region& other) = delete;
+
+    tracker& get_tracker() const {
+        return _impl->get_tracker();
+    }
 
     occupancy_stats occupancy() const;
 


### PR DESCRIPTION
This series gets rid of two globals:
* default_dirty_memory_manager
* logalloc shard tracker

The series was motivated by the desire to be able to configure LSA memory on application startup, with parameters that influence how it instantiates and configures certain member objects. This is borderline impossible currently as the LSA state is scattered across a handful of global variables with static initialization, hence their constructors cannot be customized. This series consolidates all the LSA state into a single object: `logalloc::tracker` (except the migrator functions, those are still in a separate global), then makes this a regular sharded service instantiated by main, and propagated to all object that require it (`logalloc::region` objects in memtable and cache). In the process all global objects (except the migrators) are removed.
The need to remove the `default_dirty_memory_manager` (and the `tests_mgr` in `memtable.cc`) arises from the requirement to pass a `logalloc::tracker` as a constructor parameter to `dirty_memory_manager` instances.

Refs: https://github.com/scylladb/scylla/issues/9882