### PR TITLE
Introduce system.events

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1023,6 +1023,7 @@ scylla_core = (['replica/database.cc',
                 'service/raft/raft_group0.cc',
                 'direct_failure_detector/failure_detector.cc',
                 'service/raft/raft_group0_client.cc',
+                'db/system_events.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] + [Thrift('interface/cassandra.thrift', 'Cassandra')] \
                   + scylla_raft_core
                )

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1097,7 +1097,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std:
     co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
         // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
         for (auto keyspace_to_drop : keyspaces_to_drop) {
-            db.drop_keyspace(keyspace_to_drop);
+            co_await db.drop_keyspace(keyspace_to_drop);
             co_await db.get_notifier().drop_keyspace(keyspace_to_drop);
         }
     });

--- a/db/system_events.cc
+++ b/db/system_events.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#include <seastar/core/coroutine.hh>
+
+#include "log.hh"
+#include "utils/UUID_gen.hh"
+
+#include "db/system_events.hh"
+#include "db/system_keyspace.hh"
+#include "db/query_context.hh"
+
+static logging::logger selogger("system_events");
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const db::system_event& event) {
+    out << "system_event("
+        << "category=" << event.category
+        << ", type=" << event.type
+        << ", params=" << event.params;
+    if (event.completed_at) {
+        out << ", completion_status=" << event.completion_status;
+    }
+    return out << ')';
+}
+
+}
+
+namespace db {
+
+future<> record_system_event(sstring category, sstring event_type, std::unordered_map<sstring, sstring> params, const sstring& completion_status, gc_clock::duration ttl) {
+    if (!db::qctx) {
+        co_return;
+    }
+
+    auto using_ttl = ttl != NO_TTL ? format(" USING TTL {}", gc_clock::as_int32(ttl)) : "";
+    const sstring req = format("INSERT INTO {}.{} (category, started_at, type, params, completed_at, completion_status) VALUES (?, ?, ?, ?, ?, ?){}",
+            system_keyspace::NAME, system_keyspace::EVENTS, using_ttl);
+
+    // FIXME: for now, format all params into a string.
+    // Column should be turned into a map
+    std::stringstream params_str;
+    sstring delim = "";
+    for (const auto& [k, v] : params) {
+        params_str << delim << k << '=' << v;
+        delim = ",";
+    }
+
+    auto now = utils::UUID_gen::get_time_UUID();
+    auto event = system_event{
+        .id = now,
+        .category = std::move(category),
+        .type = std::move(event_type),
+        .params = std::move(params),
+        .completed_at = now,
+        .completion_status = completion_status,
+    };
+
+    try {
+        co_await db::qctx->execute_cql(req, event.category, event.id, event.type, params_str.view(), event.completed_at, event.completion_status).discard_result();
+    } catch (...) {
+        selogger.warn("Failed to insert to {}.{}: {}: {}", system_keyspace::NAME, system_keyspace::EVENTS, event, std::current_exception());
+    }
+}
+
+future<system_event> start_system_event(sstring category, sstring event_type, event_params params, gc_clock::duration ttl) {
+    if (!db::qctx) {
+        co_return system_event{};
+    }
+
+    auto using_ttl = ttl != NO_TTL ? format(" USING TTL {}", gc_clock::as_int32(ttl)) : "";
+    const sstring req = format("INSERT INTO {}.{} (category, started_at, type, params) VALUES (?, ?, ?, ?){}",
+            system_keyspace::NAME, system_keyspace::EVENTS, using_ttl);
+
+    // FIXME: for now, format all params into a string.
+    // Column should be turned into a map
+    std::stringstream params_str;
+    sstring delim = "";
+    for (const auto& [k, v] : params) {
+        params_str << delim << k << '=' << v;
+        delim = ",";
+    }
+
+    auto now = utils::UUID_gen::get_time_UUID();
+    auto event = system_event{
+        .id = now,
+        .category = std::move(category),
+        .type = std::move(event_type),
+        .params = std::move(params),
+    };
+
+    try {
+        co_await db::qctx->execute_cql(req, event.category, event.id, event.type, params_str.view()).discard_result();
+    } catch (...) {
+        auto ex = std::current_exception();
+        event.completed_at = event.id;
+        event.completion_status = format("{}", ex);
+        event.id = utils::null_uuid();
+        selogger.warn("Failed to insert to {}.{}: {}", system_keyspace::NAME, system_keyspace::EVENTS, event);
+    }
+
+    co_return event;
+}
+
+static future<> _end_system_event(system_event& event, const sstring& completion_status) {
+    event.completed_at = utils::UUID_gen::get_time_UUID();
+    event.completion_status = completion_status;
+    const sstring req = format("UPDATE {}.{} SET completed_at = ?, completion_status = ? WHERE category = ? AND started_at = ?",
+            system_keyspace::NAME, system_keyspace::EVENTS);
+
+    try {
+        co_await db::qctx->execute_cql(req, event.completed_at, event.completion_status, event.category, event.id).discard_result();
+    } catch (...) {
+        selogger.warn("Failed to update {}.{}: {}: {}", system_keyspace::NAME, system_keyspace::EVENTS, event, std::current_exception());
+    }
+}
+
+future<> end_system_event(system_event& event, const sstring& completion_status) {
+    if (!db::qctx || !event.id) {
+        return make_ready_future<>();
+    }
+
+    return _end_system_event(event, completion_status);
+}
+
+future<> end_system_event(system_event& event, std::exception_ptr ex) {
+    if (!db::qctx || !event.id) {
+        co_return;
+    }
+
+    sstring completion_status = ex ? format("FAILED: {}", ex) : "OK";
+    co_await _end_system_event(event, completion_status);
+}
+
+} // namespace db

