### PR TITLE
range_tombstone_change_generator: update _lower_bound on early return when empty

### DIFF
--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -73,9 +73,10 @@ private:
     }
 
 public:
-    frozen_mutation_consumer_adaptor(schema_ptr s, Consumer& consumer)
+    frozen_mutation_consumer_adaptor(schema_ptr s, Consumer& consumer,
+            mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none)
         : _schema(*s)
-        , _rt_gen(_schema)
+        , _rt_gen(_schema, validation_level)
         , _consumer(consumer)
     {
     }
@@ -197,7 +198,7 @@ public:
     // will be called each time the consume is stopping, regardless of whether
     // you are pausing or the consumption is ending for good.
     template<FlattenedConsumerV2 Consumer>
-    auto consume(schema_ptr s, Consumer& consumer) const -> frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>;
+    auto consume(schema_ptr s, Consumer& consumer, mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none) const -> frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>;
 
     template<FlattenedConsumerV2 Consumer>
     auto consume(schema_ptr s, frozen_mutation_consumer_adaptor<Consumer>& adaptor) const -> frozen_mutation_consume_result<decltype(adaptor.consumer().consume_end_of_stream())>;
@@ -212,7 +213,7 @@ public:
     // will be called each time the consume is stopping, regardless of whether
     // you are pausing or the consumption is ending for good.
     template<FlattenedConsumerV2 Consumer>
-    auto consume_gently(schema_ptr s, Consumer& consumer) const -> future<frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>>;
+    auto consume_gently(schema_ptr s, Consumer& consumer, mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none) const -> future<frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>>;
 
     template<FlattenedConsumerV2 Consumer>
     auto consume_gently(schema_ptr s, frozen_mutation_consumer_adaptor<Consumer>& adaptor) const -> future<frozen_mutation_consume_result<decltype(adaptor.consumer().consume_end_of_stream())>>;
@@ -302,8 +303,8 @@ auto frozen_mutation::consume(schema_ptr s, frozen_mutation_consumer_adaptor<Con
 }
 
 template<FlattenedConsumerV2 Consumer>
-auto frozen_mutation::consume(schema_ptr s, Consumer& consumer) const -> frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())> {
-    frozen_mutation_consumer_adaptor adaptor(s, consumer);
+auto frozen_mutation::consume(schema_ptr s, Consumer& consumer, mutation_fragment_stream_validation_level validation_level) const -> frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())> {
+    frozen_mutation_consumer_adaptor adaptor(s, consumer, validation_level);
     return consume(s, adaptor);
 }
 
@@ -322,8 +323,8 @@ auto frozen_mutation::consume_gently(schema_ptr s, frozen_mutation_consumer_adap
 }
 
 template<FlattenedConsumerV2 Consumer>
