### PR TITLE
mutation_cleaner: Fix accounting of space freed during version merging

### DIFF
--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2534,8 +2534,8 @@ stop_iteration mutation_cleaner_impl::merge_some(partition_snapshot& snp) noexce
                 return stop_iteration::no;
             }
             try {
-                auto notify = defer([&, dirty_before = region.occupancy().total_space()] {
-                    auto dirty_after = region.occupancy().total_space();
+                auto notify = defer([&, dirty_before = region.occupancy().used_space()] {
+                    auto dirty_after = region.occupancy().used_space();
                     if (_on_space_freed && dirty_before > dirty_after) {
                         _on_space_freed(dirty_before - dirty_after);
                     }


### PR DESCRIPTION
Fixes the following assert failure:
    
  database_test: replica/memtable.cc:548: replica::flush_memory_accounter::~flush_memory_accounter(): Assertion `_mt._flushed_memory <= _mt.occupancy().used_space()' failed.

The assert complains that more memory was flushed than memtable
occupies. Version merging can reduce the amount of memory used by
memtable while it is being flushed. The problem is supposed to be
prevented by having the cleaner subtract from _flushed_memory when it
merges versions. But it used total_space() instead of
used_space(), so it may subtract less than was actually freed.

Fixes #10780
