### PR TITLE
Make get_range_addresses async and hold effective_replication_map_ptr around it

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -548,7 +548,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
     ss::describe_any_ring.set(r, [&ctx, &ss](std::unique_ptr<request> req) {
         // Find an arbitrary non-system keyspace.
-        auto keyspaces = ctx.db.local().get_non_system_keyspaces();
+        auto keyspaces = ctx.db.local().get_non_local_strategy_keyspaces();
         if (keyspaces.empty()) {
             throw std::runtime_error("No keyspace provided and no non system kespace exist");
         }
@@ -806,9 +806,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         if (type == "user") {
             return ctx.db.local().get_user_keyspaces();
         } else if (type == "non_local_strategy") {
-            return map_keys(ctx.db.local().get_keyspaces() | boost::adaptors::filtered([](const auto& p) {
-                return p.second.get_replication_strategy().get_type() != locator::replication_strategy_type::local;
-            }));
+            return ctx.db.local().get_non_local_strategy_keyspaces();
         }
         return map_keys(ctx.db.local().get_keyspaces());
     });

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -46,20 +46,14 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         }
         blogger.debug("nodes_to_filter={}", nodes_to_filter);
         streamer->add_source_filter(std::make_unique<range_streamer::failure_detector_source_filter>(nodes_to_filter));
-        auto keyspace = _db.local().get_non_local_strategy_keyspaces();
-        for (auto& keyspace_name : keyspace) {
-            if (!_db.local().has_keyspace(keyspace_name)) {
-                // The keyspace was dropped while we were looping.
-                continue;
-            }
-
-            auto& ks = _db.local().find_keyspace(keyspace_name);
-            auto strategy = ks.get_replication_strategy_ptr();
+        auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
+        for (const auto& [keyspace_name, erm] : ks_erms) {
+            auto& strategy = erm->get_replication_strategy();
             // We took a strategy ptr to keep it alive during the `co_await`.
             // The keyspace may be dropped in the meantime.
-            dht::token_range_vector ranges = co_await strategy->get_pending_address_ranges(_token_metadata_ptr, _tokens, _address);
+            dht::token_range_vector ranges = co_await strategy.get_pending_address_ranges(_token_metadata_ptr, _tokens, _address);
             blogger.debug("Will stream keyspace={}, ranges={}", keyspace_name, ranges);
-            co_await streamer->add_ranges(keyspace_name, ranges, gossiper, reason == streaming::stream_reason::replace);
+            co_await streamer->add_ranges(keyspace_name, erm, ranges, gossiper, reason == streaming::stream_reason::replace);
         }
         _abort_source.check();
         co_await streamer->stream_async();

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -46,8 +46,8 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         }
         blogger.debug("nodes_to_filter={}", nodes_to_filter);
         streamer->add_source_filter(std::make_unique<range_streamer::failure_detector_source_filter>(nodes_to_filter));
