### PR TITLE
scrub compaction: count validation errors and return status over the rest api

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -11,6 +11,7 @@
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "utils/hash.hh"
+#include <optional>
 #include <sstream>
 #include <time.h>
 #include <algorithm>
@@ -1266,6 +1267,13 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     });
 }
 
+enum class scrub_status {
+    successful = 0,
+    aborted,
+    unable_to_cancel,   // Not used in Scylla, included to ensure compability with nodetool api.
+    validation_errors,
+};
+
 void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_ctl) {
     ss::get_snapshot_details.set(r, [&snap_ctl](std::unique_ptr<request> req) {
         return snap_ctl.local().get_snapshot_details().then([] (std::unordered_map<sstring, std::vector<db::snapshot_ctl::snapshot_details>>&& result) {
@@ -1409,16 +1417,28 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         } else {
             throw httpd::bad_param_exception(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
         }
-        return f.then([&ctx, keyspace, column_families, opts] {
-            return ctx.db.invoke_on_all([=] (replica::database& db) {
-                return do_for_each(column_families, [=, &db](sstring cfname) {
+
+        const auto& reduce_compaction_stats = [] (const compaction_manager::compaction_stats_opt& lhs, const compaction_manager::compaction_stats_opt& rhs) {
+            sstables::compaction_stats stats{};
+            stats += lhs.value();
+            stats += rhs.value();
+            return stats;
+        };
+
+        return f.then([&ctx, keyspace, column_families, opts, &reduce_compaction_stats] {
+            return ctx.db.map_reduce0([=] (replica::database& db) {
+                return map_reduce(column_families, [=, &db] (sstring cfname) {
                     auto& cm = db.get_compaction_manager();
                     auto& cf = db.find_column_family(keyspace, cfname);
                     return cm.perform_sstable_scrub(cf.as_table_state(), opts);
-                });
-            });
-        }).then([]{
-            return make_ready_future<json::json_return_type>(0);
+                }, std::make_optional(sstables::compaction_stats{}), reduce_compaction_stats);
+            }, std::make_optional(sstables::compaction_stats{}), reduce_compaction_stats);
+        }).then([] (auto f) {
+            if (f->validation_errors) {
+                return make_ready_future<json::json_return_type>(static_cast<int>(scrub_status::validation_errors));
+            } else {
+                return make_ready_future<json::json_return_type>(static_cast<int>(scrub_status::successful));
+            }
         });
     });
 }

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include "sstables/sstables.hh"
 #include "sstables/sstable_writer.hh"
@@ -726,8 +727,8 @@ private:
     virtual bool use_interposer_consumer() const {
         return _table_s.get_compaction_strategy().use_interposer_consumer();
     }
-
-    compaction_result finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) {
+protected:
+    virtual compaction_result finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) {
         compaction_result ret {
             .new_sstables = std::move(_all_new_sstables),
             .ended_at = ended_at,
@@ -756,7 +757,7 @@ private:
 
         return ret;
     }
-
+private:
     void on_interrupt(std::exception_ptr ex) {
         log_info("{} of {} sstables interrupted due to: {}", report_start_desc(), _input_sstable_generations.size(), ex);
         delete_sstables_for_interrupted_compaction();
@@ -1242,12 +1243,14 @@ private:
         flat_mutation_reader_v2 _reader;
         mutation_fragment_stream_validator _validator;
         bool _skip_to_next_partition = false;
+        uint64_t& _validation_errors;
 
     private:
         void maybe_abort_scrub() {
             if (_scrub_mode == compaction_type_options::scrub::mode::abort) {
                 throw compaction_aborted_exception(_schema->ks_name(), _schema->cf_name(), "scrub compaction found invalid data");
             }
+            ++_validation_errors;
         }
 
         void on_unexpected_partition_start(const mutation_fragment_v2& ps) {
@@ -1367,11 +1370,12 @@ private:
         }
 
     public:
-        reader(flat_mutation_reader_v2 underlying, compaction_type_options::scrub::mode scrub_mode)
+        reader(flat_mutation_reader_v2 underlying, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors)
             : impl(underlying.schema(), underlying.permit())
             , _scrub_mode(scrub_mode)
             , _reader(std::move(underlying))
             , _validator(*_schema)
+            , _validation_errors(validation_errors)
         { }
         virtual future<> fill_buffer() override {
             if (_end_of_stream) {
@@ -1419,6 +1423,7 @@ private:
     std::string _scrub_start_description;
     mutable std::string _scrub_finish_description;
     uint64_t _bucket_count = 0;
+    mutable uint64_t _validation_errors = 0;
 
 public:
     scrub_compaction(table_state& table_s, compaction_descriptor descriptor, compaction_data& cdata, compaction_type_options::scrub options)
@@ -1441,7 +1446,7 @@ public:
 
     flat_mutation_reader_v2 make_sstable_reader() const override {
         auto crawling_reader = _compacting->make_crawling_reader(_schema, _permit, _io_priority, nullptr);
-        return make_flat_mutation_reader_v2<reader>(std::move(crawling_reader), _options.operation_mode);
+        return make_flat_mutation_reader_v2<reader>(std::move(crawling_reader), _options.operation_mode, _validation_errors);
     }
 
     uint64_t partitions_per_sstable() const override {
@@ -1472,11 +1477,17 @@ public:
         return _options.operation_mode == compaction_type_options::scrub::mode::segregate;
     }
 
-    friend flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode);
+    compaction_result finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) override {
+        auto ret = compaction::finish(started_at, ended_at);
+        ret.validation_errors = _validation_errors;
+        return ret;
+    }
+
+    friend flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors);
 };
 
-flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode) {
-    return make_flat_mutation_reader_v2<scrub_compaction::reader>(std::move(rd), scrub_mode);
+flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors) {
+    return make_flat_mutation_reader_v2<scrub_compaction::reader>(std::move(rd), scrub_mode, validation_errors);
 }
 
 class resharding_compaction final : public compaction {
@@ -1634,10 +1645,10 @@ static std::unique_ptr<compaction> make_compaction(table_state& table_s, sstable
     return descriptor.options.visit(visitor_factory);
 }
 
-future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 reader, const compaction_data& cdata) {
+future<uint64_t> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 reader, const compaction_data& cdata) {
     auto schema = reader.schema();
 
-    bool valid = true;
+    uint64_t errors = 0;
     std::exception_ptr ex;
 
     try {
@@ -1656,24 +1667,24 @@ future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 reader,
                 if (!validator(mf)) {
                     scrub_compaction::report_invalid_partition_start(compaction_type::Scrub, validator, ps.key());
                     validator.reset(mf);
-                    valid = false;
+                    ++errors;
                 }
                 if (!validator(ps.key())) {
                     scrub_compaction::report_invalid_partition(compaction_type::Scrub, validator, ps.key());
                     validator.reset(ps.key());
-                    valid = false;
+                    ++errors;
                 }
             } else {
                 if (!validator(mf)) {
                     scrub_compaction::report_invalid_mutation_fragment(compaction_type::Scrub, validator, mf);
                     validator.reset(mf);
-                    valid = false;
+                    ++errors;
                 }
             }
         }
         if (!validator.on_end_of_stream()) {
             scrub_compaction::report_invalid_end_of_stream(compaction_type::Scrub, validator);
-            valid = false;
+            ++errors;
         }
     } catch (...) {
         ex = std::current_exception();
@@ -1685,7 +1696,7 @@ future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 reader,
         co_return coroutine::exception(std::move(ex));
     }
 
-    co_return valid;
+    co_return errors;
 }
 
 static future<compaction_result> scrub_sstables_validate_mode(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s) {
@@ -1703,11 +1714,11 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
     auto permit = table_s.make_compaction_reader_permit();
     auto reader = sstables->make_crawling_reader(schema, permit, descriptor.io_priority, nullptr);
 
-    const auto valid = co_await scrub_validate_mode_validate_reader(std::move(reader), cdata);
+    const auto validation_errors = co_await scrub_validate_mode_validate_reader(std::move(reader), cdata);
 
-    clogger.info("Finished scrubbing in validate mode {} - sstable(s) are {}", sstables_list_msg, valid ? "valid" : "invalid");
+    clogger.info("Finished scrubbing in validate mode {} - sstable(s) are {}", sstables_list_msg, validation_errors == 0 ? "valid" : "invalid");
 
-    if (!valid) {
+    if (validation_errors != 0) {
         for (auto& sst : *sstables->all()) {
             co_await sst->move_to_quarantine();
         }
@@ -1716,6 +1727,7 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
     co_return compaction_result {
         .new_sstables = {},
         .ended_at = db_clock::now(),
+        .validation_errors = validation_errors,
     };
 }
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -48,6 +48,7 @@
 #include "utils/UUID_gen.hh"
 #include "utils/utf8.hh"
 #include "utils/fmt-compat.hh"
+#include "utils/error_injection.hh"
 #include "readers/filtering.hh"
 #include "readers/compacting.hh"
 #include "tombstone_gc.hh"
@@ -1333,6 +1334,7 @@ private:
         }
 
         void fill_buffer_from_underlying() {
+            utils::get_local_injector().inject("rest_api_keyspace_scrub_abort", [] { throw compaction_aborted_exception("", "", "scrub compaction found invalid data"); });
             while (!_reader.is_buffer_empty() && !is_buffer_full()) {
                 auto mf = _reader.pop_mutation_fragment();
                 if (mf.is_partition_start()) {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -731,9 +731,11 @@ protected:
     virtual compaction_result finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) {
         compaction_result ret {
             .new_sstables = std::move(_all_new_sstables),
-            .ended_at = ended_at,
-            .start_size = _start_size,
-            .end_size = _end_size,
+            .stats {
+                .ended_at = ended_at,
+                .start_size = _start_size,
+                .end_size = _end_size,
+            },
         };
 
         auto ratio = double(_end_size) / double(_start_size);
@@ -1479,7 +1481,7 @@ public:
 
     compaction_result finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) override {
         auto ret = compaction::finish(started_at, ended_at);
-        ret.validation_errors = _validation_errors;
+        ret.stats.validation_errors = _validation_errors;
         return ret;
     }
 
@@ -1726,8 +1728,10 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
 
     co_return compaction_result {
         .new_sstables = {},
-        .ended_at = db_clock::now(),
-        .validation_errors = validation_errors,
+        .stats = {
+            .ended_at = db_clock::now(),
+            .validation_errors = validation_errors,
+        },
     };
 }
 

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -90,6 +90,7 @@ struct compaction_result {
     std::chrono::time_point<db_clock> ended_at;
     uint64_t start_size = 0;
     uint64_t end_size = 0;
+    uint64_t validation_errors = 0;
 };
 
 // Compact a list of N sstables into M sstables.
@@ -108,9 +109,9 @@ std::unordered_set<sstables::shared_sstable>
 get_fully_expired_sstables(const table_state& table_s, const std::vector<sstables::shared_sstable>& compacting, gc_clock::time_point gc_before);
 
 // For tests, can drop after we virtualize sstables.
-flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode);
+flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors);
 
 // For tests, can drop after we virtualize sstables.
