### PR TITLE
Allow setting permissions for user-defined functions

### DIFF
--- a/auth/permission.cc
+++ b/auth/permission.cc
@@ -21,7 +21,8 @@ const auth::permission_set auth::permissions::ALL = auth::permission_set::of<
         auth::permission::SELECT,
         auth::permission::MODIFY,
         auth::permission::AUTHORIZE,
-        auth::permission::DESCRIBE>();
+        auth::permission::DESCRIBE,
+        auth::permission::EXECUTE>();
 
 const auth::permission_set auth::permissions::NONE;
 
@@ -34,7 +35,8 @@ static const std::unordered_map<sstring, auth::permission> permission_names({
         {"SELECT", auth::permission::SELECT},
         {"MODIFY", auth::permission::MODIFY},
         {"AUTHORIZE", auth::permission::AUTHORIZE},
-        {"DESCRIBE", auth::permission::DESCRIBE}});
+        {"DESCRIBE", auth::permission::DESCRIBE},
+        {"EXECUTE", auth::permission::EXECUTE}});
 
 const sstring& auth::permissions::to_string(permission p) {
     for (auto& v : permission_names) {

--- a/auth/permission.hh
+++ b/auth/permission.hh
@@ -38,6 +38,8 @@ enum class permission {
     AUTHORIZE, // required for GRANT and REVOKE.
     DESCRIBE, // required on the root-level role resource to list all roles.
 
+    // function/aggregate/procedure calls
+    EXECUTE,
 };
 
 typedef enum_set<
@@ -51,7 +53,8 @@ typedef enum_set<
                 permission::SELECT,
                 permission::MODIFY,
                 permission::AUTHORIZE,
-                permission::DESCRIBE>> permission_set;
+                permission::DESCRIBE,
+                permission::EXECUTE>> permission_set;
 
 bool operator<(const permission_set&, const permission_set&);
 

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -16,8 +16,11 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 
 #include "service/storage_proxy.hh"
+#include "data_dictionary/user_types_metadata.hh"
+#include "cql3/util.hh"
 
 namespace auth {
 
@@ -26,6 +29,7 @@ std::ostream& operator<<(std::ostream& os, resource_kind kind) {
         case resource_kind::data: os << "data"; break;
         case resource_kind::role: os << "role"; break;
         case resource_kind::service_level: os << "service_level"; break;
+        case resource_kind::functions: os << "functions"; break;
     }
 
     return os;
@@ -34,12 +38,14 @@ std::ostream& operator<<(std::ostream& os, resource_kind kind) {
 static const std::unordered_map<resource_kind, std::string_view> roots{
         {resource_kind::data, "data"},
         {resource_kind::role, "roles"},
-        {resource_kind::service_level, "service_levels"}};
+        {resource_kind::service_level, "service_levels"},
+        {resource_kind::functions, "functions"}};
 
 static const std::unordered_map<resource_kind, std::size_t> max_parts{
         {resource_kind::data, 2},
         {resource_kind::role, 1},
-        {resource_kind::service_level, 0}};
+        {resource_kind::service_level, 0},
+        {resource_kind::functions, 2}};
 
 static permission_set applicable_permissions(const data_resource_view& dv) {
     if (dv.table()) {
@@ -82,6 +88,15 @@ static permission_set applicable_permissions(const service_level_resource_view &
             permission::AUTHORIZE>();
 }
 
+static permission_set applicable_permissions(const functions_resource_view& fv) {
+    return permission_set::of<
+            permission::CREATE,
+            permission::ALTER,
+            permission::DROP,
+            permission::AUTHORIZE,
+            permission::EXECUTE>();
+}
+
 resource::resource(resource_kind kind) : _kind(kind) {
     _parts.emplace_back(roots.at(kind));
 }
@@ -106,6 +121,39 @@ resource::resource(role_resource_t, std::string_view role) : resource(resource_k
 resource::resource(service_level_resource_t): resource(resource_kind::service_level) {
 }
 
+resource::resource(functions_resource_t) : resource(resource_kind::functions) {
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+    _parts.emplace_back(function_name);
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name, std::vector<sstring> function_signature) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+    sstring encoded_signature = format("{}[{}]",
+            function_name,
+            ::join("^", function_signature));
+    _parts.emplace_back(encoded_signature);
+}
+
+resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature) {
+    if (keyspace.empty()) {
+        throw exceptions::invalid_request_exception("In this context function name must be explictly qualified by a keyspace");
+    }
+    std::vector<sstring> args_types;
+    for (auto& raw_type : function_signature) {
+        // FIXME(sarna): provide information on user-defined types - this is tricky, because this information
+        // is kept in a database instance, and is thus dynamic
+        args_types.emplace_back(raw_type->prepare_internal(sstring(keyspace), data_dictionary::user_types_metadata{}).get_type()->name());
+    }
+    return resource(functions_resource_t{}, keyspace, function_name, std::move(args_types));
+}
+
 sstring resource::name() const {
     return boost::algorithm::join(_parts, "/");
 }
@@ -127,6 +175,7 @@ permission_set resource::applicable_permissions() const {
         case resource_kind::data: ps = ::auth::applicable_permissions(data_resource_view(*this)); break;
         case resource_kind::role: ps = ::auth::applicable_permissions(role_resource_view(*this)); break;
         case resource_kind::service_level: ps = ::auth::applicable_permissions(service_level_resource_view(*this)); break;
+        case resource_kind::functions: ps = ::auth::applicable_permissions(functions_resource_view(*this)); break;
     }
 
     return ps;
@@ -149,6 +198,7 @@ std::ostream& operator<<(std::ostream& os, const resource& r) {
         case resource_kind::data: return os << data_resource_view(r);
         case resource_kind::role: return os << role_resource_view(r);
         case resource_kind::service_level: return os << service_level_resource_view(r);
+        case resource_kind::functions: return os << functions_resource_view(r);
     }
 
     return os;
@@ -163,6 +213,60 @@ service_level_resource_view::service_level_resource_view(const resource &r) {
 std::ostream &operator<<(std::ostream &os, const service_level_resource_view &v) {
     os << "<all service levels>";
     return os;
+}
+
+// Purely for Cassandra compatibility, types in the function signature are
+// decoded from their verbose form (org.apache.cassandra.db.marshal.Int32Type)
+// to the short form (int)
+static sstring decode_signature(std::string_view encoded_signature) {
+    auto name_delim = encoded_signature.find_last_of('[');
+    std::string_view function_name = encoded_signature.substr(0, name_delim);
+    encoded_signature.remove_prefix(name_delim + 1);
+    encoded_signature.remove_suffix(1);
+    std::vector<std::string_view> raw_types;
+    boost::split(raw_types, encoded_signature, boost::is_any_of("^"));
+    std::vector<std::string> decoded_types = boost::copy_range<std::vector<std::string>>(
+        raw_types | boost::adaptors::transformed([] (std::string_view raw_type) {
+            return abstract_type::parse_type(sstring(raw_type))->cql3_type_name();
+        })
+    );
+    return format("{}({})", cql3::util::maybe_quote(sstring(function_name)), boost::algorithm::join(decoded_types, ", "));
+}
+
+std::ostream &operator<<(std::ostream &os, const functions_resource_view &v) {
+    const auto keyspace = v.keyspace();
+    const auto function_signature = v.function_signature();
+
+    if (!keyspace) {
+        os << "<all functions>";
+    } else if (!function_signature) {
+        os << "<all functions in " << *keyspace << '>';
+    } else {
+        os << "<function " << *keyspace << '.' << decode_signature(*function_signature) << '>';
+    }
+    return os;
+}
+
+functions_resource_view::functions_resource_view(const resource& r) : _resource(r) {
+    if (r._kind != resource_kind::functions) {
+        throw resource_kind_mismatch(resource_kind::functions, r._kind);
+    }
+}
+
+std::optional<std::string_view> functions_resource_view::keyspace() const {
+    if (_resource._parts.size() == 1) {
+        return {};
+    }
+
+    return _resource._parts[1];
+}
+
+std::optional<std::string_view> functions_resource_view::function_signature() const {
+    if (_resource._parts.size() <= 2) {
+        return {};
+    }
+
+    return _resource._parts[2];
 }
 
 data_resource_view::data_resource_view(const resource& r) : _resource(r) {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -346,6 +346,18 @@ future<bool> service::exists(const resource& r) const {
         }
         case resource_kind::service_level:
             return make_ready_future<bool>(true);
+
+        case resource_kind::functions: {
+            const auto& db = _qp.db();
+
+            functions_resource_view v(r);
+            const auto keyspace = v.keyspace();
+            const auto function_signature = v.function_signature();
+
+            //FIXME(sarna): look up the function (if present), and signature too (if present)
+
+            return make_ready_future<bool>(true);
+        }
     }
 
     return make_ready_future<bool>(false);

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1121,7 +1121,7 @@ listPermissionsStatement returns [std::unique_ptr<list_permissions_statement> st
     ;
 
 permission returns [auth::permission perm]
-    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE)
+    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE)
     { $perm = auth::permissions::from_string($p.text); }
     ;
 
@@ -1131,8 +1131,9 @@ permissionOrAll returns [auth::permission_set perms]
     ;
 
 resource returns [uninitialized<auth::resource> res]
-    : d=dataResource { $res = std::move(d); }
-    | r=roleResource { $res = std::move(r); }
+    : d=dataResource     { $res = std::move(d); }
+    | r=roleResource     { $res = std::move(r); }
+    | f=functionResource { $res = std::move(f); }
     ;
 
 dataResource returns [uninitialized<auth::resource> res]
@@ -1145,6 +1146,24 @@ dataResource returns [uninitialized<auth::resource> res]
 roleResource returns [uninitialized<auth::resource> res]
     : K_ALL K_ROLES { $res = auth::resource(auth::resource_kind::role); }
     | K_ROLE role = userOrRoleName { $res = auth::make_role_resource(static_cast<const cql3::role_name&>(role).to_string()); }
+    ;
+
+functionResource returns [uninitialized<auth::resource> res]
+    @init {
+        std::vector<shared_ptr<cql3_type::raw>> args_types;
+    }
+    : K_ALL K_FUNCTIONS { $res = auth::make_functions_resource(); }
+    | K_ALL K_FUNCTIONS K_IN K_KEYSPACE ks = keyspaceName { $res = auth::make_functions_resource($ks.id); }
+    | K_FUNCTION fn=functionName
+      (
+        '('
+          (
+            v=comparatorType { args_types.push_back(v); }
+            ( ',' v=comparatorType { args_types.push_back(v); } )*
+          )?
+        ')'
+      )
+      { $res = auth::make_functions_resource($fn.s.keyspace, $fn.s.name, args_types); }
     ;
 
 /**
@@ -1934,6 +1953,8 @@ basic_unreserved_keyword returns [sstring str]
         | K_LEVEL
         | K_LEVELS
         | K_PRUNE
+        | K_EXECUTE
+        | K_FUNCTIONS
         ) { $str = $k.text; }
     ;
 
@@ -2130,6 +2151,9 @@ K_LIKE:        L I K E;
 
 K_TIMEOUT:     T I M E O U T;
 K_PRUNE:       P R U N E;
+
+K_EXECUTE:     E X E C U T E;
+K_FUNCTIONS:   F U N C T I O N S;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -149,7 +149,7 @@ void functions::remove_function(const function_name& name, const std::vector<dat
 std::optional<function_name> functions::used_by_user_aggregate(const function_name& name) {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
-        if (aggregate && (aggregate->sfunc().name() == name || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name))) {
+        if (aggregate && (aggregate->sfunc()->name() == name || (aggregate->has_finalfunc() && aggregate->finalfunc()->name() == name))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -31,14 +31,14 @@ public:
     virtual bool requires_thread() const override;
     bool has_finalfunc() const;
 
-    const scalar_function& sfunc() const {
-        return *_sfunc;
+    ::shared_ptr<scalar_function> sfunc() const {
+        return _sfunc;
     }
     const scalar_function& reducefunc() const {
         return *_reducefunc;
     }
-    const scalar_function& finalfunc() const {
-        return *_finalfunc;
+   ::shared_ptr<scalar_function> finalfunc() const {
+        return _finalfunc;
     }
     const bytes_opt& initcond() const {
         return _initcond;

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -48,6 +48,10 @@ public:
         return _fun->return_type();
     }
 
+    shared_ptr<functions::function> function() const {
+        return _fun;
+    }
+
 #if 0
     @Override
     public String toString()

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -16,6 +16,7 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/raw_selector.hh"
 #include "cql3/selection/selector_factories.hh"
+#include "cql3/selection/abstract_function_selector.hh"
 #include "cql3/result_set.hh"
 #include "cql3/query_options.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
@@ -189,6 +190,10 @@ public:
         return _factories->get_reductions();
     }
 
+    virtual std::vector<shared_ptr<functions::function>> used_functions() const override {
+        return selectors_with_processing(_factories).used_functions();
+    }
+
 protected:
     class selectors_with_processing : public selectors {
     private:
@@ -229,6 +234,20 @@ protected:
             for (auto&& s : _selectors) {
                 s->add_input(sf, rs);
             }
+        }
+
+        std::vector<shared_ptr<functions::function>> used_functions() const {
+            std::vector<shared_ptr<functions::function>> functions;
+            for (const auto& selector : _selectors) {
+                if (auto fun_selector = dynamic_pointer_cast<abstract_function_selector>(selector); fun_selector) {
+                    functions.push_back(fun_selector->function());
+                    if (auto user_aggr = dynamic_pointer_cast<functions::user_aggregate>(fun_selector); user_aggr) {
+                        functions.push_back(user_aggr->sfunc());
+                        functions.push_back(user_aggr->finalfunc());
+                    }
+                }
+            }
+            return functions;
         }
     };
 

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -15,6 +15,7 @@
 #include "query-result-reader.hh"
 #include "cql3/column_specification.hh"
 #include "cql3/selection/selector.hh"
+#include "cql3/selection/selectable.hh"
 #include "exceptions/exceptions.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
@@ -117,6 +118,8 @@ public:
     static ::shared_ptr<selection> for_columns(schema_ptr schema, std::vector<const column_definition*> columns);
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c);
+
+    virtual std::vector<shared_ptr<functions::function>> used_functions() const { return {}; }
 
     query::partition_slice::option_set get_query_options();
 private:

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -22,6 +22,7 @@ namespace cql3 {
 
 namespace statements {
 
+
 shared_ptr<functions::function> create_function_statement::create(query_processor& qp, functions::function* old) const {
     if (old && !dynamic_cast<functions::user_function*>(old)) {
         throw exceptions::invalid_request_exception(format("Cannot replace '{}' which is not a user defined function", *old));

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -13,6 +13,7 @@
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/util.hh"
 #include "mutation.hh"
 
 namespace cql3 {

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -9,6 +9,7 @@
 #include "cql3/statements/function_statement.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/functions/user_function.hh"
+#include "cql3/util.hh"
 #include "db/config.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "gms/feature_service.hh"
@@ -24,6 +25,45 @@ future<> create_function_statement_base::check_access(query_processor& qp, const
     co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
     if (_or_replace) {
         co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::ALTER);
+    }
+}
+
+future<> drop_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const
+{
+    create_arg_types(qp);
+    shared_ptr<functions::function> func;
+    if (_args_present) {
+        func = functions::functions::find(_name, _arg_types);
+        if (!func) {
+            return make_ready_future<>();
+        }
+    } else {
+        auto funcs = functions::functions::find(_name);
+        if (!funcs.empty()) {
+            auto b = funcs.begin();
+            auto i = b;
+            if (++i != funcs.end()) {
+                return make_ready_future<>();
+            }
+            func = b->second;
+        } else {
+            return make_ready_future<>();
+        }
+    }
+
+    sstring encoded_signature = format("{}[{}]",
+            _name.name,
+            ::join("^", _arg_types | boost::adaptors::transformed([] (const data_type t) {
+                return t->name();
+            })));
+
+    try {
+        return state.has_function_access(qp.db(), _name.keyspace, encoded_signature, auth::permission::DROP);
+    } catch (exceptions::invalid_request_exception&) {
+        if (!_if_exists) {
+            throw;
+        }
+        return make_ready_future();
     }
 }
 

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -20,6 +20,13 @@ namespace statements {
 
 future<> function_statement::check_access(query_processor& qp, const service::client_state& state) const { return make_ready_future<>(); }
 
+future<> create_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const {
+    co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
+    if (_or_replace) {
+        co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::ALTER);
+    }
+}
+
 function_statement::function_statement(
         functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types)
     : _name(std::move(name)), _raw_arg_types(std::move(raw_arg_types)) {}

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -65,6 +65,9 @@ protected:
 
     drop_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             bool args_present, bool if_exists);
+
+public:
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 };
 
 }

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -49,6 +49,9 @@ protected:
 
     create_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types,
             bool or_replace, bool if_not_exists);
+
+public:
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 };
 
 // common logic for dropping UDF and UDA

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -200,10 +200,22 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
         const data_dictionary::database db = qp.db();
         auto&& s = db.find_schema(keyspace(), column_family());
         auto& cf_name = s->is_view() ? s->view_info()->base_name() : column_family();
-        return state.has_column_family_access(db, keyspace(), cf_name, auth::permission::SELECT);
+        co_await state.has_column_family_access(db, keyspace(), cf_name, auth::permission::SELECT);
     } catch (const data_dictionary::no_such_column_family& e) {
         // Will be validated afterwards.
-        return make_ready_future<>();
+        co_return;
+    }
+    if (!_selection->is_trivial()) {
+        std::vector<::shared_ptr<functions::function>> used_functions = _selection->used_functions();
+        for (const auto& used_function : used_functions) {
+            sstring encoded_signature = format("{}[{}]",
+                    used_function->name().name,
+                    ::join("^", used_function->arg_types() | boost::adaptors::transformed([] (const data_type t) {
+                        return t->name();
+                    })));
+
+            co_await state.has_function_access(qp.db(), used_function->name().keyspace, encoded_signature, auth::permission::EXECUTE);
+        }
     }
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2180,15 +2180,15 @@ std::vector<mutation> make_create_aggregate_mutations(schema_features features, 
     mutation& m = p.first;
     clustering_key& ckey = p.second;
 
-    data_type state_type = aggregate->sfunc().arg_types()[0];
+    data_type state_type = aggregate->sfunc()->arg_types()[0];
     if (aggregate->has_finalfunc()) {
-        m.set_clustered_cell(ckey, "final_func", aggregate->finalfunc().name().name, timestamp);
+        m.set_clustered_cell(ckey, "final_func", aggregate->finalfunc()->name().name, timestamp);
     }
     if (aggregate->initcond()) {
         m.set_clustered_cell(ckey, "initcond", state_type->deserialize(*aggregate->initcond()).to_parsable_string(), timestamp);
     }
     m.set_clustered_cell(ckey, "return_type", aggregate->return_type()->as_cql3_type().to_string(), timestamp);
-    m.set_clustered_cell(ckey, "state_func", aggregate->sfunc().name().name, timestamp);
+    m.set_clustered_cell(ckey, "state_func", aggregate->sfunc()->name().name, timestamp);
     m.set_clustered_cell(ckey, "state_type", state_type->as_cql3_type().to_string(), timestamp);
     std::vector<mutation> muts = {m};
 

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -80,6 +80,21 @@ future<> service::client_state::has_keyspace_access(data_dictionary::database db
     co_return co_await has_access(db, ks, {p, r});
 }
 
+future<> service::client_state::has_functions_access(data_dictionary::database db, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource();
+    co_return co_await ensure_has_permission({p, r});
+}
+
+future<> service::client_state::has_functions_access(data_dictionary::database db, const sstring& ks, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource(ks);
+    co_return co_await has_access(db, ks, {p, r});
+}
+
+future<> service::client_state::has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_name, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource(ks, function_name);
+    co_return co_await has_access(db, ks, {p, r});
+}
+
 future<> service::client_state::has_column_family_access(data_dictionary::database db, const sstring& ks,
                 const sstring& cf, auth::permission p, auth::command_desc::type t) const {
     // NOTICE: callers of this function tend to assume that this error will be thrown

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -326,6 +326,9 @@ public:
     future<> has_schema_access(data_dictionary::database db, const schema& s, auth::permission p) const;
     future<> has_schema_access(data_dictionary::database db, const sstring&, const sstring&, auth::permission p) const;
 
+    future<> has_functions_access(data_dictionary::database db, auth::permission p) const;
+    future<> has_functions_access(data_dictionary::database db, const sstring& ks, auth::permission p) const;
+    future<> has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_signature, auth::permission p) const;
 private:
     future<> has_access(data_dictionary::database db, const sstring& keyspace, auth::command_desc) const;
 

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -998,8 +998,10 @@ SEASTAR_THREAD_TEST_CASE(test_user_function_db_init) {
 
 SEASTAR_TEST_CASE(test_user_function_mixups) {
     return with_udf_enabled([] (cql_test_env& e) {
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE OR REPLACE FUNCTION system.now() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get(),
                 exceptions::unauthorized_exception,
                 message_contains("system keyspace is not user-modifiable"));

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -1001,7 +1001,8 @@ SEASTAR_TEST_CASE(test_user_function_mixups) {
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE OR REPLACE FUNCTION system.now() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get(),
-                                ire, message_equals("Cannot replace 'system.now : () -> timeuuid' which is not a user defined function"));
+                exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
 
         e.execute_cql("CREATE FUNCTION my_func1(a int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get();
         e.execute_cql("CREATE FUNCTION my_func2() CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get();

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -123,3 +123,62 @@ def test_grant_revoke_data_permissions(cql, test_keyspace):
                 # Same for DROP
                 cql.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{t}(id int primary key)")
                 check_enforced(cql, username, permission='DROP', resource='ALL KEYSPACES', function=drop_table_idempotent)
+
+# Test that permissions for user-defined functions are serialized in a Cassandra-compatible way
+def test_udf_permissions_serialization(cql):
+    schema = "a int primary key"
+    user = "cassandra"
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_test_table(cql, keyspace, schema) as table:
+            # Creating a bilingual function makes this test case work for both Scylla and Cassandra
+            div_body_lua = "(b bigint, i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return b//i'"
+            div_body_java = "(b bigint, i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return b/i;'"
+            div_body = div_body_lua
+            try:
+                with new_function(cql, keyspace, div_body) as div_fun:
+                    pass
+            except:
+                div_body = div_body_java
+            with new_function(cql, keyspace, div_body) as div_fun:
+                applicable_permissions = {
+                    'all functions': ['create', 'alter', 'drop', 'authorize', 'execute'],
+                    f'all functions in keyspace {keyspace}': ['create', 'alter', 'drop', 'authorize', 'execute'],
+                    f'function {keyspace}.{div_fun}(bigint, int)': ['alter', 'drop', 'authorize', 'execute'],
+                }
+                for resource, permissions in applicable_permissions.items():
+                    # Applicable permissions can be legally granted
+                    for permission in permissions:
+                        cql.execute(f"GRANT {permission} ON {resource} TO {user}")
+
+                permissions = {row.resource: row.permissions for row in cql.execute(f"SELECT * FROM system_auth.role_permissions")}
+                assert permissions['functions'] == set(['ALTER', 'AUTHORIZE', 'CREATE', 'DROP', 'EXECUTE'])
+                assert permissions[f'functions/{keyspace}'] == set(['ALTER', 'AUTHORIZE', 'CREATE', 'DROP', 'EXECUTE'])
+                assert permissions[f'functions/{keyspace}/{div_fun}[org.apache.cassandra.db.marshal.LongType^org.apache.cassandra.db.marshal.Int32Type]'] == set(['ALTER', 'AUTHORIZE', 'DROP', 'EXECUTE'])
+
+                resources_with_execute = [row.resource for row in cql.execute(f"LIST EXECUTE OF {user}")]
+                assert '<all functions>' in resources_with_execute
+                assert f'<all functions in {keyspace}>' in resources_with_execute
+                assert f'<function {keyspace}.{div_fun}(bigint, int)>' in resources_with_execute
+
+# Test that names that require quoting (e.g. due to having nonorthodox characters)
+# are properly handled, with right permissions granted.
+# Cassandra doesn't quote names properly, so the test fails
+def test_udf_permissions_quoted_names(cassandra_bug, cql):
+    schema = "a int primary key"
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_test_table(cql, keyspace, schema) as table:
+            weird_body_lua = "(i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return 42;'"
+            weird_body_java = "(i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return 42;'"
+            weird_body = weird_body_lua
+            try:
+                with new_function(cql, keyspace, weird_body) as weird_fun:
+                    pass
+            except:
+                weird_body = weird_body_java
+            with new_function(cql, keyspace, weird_body, '"weird[name]"') as weird_fun:
+                with new_user(cql) as username:
+                    with new_session(cql, username) as user_session:
+                        grant(cql, 'EXECUTE', f'FUNCTION {keyspace}.{weird_fun}(int)', username)
+                        grant(cql, 'SELECT', table, username)
+                        cql.execute(f"INSERT INTO {table}(a) VALUES (7)")
+                        assert list([r[0] for r in user_session.execute(f"SELECT {keyspace}.{weird_fun}(a) FROM {table}")]) == [42]


### PR DESCRIPTION
This series aims for allowing users to set permissions over user-defined functions.
The following permissions on resources should be supported:
```
    CREATE ALL FUNCTIONS
    CREATE ALL FUNCTIONS IN KEYSPACE <ks>
    
    ALTER ALL FUNCTIONS
    ALTER ALL FUNCTIONS IN KEYSPACE <ks>
    
    DROP ALL FUNCTIONS
    DROP ALL FUNCTIONS IN KEYSPACE <ks>
    
    AUTHORIZE ALL FUNCTIONS
    AUTHORIZE ALL FUNCTIONS IN KEYSPACE <ks>
    
    EXECUTE ALL FUNCTIONS
    EXECUTE ALL FUNCTIONS IN KEYSPACE <ks>
    EXECUTE FUNCTION <f>
```

The implementation is based on Cassandra's documentation and should be fully compatible: https://cassandra.apache.org/doc/latest/cassandra/cql/security.html#cql-permissions

Fixes #10633