-        auto keyspaces = _db.local().get_non_system_keyspaces();
-        for (auto& keyspace_name : keyspaces) {
+        auto keyspace = _db.local().get_non_local_strategy_keyspaces();
+        for (auto& keyspace_name : keyspace) {
             if (!_db.local().has_keyspace(keyspace_name)) {
                 // The keyspace was dropped while we were looping.
                 continue;

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -84,7 +84,7 @@ std::unordered_map<dht::token_range, std::vector<inet_address>>
 range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector desired_ranges) {
     logger.debug("{} ks={}", __func__, keyspace_name);
 
-    auto range_addresses = erm->get_range_addresses();
+    auto range_addresses = erm->get_range_addresses().get0();
 
     logger.debug("keyspace={}, desired_ranges.size={}, range_addresses.size={}", keyspace_name, desired_ranges.size(), range_addresses.size());
 

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -21,7 +21,6 @@
 #include "db/config.hh"
 #include <seastar/core/semaphore.hh>
 #include <boost/range/adaptors.hpp>
-#include "locator/abstract_replication_strategy.hh"
 
 namespace dht {
 
@@ -82,11 +81,8 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
 
 // Must be called from a seastar thread
 std::unordered_map<dht::token_range, std::vector<inet_address>>
-range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges) {
+range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector desired_ranges) {
     logger.debug("{} ks={}", __func__, keyspace_name);
-
-    auto& ks = _db.local().find_keyspace(keyspace_name);
-    auto erm = ks.get_effective_replication_map();
 
     auto range_addresses = erm->get_range_addresses();
 
@@ -121,13 +117,11 @@ range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, dh
 
 // Must be called from a seastar thread
 std::unordered_map<dht::token_range, std::vector<inet_address>>
-range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges, gms::gossiper& gossiper) {
+range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector desired_ranges, gms::gossiper& gossiper) {
     logger.debug("{} ks={}", __func__, keyspace_name);
     assert (_tokens.empty() == false);
 
-    auto& ks = _db.local().find_keyspace(keyspace_name);
-    auto& strat = ks.get_replication_strategy();
-    auto erm = ks.get_effective_replication_map();
+    auto& strat = erm->get_replication_strategy();
 
     //Active ranges
     auto metadata_clone = get_token_metadata().clone_only_token_map().get0();
@@ -190,12 +184,10 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
     return range_sources;
 }
 
-bool range_streamer::use_strict_sources_for_ranges(const sstring& keyspace_name) {
-    auto& ks = _db.local().find_keyspace(keyspace_name);
-    auto erm = ks.get_effective_replication_map();
+bool range_streamer::use_strict_sources_for_ranges(const sstring& keyspace_name, const locator::effective_replication_map_ptr& erm) {
     auto rf = erm->get_replication_factor();
     auto nr_nodes_in_ring = get_token_metadata().get_all_endpoints().size();
-    bool everywhere_topology = ks.get_replication_strategy().get_type() == locator::replication_strategy_type::everywhere_topology;
+    bool everywhere_topology = erm->get_replication_strategy().get_type() == locator::replication_strategy_type::everywhere_topology;
     // Use strict when number of nodes in the ring is equal or more than RF
     auto strict = _db.local().get_config().consistent_rangemovement()
            && !_tokens.empty()
@@ -223,15 +215,15 @@ void range_streamer::add_rx_ranges(const sstring& keyspace_name, std::unordered_
 }
 
 // TODO: This is the legacy range_streamer interface, it is add_rx_ranges which adds rx ranges.
-future<> range_streamer::add_ranges(const sstring& keyspace_name, dht::token_range_vector ranges, gms::gossiper& gossiper, bool is_replacing) {
-  return seastar::async([this, keyspace_name, ranges= std::move(ranges), &gossiper, is_replacing] () mutable {
+future<> range_streamer::add_ranges(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector ranges, gms::gossiper& gossiper, bool is_replacing) {
+  return seastar::async([this, keyspace_name, erm = std::move(erm), ranges= std::move(ranges), &gossiper, is_replacing] () mutable {
     if (_nr_tx_added) {
         throw std::runtime_error("Mixed sending and receiving is not supported");
     }
     _nr_rx_added++;
-    auto ranges_for_keyspace = !is_replacing && use_strict_sources_for_ranges(keyspace_name)
-        ? get_all_ranges_with_strict_sources_for(keyspace_name, ranges, gossiper)
-        : get_all_ranges_with_sources_for(keyspace_name, ranges);
+    auto ranges_for_keyspace = !is_replacing && use_strict_sources_for_ranges(keyspace_name, erm)
+        ? get_all_ranges_with_strict_sources_for(keyspace_name, erm, ranges, gossiper)
+        : get_all_ranges_with_sources_for(keyspace_name, erm, ranges);
 
     if (logger.is_enabled(logging::log_level::debug)) {
         for (auto& x : ranges_for_keyspace) {

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "locator/token_metadata.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "streaming/stream_plan.hh"
 #include "streaming/stream_state.hh"
 #include "streaming/stream_reason.hh"
@@ -97,24 +97,24 @@ public:
         _source_filters.emplace(std::move(filter));
     }
 
-    future<> add_ranges(const sstring& keyspace_name, dht::token_range_vector ranges, gms::gossiper& gossiper, bool is_replacing);
+    future<> add_ranges(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector ranges, gms::gossiper& gossiper, bool is_replacing);
     void add_tx_ranges(const sstring& keyspace_name, std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint);
     void add_rx_ranges(const sstring& keyspace_name, std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint);
 private:
-    bool use_strict_sources_for_ranges(const sstring& keyspace_name);
+    bool use_strict_sources_for_ranges(const sstring& keyspace_name, const locator::effective_replication_map_ptr& erm);
     /**
      * Get a map of all ranges and their respective sources that are candidates for streaming the given ranges
      * to us. For each range, the list of sources is sorted by proximity relative to the given destAddress.
      */
     std::unordered_map<dht::token_range, std::vector<inet_address>>
-    get_all_ranges_with_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges);
+    get_all_ranges_with_sources_for(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector desired_ranges);
     /**
      * Get a map of all ranges and the source that will be cleaned up once this bootstrapped node is added for the given ranges.
      * For each range, the list should only contain a single source. This allows us to consistently migrate data without violating
      * consistency.
      */
     std::unordered_map<dht::token_range, std::vector<inet_address>>
-    get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, dht::token_range_vector desired_ranges, gms::gossiper& gossiper);
+    get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, locator::effective_replication_map_ptr erm, dht::token_range_vector desired_ranges, gms::gossiper& gossiper);
 private:
     /**
      * @param rangesWithSources The ranges we want to fetch (key) and their potential sources (value)

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -176,7 +176,7 @@ abstract_replication_strategy::get_ranges(inet_address ep, token_metadata_ptr tm
     for (auto tok : sorted_tokens) {
         auto eps = co_await calculate_natural_endpoints(tok, tm);
         if (eps.contains(ep)) {
-                insert_token_range_to_sorted_container_while_unwrapping(prev_tok, tok, ret);
+            insert_token_range_to_sorted_container_while_unwrapping(prev_tok, tok, ret);
         }
         prev_tok = tok;
     }
@@ -295,7 +295,7 @@ abstract_replication_strategy::get_pending_address_ranges(const token_metadata_p
     temp = co_await tmptr->clone_only_token_map();
     co_await temp.update_normal_tokens(pending_tokens, pending_address);
     for (auto& x : co_await get_address_ranges(temp, pending_address)) {
-            ret.push_back(x.second);
+        ret.push_back(x.second);
     }
     co_await temp.clear_gently();
     co_return ret;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -256,7 +256,7 @@ abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet
     co_return ret;
 }
 
-std::unordered_map<dht::token_range, inet_address_vector_replica_set>
+future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 effective_replication_map::get_range_addresses() const {
     const token_metadata& tm = *_tmptr;
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> ret;
@@ -265,8 +265,9 @@ effective_replication_map::get_range_addresses() const {
         for (auto& r : ranges) {
             ret.emplace(r, eps);
         }
+        co_await coroutine::maybe_yield();
     }
-    return ret;
+    co_return ret;
 }
 
 future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -286,7 +286,7 @@ abstract_replication_strategy::get_range_addresses(const token_metadata& tm) con
         dht::token_range_vector ranges = tm.get_primary_ranges_for(t);
         auto eps = co_await calculate_natural_endpoints(t, tm);
         for (auto& r : ranges) {
-            ret.emplace(r, eps);
+            ret.emplace(r, eps.get_vector());
         }
     }
     co_return ret;
@@ -314,7 +314,8 @@ future<mutable_effective_replication_map_ptr> calculate_effective_replication_ma
     replication_map replication_map;
 
     for (const auto &t : tmptr->sorted_tokens()) {
-        replication_map.emplace(t, co_await rs->calculate_natural_endpoints(t, *tmptr));
+        auto eps = co_await rs->calculate_natural_endpoints(t, *tmptr);
+        replication_map.emplace(t, eps.get_vector());
     }
 
     auto rf = rs->get_replication_factor(*tmptr);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -294,8 +294,13 @@ abstract_replication_strategy::get_pending_address_ranges(const token_metadata_p
     token_metadata temp;
     temp = co_await tmptr->clone_only_token_map();
     co_await temp.update_normal_tokens(pending_tokens, pending_address);
-    for (auto& x : co_await get_address_ranges(temp, pending_address)) {
-        ret.push_back(x.second);
+    for (const auto& t : temp.sorted_tokens()) {
+        auto eps = co_await calculate_natural_endpoints(t, temp);
+        if (eps.contains(pending_address)) {
+            dht::token_range_vector r = temp.get_primary_ranges_for(t);
+            rslogger.debug("get_pending_address_ranges: token={} primary_range={} endpoint={}", t, r, pending_address);
+            ret.insert(ret.end(), r.begin(), r.end());
+        }
     }
     co_await temp.clear_gently();
     co_return ret;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -260,9 +260,8 @@ std::unordered_map<dht::token_range, inet_address_vector_replica_set>
 effective_replication_map::get_range_addresses() const {
     const token_metadata& tm = *_tmptr;
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> ret;
-    for (auto& t : tm.sorted_tokens()) {
+    for (const auto& [t, eps] : _replication_map) {
         dht::token_range_vector ranges = tm.get_primary_ranges_for(t);
-        auto eps = get_natural_endpoints(t);
         for (auto& r : ranges) {
             ret.emplace(r, eps);
         }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -222,7 +222,7 @@ public:
     // Note: must be called after token_metadata has been initialized.
     dht::token_range_vector get_primary_ranges_within_dc(inet_address ep) const;
 
-    std::unordered_map<dht::token_range, inet_address_vector_replica_set>
+    future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
     get_range_addresses() const;
 
 private:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -174,6 +174,10 @@ public:
         return _tmptr;
     }
 
+    const locator::abstract_replication_strategy& get_replication_strategy() const noexcept {
+        return *_rs;
+    }
+
     const replication_map& get_replication_map() const noexcept {
         return _replication_map;
     }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -18,6 +18,7 @@
 #include "snitch_base.hh"
 #include <seastar/util/bool_class.hh>
 #include "utils/maybe_yield.hh"
+#include "utils/sequenced_set.hh"
 
 // forward declaration since replica/database.hh includes this file
 namespace replica {
@@ -43,6 +44,8 @@ using can_yield = utils::can_yield;
 using replication_strategy_config_options = std::map<sstring, sstring>;
 
 using replication_map = std::unordered_map<token, inet_address_vector_replica_set>;
+
+using endpoint_set = utils::basic_sequenced_set<inet_address, inet_address_vector_replica_set>;
 
 class effective_replication_map;
 class effective_replication_map_factory;
@@ -80,7 +83,7 @@ public:
     // is small, that implementation may not yield since by itself it won't cause a reactor stall (assuming practical
     // cluster sizes and number of tokens per node). The caller is responsible for yielding if they call this function
     // in a loop.
-    virtual future<inet_address_vector_replica_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
+    virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
 
     virtual ~abstract_replication_strategy() {}
     static ptr_type create_replication_strategy(const sstring& strategy_name, const replication_strategy_config_options& config_options);

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -19,8 +19,9 @@ namespace locator {
 everywhere_replication_strategy::everywhere_replication_strategy(const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options, replication_strategy_type::everywhere_topology) {}
 
-future<inet_address_vector_replica_set> everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const {
-    return make_ready_future<inet_address_vector_replica_set>(boost::copy_range<inet_address_vector_replica_set>(tm.get_all_endpoints()));
+future<endpoint_set> everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const {
+    auto eps = tm.get_all_endpoints();
+    return make_ready_future<endpoint_set>(endpoint_set(eps.begin(), eps.end()));
 }
 
 size_t everywhere_replication_strategy::get_replication_factor(const token_metadata& tm) const {

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -18,7 +18,7 @@ class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
     everywhere_replication_strategy(const replication_strategy_config_options& config_options);
 
-    virtual future<inet_address_vector_replica_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
+    virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options() const override { /* noop */ }
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -17,8 +17,8 @@ namespace locator {
 local_strategy::local_strategy(const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options, replication_strategy_type::local) {}
 
-future<inet_address_vector_replica_set> local_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
-    return make_ready_future<inet_address_vector_replica_set>(inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()}));
+future<endpoint_set> local_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
+    return make_ready_future<endpoint_set>(endpoint_set({utils::fb_utilities::get_broadcast_address()}));
 }
 
 void local_strategy::validate_options() const {

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -27,7 +27,7 @@ public:
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 
-    virtual future<inet_address_vector_replica_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
+    virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options() const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -14,7 +14,6 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include "locator/network_topology_strategy.hh"
-#include "utils/sequenced_set.hh"
 #include <boost/algorithm/string.hpp>
 #include "utils/hash.hh"
 
@@ -75,7 +74,6 @@ network_topology_strategy::network_topology_strategy(
     }
 }
 
-using endpoint_set = utils::sequenced_set<inet_address>;
 using endpoint_dc_rack_set = std::unordered_set<endpoint_dc_rack>;
 
 class natural_endpoints_tracker {
@@ -234,12 +232,12 @@ public:
         return _dcs_to_fill == 0;
     }
 
-    const endpoint_set& replicas() const noexcept {
+    endpoint_set& replicas() noexcept {
         return _replicas;
     }
 };
 
-future<inet_address_vector_replica_set>
+future<endpoint_set>
 network_topology_strategy::calculate_natural_endpoints(
     const token& search_token, const token_metadata& tm) const {
 
@@ -254,7 +252,7 @@ network_topology_strategy::calculate_natural_endpoints(
         }
     }
 
-    co_return boost::copy_range<inet_address_vector_replica_set>(tracker.replicas().get_vector());
+    co_return std::move(tracker.replicas());
 }
 
 void network_topology_strategy::validate_options() const {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -44,7 +44,7 @@ protected:
      * calculate endpoints in one pass through the tokens by tracking our
      * progress in each DC, rack etc.
      */
-    virtual future<inet_address_vector_replica_set> calculate_natural_endpoints(
+    virtual future<endpoint_set> calculate_natural_endpoints(
         const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options() const override;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -33,15 +33,15 @@ simple_strategy::simple_strategy(const replication_strategy_config_options& conf
     }
 }
 
-future<inet_address_vector_replica_set> simple_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
+future<endpoint_set> simple_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
     const std::vector<token>& tokens = tm.sorted_tokens();
 
     if (tokens.empty()) {
-        co_return inet_address_vector_replica_set();
+        co_return endpoint_set();
     }
 
     size_t replicas = _replication_factor;
-    utils::sequenced_set<inet_address> endpoints;
+    endpoint_set endpoints;
     endpoints.reserve(replicas);
 
     for (auto& token : tm.ring_range(t)) {
@@ -60,7 +60,7 @@ future<inet_address_vector_replica_set> simple_strategy::calculate_natural_endpo
         co_await coroutine::maybe_yield();
     }
 
-    co_return boost::copy_range<inet_address_vector_replica_set>(endpoints.get_vector());
+    co_return endpoints;
 }
 
 size_t simple_strategy::get_replication_factor(const token_metadata&) const {

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -26,7 +26,7 @@ public:
         return true;
     }
 
-    virtual future<inet_address_vector_replica_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
+    virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 private:
     size_t _replication_factor = 1;
 };

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -816,13 +816,10 @@ void token_metadata_impl::calculate_pending_ranges_for_leaving(
         auto t = r.end() ? r.end()->value() : dht::maximum_token();
         auto current_endpoints = strategy.calculate_natural_endpoints(t, metadata).get0();
         auto new_endpoints = strategy.calculate_natural_endpoints(t, *all_left_metadata).get0();
-        std::vector<inet_address> diff;
-        std::sort(current_endpoints.begin(), current_endpoints.end());
-        std::sort(new_endpoints.begin(), new_endpoints.end());
-        std::set_difference(new_endpoints.begin(), new_endpoints.end(),
-            current_endpoints.begin(), current_endpoints.end(), std::back_inserter(diff));
-        for (auto& ep : diff) {
+        for (auto ep : new_endpoints) {
+          if (!current_endpoints.contains(ep)) {
             new_pending_ranges.emplace(r, ep);
+          }
         }
         seastar::thread::maybe_yield();
     }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1342,17 +1342,16 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
     using inet_address = gms::inet_address;
     return seastar::async([this, tmptr = std::move(tmptr), tokens = std::move(bootstrap_tokens)] () mutable {
         seastar::sharded<replica::database>& db = get_db();
-        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
+        auto ks_erms = db.local().get_non_local_strategy_keyspaces_erms();
         auto myip = utils::fb_utilities::get_broadcast_address();
         auto reason = streaming::stream_reason::bootstrap;
         // Calculate number of ranges to sync data
         size_t nr_ranges_total = 0;
-        for (auto& keyspace_name : keyspaces) {
+        for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.local().has_keyspace(keyspace_name)) {
                 continue;
             }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            auto& strat = ks.get_replication_strategy();
+            auto& strat = erm->get_replication_strategy();
             dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip).get0();
             seastar::thread::maybe_yield();
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
@@ -1362,18 +1361,16 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             rs.get_metrics().bootstrap_finished_ranges = 0;
             rs.get_metrics().bootstrap_total_ranges = nr_ranges_total;
         }).get();
-        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", keyspaces, nr_ranges_total);
-        for (auto& keyspace_name : keyspaces) {
+        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", ks_erms | boost::adaptors::map_keys, nr_ranges_total);
+        for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.local().has_keyspace(keyspace_name)) {
                 rlogger.info("bootstrap_with_repair: keyspace={} does not exist any more, ignoring it", keyspace_name);
                 continue;
             }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            auto& strat = ks.get_replication_strategy();
+            auto& strat = erm->get_replication_strategy();
             dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip).get0();
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
             bool everywhere_topology = strat.get_type() == locator::replication_strategy_type::everywhere_topology;
-            auto erm = ks.get_effective_replication_map();
             auto replication_factor = erm->get_replication_factor();
 
             //Active ranges
@@ -1420,7 +1417,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                         std::vector<inet_address> neighbors;
                         auto& topology = db.local().get_token_metadata().get_topology();
                         auto local_dc = topology.get_datacenter();
-                        auto get_node_losing_the_ranges = [&] (const std::vector<gms::inet_address>& old_nodes, const std::unordered_set<gms::inet_address>& new_nodes) {
+                        auto get_node_losing_the_ranges = [&, &keyspace_name = keyspace_name] (const std::vector<gms::inet_address>& old_nodes, const std::unordered_set<gms::inet_address>& new_nodes) {
                             // Remove the new nodes from the old nodes list, so
                             // that it contains only the node that will lose
                             // the ownership of the range.
@@ -1432,10 +1429,10 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                             }
                             return nodes;
                         };
-                        auto get_rf_in_local_dc = [&] () {
+                        auto get_rf_in_local_dc = [&, &keyspace_name = keyspace_name] () {
                             size_t rf_in_local_dc = replication_factor;
                             if (strat.get_type() == locator::replication_strategy_type::network_topology) {
-                                auto nts = dynamic_cast<locator::network_topology_strategy*>(&strat);
+                                auto nts = dynamic_cast<const locator::network_topology_strategy*>(&strat);
                                 if (!nts) {
                                     throw std::runtime_error(format("bootstrap_with_repair: keyspace={}, range={}, failed to cast to network_topology_strategy",
                                             keyspace_name, desired_range));
@@ -1510,7 +1507,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             sync_data_using_repair(keyspace_name, std::move(desired_ranges), std::move(range_sources), reason, {}).get();
             rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges);
         }
-        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", keyspaces);
+        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | boost::adaptors::map_keys);
     });
 }
 
@@ -1519,17 +1516,13 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
     return seastar::async([this, tmptr = std::move(tmptr), leaving_node = std::move(leaving_node), ops] () mutable {
         seastar::sharded<replica::database>& db = get_db();
         auto myip = utils::fb_utilities::get_broadcast_address();
-        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
+        auto ks_erms = db.local().get_non_local_strategy_keyspaces_erms();
         bool is_removenode = myip != leaving_node;
         auto op = is_removenode ? "removenode_with_repair" : "decommission_with_repair";
         streaming::stream_reason reason = is_removenode ? streaming::stream_reason::removenode : streaming::stream_reason::decommission;
         size_t nr_ranges_total = 0;
-        for (auto& keyspace_name : keyspaces) {
-            if (!db.local().has_keyspace(keyspace_name)) {
-                continue;
-            }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            dht::token_range_vector ranges = ks.get_effective_replication_map()->get_ranges(leaving_node);
+        for (const auto& [keyspace_name, erm] : ks_erms) {
+            dht::token_range_vector ranges = erm->get_ranges(leaving_node);
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
             nr_ranges_total += ranges.size() * nr_tables;
         }
@@ -1544,15 +1537,13 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                 rs.get_metrics().removenode_total_ranges = nr_ranges_total;
             }).get();
         }
-        rlogger.info("{}: started with keyspaces={}, leaving_node={}", op, keyspaces, leaving_node);
-        for (auto& keyspace_name : keyspaces) {
+        rlogger.info("{}: started with keyspaces={}, leaving_node={}", op, ks_erms | boost::adaptors::map_keys, leaving_node);
+        for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.local().has_keyspace(keyspace_name)) {
                 rlogger.info("{}: keyspace={} does not exist any more, ignoring it", op, keyspace_name);
                 continue;
             }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            auto& strat = ks.get_replication_strategy();
-            auto erm = ks.get_effective_replication_map();
+            auto& strat = erm->get_replication_strategy();
             // First get all ranges the leaving node is responsible for
             dht::token_range_vector ranges = erm->get_ranges(leaving_node);
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
@@ -1583,7 +1574,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                     ops->check_abort();
                 }
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
-                const auto new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp).get0();
+                const auto new_eps = strat.calculate_natural_endpoints(end_token, temp).get0();
                 const auto& current_eps = current_replica_endpoints[r];
                 std::unordered_set<inet_address> neighbors_set = new_eps.get_set();
                 bool skip_this_range = false;