--- a/db/system_events.hh
+++ b/db/system_events.hh
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+#include <iostream>
+
+#include "schema_fwd.hh"
+#include "system_keyspace.hh"
+#include "utils/UUID.hh"
+#include "gc_clock.hh"
+
+using namespace std::literals::chrono_literals;
+
+namespace db {
+
+constexpr gc_clock::duration NO_TTL = 0s;
+constexpr gc_clock::duration ONE_DAY_TTL = 86400s;
+constexpr gc_clock::duration ONE_MONTH_TTL = 2628000s;
+constexpr gc_clock::duration ONE_YEAR_TTL = 31536000s;
+constexpr gc_clock::duration DEFAULT_SYSTEM_EVENTS_TTL = 3 * ONE_YEAR_TTL;
+
+using event_params = std::unordered_map<sstring, sstring>;
+
+struct system_event {
+    utils::UUID id = utils::null_uuid();   // started_at
+    sstring category;
+    sstring type;
+    event_params params;
+    utils::UUID completed_at;
+    sstring completion_status = "";
+};
+
+// The following functions update the system.events table.
+// They do not report query errors back, but rather log a warning
+// and clear the event.id where a system_event is available to the caller.
+future<> record_system_event(sstring category, sstring event_type, std::unordered_map<sstring, sstring> params = {}, const sstring& completion_status = "", gc_clock::duration ttl = DEFAULT_SYSTEM_EVENTS_TTL);
+future<system_event> start_system_event(sstring category, sstring event_type, std::unordered_map<sstring, sstring> params = {}, gc_clock::duration ttl = DEFAULT_SYSTEM_EVENTS_TTL);
+
+// end_system_event is a noop if event.id is null.
+future<> end_system_event(system_event& event, const sstring& completion_status);
+future<> end_system_event(system_event& event, std::exception_ptr = nullptr);
+
+} // namespace db
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const db::system_event& event);
+
+}

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -126,6 +126,7 @@ public:
     static constexpr auto REPAIR_HISTORY = "repair_history";
     static constexpr auto GROUP0_HISTORY = "group0_history";
     static constexpr auto DISCOVERY = "discovery";