-auto frozen_mutation::consume_gently(schema_ptr s, Consumer& consumer) const -> future<frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>> {
-    frozen_mutation_consumer_adaptor adaptor(s, consumer);
+auto frozen_mutation::consume_gently(schema_ptr s, Consumer& consumer, mutation_fragment_stream_validation_level validation_level) const -> future<frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>> {
+    frozen_mutation_consumer_adaptor adaptor(s, consumer, validation_level);
     co_return co_await consume_gently(s, adaptor);
 }
 

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -195,7 +195,7 @@ size_t mutation::memory_usage(const ::schema& s) const {
 mutation reverse(mutation mut) {
     auto reverse_schema = mut.schema()->make_reversed();
     mutation_rebuilder_v2 reverse_rebuilder(reverse_schema);
-    return *std::move(mut).consume(reverse_rebuilder, consume_in_reverse::yes).result;
+    return *std::move(mut).consume(reverse_rebuilder, consume_in_reverse::yes, mutation_fragment_stream_validation_level::none).result;
 }
 
 namespace {

--- a/mutation/range_tombstone_change_generator.hh
+++ b/mutation/range_tombstone_change_generator.hh
@@ -78,6 +78,7 @@ public:
     template<RangeTombstoneChangeConsumer C>
     void flush(const position_in_partition_view upper_bound, C consumer, bool end_of_range = false) {
         if (_range_tombstones.empty()) {
+            _lower_bound = upper_bound;
             return;
         }
 

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -175,7 +175,8 @@ future<query::result> to_data_query_result(
         const query::partition_slice&,
         uint64_t row_limit,
         uint32_t partition_limit,
-        query::result_options opts = query::result_options::only_result());
+        query::result_options opts = query::result_options::only_result(),
+        mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // Query the content of the mutation.
 //
@@ -185,7 +186,8 @@ query::result query_mutation(
         const query::partition_slice& slice,
         uint64_t row_limit = query::max_rows,
         gc_clock::time_point now = gc_clock::now(),
-        query::result_options opts = query::result_options::only_result());
+        query::result_options opts = query::result_options::only_result(),
+        mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // Performs a query for counter updates.
 future<mutation_opt> counter_write_query(schema_ptr, const mutation_source&, reader_permit permit,

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -189,6 +189,13 @@ query::result query_mutation(
         query::result_options opts = query::result_options::only_result(),
         mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
+inline query::result query_mutation(
+        mutation&& m,
+        const query::partition_slice& slice,
+        mutation_fragment_stream_validation_level validation_level) {
+    return query_mutation(std::move(m), slice, query::max_rows, gc_clock::now(), query::result_options::only_result(), validation_level);
+}
+
 // Performs a query for counter updates.
 future<mutation_opt> counter_write_query(schema_ptr, const mutation_source&, reader_permit permit,
                                          const dht::decorated_key& dk,

--- a/query-result-set.cc
+++ b/query-result-set.cc
@@ -206,9 +206,9 @@ result_set::from_raw_result(schema_ptr s, const partition_slice& slice, const re
     return builder.build();
 }
 
-result_set::result_set(const mutation& m) : result_set([&m] {
+result_set::result_set(const mutation& m, mutation_fragment_stream_validation_level validation_level) : result_set([&m, validation_level] {
     auto slice = partition_slice_builder(*m.schema()).build();
-    auto qr = query_mutation(mutation(m), slice);
+    auto qr = query_mutation(mutation(m), slice, validation_level);
     return result_set::from_raw_result(m.schema(), slice, qr);
 }())
 { }

--- a/query-result-set.hh
+++ b/query-result-set.hh
@@ -13,6 +13,7 @@
 #include <fmt/ostream.h>
 #include "types/types.hh"
 #include "schema/schema.hh"
+#include "mutation/mutation_fragment_stream_validator.hh"
 
 #include <optional>
 #include <stdexcept>
@@ -104,7 +105,7 @@ public:
     result_set(schema_ptr s, std::vector<result_set_row>&& rows)
         : _schema(std::move(s)), _rows{std::move(rows)}
     { }
-    explicit result_set(const mutation&);
+    explicit result_set(const mutation&, mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
     bool empty() const {
         return _rows.empty();
     }

--- a/readers/from_mutations_v2.hh
+++ b/readers/from_mutations_v2.hh
@@ -28,7 +28,8 @@ make_flat_mutation_reader_from_mutations_v2(
     reader_permit permit,
     mutation m,
     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-    bool reversed = false);
+    bool reversed = false,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // Reader optimized for a single mutation.
 flat_mutation_reader_v2
@@ -37,7 +38,8 @@ make_flat_mutation_reader_from_mutations_v2(
     reader_permit permit,
     mutation m,
     const query::partition_slice& slice,
-    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // All mutations should have the same schema.
 flat_mutation_reader_v2 make_flat_mutation_reader_from_mutations_v2(
@@ -45,18 +47,21 @@ flat_mutation_reader_v2 make_flat_mutation_reader_from_mutations_v2(
     reader_permit permit,
     std::vector<mutation>,
     const dht::partition_range& pr,
-    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // All mutations should have the same schema.
 inline flat_mutation_reader_v2 make_flat_mutation_reader_from_mutations_v2(
     schema_ptr schema,
     reader_permit permit,
     std::vector<mutation> ms,
-    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no) {
+    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none) {
     if (ms.size() == 1) {
-        return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms.back()), fwd);
+        constexpr bool reversed = false;
+        return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms.back()), fwd, reversed, validation_level);
     }
-    return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms), query::full_partition_range, fwd);
+    return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms), query::full_partition_range, fwd, validation_level);
 }
 
 // All mutations should have the same schema.
@@ -67,7 +72,8 @@ make_flat_mutation_reader_from_mutations_v2(
     std::vector<mutation> ms,
     const dht::partition_range& pr,
     const query::partition_slice& slice,
-    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
 // All mutations should have the same schema.
 inline flat_mutation_reader_v2
@@ -76,9 +82,10 @@ make_flat_mutation_reader_from_mutations_v2(
     reader_permit permit,
     std::vector<mutation> ms,
     const query::partition_slice& slice,
-    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no) {
+    streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+    mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none) {
     if (ms.size() == 1) {
-        return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms.back()), slice, fwd);
+        return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms.back()), slice, fwd, validation_level);
     }
-    return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms), query::full_partition_range, slice, fwd);
+    return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(ms), query::full_partition_range, slice, fwd, validation_level);
 }

--- a/readers/from_mutations_v2.hh
+++ b/readers/from_mutations_v2.hh
@@ -31,6 +31,17 @@ make_flat_mutation_reader_from_mutations_v2(
     bool reversed = false,
     mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);
 
