### PR TITLE
Secondary index of collection columns

### DIFF
--- a/column_computation.hh
+++ b/column_computation.hh
@@ -17,7 +17,7 @@ struct atomic_cell_view;
 struct tombstone;
 
 namespace db::view {
-struct bytes_with_action;
+struct view_key_and_action;
 }
 
 class column_computation;
@@ -96,6 +96,15 @@ public:
     virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
 };
 
+/*
+ * collection_column_computation is used for a secondary index on a collection
+ * column. In this case we don't have a single value to compute, but rather we
+ * want to return multiple values (e.g., all the keys in the collection).
+ * So this class does not implement the base class's compute_value() -
+ * instead it implements a new method compute_collection_values(), which
+ * can return multiple values. This new method is currently called only from
+ * the materialized-view code which uses collection_column_computation.
+ */
 class collection_column_computation final : public column_computation {
     enum class kind {
         keys,
@@ -132,5 +141,5 @@ public:
         return true;
     }
 
-    std::vector<db::view::bytes_with_action> compute_values_with_action(const schema& schema, const partition_key& key, const clustering_row& row, const std::optional<clustering_row>& existing) const;
+    std::vector<db::view::view_key_and_action> compute_values_with_action(const schema& schema, const partition_key& key, const clustering_row& row, const std::optional<clustering_row>& existing) const;
 };

--- a/column_computation.hh
+++ b/column_computation.hh
@@ -22,7 +22,7 @@ using column_computation_ptr = std::unique_ptr<column_computation>;
  * Computed columns description is also available at docs/dev/system_schema_keyspace.md. They hold values
  * not provided directly by the user, but rather computed: from other column values and possibly other sources.
  * This class is able to serialize/deserialize column computations and perform the computation itself,
- * based on given schema, partition key and clustering row. Responsibility for providing enough data
+ * based on given schema, and partition key. Responsibility for providing enough data
  * in the clustering row in order for computation to succeed belongs to the caller. In particular,
  * generating a value might involve performing a read-before-write if the computation is performed
  * on more values than are present in the update request.
@@ -36,7 +36,7 @@ public:
     virtual column_computation_ptr clone() const = 0;
 
     virtual bytes serialize() const = 0;
