### PR TITLE
Memtable flush: wait for sstable count reduction if needed

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -66,6 +66,13 @@ private:
         // Raised by any function running under run_with_compaction_disabled();
         long compaction_disabled_counter = 0;
 
+        // Signaled whenever a compaction task completes.
+        condition_variable compaction_done;
+
+        compaction_state() = default;
+        compaction_state(compaction_state&&) = default;
+        ~compaction_state();
+
         bool compaction_disabled() const noexcept {
             return compaction_disabled_counter > 0;
         }
@@ -378,6 +385,13 @@ public:
 
     // Submit a table to be compacted.
     void submit(compaction::table_state& t);
+
+    // Can regular compaction be performed in the given table
+    bool can_perform_regular_compaction(compaction::table_state& t);
+
+    // Maybe wait before adding more sstables
+    // if there are too many sstables.
+    future<> maybe_wait_for_sstable_count_reduction(compaction::table_state& t);
 
     // Submit a table to be off-strategy compacted.
     // Returns true iff off-strategy compaction was required and performed.

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -141,7 +141,7 @@ public:
 
 
     sstables::compaction_descriptor get_descriptor_for_level(int level, const std::vector<std::optional<dht::decorated_key>>& last_compacted_keys,
-                                                             std::vector<int>& compaction_counter) {
+                                                             const std::vector<int>& compaction_counter) {
         auto info = get_candidates_for(level, last_compacted_keys);
         if (!info.candidates.empty()) {
             int next_level = get_next_level(info.candidates, info.can_promote);
@@ -162,7 +162,7 @@ public:
      * If no compactions are necessary, will return null
      */
     sstables::compaction_descriptor get_compaction_candidates(const std::vector<std::optional<dht::decorated_key>>& last_compacted_keys,
-        std::vector<int>& compaction_counter) {
+        const std::vector<int>& compaction_counter) {
         // LevelDB gives each level a score of how much data it contains vs its ideal amount, and
         // compacts the level with the highest score. But this falls apart spectacularly once you
         // get behind.  Consider this set of levels:

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -221,20 +221,22 @@ time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_
         return compaction_descriptor();
     }
 
-    // Find fully expired SSTables. Those will be included no matter what.
-    std::unordered_set<shared_sstable> expired;
-
     if (db_clock::now() - _last_expired_check > _options.expired_sstable_check_frequency) {
         clogger.debug("[{}] TWCS expired check sufficiently far in the past, checking for fully expired SSTables", fmt::ptr(this));
+
+        // Find fully expired SSTables. Those will be included no matter what.
+        std::unordered_set<shared_sstable> expired;
         expired = table_s.fully_expired_sstables(candidates, compaction_time);
+        if (!expired.empty()) {
+            clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
+            return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
+        }
+        // Keep checking for fully_expired_sstables until we don't find
+        // any among the candidates, meaning they are either already compacted
+        // or registered for compaction.
         _last_expired_check = db_clock::now();
     } else {
         clogger.debug("[{}] TWCS skipping check for fully expired SSTables", fmt::ptr(this));
-    }
-
-    if (!expired.empty()) {
-        clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
-        return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
     }
 
     auto compaction_candidates = get_next_non_expired_sstables(table_s, control, std::move(candidates), compaction_time);

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -225,19 +225,20 @@ time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_
     std::unordered_set<shared_sstable> expired;
 
     if (db_clock::now() - _last_expired_check > _options.expired_sstable_check_frequency) {
-        clogger.debug("TWCS expired check sufficiently far in the past, checking for fully expired SSTables");
+        clogger.debug("[{}] TWCS expired check sufficiently far in the past, checking for fully expired SSTables", fmt::ptr(this));
         expired = table_s.fully_expired_sstables(candidates, compaction_time);
         _last_expired_check = db_clock::now();
     } else {
-        clogger.debug("TWCS skipping check for fully expired SSTables");
+        clogger.debug("[{}] TWCS skipping check for fully expired SSTables", fmt::ptr(this));
     }
 
     if (!expired.empty()) {
-        clogger.debug("Going to compact {} expired sstables", expired.size());
+        clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
         return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
     }
 
     auto compaction_candidates = get_next_non_expired_sstables(table_s, control, std::move(candidates), compaction_time);
+    clogger.debug("[{}] Going to compact {} non-expired sstables", fmt::ptr(this), compaction_candidates.size());
     return compaction_descriptor(std::move(compaction_candidates), service::get_local_compaction_priority());
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -761,6 +761,9 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
                 _memtables->erase(old);
                 co_return;
             }
+            if (!_async_gate.is_closed()) {
+                co_await _compaction_manager.maybe_wait_for_sstable_count_reduction(as_table_state());
+            }
         } catch (...) {
             err = std::current_exception();
         }

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -32,6 +32,7 @@
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/simple_schema.hh"
 #include "utils/error_injection.hh"