+inline flat_mutation_reader_v2
+make_flat_mutation_reader_from_mutations_v2(
+    schema_ptr schema,
+    reader_permit permit,
+    mutation m,
+    mutation_fragment_stream_validation_level validation_level) {
+    constexpr bool reversed = false;
+    return make_flat_mutation_reader_from_mutations_v2(std::move(schema), std::move(permit), std::move(m),
+            streamed_mutation::forwarding::no, reversed, validation_level);
+}
+
 // Reader optimized for a single mutation.
 flat_mutation_reader_v2
 make_flat_mutation_reader_from_mutations_v2(

--- a/readers/generating_v2.hh
+++ b/readers/generating_v2.hh
@@ -10,6 +10,7 @@
 #include "schema/schema_fwd.hh"
 #include <seastar/core/future.hh>
 #include "mutation/mutation_fragment_fwd.hh"
+#include "mutation/mutation_fragment_stream_validator.hh"
 
 using namespace seastar;
 
@@ -20,4 +21,5 @@ flat_mutation_reader_v2
 make_generating_reader_v2(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_v2_opt> ()> get_next_fragment);
 
 flat_mutation_reader_v2
-make_generating_reader_v1(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_opt> ()> get_next_fragment);
+make_generating_reader_v1(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_opt> ()> get_next_fragment,
+        mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none);

--- a/readers/upgrading_consumer.hh
+++ b/readers/upgrading_consumer.hh
@@ -30,8 +30,9 @@ class upgrading_consumer {
     }
 
 public:
-    upgrading_consumer(const schema& schema, reader_permit permit, EndConsumer&& end_consumer)
-        : _schema(schema), _permit(std::move(permit)), _end_consumer(std::move(end_consumer)), _rt_gen(_schema)
+    upgrading_consumer(const schema& schema, reader_permit permit, EndConsumer&& end_consumer,
+            mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::none)
+        : _schema(schema), _permit(std::move(permit)), _end_consumer(std::move(end_consumer)), _rt_gen(_schema, validation_level)
     {}
     void set_position_range(position_range pr) {
         _rt_gen.trim(pr.start());

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -56,9 +56,9 @@ private:
     upgrading_consumer<consumer> _consumer;
 
 public:
-    mutation_fragment_queue(schema_ptr s, reader_permit permit, seastar::shared_ptr<impl> impl)
+    mutation_fragment_queue(schema_ptr s, reader_permit permit, seastar::shared_ptr<impl> impl, mutation_fragment_stream_validation_level validation_level)
         : _impl(std::move(impl))
-        , _consumer(*s, std::move(permit), consumer(_impl->pending()))
+        , _consumer(*s, std::move(permit), consumer(_impl->pending()), validation_level)
     {}
 
     future<> push(mutation_fragment mf) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1249,6 +1249,9 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair();
+    cfg.validation_level = db_config.enable_sstable_key_validation()
+            ? mutation_fragment_stream_validation_level::clustering_key
+            : mutation_fragment_stream_validation_level::token;
 
     return cfg;
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -419,6 +419,7 @@ public:
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
+        mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::token;
     };
 
     struct snapshot_details {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2646,7 +2646,7 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
             *this,
             base,
             std::move(views),
-            make_flat_mutation_reader_from_mutations_v2(std::move(m_schema), std::move(permit), std::move(m)),
+            make_flat_mutation_reader_from_mutations_v2(std::move(m_schema), std::move(permit), std::move(m), _config.validation_level),
             std::move(existings),
             now);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5098,8 +5098,12 @@ protected:
                         && !data_resolver->any_partition_short_read()) {
                     tracing::trace(_trace_state, "Read stage is done for read-repair");
                     mlogger.trace("reconciled: {}", rr_opt->pretty_printer(_schema));
+                    auto validation_level = _proxy->local_db().get_config().enable_sstable_key_validation()
+                        ? mutation_fragment_stream_validation_level::clustering_key
+                        : mutation_fragment_stream_validation_level::token;
                     auto result = ::make_foreign(::make_lw_shared<query::result>(
-                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit)));
+                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit,
+                                    query::result_options::only_result(), validation_level)));
                     qlogger.trace("reconciled: {}", result->pretty_printer(_schema, _cmd->slice));
                     // wait for write to complete before returning result to prevent multiple concurrent read requests to
                     // trigger repair multiple times and to prevent quorum read to return an old value, even after a quorum
@@ -6439,8 +6443,11 @@ storage_proxy::query_nonsingular_data_locally(schema_ptr s, lw_shared_ptr<query:
         ret = co_await query_data_on_all_shards(_db, std::move(s), *local_cmd, ranges, opts, std::move(trace_state), timeout);
     } else {
         auto res = co_await query_mutations_on_all_shards(_db, s, *local_cmd, ranges, std::move(trace_state), timeout);
+        auto validation_level = _db.local().get_config().enable_sstable_key_validation()
+            ? mutation_fragment_stream_validation_level::clustering_key
+            : mutation_fragment_stream_validation_level::token;
         ret = rpc::tuple(make_foreign(make_lw_shared<query::result>(co_await to_data_query_result(std::move(*std::get<0>(res)), std::move(s), local_cmd->slice,
-                local_cmd->get_row_limit(), local_cmd->partition_limit, opts))), std::get<1>(res));
+                local_cmd->get_row_limit(), local_cmd->partition_limit, opts, validation_level))), std::get<1>(res));
     }
     co_return ret;
 }

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -104,7 +104,7 @@ public:
         std::function<bool(const sstable&)> filter,
         partition_key pk, schema_ptr schema, reader_permit permit,
         streamed_mutation::forwarding fwd_sm,
-        bool reversed) const;
+        bool reversed, mutation_fragment_stream_validation_level validation_level) const;
 
     virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
         replica::column_family*,

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -31,6 +31,7 @@
 #include "readers/generating_v2.hh"
 #include "service/topology_guard.hh"
 #include "utils/error_injection.hh"
+#include "db/config.hh"
 
 namespace streaming {
 
@@ -197,9 +198,12 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             auto op = table.stream_in_progress();
             auto sharder_ptr = std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this());
             auto& sharder = *sharder_ptr;
