### PR TITLE
Branch 5.0: backport 'range_tombstone_change_generator: flush: emit closing range_tombstone_change'

### DIFF
--- a/range_tombstone_change_generator.hh
+++ b/range_tombstone_change_generator.hh
@@ -71,6 +71,11 @@ public:
     // FIXME: respect preemption
     template<RangeTombstoneChangeConsumer C>
     void flush(position_in_partition_view upper_bound, C consumer) {
+        if (_range_tombstones.empty()) {
+            _lower_bound = upper_bound;
+            return;
+        }
+
         position_in_partition::less_compare less(_schema);
         std::optional<range_tombstone> prev;
 


### PR DESCRIPTION
This series backports 0a3aba36e6e4b78ef6e7bb2f5ee204aa2cccfe1c to branch 5.0.

It ensures that a closing range_tombstone_change is emitted if the highest tombstone is open ended
since range_tombstone_change_generator::flush does not do it by default.

With the additional testing added 9a59e9369b87b1bcefed6d1d5edf25c5d3451bc4 unit tests fail without the additional patches in the series, so it exposes a latent bug in the branch where the closing range_tombstone_change is not always emitted when flushing on end of partition of end of position range.

One additional change was required for unit tests to pass:
```diff
diff --git a/range_tombstone_change_generator.hh b/range_tombstone_change_generator.hh
index 6f98be5dce..9cde8d9b20 100644
--- a/range_tombstone_change_generator.hh
+++ b/range_tombstone_change_generator.hh
@@ -78,6 +78,7 @@ class range_tombstone_change_generator {
     template<RangeTombstoneChangeConsumer C>
     void flush(const position_in_partition_view upper_bound, C consumer) {
         if (_range_tombstones.empty()) {
+            _lower_bound = upper_bound;
             return;
         }
 
```

Refs https://github.com/scylladb/scylla/issues/10316