### PR TITLE
Implement Raft upgrade procedure

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1528,6 +1528,17 @@ future<std::unordered_map<gms::inet_address, locator::host_id>> system_keyspace:
     });
 }
 
+future<std::vector<gms::inet_address>> system_keyspace::load_peers() {
+    auto res = co_await execute_cql(format("SELECT peer FROM system.{}", PEERS));
+    assert(res);
+
+    std::vector<gms::inet_address> ret;
+    for (auto& row: *res) {
+        ret.emplace_back(row.get_as<net::inet_address>("peer"));
+    }
+    co_return ret;
+}
+
 future<std::unordered_map<gms::inet_address, sstring>> system_keyspace::load_peer_features() {
     sstring req = format("SELECT peer, supported_features FROM system.{}", PEERS);
     return qctx->execute_cql(req).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3262,6 +3262,56 @@ future<mutation> system_keyspace::get_group0_history(distributed<service::storag
     co_return mutation(s, partition_key::from_singular(*s, GROUP0_HISTORY_KEY));
 }
 
+static constexpr auto GROUP0_UPGRADE_STATE_KEY = "group0_upgrade_state";
+
+future<service::group0_upgrade_state> system_keyspace::load_group0_upgrade_state() {
+    auto s = co_await get_scylla_local_param_as<sstring>(GROUP0_UPGRADE_STATE_KEY);
+
+    if (!s || *s == "use_pre_raft_procedures") {
+        co_return service::group0_upgrade_state::use_pre_raft_procedures;
+    } else if (*s == "synchronize") {
+        co_return service::group0_upgrade_state::synchronize;
+    } else if (*s == "use_post_raft_procedures") {
+        co_return service::group0_upgrade_state::use_post_raft_procedures;
+    } else if (*s == "recovery") {
+        co_return service::group0_upgrade_state::recovery;
+    }
+
+    slogger.error(
+            "load_group0_upgrade_state(): unknown value '{}' for key 'group0_upgrade_state' in Scylla local table."
+            " Did you change the value manually?"
+            " Correct values are: 'use_pre_raft_procedures', 'synchronize', 'use_post_raft_procedures', 'recovery'."
+            " Assuming 'recovery'.", *s);
+    // We don't call `on_internal_error` which would probably prevent the node from starting, but enter `recovery`
+    // allowing the user to fix their cluster.
+    co_return service::group0_upgrade_state::recovery;
+}
+
+future<> system_keyspace::save_group0_upgrade_state(service::group0_upgrade_state s) {
+    auto value = [s] () constexpr {
+        switch (s) {
+            case service::group0_upgrade_state::use_post_raft_procedures:
+                return "use_post_raft_procedures";
+            case service::group0_upgrade_state::synchronize:
+                return "synchronize";
+            case service::group0_upgrade_state::recovery:
+                // It should not be necessary to ever save this state internally - the user sets it manually
+                // (e.g. from cqlsh) if recovery is needed - but handle the case anyway.
+                return "recovery";
+            case service::group0_upgrade_state::use_pre_raft_procedures:
+                // It should not be necessary to ever save this state, but handle the case anyway.
+                return "use_pre_raft_procedures";
+        }
+
+        on_internal_error(slogger, format(
+                "save_group0_upgrade_state: given value is outside the set of possible values (integer value: {})."
+                " This may have been caused by undefined behavior; best restart your system.",
+                static_cast<uint8_t>(s)));
+    }();
+
+    return set_scylla_local_param(GROUP0_UPGRADE_STATE_KEY, value);
+}
+
 sstring system_keyspace_name() {
     return system_keyspace::NAME;
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -25,6 +25,7 @@
 #include <seastar/core/distributed.hh>
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
+#include "service/raft/group0_upgrade.hh"
 
 namespace service {
 
@@ -456,6 +457,9 @@ public:
     // Obtain the contents of the group 0 history table in mutation form.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<mutation> get_group0_history(distributed<service::storage_proxy>&);
+
+    future<service::group0_upgrade_state> load_group0_upgrade_state();
+    future<> save_group0_upgrade_state(service::group0_upgrade_state);
 
     system_keyspace(sharded<cql3::query_processor>& qp, sharded<replica::database>& db) noexcept;
     ~system_keyspace();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -342,6 +342,8 @@ public:
      */
     future<std::unordered_map<gms::inet_address, locator::host_id>> load_host_ids();
 
+    future<std::vector<gms::inet_address>> load_peers();
+
     /*
      * Read this node's tokens stored in the LOCAL table.
      * Used to initialize a restarting node.

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -478,6 +478,11 @@ class RpcVerb(ASTBase):
     - [[with_timeout]] - an additional time_point parameter is supplied
       to the handler function and send* method uses send_message_*_timeout
       variant of internal function to actually send the message.
+      Incompatible with [[cancellable]].
+    - [[cancellable]] - an additional abort_source& parameter is supplied
+      to the handler function and send* method uses send_message_*_cancellable
+      variant of internal function to actually send the message.
+      Incompatible with [[with_timeout]].
     - [[one_way]] - the handler function is annotated by
       future<rpc::no_wait_type> return type to designate that a client
       doesn't need to wait for an answer.
@@ -486,16 +491,17 @@ class RpcVerb(ASTBase):
     the return type is set to be `future<>`.
     For one-way verbs, the use of return clause is prohibited and the
     signature of `send*` function always returns `future<>`."""
-    def __init__(self, name, parameters, return_values, with_client_info, with_timeout, one_way):
+    def __init__(self, name, parameters, return_values, with_client_info, with_timeout, cancellable, one_way):
         super().__init__(name)
         self.params = parameters
         self.return_values = return_values
         self.with_client_info = with_client_info
         self.with_timeout = with_timeout
+        self.cancellable = cancellable
         self.one_way = one_way
 
     def __str__(self):
-        return f"<RpcVerb(name={self.name}, params={self.params}, return_values={self.return_values}, with_client_info={self.with_client_info}, with_timeout={self.with_timeout}, one_way={self.one_way})>"
+        return f"<RpcVerb(name={self.name}, params={self.params}, return_values={self.return_values}, with_client_info={self.with_client_info}, with_timeout={self.with_timeout}, cancellable={self.cancellable}, one_way={self.one_way})>"
 
     def __repr__(self):
         return self.__str__()
@@ -506,6 +512,8 @@ class RpcVerb(ASTBase):
             send_fn += '_oneway'
         if self.with_timeout:
             send_fn += '_timeout'
+        if self.cancellable:
+            send_fn += '_cancellable'
         return send_fn
 
     def handler_function_return_values(self):
@@ -551,6 +559,8 @@ class RpcVerb(ASTBase):
         res = 'netw::messaging_service* ms, netw::msg_addr id'
         if self.with_timeout:
             res += ', netw::messaging_service::clock_type::time_point timeout'
+        if self.cancellable:
+            res += ', abort_source& as'
         if self.params:
             for idx, p in enumerate(self.params):
                 res += ', ' + p.to_string_send_fn_signature()
@@ -562,6 +572,8 @@ class RpcVerb(ASTBase):
         res = f'ms, {self.messaging_verb_enum_case()}, id'
         if self.with_timeout:
             res += ', timeout'
+        if self.cancellable:
+            res += ', as'
         if self.params:
             for idx, p in enumerate(self.params):
                 res += ', ' + f'std::move({p.name if p.name else f"_{idx + 1}"})'
@@ -675,11 +687,14 @@ def rpc_verb_parse_action(tokens):
     raw_attrs = tokens['attributes']
     params = tokens['params'] if 'params' in tokens else []
     with_timeout = not raw_attrs.empty() and 'with_timeout' in raw_attrs.attr_items
+    cancellable = not raw_attrs.empty() and 'cancellable' in raw_attrs.attr_items
     with_client_info = not raw_attrs.empty() and 'with_client_info' in raw_attrs.attr_items
     one_way = not raw_attrs.empty() and 'one_way' in raw_attrs.attr_items
     if one_way and 'return_values' in tokens:
         raise Exception(f"Invalid return type specification for one-way RPC verb '{name}'")
-    return RpcVerb(name=name, parameters=params, return_values=tokens.get('return_values'), with_client_info=with_client_info, with_timeout=with_timeout, one_way=one_way)
+    if with_timeout and cancellable:
+        raise Exception(f"Error in verb {name}: [[with_timeout]] cannot be used together with [[cancellable]] in the same verb")
+    return RpcVerb(name=name, parameters=params, return_values=tokens.get('return_values'), with_client_info=with_client_info, with_timeout=with_timeout, cancellable=cancellable, one_way=one_way)
 
 
 def namespace_parse_action(tokens):

--- a/idl/group0.idl.hh
+++ b/idl/group0.idl.hh
@@ -26,6 +26,7 @@ enum class group0_upgrade_state : uint8_t {
     use_post_raft_procedures = 3,
 };
 
+verb [[with_client_info, cancellable]] get_group0_upgrade_state () -> service::group0_upgrade_state;
 verb [[with_client_info, with_timeout]] group0_peer_exchange (std::vector<raft::server_address> peers) -> service::group0_peer_exchange;
 verb [[with_client_info, with_timeout]] group0_modify_config (raft::group_id gid, std::vector<raft::config_member> add, std::vector<raft::server_id> del);
 

--- a/idl/group0.idl.hh
+++ b/idl/group0.idl.hh
@@ -19,6 +19,13 @@ struct group0_peer_exchange {
     std::variant<std::monostate, service::group0_info, std::vector<raft::server_address>> info;
 };
 
+enum class group0_upgrade_state : uint8_t {
+    recovery = 0,
+    use_pre_raft_procedures = 1,
+    synchronize = 2,
+    use_post_raft_procedures = 3,
+};
+
 verb [[with_client_info, with_timeout]] group0_peer_exchange (std::vector<raft::server_address> peers) -> service::group0_peer_exchange;
 verb [[with_client_info, with_timeout]] group0_modify_config (raft::group_id gid, std::vector<raft::config_member> add, std::vector<raft::server_id> del);
 

--- a/main.cc
+++ b/main.cc
@@ -1358,7 +1358,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging.local(),
-                    gossiper.local(), qp.local(), mm.local(), group0_client};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), group0_client};
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
                 group0_service.abort().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1023,10 +1023,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
                 std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();
 
-            // gropu0 client exists only on shard 0
+            // group0 client exists only on shard 0.
             // The client has to be created before `stop_raft` since during
-            // desctructiun is has to exists untill raft_gr.stop() completes
-            service::raft_group0_client group0_client(raft_gr.local());
+            // destruction it has to exist until raft_gr.stop() completes.
+            service::raft_group0_client group0_client{raft_gr.local(), sys_ks.local()};
 
             supervisor::notify("starting migration manager");
             debug::the_migration_manager = &mm;
@@ -1079,6 +1079,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // start, but we only have query processor started that late
             sys_ks.invoke_on_all(&db::system_keyspace::start).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+
+            group0_client.init().get();
 
             db::sstables_format_selector sst_format_selector(gossiper.local(), feature_service, db);
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -41,6 +41,7 @@
 #include "cache_temperature.hh"
 #include "raft/raft.hh"
 #include "service/raft/messaging.hh"
+#include "service/raft/group0_upgrade.hh"
 #include "replica/exceptions.hh"
 #include "serializer.hh"
 #include "full_position.hh"

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -465,6 +465,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     // should not be blocked by any data requests.
     case messaging_verb::GROUP0_PEER_EXCHANGE:
     case messaging_verb::GROUP0_MODIFY_CONFIG:
+    case messaging_verb::GET_GROUP0_UPGRADE_STATE:
         return 0;
     case messaging_verb::PREPARE_MESSAGE:
     case messaging_verb::PREPARE_DONE_MESSAGE:

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1099,6 +1099,9 @@ future<> messaging_service::unregister_schema_check() {
 future<table_schema_version> messaging_service::send_schema_check(msg_addr dst) {
     return send_message<table_schema_version>(this, netw::messaging_verb::SCHEMA_CHECK, dst);
 }
+future<table_schema_version> messaging_service::send_schema_check(msg_addr dst, abort_source& as) {
+    return send_message_cancellable<table_schema_version>(this, netw::messaging_verb::SCHEMA_CHECK, dst, as);
+}
 
 // Wrapper for REPLICATION_FINISHED
 void messaging_service::register_replication_finished(std::function<future<> (inet_address)>&& func) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -177,7 +177,8 @@ enum class messaging_verb : int32_t {
     REPAIR_UPDATE_SYSTEM_TABLE = 59,
     REPAIR_FLUSH_HINTS_BATCHLOG = 60,
     FORWARD_REQUEST = 61,
-    LAST = 62,
+    GET_GROUP0_UPGRADE_STATE = 62,
+    LAST = 63,
 };
 
 } // namespace netw

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -487,6 +487,7 @@ public:
     void register_schema_check(std::function<future<table_schema_version>()>&& func);
     future<> unregister_schema_check();
     future<table_schema_version> send_schema_check(msg_addr);
+    future<table_schema_version> send_schema_check(msg_addr, abort_source&);
 
     // Wrapper for REPLICATION_FINISHED verb
     void register_replication_finished(std::function<future<> (inet_address from)>&& func);

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -156,9 +156,6 @@ public:
     // Requires a quorum of nodes to be available in order to finish.
     future<group0_guard> start_group0_operation();
 
-    // used to check if raft is enabled on the cluster
-    bool is_raft_enabled() { return _group0_client.is_enabled(); }
-
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
     future<> announce(std::vector<mutation> schema, group0_guard, std::string_view description = "");
@@ -193,7 +190,7 @@ private:
     future<> maybe_schedule_schema_pull(const table_schema_version& their_version, const gms::inet_address& endpoint);
 
     future<> announce_with_raft(std::vector<mutation> schema, group0_guard, std::string_view description);
-    future<> announce_without_raft(std::vector<mutation> schema);
+    future<> announce_without_raft(std::vector<mutation> schema, group0_guard);
 
 public:
     future<> maybe_sync(const schema_ptr& s, netw::msg_addr endpoint);

--- a/service/raft/group0_upgrade.hh
+++ b/service/raft/group0_upgrade.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <iostream>
+
+namespace service {
+
+enum class group0_upgrade_state : uint8_t {
+    // In recovery state group 0 is disabled.
+    // The node does not attempt any Raft/group 0 related operations, including upgrade.
+    recovery = 0,
+
+    // In `use_pre_raft_procedures` state the node performs schema changes without using group 0,
+    // using the 'old ways': by updating its local schema tables and attempting to push the change to others
+    // through direct RPC. If necessary, changes are later propagated with gossip.
+    use_pre_raft_procedures = 1,
+
+    // In `synchronize` state the node rejects any attempts for changing the schema.
+    // Schema changes may still arrive from other nodes for some time. However, if no failures occur
+    // during the upgrade procedure, eventually all nodes should enter `synchronize` state. Then
+    // the nodes ensure that schema is synchronized across the entire cluster before entering `use_post_raft_procedures`.
+    synchronize = 2,
+
+    // In `use_post_raft_procedures` state the upgrade is finished. The node performs schema changes
+    // using group 0, i.e. by constructing appropriate Raft commands and sending them to the Raft group 0 cluster.
+    use_post_raft_procedures = 3,
+};
+
+inline constexpr uint8_t group0_upgrade_state_last = 3;
+
+std::ostream& operator<<(std::ostream&, group0_upgrade_state);
+
+} // namespace service

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -15,13 +15,17 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "service/storage_proxy.hh"
+#include "service/migration_manager.hh"
 #include "direct_failure_detector/failure_detector.hh"
 #include "gms/gossiper.hh"
+#include "gms/feature_service.hh"
 #include "db/system_keyspace.hh"
+#include "replica/database.hh"
 
 #include <seastar/core/smp.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/rpc/rpc_types.hh>
@@ -85,8 +89,9 @@ raft_group0::raft_group0(seastar::abort_source& abort_source,
         gms::gossiper& gs,
         cql3::query_processor& qp,
         service::migration_manager& mm,
+        gms::feature_service& feat,
         raft_group0_client& client)
-    : _abort_source(abort_source), _raft_gr(raft_gr), _ms(ms), _gossiper(gs), _qp(qp), _mm(mm), _client(client)
+    : _abort_source(abort_source), _raft_gr(raft_gr), _ms(ms), _gossiper(gs), _qp(qp), _mm(mm), _feat(feat), _client(client)
 {
     init_rpc_verbs();
 }
@@ -115,10 +120,10 @@ future<> raft_group0::uninit_rpc_verbs() {
     ).discard_result();
 }
 
-/* static */ future<group0_upgrade_state> send_get_group0_upgrade_state(netw::messaging_service& ms, const gms::inet_address& addr, abort_source& as) {
+static future<group0_upgrade_state> send_get_group0_upgrade_state(netw::messaging_service& ms, const gms::inet_address& addr, abort_source& as) {
     auto state = co_await ser::group0_rpc_verbs::send_get_group0_upgrade_state(&ms, netw::msg_addr(addr), as);
     auto state_int = static_cast<int8_t>(state);
-    if (state_int > 3) {
+    if (state_int > group0_upgrade_state_last) {
         on_internal_error(upgrade_log, format(
             "send_get_group0_upgrade_state: unknown value for `group0_upgrade_state` received from node {}: {}",
             addr, state_int));
@@ -365,6 +370,16 @@ future<> raft_group0::join_group0(std::vector<raft::server_info> seeds, bool as_
     group0_log.info("{} joined group 0 with id {}", my_addr.id, group0_id);
 }
 
+static future<bool> wait_for_peers_to_enter_synchronize_state(
+        const raft::server& group0_server, netw::messaging_service&, abort_source&, gate::holder pause_shutdown);
+static future<bool> anyone_finished_upgrade(
+        const raft::server& group0_server, netw::messaging_service&, abort_source&);
+static future<bool> synchronize_schema(
+        replica::database&, netw::messaging_service&,
+        const raft::server& group0_server, service::migration_manager&,
+        const noncopyable_function<future<bool>()>& can_finish_early,
+        abort_source&);
+
 future<> raft_group0::setup_group0(db::system_keyspace& sys_ks, const std::unordered_set<gms::inet_address>& initial_contact_nodes) {
     assert(this_shard_id() == 0);
 
@@ -376,6 +391,11 @@ future<> raft_group0::setup_group0(db::system_keyspace& sys_ks, const std::unord
         co_return;
     }
 
+    if (((co_await _client.get_group0_upgrade_state()).second) == group0_upgrade_state::recovery) {
+        group0_log.warn("setup_group0: Raft RECOVERY mode, skipping group 0 setup.");
+        co_return;
+    }
+
     if (sys_ks.bootstrap_complete()) {
         auto group0_id = raft::group_id{co_await db::system_keyspace::get_raft_group0_id()};
         if (group0_id) {
@@ -384,7 +404,13 @@ future<> raft_group0::setup_group0(db::system_keyspace& sys_ks, const std::unord
             co_await start_server_for_group0(group0_id);
         } else {
             // Scylla has bootstrapped earlier but group 0 ID not present. This means we're upgrading.
-            // TODO: Prepare for upgrade.
+            // Upgrade will start through a feature listener created after we enter NORMAL state.
+            //
+            // See `raft_group0::finish_setup_after_join`.
+            upgrade_log.info(
+                "setup_group0: Scylla bootstrap completed before but group 0 ID not present."
+                " Internal upgrade-to-raft procedure will automatically start after every node finishes"
+                " upgrading to the new Scylla version.");
         }
 
         co_return;
@@ -400,20 +426,83 @@ future<> raft_group0::setup_group0(db::system_keyspace& sys_ks, const std::unord
     group0_log.info("setup_group0: joining group 0...");
     co_await join_group0(std::move(initial_contacts_as_raft_addrs), false /* non-voter */);
     group0_log.info("setup_group0: successfully joined group 0.");
+
+    // Enter `synchronize` upgrade state in case the cluster we're joining has recently enabled Raft
+    // and is currently in the middle of `upgrade_to_group0()`. For that procedure to finish
+    // every member of group 0 (now including us) needs to enter `synchronize` state.
+    co_await _client.set_group0_upgrade_state(group0_upgrade_state::synchronize);
+
+    group0_log.info("setup_group0: ensuring that the cluster has fully upgraded to use Raft...");
+    auto& group0_server = _raft_gr.group0();
+
+    // Perform a Raft read barrier so we know the set of group 0 members and our group 0 state is up-to-date.
+    co_await group0_server.read_barrier(&_abort_source);
+
+    auto cfg = group0_server.get_configuration();
+    if (!cfg.is_joint() && cfg.current.size() == 1) {
+        group0_log.info("setup_group0: we're the only member of the cluster.");
+    } else {
+        // We're joining an existing cluster - we're not the only member.
+        //
+        // Wait until one of group 0 members enters `group0_upgrade_state::use_post_raft_procedures`
+        // or all members enter `group0_upgrade_state::synchronize`.
+        //
+        // In a fully upgraded cluster this should finish immediately (if the network works well) - everyone is in `use_post_raft_procedures`.
+        // In a cluster that is currently in the middle of `upgrade_to_group0`, this will cause us to wait until the procedure finishes.
+        group0_log.info("setup_group0: ensuring that the cluster has fully upgraded to use Raft...");
+        if (co_await wait_for_peers_to_enter_synchronize_state(group0_server, _ms, _abort_source, _shutdown_gate.hold())) {
+            // Everyone entered `synchronize` state. That means we're bootstrapping in the middle of `upgrade_to_group0`.
+            // We need to finish upgrade as others do.
+            auto can_finish_early = std::bind_front(anyone_finished_upgrade, std::cref(group0_server), std::ref(_ms), std::ref(_abort_source));
+            co_await synchronize_schema(_qp.db().real_database(), _ms, group0_server, _mm, can_finish_early, _abort_source);
+        }
+    }
+
+
+    group0_log.info("setup_group0: the cluster is ready to use Raft. Finishing.");
+    co_await _client.set_group0_upgrade_state(group0_upgrade_state::use_post_raft_procedures);
 }
 
-future<> raft_group0::become_voter() {
-    if (!_raft_gr.is_enabled() || !joined_group0()) {
+future<> raft_group0::finish_setup_after_join() {
+    if (joined_group0()) {
+        group0_log.info("finish_setup_after_join: group 0 ID present, loading server info.");
+        auto my_addr = co_await load_my_addr();
+        if (!_raft_gr.group0().get_configuration().can_vote(my_addr.id)) {
+            group0_log.info("finish_setup_after_join: becoming a voter in the group 0 configuration...");
+            // Just bootstrapped and joined as non-voter. Become a voter.
+            auto pause_shutdown = _shutdown_gate.hold();
+            co_await _raft_gr.group0().modify_config({{my_addr, true}}, {}, &_abort_source);
+            group0_log.info("finish_setup_after_join: became a group 0 voter.");
+
+            // No need to run `upgrade_to_group0()` since we must have bootstrapped with Raft
+            // (that's the only way to join as non-voter today).
+            co_return;
+        }
+    } else if (!_raft_gr.is_enabled()) {
+        group0_log.info("finish_setup_after_join: local RAFT feature disabled, skipping.");
         co_return;
+    } else {
+        // We're either upgrading or in recovery mode.
     }
 
-    auto my_addr = co_await load_my_addr();
-    assert(std::holds_alternative<raft::group_id>(_group0));
-    auto& gid = std::get<raft::group_id>(_group0);
-    if (!_raft_gr.get_server(gid).get_configuration().can_vote(my_addr.id)) {
-        auto pause_shutdown = _shutdown_gate.hold();
-        co_return co_await _raft_gr.group0().modify_config({{my_addr, true}}, {}, &_abort_source);
+    // Note: even if we joined group 0 before, it doesn't necessarily mean we finished with the whole
+    // upgrade procedure which has follow-up steps after joining group 0, hence we need to prepare
+    // the listener below (or fire the upgrade procedure if the feature is already enabled) even if
+    // we're already a member of group 0 by this point.
+    // `upgrade_to_group0()` will correctly detect and handle which case we're in: whether the procedure
+    // has already finished or we restarted in the middle after a crash.
+
+    if (!_feat.supports_raft_cluster_mgmt) {
+        group0_log.info("finish_setup_after_join: SUPPORTS_RAFT feature not yet enabled, scheduling upgrade to start when it is.");
     }
+
+    // The listener may fire immediately, create a thread for that case.
+    co_await seastar::async([this] {
+        _raft_support_listener = _feat.supports_raft_cluster_mgmt.when_enabled([this] {
+            group0_log.info("finish_setup_after_join: SUPPORTS_RAFT feature enabled. Starting internal upgrade-to-raft procedure.");
+            upgrade_to_group0().get();
+        });
+    });
 }
 
 future<> raft_group0::leave_group0() {
@@ -424,9 +513,63 @@ future<> raft_group0::leave_group0() {
         co_return;
     }
 
-    if (!joined_group0()) {
-        // TODO: unimplemented upgrade case.
+    auto upgrade_state = (co_await _client.get_group0_upgrade_state()).second;
+    if (upgrade_state == group0_upgrade_state::recovery) {
+        group0_log.warn("leave_group0: in Raft RECOVERY mode, skipping.");
         co_return;
+    }
+
+    if (!_feat.supports_raft_cluster_mgmt) {
+        // The Raft feature is not yet enabled.
+        //
+        // In that case we assume the cluster is in a partially-upgraded state (some nodes still use a version
+        // without the raft/group 0 code enabled) and skip the leaving group 0 step.
+        //
+        // In theory we could be wrong: the cluster may have just upgraded but the user managed to call decommission
+        // before we noticed it. Us leaving at this point could cause `upgrade_to_group0`
+        // on other nodes to get stuck because it requires contacting all peers which may include us.
+        //
+        // For this to happen, the following conditions would have to be true:
+        // 1. decommission is called immediately after upgrade, before we notice that the Raft feature is enabled
+        // 2. we don't notice it during decommission - including the long streaming phase - even until we reach
+        //    the `leave_group0` step which is almost at the end of the procedure
+        // 3. some node did notice that the feature is enabled and started `upgrade_to_group0`, using us
+        //    as one of the peers for running group 0 discovery, before we entered LEFT state
+        //
+        // These conditions together give a very unlikely scenario. If it does happen the user can perform
+        // the manual recovery procedure for group 0.
+        group0_log.warn(
+            "leave_group0: Raft feature not enabled yet. Assuming that the cluster is partially upgraded"
+            " and skipping the step. However, if your already finished the rolling upgrade procedure,"
+            " this means we just haven't noticed it yet. The internal upgrade-to-raft procedure on other nodes"
+            " may get stuck (they may try to contact us during the procedure). If that happens, manual recovery"
+            " will be required. Consult the documentation for more details.");
+        // TODO: link to the docs
+        co_return;
+    }
+
+    if (upgrade_state != group0_upgrade_state::use_post_raft_procedures) {
+        // The feature is enabled but `upgrade_to_group0` did not finish yet.
+        // The upgrade procedure requires everyone to participate. In order to not block others
+        // from doing their upgrades, we'll wait until we finish our procedure - then we can safely leave.
+        //
+        // FIXME: well, to be completely precise, it could happen that everyone enters `synchronize` state,
+        // then we're the first to enter `use_post_raft_procedures` state and consider the procedure finished,
+        // then we leave before others contact us to confirm that everyone entered `synchronize` and
+        // they get stuck trying to contact us. To completely ensure liveness we should wait not only until
+        // we enter `use_post_raft_procedures`, but until somebody else also does (then others can use that
+        // node to confirm that they can also finish their procedures).
+        // Extend `wait_until_upgrade_to_group0_finishes` with an extra step which RPCs a peer
+        // to confirm they entered `use_post_raft_procedures`.
+        group0_log.info("leave_group0: waiting until cluster fully upgrades to use Raft before proceeding...");
+        co_await _client.wait_until_group0_upgraded(_abort_source);
+        group0_log.info("leave_group0: cluster finished upgrade, continuing.");
+    }
+
+    // We're fully upgraded, we must have joined group 0.
+    if (!joined_group0()) {
+        on_internal_error(group0_log,
+            "leave_group0: we're fully upgraded to use Raft but didn't join group 0. Please report a bug.");
     }
 
     auto my_id = raft::server_id{co_await db::system_keyspace::get_raft_server_id()};
@@ -449,9 +592,44 @@ future<> raft_group0::remove_from_group0(gms::inet_address node) {
         co_return;
     }
 
-    if (!joined_group0()) {
-        // TODO: unimplemented upgrade case.
+    auto upgrade_state = (co_await _client.get_group0_upgrade_state()).second;
+    if (upgrade_state == group0_upgrade_state::recovery) {
+        group0_log.warn("remove_from_group0({}): in Raft RECOVERY mode, skipping.", node);
         co_return;
+    }
+
+    if (!_feat.supports_raft_cluster_mgmt) {
+        // Similar situation as in `leave_group0` (read the comment there for detailed explanations).
+        //
+        // We assume that nobody started `upgrade_to_group0` yet so it's safe to remove nodes
+        // from the cluster without `upgrade_to_group0` getting stuck due to unavailable peers.
+        group0_log.warn(
+            "remove_from_group0({}): Raft feature not enabled yet. Assuming that the cluster is partially upgraded"
+            " and skipping the step. However, if your already finished the rolling upgrade procedure,"
+            " this means we just haven't noticed it yet. The internal upgrade-to-raft procedure may get stuck"
+            " (remaining nodes may try to contact the removed node during the procedure). If that happens,"
+            " manual recovery will be required. Consult the documentation for more details.", node);
+        // TODO: link to the docs
+        co_return;
+    }
+
+    if (upgrade_state != group0_upgrade_state::use_post_raft_procedures) {
+        // Similar situation as in `leave_group0`.
+        // Wait until the upgrade procedure finishes before removing the node.
+        //
+        // Note: if we enter `use_post_raft_procedures`, it's safe to remove anyone else without blocking upgrade:
+        // remaining nodes will observe that the procedure is finished by contacting us, even if they won't
+        // be able to contact the removed node.
+        group0_log.info("remove_from_group0({}): waiting until cluster fully upgrades to use Raft before proceeding...", node);
+        co_await _client.wait_until_group0_upgraded(_abort_source);
+        group0_log.info("remove_from_group0({}): cluster finished upgrade, continuing.", node);
+    }
+
+    // We're fully upgraded, we must have joined group 0.
+    if (!joined_group0()) {
+        on_internal_error(group0_log, format(
+            "remove_from_group0({}): we're fully upgraded to use Raft but not a member of group 0."
+            " Please report a bug.", node));
     }
 
     auto my_id = raft::server_id{co_await db::system_keyspace::get_raft_server_id()};
@@ -476,7 +654,7 @@ future<> raft_group0::remove_from_group0(gms::inet_address node) {
         // To handle the second case we perform a read barrier now and check the address again.
         // Ignore the returned guard, we don't need it.
         group0_log.info("remove_from_group0({}): did not find them in group 0 configuration, synchronizing Raft before retrying...", node);
-        (void)co_await _client.start_operation(&_abort_source);
+        co_await _raft_gr.group0().read_barrier(&_abort_source);
 
         their_id = _raft_gr.address_map().find_replace_id(node, my_id);
         if (!their_id) {
@@ -616,6 +794,635 @@ persistent_discovery::persistent_discovery(raft::server_address self, const peer
     for (auto& addr: seeds) {
         group0_log.debug("discovery: seed peer: id={}, info={}", addr.id, addr.info);
     }
+}
+
+static std::vector<raft::server_info> inet_addrs_to_raft_infos(const std::vector<gms::inet_address>& addrs) {
+    std::vector<raft::server_info> ret;
+    std::transform(addrs.begin(), addrs.end(), std::back_inserter(ret), &inet_addr_to_raft_addr);
+    return ret;
+}
+
+static std::vector<gms::inet_address> get_raft_members_inet_addrs(const raft::config_member_set& members) {
+    std::vector<gms::inet_address> ret;
+    for (auto& srv: members) {
+        ret.push_back(raft_addr_to_inet_addr(srv.addr));
+    }
+    return ret;
+}
+
+static future<std::vector<raft::server_info>> get_peers_as_raft_infos(db::system_keyspace& sys_ks) {
+    co_return inet_addrs_to_raft_infos(co_await sys_ks.load_peers());
+}
+
+// Given a function `fun` that takes an `abort_source&` as parameter,
+// call `fun` with an internally constructed abort source which is aborted after the given time duration.
+//
+// The internal abort source also subscribes to the provided `abort_source& as` so the function will also react
+// to top-level aborts.
+//
+// `abort_requested_exception` thrown by `fun` is translated to `timed_out_error` exception
+// unless `as` requested abort or we didn't reach timeout yet.
+template <std::invocable<abort_source&> F>
+static futurize_t<std::invoke_result_t<F, abort_source&>>
+with_timeout(abort_source& as, db::timeout_clock::duration d, F&& fun) {
+    using future_t = futurize_t<std::invoke_result_t<F, abort_source&>>;
+
+    // FIXME: using lambda as workaround for clang bug #50345 (miscompiling coroutine templates).
+    auto impl = [] (abort_source& as, db::timeout_clock::duration d, F&& fun) -> future_t {
+        abort_source timeout_src;
+        auto sub = as.subscribe([&timeout_src] () noexcept { timeout_src.request_abort(); });
+        if (!sub) {
+            throw abort_requested_exception{};
+        }
+
+        // Using lambda here as workaround for seastar#1005
+        future_t f = futurize_invoke([fun = std::move(fun)]
+                (abort_source& s) mutable { return std::forward<F>(fun)(s); }, timeout_src);
+
+        auto sleep_and_abort = [] (db::timeout_clock::duration d, abort_source& timeout_src) -> future<> {
+            co_await sleep_abortable(d, timeout_src);
+            if (!timeout_src.abort_requested()) {
+                // We resolved before `f`. Abort the operation.
+                timeout_src.request_abort();
+            }
+        }(d, timeout_src);
+
+        f = co_await coroutine::as_future(std::move(f));
+
+        if (!timeout_src.abort_requested()) {
+            // `f` has already resolved, but abort the sleep.
+            timeout_src.request_abort();
+        }
+
+        // Wait on the sleep as well (it should return shortly, being aborted) so we don't discard the future.
+        try {
+            co_await std::move(sleep_and_abort);
+        } catch (const sleep_aborted&) {
+            // Expected (if `f` resolved first or we were externally aborted).
+        } catch (...) {
+            // There should be no other exceptions, but just in case, catch and discard.
+            // we want to propagate exceptions from `f`, not from sleep.
+            group0_log.error("unexpected exception from sleep_and_abort", std::current_exception());
+        }
+
+        // Translate aborts caused by timeout to `timed_out_error`.
+        // Top-level aborts (from `as`) are not translated.
+        try {
+            co_return co_await std::move(f);
+        } catch (abort_requested_exception&) {
+            if (as.abort_requested()) {
+                // Assume the abort was caused by `as` (it may have been our timeout abort - doesn't matter)
+                // and don't translate.
+                throw;
+            }
+
+            if (!timeout_src.abort_requested()) {
+                // Neither `as` nor `timeout_src` requested abort.
+                // This must be another abort source internal to `fun`.
+                // Don't translate.
+                throw;
+            }
+
+            throw seastar::timed_out_error{};
+        }
+    };
+
+    return impl(as, d, std::forward<F>(fun));
+}
+
+// Precondition: we joined group 0 and the server is running.
+// Assumes we don't leave group 0 while running.
+static future<> wait_until_every_peer_joined_group0(db::system_keyspace& sys_ks, const raft::server& group0_server, abort_source& as) {
+    static constexpr auto retry_period = std::chrono::seconds{1};
+
+    while (true) {
+        // We fetch both config and peers on each iteration; we don't assume that they don't change.
+        // No new node should join while the procedure is running, but nodes may leave.
+        auto group0_config = group0_server.get_configuration();
+
+        auto current_config = get_raft_members_inet_addrs(group0_config.current);
+        std::sort(current_config.begin(), current_config.end());
+
+        auto peers = co_await sys_ks.load_peers();
+        std::sort(peers.begin(), peers.end());
+
+        std::vector<gms::inet_address> missing_peers;
+        std::set_difference(peers.begin(), peers.end(), current_config.begin(), current_config.end(), std::back_inserter(missing_peers));
+
+        if (missing_peers.empty()) {
+            if (!group0_config.is_joint()) {
+                co_return;
+            }
+
+            upgrade_log.info("group 0 configuration is joint: {}. Sleeping for a while before retrying...", group0_config);
+            co_await sleep_abortable(retry_period, as);
+            continue;
+        }
+
+        upgrade_log.info(
+            "group 0 configuration does not contain all peers yet."
+            " Missing peers: {}. Current group 0 config: {}. Current group 0 config addresses: {}. Sleeping for a while before retrying...",
+            missing_peers, group0_config, current_config);
+
+        co_await sleep_abortable(retry_period, as);
+    }
+}
+
+// Check if anyone entered `use_post_raft_procedures`.
+// This is a best-effort single round-trip check; we don't retry if some nodes fail to answer.
+static future<bool> anyone_finished_upgrade(
+        const raft::server& group0_server, netw::messaging_service& ms, abort_source& as) {
+    static constexpr auto max_concurrency = 10;
+    static constexpr auto rpc_timeout = std::chrono::seconds{5};
+
+    auto current_config = get_raft_members_inet_addrs(group0_server.get_configuration().current);
+    bool finished = false;
+    co_await max_concurrent_for_each(current_config, max_concurrency, [&] (const gms::inet_address& node) -> future<> {
+        try {
+            auto state = co_await with_timeout(as, rpc_timeout, std::bind_front(send_get_group0_upgrade_state, std::ref(ms), node));
+            if (state == group0_upgrade_state::use_post_raft_procedures) {
+                finished = true;
+            }
+        } catch (abort_requested_exception&) {
+            upgrade_log.warn("anyone_finished_upgrade: abort requested during `send_get_group0_upgrade_state({})`", node);
+            throw;
+        } catch (...) {
+            // XXX: are there possible fatal errors which should cause us to abort the entire procedure?
+            upgrade_log.warn("anyone_finished_upgrade: `send_get_group0_upgrade_state({})` failed: {}", node, std::current_exception());
+        }
+    });
+    co_return finished;
+}
+
+// Check if it's possible to reach everyone through `get_group0_upgrade_state` RPC.
+static future<> check_remote_group0_upgrade_state_dry_run(
+        const noncopyable_function<future<std::vector<gms::inet_address>>()>& get_peers,
+        netw::messaging_service& ms, abort_source& as) {
+    static constexpr auto max_retry_period = std::chrono::seconds{16};
+    static constexpr auto rpc_timeout = std::chrono::seconds{5};
+    static constexpr auto max_concurrency = 10;
+
+    auto retry_period = std::chrono::seconds{1};
+    while (true) {
+        // Note: we strive to get a response from everyone in a 'single round-trip',
+        // so we don't skip nodes which responded in earlier iterations.
+        // We contact everyone in each iteration even if some of these guys already answered.
+        // We fetch peers again on every attempt to handle the possibility of leaving nodes.
+        auto peers = co_await get_peers();
+
+        bool retry = false;
+        co_await max_concurrent_for_each(peers, max_concurrency, [&] (const gms::inet_address& node) -> future<> {
+            try {
+                upgrade_log.info("check_remote_group0_upgrade_state_dry_run: `send_get_group0_upgrade_state({})`", node);
+                co_await with_timeout(as, rpc_timeout, std::bind_front(send_get_group0_upgrade_state, std::ref(ms), node));
+            } catch (abort_requested_exception&) {
+                upgrade_log.warn("check_remote_group0_upgrade_state_dry_run: abort requested during `send_get_group0_upgrade_state({})`", node);
+                throw;
+            } catch (...) {
+                // XXX: are there possible fatal errors which should cause us to abort the entire procedure?
+                upgrade_log.warn(
+                        "check_remote_group0_upgrade_state_dry_run: `send_get_group0_upgrade_state({})` failed: {}",
+                        node, std::current_exception());
+                retry = true;
+            }
+        });
+
+        if (!retry) {
+            co_return;
+        }
+
+        upgrade_log.warn("check_remote_group0_upgrade_state_dry_run: retrying in a while...");
+
+        co_await sleep_abortable(retry_period, as);
+        if (retry_period < max_retry_period) {
+            retry_period *= 2;
+        }
+    }
+}
+
+// Wait until all members of group 0 enter `group0_upgrade_state::synchronize` or some node enters
+// `group0_upgrade_state::use_post_raft_procedures` (the latter meaning upgrade is finished and we can also finish).
+//
+// Precondition: we're in `synchronize` state.
+//
+// Returns `true` if we finished because everybody entered `synchronize`.
+// Returns `false` if we finished because somebody entered `use_post_raft_procedures`.
+static future<bool> wait_for_peers_to_enter_synchronize_state(
+        const raft::server& group0_server, netw::messaging_service& ms, abort_source& as, gate::holder pause_shutdown) {
+    static constexpr auto retry_period = std::chrono::seconds{1};
+    static constexpr auto rpc_timeout = std::chrono::seconds{5};
+    static constexpr auto max_concurrency = 10;
+
+    auto entered_synchronize = make_lw_shared<std::unordered_set<gms::inet_address>>();
+
+    // This is a work-around for boost tests where RPC module is not listening so we cannot contact ourselves.
+    // But really, except the (arguably broken) test code, we don't need to be treated as an edge case. All nodes are symmetric.
+    // For production code this line is unnecessary.
+    entered_synchronize->insert(utils::fb_utilities::get_broadcast_address());
+
+    while (true) {
+        // We fetch the config again on every attempt to handle the possibility of removing failed nodes.
+        auto current_config = get_raft_members_inet_addrs(group0_server.get_configuration().current);
+
+        ::tracker<bool> tracker;
+        auto retry = make_lw_shared<bool>(false);
+
+        auto sub = as.subscribe([tracker] () mutable noexcept {
+            tracker.set_exception(std::make_exception_ptr(abort_requested_exception{}));
+        });
+        if (!sub) {
+            upgrade_log.warn("wait_for_peers_to_enter_synchronize_state: abort requested");
+            throw abort_requested_exception{};
+        }
+
+        (void) [] (netw::messaging_service& ms, abort_source& as, gate::holder pause_shutdown,
+                   std::vector<gms::inet_address> current_config,
+                   lw_shared_ptr<std::unordered_set<gms::inet_address>> entered_synchronize,
+                   lw_shared_ptr<bool> retry, ::tracker<bool> tracker) -> future<> {
+            co_await max_concurrent_for_each(current_config, max_concurrency, [&] (const gms::inet_address& node) -> future<> {
+                if (entered_synchronize->contains(node)) {
+                    co_return;
+                }
+
+                try {
+                    auto state = co_await with_timeout(as, rpc_timeout, std::bind_front(send_get_group0_upgrade_state, std::ref(ms), node));
+                    if (tracker.finished()) {
+                        // A response from another node caused us to finish already.
+                        co_return;
+                    }
+
+                    switch (state) {
+                        case group0_upgrade_state::use_post_raft_procedures:
+                            upgrade_log.info("wait_for_peers_to_enter_synchronize_state: {} confirmed that they finished upgrade.", node);
+                            tracker.set_value(true);
+                            break;
+                        case group0_upgrade_state::synchronize:
+                            entered_synchronize->insert(node);
+                            break;
+                        default:
+                            upgrade_log.info("wait_for_peers_to_enter_synchronize_state: node {} not in synchronize state yet...", node);
+                            *retry = true;
+                    }
+                } catch (abort_requested_exception&) {
+                    upgrade_log.warn("wait_for_peers_to_enter_synchronize_state: abort requested during `send_get_group0_upgrade_state({})`", node);
+                    tracker.set_exception(std::current_exception());
+                } catch (...) {
+                    // XXX: are there possible fatal errors which should cause us to abort the entire procedure?
+                    upgrade_log.warn(
+                            "wait_for_peers_to_enter_synchronize_state: `send_get_group0_upgrade_state({})` failed: {}",
+                            node, std::current_exception());
+                    *retry = true;
+                }
+            });
+
+            tracker.set_value(false);
+        }(ms, as, pause_shutdown, std::move(current_config), entered_synchronize, retry, tracker);
+
+        auto finish_early = co_await tracker.get();
+        if (finish_early) {
+            co_return false;
+        }
+
+        if (!*retry) {
+            co_return true;
+        }
+
+        upgrade_log.warn("wait_for_peers_to_enter_synchronize_state: retrying in a while...");
+
+        co_await sleep_abortable(retry_period, as);
+    }
+}
+
+// Returning nullopt means we finished early (`can_finish_early` returned true).
+static future<std::optional<std::unordered_map<gms::inet_address, table_schema_version>>>
+collect_schema_versions_from_group0_members(
+        netw::messaging_service& ms, const raft::server& group0_server,
+        const noncopyable_function<future<bool>()>& can_finish_early,
+        abort_source& as) {
+    static constexpr auto max_retry_period = std::chrono::seconds{16};
+    static constexpr auto rpc_timeout = std::chrono::seconds{5};
+    static constexpr auto max_concurrency = 10;
+
+    auto retry_period = std::chrono::seconds{1};
+    std::unordered_map<gms::inet_address, table_schema_version> versions;
+    while (true) {
+        // We fetch the config on each iteration; some nodes may leave.
+        auto group0_config = group0_server.get_configuration();
+        auto current_config = get_raft_members_inet_addrs(group0_config.current);
+
+        bool failed = false;
+        co_await max_concurrent_for_each(current_config, max_concurrency, [&] (const gms::inet_address& node) -> future<> {
+            if (versions.contains(node)) {
+                // This node was already contacted in a previous iteration.
+                co_return;
+            }
+
+            try {
+                upgrade_log.info("synchronize_schema: `send_schema_check({})`", node);
+                versions.emplace(node,
+                    co_await with_timeout(as, rpc_timeout, [&ms, addr = netw::msg_addr(node)] (abort_source& as) mutable {
+                            return ms.send_schema_check(std::move(addr), as);
+                        }));
+            } catch (abort_requested_exception&) {
+                upgrade_log.warn("synchronize_schema: abort requested during `send_schema_check({})`", node);
+                throw;
+            } catch (...) {
+                // XXX: are there possible fatal errors which should cause us to abort the entire procedure?
+                upgrade_log.warn("synchronize_schema: `send_schema_check({})` failed: {}", node, std::current_exception());
+                failed = true;
+            }
+        });
+
+        if (failed) {
+            upgrade_log.warn("synchronize_schema: there were some failures when collecting remote schema versions.");
+        } else if (group0_config.is_joint()) {
+            upgrade_log.warn("synchronize_schema: group 0 configuration is joint: {}.", group0_config);
+        } else {
+            co_return versions;
+        }
+
+        upgrade_log.info("synchronize_schema: checking if we can finish early before retrying...");
+
+        if (co_await can_finish_early()) {
+            co_return std::nullopt;
+        }
+
+        upgrade_log.info(
+                "synchronize_schema: could not finish early."
+                " Sleeping for a while before retrying remote schema version collection...");
+        co_await sleep_abortable(retry_period, as);
+        if (retry_period < max_retry_period) {
+            retry_period *= 2;
+        }
+    }
+}
+
+// Returning `true` means we synchronized schema.
+// `false` means we finished early after calling `can_finish_early`.
+//
+// Postcondition for synchronizing schema (i.e. we return `true`):
+// Let T0 be the point in time when this function starts.
+// There is a schema version X and a point in time T > T0 such that:
+//     - the local schema version at T was X,
+//     - for every member of group 0 configuration there was a point in time T'
+//       such that T > T' > T0 and the schema version at this member at T' was X.
+//
+// Assuming that merging schema mutations is an associative, commutative and idempotent
+// operation, everybody pulling from everybody (or verifying they have the same mutations)
+// should cause everybody to arrive at the same result.
+static future<bool> synchronize_schema(
+        replica::database& db, netw::messaging_service& ms,
+        const raft::server& group0_server, service::migration_manager& mm,
+        const noncopyable_function<future<bool>()>& can_finish_early,
+        abort_source& as) {
+    static constexpr auto max_retry_period = std::chrono::seconds{32};
+    static constexpr auto rpc_timeout = std::chrono::seconds{5};
+    static constexpr auto max_concurrency = 10;
+
+    auto retry_period = std::chrono::seconds{1};
+    bool last_pull_successful = false;
+    size_t num_attempts_after_successful_pull = 0;
+
+    while (true) {
+        upgrade_log.info("synchronize_schema: collecting schema versions from group 0 members...");
+        auto remote_versions = co_await collect_schema_versions_from_group0_members(ms, group0_server, can_finish_early, as);
+        if (!remote_versions) {
+            upgrade_log.info("synchronize_schema: finished early.");
+            co_return false;
+        }
+        upgrade_log.info("synchronize_schema: collected remote schema versions.");
+
+        auto my_version = db.get_version();
+        upgrade_log.info("synchronize_schema: my version: {}", my_version);
+
+        auto matched = std::erase_if(*remote_versions, [my_version] (const auto& p) { return p.second == my_version; });
+        upgrade_log.info("synchronize_schema: schema mismatches: {}. {} nodes had a matching version.", *remote_versions, matched);
+
+        if (remote_versions->empty()) {
+            upgrade_log.info("synchronize_schema: finished.");
+            co_return true;
+        }
+
+        // Note: if we successfully merged schema from everyone in earlier iterations, but our schema versions
+        // are still not matching, that means our version is strictly more up-to-date than someone else's version.
+        // In that case we could switch to a push mode instead of pull mode (we push schema mutations to them);
+        // on the other hand this would further complicate the code and I assume that the regular schema synchronization
+        // mechanisms (gossiping schema digests and triggering pulls on the other side) should deal with this case,
+        // even though it may potentially take a bit longer than a pro-active approach. Furthermore, the other side
+        // is also executing `synchronize_schema` at some point, so having this problem should be extremely unlikely.
+        if (last_pull_successful) {
+            if ((++num_attempts_after_successful_pull) > 3) {
+                upgrade_log.error(
+                        "synchronize_schema: we managed to pull schema from every other node, but our schema versions"
+                        " are still different. The other side must have an outdated version and fail to pull it for some"
+                        " reason. If this message keeps showing up, the internal upgrade-to-raft procedure is stuck;"
+                        " try performing a rolling restart of your cluster."
+                        " If that doesn't fix the problem, the system may require manual fixing of schema tables.");
+            }
+        }
+
+        last_pull_successful = true;
+        co_await max_concurrent_for_each(*remote_versions, max_concurrency, [&] (const auto& p) -> future<> {
+            auto& [addr, _] = p;
+
+            try {
+                upgrade_log.info("synchronize_schema: `merge_schema_from({})`", addr);
+                co_await mm.merge_schema_from(netw::msg_addr(addr));
+            } catch (const rpc::closed_error& e) {
+                upgrade_log.warn("synchronize_schema: `merge_schema_from({})` failed due to connection error: {}", addr, e);
+                last_pull_successful = false;
+            } catch (timed_out_error&) {
+                upgrade_log.warn("synchronize_schema: `merge_schema_from({})` timed out", addr);
+                last_pull_successful = false;
+            } catch (abort_requested_exception&) {
+                upgrade_log.warn("synchronize_schema: abort requested during `merge_schema_from({})`", addr);
+                throw;
+            } catch (...) {
+                // We assume that every other exception type indicates a fatal error and happens because `merge_schema_from`
+                // failed to apply schema mutations from a remote, which is not something we can automatically recover from.
+                upgrade_log.error(
+                        "synchronize_schema: fatal error in `merge_schema_from({})`: {}."
+                        "\nCannot finish the upgrade procedure."
+                        " Please fix your schema tables manually and try again by restarting the node.",
+                        addr, std::current_exception());
+                throw;
+            }
+        });
+
+        if (co_await can_finish_early()) {
+            upgrade_log.info("synchronize_schema: finishing early.");
+            co_return false;
+        }
+
+        upgrade_log.info("synchronize_schema: sleeping for a while before collecting schema versions again...");
+        co_await sleep_abortable(retry_period, as);
+
+        if (retry_period < max_retry_period) {
+            retry_period *= 2;
+        }
+    }
+}
+
+static auto warn_if_upgrade_takes_too_long() {
+    auto as = std::make_unique<abort_source>();
+    auto task = [] (abort_source& as) -> future<> {
+        static constexpr auto warn_period = std::chrono::minutes{1};
+
+        while (!as.abort_requested()) {
+            try {
+                co_await sleep_abortable(warn_period, as);
+            } catch (const sleep_aborted&) {
+                co_return;
+            }
+
+            upgrade_log.warn(
+                "Raft upgrade procedure taking longer than expected. Please check if all nodes are live and the network is healthy."
+                " If the upgrade procedure does not progress even though the cluster is healthy, try performing a rolling restart of the cluster."
+                " If that doesn't help or some nodes are dead and irrecoverable, manual recovery may be required."
+                " Consult the relevant documentation.");
+            // TODO: link to the docs.
+        }
+    }(*as);
+
+    return defer([task = std::move(task), as = std::move(as)] () mutable {
+        // Stop in background.
+        as->request_abort();
+        (void)std::move(task).then([as = std::move(as)] {});
+    });
+}
+
+future<> raft_group0::upgrade_to_group0() {
+    assert(this_shard_id() == 0);
+
+    // The SUPPORTS_RAFT cluster feature is enabled, so the local RAFT feature must also be enabled
+    // (otherwise we wouldn't 'know' the cluster feature).
+    assert(_raft_gr.is_enabled());
+
+    auto start_state = (co_await _client.get_group0_upgrade_state()).second;
+    switch (start_state) {
+        case group0_upgrade_state::recovery:
+            upgrade_log.info("RECOVERY mode. Not attempting upgrade.");
+            co_return;
+        case group0_upgrade_state::use_post_raft_procedures:
+            upgrade_log.info("Already upgraded.");
+            co_return;
+        case group0_upgrade_state::synchronize:
+            upgrade_log.warn(
+                "Restarting upgrade in `synchronize` state."
+                " A previous upgrade attempt must have been interrupted or failed.");
+            break;
+        case group0_upgrade_state::use_pre_raft_procedures:
+            upgrade_log.info("starting in `use_pre_raft_procedures` state.");
+    }
+
+    (void)[] (raft_group0& self, abort_source& as, group0_upgrade_state start_state, gate::holder pause_shutdown) -> future<> {
+        auto warner = warn_if_upgrade_takes_too_long();
+        try {
+            co_await self.do_upgrade_to_group0(start_state);
+            co_await self._client.set_group0_upgrade_state(group0_upgrade_state::use_post_raft_procedures);
+            upgrade_log.info("Raft upgrade finished.");
+        } catch (...) {
+            upgrade_log.error(
+                "Raft upgrade failed: {}.\nTry restarting the node to retry upgrade."
+                " If the procedure gets stuck, manual recovery may be required. Consult the relevant documentation.",
+                std::current_exception());
+                // TODO: link to the doc
+        }
+    }(std::ref(*this), std::ref(_abort_source), start_state, _shutdown_gate.hold());
+}
+
+// `start_state` is either `use_pre_raft_procedures` or `synchronize`.
+future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state) {
+    assert(this_shard_id() == 0);
+
+    auto& sys_ks = _gossiper.get_system_keyspace().local();
+
+    // Check if every peer knows about the upgrade procedure.
+    //
+    // In a world in which post-conditions and invariants are respected, the fact that `SUPPORTS_RAFT` feature
+    // is enabled would guarantee this. However, the cluster features mechanism is unreliable and there are
+    // scenarios where the feature gets enabled even though not everybody supports it. Attempts to fix this
+    // only unmask more issues; see #11225. In general, fixing the gossiper/features subsystem is a big
+    // project and we don't want this to block the Raft group 0 project (and we probably want to eventually
+    // move most application states - including supported feature sets - to group 0 anyway).
+    //
+    // Work around that by ensuring that everybody is able to answer to the `get_group0_upgrade_state` call
+    // before we proceed to the `join_group0` step, which doesn't tolerate servers leaving in the middle;
+    // once a node is selected as one of the seeds of the discovery algorithm, it must answer. This 'dry run'
+    // step, on the other hand, allows nodes to leave and will unblock as soon as all remaining peers are
+    // ready to answer.
+    upgrade_log.info("Waiting until everyone is ready to start upgrade...");
+    co_await check_remote_group0_upgrade_state_dry_run(std::bind_front(&db::system_keyspace::load_peers, &sys_ks), _ms, _abort_source);
+
+    if (!joined_group0()) {
+        upgrade_log.info("Joining group 0...");
+        co_await join_group0(co_await get_peers_as_raft_infos(sys_ks), true);
+    } else {
+        upgrade_log.info(
+            "We're already a member of group 0."
+            " Apparently we're restarting after a previous upgrade attempt failed.");
+    }
+
+    // After we joined, we shouldn't be removed from group 0 until the end of the procedure.
+    // The implementation of `leave_group0` waits until upgrade finishes before leaving the group.
+    // There is no guarantee that `remove_from_group0` from another node (that has
+    // finished upgrading) won't remove us after we enter `synchronize` but before we leave it;
+    // but then we're not needed for anything anymore and we can be shutdown,
+    // and we won't do anything harmful to other nodes while in `synchronize`, worst case being
+    // that we get stuck.
+
+    auto& group0_server = _raft_gr.group0();
+
+    upgrade_log.info("Waiting until every peer has joined Raft group 0...");
+    co_await wait_until_every_peer_joined_group0(sys_ks, group0_server, _abort_source);
+    upgrade_log.info("Every peer is a member of Raft group 0.");
+
+    if (start_state == group0_upgrade_state::use_pre_raft_procedures) {
+        // We perform a schema synchronization step before entering `synchronize` upgrade state.
+        //
+        // This step is not necessary for correctness: we will make sure schema is synchronized
+        // after every node enters `synchronize`, where schema changes are disabled.
+        //
+        // However, it's good for reducing the chance that we get stuck later. If we manage to ensure that schema
+        // is synchronized now, there's a high chance that after entering `synchronize` state we won't have
+        // to do any additional schema pulls (only verify quickly that the schema is still in sync).
+        upgrade_log.info("Waiting for schema to synchronize across all nodes in group 0...");
+        auto can_finish_early = [] { return make_ready_future<bool>(false); };
+        co_await synchronize_schema(_qp.db().real_database(), _ms, group0_server, _mm, can_finish_early, _abort_source);
+
+        // Before entering `synchronize`, perform a round-trip of `get_group0_upgrade_state` RPC calls
+        // to everyone as a dry run, just to check that nodes respond to this RPC.
+        // Obviously we may lose connectivity immediately after this function finishes,
+        // causing later steps to fail, but if network/RPC module is already broken, better to detect
+        // it now than after entering `synchronize` state. And if this steps succeeds, then there's
+        // a very high chance that the following steps succeed as well (we would need to be very unlucky otherwise).
+        upgrade_log.info("Performing a dry run of remote `get_group0_upgrade_state` calls...");
+        co_await check_remote_group0_upgrade_state_dry_run(
+                [&group0_server] {
+                    auto current_config = get_raft_members_inet_addrs(group0_server.get_configuration().current);
+                    return make_ready_future<std::vector<gms::inet_address>>(std::move(current_config));
+                }, _ms, _abort_source);
+
+        upgrade_log.info("Entering synchronize state.");
+        upgrade_log.warn("Schema changes are disabled in synchronize state."
+                " If a failure makes us unable to proceed, manual recovery will be required.");
+        co_await _client.set_group0_upgrade_state(group0_upgrade_state::synchronize);
+    }
+
+    upgrade_log.info("Waiting for all peers to enter synchronize state...");
+    if (!(co_await wait_for_peers_to_enter_synchronize_state(group0_server, _ms, _abort_source, _shutdown_gate.hold()))) {
+        upgrade_log.info("Another node already finished upgrade. We can finish early.");
+        co_return;
+    }
+
+    upgrade_log.info("All peers in synchronize state. Waiting for schema to synchronize...");
+    auto can_finish_early = std::bind_front(anyone_finished_upgrade, std::cref(group0_server), std::ref(_ms), std::ref(_abort_source));
+    if (!(co_await synchronize_schema(_qp.db().real_database(), _ms, group0_server, _mm, can_finish_early, _abort_source))) {
+        upgrade_log.info("Another node already finished upgrade. We can finish early.");
+        co_return;
+    }
+
+    upgrade_log.info("Schema synchronized.");
 }
 
 std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -570,5 +570,24 @@ persistent_discovery::persistent_discovery(raft::server_address self, const peer
     }
 }
 
+std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {
+    switch (state) {
+        case group0_upgrade_state::recovery:
+            os << "recovery";
+            break;
+        case group0_upgrade_state::use_post_raft_procedures:
+            os << "use_post_raft_procedures";
+            break;
+        case group0_upgrade_state::synchronize:
+            os << "synchronize";
+            break;
+        case group0_upgrade_state::use_pre_raft_procedures:
+            os << "use_pre_raft_procedures";
+            break;
+    }
+
+    return os;
+}
+
 } // end of namespace service
 

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -15,7 +15,7 @@ namespace cql3 { class query_processor; }
 
 namespace db { class system_keyspace; }
 
-namespace gms { class gossiper; }
+namespace gms { class gossiper; class feature_service; }
 
 namespace service {
 
@@ -70,6 +70,7 @@ class raft_group0 {
     gms::gossiper& _gossiper;
     cql3::query_processor& _qp;
     service::migration_manager& _mm;
+    gms::feature_service& _feat;
     raft_group0_client& _client;
 
     // Status of leader discovery. Initially there is no group 0,
@@ -79,6 +80,8 @@ class raft_group0 {
     // created.
     std::variant<std::monostate, service::persistent_discovery, raft::group_id> _group0;
 
+    gms::feature::listener_registration _raft_support_listener;
+
 public:
     // Assumes that the provided services are fully started.
     raft_group0(seastar::abort_source& abort_source,
@@ -87,6 +90,7 @@ public:
         gms::gossiper& gs,
         cql3::query_processor& qp,
         migration_manager& mm,
+        gms::feature_service& feat,
         raft_group0_client& client);
 
     // Call before destroying the object.
@@ -101,12 +105,18 @@ public:
     //
     // Cannot be called twice.
     //
+    // Also make sure to call `finish_setup_after_join` after the node has joined the cluster and entered NORMAL state.
     // TODO: specify dependencies on other services: where during startup should we setup group 0?
     future<> setup_group0(db::system_keyspace&, const std::unordered_set<gms::inet_address>& initial_contact_nodes);
 
-    // After successful bootstrapping, make this node a voting member.
-    // Precondition: `setup_group0` successfully finished earlier.
-    future<> become_voter();
+    // Call at the end of the startup procedure, after the node entered NORMAL state.
+    // `setup_group0()` must have finished earlier.
+    //
+    // If the node has just bootstrapped, causes the group 0 server to become a voter.
+    //
+    // If the node has just upgraded, enables a feature listener for the RAFT feature
+    // which will start a procedure to create group 0 and switch administrative operations to use it.
+    future<> finish_setup_after_join();
 
     // Remove ourselves from group 0.
     //
@@ -163,6 +173,19 @@ private:
     //
     // See 'raft-in-scylla.md', 'Establishing group 0 in a fresh cluster'.
     future<group0_info> discover_group0(raft::server_address my_addr, const std::vector<raft::server_info>& seeds);
+
+    // Creates or joins group 0 and switches schema/topology changes to use group 0.
+    // Can be restarted after a crash. Does nothing if the procedure was already finished once.
+    //
+    // The main part of the procedure which may block (due to concurrent schema changes or communication with
+    // other nodes) runs in background, so it's safe to call `upgrade_to_group0` and wait for it to finish
+    // from places which must not block.
+    //
+    // Precondition: the SUPPORTS_RAFT cluster feature is enabled.
+    future<> upgrade_to_group0();
+
+    // Blocking part of `upgrade_to_group0`, runs in background.
+    future<> do_upgrade_to_group0(group0_upgrade_state start_state);
 
     // Start a Raft server for the cluster-wide group 0 and join it to the group.
     // Called during bootstrap or upgrade.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -9,6 +9,7 @@
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/discovery.hh"
 #include "service/raft/messaging.hh"
+#include "service/raft/group0_upgrade.hh"
 
 namespace cql3 { class query_processor; }
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -50,6 +50,7 @@ class raft_group_registry : public seastar::peering_sharded_service<raft_group_r
 private:
     // True if the feature is enabled
     bool _is_enabled;
+
     netw::messaging_service& _ms;
     // Raft servers along with the corresponding timers to tick each instance.
     // Currently ticking every 100ms.
@@ -71,7 +72,7 @@ private:
 
     raft_server_for_group& server_for_group(raft::group_id id);
 
-    // Group 0 id, valid only on shard 0 after boot is over
+    // Group 0 id, valid only on shard 0 after boot/upgrade is over
     std::optional<raft::group_id> _group0_id;
 
 public:
@@ -95,7 +96,7 @@ public:
     raft::server& get_server(raft::group_id gid);
 
     // Return an instance of group 0. Valid only on shard 0,
-    // after boot is complete
+    // after boot/upgrade is complete
     raft::server& group0();
 
     // Start raft server instance, store in the map of raft servers and
@@ -106,6 +107,8 @@ public:
     raft_address_map<>& address_map() { return _srv_address_mappings; }
     direct_failure_detector::failure_detector& direct_fd() { return _direct_fd; }
 
+    // Is the RAFT local feature enabled?
+    // Note: do not confuse with the SUPPORTS_RAFT cluster feature.
     bool is_enabled() const { return _is_enabled; }
 };
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -586,9 +586,6 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     co_await _sys_ks.local().set_bootstrap_state(db::system_keyspace::bootstrap_state::COMPLETED);
     // At this point our local tokens and CDC streams timestamp are chosen (bootstrap_tokens, cdc_gen_id) and will not be changed.
 
-    assert(_group0);
-    co_await _group0->become_voter();
-
     // start participating in the ring.
     co_await set_gossip_tokens(_gossiper, bootstrap_tokens, cdc_gen_id);
 
@@ -600,6 +597,8 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         throw std::runtime_error(err);
     }
 
+    assert(_group0);
+    co_await _group0->finish_setup_after_join();
     co_await cdc_gen_service.after_join(std::move(cdc_gen_id));
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -693,7 +693,7 @@ public:
             auto stop_forward_service =  defer([&forward_service] { forward_service.stop().get(); });
 
             // gropu0 client exists only on shard 0
-            service::raft_group0_client group0_client(raft_gr.local());
+            service::raft_group0_client group0_client(raft_gr.local(), sys_ks.local());
 
             mm.start(std::ref(mm_notif), std::ref(feature_service), std::ref(ms), std::ref(proxy), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();
             auto stop_mm = defer([&mm] { mm.stop().get(); });
@@ -757,6 +757,7 @@ public:
                 }
             }).get();
 
+            group0_client.init().get();
             auto stop_system_keyspace = defer([] { db::qctx = {}; });
 
             auto shutdown_db = defer([&db] {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -469,6 +469,7 @@ public:
 
             sharded<abort_source> abort_sources;
             abort_sources.start().get();
+            // FIXME: handle signals (SIGINT, SIGTERM) - request aborts
             auto stop_abort_sources = defer([&] { abort_sources.stop().get(); });
             sharded<compaction_manager> cm;
             sharded<replica::database> db;
@@ -809,7 +810,7 @@ public:
 
             service::raft_group0 group0_service{
                     abort_sources.local(), raft_gr.local(), ms.local(),
-                    gossiper.local(), qp.local(), mm.local(), group0_client};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), group0_client};
             auto stop_group0_service = defer([&group0_service] {
                 group0_service.abort().get();
             });


### PR DESCRIPTION
Start with a cluster with Raft disabled, end up with a cluster that performs
schema operations using group 0.

Design doc:
https://docs.google.com/document/d/1PvZ4NzK3S0ohMhyVNZZ-kCxjkK5URmz1VP65rrkTOCQ/
(TODO: replace this with .md file - we can do it as a follow-up)

The procedure, on a high level, works as follows:
- join group 0
- wait until every peer joined group 0 (peers are taken from `system.peers`
  table)
- enter `synchronize` upgrade state, in which group 0 operations are disabled 
- wait until all members of group 0 entered `synchronize` state or some member
  entered the final state
- synchronize schema by comparing versions and pulling if necessary
- enter the final state (`use_new_procedures`), in which group 0 is used for
  schema operations.

With the procedure comes a recovery mode in case the upgrade procedure gets
stuck (and it may if we lose a node during recovery - the procedure, to
correctly establish a single group 0 cluster, requires contacting every node).

This recovery mode can also be used to recover clusters with group 0 already
established if they permanently lose a majority of nodes - killing two birds with
one stone. Details in the last commit message.

Read the design doc, then read the commits in topological order
for best reviewing experience.

---

I did some manual tests: upgrading a cluster, using the cluster to add nodes,
remove nodes (both with `decommission` and `removenode`), replacing nodes.
Performing recovery.

As a follow-up, we'll need to implement tests using the new framework (after
it's ready). It will be easy to test upgrades and recovery even with a single
Scylla version - we start with a cluster with the RAFT flag disabled, then
rolling-restart while enabling the flag (and recovery is done through simple
CQL statements).