-future<bool> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 rd, const compaction_data& info);
+future<uint64_t> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 rd, const compaction_data& info);
 
 }

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -85,12 +85,29 @@ struct compaction_data {
     }
 };
 
-struct compaction_result {
-    std::vector<sstables::shared_sstable> new_sstables;
+struct compaction_stats {
     std::chrono::time_point<db_clock> ended_at;
     uint64_t start_size = 0;
     uint64_t end_size = 0;
     uint64_t validation_errors = 0;
+
+    compaction_stats& operator+=(const compaction_stats& r) {
+        ended_at = std::max(ended_at, r.ended_at);
+        start_size += r.start_size;
+        end_size += r.end_size;
+        validation_errors += r.validation_errors;
+        return *this;
+    }
+    friend compaction_stats operator+(const compaction_stats& l, const compaction_stats& r) {
+        auto tmp = l;
+        tmp += r;
+        return tmp;
+    }
+};
+
+struct compaction_result {
+    std::vector<sstables::shared_sstable> new_sstables;
+    compaction_stats stats;
 };
 
 // Compact a list of N sstables into M sstables.

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -343,10 +343,10 @@ future<sstables::compaction_result> compaction_manager::task::compact_sstables(s
     co_return co_await sstables::compact_sstables(std::move(descriptor), cdata, t);
 }
 future<> compaction_manager::task::update_history(compaction::table_state& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata) {
-    auto ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.ended_at.time_since_epoch());
+    auto ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.stats.ended_at.time_since_epoch());
 
     co_return co_await t.update_compaction_history(cdata.compaction_uuid, t.schema()->ks_name(), t.schema()->cf_name(), ended_at,
-                                                                    res.start_size, res.end_size);
+                                                                    res.stats.start_size, res.stats.end_size);
 }
 
 class compaction_manager::major_compaction_task : public compaction_manager::task {
@@ -1192,7 +1192,7 @@ protected:
         while (!_sstables.empty() && can_proceed()) {
             auto sst = consume_sstable();
             auto res = co_await rewrite_sstable(std::move(sst));
-            _cm._validation_errors += res.validation_errors;
+            _cm._validation_errors += res.stats.validation_errors;
         }
     }
 