-    virtual bytes_opt compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const = 0;
+    virtual bytes compute_value(const schema& schema, const partition_key& key) const = 0;
 };
 
 /*
@@ -54,7 +54,7 @@ public:
         return std::make_unique<legacy_token_column_computation>(*this);
     }
     virtual bytes serialize() const override;
-    virtual bytes_opt compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const override;
+    virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
 };
 
 
@@ -75,5 +75,5 @@ public:
         return std::make_unique<token_column_computation>(*this);
     }
     virtual bytes serialize() const override;
-    virtual bytes_opt compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const override;
+    virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
 };

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -857,7 +857,8 @@ indexIdent returns [::shared_ptr<index_target::raw> id]
     @init {
         std::vector<::shared_ptr<cql3::column_identifier::raw>> columns;
     }
-    : c=cident                   { $id = index_target::raw::values_of(c); }
+    : c=cident                   { $id = index_target::raw::regular_values_of(c); }
+    | K_VALUES '(' c=cident ')'  { $id = index_target::raw::collection_values_of(c); }
     | K_KEYS '(' c=cident ')'    { $id = index_target::raw::keys_of(c); }
     | K_ENTRIES '(' c=cident ')' { $id = index_target::raw::keys_and_values_of(c); }
     | K_FULL '(' c=cident ')'    { $id = index_target::raw::full_collection(c); }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1005,11 +1005,26 @@ nonwrapping_range<managed_bytes> to_range(const value_set& s) {
         }, s);
 }
 
-bool is_supported_by(const expression& expr, const secondary_index::index& idx) {
-    using std::placeholders::_1;
+namespace {
+constexpr inline secondary_index::index::supports_expression_v operator&&(secondary_index::index::supports_expression_v v1, secondary_index::index::supports_expression_v v2) {
+    using namespace secondary_index;
+    auto True = index::supports_expression_v::from_bool(true);
+    return v1 == True && v2 == True ? True : index::supports_expression_v::from_bool(false);
+}
+
+secondary_index::index::supports_expression_v is_supported_by_helper(const expression& expr, const secondary_index::index& idx) {
+    using ret_t = secondary_index::index::supports_expression_v;
+    using namespace secondary_index;
     return expr::visit(overloaded_functor{
-            [&] (const conjunction& conj) {
-                return boost::algorithm::all_of(conj.children, std::bind(is_supported_by, _1, idx));
+            [&] (const conjunction& conj) -> ret_t {
+                if (conj.children.empty()) {
+                    return index::supports_expression_v::from_bool(true);
+                }
+                auto init = is_supported_by_helper(conj.children[0], idx);
+                return std::accumulate(std::begin(conj.children) + 1, std::end(conj.children), init, 
+                        [&] (ret_t acc, const expression& child) -> ret_t {
+                            return acc && is_supported_by_helper(child, idx);
+                });
             },
             [&] (const binary_operator& oper) {
                 return expr::visit(overloaded_functor{
@@ -1023,57 +1038,64 @@ bool is_supported_by(const expression& expr, const secondary_index::index& idx) 
                                 }
                             }
                             // We don't use index table for multi-column restrictions, as it cannot avoid filtering.
-                            return false;
+                            return index::supports_expression_v::from_bool(false);
                         },
-                        [&] (const token&) { return false; },
-                        [&] (const subscript& s) -> bool {
+                        [&] (const token&) { return index::supports_expression_v::from_bool(false); },
+                        [&] (const subscript& s) -> ret_t {
                             const column_value& col = get_subscripted_column(s);
                             return idx.supports_subscript_expression(*col.col, oper.op);
                         },
-                        [&] (const binary_operator&) -> bool {
+                        [&] (const binary_operator&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: nested binary operators are not supported");
                         },
-                        [&] (const conjunction&) -> bool {
+                        [&] (const conjunction&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: conjunctions are not supported as the LHS of a binary expression");
                         },
-                        [] (const constant&) -> bool {
+                        [] (const constant&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: constants are not supported as the LHS of a binary expression");
                         },
-                        [] (const unresolved_identifier&) -> bool {
+                        [] (const unresolved_identifier&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: an unresolved identifier is not supported as the LHS of a binary expression");
                         },
-                        [&] (const column_mutation_attribute&) -> bool {
+                        [&] (const column_mutation_attribute&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: writetime/ttl are not supported as the LHS of a binary expression");
                         },
-                        [&] (const function_call&) -> bool {
+                        [&] (const function_call&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: function calls are not supported as the LHS of a binary expression");
                         },
-                        [&] (const cast&) -> bool {
+                        [&] (const cast&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: typecasts are not supported as the LHS of a binary expression");
                         },
-                        [&] (const field_selection&) -> bool {
+                        [&] (const field_selection&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: field selections are not supported as the LHS of a binary expression");
                         },
-                        [&] (const null&) -> bool {
+                        [&] (const null&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: nulls are not supported as the LHS of a binary expression");
                         },
-                        [&] (const bind_variable&) -> bool {
+                        [&] (const bind_variable&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: bind variables are not supported as the LHS of a binary expression");
                         },
-                        [&] (const untyped_constant&) -> bool {
+                        [&] (const untyped_constant&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: untyped constants are not supported as the LHS of a binary expression");
                         },
-                        [&] (const collection_constructor&) -> bool {
+                        [&] (const collection_constructor&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: collection constructors are not supported as the LHS of a binary expression");
                         },
-                        [&] (const usertype_constructor&) -> bool {
+                        [&] (const usertype_constructor&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: user type constructors are not supported as the LHS of a binary expression");
                         },
                     }, oper.lhs);
             },
-            [] (const auto& default_case) { return false; }
+            [] (const auto& default_case) { return index::supports_expression_v::from_bool(false); }
         }, expr);
 }
+}
+
+bool is_supported_by(const expression& expr, const secondary_index::index& idx) {
+    auto s = is_supported_by_helper(expr, idx);
+    return s != secondary_index::index::supports_expression_v::from_bool(false);
+}
+
 
 bool has_supporting_index(
         const expression& expr,

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -818,6 +818,12 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                                         : to_range(oper.op, std::move(*val));
                             } else if (oper.op == oper_t::IN) {
                                 return get_IN_values(oper.rhs, options, type->as_less_comparator(), cdef->name_as_text());
+                            } else if (oper.op == oper_t::CONTAINS || oper.op == oper_t::CONTAINS_KEY) {
+                                managed_bytes_opt val = evaluate(oper.rhs, options).value.to_managed_bytes_opt();
+                                if (!val) {
+                                    return empty_value_set; // All NULL comparisons fail; no column values match.
+                                }
+                                return value_set(value_list{*val});
                             }
                             throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
                         },

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1879,17 +1879,12 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
     std::transform(pk_value.cbegin(), pk_value.cend(), pkv_linearized.begin(),
                    [] (const managed_bytes& mb) { return to_bytes(mb); });
     auto& token_column = idx_tbl_schema.clustering_column_at(0);
-    bytes_opt token_bytes = token_column.get_computation().compute_value(
-            *_schema, pkv_linearized, clustering_row(clustering_key_prefix::make_empty()));
-    if (!token_bytes) {
-        on_internal_error(rlogger,
-                          format("null value for token column in indexing table {}",
-                                 token_column.name_as_text()));
-    }
+    bytes token_bytes = token_column.get_computation().compute_value(*_schema, pkv_linearized);
+
     // WARNING: We must not yield to another fiber from here until the function's end, lest this RHS be
     // overwritten.
     const_cast<expr::expression&>(expr::as<binary_operator>((*_idx_tbl_ck_prefix)[0]).rhs) =
-            expr::constant(raw_value::make_value(*token_bytes), token_column.type);
+            expr::constant(raw_value::make_value(token_bytes), token_column.type);
 
     // Multi column restrictions are not added to _idx_tbl_ck_prefix, they are handled later by filtering.
     return get_single_column_clustering_bounds(options, idx_tbl_schema, *_idx_tbl_ck_prefix);

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -145,6 +145,10 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
 
         if (cd->type->is_multi_cell()) {
             if (cd->type->is_collection()) {
+                if (!db.features().collection_indexing) {
+                    throw exceptions::invalid_request_exception(
+                        "Indexing of collection columns not supported by some older nodes in this cluster. Please upgrade them.");
+                }
                 if (is_local_index) {
                     throw exceptions::invalid_request_exception(
                             format("Local secondary index on collection column {} is not implemented yet.", target->column_name()));

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -210,7 +210,7 @@ void create_index_statement::validate_is_values_index_if_target_column_not_colle
         const column_definition* cd, const index_target& target) const
 {
     if (!cd->type->is_collection()
-            && target.type != index_target::target_type::values) {
+            && target.type != index_target::target_type::regular_values) {
         throw exceptions::invalid_request_exception(
                 format("Cannot create index on {} of column {}; only non-frozen collections support {} indexes",
                        index_target::index_option(target.type),

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -55,6 +55,7 @@ private:
     void validate_for_local_index(const schema& schema) const;
     void validate_for_frozen_collection(const index_target& target) const;
     void validate_not_full_index(const index_target& target) const;
+    void validate_for_collection(const index_target& target, const column_definition&) const;
     void rewrite_target_for_collection(index_target& target, const column_definition&) const;
     void validate_is_values_index_if_target_column_not_collection(const column_definition* cd,
                                                                   const index_target& target) const;

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -55,6 +55,7 @@ private:
     void validate_for_local_index(const schema& schema) const;
     void validate_for_frozen_collection(const index_target& target) const;
     void validate_not_full_index(const index_target& target) const;
+    void rewrite_target_for_collection(index_target& target, const column_definition&) const;
     void validate_is_values_index_if_target_column_not_collection(const column_definition* cd,
                                                                   const index_target& target) const;
     void validate_target_column_is_map_if_index_involves_keys(bool is_map, const index_target& target) const;

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -140,7 +140,7 @@ sstring to_sstring(index_target::target_type type)
     case index_target::target_type::collection_values: return "values";
     case index_target::target_type::full: return "full";
     }
-    return "";
+    throw std::runtime_error("to_sstring(index_target::target_type): should not reach");
 }
 
 }

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -24,7 +24,7 @@ const sstring index_target::target_option_name = "target";
 const sstring index_target::custom_index_option_name = "class_name";
 const std::regex index_target::target_regex("^(keys|entries|values|full)\\((.+)\\)$");
 
-sstring index_target::as_string() const {
+sstring index_target::column_name() const {
     struct as_string_visitor {
         const index_target* target;
         sstring operator()(const std::vector<::shared_ptr<column_identifier>>& columns) const {
@@ -35,19 +35,7 @@ sstring index_target::as_string() const {
         }
 
         sstring operator()(const ::shared_ptr<column_identifier>& column) const {
-            sstring postfix;
-            switch (target->type) {
-                case index_target::target_type::keys:
-                    [[fallthrough]];
-                case index_target::target_type::collection_values:
-                    [[fallthrough]];
-                case index_target::target_type::keys_and_values:
-                    postfix = "_" + to_sstring(target->type);
-                    break;
-                default:
-                    break;
-            }
-            return column->to_string() + postfix;
+            return column->to_string();
         }
     };
 

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -74,16 +74,6 @@ sstring index_target::column_name_from_target_string(const sstring& target) {
     return target;
 }
 
-sstring index_target::index_option(target_type type) {
-    switch (type) {
-        case target_type::keys: return secondary_index::index_keys_option_name;
-        case target_type::keys_and_values: return secondary_index::index_entries_option_name;
-        case target_type::collection_values: return secondary_index::index_collection_values_option_name;
-        case target_type::regular_values: return secondary_index::index_regular_values_option_name;
-        default: throw std::invalid_argument("should not reach");
-    }
-}
-
 ::shared_ptr<index_target::raw>
 index_target::raw::regular_values_of(::shared_ptr<column_identifier::raw> c) {
     return ::make_shared<raw>(c, target_type::regular_values);

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -45,8 +45,10 @@ index_target::target_type index_target::from_sstring(const sstring& s)
         return index_target::target_type::keys;
     } else if (s == "entries") {
         return index_target::target_type::keys_and_values;
+    } else if (s == "regular_values") {
+        return index_target::target_type::regular_values;
     } else if (s == "values") {
-        return index_target::target_type::values;
+        return index_target::target_type::collection_values;
     } else if (s == "full") {
         return index_target::target_type::full;
     }
@@ -57,14 +59,20 @@ sstring index_target::index_option(target_type type) {
     switch (type) {
         case target_type::keys: return secondary_index::index_keys_option_name;
         case target_type::keys_and_values: return secondary_index::index_entries_option_name;
-        case target_type::values: return secondary_index::index_values_option_name;
+        case target_type::collection_values: return secondary_index::index_collection_values_option_name;
+        case target_type::regular_values: return secondary_index::index_regular_values_option_name;
         default: throw std::invalid_argument("should not reach");
     }
 }
 
 ::shared_ptr<index_target::raw>
-index_target::raw::values_of(::shared_ptr<column_identifier::raw> c) {
-    return ::make_shared<raw>(c, target_type::values);
+index_target::raw::regular_values_of(::shared_ptr<column_identifier::raw> c) {
+    return ::make_shared<raw>(c, target_type::regular_values);
+}
+
+::shared_ptr<index_target::raw>
+index_target::raw::collection_values_of(::shared_ptr<column_identifier::raw> c) {
+    return ::make_shared<raw>(c, target_type::collection_values);
 }
 
 ::shared_ptr<index_target::raw>
@@ -84,7 +92,7 @@ index_target::raw::full_collection(::shared_ptr<column_identifier::raw> c) {
 
 ::shared_ptr<index_target::raw>
 index_target::raw::columns(std::vector<::shared_ptr<column_identifier::raw>> c) {
-    return ::make_shared<raw>(std::move(c), target_type::values);
+    return ::make_shared<raw>(std::move(c), target_type::regular_values);
 }
 
 ::shared_ptr<index_target>
@@ -115,7 +123,8 @@ sstring to_sstring(index_target::target_type type)
     switch (type) {
     case index_target::target_type::keys: return "keys";
     case index_target::target_type::keys_and_values: return "entries";
-    case index_target::target_type::values: return "values";
+    case index_target::target_type::regular_values: return "regular_values";
+    case index_target::target_type::collection_values: return "values";
     case index_target::target_type::full: return "full";
     }
     return "";

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -51,6 +51,14 @@ struct index_target {
     // e.g. column_name_from_target_string("keys(some_column)") == "some_column"
     static sstring column_name_from_target_string(const sstring& s);
 
+    // A CQL column's name may contain any characters. If we use this string
+    // as-is inside a target string, it may confuse us when we later try to
+    // parse the resulting string (e.g., see issue #10707). We should
+    // therefore use the function escape_target_column() to "escape" the
+    // target column name, and the reverse function unescape_target_column().
+    static sstring escape_target_column(const cql3::column_identifier& col);
+    static sstring unescape_target_column(std::string_view str);
+
     class raw {
     public:
         using single_column = ::shared_ptr<column_identifier::raw>;

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -38,7 +38,7 @@ struct index_target {
     index_target(::shared_ptr<column_identifier> c, target_type t) : value(c) , type(t) {}
     index_target(std::vector<::shared_ptr<column_identifier>> c, target_type t) : value(std::move(c)), type(t) {}
 
-    sstring as_string() const;
+    sstring column_name() const;
 
     static sstring index_option(target_type type);
     static target_type from_column_definition(const column_definition& cd);

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -31,7 +31,7 @@ struct index_target {
     using value_type = std::variant<single_column, multiple_columns>;
 
     const value_type value;
-    const target_type type;
+    target_type type;
 
     index_target(::shared_ptr<column_identifier> c, target_type t) : value(c) , type(t) {}
     index_target(std::vector<::shared_ptr<column_identifier>> c, target_type t) : value(std::move(c)), type(t) {}

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "cql3/column_identifier.hh"
 #include <variant>
+#include <regex>
 
 namespace cql3 {
 
@@ -21,6 +22,7 @@ namespace statements {
 struct index_target {
     static const sstring target_option_name;
     static const sstring custom_index_option_name;
+    static const std::regex target_regex;
 
     enum class target_type {
         regular_values, collection_values, keys, keys_and_values, full
@@ -40,7 +42,15 @@ struct index_target {
 
     static sstring index_option(target_type type);
     static target_type from_column_definition(const column_definition& cd);
+    // Parses index_target::target_type from it's textual form.
+    // e.g. from_sstring("keys") == index_target::target_type::keys
     static index_target::target_type from_sstring(const sstring& s);
+    // Parses index_target::target_type from index target string form.
+    // e.g. from_target_string("keys(some_column)") == index_target::target_type::keys
+    static index_target::target_type from_target_string(const sstring& s);
+    // Parses column name from index target string form
+    // e.g. column_name_from_target_string("keys(some_column)") == "some_column"
+    static sstring column_name_from_target_string(const sstring& s);
 
     class raw {
     public:

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -22,13 +22,13 @@ struct index_target {
     static const sstring target_option_name;
     static const sstring custom_index_option_name;
 
-    using single_column =::shared_ptr<column_identifier>;
+    enum class target_type {
+        regular_values, collection_values, keys, keys_and_values, full
+    };
+
+    using single_column = ::shared_ptr<column_identifier>;
     using multiple_columns = std::vector<::shared_ptr<column_identifier>>;
     using value_type = std::variant<single_column, multiple_columns>;
-
-    enum class target_type {
-        values, keys, keys_and_values, full
-    };
 
     const value_type value;
     const target_type type;
@@ -54,7 +54,8 @@ struct index_target {
         raw(::shared_ptr<column_identifier::raw> c, target_type t) : value(c), type(t) {}
         raw(std::vector<::shared_ptr<column_identifier::raw>> pk_columns, target_type t) : value(pk_columns), type(t) {}
 
-        static ::shared_ptr<raw> values_of(::shared_ptr<column_identifier::raw> c);
+        static ::shared_ptr<raw> regular_values_of(::shared_ptr<column_identifier::raw> c);
+        static ::shared_ptr<raw> collection_values_of(::shared_ptr<column_identifier::raw> c);
         static ::shared_ptr<raw> keys_of(::shared_ptr<column_identifier::raw> c);
         static ::shared_ptr<raw> keys_and_values_of(::shared_ptr<column_identifier::raw> c);
         static ::shared_ptr<raw> full_collection(::shared_ptr<column_identifier::raw> c);

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -40,7 +40,6 @@ struct index_target {
 
     sstring column_name() const;
 
-    static sstring index_option(target_type type);
     static target_type from_column_definition(const column_definition& cd);
     // Parses index_target::target_type from it's textual form.
     // e.g. from_sstring("keys") == index_target::target_type::keys

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -965,18 +965,15 @@ static void append_base_key_to_index_ck(std::vector<managed_bytes_view>& explode
 bytes indexed_table_select_statement::compute_idx_token(const partition_key& key) const {
     const column_definition& cdef = *_view_schema->clustering_key_columns().begin();
     clustering_row empty_row(clustering_key_prefix::make_empty());
-    bytes_opt computed_value;
+    bytes computed_value;
     if (!cdef.is_computed()) {
         // FIXME(pgrabowski): this legacy code is here for backward compatibility and should be removed
         // once "computed_columns feature" is supported by every node
-        computed_value = legacy_token_column_computation().compute_value(*_schema, key, empty_row);
+        computed_value = legacy_token_column_computation().compute_value(*_schema, key);
     } else {
-        computed_value = cdef.get_computation().compute_value(*_schema, key, empty_row);
+        computed_value = cdef.get_computation().compute_value(*_schema, key);
     }
-    if (!computed_value) {
-        throw std::logic_error(format("No value computed for idx_token column {}", cdef.name()));
-    }
-    return *computed_value;
+    return computed_value;
 }
 
 lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement::generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2147,7 +2147,10 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
         out << join(", ", cols);
     }
     // Note that cf_name may need to be quoted, just like column names above.
-    out << " FROM " << util::maybe_quote(sstring(cf_name)) << " WHERE " << where_clause << " ALLOW FILTERING";
+    out << " FROM " << util::maybe_quote(sstring(cf_name));
+    if (!where_clause.empty()) {
+        out << " WHERE " << where_clause << " ALLOW FILTERING";
+    }
     return do_with_parser(out.str(), std::mem_fn(&cql3_parser::CqlParser::selectStatement));
 }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include <boost/range/adaptor/transformed.hpp>
 #include <deque>
 #include <functional>
 #include <optional>
@@ -46,6 +47,7 @@
 #include "mutation_partition.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
+#include "utils/small_vector.hh"
 #include "view_info.hh"
 #include "view_update_checks.hh"
 #include "types/user.hh"
@@ -59,6 +61,7 @@
 #include "readers/evictable.hh"
 #include "delete_ghost_rows_visitor.hh"
 #include "locator/host_id.hh"
+#include "cartesian_product.hh"
 
 using namespace std::chrono_literals;
 
@@ -471,7 +474,6 @@ row_marker view_updates::compute_row_marker(const clustering_row& base_row) cons
      *      will all unselected columns.
      */
 
