### PR TITLE
Commitlog: complete prerequisites and enforce hard limit by default

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1380,11 +1380,21 @@ db::commitlog::segment_manager::segment_manager(config c)
     , max_mutation_size(max_size >> 1)
     , max_disk_size(size_t(std::ceil(cfg.commitlog_total_space_in_mb / double(smp::count))) * 1024 * 1024)
     // our threshold for trying to force a flush. needs heristics, for now max - segment_size/2.
-    , disk_usage_threshold(cfg.commitlog_flush_threshold_in_mb.has_value() 
-        ? size_t(std::ceil(*cfg.commitlog_flush_threshold_in_mb / double(smp::count))) * 1024 * 1024 
-        : (max_disk_size -
-            (max_disk_size >= (max_size*2) ? max_size
-                : (max_disk_size > (max_size/2) ? (max_size/2) : max_disk_size/3))))
+    , disk_usage_threshold([&] {
+        if (cfg.commitlog_flush_threshold_in_mb.has_value()) {
+            return size_t(std::ceil(*cfg.commitlog_flush_threshold_in_mb / double(smp::count))) * 1024 * 1024;
+        } else {
+            if (max_disk_size >= (max_size*2)) {
+                return max_disk_size - max_size;
+            } else {
+                if (max_disk_size > (max_size/2)) {
+                    return max_disk_size - (max_size/2);
+                } else {
+                    return max_disk_size - max_disk_size/3;
+                }
+            }
+        }
+    }())
     , _flush_semaphore(cfg.max_active_flushes)
     // That is enough concurrency to allow for our largest mutation (max_mutation_size), plus
     // an existing in-flight buffer. Since we'll force the cycling() of any buffer that is bigger

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1384,15 +1384,7 @@ db::commitlog::segment_manager::segment_manager(config c)
         if (cfg.commitlog_flush_threshold_in_mb.has_value()) {
             return size_t(std::ceil(*cfg.commitlog_flush_threshold_in_mb / double(smp::count))) * 1024 * 1024;
         } else {
-            if (max_disk_size >= (max_size*2)) {
-                return max_disk_size - max_size;
-            } else {
-                if (max_disk_size > (max_size/2)) {
-                    return max_disk_size - (max_size/2);
-                } else {
-                    return max_disk_size - max_disk_size/3;
-                }
-            }
+            return max_disk_size / 2;
         }
     }())
     , _flush_semaphore(cfg.max_active_flushes)

--- a/db/config.cc
+++ b/db/config.cc
@@ -540,8 +540,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency. Default is (approximately) commitlog_total_space_in_mb - <num shards>*commitlog_segment_size_in_mb.")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
         "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
-    , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, false,
-        "Whether or not to use a hard size limit for commitlog disk usage. Default is false. Enabling this can cause latency spikes, whereas the default can lead to occasional disk usage peaks.\n")
+    , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, true,
+        "Whether or not to use a hard size limit for commitlog disk usage. Default is true. Enabling this can cause latency spikes, whereas the default can lead to occasional disk usage peaks.\n")
     /**
     * @Group Compaction settings
     * @GroupDescription Related information: Configuring compaction


### PR DESCRIPTION
This miniset, completes the prerequisites for enabling commitlog hard limit on by default.
Namely, start flushing and evacuating segments halfway to the limit in order to never hit it under normal circumstances.
It is worth mentioning that hitting the limit is an exceptional condition which it's root cause need to be resolved, however,
once we do hit the limit, the performance impact that is inflicted as a result of this enforcement is irrelevant.

Tests: unit tests.
          LWT write test (#9331)
#Whitebox testing
A whitebox testing has been performed by @wmitros , the test aimed at putting as much pressure as possible on the commitlog segments by using a write pattern that rewrites the partitions in the memtable keeping it at ~85% occupancy so the dirty memory manager will not kick in. The test compared 3 configurations:
1. The default configuration
2. Hard limit on (without changing the flush threshold)
3. the changes in this PR applied.
The last exhibited the "best" behavior in terms of metrics, the graphs were the flattest and less jaggy from the others.