@@ -1281,7 +1281,7 @@ protected:
         while (!_sstables.empty() && can_proceed()) {
             auto sst = consume_sstable();
             auto res = co_await validate_sstable(std::move(sst));
-            _cm._validation_errors += res.validation_errors;
+            _cm._validation_errors += res.stats.validation_errors;
         }
     }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -299,7 +299,7 @@ private:
     class strategy_control;
     std::unique_ptr<strategy_control> _strategy_control;
 private:
-    future<> perform_task(shared_ptr<task>);
+    future<compaction_stats_opt> perform_task(shared_ptr<task>);
 
     future<> stop_tasks(std::vector<shared_ptr<task>> tasks, sstring reason);
     future<> update_throughput(uint32_t value_mbs);
@@ -340,7 +340,7 @@ private:
     // similar-sized compaction.
     void postpone_compaction_for_table(compaction::table_state* t);
 
-    future<> perform_sstable_scrub_validate_mode(compaction::table_state& t);
+    future<compaction_stats_opt> perform_sstable_scrub_validate_mode(compaction::table_state& t);
     future<> update_static_shares(float shares);
 
     using get_candidates_func = std::function<future<std::vector<sstables::shared_sstable>>()>;
@@ -349,9 +349,9 @@ private:
     // by retrieving set of candidates only after all compactions for table T were stopped, if any.
     template<typename TaskType, typename... Args>
     requires std::derived_from<TaskType, task>