-    auto marker = base_row.marker();
     // WARNING: The code assumes that if multiple regular base columns are present in the view key,
     // they share liveness information. It's true especially in the only case currently allowed by CQL,
     // which assumes there's up to one non-pk column in the view key. It's also true in alternator,
@@ -484,41 +486,187 @@ row_marker view_updates::compute_row_marker(const clustering_row& base_row) cons
         return cell.is_live_and_has_ttl() ? row_marker(cell.timestamp(), cell.ttl(), cell.expiry()) : row_marker(cell.timestamp());
     }
 
-    return marker;
+    return base_row.marker();
 }
 
-deletable_row& view_updates::get_view_row(const partition_key& base_key, const clustering_row& update) {
-    std::vector<bytes> linearized_values;
-    auto get_value = boost::adaptors::transformed([&, this] (const column_definition& cdef) -> managed_bytes_view {
-        auto* base_col = _base->get_column_definition(cdef.name());
+
+namespace {
+struct bytes_view_with_action {
+    managed_bytes_view _bytes_view;
+    bytes_with_action::action _action;
+    bytes_view_with_action(managed_bytes_view view, bytes_with_action::action action)
+        : _bytes_view(view)
+        , _action(action)
+    {}
+    bytes_view_with_action(managed_bytes_view view)
+        : _bytes_view(view)
+    {}
+    bytes_view_with_action(bytes_with_action&& bwa, std::deque<bytes>& linearized_values)
+        : bytes_view_with_action(managed_bytes_view(linearized_values.emplace_back(std::move(bwa._view))), bwa._action)
+    {}
+    static managed_bytes_view get_view(const bytes_view_with_action& bvwa) {
+        return bvwa._bytes_view;
+    }
+};
+
+// value_getter is used to extract values for specific columns during view update.
+struct value_getter {
+    // linearized_values hold bytes for values of computed columns, for which we later store references in the form of managed_bytes_view.
+    // deque doesn't invalidate references at emplace_back.
+    std::deque<bytes> linearized_values;
+
+    // Index of column being currently processed.
+    size_t column_position = 0;
+    // Discovered index of collection computed column.
+    std::optional<size_t> collection_column_position;
+private:
+    // Schemas of base table and view.
+    const schema& _base;
+    const view_ptr& _view;
+
+    const partition_key& _base_key;
+    const clustering_row& _update;
+    const std::optional<clustering_row>& _existing;
+
+public:
+    value_getter(const schema& base, const view_ptr& view, const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing)
+        : _base(base)
+        , _view(view)
+        , _base_key(base_key)
+        , _update(update)
+        , _existing(existing)
+    {}
+
+    using vector_type = utils::small_vector<bytes_view_with_action, 1>;
+    vector_type operator()(const column_definition& cdef) {
+        column_position++;
+
+        auto* base_col = _base.get_column_definition(cdef.name());
         if (!base_col) {
-            bytes_opt computed_value;
-            if (!cdef.is_computed()) {
-                //FIXME(sarna): this legacy code is here for backward compatibility and should be removed
-                // once "computed_columns feature" is supported by every node
-                if (!service::get_local_storage_proxy().local_db().find_column_family(_base->id()).get_index_manager().is_index(*_view)) {
-                    throw std::logic_error(format("Column {} doesn't exist in base and this view is not backing a secondary index", cdef.name_as_text()));
-                }
-                computed_value = legacy_token_column_computation().compute_value(*_base, base_key);
-            } else {
-                computed_value = cdef.get_computation().compute_value(*_base, base_key);
-            }
-            return managed_bytes_view(linearized_values.emplace_back(*computed_value));
+            return handle_computed_column(cdef);
         }
         switch (base_col->kind) {
         case column_kind::partition_key:
-            return base_key.get_component(*_base, base_col->position());
+            return {_base_key.get_component(_base, base_col->position())};
         case column_kind::clustering_key:
-            return update.key().get_component(*_base, base_col->position());
+            return {_update.key().get_component(_base, base_col->position())};
         default:
-            auto& c = update.cells().cell_at(base_col->id);
+            auto& c = _update.cells().cell_at(base_col->id);
             auto value_view = base_col->is_atomic() ? c.as_atomic_cell(cdef).value() : c.as_collection_mutation().data;
-            return value_view;
+            return {managed_bytes_view{value_view}};
         }
-    });
-    auto& partition = partition_for(partition_key::from_range(_view->partition_key_columns() | get_value));
-    auto ckey = clustering_key::from_range(_view->clustering_key_columns() | get_value);
-    return partition.clustered_row(*_view, std::move(ckey));
+    }
+
+private:
+    vector_type handle_computed_column(const column_definition& cdef) {
+        bytes computed_value;
+        if (!cdef.is_computed()) {
+            //FIXME(sarna): this legacy code is here for backward compatibility and should be removed
+            // once "computed_columns feature" is supported by every node
+            if (!service::get_local_storage_proxy().local_db().find_column_family(_base.id()).get_index_manager().is_index(*_view)) {
+                throw std::logic_error(format("Column {} doesn't exist in base and this view is not backing a secondary index", cdef.name_as_text()));
+            }
+            computed_value = legacy_token_column_computation().compute_value(_base, _base_key);
+        } else {
+            auto& computation = cdef.get_computation();
+            if (auto* collection_computation = dynamic_cast<const collection_column_computation*>(&computation)) {
+                return handle_collection_column_computation(collection_computation);
+            }
+            computed_value = computation.compute_value(_base, _base_key);
+        }
+
+        return {managed_bytes_view(linearized_values.emplace_back(std::move(computed_value)))};
+    }
+
+    vector_type handle_collection_column_computation(const collection_column_computation* collection_computation) {
+        vector_type ret;
+        if (collection_column_position.has_value()) {
+            on_internal_error(vlogger, format("Multiple columns in view (either pk or ck) are collection computed columns. Current is {}, the previous one found was {}", column_position - 1, *collection_column_position));
+        }
+        collection_column_position = column_position - 1;
+
+        for (auto& bwa : collection_computation->compute_values_with_action(_base, _base_key, _update, _existing)) {
+            ret.push_back({std::move(bwa), linearized_values});
+        }
+        return ret;
+    }
+};
+}
+
+
+std::vector<view_updates::view_row_entry>
+view_updates::get_view_rows(const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing) {
+    value_getter getter(*_base, _view, base_key, update, existing);
+    auto get_value = boost::adaptors::transformed(std::ref(getter));
+
+
+    std::vector<value_getter::vector_type> pk_elems, ck_elems;
+    boost::copy(_view->partition_key_columns() | get_value, std::back_inserter(pk_elems));
+    // If no collection column was found, each of the actions will contain no_action,
+    // in particular, it does not harm to use column 0.
+    const bool had_multiple_values_in_pk = bool(getter.collection_column_position);
+    const size_t action_column = getter.collection_column_position.value_or(0);
+    // Allow for at most one collection computed column in pk and in ck.
+    getter.collection_column_position.reset();
+    boost::copy(_view->clustering_key_columns() | get_value, std::back_inserter(ck_elems));
+    const bool had_multiple_values_in_ck = bool(getter.collection_column_position);
+
+
+    std::vector<view_updates::view_row_entry> ret;
+    auto compute_row = [&]<typename Range>(Range&& pk, Range&& ck) {
+        partition_key pkey = partition_key::from_range(boost::adaptors::transform(pk, bytes_view_with_action::get_view));
+        clustering_key ckey = clustering_key::from_range(boost::adaptors::transform(ck, bytes_view_with_action::get_view));
+        auto action = (action_column < pk.size() ? pk[action_column] : ck[action_column - pk.size()])._action;
+        mutation_partition& partition = partition_for(std::move(pkey));
+        ret.push_back({&partition.clustered_row(*_view, std::move(ckey)), action});
+    };
+
+    if (had_multiple_values_in_pk) {
+        // cartesian_product expects std::vector<std::vector<>>, while we have std::vector<small_vector>.
+        std::vector<std::vector<bytes_view_with_action>> pk_elems_, ck_elems_;
+        auto std_vector_from_small_vector = boost::adaptors::transformed([](const auto& vector) {
+            return std::vector<bytes_view_with_action>{vector.begin(), vector.end()};
+        });
+        boost::copy(pk_elems | std_vector_from_small_vector, std::back_inserter(pk_elems_));
+        boost::copy(ck_elems | std_vector_from_small_vector, std::back_inserter(ck_elems_));
+
+        auto cartesian_product_pk = cartesian_product(pk_elems_),
+             cartesian_product_ck = cartesian_product(ck_elems_);
+        auto ck_it = cartesian_product_ck.begin();
+
+        if (had_multiple_values_in_ck) {
+            // The computed collection column in clustering key was associated with the computed collection column from the partition key.
+            // This is a case for indexes over collection values.
+
+            auto throw_length_error = [&] {
+                size_t pk_size = cartesian_product_size(pk_elems_),
+                       ck_size = cartesian_product_size(ck_elems_);
+                on_internal_error(vlogger, format("Computed sizes of possible partition keys and clustering keys don't match: {} != {}", pk_size, ck_size));
+            };
+            for (std::vector<bytes_view_with_action>& pk : cartesian_product_pk) {
+                if (ck_it == cartesian_product_ck.end()) {
+                    throw_length_error();
+                }
+                compute_row(pk, *ck_it);
+                ++ck_it;
+            }
+            if (ck_it != cartesian_product_ck.end()) {
+                throw_length_error();
+            }
+        } else {
+            for (std::vector<bytes_view_with_action>& pk : cartesian_product_pk) {
+                for (std::vector<bytes_view_with_action>& ck : cartesian_product_ck) {
+                    compute_row(pk, ck);
+                }
+            }
+        }
+    } else {
+        // Here it's the old regular index over regular values. Each vector has just one element.
+        auto get_front = boost::adaptors::transformed([](const auto& v) { return v.front(); });
+        compute_row(pk_elems | get_front, ck_elems | get_front);
+    }
+
+    return ret;
 }
 
 static const column_definition* view_column(const schema& base, const schema& view, column_id base_id) {
@@ -680,12 +828,19 @@ void view_updates::create_entry(const partition_key& base_key, const clustering_
     if (!matches_view_filter(*_base, _view_info, base_key, update, now)) {
         return;
     }
-    deletable_row& r = get_view_row(base_key, update);
-    auto marker = compute_row_marker(update);
-    r.apply(marker);
-    r.apply(update.tomb());
-    add_cells_to_view(*_base, *_view, row(*_base, column_kind::regular_column, update.cells()), r.cells());
-    _op_count++;
+
+    auto view_rows = get_view_rows(base_key, update, std::nullopt);
+    auto update_marker = compute_row_marker(update);
+    for (const auto& [r, action]: view_rows) {
+        if (auto rm = std::get_if<row_marker>(&action)) {
+            r->apply(*rm);
+        } else {
+            r->apply(update_marker);
+        }
+        r->apply(update.tomb());
+        add_cells_to_view(*_base, *_view, row(*_base, column_kind::regular_column, update.cells()), r->cells());
+    }
+    _op_count += view_rows.size();
 }
 
 /**
@@ -701,27 +856,33 @@ void view_updates::delete_old_entry(const partition_key& base_key, const cluster
 }
 
 void view_updates::do_delete_old_entry(const partition_key& base_key, const clustering_row& existing, const clustering_row& update, gc_clock::time_point now) {
-    auto& r = get_view_row(base_key, existing);
-    const auto& col_ids = _base_info->base_non_pk_columns_in_view_pk();
-    if (!col_ids.empty()) {
-        // We delete the old row using a shadowable row tombstone, making sure that
-        // the tombstone deletes everything in the row (or it might still show up).
-        // Note: multi-cell columns can't be part of the primary key.
-        auto& def = _base->regular_column_at(col_ids[0]);
-        auto cell = existing.cells().cell_at(col_ids[0]).as_atomic_cell(def);
-        if (cell.is_live()) {
-            r.apply(shadowable_tombstone(cell.timestamp(), now));
+    auto view_rows = get_view_rows(base_key, existing, std::nullopt);
+    for (const auto& [r, action] : view_rows) {
+        const auto& col_ids = _base_info->base_non_pk_columns_in_view_pk();
+        if (_view_info.has_computed_column_depending_on_base_non_primary_key()) {
+            if (auto ts_tag = std::get_if<bytes_with_action::shadowable_tombstone_tag>(&action)) {
+                r->apply(ts_tag->into_shadowable_tombstone(now));
+            }
+        } else if (!col_ids.empty()) {
+            // We delete the old row using a shadowable row tombstone, making sure that
+            // the tombstone deletes everything in the row (or it might still show up).
+            // Note: multi-cell columns can't be part of the primary key.
+            auto& def = _base->regular_column_at(col_ids[0]);
+            auto cell = existing.cells().cell_at(col_ids[0]).as_atomic_cell(def);
+            if (cell.is_live()) {
+                r->apply(shadowable_tombstone(cell.timestamp(), now));
+            }
+        } else {
+            // "update" caused the base row to have been deleted, and !col_id
+            // means view row is the same - so it needs to be deleted as well
+            // using the same deletion timestamps for the individual cells.
+            r->apply(update.marker());
+            auto diff = update.cells().difference(*_base, column_kind::regular_column, existing.cells());
+            add_cells_to_view(*_base, *_view, std::move(diff), r->cells());
         }
-    } else {
-        // "update" caused the base row to have been deleted, and !col_id
-        // means view row is the same - so it needs to be deleted as well
-        // using the same deletion timestamps for the individual cells.
-        r.apply(update.marker());
-        auto diff = update.cells().difference(*_base, column_kind::regular_column, existing.cells());
-        add_cells_to_view(*_base, *_view, std::move(diff), r.cells());
+        r->apply(update.tomb());
     }
-    r.apply(update.tomb());
-    _op_count++;
+    _op_count += view_rows.size();
 }
 
 /*
@@ -819,14 +980,42 @@ void view_updates::update_entry(const partition_key& base_key, const clustering_
         return;
     }
 
-    deletable_row& r = get_view_row(base_key, update);
-    auto marker = compute_row_marker(update);
-    r.apply(marker);
-    r.apply(update.tomb());
+    auto view_rows = get_view_rows(base_key, update, std::nullopt);
+    auto update_marker = compute_row_marker(update);
+    for (const auto& [r, action] : view_rows) {
+        if (auto rm = std::get_if<row_marker>(&action)) {
+            r->apply(*rm);
+        } else {
+            r->apply(update_marker);
+        }
+        r->apply(update.tomb());
 
-    auto diff = update.cells().difference(*_base, column_kind::regular_column, existing.cells());
-    add_cells_to_view(*_base, *_view, std::move(diff), r.cells());
-    _op_count++;
+        auto diff = update.cells().difference(*_base, column_kind::regular_column, existing.cells());
+        add_cells_to_view(*_base, *_view, std::move(diff), r->cells());
+    }
+    _op_count += view_rows.size();
+}
+
+void view_updates::update_entry_for_computed_column(
+        const partition_key& base_key,
+        const clustering_row& update,
+        const std::optional<clustering_row>& existing,
+        gc_clock::time_point now) {
+    auto view_rows = get_view_rows(base_key, update, existing);
+    for (const auto& [r, action] : view_rows) {
+        struct visitor {
+            deletable_row* row;
+            gc_clock::time_point now;
+            void operator()(bytes_with_action::no_action) {}
+            void operator()(bytes_with_action::shadowable_tombstone_tag t) {
+                row->apply(t.into_shadowable_tombstone(now));
+            }
+            void operator()(row_marker rm) {
+                row->apply(rm);
+            }
+        };
+        std::visit(visitor{r, now}, action);
+    }
 }
 
 void view_updates::generate_update(
@@ -846,6 +1035,9 @@ void view_updates::generate_update(
     }
 
     const auto& col_ids = _base_info->base_non_pk_columns_in_view_pk();
+    if (_view_info.has_computed_column_depending_on_base_non_primary_key()) {
+        return update_entry_for_computed_column(base_key, update, existing, now);
+    }
     if (col_ids.empty()) {
         // The view key is necessarily the same pre and post update.
         if (existing && existing->is_live(*_base)) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -495,12 +495,9 @@ deletable_row& view_updates::get_view_row(const partition_key& base_key, const c
                 if (!service::get_local_storage_proxy().local_db().find_column_family(_base->id()).get_index_manager().is_index(*_view)) {
                     throw std::logic_error(format("Column {} doesn't exist in base and this view is not backing a secondary index", cdef.name_as_text()));
                 }
-                computed_value = legacy_token_column_computation().compute_value(*_base, base_key, update);
+                computed_value = legacy_token_column_computation().compute_value(*_base, base_key);
             } else {
-                computed_value = cdef.get_computation().compute_value(*_base, base_key, update);
-            }
-            if (!computed_value) {
-                throw std::logic_error(format("No value computed for primary key column {}", cdef.name()));
+                computed_value = cdef.get_computation().compute_value(*_base, base_key);
             }
             return managed_bytes_view(linearized_values.emplace_back(*computed_value));
         }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -123,6 +123,33 @@ bool matches_view_filter(const schema& base, const view_info& view, const partit
 
 bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck);
 
+/**
+ * The liveness of rows resulting from an update to a table with an index over collection column
+ * depends on the liveness of the collection cells. bytes_with_action is used to return this information
+ * from the function computing the result for a particular computed column.
+ */
+struct bytes_with_action {
+    struct no_action {};
+    struct shadowable_tombstone_tag {
+        api::timestamp_type ts;
+        shadowable_tombstone into_shadowable_tombstone(gc_clock::time_point now) const {
+            return shadowable_tombstone{ts, now};
+        }
+    };
+    using action = std::variant<no_action, row_marker, shadowable_tombstone_tag>;
+
+    bytes _view;
+    action _action = no_action{};
+
+    bytes_with_action(bytes view)
+        : _view(std::move(view))
+    {}
+    bytes_with_action(bytes view, action action)
+        : _view(std::move(view))
+        , _action(action)
+    {}
+};
+
 class view_updates final {
     view_ptr _view;
     const view_info& _view_info;

--- a/docs/dev/secondary_index.md
+++ b/docs/dev/secondary_index.md
@@ -32,12 +32,13 @@ When in doubt, `DESCRIBE index_name` or `SELECT * FROM system_schema.indexes` co
 
 Global index's target is usually just the indexed column name, unless the index has a specific type. All supported types are:
  - regular index: v
- - full collection index: FULL(v)
+ - full collection index (for frozen collection): FULL(v)
  - index on map keys: KEYS(v)
- - index on map values: ENTRIES(v)
+ - index on map, set or list values: VALUES(v)
+ - index on map entries: ENTRIES(v)
 
 Their serialization is just string representation, so:
-"v", "FULL(v)", "KEYS(v)", "ENTRIES(v)" are all valid targets.
+"v", "FULL(v)", "KEYS(v)", "VALUES(v)", "ENTRIES(v)" are all valid targets.
 
 ## Local index
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -114,6 +114,7 @@ public:
     gms::feature schema_commitlog { *this, "SCHEMA_COMMITLOG"sv };
     gms::feature uda_native_parallelized_aggregation { *this, "UDA_NATIVE_PARALLELIZED_AGGREGATION"sv };
     gms::feature aggregate_storage_options { *this, "AGGREGATE_STORAGE_OPTIONS"sv };
+    gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
 
 public:
 

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -127,7 +127,17 @@ sstring target_parser::serialize_targets(const std::vector<::shared_ptr<cql3::st
     };
 
     if (targets.size() == 1 && std::holds_alternative<index_target::single_column>(targets.front()->value)) {
-        return std::get<index_target::single_column>(targets.front()->value)->to_string();
+        auto& target = targets.front();
+        auto single_target = std::get<index_target::single_column>(target->value);
+        switch (target->type) {
+            case index_target::target_type::regular_values:     [[fallthrough]];
+            case index_target::target_type::full:
+                return single_target->to_string();
+            case index_target::target_type::collection_values:  [[fallthrough]];
+            case index_target::target_type::keys:               [[fallthrough]];
+            case index_target::target_type::keys_and_values:
+                return cql3::statements::to_sstring(target->type) + "(" + single_target->to_string() + ")";
+        }
     }
 
     rjson::value json_map = rjson::empty_object();

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -22,7 +22,8 @@
 
 const sstring db::index::secondary_index::custom_index_option_name = "class_name";
 const sstring db::index::secondary_index::index_keys_option_name = "index_keys";
-const sstring db::index::secondary_index::index_values_option_name = "index_values";
+const sstring db::index::secondary_index::index_collection_values_option_name = "index_collection_values";
+const sstring db::index::secondary_index::index_regular_values_option_name = "index_regular_values";
 const sstring db::index::secondary_index::index_entries_option_name = "index_keys_and_values";
 
 namespace secondary_index {
@@ -73,12 +74,12 @@ target_parser::target_info target_parser::parse(schema_ptr schema, const sstring
         for (const rjson::value& v : ck->GetArray()) {
             info.ck_columns.push_back(get_column(sstring(rjson::to_string_view(v))));
         }
-        info.type = index_target::target_type::values;
+        info.type = index_target::target_type::regular_values;
         return info;
     }
 
     // Fallback and treat the whole string as a single target
-    return target_info{{get_column(target)}, {}, index_target::target_type::values};
+    return target_info{{get_column(target)}, {}, index_target::target_type::regular_values};
 }
 
 bool target_parser::is_local(sstring target_string) {

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -21,10 +21,6 @@
 #include "log.hh"
 
 const sstring db::index::secondary_index::custom_index_option_name = "class_name";
-const sstring db::index::secondary_index::index_keys_option_name = "index_keys";
-const sstring db::index::secondary_index::index_collection_values_option_name = "index_collection_values";
-const sstring db::index::secondary_index::index_regular_values_option_name = "index_regular_values";
-const sstring db::index::secondary_index::index_entries_option_name = "index_keys_and_values";
 
 namespace secondary_index {
 

--- a/index/secondary_index.hh
+++ b/index/secondary_index.hh
@@ -33,13 +33,17 @@ public:
     /**
      * The name of the option used to specify that the index is on the collection values.
      */
-    static const sstring index_values_option_name;
+    static const sstring index_collection_values_option_name;
 
     /**
      * The name of the option used to specify that the index is on the collection (map) entries.
      */
     static const sstring index_entries_option_name;
 
+    /**
+     * The name of the option used to specify that the index is on the collection values.
+     */
+    static const sstring index_regular_values_option_name;
 };
 
 }

--- a/index/secondary_index.hh
+++ b/index/secondary_index.hh
@@ -25,25 +25,6 @@ class secondary_index {
 public:
     static const sstring custom_index_option_name;
 
-    /**
-     * The name of the option used to specify that the index is on the collection keys.
-     */
-    static const sstring index_keys_option_name;
-
-    /**
-     * The name of the option used to specify that the index is on the collection values.
-     */
-    static const sstring index_collection_values_option_name;
-
-    /**
-     * The name of the option used to specify that the index is on the collection (map) entries.
-     */
-    static const sstring index_entries_option_name;
-
-    /**
-     * The name of the option used to specify that the index is on the collection values.
-     */
-    static const sstring index_regular_values_option_name;
 };
 
 }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -273,7 +273,12 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
             db::view::create_virtual_column(builder, def.name(), def.type);
         }
     }