@@ -1595,7 +1586,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                     throw std::runtime_error(format("{}: keyspace={}, range={}, current_replica_endpoints={}, new_replica_endpoints={}, zero replica after the removal",
                             op, keyspace_name, r, current_eps, new_eps));
                 }
-                auto get_neighbors_set = [&] (const std::vector<inet_address>& nodes) {
+                auto get_neighbors_set = [&, &keyspace_name = keyspace_name] (const std::vector<inet_address>& nodes) {
                     for (auto& node : nodes) {
                         if (topology.get_datacenter(node) == local_dc) {
                             return std::unordered_set<inet_address>{node};;
@@ -1708,7 +1699,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
                 op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced, nr_ranges_skipped);
         }
-        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, keyspaces, leaving_node);
+        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, ks_erms | boost::adaptors::map_keys, leaving_node);
     });
 }
 
@@ -1737,15 +1728,14 @@ future<> repair_service::abort_repair_node_ops(utils::UUID ops_uuid) {
 future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes) {
     return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         seastar::sharded<replica::database>& db = get_db();
-        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
+        auto ks_erms = db.local().get_non_local_strategy_keyspaces_erms();
         auto myip = utils::fb_utilities::get_broadcast_address();
         size_t nr_ranges_total = 0;
-        for (auto& keyspace_name : keyspaces) {
+        for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.local().has_keyspace(keyspace_name)) {
                 continue;
             }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            auto& strat = ks.get_replication_strategy();
+            auto& strat = erm->get_replication_strategy();
             // Okay to yield since tm is immutable
             dht::token_range_vector ranges = strat.get_ranges(myip, tmptr).get0();
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
@@ -1763,15 +1753,14 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
                 rs.get_metrics().replace_total_ranges = nr_ranges_total;
             }).get();
         }