-    future<> perform_task_on_all_files(compaction::table_state& t, sstables::compaction_type_options options, get_candidates_func, Args... args);
+    future<compaction_stats_opt> perform_task_on_all_files(compaction::table_state& t, sstables::compaction_type_options options, get_candidates_func, Args... args);
 
-    future<> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
+    future<compaction_stats_opt> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
     // Stop all fibers, without waiting. Safe to be called multiple times.
     void do_stop() noexcept;
@@ -411,7 +411,7 @@ public:
     future<> perform_sstable_upgrade(replica::database& db, compaction::table_state& t, bool exclude_current_version);
 
     // Submit a table to be scrubbed and wait for its termination.
-    future<> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);
+    future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);
 
     // Submit a table for major compaction.
     future<> perform_major_compaction(compaction::table_state& t);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -141,7 +141,7 @@ public:
         // stop of transportation services. It cannot make progress anyway.
         // Returns exception if error is judged fatal, and compaction task must be stopped,
         // otherwise, returns stop_iteration::no after sleep for exponential retry.
-        future<stop_iteration> maybe_retry(std::exception_ptr err);
+        future<stop_iteration> maybe_retry(std::exception_ptr err, bool throw_on_abort = false);
 
         // Compacts set of SSTables according to the descriptor.
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -293,6 +293,7 @@ private:
     utils::updateable_value<float> _static_shares;
     serialized_action _update_compaction_static_shares_action;
     utils::observer<float> _compaction_static_shares_observer;