-    const sstring where_clause = format("{} IS NOT NULL", index_target->name_as_cql_string());
+    // "WHERE col IS NOT NULL" is not needed (and doesn't work)
+    // when col is a collection.
+    const sstring where_clause =
+        (target_type == cql3::statements::index_target::target_type::regular_values) ?
+        format("{} IS NOT NULL", index_target->name_as_cql_string()) :
+        "";
     builder.with_view_info(*schema, false, where_clause);
     return view_ptr{builder.build()};
 }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -96,9 +96,6 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
     auto target_info = target_parser::parse(schema, im);
     const auto* index_target = im.local() ? target_info.ck_columns.front() : target_info.pk_columns.front();
     auto target_type = target_info.type;
-    if (target_type != cql3::statements::index_target::target_type::values) {
-        throw std::runtime_error(format("Unsupported index target type: {}", to_sstring(target_type)));
-    }
 
     // For local indexing, start with base partition key
     if (im.local()) {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -68,6 +68,15 @@ bool index::supports_expression(const column_definition& cdef, const cql3::expr:
     }
 }
 
+bool index::supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const {
+    using target_type = cql3::statements::index_target::target_type;
+    if (cdef.name_as_text() != _target_column) {
+        return false;
+    }
+
+    return op == cql3::expr::oper_t::EQ && _target_type == target_type::keys_and_values;
+}
+
 const index_metadata& index::metadata() const {
     return _im;
 }

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -42,8 +42,27 @@ class index {
 public:
     index(const sstring& target_column, const index_metadata& im);
     bool depends_on(const column_definition& cdef) const;
-    bool supports_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
-    bool supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
+    struct supports_expression_v {
+        enum class value_type {
+            UsualYes,
+            CollectionYes,
+            No,
+        };
+        value_type value;
+        operator bool() const {
+            return value != value_type::No;
+        }
+        static constexpr supports_expression_v from_bool(bool b) {
+            return {b ? value_type::UsualYes : value_type::No};
+        }
+        static constexpr supports_expression_v from_bool_collection(bool b) {
+            return {b ? value_type::CollectionYes : value_type::No};
+        }
+        friend bool operator==(supports_expression_v, supports_expression_v) = default;
+    };
+
+    supports_expression_v supports_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
+    supports_expression_v supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
     const index_metadata& metadata() const;
     const sstring& target_column() const {
         return _target_column;

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -43,6 +43,7 @@ public:
     index(const sstring& target_column, const index_metadata& im);
     bool depends_on(const column_definition& cdef) const;
     bool supports_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
+    bool supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
     const index_metadata& metadata() const;
     const sstring& target_column() const {
         return _target_column;

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -13,6 +13,7 @@
 #include "schema.hh"
 
 #include "data_dictionary/data_dictionary.hh"
+#include "cql3/statements/index_target.hh"
 
 #include <vector>
 #include <set>
@@ -35,8 +36,9 @@ sstring index_table_name(const sstring& index_name);
 sstring index_name_from_table_name(const sstring& table_name);
 
 class index {
-    sstring _target_column;
     index_metadata _im;
+    cql3::statements::index_target::target_type _target_type;
+    sstring _target_column;
 public:
     index(const sstring& target_column, const index_metadata& im);
     bool depends_on(const column_definition& cdef) const;
@@ -44,6 +46,9 @@ public:
     const index_metadata& metadata() const;
     const sstring& target_column() const {
         return _target_column;
+    }
+    cql3::statements::index_target::target_type target_type() const {
+        return _target_type;
     }
 };
 

--- a/schema.cc
+++ b/schema.cc
@@ -22,6 +22,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include <type_traits>
 #include "view_info.hh"
 #include "partition_slice_builder.hh"
 #include "replica/database.hh"
@@ -162,7 +163,7 @@ bool schema::has_custom_partitioner() const {
 }
 
 lw_shared_ptr<cql3::column_specification>
-schema::make_column_specification(const column_definition& def) {
+schema::make_column_specification(const column_definition& def) const {
     auto id = ::make_shared<cql3::column_identifier>(def.name(), column_name_type(def));
     return make_lw_shared<cql3::column_specification>(_raw._ks_name, _raw._cf_name, std::move(id), def.type);
 }

--- a/schema.cc
+++ b/schema.cc
@@ -1706,8 +1706,8 @@ bytes legacy_token_column_computation::serialize() const {
     return to_bytes(rjson::print(serialized));
 }
 
-bytes_opt legacy_token_column_computation::compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const {
-    return dht::get_token(schema, key).data();
+bytes legacy_token_column_computation::compute_value(const schema& schema, const partition_key& key) const {
+    return {dht::get_token(schema, key).data()};
 }
 
 bytes token_column_computation::serialize() const {
@@ -1716,7 +1716,7 @@ bytes token_column_computation::serialize() const {
     return to_bytes(rjson::print(serialized));
 }
 
-bytes_opt token_column_computation::compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const {
+bytes token_column_computation::compute_value(const schema& schema, const partition_key& key) const {
     auto long_value = dht::token::to_int64(dht::get_token(schema, key));
     return long_type->decompose(long_value);
 }

--- a/schema.hh
+++ b/schema.hh
@@ -673,7 +673,7 @@ public:
 private:
     struct reversed_tag { };
 
-    lw_shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def);
+    lw_shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def) const;
     void rebuild();
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -580,60 +580,103 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
 
         using ire = exceptions::invalid_request_exception;
         using exception_predicate::message_contains;
-        auto non_frozen = message_contains("index on non-frozen");
+        auto non_frozen = message_contains("full() indexes can only be created on frozen collections");
+        auto non_map = message_contains("with non-map type");
         auto non_full = message_contains("Cannot create index");
         auto duplicate = message_contains("duplicate");
         auto entry_eq = message_contains("entry equality predicates on frozen map");
-
-        //NOTICE(sarna): should be lifted after issue #2962 is resolved
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(s1)").get(), ire, non_frozen);
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(m1)").get(), ire, non_frozen);
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(l1)").get(), ire, non_frozen);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(s1))").get(), ire, non_frozen);
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(m1))").get(), ire, non_frozen);
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(l1))").get(), ire, non_frozen);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(     s2 )").get(), ire, non_full);
-        e.execute_cql("create index on t(FULL(s2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(s2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(     m2 )").get(), ire, non_full);
-        e.execute_cql("create index on t(FULL(m2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(m2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(     l2 )").get(), ire, non_full);
-        e.execute_cql("create index on t(FULL(l2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL(l2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t where m2[1] = '1'").get(), ire, entry_eq);
-
-        e.execute_cql("insert into t(p, s2, m2, l2) values (1, {1}, {1: 'one', 2: 'two'}, [2])").get();
-        e.execute_cql("insert into t(p, s2, m2, l2) values (2, {2}, {3: 'three'}, [3, 4, 5])").get();
-        e.execute_cql("insert into t(p, s2, m2, l2) values (3, {3}, {5: 'five', 7: 'seven'}, [7, 8, 9])").get();
 
         auto set_type = set_type_impl::get_instance(int32_type, true);
         auto map_type = map_type_impl::get_instance(int32_type, utf8_type, true);
         auto list_type = list_type_impl::get_instance(int32_type, true);
 