+            auto validation_level = _db.local().get_config().enable_sstable_key_validation()
+                ? mutation_fragment_stream_validation_level::clustering_key
+                : mutation_fragment_stream_validation_level::token;
             //FIXME: discarded future.
             (void)mutation_writer::distribute_reader_and_consume_on_shards(s, sharder,
-                make_generating_reader_v1(s, permit, std::move(get_next_mutation_fragment)),
+                make_generating_reader_v1(s, permit, std::move(get_next_mutation_fragment), validation_level),
                 make_streaming_consumer("streaming", _db, _sys_dist_ks, _view_update_generator, estimated_partitions, reason, is_offstrategy_supported(reason), topo_guard),
                 std::move(op)
             ).then_wrapped([s, plan_id, from, sink, estimated_partitions, log_done, sh_ptr = std::move(sharder_ptr)] (future<uint64_t> f) mutable {

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -118,7 +118,7 @@ SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_fragment) {
     for_each_mutation([&] (const mutation& m) {
         auto& s = *m.schema();
         std::vector<mutation_fragment> mfs;
-        auto rd = mutation_fragment_v1_stream{make_flat_mutation_reader_from_mutations_v2(m.schema(), semaphore.make_permit(), { m })};
+        auto rd = mutation_fragment_v1_stream{make_flat_mutation_reader_from_mutations_v2(m.schema(), semaphore.make_permit(), m, mutation_fragment_stream_validation_level::clustering_key)};
         auto close_rd = deferred_close(rd);
         rd.consume_pausable([&] (mutation_fragment mf) {
             mfs.emplace_back(std::move(mf));
@@ -202,7 +202,7 @@ SEASTAR_TEST_CASE(frozen_mutation_is_consumed_in_order) {
 
         testlog.info("Validating frozen_mutation::consume_gently: rebuilding mutation");
         mutation_rebuilder_v2 rebuilder(s);
-        auto rebuilt_mut = fm.consume(s, rebuilder).result;
+        auto rebuilt_mut = fm.consume(s, rebuilder, mutation_fragment_stream_validation_level::clustering_key).result;
         assert_that(rebuilt_mut).has_mutation();
         assert_that(std::move(*rebuilt_mut)).is_equal_to(m);
     };

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -185,11 +185,11 @@ SEASTAR_TEST_CASE(frozen_mutation_is_consumed_in_order) {
     auto validate_consume = [] (schema_ptr s, const frozen_mutation& fm, const mutation& m) {
         testlog.info("Validating frozen_mutation::consume");
         auto c = validating_consumer(*s);
-        fm.consume(s, c);
+        fm.consume(s, c, mutation_fragment_stream_validation_level::clustering_key);
 
         testlog.info("Validating frozen_mutation::consume: rebuilding mutation");
         mutation_rebuilder_v2 rebuilder(s);
-        auto rebuilt_mut = fm.consume(s, rebuilder).result;
+        auto rebuilt_mut = fm.consume(s, rebuilder, mutation_fragment_stream_validation_level::clustering_key).result;
         assert_that(rebuilt_mut).has_mutation();
         assert_that(std::move(*rebuilt_mut)).is_equal_to(m);
     };
@@ -197,7 +197,7 @@ SEASTAR_TEST_CASE(frozen_mutation_is_consumed_in_order) {
     auto validate_consume_gently = [] (schema_ptr s, const frozen_mutation& fm, const mutation& m) -> future<> {
         testlog.info("Validating frozen_mutation::consume_gently");
         auto c = validating_consumer(*s);
-        auto adaptor = frozen_mutation_consumer_adaptor(s, c);
+        auto adaptor = frozen_mutation_consumer_adaptor(s, c, mutation_fragment_stream_validation_level::clustering_key);
         co_await fm.consume_gently(s, adaptor);
 
         testlog.info("Validating frozen_mutation::consume_gently: rebuilding mutation");

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -790,7 +790,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_reversed) {
 
             std::vector<query::result_set_row> expected_rows;
             for (const auto& mut : expected_results) {
-                auto rs = query::result_set(mut);
+                auto rs = query::result_set(mut, mutation_fragment_stream_validation_level::clustering_key);
                 // mut re-sorts rows into forward order, so we have to reverse them again here
                 std::copy(rs.rows().rbegin(), rs.rows().rend(), std::back_inserter(expected_rows));
             }

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -45,7 +45,7 @@ SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
             }
 
             for (auto&& m : partitions) {
-                auto rd = make_flat_mutation_reader_from_mutations_v2(s, semaphore.make_permit(), {m});
+                auto rd = make_flat_mutation_reader_from_mutations_v2(s, semaphore.make_permit(), {m}, mutation_fragment_stream_validation_level::clustering_key);
                 auto close_rd = deferred_close(rd);
                 auto muts = rd.consume(fragment_scatterer(s, n)).get();
                 for (int i = 0; i < n; ++i) {
@@ -335,7 +335,7 @@ SEASTAR_TEST_CASE(test_schema_upgrader_is_equivalent_with_mutation_upgrade) {
             if (m1.schema()->version() != m2.schema()->version()) {
                 // upgrade m1 to m2's schema
 
-                auto reader = transform(make_flat_mutation_reader_from_mutations_v2(m1.schema(), semaphore.make_permit(), {m1}), schema_upgrader_v2(m2.schema()));
+                auto reader = transform(make_flat_mutation_reader_from_mutations_v2(m1.schema(), semaphore.make_permit(), {m1}, mutation_fragment_stream_validation_level::clustering_key), schema_upgrader_v2(m2.schema()));
                 auto close_reader = deferred_close(reader);
                 auto from_upgrader = read_mutation_from_flat_mutation_reader(reader).get();
 

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -62,7 +62,7 @@ static mutation_source make_source(std::vector<mutation> mutations) {
                 assert(m.schema() == s);
             }
         }
-        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), mutations, slice, fwd);
+        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), mutations, slice, fwd, mutation_fragment_stream_validation_level::clustering_key);
     });
 }
 
@@ -579,7 +579,7 @@ SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer) {
 
     // Rebuild mutation by consuming from the frozen_mutation
     mutation_rebuilder_v2 rebuilder(s);
-    auto res = fm.consume(s, rebuilder);
+    auto res = fm.consume(s, rebuilder, mutation_fragment_stream_validation_level::clustering_key);
     BOOST_REQUIRE(res.result);
     const auto& rebuilt = *res.result;
     BOOST_REQUIRE_EQUAL(rebuilt, m);

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -78,7 +78,8 @@ static query::result_memory_accounter make_accounter() {
 
 // Called from a seastar thread
 query::result_set to_result_set(const reconcilable_result& r, schema_ptr s, const query::partition_slice& slice) {
-    return query::result_set::from_raw_result(s, slice, to_data_query_result(r, s, slice, inf32, inf32).get());
+    return query::result_set::from_raw_result(s, slice, to_data_query_result(r, s, slice, inf32, inf32,
+            query::result_options::only_result(), mutation_fragment_stream_validation_level::clustering_key).get());
 }
 
 static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, const mutation_source& source, const dht::partition_range& range,
@@ -462,29 +463,29 @@ SEASTAR_TEST_CASE(test_result_row_count) {
 
             auto src = make_source({m1});
 
-            auto r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32).get();
+            auto get_query_result = [&] (const reconcilable_result& result) {
+                return to_data_query_result(result, s, slice, inf32, inf32,
+                        query::result_options::only_result(), mutation_fragment_stream_validation_level::clustering_key).get();
+            };
+
+            auto r = get_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now));
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 0);
 
             m1.set_static_cell("s1", data_value(bytes("S_v1")), 1);
-            r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32).get();
+            r = get_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now));
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 1);
 
             m1.set_clustered_cell(clustering_key::from_single_value(*s, bytes("A")), "v1", data_value(bytes("A_v1")), 1);