+    uint64_t _validation_errors = 0;
 
     class strategy_control;
     std::unique_ptr<strategy_control> _strategy_control;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -98,7 +98,6 @@ public:
                         // counted in compaction_manager::stats::errors
         };
         static std::string_view to_string(state);
-
     protected:
         compaction_manager& _cm;
         compaction::table_state* _compacting_table = nullptr;
@@ -145,7 +144,7 @@ public:
 
         // Compacts set of SSTables according to the descriptor.
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;
-        future<> compact_sstables_and_update_history(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
+        future<sstables::compaction_result> compact_sstables_and_update_history(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);
         future<sstables::compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);

--- a/test/alternator/alternator_util.py
+++ b/test/alternator/alternator_util.py
@@ -8,9 +8,6 @@ import string
 import random
 import collections
 import time
-import re
-import requests
-import pytest
 from contextlib import contextmanager
 from botocore.hooks import HierarchicalEmitter
 
@@ -215,19 +212,3 @@ def client_no_transform(client):
 
 def is_aws(dynamodb):
     return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
-
-# Tries to inject an error via Scylla REST API. It only works on Scylla,
-# and only in specific build modes (dev, debug, sanitize), so this function
-# will trigger a test to be skipped if it cannot be executed.
-@contextmanager
-def scylla_inject_error(rest_api, err, one_shot=False):
-    response = requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}')
-    response = requests.get(f'{rest_api}/v2/error_injection/injection')
-    print("Enabled error injections:", response.content.decode('utf-8'))
-    if response.content.decode('utf-8') == "[]":
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
-    try:
-        yield
-    finally:
-        print("Disabling error injection", err)
-        response = requests.delete(f'{rest_api}/v2/error_injection/injection/{err}')

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import boto3
 import requests
 import re
-from util import create_test_table, is_aws
+from alternator_util import create_test_table, is_aws
 
 # When tests are run with HTTPS, the server often won't have its SSL
 # certificate signed by a known authority. So we will disable certificate

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -8,8 +8,12 @@
 
 import pytest
 import random
+import sys
 from botocore.exceptions import ClientError
-from util import random_string, full_scan, full_query, multiset, scylla_inject_error
+from alternator_util import random_string, full_scan, full_query, multiset
+
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+from util import scylla_inject_error
 
 # Test ensuring that items inserted by a batched statement can be properly extracted
 # via GetItem. Schema has both hash and sort keys.

--- a/test/alternator/test_condition_expression.py
+++ b/test/alternator/test_condition_expression.py
@@ -19,7 +19,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string
+from alternator_util import random_string
 from sys import version_info
 
 # A helper function for changing write isolation policies

--- a/test/alternator/test_describe_table.py
+++ b/test/alternator/test_describe_table.py
@@ -18,7 +18,7 @@ import pytest
 from botocore.exceptions import ClientError
 import re
 import time
-from util import multiset
+from alternator_util import multiset
 
 # Test that DescribeTable correctly returns the table's name and state
 def test_describe_table_basic(test_table):

--- a/test/alternator/test_expected.py
+++ b/test/alternator/test_expected.py
@@ -9,7 +9,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string
+from alternator_util import random_string
 
 # Most of the tests in this file check that the "Expected" parameter works for
 # the UpdateItem operation. It should also work the same for the PutItem and

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from util import full_query, full_query_and_counts, full_scan, random_string, random_bytes, multiset
+from alternator_util import full_query, full_query_and_counts, full_scan, random_string, random_bytes, multiset
 
 # The test_table_sn_with_data fixture is the regular test_table_sn fixture
 # with a partition inserted with many items. The sort key 'c' of the items

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -11,7 +11,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table
+from alternator_util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table
 
 # GSIs only support eventually consistent reads, so tests that involve
 # writing to a table and then expect to read something from it cannot be