-        eventually([&] {
-            auto res = e.execute_cql("SELECT p from t where s2 = {2}").get0();
-            assert_that(res).is_rows().with_rows({{{int32_type->decompose(2)}}});
-            res = e.execute_cql("SELECT p from t where s2 = {}").get0();
-            assert_that(res).is_rows().with_size(0);
-        });
-        eventually([&] {
-            auto res = e.execute_cql("SELECT p from t where m2 = {5: 'five', 7: 'seven'}").get0();
-            assert_that(res).is_rows().with_rows({{{int32_type->decompose(3)}}});
-            res = e.execute_cql("SELECT p from t where m2 = {1: 'one', 2: 'three'}").get0();
-            assert_that(res).is_rows().with_size(0);
-        });
-        eventually([&] {
-            auto res = e.execute_cql("SELECT p from t where l2 = [2]").get0();
-            assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}}});
-            res = e.execute_cql("SELECT p from t where l2 = [3]").get0();
-            assert_that(res).is_rows().with_size(0);
-        });
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (s1))").get(), ire, non_frozen);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(KEYS    (s1))").get(), ire, non_map);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(ENTRIES (s1))").get(), ire, non_map);
+        e.execute_cql(                        "create index on t(VALUES  (s1))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(VALUES  (s1))").get(), ire, duplicate);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         s1 )").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (m1))").get(), ire, non_frozen);
+        e.execute_cql(                        "create index on t(KEYS    (m1))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(KEYS    (m1))").get(), ire, duplicate);
+        e.execute_cql(                        "create index on t(ENTRIES (m1))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(ENTRIES (m1))").get(), ire, duplicate);
+        e.execute_cql(                        "create index on t(VALUES  (m1))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(VALUES  (m1))").get(), ire, duplicate);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         m1 )").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (l1))").get(), ire, non_frozen);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(KEYS    (l1))").get(), ire, non_map);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(ENTRIES (l1))").get(), ire, non_map);
+        e.execute_cql(                        "create index on t(VALUES  (l1))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(VALUES  (l1))").get(), ire, duplicate);
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         l1 )").get(), ire, duplicate);
+
+        const sstring insert_into = "insert into t(p, s1, m1, l1, s2, m2, l2) values ";
+        e.execute_cql(insert_into + "(1, {1},    {1: 'one', 2: 'two'},                [2],       {1}, {1: 'one', 2: 'two'},    [2])").get();
+        e.execute_cql(insert_into + "(2, {2},    {3: 'three', 7: 'five'},             [3, 4, 5], {2}, {3: 'three'},            [3, 4, 5])").get();
+        e.execute_cql(insert_into + "(3, {2, 3}, {3: 'three', 5: 'five', 7: 'seven'}, [2, 8, 9], {3}, {5: 'five', 7: 'seven'}, [7, 8, 9])").get();
+
+        auto res = e.execute_cql("SELECT p from t where s1 CONTAINS 2").get0();
+        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where s1 CONTAINS 4").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'three'").get0();
+        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'seven'").get0();
+        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'ten'").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 3").get0();
+        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 5").get0();
+        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 10").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where m1[3] = 'three'").get0();
+        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(3)}}}, {{{int32_type->decompose(2)}}}});
+        res = e.execute_cql("SELECT p from t where m1[7] = 'seven'").get0();
+        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where m1[3] = 'five'").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where l1 CONTAINS 2").get0();
+        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(1)}}}, {{{int32_type->decompose(3)}}}});
+        res = e.execute_cql("SELECT p from t where l1 CONTAINS 1").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         s2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (s2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (s2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         m2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (m2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (m2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         l2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (l2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (l2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t where m2[1] = '1'").get(), ire, entry_eq);
+
+        res = e.execute_cql("SELECT p from t where s2 = {2}").get0();
+        assert_that(res).is_rows().with_rows({{{int32_type->decompose(2)}}});
+        res = e.execute_cql("SELECT p from t where s2 = {}").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where m2 = {5: 'five', 7: 'seven'}").get0();
+        assert_that(res).is_rows().with_rows({{{int32_type->decompose(3)}}});
+        res = e.execute_cql("SELECT p from t where m2 = {1: 'one', 2: 'three'}").get0();
+        assert_that(res).is_rows().with_size(0);
+
+        res = e.execute_cql("SELECT p from t where l2 = [2]").get0();
+        assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}}});
+        res = e.execute_cql("SELECT p from t where l2 = [3]").get0();
+        assert_that(res).is_rows().with_size(0);
     });
 }
 

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
@@ -147,8 +147,11 @@ def testShouldRecognizeAlteredOrDeletedMapEntries(cql, simple_table_and_index):
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["common", 31415], bar, baz)
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["target", 4096], baz)
 
