### PR TITLE
Backport "Redefine Compaction Backlog to tame compaction aggressiveness" to branch-5.0

### DIFF
--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -60,8 +60,7 @@ public:
     using ongoing_compactions = std::unordered_map<sstables::shared_sstable, backlog_read_progress_manager*>;
 
     struct impl {
-        virtual void add_sstable(sstables::shared_sstable sst) = 0;
-        virtual void remove_sstable(sstables::shared_sstable sst) = 0;
+        virtual void replace_sstables(std::vector<sstables::shared_sstable> old_ssts, std::vector<sstables::shared_sstable> new_ssts) = 0;
         virtual double backlog(const ongoing_writes& ow, const ongoing_compactions& oc) const = 0;
         virtual ~impl() { }
     };
@@ -72,22 +71,21 @@ public:
     ~compaction_backlog_tracker();
 
     double backlog() const;
-    void add_sstable(sstables::shared_sstable sst);
-    void remove_sstable(sstables::shared_sstable sst);
+    void replace_sstables(const std::vector<sstables::shared_sstable>& old_ssts, const std::vector<sstables::shared_sstable>& new_ssts);
     void register_partially_written_sstable(sstables::shared_sstable sst, backlog_write_progress_manager& wp);
     void register_compacting_sstable(sstables::shared_sstable sst, backlog_read_progress_manager& rp);
     void transfer_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges = true);
     void revert_charges(sstables::shared_sstable sst);
-private:
-    // Returns true if this SSTable can be added or removed from the tracker.
-    bool sstable_belongs_to_tracker(const sstables::shared_sstable& sst);
 
     void disable() {
-        _disabled = true;
+        _impl = {};
         _ongoing_writes = {};
         _ongoing_compactions = {};
     }
-    bool _disabled = false;
+private:
+    // Returns true if this SSTable can be added or removed from the tracker.
+    bool sstable_belongs_to_tracker(const sstables::shared_sstable& sst);
+    bool disabled() const noexcept { return !_impl; }
     std::unique_ptr<impl> _impl;
     // We keep track of this so that we can transfer to a new tracker if the compaction strategy is
     // changed in the middle of a compaction.

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -237,8 +237,7 @@ private:
     virtual double backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const override {
         return _added_backlog * _available_memory;
     }
-    virtual void add_sstable(sstables::shared_sstable sst)  override { }
-    virtual void remove_sstable(sstables::shared_sstable sst)  override { }
+    virtual void replace_sstables(std::vector<sstables::shared_sstable> old_ssts, std::vector<sstables::shared_sstable> new_ssts) override {}
 };
 
 compaction_manager::compaction_state& compaction_manager::get_compaction_state(replica::table* t) {
@@ -489,6 +488,8 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of compaction tasks waiting for an opportunity to run.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
+        sm::make_gauge("normalized_backlog", [this] { return _last_backlog / _available_memory; },
+                       sm::description("Holds the sum of normalized compaction backlog for all tables in the system. Backlog is normalized by dividing backlog by shard's available memory.")),
     });
 }
 
@@ -1153,30 +1154,26 @@ compaction::strategy_control& compaction_manager::get_strategy_control() const n
 }
 
 double compaction_backlog_tracker::backlog() const {
-    return _disabled ? compaction_controller::disable_backlog : _impl->backlog(_ongoing_writes, _ongoing_compactions);
+    return disabled() ? compaction_controller::disable_backlog : _impl->backlog(_ongoing_writes, _ongoing_compactions);
 }
 