-        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={}", op, keyspaces, source_dc, nr_ranges_total, ignore_nodes);
-        for (auto& keyspace_name : keyspaces) {
+        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={}", op, ks_erms | boost::adaptors::map_keys, source_dc, nr_ranges_total, ignore_nodes);
+        for (const auto& [keyspace_name, erm] : ks_erms) {
             size_t nr_ranges_skipped = 0;
             if (!db.local().has_keyspace(keyspace_name)) {
                 rlogger.info("{}: keyspace={} does not exist any more, ignoring it", op, keyspace_name);
                 continue;
             }
-            auto& ks = db.local().find_keyspace(keyspace_name);
-            auto& strat = ks.get_replication_strategy();
+            auto& strat = erm->get_replication_strategy();
             dht::token_range_vector ranges = strat.get_ranges(myip, tmptr).get0();
             std::unordered_map<dht::token_range, repair_neighbors> range_sources;
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
@@ -1815,7 +1804,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
             sync_data_using_repair(keyspace_name, std::move(ranges), std::move(range_sources), reason, {}).get();
             rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc, nr_ranges);
         }
-        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, keyspaces, source_dc);
+        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | boost::adaptors::map_keys, source_dc);
     });
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1559,7 +1559,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             rlogger.info("{}: started with keyspace={}, leaving_node={}, nr_ranges={}", op, keyspace_name, leaving_node, ranges.size() * nr_tables);
             size_t nr_ranges_total = ranges.size() * nr_tables;
             size_t nr_ranges_skipped = 0;