-def testShouldRejectQueriesForNullEntries(cql, simple_table_and_index):
-    assert_invalid(cql, simple_table_and_index, "SELECT * FROM %s WHERE v['somekey'] = null")
+
+# Scylla does not consider "= null" an error, it just matches nothing.
+# See issue #4776.
+#def testShouldRejectQueriesForNullEntries(cql, simple_table_and_index):
+#    assert_invalid(cql, simple_table_and_index, "SELECT * FROM %s WHERE v['somekey'] = null")
 
 def testShouldTreatQueriesAgainstFrozenMapIndexesAsInvalid(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k TEXT PRIMARY KEY, v FROZEN<MAP<TEXT, TEXT>>)") as table:

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
@@ -34,7 +34,6 @@ def simple_table_and_index(cql, test_keyspace):
         cql.execute(f"CREATE INDEX ON {table}(ENTRIES(v))")
         yield table
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldValidateMapKeyAndValueTypes(cql, simple_table_and_index):
     # The Java version of this test used prepared statements, but the Python
     # driver verifies the types of the bound variables before using them,
@@ -60,7 +59,6 @@ def assertRowsForConditions(cql, table, whereClause, params, *rows):
 def assertNoRowsForConditions(cql, table, whereClause, params):
     assert_empty(execute(cql, table, "SELECT * FROM %s WHERE " + whereClause + " ALLOW FILTERING", *params))
  
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldFindRowsMatchingSingleEqualityRestriction(cql, simple_table_and_index):
     foo = insertIntoSimpleTable(cql, simple_table_and_index, "foo", {"a": 1, "c": 3})
     bar = insertIntoSimpleTable(cql, simple_table_and_index, "bar", {"a": 1, "b": 2})
@@ -73,13 +71,11 @@ def testShouldFindRowsMatchingSingleEqualityRestriction(cql, simple_table_and_in
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["c", 5], baz)
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["d", 4], baz, qux)
 
-@pytest.mark.xfail(reason="issues #2962")
 def testRequireFilteringDirectiveIfMultipleRestrictionsSpecified(cql, simple_table_and_index):
     baseQuery = "SELECT * FROM %s WHERE v['foo'] = 31415 AND v['baz'] = 31416"
     assert_invalid(cql, simple_table_and_index, baseQuery)
     assert_empty(execute(cql, simple_table_and_index, baseQuery + " ALLOW FILTERING"))
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldFindRowsMatchingMultipleEqualityRestrictions(cql, simple_table_and_index):
     foo = insertIntoSimpleTable(cql, simple_table_and_index, "foo", {"k1": 1})
     bar = insertIntoSimpleTable(cql, simple_table_and_index, "bar", {"k1": 1, "k2": 2})
@@ -93,7 +89,6 @@ def testShouldFindRowsMatchingMultipleEqualityRestrictions(cql, simple_table_and
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=? AND v[?]=?", ["k3", 3, "k4", 4], qux)
     assertNoRowsForConditions(cql, simple_table_and_index, "v[?]=? AND v[?]=? AND v[?]=?", ["k3", 3, "k4", 4, "k5", 5])
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldFindRowsMatchingEqualityAndContainsRestrictions(cql, simple_table_and_index):
     foo = insertIntoSimpleTable(cql, simple_table_and_index, "foo", {"common": 31415, "k1": 1, "k2": 2, "k3": 3})
     bar = insertIntoSimpleTable(cql, simple_table_and_index, "bar", {"common": 31415, "k3": 3, "k4": 4, "k5": 5})
@@ -117,7 +112,6 @@ def assertInvalidRelation(cql, table, rel):
     query = "SELECT * FROM %s WHERE v " + rel
     assert_invalid(cql, table, query)
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldNotAcceptUnsupportedRelationsOnEntries(cql, simple_table_and_index):
     assertInvalidRelation(cql, simple_table_and_index, "< 31415")
     assertInvalidRelation(cql, simple_table_and_index, "<= 31415")
@@ -138,7 +132,6 @@ def updateMapInSimpleTable(cql, table, row, mapKey, mapValue):
     row[1] = value
     return row
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldRecognizeAlteredOrDeletedMapEntries(cql, simple_table_and_index):
     foo = insertIntoSimpleTable(cql, simple_table_and_index, "foo", {"common": 31415, "target": 8192})
     bar = insertIntoSimpleTable(cql, simple_table_and_index, "bar", {"common": 31415, "target": 8192})
@@ -154,7 +147,6 @@ def testShouldRecognizeAlteredOrDeletedMapEntries(cql, simple_table_and_index):
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["common", 31415], bar, baz)
     assertRowsForConditions(cql, simple_table_and_index, "v[?]=?", ["target", 4096], baz)
 