+#include "db/commitlog/commitlog.hh"
 #include "test/lib/make_random_string.hh"
 
 static api::timestamp_type next_timestamp() {
@@ -1005,3 +1006,81 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
     });
 #endif
 }
+
+SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
+    BOOST_ASSERT(smp::count == 2);
+    // The test simulates a situation where 2 threads issue flushes to 2
+    // tables. Both issue small flushes, but one has injected reactor stalls.
+    // This can lead to a situation where lots of small sstables accumulate on
+    // disk, and, if compaction never has a chance to keep up, resources can be
+    // exhausted.
+    return do_with_cql_env([](cql_test_env& env) -> future<> {
+        struct flusher {
+            cql_test_env& env;
+            const int num_flushes;
+            const int sleep_ms;
+
+            static sstring cf_name(unsigned thread_id) {
+                return format("cf_{}", thread_id);
+            }
+
+            static sstring ks_name() {
+                return "ks";
+            }
+
+            future<> create_table(schema_ptr s) {
+                return env.migration_manager().invoke_on(0, [s = global_schema_ptr(std::move(s))] (service::migration_manager& mm) -> future<> {
+                    auto group0_guard = co_await mm.start_group0_operation();
+                    auto ts = group0_guard.write_timestamp();
+                    auto announcement = co_await mm.prepare_new_column_family_announcement(s, ts);
+                    co_await mm.announce(std::move(announcement), std::move(group0_guard));
+                });
+            }
+
+            future<> drop_table() {
+                return env.migration_manager().invoke_on(0, [shard = this_shard_id()] (service::migration_manager& mm) -> future<> {
+                    auto group0_guard = co_await mm.start_group0_operation();
+                    auto ts = group0_guard.write_timestamp();
+                    auto announcement = co_await mm.prepare_column_family_drop_announcement(ks_name(), cf_name(shard), ts);
+                    co_await mm.announce(std::move(announcement), std::move(group0_guard));
+                });
+            }
+
+            future<> operator()() {
+                const sstring ks_name = this->ks_name();
+                const sstring cf_name = this->cf_name(this_shard_id());
+                random_mutation_generator gen{
+                    random_mutation_generator::generate_counters::no,
+                    local_shard_only::yes,
+                    random_mutation_generator::generate_uncompactable::no,
+                    std::nullopt,
+                    ks_name.c_str(),
+                    cf_name.c_str()
+                };
+                schema_ptr s = gen.schema();
+
+                co_await create_table(s);
+                replica::database& db = env.local_db();
+                replica::table& t = db.find_column_family(ks_name, cf_name);
+
+                for (int value : boost::irange<int>(0, num_flushes)) {
+                    ::usleep(sleep_ms * 1000);
+                    co_await db.apply(t.schema(), freeze(gen()), tracing::trace_state_ptr(), db::commitlog::force_sync::yes, db::no_timeout);
+                    co_await t.flush();
+                    BOOST_ASSERT(t.sstables_count() < t.schema()->max_compaction_threshold() * 2);
+                }
+                co_await drop_table();
+            }
+        };
+
+        int sleep_ms = 2;
+        for (int i : boost::irange<int>(8)) {
+            future<> f0 = smp::submit_to(0, flusher{.env=env, .num_flushes=100, .sleep_ms=0});
+            future<> f1 = smp::submit_to(1, flusher{.env=env, .num_flushes=3, .sleep_ms=sleep_ms});
+            co_await std::move(f0);
+            co_await std::move(f1);
+            sleep_ms *= 2;
+        }
+    });
+}
+

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -52,7 +52,7 @@ public:
     // tombstone will cover data, i.e. compacting the mutation will not result
     // in any changes.
     explicit random_mutation_generator(generate_counters, local_shard_only lso = local_shard_only::yes,
-            generate_uncompactable uc = generate_uncompactable::no, std::optional<uint32_t> seed_opt = std::nullopt);
+            generate_uncompactable uc = generate_uncompactable::no, std::optional<uint32_t> seed_opt = std::nullopt, const char* ks_name="ks", const char* cf_name="cf");
     random_mutation_generator(generate_counters gc, uint32_t seed)
             : random_mutation_generator(gc, local_shard_only::yes, generate_uncompactable::no, seed) {}
     ~random_mutation_generator();


### PR DESCRIPTION
Called from try_flush_memtable_to_sstable,
maybe_wait_for_sstable_count_reduction will wait for
compaction to catch up with memtable flush if there
the bucket to compact is inflated, having too many
sstables.  In that case we don't want to add fuel
to the fire by creating yet another sstable.

Fixes #4116