+    static constexpr auto EVENTS = "events";
 
     struct v3 {
         static constexpr auto BATCHES = "batches";
@@ -209,6 +210,7 @@ public:
     static schema_ptr repair_history();
     static schema_ptr group0_history();
     static schema_ptr discovery();
+    static schema_ptr events();
 
     static table_schema_version generate_schema_version(utils::UUID table_id, uint16_t offset = 0);
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -131,7 +131,7 @@ public:
     future<> cleanup_history(utils::UUID repair_id);
     future<> load_history();
 
-    int do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map);
+    future<int> do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map);
 
     // The tokens are the tokens assigned to the bootstrap node.
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -853,6 +853,11 @@ database::init_commitlog() {
     });
 }
 
+static bool is_system_keyspace(const sstring& ks_name) {
+    return ks_name == db::system_keyspace::NAME || ks_name == db::system_distributed_keyspace::NAME
+        || ks_name == db::system_distributed_keyspace::NAME_EVERYWHERE;
+}
+
 future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name) {
     auto v = co_await db::schema_tables::read_schema_partition_for_keyspace(proxy, db::schema_tables::KEYSPACES, name);
     auto& ks = find_keyspace(name);
@@ -880,8 +885,7 @@ void database::drop_keyspace(const sstring& name) {
 }
 
 static bool is_system_table(const schema& s) {
-    return s.ks_name() == db::system_keyspace::NAME || s.ks_name() == db::system_distributed_keyspace::NAME
-        || s.ks_name() == db::system_distributed_keyspace::NAME_EVERYWHERE;
+    return is_system_keyspace(s.ks_name());
 }
 
 void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1276,23 +1276,23 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
         event = co_await db::start_system_event("database", "create_keyspace", std::move(params));
     }
     std::exception_ptr ex;