-@pytest.mark.xfail(reason="issues #2962")
 def testShouldRejectQueriesForNullEntries(cql, simple_table_and_index):
     assert_invalid(cql, simple_table_and_index, "SELECT * FROM %s WHERE v['somekey'] = null")
 

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -286,7 +286,6 @@ def testIndexOnCountersInvalid(cql, test_keyspace):
         assert_invalid(cql, table, "CREATE INDEX ON %s(c)")
 
 # Migrated from cql_tests.py:TestCQL.collection_indexing_test()
-@pytest.mark.xfail(reason="issue #2962")
 def testIndexOnCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, v int, l list<int>, s set<text>, m map<text, int>, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s (l)")
@@ -318,7 +317,6 @@ def testIndexOnCollections(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE m CONTAINS 2"), [0, 1])
             assert_empty(execute(cql, table, "SELECT k, v FROM %s  WHERE m CONTAINS 4"))
 
-@pytest.mark.xfail(reason="issue #2962")
 def testSelectOnMultiIndexOnCollectionsWithNull(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, v int, x text, l list<int>, s set<text>, m map<text, int>, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s (x)")
@@ -353,7 +351,6 @@ def testSelectOnMultiIndexOnCollectionsWithNull(cql, test_keyspace):
             assert_empty(execute(cql, table, "SELECT k, v FROM %s  WHERE x = 'x' AND m CONTAINS 4 ALLOW FILTERING"))
 
 # Migrated from cql_tests.py:TestCQL.map_keys_indexing()
-@pytest.mark.xfail(reason="issue #2962")
 def testIndexOnMapKeys(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, v int, m map<text, int>, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(m))")
@@ -414,7 +411,6 @@ def createAndDropCollectionValuesIndex(cql, keyspace, table, columnName):
     execute(cql, table, f"CREATE INDEX {indexName} on %s(values({columnName}))")
     execute(cql, table, f"DROP INDEX {keyspace}.{indexName}")
 
-@pytest.mark.xfail(reason="issue #2962")
 def testSyntaxVariationsForIndexOnCollectionsValue(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, m map<int, int>, l list<int>, s set<int>, PRIMARY KEY (k))") as table:
         createAndDropCollectionValuesIndex(cql, test_keyspace, table, "m")
@@ -426,7 +422,6 @@ def createAndDropIndexWithQuotedColumnIdentifier(cql, keyspace, table, target):
     execute(cql, table, f"CREATE INDEX {indexName} ON %s({target})")
     execute(cql, table, f"DROP INDEX {keyspace}.{indexName}")
 
-@pytest.mark.xfail(reason="issue #2962")
 def testCreateIndexWithQuotedColumnNames(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(" +
                     " k int," +
@@ -985,7 +980,6 @@ def testIndexOnFrozenCollectionOfUDT(cql, test_keyspace):
             assert_invalid_message(cql, table, "ALLOW FILTERING",
                              "SELECT * FROM %s WHERE v CONTAINS ?", udt1)
 
-@pytest.mark.xfail(reason="issues #2962, #8745")
 def testIndexOnNonFrozenCollectionOfFrozenUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as t:
         with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v set<frozen<{t}>>)") as table:

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -8,7 +8,6 @@
 from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testInvalidCollectionEqualityRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)") as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -216,7 +216,6 @@ def testSelectKeyIn(cql, test_keyspace):
 
         assert_row_count(execute(cql, table, "SELECT firstname, lastname FROM %s WHERE userid IN (?, ?)", id1, id2), 2)
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testSetContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories set<text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -245,7 +244,6 @@ def testSetContainsWithIndex(cql, test_keyspace):
                                  "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ?", "xyz", "lmn", "notPresent")
             assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING", "xyz", "lmn", "notPresent"))
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testListContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories list<text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -275,7 +273,6 @@ def testListContainsWithIndex(cql, test_keyspace):
             assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
                                 "test", 5, "lmn", "notPresent"))
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testListContainsWithIndexAndFiltering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(e int PRIMARY KEY, f list<text>, s int)") as table:
         execute(cql, table, "CREATE INDEX ON %s(f)")
@@ -289,7 +286,6 @@ def testListContainsWithIndexAndFiltering(cql, test_keyspace):
                        [4, ["Dubai"], 3],
                        [3, ["Dubai"], 3])
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testMapKeyContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(categories))")
@@ -323,7 +319,6 @@ def testMapKeyContainsWithIndex(cql, test_keyspace):
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS ?",
                                  "test", 5, "lmn", "foo")
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testMapValueContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -356,7 +351,6 @@ def testMapValueContainsWithIndex(cql, test_keyspace):
                                 "test", 5, "foo", "notPresent"))
 
 # See CASSANDRA-7525
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testQueryMultipleIndexTypes(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         # create an index on
@@ -392,7 +386,6 @@ def testFilterWithIndexForContains(cql, test_keyspace):
             assert_empty(execute(cql, table, "SELECT * FROM %s WHERE k2 = ? AND v CONTAINS ? ALLOW FILTERING", 1, 7))
 
 # See CASSANDRA-8073
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testIndexLookupWithClusteringPrefix(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d set<int>, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "CREATE INDEX ON %s(d)")
@@ -412,7 +405,6 @@ def testIndexLookupWithClusteringPrefix(cql, test_keyspace):
             assert_rows(execute(cql, table,"SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?", 0, 1, 5),
                        [0, 1, 1, {3, 4, 5}])
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testContainsKeyAndContainsWithIndexOnMapKey(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(categories))")
@@ -433,7 +425,6 @@ def testContainsKeyAndContainsWithIndexOnMapKey(cql, test_keyspace):
                                "test", "foo", "lmn"),
                        ["test", 5, {"lmn": "foo"}])
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testContainsKeyAndContainsWithIndexOnMapValue(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -2544,7 +2535,6 @@ def testFilteringOnUdtContainingDurations(cql, test_keyspace):
                 assert_invalid_message(cql, table, "Slice restrictions are not supported on UDTs containing durations",
                     "SELECT * FROM %s WHERE u < {i: 1, d:3s} ALLOW FILTERING")
 
-@pytest.mark.xfail(reason="#2962 - we don't support index on collection column")
 def testFilteringOnCollectionsWithNull(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int, v int, l list<int>, s set<text>, m map<text, int>, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s (v)")

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -216,6 +216,7 @@ def testSelectKeyIn(cql, test_keyspace):
 
         assert_row_count(execute(cql, table, "SELECT firstname, lastname FROM %s WHERE userid IN (?, ?)", id1, id2), 2)
 
+@pytest.mark.xfail(reason="#10358 - Scylla doesn't throw error when UNSET_VALUE is used in WHERE clause")
 def testSetContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories set<text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -234,8 +235,10 @@ def testSetContainsWithIndex(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, "lmn"),
                        ["test", 5, {"lmn"}])
 
-            assert_invalid_message(cql, table, "Unsupported null value for column categories",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
+            # Scylla does not consider "= null" an error, it just matches nothing.
+            # See issue #4776.
+            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
             assert_invalid_message(cql, table, "Unsupported unset value for column categories",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
@@ -244,6 +247,7 @@ def testSetContainsWithIndex(cql, test_keyspace):
                                  "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ?", "xyz", "lmn", "notPresent")
             assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING", "xyz", "lmn", "notPresent"))
 
+@pytest.mark.xfail(reason="#10358 - Scylla doesn't throw error when UNSET_VALUE is used in WHERE clause")
 def testListContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories list<text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -261,8 +265,10 @@ def testListContainsWithIndex(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?;", "test", 5, "lmn"),
                        ["test", 5, ["lmn"]])
 
-            assert_invalid_message(cql, table, "Unsupported null value for column categories",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
+            # Scylla does not consider "= null" an error, it just matches nothing.
+            # See issue #4776.
+            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
             assert_invalid_message(cql, table, "Unsupported unset value for column categories",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
@@ -286,6 +292,7 @@ def testListContainsWithIndexAndFiltering(cql, test_keyspace):
                        [4, ["Dubai"], 3],
                        [3, ["Dubai"], 3])
 
+@pytest.mark.xfail(reason="#10358 - Scylla doesn't throw error when UNSET_VALUE is used in WHERE clause")
 def testMapKeyContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(categories))")
@@ -303,8 +310,10 @@ def testMapKeyContainsWithIndex(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, "lmn"),
                        ["test", 5, {"lmn": "foo"}])
 
-            assert_invalid_message(cql, table, "Unsupported null value for column categories",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, None)
+            # Scylla does not consider "= null" an error, it just matches nothing.
+            # See issue #4776.
+            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, None)
 
             assert_invalid_message(cql, table, "Unsupported unset value for column categories",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, UNSET_VALUE)
@@ -319,6 +328,7 @@ def testMapKeyContainsWithIndex(cql, test_keyspace):
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS ?",
                                  "test", 5, "lmn", "foo")
 
+@pytest.mark.xfail(reason="#10358 - Scylla doesn't throw error when UNSET_VALUE is used in WHERE clause")
 def testMapValueContainsWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
@@ -337,8 +347,10 @@ def testMapValueContainsWithIndex(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, "foo"),
                        ["test", 5, {"lmn": "foo"}])
 