--- a/test/alternator/test_item.py
+++ b/test/alternator/test_item.py
@@ -7,7 +7,7 @@
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from util import random_string, random_bytes
+from alternator_util import random_string, random_bytes
 
 # Basic test for creating a new item with a random name, and reading it back
 # with strong consistency.

--- a/test/alternator/test_key_condition_expression.py
+++ b/test/alternator/test_key_condition_expression.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from util import random_string, full_query, multiset
+from alternator_util import random_string, full_query, multiset
 
 # The test_table_{sn,ss,sb}_with_sorted_partition fixtures are the regular
 # test_table_{sn,ss,sb} fixture with a partition inserted with many items.

--- a/test/alternator/test_key_conditions.py
+++ b/test/alternator/test_key_conditions.py
@@ -9,7 +9,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string, random_bytes, full_query, multiset
+from alternator_util import random_string, random_bytes, full_query, multiset
 
 # The test_table_{sn,ss,sb}_with_sorted_partition fixtures are the regular
 # test_table_{sn,ss,sb} fixture with a partition inserted with many items.

--- a/test/alternator/test_limits.py
+++ b/test/alternator/test_limits.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from util import random_string, new_test_table, full_query
+from alternator_util import random_string, new_test_table, full_query
 from botocore.exceptions import ClientError
 from test_gsi import assert_index_query
 

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -11,7 +11,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, list_tables
+from alternator_util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, list_tables
 
 # LSIs support strongly-consistent reads, so the following functions do not
 # need to retry like we did in test_gsi.py for GSIs:

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -28,7 +28,7 @@ import re
 from contextlib import contextmanager
 from botocore.exceptions import ClientError
 
-from util import random_string, new_test_table
+from alternator_util import random_string, new_test_table
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for

--- a/test/alternator/test_nested.py
+++ b/test/alternator/test_nested.py
@@ -6,7 +6,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string
+from alternator_util import random_string
 
 # Test that we can write a top-level attribute that is a nested document, and
 # read it back correctly.

--- a/test/alternator/test_number.py
+++ b/test/alternator/test_number.py
@@ -28,7 +28,7 @@
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from util import random_string, client_no_transform
+from alternator_util import random_string, client_no_transform
 
 # Monkey-patch the boto3 library to stop doing its own error-checking on
 # numbers. This works around a bug https://github.com/boto/boto3/issues/2500

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -13,7 +13,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string, full_scan, full_query, multiset
+from alternator_util import random_string, full_scan, full_query, multiset
 
 # Basic test for ProjectionExpression, requesting only top-level attributes.
 # Result should include the selected attributes only - if one wants the key

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -14,7 +14,7 @@ import random
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from util import random_string, random_bytes, full_query, multiset
+from alternator_util import random_string, random_bytes, full_query, multiset
 from boto3.dynamodb.conditions import Key, Attr
 
 def test_query_nonexistent_table(dynamodb):

--- a/test/alternator/test_query_filter.py
+++ b/test/alternator/test_query_filter.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from util import full_query, full_query_and_counts, random_string, random_bytes
+from alternator_util import full_query, full_query_and_counts, random_string, random_bytes
 
 # The test_table_sn_with_data fixture is the regular test_table_sn fixture
 # with a partition inserted with 20 items. The sort key 'c' of the items

--- a/test/alternator/test_returnvalues.py
+++ b/test/alternator/test_returnvalues.py
@@ -7,7 +7,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string
+from alternator_util import random_string
 
 # Test trivial support for the ReturnValues parameter in PutItem, UpdateItem
 # and DeleteItem - test that "NONE" works (and changes nothing), while a

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -7,7 +7,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table
+from alternator_util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table
 from boto3.dynamodb.conditions import Attr
 
 # Test that scanning works fine with/without pagination

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -10,7 +10,7 @@ import time
 import urllib.request
 
 from botocore.exceptions import ClientError