-            r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32).get();
+            r = get_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now));
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 1);
 
             m1.set_clustered_cell(clustering_key::from_single_value(*s, bytes("B")), "v1", data_value(bytes("B_v1")), 1);
-            r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32).get();
+            r = get_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now));
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 2);
 
             mutation m2(s, partition_key::from_single_value(*s, "key2"));
             m2.set_static_cell("s1", data_value(bytes("S_v1")), 1);
-            r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1, m2}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32).get();
+            r = get_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1, m2}), query::full_partition_range, slice, 10000, query::max_partitions, now));
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 3);
     });
 }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3895,7 +3895,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
                                           query_slice, nullptr, fwd);
             },
             [included_gens] (const sstable& sst) { return included_gens.contains(sst.generation()); },
-            pk.key(), query_schema, permit, fwd, reversed);
+            pk.key(), query_schema, permit, fwd, reversed, mutation_fragment_stream_validation_level::clustering_key);
         return make_clustering_combined_reader(query_schema, permit, fwd, std::move(q));
     };
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -796,7 +796,7 @@ SEASTAR_TEST_CASE(test_querying_of_mutation) {
 
         auto resultify = [s] (const mutation& m) -> query::result_set {
             auto slice = make_full_slice(*s);
-            return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice));
+            return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, mutation_fragment_stream_validation_level::clustering_key));
         };
 
         mutation m(s, partition_key::from_single_value(*s, "key1"));
@@ -831,7 +831,7 @@ SEASTAR_TEST_CASE(test_partition_with_no_live_data_is_absent_in_data_query_resul
 
         auto slice = make_full_slice(*s);
 
-        assert_that(query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice)))
+        assert_that(query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, mutation_fragment_stream_validation_level::clustering_key)))
             .is_empty();
     });
 }
@@ -855,7 +855,7 @@ SEASTAR_TEST_CASE(test_partition_with_live_data_in_static_row_is_present_in_the_
             .build();
 
         assert_that(query::result_set::from_raw_result(s, slice,
-                query_mutation(mutation(m), slice)))
+                query_mutation(mutation(m), slice, mutation_fragment_stream_validation_level::clustering_key)))
             .has_only(a_row()
                 .with_column("pk", data_value(bytes("key1")))
                 .with_column("v", data_value::make_null(bytes_type)));
@@ -879,7 +879,7 @@ SEASTAR_TEST_CASE(test_query_result_with_one_regular_column_missing) {
         auto slice = partition_slice_builder(*s).build();
 
         assert_that(query::result_set::from_raw_result(s, slice,
-                query_mutation(mutation(m), slice)))
+                query_mutation(mutation(m), slice, mutation_fragment_stream_validation_level::clustering_key)))
             .has_only(a_row()
                 .with_column("pk", data_value(bytes("key1")))
                 .with_column("ck", data_value(bytes("ck:A")))
@@ -1385,9 +1385,9 @@ SEASTAR_TEST_CASE(test_query_digest) {
             auto ps1 = partition_slice_builder(*m1.schema()).build();
             auto ps2 = partition_slice_builder(*m2.schema()).build();
             auto digest1 = *query_mutation(mutation(m1), ps1, query::max_rows, now,
-                    query::result_options::only_digest(query::digest_algorithm::xxHash)).digest();
-            auto digest2 = *query_mutation( mutation(m2), ps2, query::max_rows, now,
-                    query::result_options::only_digest(query::digest_algorithm::xxHash)).digest();
+                    query::result_options::only_digest(query::digest_algorithm::xxHash), mutation_fragment_stream_validation_level::clustering_key).digest();
+            auto digest2 = *query_mutation(mutation(m2), ps2, query::max_rows, now,
+                    query::result_options::only_digest(query::digest_algorithm::xxHash), mutation_fragment_stream_validation_level::clustering_key).digest();
 
             if (digest1 != digest2) {
                 BOOST_FAIL(format("Digest should be the same for {} and {}", m1, m2));
@@ -1637,7 +1637,7 @@ SEASTAR_THREAD_TEST_CASE(test_querying_expired_rows) {
                 .without_partition_key_columns()
                 .build();
         auto opts = query::result_options{query::result_request::result_and_digest, query::digest_algorithm::xxHash};
-        return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, query::max_rows, t, opts));
+        return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, query::max_rows, t, opts, mutation_fragment_stream_validation_level::clustering_key));
     };
 
     mutation m(s, pk);