-            std::unordered_map<dht::token_range, inet_address_vector_replica_set> current_replica_endpoints;
+            std::unordered_map<dht::token_range, locator::endpoint_set> current_replica_endpoints;
             // Find (for each range) all nodes that store replicas for these ranges as well
             for (auto& r : ranges) {
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
@@ -1583,8 +1583,8 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                     ops->check_abort();
                 }
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
-                const inet_address_vector_replica_set new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp).get0();
-                const inet_address_vector_replica_set& current_eps = current_replica_endpoints[r];
+                const auto new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp).get0();
+                const auto& current_eps = current_replica_endpoints[r];
                 std::unordered_set<inet_address> neighbors_set(new_eps.begin(), new_eps.end());
                 bool skip_this_range = false;
                 auto new_owner = neighbors_set;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1585,7 +1585,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
                 const auto new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp).get0();
                 const auto& current_eps = current_replica_endpoints[r];
-                std::unordered_set<inet_address> neighbors_set(new_eps.begin(), new_eps.end());
+                std::unordered_set<inet_address> neighbors_set = new_eps.get_set();
                 bool skip_this_range = false;
                 auto new_owner = neighbors_set;
                 for (const auto& node : current_eps) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1342,7 +1342,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
     using inet_address = gms::inet_address;
     return seastar::async([this, tmptr = std::move(tmptr), tokens = std::move(bootstrap_tokens)] () mutable {
         seastar::sharded<replica::database>& db = get_db();
-        auto keyspaces = db.local().get_non_system_keyspaces();
+        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
         auto myip = utils::fb_utilities::get_broadcast_address();
         auto reason = streaming::stream_reason::bootstrap;
         // Calculate number of ranges to sync data
@@ -1519,7 +1519,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
     return seastar::async([this, tmptr = std::move(tmptr), leaving_node = std::move(leaving_node), ops] () mutable {
         seastar::sharded<replica::database>& db = get_db();
         auto myip = utils::fb_utilities::get_broadcast_address();
-        auto keyspaces = db.local().get_non_system_keyspaces();
+        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
         bool is_removenode = myip != leaving_node;
         auto op = is_removenode ? "removenode_with_repair" : "decommission_with_repair";
         streaming::stream_reason reason = is_removenode ? streaming::stream_reason::removenode : streaming::stream_reason::decommission;
@@ -1737,7 +1737,7 @@ future<> repair_service::abort_repair_node_ops(utils::UUID ops_uuid) {
 future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes) {
     return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         seastar::sharded<replica::database>& db = get_db();
-        auto keyspaces = db.local().get_non_system_keyspaces();
+        auto keyspaces = db.local().get_non_local_strategy_keyspaces();
         auto myip = utils::fb_utilities::get_broadcast_address();
         size_t nr_ranges_total = 0;
         for (auto& keyspace_name : keyspaces) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1121,6 +1121,17 @@ std::vector<sstring> database::get_non_local_strategy_keyspaces() const {
     return res;
 }
 
+std::unordered_map<sstring, locator::effective_replication_map_ptr> database::get_non_local_strategy_keyspaces_erms() const {
+    std::unordered_map<sstring, locator::effective_replication_map_ptr> res;
+    res.reserve(_keyspaces.size());
+    for (auto const& i : _keyspaces) {
+        if (i.second.get_replication_strategy().get_type() != locator::replication_strategy_type::local) {
+            res.emplace(i.first, i.second.get_effective_replication_map());
+        }
+    }
+    return res;
+}
+
 std::vector<lw_shared_ptr<column_family>> database::get_non_system_column_families() const {
     return boost::copy_range<std::vector<lw_shared_ptr<column_family>>>(
         get_column_families()

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1110,6 +1110,17 @@ std::vector<sstring> database::get_all_keyspaces() const {
     return res;
 }
 
+std::vector<sstring> database::get_non_local_strategy_keyspaces() const {
+    std::vector<sstring> res;
+    res.reserve(_keyspaces.size());
+    for (auto const& i : _keyspaces) {
+        if (i.second.get_replication_strategy().get_type() != locator::replication_strategy_type::local) {
+            res.push_back(i.first);
+        }
+    }
+    return res;
+}
+
 std::vector<lw_shared_ptr<column_family>> database::get_non_system_column_families() const {
     return boost::copy_range<std::vector<lw_shared_ptr<column_family>>>(
         get_column_families()

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1501,6 +1501,7 @@ public:
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;
     std::vector<sstring> get_non_local_strategy_keyspaces() const;
+    std::unordered_map<sstring, locator::effective_replication_map_ptr> get_non_local_strategy_keyspaces_erms() const;
     column_family& find_column_family(std::string_view ks, std::string_view name);
     const column_family& find_column_family(std::string_view ks, std::string_view name) const;
     column_family& find_column_family(const utils::UUID&);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1500,6 +1500,7 @@ public:
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;
+    std::vector<sstring> get_non_local_strategy_keyspaces() const;
     column_family& find_column_family(std::string_view ks, std::string_view name);
     const column_family& find_column_family(std::string_view ks, std::string_view name) const;
     column_family& find_column_family(const utils::UUID&);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2805,7 +2805,7 @@ future<> storage_service::removenode_add_ranges(lw_shared_ptr<dht::range_streame
                 my_new_ranges.emplace_back(x.first);
             }
         }
-        std::unordered_multimap<inet_address, dht::token_range> source_ranges = get_new_source_ranges(erm, my_new_ranges);
+        std::unordered_multimap<inet_address, dht::token_range> source_ranges = co_await get_new_source_ranges(erm, my_new_ranges);
         std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint;
         for (auto& x : source_ranges) {
             ranges_per_endpoint[x.first].emplace_back(x.second);
@@ -3034,10 +3034,10 @@ future<> storage_service::shutdown_protocol_servers() {
     }
 }
 
-std::unordered_multimap<inet_address, dht::token_range>
+future<std::unordered_multimap<inet_address, dht::token_range>>
 storage_service::get_new_source_ranges(locator::effective_replication_map_ptr erm, const dht::token_range_vector& ranges) const {
     auto my_address = get_broadcast_address();
-    std::unordered_map<dht::token_range, inet_address_vector_replica_set> range_addresses = erm->get_range_addresses();
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> range_addresses = co_await erm->get_range_addresses();
     std::unordered_multimap<inet_address, dht::token_range> source_ranges;
 
     // find alive sources for our new ranges
@@ -3064,8 +3064,10 @@ storage_service::get_new_source_ranges(locator::effective_replication_map_ptr er
                 break;
             }
         }
+
+        co_await coroutine::maybe_yield();
     }
-    return source_ranges;
+    co_return source_ranges;
 }
 
 future<> storage_service::move(token new_token) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2663,7 +2663,7 @@ future<> storage_service::rebuild(sstring source_dc) {
             }
             auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
             for (const auto& [keyspace_name, erm] : ks_erms) {
-                co_await streamer->add_ranges(keyspace_name, ss.get_ranges_for_endpoint(erm, utils::fb_utilities::get_broadcast_address()), ss._gossiper, false);
+                co_await streamer->add_ranges(keyspace_name, erm, ss.get_ranges_for_endpoint(erm, utils::fb_utilities::get_broadcast_address()), ss._gossiper, false);
             }
             try {
                 co_await streamer->stream_async();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2805,7 +2805,7 @@ future<> storage_service::removenode_add_ranges(lw_shared_ptr<dht::range_streame
                 my_new_ranges.emplace_back(x.first);
             }
         }
-        std::unordered_multimap<inet_address, dht::token_range> source_ranges = get_new_source_ranges(keyspace_name, my_new_ranges);
+        std::unordered_multimap<inet_address, dht::token_range> source_ranges = get_new_source_ranges(erm, my_new_ranges);
         std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint;
         for (auto& x : source_ranges) {
             ranges_per_endpoint[x.first].emplace_back(x.second);
@@ -3035,10 +3035,8 @@ future<> storage_service::shutdown_protocol_servers() {
 }
 
 std::unordered_multimap<inet_address, dht::token_range>
-storage_service::get_new_source_ranges(const sstring& keyspace_name, const dht::token_range_vector& ranges) const {
+storage_service::get_new_source_ranges(locator::effective_replication_map_ptr erm, const dht::token_range_vector& ranges) const {
     auto my_address = get_broadcast_address();
-    auto& ks = _db.local().find_keyspace(keyspace_name);
-    auto erm = ks.get_effective_replication_map();
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> range_addresses = erm->get_range_addresses();
     std::unordered_multimap<inet_address, dht::token_range> source_ranges;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2716,7 +2716,7 @@ future<std::unordered_multimap<dht::token_range, inet_address>> storage_service:
     // is gone. Whoever is present in newReplicaEndpoints list, but
     // not in the currentReplicaEndpoints list, will be needing the
     // range.
-    auto& rs = ks.get_replication_strategy();
+    const auto& rs = erm->get_replication_strategy();
     for (auto& r : ranges) {
         auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
         auto new_replica_endpoints = co_await rs.calculate_natural_endpoints(end_token, temp);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3184,10 +3184,9 @@ future<> storage_service::update_pending_ranges(mutable_token_metadata_ptr tmptr
     assert(this_shard_id() == 0);
 
     try {
-        auto keyspaces = _db.local().get_non_local_strategy_keyspaces();
-        for (const auto& keyspace_name : keyspaces) {
-            auto& ks = this->_db.local().find_keyspace(keyspace_name);
-            auto& strategy = ks.get_replication_strategy();
+        auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
+        for (const auto& [keyspace_name, erm] : ks_erms) {
+            auto& strategy = erm->get_replication_strategy();
             slogger.debug("Updating pending ranges for keyspace={} starts", keyspace_name);
             co_await tmptr->update_pending_ranges(strategy, keyspace_name);
             slogger.debug("Updating pending ranges for keyspace={} ends", keyspace_name);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -611,12 +611,12 @@ public:
 
 
     /**
-     * Get all ranges an endpoint is responsible for (by keyspace)
+     * Get all ranges an endpoint is responsible for (by keyspace effective_replication_map)
      * Replication strategy's get_ranges() guarantees that no wrap-around range is returned.
      * @param ep endpoint we are interested in.
      * @return ranges for the specified endpoint.
      */
-    dht::token_range_vector get_ranges_for_endpoint(const sstring& name, const gms::inet_address& ep) const;
+    dht::token_range_vector get_ranges_for_endpoint(const locator::effective_replication_map_ptr& erm, const gms::inet_address& ep) const;
 
     /**
      * Get all ranges that span the ring given a set

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -570,11 +570,11 @@ private:
     /**
      * Finds living endpoints responsible for the given ranges
      *
-     * @param keyspaceName the keyspace ranges belong to
+     * @param erm the keyspace effective_replication_map ranges belong to
      * @param ranges the ranges to find sources for
      * @return multimap of addresses to ranges the address is responsible for
      */
-    std::unordered_multimap<inet_address, dht::token_range> get_new_source_ranges(const sstring& keyspaceName, const dht::token_range_vector& ranges) const;
+    std::unordered_multimap<inet_address, dht::token_range> get_new_source_ranges(locator::effective_replication_map_ptr erm, const dht::token_range_vector& ranges) const;
 
     /**
      * Sends a notification to a node indicating we have finished replicating data.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -598,7 +598,7 @@ private:
     future<> removenode_add_ranges(lw_shared_ptr<dht::range_streamer> streamer, gms::inet_address leaving_node);
 
     // needs to be modified to accept either a keyspace or ARS.
-    future<std::unordered_multimap<dht::token_range, inet_address>> get_changed_ranges_for_leaving(sstring keyspace_name, inet_address endpoint);
+    future<std::unordered_multimap<dht::token_range, inet_address>> get_changed_ranges_for_leaving(locator::effective_replication_map_ptr erm, inet_address endpoint);
 
     future<> maybe_reconnect_to_preferred_ip(inet_address ep, inet_address local_ip);
 public:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -574,7 +574,7 @@ private:
      * @param ranges the ranges to find sources for
      * @return multimap of addresses to ranges the address is responsible for
      */
-    std::unordered_multimap<inet_address, dht::token_range> get_new_source_ranges(locator::effective_replication_map_ptr erm, const dht::token_range_vector& ranges) const;
+    future<std::unordered_multimap<inet_address, dht::token_range>> get_new_source_ranges(locator::effective_replication_map_ptr erm, const dht::token_range_vector& ranges) const;
 
     /**
      * Sends a notification to a node indicating we have finished replicating data.

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -369,7 +369,7 @@ static bool has_sufficient_replicas(
     return true;
 }
 
-static std::vector<inet_address> calculate_natural_endpoints(
+static locator::endpoint_set calculate_natural_endpoints(
                 const token& search_token, const token_metadata& tm,
                 snitch_ptr& snitch,
                 const std::unordered_map<sstring, size_t>& datacenters) {
@@ -377,7 +377,7 @@ static std::vector<inet_address> calculate_natural_endpoints(
     // We want to preserve insertion order so that the first added endpoint
     // becomes primary.
     //
-    utils::sequenced_set<inet_address> replicas;
+    locator::endpoint_set replicas;
 
     // replicas we have found in each DC
     std::unordered_map<sstring, std::unordered_set<inet_address>> dc_replicas;
@@ -388,7 +388,7 @@ static std::vector<inet_address> calculate_natural_endpoints(
     // when we relax the rack uniqueness we can append this to the current
     // result so we don't have to wind back the iterator
     //
-    std::unordered_map<sstring, utils::sequenced_set<inet_address>>
+    std::unordered_map<sstring, locator::endpoint_set>
         skipped_dc_endpoints;
 
     //
@@ -477,7 +477,7 @@ static std::vector<inet_address> calculate_natural_endpoints(
         }
     }
 
-    return std::move(replicas.get_vector());
+    return replicas;
 }
 
 // Called in a seastar thread.

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -21,8 +21,12 @@ namespace utils {
  * class.
  */
 template<typename T>
-struct sequenced_set {
-    typedef typename std::vector<T>::iterator iterator;
+class sequenced_set {
+public:
+    using value_type = T;
+    using size_type = size_t;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
 
     void push_back(const T& val) {
         insert(val);
@@ -42,23 +46,39 @@ struct sequenced_set {
         return std::make_pair(_vec.end(), false);
     }
 
-    size_t size() {
+    size_type size() const noexcept {
         return _vec.size();
     }
 
-    iterator begin() {
+    iterator begin() noexcept {
         return _vec.begin();
     }
 
-    iterator end() {
+    iterator end() noexcept {
         return _vec.end();
     }
 
-    const std::vector<T>& get_vector() const {
+    const_iterator begin() const noexcept {
+        return _vec.begin();
+    }
+
+    const_iterator end() const noexcept {
+        return _vec.end();
+    }
+
+    const_iterator cbegin() const noexcept {
+        return _vec.cbegin();
+    }
+
+    const_iterator cend() const noexcept {
+        return _vec.cend();
+    }
+
+    const auto& get_vector() const noexcept {
         return _vec;
     }
 
-    void reserve(size_t sz) {
+    void reserve(size_type sz) {
         _set.reserve(sz);
         _vec.reserve(sz);
     }

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -125,6 +125,14 @@ public:
         return _vec;
     }
 
+    const auto& get_set() const noexcept {
+        return _set;
+    }
+
+    bool contains(const T& t) const noexcept {
+        return _set.contains(t);
+    }
+
     void reserve(size_type sz) {
         _set.reserve(sz);
         _vec.reserve(sz);

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -20,13 +20,13 @@ namespace utils {
  * This class provides a similar functionality to the Java's LinkedHashSet
  * class.
  */
-template<typename T>
-class sequenced_set {
+template<typename T, typename VectorType>
+class basic_sequenced_set {
 public:
     using value_type = T;
     using size_type = size_t;
-    using iterator = typename std::vector<T>::iterator;
-    using const_iterator = typename std::vector<T>::const_iterator;
+    using iterator = typename VectorType::iterator;
+    using const_iterator = typename VectorType::const_iterator;
 
     void push_back(const T& val) {
         insert(val);
@@ -85,7 +85,11 @@ public:
 
 private:
     std::unordered_set<T> _set;
-    std::vector<T> _vec;
+    VectorType _vec;
 };
+
+template <typename T>
+using sequenced_set = basic_sequenced_set<T, std::vector<T>>;
+
 } // namespace utils
 

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -58,10 +58,6 @@ struct sequenced_set {
         return _vec;
     }
 
-    std::vector<T>& get_vector() {
-        return _vec;
-    }
-
     void reserve(size_t sz) {
         _set.reserve(sz);
         _vec.reserve(sz);

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -11,6 +11,7 @@
 #include <vector>
 #include <unordered_set>
 #include <cstddef>
+#include <iostream>
 
 namespace utils {
 /**
@@ -27,6 +28,36 @@ public:
     using size_type = size_t;
     using iterator = typename VectorType::iterator;
     using const_iterator = typename VectorType::const_iterator;
+
+    basic_sequenced_set() = default;
+
+    basic_sequenced_set(std::initializer_list<T> init)
+        : _set(init)
+        , _vec(init)
+    { }
+
+    explicit basic_sequenced_set(VectorType v)
+        : _set(v.begin(), v.end())
+        , _vec(std::move(v))
+    { }
+
+    template <typename InputIt>
+    explicit basic_sequenced_set(InputIt first, InputIt last)
+        : _set(first, last)
+        , _vec(first, last)
+    { }
+
+    const T& operator[](size_t i) const noexcept {
+        return _vec[i];
+    }
+
+    T& operator[](size_t i) noexcept {
+        return _vec[i];
+    }
+
+    bool empty() const noexcept {
+        return _vec.empty();
+    }
 
     void push_back(const T& val) {
         insert(val);
@@ -74,6 +105,22 @@ public:
         return _vec.cend();
     }
 
+    auto& front() const noexcept {
+        return _vec.front();
+    }
+
+    auto& front() noexcept {
+        return _vec.front();
+    }
+
+    auto& back() const noexcept {
+        return _vec.back();
+    }
+
+    auto& back() noexcept {
+        return _vec.back();
+    }
+
     const auto& get_vector() const noexcept {
         return _vec;
     }
@@ -81,6 +128,22 @@ public:
     void reserve(size_type sz) {
         _set.reserve(sz);
         _vec.reserve(sz);
+    }
+
+    iterator erase(const_iterator pos) {
+        auto val = *pos;
+        auto it = _vec.erase(pos);
+        _set.erase(val);
+        return it;
+    }
+
+    // The implementation is not exception safe
+    // so mark the method noexcept to terminate in case anything throws
+    iterator erase(const_iterator first, const_iterator last) noexcept {
+        for (auto it = first; it != last; ++it) {
+            _set.erase(*it);
+        }
+        return _vec.erase(first, last);
     }
 
 private:
@@ -93,3 +156,11 @@ using sequenced_set = basic_sequenced_set<T, std::vector<T>>;
 
 } // namespace utils
 
+namespace std {
+
+template <typename T, typename VectorType>
+ostream& operator<<(ostream& os, const utils::basic_sequenced_set<T, VectorType>& s) {
+    return os << s.get_vector();
+}
+
+} // namespace std


### PR DESCRIPTION
This series converts the synchronous `effective_replication_map::get_range_addresses` to async
by calling the replication strategy async entry point with the same name, as its callers are already async
or can be made so easily.

To allow it to yield and work on a coherent view of the token_metadata / topology / replication_map,
let the callers of this patch hold a effective_replication_map per keyspace and pass it down
to the (now asynchronous) functions that use it (making affected storage_service methods static where possible
if they no longer depend on the storage_service instance).

Also, the repeated calls to everywhere_replication_strategy::calculate_natural_endpoints
are optimized in this series by introducing a virtual abstract_replication_strategy::has_static_natural_endpoints predicate
that is true for local_strategy and everywhere_replication_strategy, and is false otherwise.
With it, functions repeatedly calling calculate_natural_endpoints in a loop, for every token, will call it only once since it will return the same result every time anyhow.

Refs #11005 

Doesn't fix the issue as the large allocation still remains until we make change dht::token_range_vector chunked (chunked_vector cannot be used as is at the moment since we require the ability to push also to the front when unwrapping)