### PR TITLE
Raft test topology

### DIFF
--- a/test.py
+++ b/test.py
@@ -835,8 +835,6 @@ class PythonTest(Test):
 
 class TopologyTest(PythonTest):
     """Run a pytest collection of cases against Scylla clusters handling topology changes"""
-    is_before_test_ok: bool
-    is_after_test_ok: bool
     status: bool
 
     def __init__(self, test_no: int, shortname: str, suite) -> None:
@@ -846,21 +844,18 @@ class TopologyTest(PythonTest):
 
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
         async with get_cluster_manager(self.shortname, self.suite.clusters, test_path) as manager:
-            logging.info("Leasing Scylla cluster %s for test %s", manager.cluster, self.uname)
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
                 manager.cluster.before_test(self.uname)
-                self.is_before_test_ok = True
                 manager.cluster[0].take_log_savepoint()
                 status = await run_test(self, options)
                 manager.cluster.after_test(self.uname)
-                self.is_after_test_ok = True
                 self.success = status
             except Exception as e:
                 self.server_log = manager.cluster[0].read_log()
                 self.server_log_filename = manager.cluster[0].log_filename
-                if self.is_before_test_ok is False:
+                if manager.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))
                     # Don't try to continue if the cluster is broken

--- a/test.py
+++ b/test.py
@@ -847,10 +847,8 @@ class TopologyTest(PythonTest):
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
-                manager.cluster.before_test(self.uname)
                 manager.cluster[0].take_log_savepoint()
                 status = await run_test(self, options)
-                manager.cluster.after_test(self.uname)
                 self.success = status
             except Exception as e:
                 self.server_log = manager.cluster[0].read_log()

--- a/test.py
+++ b/test.py
@@ -844,9 +844,10 @@ class TopologyTest(PythonTest):
 
     async def run(self, options: argparse.Namespace) -> Test:
 
-        async with get_cluster_manager(self.shortname, self.suite.clusters) as manager:
-            self.args.insert(0, "--host={}".format(manager.cluster[0].host))
+        test_path = os.path.join(self.suite.options.tmpdir, self.mode)
+        async with get_cluster_manager(self.shortname, self.suite.clusters, test_path) as manager:
             logging.info("Leasing Scylla cluster %s for test %s", manager.cluster, self.uname)
+            self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
                 manager.cluster.before_test(self.uname)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -102,3 +102,8 @@ class ManagerClient():
         """Get list of running servers"""
         host_list = await self._request("http://localhost/cluster/servers")
         return host_list.split(',')