-  try {
-    co_await create_in_memory_keyspace(ksm, erm_factory, system);
-    auto& ks = _keyspaces.at(ksm->name());
-    auto& datadir = ks.datadir();
+    try {
+        co_await create_in_memory_keyspace(ksm, erm_factory, system);
+        auto& ks = _keyspaces.at(ksm->name());
+        auto& datadir = ks.datadir();
 
-    // keyspace created by either cql or migration 
-    // is by definition populated
-    if (!is_bootstrap) {
-        ks.mark_as_populated();
-    }
+        // keyspace created by either cql or migration 
+        // is by definition populated
+        if (!is_bootstrap) {
+            ks.mark_as_populated();
+        }
 
-    if (datadir != "") {
-        co_await io_check([&datadir] { return touch_directory(datadir); });
+        if (datadir != "") {
+            co_await io_check([&datadir] { return touch_directory(datadir); });
+        }
+    } catch (...) {
+        ex = std::current_exception();
     }
-  } catch (...) {
-    ex = std::current_exception();
-  }
 
     co_await db::end_system_event(event, ex);
     if (ex) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1454,7 +1454,7 @@ public:
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
     future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
-    void drop_keyspace(const sstring& name);
+    future<> drop_keyspace(const sstring& name);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;
     column_family& find_column_family(std::string_view ks, std::string_view name);

--- a/test/cql-pytest/nodetool.py
+++ b/test/cql-pytest/nodetool.py
@@ -95,6 +95,15 @@ def take_snapshot(cql, table, tag, skip_flush):
         args.append(ks)
         run_nodetool(cql, "snapshot", *args)
 
+def repair(cql, ks):
+    if has_rest_api(cql):
+        res = requests.post(f'{rest_api_url(cql)}/storage_service/repair_async/{ks}')
+        res.raise_for_status()
+        id = res.text
+        requests.get(f'{rest_api_url(cql)}/storage_service/repair_async/{ks}', params={'id': id})
+    else:
+        run_nodetool(cql, "repair", ks)
+
 def refreshsizeestimates(cql):
     if has_rest_api(cql):
         # The "nodetool refreshsizeestimates" is not available, or needed, in Scylla

--- a/test/cql-pytest/test_system_events.py
+++ b/test/cql-pytest/test_system_events.py
@@ -33,6 +33,24 @@ def test_system_events(scylla_only, cql, this_dc):
             keyspace_found = search_str in e
         assert keyspace_found, f"'{test_keyspace}' not found in: {events['database']['create_keyspace']}"
 
+        test_table = ""
+        with util.new_test_table(cql, test_keyspace, "k int PRIMARY KEY") as test_table:
+            events = get_system_events(cql)
+            table_found = False
+            keyspace_search_str = f"keyspace_name={test_keyspace}"
+            table_search_str = f"table_name={test_table.split('.')[1]}"
+            for e in events['database']['create_table'].values():
+                table_found = keyspace_search_str in e and table_search_str in e
+            assert table_found, f"'{test_table}' not found in: {events['database']['create_table']}"
+
+        events = get_system_events(cql)
+        table_found = False
+        keyspace_search_str = f"keyspace_name={test_keyspace}"
+        table_search_str = f"table_name={test_table.split('.')[1]}"
+        for e in events['database']['drop_table'].values():
+            table_found = keyspace_search_str in e and table_search_str in e
+        assert table_found, f"'{test_table}' not found in: {events['database']['drop_table']}"
+
     events = get_system_events(cql)
     keyspace_found = False
     search_str = f"keyspace_name={test_keyspace}"

--- a/test/cql-pytest/test_system_events.py
+++ b/test/cql-pytest/test_system_events.py
@@ -5,6 +5,7 @@
 
 import pytest
 import util
+import nodetool
 
 def get_system_events(cql):
     events = dict()
@@ -57,3 +58,16 @@ def test_system_events(scylla_only, cql, this_dc):
     for e in events['database']['drop_keyspace'].values():
         keyspace_found = search_str in e
     assert keyspace_found, f"'{test_keyspace}' not found in: {events['database']['drop_keyspace']}"
+
+def test_major_compaction(scylla_only, cql, test_keyspace):
+    with util.new_test_table(cql, test_keyspace, "k int PRIMARY KEY") as test_table:
+        cql.execute(f"INSERT INTO {test_table} (k) VALUES (0)")
+        nodetool.flush(cql, test_table)
+        nodetool.compact(cql, test_table)
+        events = get_system_events(cql)
+        table_found = False
+        keyspace_search_str = f"keyspace_name={test_keyspace}"
+        table_search_str = f"table_name={test_table.split('.')[1]}"
+        for e in events['compaction']['major'].values():
+            table_found = keyspace_search_str in e and table_search_str in e
+        assert table_found, f"'{test_table}' not found in: {events['compaction']['major']}"

--- a/test/cql-pytest/test_system_events.py
+++ b/test/cql-pytest/test_system_events.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+import util
+
+def get_system_events(cql):
+    events = dict()
+    rows = list(cql.execute("SELECT category, started_at, type, params FROM system.events"))
+    assert(len(rows) > 0)
+    for row in rows:
+        if not row.category in events:
+            events[row.category] = dict()
+        if not row.type in events[row.category]:
+            events[row.category][row.type] = dict()
+        events[row.category][row.type][row.started_at] = row.params
+    return events
+
+# Check reading the system.events table, which should list major system events
+# like start/stop.
+def test_system_events(scylla_only, cql):
+    events = get_system_events(cql)
+    assert len(events['system']['start']) > 0


### PR DESCRIPTION
Add a node-local system.events table to hold high-level events (typically administrative)
for the long term.

Events types include, for example:
- system start/stop
- keyspace and table create and drop
- major compaction
- repair

This series introduces a rudimentary implementation of such a table
and makes use of it for the above events.

Unit tests were added to test/cql-pytest for the above cases.

TODO: The schema for system.events in the series uses a text column to keep the event parameters, and each event passes a dictionary that is formatted into a string to keep them.

It would be better to keep the event params in a map collection so they will be stored in a more structured way and be searched more easily.