-void compaction_backlog_tracker::add_sstable(sstables::shared_sstable sst) {
-    if (_disabled || !sstable_belongs_to_tracker(sst)) {
+void compaction_backlog_tracker::replace_sstables(const std::vector<sstables::shared_sstable>& old_ssts, const std::vector<sstables::shared_sstable>& new_ssts) {
+    if (disabled()) {
         return;
     }
-    _ongoing_writes.erase(sst);
-    try {
-        _impl->add_sstable(std::move(sst));
-    } catch (...) {
-        cmlog.warn("Disabling backlog tracker due to exception {}", std::current_exception());
-        disable();
-    }
-}
+    auto filter_and_revert_charges = [this] (const std::vector<sstables::shared_sstable>& ssts) {
+        std::vector<sstables::shared_sstable> ret;
+        for (auto& sst : ssts) {
+            if (sstable_belongs_to_tracker(sst)) {
+                revert_charges(sst);
+                ret.push_back(sst);
+            }
+        }
+        return ret;
+    };
 
-void compaction_backlog_tracker::remove_sstable(sstables::shared_sstable sst) {
-    if (_disabled || !sstable_belongs_to_tracker(sst)) {
-        return;
-    }
-
-    _ongoing_compactions.erase(sst);
     try {
-        _impl->remove_sstable(std::move(sst));
+        _impl->replace_sstables(filter_and_revert_charges(old_ssts), filter_and_revert_charges(new_ssts));
     } catch (...) {
         cmlog.warn("Disabling backlog tracker due to exception {}", std::current_exception());
         disable();
@@ -1188,7 +1185,7 @@ bool compaction_backlog_tracker::sstable_belongs_to_tracker(const sstables::shar
 }
 
 void compaction_backlog_tracker::register_partially_written_sstable(sstables::shared_sstable sst, backlog_write_progress_manager& wp) {
-    if (_disabled) {
+    if (disabled()) {
         return;
     }
     try {
@@ -1203,7 +1200,7 @@ void compaction_backlog_tracker::register_partially_written_sstable(sstables::sh
 }
 
 void compaction_backlog_tracker::register_compacting_sstable(sstables::shared_sstable sst, backlog_read_progress_manager& rp) {
-    if (_disabled) {
+    if (disabled()) {
         return;
     }
 

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -263,7 +263,7 @@ public:
 
         for (auto& sst : new_ssts) {
             auto bound = lower_bound_of(sst->get_stats_metadata().max_timestamp);
-            if (_windows.contains(bound)) {
+            if (!_windows.contains(bound)) {
                 _windows.emplace(bound, size_tiered_backlog_tracker(_stcs_options));
             }
             per_window_replacement[bound].new_ssts.push_back(std::move(sst));

--- a/compaction/size_tiered_backlog_tracker.hh
+++ b/compaction/size_tiered_backlog_tracker.hh
@@ -7,6 +7,7 @@
 
 #pragma once
 #include "compaction_backlog_manager.hh"
+#include "size_tiered_compaction_strategy.hh"
 #include <cmath>
 #include <ctgmath>
 
@@ -63,15 +64,16 @@
 // certain point in time, whose size is the amount of bytes currently written. So all we need
 // to do is keep track of them too, and add the current estimate to the static part of (4).
 class size_tiered_backlog_tracker final : public compaction_backlog_tracker::impl {
+    sstables::size_tiered_compaction_strategy_options _stcs_options;
     int64_t _total_bytes = 0;
     double _sstables_backlog_contribution = 0.0f;
+    std::unordered_set<sstables::shared_sstable> _sstables_contributing_backlog;
+    std::unordered_set<sstables::shared_sstable> _all;
 
     struct inflight_component {
-        int64_t total_bytes = 0;
+        uint64_t total_bytes = 0;
         double contribution = 0;
     };
-
-    inflight_component partial_backlog(const compaction_backlog_tracker::ongoing_writes& ongoing_writes) const;
 
     inflight_component compacted_backlog(const compaction_backlog_tracker::ongoing_compactions& ongoing_compactions) const;
 
@@ -79,14 +81,16 @@ class size_tiered_backlog_tracker final : public compaction_backlog_tracker::imp
         double inv_log_4 = 1.0f / std::log(4);
         return log(x) * inv_log_4;
     }
-public:
-    virtual double backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const override;
 
-    virtual void add_sstable(sstables::shared_sstable sst) override;
+    void refresh_sstables_backlog_contribution();
+public:
+    size_tiered_backlog_tracker(sstables::size_tiered_compaction_strategy_options stcs_options) : _stcs_options(stcs_options) {}
+
+    virtual double backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const override;
 
     // Removing could be the result of a failure of an in progress write, successful finish of a
     // compaction, or some one-off operation, like drop
-    virtual void remove_sstable(sstables::shared_sstable sst) override;
+    virtual void replace_sstables(std::vector<sstables::shared_sstable> old_ssts, std::vector<sstables::shared_sstable> new_ssts) override;
 
     int64_t total_bytes() const {
         return _total_bytes;

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -13,6 +13,8 @@
 #include "sstables/sstables.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 
+class size_tiered_backlog_tracker;
+
 namespace sstables {
 
 class size_tiered_compaction_strategy_options {
@@ -106,7 +108,7 @@ class size_tiered_compaction_strategy : public compaction_strategy_impl {
         return n / sstables.size();
     }
 
-    bool is_bucket_interesting(const std::vector<sstables::shared_sstable>& bucket, int min_threshold) const {
+    static bool is_bucket_interesting(const std::vector<sstables::shared_sstable>& bucket, int min_threshold) {
         return bucket.size() >= size_t(min_threshold);
     }
 
@@ -142,6 +144,7 @@ public:
 
     virtual compaction_descriptor get_reshaping_job(std::vector<shared_sstable> input, schema_ptr schema, const ::io_priority_class& iop, reshape_mode mode) override;
 
+    friend class ::size_tiered_backlog_tracker;
 };
 
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -368,21 +368,16 @@ void table::update_stats_for_new_sstable(uint64_t disk_space_used_by_sstable) no
 }
 
 inline void table::add_sstable_to_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable) {
-    tracker.add_sstable(std::move(sstable));
+    tracker.replace_sstables({}, {std::move(sstable)});
 }
 
 inline void table::remove_sstable_from_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable) {
-    tracker.remove_sstable(std::move(sstable));
+    tracker.replace_sstables({std::move(sstable)}, {});
 }
 
 void table::backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables) {
     auto& tracker = _compaction_strategy.get_backlog_tracker();
-    for (auto& sst : new_sstables) {
-        tracker.add_sstable(sst);
-    }
-    for (auto& sst : old_sstables) {
-        tracker.remove_sstable(sst);
-    }
+    tracker.replace_sstables(old_sstables, new_sstables);
 }
 
 lw_shared_ptr<sstables::sstable_set>
@@ -737,6 +732,7 @@ table::stop() {
                             _sstables = make_compound_sstable_set();
                             _sstables_staging.clear();
                         })).then([this] {
+                            _compaction_strategy.get_backlog_tracker().disable();
                             _cache.refresh_snapshot();
                         });
                     });

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -198,6 +198,7 @@ public:
     // Used to create synthetic sstables for testing leveled compaction strategy.
     void set_values_for_leveled_strategy(uint64_t fake_data_size, uint32_t sstable_level, int64_t max_timestamp, sstring first_key, sstring last_key) {
         _sst->_data_file_size = fake_data_size;
+        _sst->_bytes_on_disk = fake_data_size;
         // Create a synthetic stats metadata
         stats_metadata stats = {};
         // leveled strategy sorts sstables by age using max_timestamp, let's set it to 0.


### PR DESCRIPTION
The series fixes issue #4588, which causes shares we get for an uncompacting tier of a table A to be incorrectly pushed to a compacting tier of a table B. Therefore compaction on table B uses more resources than needed. Unit test included in the series show that shares can easily get stuck at high values, up to maximum value of 1k, even though each tier is perfectly compacted. As tiered backlog is used for LCS' L0 and on TWCS' individual windows, then all strategies (but ICS) will benefit from this.

tests: unit(dev).