+
+    async def mark_dirty(self) -> None:
+        """Manually mark current cluster dirty.
+           To be used when a server was modified outside of this API."""
+        await self._request("http://localhost/cluster/mark-dirty", "Could not mark cluster dirty")

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""Manager client.
+   Communicates with Manager server via socket.
+   Provides helper methods to test cases.
+   Manages driver refresh when cluster is cycled.
+"""
+
+from typing import List
+import aiohttp                                                             # type: ignore
+import aiohttp.web                                                         # type: ignore
+
+
+class ManagerClient():
+    """Helper Manager API client
+    Args:
+        sock_path (str): path to an AF_UNIX socket where Manager server is listening
+    """
+    conn: aiohttp.UnixConnector
+    session: aiohttp.ClientSession
+
+    def __init__(self, sock_path: str) -> None:
+        self.sock_path = sock_path
+
+    async def start(self):
+        """Setup connection to Manager server"""
+        self.conn = aiohttp.UnixConnector(path=self.sock_path)
+        self.session = aiohttp.ClientSession(connector=self.conn)
+
+    async def _request(self, url: str) -> str:
+        # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html
+        resp = await self.session.get(url)
+        return await resp.text()
+
+    async def is_manager_up(self) -> bool:
+        """Check if Manager server is up"""
+        ret = await self._request("http://localhost/up")
+        return ret == "True"
+
+    async def is_cluster_up(self) -> bool:
+        """Check if cluster is up"""
+        ret = await self._request("http://localhost/cluster/up")
+        return ret == "True"
+
+    async def is_dirty(self) -> bool:
+        """Check if current cluster dirty."""
+        dirty = await self._request("http://localhost/cluster/is-dirty")
+        return dirty == "True"
+
+    async def replicas(self) -> int:
+        """Get number of configured replicas for the cluster (replication factor)"""
+        resp = await self._request("http://localhost/cluster/replicas")
+        return int(resp)
+
+    async def servers(self) -> List[str]:
+        """Get list of running servers"""
+        host_list = await self._request("http://localhost/cluster/servers")
+        return host_list.split(',')

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -106,4 +106,37 @@ class ManagerClient():
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
-        await self._request("http://localhost/cluster/mark-dirty", "Could not mark cluster dirty")
+        await self._request("http://localhost/cluster/mark-dirty")
+
+    async def server_stop(self, server_id: str) -> bool:
+        """Stop specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/stop")
+        return ret == "OK"
+
+    async def server_stop_gracefully(self, server_id: str) -> bool:
+        """Stop specified node gracefully"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/stop_gracefully")
+        return ret == "OK"
+
+    async def server_start(self, server_id: str) -> bool:
+        """Start specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/start")
+        self._driver_update()
+        return ret == "OK"
+
+    async def server_restart(self, server_id: str) -> bool:
+        """Restart specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/restart")
+        self._driver_update()
+        return ret == "OK"
+
+    async def server_add(self) -> str:
+        """Add a new node"""
+        server_id = await self._request("http://localhost/cluster/addnode")
+        self._driver_update()
+        return server_id
+
+    async def server_remove(self, server_id: str) -> None:
+        """Remove a specified node"""
+        await self._request(f"http://localhost/cluster/removenode/{server_id}")
+        self._driver_update()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -658,6 +658,7 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/servers', self._cluster_servers)
         self.app.router.add_get('/cluster/before-test/{test_name}', self._before_test_req)
         self.app.router.add_get('/cluster/after-test/{test_name}', self._after_test)
+        self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
 
     async def _manager_up(self, request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -693,6 +694,11 @@ class ScyllaClusterManager:
         self.is_after_test_ok = True
         return aiohttp.web.Response(text="True")
 
+    async def _mark_dirty(self, request) -> aiohttp.web.Response:
+        """Mark current cluster dirty"""
+        assert self.cluster
+        self.cluster.is_dirty = True
+        return aiohttp.web.Response(text="OK")
 
 @asynccontextmanager
 async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-import aiohttp
 import asyncio
 from contextlib import asynccontextmanager
 import itertools
@@ -11,6 +10,7 @@ import logging
 import os
 import pathlib
 import shutil
+import tempfile
 import time
 import uuid
 from typing import Optional, Dict, List, Set, Callable, AsyncIterator, NamedTuple
@@ -24,6 +24,8 @@ from cassandra.cluster import Cluster, NoHostAvailable  # type: ignore
 from cassandra.cluster import Session                   # type: ignore
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
+import aiohttp
+import aiohttp.web
 
 #
 # Put all Scylla options in a template file. Sic: if you make a typo in the
@@ -596,21 +598,40 @@ class ScyllaCluster:
 
 
 class ScyllaClusterManager:
-    """Manages a Scylla cluster for running test cases"""
+    """Manages a Scylla cluster for running test cases
+       Provides an async API for tests to request changes in the Cluster.
+       Parallel requests are not supported.
+    """
     cluster: ScyllaCluster
+    site: aiohttp.web.UnixSite
 
-    def __init__(self, test_name: str, clusters: Pool[ScyllaCluster]) -> None:
+    def __init__(self, test_name: str, clusters: Pool[ScyllaCluster], base_dir: str) -> None:
         self.test_name: str = test_name
         self.clusters: Pool[ScyllaCluster] = clusters
+        self.is_running: bool = False
+        # API
+        # NOTE: need to make a safe temp dir as tempfile can't make a safe temp sock name
+        self.manager_dir: str = tempfile.mkdtemp(prefix="manager-", dir=base_dir)
+        self.sock_path: str = f"{self.manager_dir}/api"
+        self.app = aiohttp.web.Application()
+        self._setup_routes()
+        self.runner = aiohttp.web.AppRunner(self.app)
 
     async def start(self) -> None:
-        """Start, start first cluster"""
+        """Get first cluster, setup API"""
         await self._get_cluster()
+        await self.runner.setup()
+        self.site = aiohttp.web.UnixSite(self.runner, path=self.sock_path)
+        await self.site.start()
+        self.is_running = True
 
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
+        await self.site.stop()
         self.cluster.after_test(self.test_name)
         await self._return_cluster()
+        if os.path.exists(self.manager_dir):
+            shutil.rmtree(self.manager_dir)
 
     async def _get_cluster(self) -> None:
         self.cluster = await self.clusters.get()
@@ -621,13 +642,42 @@ class ScyllaClusterManager:
         await self.clusters.put(self.cluster)
         del self.cluster
 
+    def _setup_routes(self) -> None:
+        self.app.router.add_get('/up', self._manager_up)
+        self.app.router.add_get('/cluster/up', self._cluster_up)
+        self.app.router.add_get('/cluster/is-dirty', self._is_dirty)
+        self.app.router.add_get('/cluster/replicas', self._cluster_replicas)
+        self.app.router.add_get('/cluster/servers', self._cluster_servers)
+
+    async def _manager_up(self, request) -> aiohttp.web.Response:
+        return aiohttp.web.Response(text=f"{self.is_running}")
+
+    async def _cluster_up(self, request) -> aiohttp.web.Response:
+        """Is cluster running"""
+        return aiohttp.web.Response(text=f"{self.cluster is not None and self.cluster.is_running}")
+
+    async def _is_dirty(self, request) -> aiohttp.web.Response:
+        """Report if current cluster is dirty"""
+        if self.cluster is None:
+            return aiohttp.web.Response(status=500, text="No cluster active")
+        return aiohttp.web.Response(text=f"{self.cluster.is_dirty}")
+
+    async def _cluster_replicas(self, request) -> aiohttp.web.Response:
+        """Return cluster's configured number of replicas (replication factor)"""
+        if self.cluster is None:
+            return aiohttp.web.Response(status=500, text="No cluster active")
+        return aiohttp.web.Response(text=f"{self.cluster.replicas}")
+
+    async def _cluster_servers(self, request) -> aiohttp.web.Response:
+        """Return a list of active server ids (IPs)"""
+        return aiohttp.web.Response(text=f"{','.join(sorted(self.cluster.running.keys()))}")
 
 @asynccontextmanager