-from util import list_tables, unique_table_name, create_test_table, random_string, freeze
+from alternator_util import list_tables, unique_table_name, create_test_table, random_string, freeze
 from contextlib import contextmanager
 from urllib.error import URLError
 from boto3.dynamodb.types import TypeDeserializer

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -11,7 +11,7 @@ import pytest
 import time
 import threading
 from botocore.exceptions import ClientError
-from util import list_tables, unique_table_name, create_test_table, random_string
+from alternator_util import list_tables, unique_table_name, create_test_table, random_string
 
 # Utility function for create a table with a given name and some valid
 # schema.. This function initiates the table's creation, but doesn't
@@ -326,7 +326,7 @@ def test_update_table_non_existent(dynamodb, test_table):
 # default, this fixture can be removed.
 @pytest.fixture(scope="session")
 def check_pre_raft(dynamodb):
-    from util import is_aws
+    from alternator_util import is_aws
     # If not running on Scylla, return false.
     if is_aws(dynamodb):
         return false

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -12,7 +12,7 @@ import pytest
 from botocore.exceptions import ClientError
 import re
 import time
-from util import multiset, create_test_table, unique_table_name, random_string
+from alternator_util import multiset, create_test_table, unique_table_name, random_string
 from packaging.version import Version
 
 def delete_tags(table, arn):

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -19,7 +19,7 @@ import requests
 import time
 import json
 from botocore.exceptions import ClientError
-from util import random_string, full_scan, full_query, create_test_table
+from alternator_util import random_string, full_scan, full_query, create_test_table
 
 # The "with_tracing" fixture ensures that tracing is enabled throughout
 # the run of a test function, and disabled when it ends. If tracing cannot be

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -9,7 +9,7 @@ import time
 import re
 import math
 from botocore.exceptions import ClientError
-from util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform
+from alternator_util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform
 from contextlib import contextmanager
 from decimal import Decimal
 

--- a/test/alternator/test_update_expression.py
+++ b/test/alternator/test_update_expression.py
@@ -8,7 +8,7 @@ import random
 import string
 import pytest
 from botocore.exceptions import ClientError
-from util import random_string
+from alternator_util import random_string
 
 # The simplest test of using UpdateExpression to set a top-level attribute,
 # instead of the older AttributeUpdates parameter.

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1494,7 +1494,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
 
         auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(ssts, default_priority_class()), *cf, sst_gen).get0();
         BOOST_REQUIRE(ret.new_sstables.empty());
-        BOOST_REQUIRE(ret.end_size == 0);
+        BOOST_REQUIRE(ret.stats.end_size == 0);
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2419,8 +2419,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_partition_start(2));
         frags.emplace_back(make_partition_end());
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_EQUAL(errors, 0);
     }
 
     BOOST_TEST_MESSAGE("out-of-order clustering row");
@@ -2430,8 +2430,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_clustering_row(0));
         frags.emplace_back(make_partition_end());
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(!valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_NE(errors, 0);
     }
 
     BOOST_TEST_MESSAGE("out-of-order static row");
@@ -2441,8 +2441,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_static_row());
         frags.emplace_back(make_partition_end());
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(!valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_NE(errors, 0);
     }
 
     BOOST_TEST_MESSAGE("out-of-order partition start");
@@ -2452,8 +2452,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_partition_start(2));
         frags.emplace_back(make_partition_end());
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(!valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_NE(errors, 0);
     }
 
     BOOST_TEST_MESSAGE("out-of-order partition");
@@ -2464,8 +2464,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_partition_start(0));
         frags.emplace_back(make_partition_end());
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(!valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_NE(errors, 0);
     }
 
     BOOST_TEST_MESSAGE("missing end-of-partition at EOS");