@@ -1701,7 +1701,7 @@ SEASTAR_TEST_CASE(test_querying_expired_cells) {
                     .without_partition_key_columns()
                     .build();
             auto opts = query::result_options{query::result_request::result_and_digest, query::digest_algorithm::xxHash};
-            return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, query::max_rows, t, opts));
+            return query::result_set::from_raw_result(s, slice, query_mutation(mutation(m), slice, query::max_rows, t, opts, mutation_fragment_stream_validation_level::clustering_key));
         };
 
         {
@@ -2794,7 +2794,7 @@ void run_compaction_data_stream_split_test(const schema& schema, reader_permit p
         mut.partition().compact_for_compaction(schema, never_gc, mut.decorated_key(), query_time, tombstone_gc_state(nullptr));
     }
 
-    auto reader = make_flat_mutation_reader_from_mutations_v2(schema.shared_from_this(), std::move(permit), mutations);
+    auto reader = make_flat_mutation_reader_from_mutations_v2(schema.shared_from_this(), std::move(permit), mutations, streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key);
     auto close_reader = deferred_close(reader);
     auto get_max_purgeable = [] (const dht::decorated_key&) {
         return api::max_timestamp;
@@ -3009,7 +3009,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume) {
     {
         for (const auto& mut : muts) {
             mutation_rebuilder_v2 rebuilder(forward_schema);
-            auto rebuilt_mut = *mutation(mut).consume(rebuilder, consume_in_reverse::no).result;
+            auto rebuilt_mut = *mutation(mut).consume(rebuilder, consume_in_reverse::no, mutation_fragment_stream_validation_level::clustering_key).result;
             assert_that(std::move(rebuilt_mut)).is_equal_to(mut);
         }
     }
@@ -3017,7 +3017,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume) {
     {
         for (const auto& mut : muts) {
             mutation_rebuilder_v2 rebuilder(reverse_schema);
-            auto rebuilt_mut = *mutation(mut).consume(rebuilder, consume_in_reverse::yes).result;
+            auto rebuilt_mut = *mutation(mut).consume(rebuilder, consume_in_reverse::yes, mutation_fragment_stream_validation_level::clustering_key).result;
             assert_that(reverse(std::move(rebuilt_mut))).is_equal_to(mut);
         }
     }
@@ -3048,26 +3048,26 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume_position_monotonicity) {
     {
         auto mut = muts.front();
         validating_consumer consumer(*forward_schema);
-        std::move(mut).consume(consumer, consume_in_reverse::no);
+        std::move(mut).consume(consumer, consume_in_reverse::no, mutation_fragment_stream_validation_level::clustering_key);
     }
     BOOST_TEST_MESSAGE("Reverse");
     {
         auto mut = muts.front();
         validating_consumer consumer(*reverse_schema);
-        std::move(mut).consume(consumer, consume_in_reverse::yes);
+        std::move(mut).consume(consumer, consume_in_reverse::yes, mutation_fragment_stream_validation_level::clustering_key);
     }
 
     BOOST_TEST_MESSAGE("Forward gently");
     {
         auto mut = muts.front();
         validating_consumer consumer(*forward_schema);
-        std::move(mut).consume_gently(consumer, consume_in_reverse::no).get();
+        std::move(mut).consume_gently(consumer, consume_in_reverse::no, mutation_fragment_stream_validation_level::clustering_key).get();
     }
     BOOST_TEST_MESSAGE("Reverse gently");
     {
         auto mut = muts.front();
         validating_consumer consumer(*reverse_schema);
-        std::move(mut).consume_gently(consumer, consume_in_reverse::yes).get();
+        std::move(mut).consume_gently(consumer, consume_in_reverse::yes, mutation_fragment_stream_validation_level::clustering_key).get();
     }
 }
 
@@ -3173,11 +3173,11 @@ SEASTAR_TEST_CASE(mutation_with_dummy_clustering_row_is_consumed_monotonically) 
         {
             schema_ptr reverse_schema = s->make_reversed();
             validating_consumer consumer{*reverse_schema};
-            std::move(m).consume(consumer, consume_in_reverse::yes);
+            std::move(m).consume(consumer, consume_in_reverse::yes, mutation_fragment_stream_validation_level::clustering_key);
         }
         {
             validating_consumer consumer{*s};
-            std::move(m1).consume(consumer, consume_in_reverse::no);
+            std::move(m1).consume(consumer, consume_in_reverse::no, mutation_fragment_stream_validation_level::clustering_key);
         }
     });
 }

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -158,7 +158,8 @@ public:
         , _cache(is_user_semaphore ? std::move(is_user_semaphore) : [] (const reader_concurrency_semaphore&) { return true; }, entry_ttl)
         , _mutations(make_mutations(_s, external_make_value))
         , _mutation_source([this] (schema_ptr schema, reader_permit permit, const dht::partition_range& range) {
-            auto rd = make_flat_mutation_reader_from_mutations_v2(schema, std::move(permit), _mutations, range);
+            auto rd = make_flat_mutation_reader_from_mutations_v2(schema, std::move(permit), _mutations, range,
+                    streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key);
             rd.set_max_buffer_size(max_reader_buffer_size);
             return rd;
         }) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1347,7 +1347,8 @@ memory_limit_table create_memory_limit_table(cql_test_env& env, uint64_t target_
                 auto sst = tbl.make_sstable();
                 auto writer_cfg = sst_man.configure_writer("test");
                 sst->write_components(
-                    make_flat_mutation_reader_from_mutations_v2(s, semaphore.make_tracking_only_permit(s, "test", db::no_timeout, {}), mut, s->full_slice()),
+                    make_flat_mutation_reader_from_mutations_v2(s, semaphore.make_tracking_only_permit(s, "test", db::no_timeout, {}), mut, s->full_slice(),
+                            streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key),
                     1,
                     s,
                     writer_cfg,

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -44,7 +44,7 @@ public:
 };
 
 mutation_fragment_queue make_test_mutation_fragment_queue(schema_ptr s, reader_permit permit, std::deque<mutation_fragment_v2>& fragments) {
-    return mutation_fragment_queue(std::move(s), std::move(permit), seastar::make_shared<test_mutation_fragment_queue_impl>(fragments));
+    return mutation_fragment_queue(std::move(s), std::move(permit), seastar::make_shared<test_mutation_fragment_queue_impl>(fragments), mutation_fragment_stream_validation_level::clustering_key);
 }
 
 // repair_writer::impl abstracts away underlying writer that will receive

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -87,7 +87,9 @@ snapshot_source make_decorated_snapshot_source(snapshot_source src, std::functio
 mutation_source make_source_with(mutation m) {
     return mutation_source([m] (schema_ptr s, reader_permit permit, const dht::partition_range&, const query::partition_slice&, tracing::trace_state_ptr, streamed_mutation::forwarding fwd) {
         assert(m.schema() == s);
-        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd));
+        constexpr bool reversed = false;
+        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd),
+                reversed, mutation_fragment_stream_validation_level::clustering_key);
     });
 }
 