-async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster]) \
+async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \
         -> AsyncIterator[ScyllaClusterManager]:
     """Create a temporary manager for the active cluster used in a test
        and provide the cluster to the caller."""
-    manager = ScyllaClusterManager(test_name, clusters)
+    manager = ScyllaClusterManager(test_name, clusters, test_path)
     await manager.start()
     try:
         yield manager

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -659,6 +659,13 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/before-test/{test_name}', self._before_test_req)
         self.app.router.add_get('/cluster/after-test/{test_name}', self._after_test)
         self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
+        self.app.router.add_get('/cluster/server/{id}/stop', self._cluster_server_stop)
+        self.app.router.add_get('/cluster/server/{id}/stop_gracefully',
+                                self._cluster_server_stop_gracefully)
+        self.app.router.add_get('/cluster/server/{id}/start', self._cluster_server_start)
+        self.app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
+        self.app.router.add_get('/cluster/addserver', self._cluster_server_add)
+        self.app.router.add_get('/cluster/removeserver/{id}', self._cluster_server_remove)
 
     async def _manager_up(self, request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -698,6 +705,49 @@ class ScyllaClusterManager:
         """Mark current cluster dirty"""
         assert self.cluster
         self.cluster.is_dirty = True
+        return aiohttp.web.Response(text="OK")
+
+    async def _server_stop(self, request: aiohttp.web.Request, gracefully: bool) \
+                        -> aiohttp.web.Response:
+        """Stop a server. No-op if already stopped."""
+        assert self.cluster
+        ret = await self.cluster.server_stop(request.match_info['id'], gracefully)
+        return aiohttp.web.Response(status=200 if ret[0] else 500, text=ret[1])
+
+    async def _cluster_server_stop(self, request) -> aiohttp.web.Response:
+        """Stop a specified server"""
+        assert self.cluster
+        return await self._server_stop(request, gracefully = False)
+
+    async def _cluster_server_stop_gracefully(self, request) -> aiohttp.web.Response:
+        """Stop a specified server gracefully"""
+        assert self.cluster
+        return await self._server_stop(request, gracefully = True)
+
+    async def _cluster_server_start(self, request) -> aiohttp.web.Response:
+        """Start a specified server (must be stopped)"""
+        assert self.cluster
+        ret = await self.cluster.server_start(request.match_info['id'])
+        return aiohttp.web.Response(status=200 if ret[0] else 500, text=ret[1])
+
+    async def _cluster_server_restart(self, request) -> aiohttp.web.Response:
+        """Restart a specified server (must be already started)"""
+        assert self.cluster
+        ret = await self.cluster.server_restart(request.match_info['id'])
+        return aiohttp.web.Response(status=200 if ret[0] else 500, text=ret[1])
+
+    async def _cluster_server_add(self, request) -> aiohttp.web.Response:
+        """Add a new server"""
+        assert self.cluster
+        server_id = await self.cluster.add_server()
+        return aiohttp.web.Response(text=server_id)
+
+    async def _cluster_server_remove(self, request) -> aiohttp.web.Response:
+        """Remove a specified server"""
+        assert self.cluster
+        server_id = request.match_info['id']
+        if not await self.cluster.server_remove(server_id):
+            return aiohttp.web.Response(status=500, text=f"Host {server_id} not found")
         return aiohttp.web.Response(text="OK")
 
 @asynccontextmanager

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Test consistency of schema changes with topology changes.
+"""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_add_server_add_column(manager, random_tables):
+    """Add a node and then add a column to a table and verify"""
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_stop_server_add_column(manager, random_tables):
+    """Add a node, stop an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await manager.server_stop(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_restart_server_add_column(manager, random_tables):
+    """Add a node, stop an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    ret = await manager.server_restart(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_remove_server_add_column(manager, random_tables):
+    """Add a node, remove an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await manager.server_remove(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()


### PR DESCRIPTION
Give cluster control to pytests. While there add missing stop gracefully and add server to ScyllaCluster.

Clusters can be marked dirty but they are not recycled yet. This will be done in a later series.

Commits are

- test.py: ScyllaServer stop gracefully
- test.py: ScyllaCluster add_server helper
- test.py: harness for cluster management from test