@@ -2473,8 +2473,8 @@ SEASTAR_THREAD_TEST_CASE(scrub_validate_mode_validate_reader_test) {
         frags.emplace_back(make_partition_start(0));
         frags.emplace_back(make_clustering_row(0));
 
-        const auto valid = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
-        BOOST_REQUIRE(!valid);
+        const auto errors = scrub_validate_mode_validate_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags)), *info).get();
+        BOOST_REQUIRE_NE(errors, 0);
     }
 }
 
@@ -2894,8 +2894,9 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
 
     std::list<std::deque<mutation_fragment_v2>> segregated_fragment_streams;
 
+    uint64_t validation_errors = 0;
     mutation_writer::segregate_by_partition(
-            make_scrubbing_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(all_fragments)), sstables::compaction_type_options::scrub::mode::segregate),
+            make_scrubbing_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(all_fragments)), sstables::compaction_type_options::scrub::mode::segregate, validation_errors),
             mutation_writer::segregate_config{default_priority_class(), 100000},
             [&schema, &segregated_fragment_streams] (flat_mutation_reader_v2 rd) {
         return async([&schema, &segregated_fragment_streams, rd = std::move(rd)] () mutable {
@@ -3035,8 +3036,9 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_reader_test) {
     add_fragment(make_clustering_row(3));
     scrubbed_fragments.emplace_back(*schema, permit, partition_end{}); // missing partition-end - at EOS
 
+    uint64_t validation_errors = 0;
     auto r = assert_that(make_scrubbing_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(corrupt_fragments)),
-                compaction_type_options::scrub::mode::skip));
+                compaction_type_options::scrub::mode::skip, validation_errors));
     for (const auto& mf : scrubbed_fragments) {
        testlog.info("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
        r.produces(*schema, mf);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2555,7 +2555,7 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
             // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
             sstables::compaction_type_options::scrub opts = {};
             opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            compaction_manager.perform_sstable_scrub(table->as_table_state(), opts).get();
+            BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(table->as_table_state(), opts).get(), sstables::compaction_aborted_exception);
 
             BOOST_REQUIRE(in_strategy_sstables(table->as_table_state()).size() == 1);
             verify_fragments(sst, corrupt_fragments);
@@ -2652,7 +2652,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
             // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
             sstables::compaction_type_options::scrub opts = {};
             opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            compaction_manager.perform_sstable_scrub(table->as_table_state(), opts).get();
+            BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(table->as_table_state(), opts).get(), sstables::compaction_aborted_exception);
 
             BOOST_REQUIRE(in_strategy_sstables(table->as_table_state()).size() == 1);
             verify_fragments(sst, corrupt_fragments);

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -903,8 +903,8 @@ void validate_operation(schema_ptr schema, reader_permit permit, const std::vect
         if (sst) {
             sst_log.info("validating {}", sst->get_filename());
         }
-        const auto valid = sstables::scrub_validate_mode_validate_reader(std::move(rd), info).get();
-        sst_log.info("validated {}: {}", sst ? sst->get_filename() : "the stream", valid ? "valid" : "invalid");
+        const auto errors = sstables::scrub_validate_mode_validate_reader(std::move(rd), info).get();
+        sst_log.info("validated {}: {}", sst ? sst->get_filename() : "the stream", errors == 0 ? "valid" : "invalid");
         return stop_iteration::no;
     });
 }


### PR DESCRIPTION
Currently, scrub returns to user the number indicating operation
result as follows:
- 1 when the operation was aborted;
- 3 in validate and segregate modes when validation errors were found
  (and in segregate mode - fixed);
- 0 if operation ended successfully.

To achieve so, if an operation was aborted in abort mode, then
the exception is propagated to storage_service.cc. Also the number
of validation errors for current scrub is gathered and summed
from each shard there.

The number of validation errors is counted and registered in metrics.
Metrics provide common counters for all scrub operation within
a compaction manager, though. Thus, to check the exact number
of validation errors, the comparison of counter value before and after
scrub operation needs to be done.