@@ -286,7 +288,9 @@ void test_cache_delegates_to_underlying_only_once_with_single_partition(schema_p
             streamed_mutation::forwarding fwd) {
         assert(m.schema() == s);
         if (range.contains(dht::ring_position(m.decorated_key()), dht::ring_position_comparator(*s))) {
-            return make_counting_reader(make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd)), secondary_calls_count);
+            constexpr bool reversed = false;
+            return make_counting_reader(make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd),
+                    reversed, mutation_fragment_stream_validation_level::clustering_key), secondary_calls_count);
         } else {
             return make_counting_reader(make_empty_flat_reader_v2(s, std::move(permit)), secondary_calls_count);
         }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2912,7 +2912,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         sstable_writer_config sst_cfg = env.manager().configure_writer();
         sst_cfg.run_identifier = partial_sstable_run_identifier;
-        auto partial_sstable_run_sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut)), sst_cfg);
+        auto partial_sstable_run_sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), { std::move(mut) }, mutation_fragment_stream_validation_level::clustering_key), sst_cfg);
 
         column_family_test(cf).add_sstable(partial_sstable_run_sst).get();
         column_family_test::update_sstables_known_generation(*cf, partial_sstable_run_sst->generation());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1673,7 +1673,7 @@ SEASTAR_TEST_CASE(test_repeated_tombstone_skipping) {
         for (auto&& mf : fragments) {
             mut.apply(mf);
         }
-        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), std::move(mut)), cfg, version)->as_mutation_source();
+        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), std::move(mut), mutation_fragment_stream_validation_level::clustering_key), cfg, version)->as_mutation_source();
 
         for (uint32_t i = 3; i < seq; i++) {
             auto ck1 = table.make_ckey(1);
@@ -1721,7 +1721,8 @@ SEASTAR_TEST_CASE(test_skipping_using_index) {
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1; // So that every fragment is indexed
         cfg.promoted_index_auto_scale_threshold = 0; // disable auto-scaling
-        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), env.make_reader_permit(), partitions), cfg, version)->as_mutation_source();
+        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), env.make_reader_permit(), partitions,
+                streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key), cfg, version)->as_mutation_source();
         auto rd = ms.make_reader_v2(table.schema(),
             env.make_reader_permit(),
             query::full_partition_range,
@@ -2410,7 +2411,7 @@ SEASTAR_TEST_CASE(sstable_run_identifier_correctness) {
 
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.run_identifier = sstables::run_id::create_random_id();
-        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut)), cfg);
+        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut), mutation_fragment_stream_validation_level::clustering_key), cfg);
 
         BOOST_REQUIRE(sst->run_identifier() == cfg.run_identifier);
     });
@@ -2587,7 +2588,7 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
         for (const auto version : writable_sstable_versions) {
             testlog.info("version={}", version);
 
-            auto mr = make_flat_mutation_reader_from_mutations_v2(ss.schema(), env.make_reader_permit(), mut);
+            auto mr = make_flat_mutation_reader_from_mutations_v2(ss.schema(), env.make_reader_permit(), mut, mutation_fragment_stream_validation_level::clustering_key);
             sstable_writer_config cfg = env.manager().configure_writer();
             auto sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);
 
@@ -2690,13 +2691,13 @@ SEASTAR_TEST_CASE(test_sstable_origin) {
             }
 
             // Test empty sstable_origin.
-            auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+            auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut, mutation_fragment_stream_validation_level::clustering_key);
             sstable_writer_config cfg = env.manager().configure_writer("");
             auto sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);
             BOOST_REQUIRE_EQUAL(sst->get_origin(), "");
 
             // Test that a random sstable_origin is stored and retrieved properly.
-            mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+            mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut, mutation_fragment_stream_validation_level::clustering_key);
             sstring origin = fmt::format("test-{}", tests::random::get_sstring());
             cfg = env.manager().configure_writer(origin);
             sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);