-            assert_invalid_message(cql, table, "Unsupported null value for column categories",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
+            # Scylla does not consider "= null" an error, it just matches nothing.
+            # See issue #4776.
+            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
             assert_invalid_message(cql, table, "Unsupported unset value for column categories",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -259,3 +259,72 @@ def test_mv_synchronous_updates(cql, test_keyspace):
                 if wanted_trace2 in event.description:
                     wanted_traces_were_found[1] = True
             assert all(wanted_traces_were_found)
+
+# Reproduces #8627:
+# Whereas regular columns values are limited in size to 2GB, key columns are
+# limited to 64KB. This means that if a certain column is regular in the base
+# table but a key in one of its views, we cannot write to this regular column
+# an over-64KB value. Ideally, such a write should fail cleanly with an
+# InvalidQuery.
+# But today, neither Cassandra nor Scylla does this correctly. Both do not
+# detect the problem at the coordinator level, and both send the writes to the
+# replicas and fail the view update in each replica. The user's write may or
+# may not fail depending on whether the view update is done synchronously
+# (Scylla, sometimes) or asynchrhonously (Casandra). But even in the failure
+# case the failure does not explain why the replica writes failed - the only
+# message about a key being too long appears in the log.
+# Note that the same issue also applies to secondary indexes, and this is
+# tested in test_secondary_index.py.
+@pytest.mark.xfail(reason="issue #8627")
+def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
+    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
+        with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
+            big = 'x'*66536
+            with pytest.raises(InvalidRequest, match='size'):
+                cql.execute(f"INSERT INTO {table}(p,v) VALUES (1,'{big}')")
+            # Ideally, the entire write operation should be considered
+            # invalid, and no part of it will be done. In particular, the
+            # base write will also not happen.
+            assert [] == list(cql.execute(f"SELECT * FROM {table} WHERE p=1"))
+
+# Reproduces #8627:
+# Same as test_oversized_base_regular_view_key above, just check *view
+# building*- i.e., pre-existing data in the base table that needs to be
+# copied to the view. The view building cannot return an error to the user,
+# but we do expect it to skip the problematic row and continue to complete
+# the rest of the vew build.
+@pytest.mark.xfail(reason="issue #8627")
+# This test currently breaks the build (it repeats a failing build step,
+# and never complete) and we cannot quickly recognize this failure, so
+# to avoid a very slow failure, we currently "skip" this test.
+@pytest.mark.skip(reason="issue #8627, fails very slow")
+def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
+    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
+        # No materialized view yet - a "big" value in v is perfectly fine:
+        stmt = cql.prepare(f'INSERT INTO {table} (p,v) VALUES (?, ?)')
+        for i in range(30):
+            cql.execute(stmt, [i, str(i)])
+        big = 'x'*66536
+        cql.execute(stmt, [30, big])
+        assert [(30,big)] == list(cql.execute(f'SELECT * FROM {table} WHERE p=30'))
+        # Add a materialized view with v as the new key. The view build,
+        # copying data from the base table to the view, should start promptly.
+        with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
+            # If Scylla's view builder hangs or stops, there is no way to
+            # tell this state apart from a view build that simply hasn't
+            # completed yet (besides looking at the logs, which we don't).
+            # This means, unfortunately, that a failure of this test is slow -
+            # it needs to wait for a timeout.
+            start_time = time.time()
+            while time.time() < start_time + 30:
+                results = set(list(cql.execute(f'SELECT * from {mv}')))
+                # The oversized "big" cannot be a key in the view, so
+                # shouldn't be in results:
+                assert not (big, 30) in results
+                print(results)
+                # The rest of the items in the base table should be in
+                # the view:
+                if results == {(str(i), i) for i in range(30)}:
+                        break
+                time.sleep(0.1)
+            assert results == {(str(i), i) for i in range(30)}

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -475,7 +475,6 @@ def test_filter_and_limit_2(cql, test_keyspace):
 # (and therefore index) updates are synchronous, so none of these tests need
 # loops to wait for a change to be indexed.
 
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_list(cql, test_keyspace):
     schema = 'pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -532,7 +531,6 @@ def test_index_list(cql, test_keyspace):
         cql.execute(f'UPDATE {table} SET l = [] WHERE pk=1 AND ck=2')
         assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
 
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_set(cql, test_keyspace):
     schema = 'pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -585,7 +583,6 @@ def test_index_set(cql, test_keyspace):
         assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 17'))
         assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 18'))
 
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_map_values(cql, test_keyspace):
     schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -643,7 +640,6 @@ def test_index_map_values(cql, test_keyspace):
         cql.execute(f'UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2')
         assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 6'))
 
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_map_keys(cql, test_keyspace):
     schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -691,7 +687,6 @@ def test_index_map_keys(cql, test_keyspace):
         assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3'))
         assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4'))
 
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_map_entries(cql, test_keyspace):
     schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -740,7 +735,6 @@ def test_index_map_entries(cql, test_keyspace):
 
 # Check that it is possible to index the same map column in different ways
 # (values, keys and entries) at the same time:
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_map_multiple(cql, test_keyspace):
     schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -827,7 +821,7 @@ def test_index_collection_wrong_type(cql, test_keyspace):
 # Reproducer for issue #10707 - indexing a column whose name is a quoted
 # string should work fine. Even if the quoted string happens to look like
 # an instruction to index a collection, e.g., "keys(m)".
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962, #10707")
+@pytest.mark.xfail(reason="#10707")
 def test_index_quoted_names(cql, test_keyspace):
     quoted_names = ['"hEllo"', '"x y"', '"keys(m)"', '"values(m)"', '"entries(m)"']
     schema = 'pk int, ck int, m int, ' + ','.join([name + " int" for name in quoted_names]) + ', PRIMARY KEY (pk, ck)'

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -850,9 +850,8 @@ def test_index_collection_default_name(cql, test_keyspace):
 # Reproducer for issue #10707 - indexing a column whose name is a quoted
 # string should work fine. Even if the quoted string happens to look like
 # an instruction to index a collection, e.g., "keys(m)".
-@pytest.mark.xfail(reason="#10707")
 def test_index_quoted_names(cql, test_keyspace):
-    quoted_names = ['"hEllo"', '"x y"', '"keys(m)"', '"values(m)"', '"entries(m)"']
+    quoted_names = ['"hEllo"', '"x y"', '"hi""hello""yo"', '"""hi"""', '"keys(m)"', '"values(m)"', '"entries(m)"']
     schema = 'pk int, ck int, m int, ' + ','.join([name + " int" for name in quoted_names]) + ', PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
         for name in quoted_names:

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -751,7 +751,6 @@ def test_index_map_multiple(cql, test_keyspace):
 
 # Test that indexing keys(x), values(x) or entries(x) is only allowed for
 # specific column types (namely, specific kinds of collections).
-@pytest.mark.xfail(reason="collection indexing not implemented yet: issue #2962")
 def test_index_collection_wrong_type(cql, test_keyspace):
     schema = 'pk int primary key, x int, l list<int>, s set<int>, m map<int,int>, t tuple<int,int>'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -852,6 +852,12 @@ def test_index_quoted_names(cql, test_keyspace):
         for name in quoted_names:
             assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE {name} CONTAINS KEY 3'))
 
+@pytest.mark.xfail(reason="#10713 - local collection indexing is not implemented yet")
+def test_local_secondary_index_on_collection(cql, test_keyspace):
+    schema = 'pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'CREATE INDEX ON {table}((pk), l)')
+
 # Test that queries with the index over collection provide the same answer as it
 # would be without index, but with ALLOW FILTERING.
 # The operations on collections here are picked up randomly.

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -182,7 +182,7 @@ public:
         return ret;
     }
     template <typename Range> // range of managed_bytes_opt or managed_bytes_view_opt
-    requires requires (Range it) { {it.begin()->value()} -> std::convertible_to<managed_bytes_view>; }
+    requires requires (Range it) { {std::begin(it)->value()} -> std::convertible_to<managed_bytes_view>; }
     static managed_bytes build_value_fragmented(Range&& range) {
         size_t size = 0;
         for (auto&& v : range) {

--- a/view_info.hh
+++ b/view_info.hh
@@ -24,6 +24,7 @@ class view_info final {
     mutable shared_ptr<cql3::statements::select_statement> _select_statement;
     mutable std::optional<query::partition_slice> _partition_slice;
     db::view::base_info_ptr _base_info;
+    mutable bool _has_computed_column_depending_on_base_non_primary_key;
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info);
 
@@ -52,6 +53,9 @@ public:
     const column_definition* view_column(const schema& base, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;
     bool has_base_non_pk_columns_in_view_pk() const;
+    bool has_computed_column_depending_on_base_non_primary_key() const {
+        return _has_computed_column_depending_on_base_non_primary_key;
+    }
 
     /// Returns a pointer to the base_dependent_view_info which matches the current
     /// schema of the base table.


### PR DESCRIPTION
This pull request introduces global secondary-indexing for non-frozen collections.

The intent is to enable such queries:

```
CREATE TABLE test(int id, somemap map<int, int>, somelist<int>, someset<int>, PRIMARY KEY(id));
CREATE INDEX ON test(keys(somemap));
CREATE INDEX ON test(values(somemap));
CREATE INDEX ON test(entries(somemap));
CREATE INDEX ON test(values(somelist));
CREATE INDEX ON test(values(someset));

-- index on test(c) is the same as index on (values(c))
CREATE INDEX IF NOT EXISTS ON test(somelist);    
CREATE INDEX IF NOT EXISTS ON test(someset);
CREATE INDEX IF NOT EXISTS ON test(somemap);

SELECT * FROM test WHERE someset CONTAINS 7;
SELECT * FROM test WHERE somelist CONTAINS 7;
SELECT * FROM test WHERE somemap CONTAINS KEY 7;
SELECT * FROM test WHERE somemap CONTAINS 7;
SELECT * FROM test WHERE somemap[7] = 7;
```

We use here all-familiar materialized views (MVs). Scylla treats all the collections the same way - they're a list of pairs (key, value). In case of sets, the value type is dummy one. In case of lists, the key type is TIMEUUID. When describing the design, I will forget that there is more than one collection type.
Suppose that the columns in the base table were as follows:

```
pkey int, ckey1 int, ckey2 int, somemap map<int, text>, PRIMARY KEY(pkey, ckey1, ckey2)
```

The MV schema is as follows (the names of columns which are not the same as in base might be different). All the columns here form the primary key.

```
-- for index over entries
indexed_coll (int, text), idx_token long, pkey int, ckey1 int, ckey2 int
-- for index over keys
indexed_coll int, idx_token long, pkey int, ckey1 int, ckey2 int
-- for index over values
indexed_coll text, idx_token long, pkey int, ckey1 int, ckey2 int, coll_keys_for_values_index int
```

The reason for the last additional column is that the values from a collection might not be unique.

Fixes #2962
Fixes #8745
Fixes #10707

This patch does not implement **local** secondary indexes for collection columns: Refs #10713.