### PR TITLE
gossiper: shed non-ciritcal messages when message queue explodes

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -188,6 +188,10 @@ public:
     // value this node would get if this node were restarted that we are
     // willing to accept about a peer.
     static constexpr int64_t MAX_GENERATION_DIFFERENCE = 86400 * 365;
+    // Maximum queue size on _apply_state_locally_semaphore.
+    // After this queue size is reached, we drop non-critical updates.
+    static constexpr size_t apply_max_queue_size{100};
+
     std::chrono::milliseconds fat_client_timeout;
 
     std::chrono::milliseconds quarantine_delay() const noexcept;
@@ -431,7 +435,8 @@ public:
     // Wait for nodes to be alive on all shards
     future<> wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout);
 
-    future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
+    using is_critical_message = bool_class<class is_critical_message_tag>;
+    future<> apply_state_locally(std::map<inet_address, endpoint_state> map, is_critical_message is_critical);
 
     // filter `endpoints` by `local_rack`
     inet_address_vector_replica_set endpoint_filter(const sstring& local_rack, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>& endpoints);


### PR DESCRIPTION
Currently the gossiper applies each message as it lands. The apply
process splits the message into per-endpoint states and applies these
states individually. This has a limited concurrency of 100, further
updates are queued on the semaphore. In practice this concurrency can be
reduced further as each update locks the endpoint it is updating, so if
there are multiple concurrent updates for the same endpoint, only one is
processed, the rest waits on the lock.
Updates are replicated to other shards as they are applied. This has
negligible impact usually. But as the number of nodes (and therefore the
number of messages to process) and number of shards scales up, the
chance of some shard lagging behind with applying the updates increases.
Applying the updates on remote shards is very little amount of work, but
the entire process is very sensitive to latency: the latency of applying
the message is that of the slowest shard replicating the update. It is
particularly bad if one of the shards is loaded with a process that is
violating its task-quota for an extended period of time. This means that
even though the gossip scheduling group still gets it runtime, it will
get it as little as just a few times per second, meaning that only a few
endpoint updates can be replicated per second. In a large cluster where
a single message can contain dozens of endpoint state updates, this can
lead to unprocessed messages queueing up unbounded, leading to OOM.

This patch attempts to alleviate this problem by shedding non-critical
updates, once the queue size on the concurrency semaphore reaches some
limit (1000). We already have a method to check if a message is
non-critical: should_count_as_msg_processing(). It is used to disregard
non-critical messages when determining whether gossip has settled. We
use the same method to determine which message can be discarded when
messages start to pile up.
Non-critical messages are also the ones that are the most frequent and
largest in terms of raw size, so this shedding should allow for the node
to catch up and still be able to process any critical updates at all
times.

Fixes: #10967