@@ -2800,7 +2801,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 testlog.info("compression={}", compression_params);
                 auto sst_schema = schema_builder(schema).set_compressor_params(compression_params).build();
 
-                auto mr = make_flat_mutation_reader_from_mutations_v2(schema, permit, muts);
+                auto mr = make_flat_mutation_reader_from_mutations_v2(schema, permit, muts, streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key);
                 auto close_mr = deferred_close(mr);
 
                 auto sst = env.make_sstable(sst_schema, version);
@@ -2882,7 +2883,7 @@ SEASTAR_TEST_CASE(test_index_fast_forwarding_after_eof) {
 
         auto sst = env.make_sstable(schema, writable_sstable_versions.back());
         {
-            auto mr = make_flat_mutation_reader_from_mutations_v2(schema, permit, muts);
+            auto mr = make_flat_mutation_reader_from_mutations_v2(schema, permit, muts, streamed_mutation::forwarding::no, mutation_fragment_stream_validation_level::clustering_key);
             auto close_mr = deferred_close(mr);
 
             sstable_writer_config cfg = env.manager().configure_writer();

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -36,7 +36,7 @@ SEASTAR_TEST_CASE(test_sstables_sstable_set_read_modify_write) {
         auto mut = mutation(s, pk);
         ss.add_row(mut, ss.make_ckey(0), "val");
 
-        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut}, mutation_fragment_stream_validation_level::clustering_key);
         sstable_writer_config cfg = env.manager().configure_writer("");
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
 
@@ -44,7 +44,7 @@ SEASTAR_TEST_CASE(test_sstables_sstable_set_read_modify_write) {
         BOOST_REQUIRE_EQUAL(ss1->all()->size(), 1);
 
         // Test that a random sstable_origin is stored and retrieved properly.
-        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut}, mutation_fragment_stream_validation_level::clustering_key);
         auto sst2 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss2 = make_lw_shared<sstables::sstable_set>(*ss1);
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         ss.add_row(mut, ss.make_ckey(0), "val");
         sstable_writer_config cfg = env.manager().configure_writer("");
 
-        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut}, mutation_fragment_stream_validation_level::clustering_key);
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss1 = make_lw_shared<time_series_sstable_set>(ss.schema(), true);
@@ -72,7 +72,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         BOOST_REQUIRE_EQUAL(ss1->all()->size(), 1);
 
         // Test that a random sstable_origin is stored and retrieved properly.
-        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
+        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut}, mutation_fragment_stream_validation_level::clustering_key);
         auto sst2 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss2 = make_lw_shared<time_series_sstable_set>(*ss1);

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -440,7 +440,7 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
             auto sst = t->make_streaming_staging_sstable();
             sstables::sstable_writer_config sst_cfg = e.db().local().get_user_sstables_manager().configure_writer("test");
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m, mutation_fragment_stream_validation_level::clustering_key), 1ul, s, sst_cfg, {}).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;
@@ -552,7 +552,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         auto sst = t->make_streaming_staging_sstable();
         sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer("test");
         auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "test", db::no_timeout, {});
-        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
+        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m, mutation_fragment_stream_validation_level::clustering_key), 1ul, s, sst_cfg, {}).get();
         sst->open_data().get();
         t->add_sstable_and_update_cache(sst).get();
 
@@ -624,7 +624,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
             auto sst = t->make_streaming_staging_sstable();
             sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer("test");
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m, mutation_fragment_stream_validation_level::clustering_key), 1ul, s, sst_cfg, {}).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -130,6 +130,7 @@ table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, c
     : _data(make_lw_shared<data>())
 {
     cfg.cf_stats = &_data->cf_stats;
+    cfg.validation_level = mutation_fragment_stream_validation_level::clustering_key;
     _data->s = s ? s : make_default_schema();
     _data->cf = make_lw_shared<replica::column_family>(_data->s, std::move(cfg), make_lw_shared<replica::storage_options>(), cm, sstables_manager, _data->cl_stats, sstables_manager.get_cache_tracker(), nullptr);
     _data->cf->mark_ready_for_writes(nullptr);
@@ -443,7 +444,8 @@ test_env::make_reader_permit(db::timeout_clock::time_point timeout) {
 
 replica::table::config
 test_env::make_table_config() {
-    return replica::table::config{.compaction_concurrency_semaphore = &_impl->semaphore};
+    return replica::table::config{.compaction_concurrency_semaphore = &_impl->semaphore,
+            .validation_level = mutation_fragment_stream_validation_level::clustering_key};
 }
 
 future<>

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -200,7 +200,7 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
     result.cache = tracker.region().occupancy().used_space() - cache_initial_occupancy;
     result.frozen = freeze(m).representation().size();
     result.canonical = canonical_mutation(m).representation().size();
-    result.query_result = query_mutation(mutation(m), partition_slice_builder(*s).build()).buf().size();
+    result.query_result = query_mutation(mutation(m), partition_slice_builder(*s).build(), mutation_fragment_stream_validation_level::clustering_key).buf().size();
 
     tmpdir sstable_dir;
     sstables::test_env::do_with_async([&] (sstables::test_env& env) {


### PR DESCRIPTION
With change 18a80a98b870c1104295fc48a31e2e4b5089ef3a flush
returns early if _range_tombstones.empty.

This missed a side effect of the function of
setting _lower_bound to upper_bound, that happens
without the optimization.

Although it seems to be benign in 5.1.dev,
it proved to be required for backporting to 5.0
(See https://github.com/scylladb/scylla/pull/10969)
so let's add it to 5.1.dev as well.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>