### PR TITLE
Decouple compaction manager from database

### DIFF
--- a/backlog_controller.hh
+++ b/backlog_controller.hh
@@ -39,7 +39,7 @@ class backlog_controller {
 public:
     struct scheduling_group {
         seastar::scheduling_group cpu = default_scheduling_group();
-        const ::io_priority_class& io = default_priority_class();
+        seastar::io_priority_class io = default_priority_class();
     };
     future<> shutdown() {
         _update_timer.cancel();

--- a/backlog_controller.hh
+++ b/backlog_controller.hh
@@ -57,7 +57,7 @@ protected:
         float output;
     };
 
-    scheduling_group& _scheduling_group;
+    scheduling_group _scheduling_group;
     timer<> _update_timer;
 
     std::vector<control_point> _control_points;
@@ -78,10 +78,10 @@ protected:
 
     void adjust();
 
-    backlog_controller(scheduling_group& sg, std::chrono::milliseconds interval,
+    backlog_controller(scheduling_group sg, std::chrono::milliseconds interval,
                        std::vector<control_point> control_points, std::function<float()> backlog,
                        float static_shares = 0)
-        : _scheduling_group(sg)
+        : _scheduling_group(std::move(sg))
         , _update_timer([this] { adjust(); })
         , _control_points()
         , _current_backlog(std::move(backlog))
@@ -116,8 +116,8 @@ public:
 class flush_controller : public backlog_controller {
     static constexpr float hard_dirty_limit = 1.0f;
 public:
-    flush_controller(backlog_controller::scheduling_group& sg, float static_shares, std::chrono::milliseconds interval, float soft_limit, std::function<float()> current_dirty)
-        : backlog_controller(sg, std::move(interval),
+    flush_controller(backlog_controller::scheduling_group sg, float static_shares, std::chrono::milliseconds interval, float soft_limit, std::function<float()> current_dirty)
+        : backlog_controller(std::move(sg), std::move(interval),
           std::vector<backlog_controller::control_point>({{0.0, 0.0}, {soft_limit, 10}, {soft_limit + (hard_dirty_limit - soft_limit) / 2, 200} , {hard_dirty_limit, 1000}}),
           std::move(current_dirty),
           static_shares
@@ -130,8 +130,8 @@ public:
     static constexpr unsigned normalization_factor = 30;
     static constexpr float disable_backlog = std::numeric_limits<double>::infinity();
     static constexpr float backlog_disabled(float backlog) { return std::isinf(backlog); }
-    compaction_controller(backlog_controller::scheduling_group& sg, float static_shares, std::chrono::milliseconds interval, std::function<float()> current_backlog)
-        : backlog_controller(sg, std::move(interval),
+    compaction_controller(backlog_controller::scheduling_group sg, float static_shares, std::chrono::milliseconds interval, std::function<float()> current_backlog)
+        : backlog_controller(std::move(sg), std::move(interval),
           std::vector<backlog_controller::control_point>({{0.0, 50}, {1.5, 100} , {normalization_factor, 1000}}),
           std::move(current_backlog),
           static_shares

--- a/backlog_controller.hh
+++ b/backlog_controller.hh
@@ -58,7 +58,6 @@ protected:
     };
 
     scheduling_group& _scheduling_group;
-    std::chrono::milliseconds _interval;
     timer<> _update_timer;
 
     std::vector<control_point> _control_points;
@@ -83,7 +82,6 @@ protected:
                        std::vector<control_point> control_points, std::function<float()> backlog,
                        float static_shares = 0)
         : _scheduling_group(sg)
-        , _interval(interval)
         , _update_timer([this] { adjust(); })
         , _control_points()
         , _current_backlog(std::move(backlog))
@@ -91,7 +89,7 @@ protected:
         , _static_shares(static_shares)
     {
         _control_points.insert(_control_points.end(), control_points.begin(), control_points.end());
-        _update_timer.arm_periodic(_interval);
+        _update_timer.arm_periodic(interval);
     }
 
     virtual ~backlog_controller() {}

--- a/backlog_controller.hh
+++ b/backlog_controller.hh
@@ -38,8 +38,8 @@
 class backlog_controller {
 public:
     struct scheduling_group {
-        seastar::scheduling_group cpu;
-        const ::io_priority_class& io;
+        seastar::scheduling_group cpu = default_scheduling_group();
+        const ::io_priority_class& io = default_priority_class();
     };
     future<> shutdown() {
         _update_timer.cancel();

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1094,13 +1094,13 @@ class cleanup_compaction final : public regular_compaction {
         }
     };
 
-    const dht::token_range_vector _owned_ranges;
+    owned_ranges_ptr _owned_ranges;
     incremental_owned_ranges_checker _owned_ranges_checker;
 private:
     // Called in a seastar thread
     dht::partition_range_vector
     get_ranges_for_invalidation(const std::vector<shared_sstable>& sstables) {
-        auto owned_ranges = dht::to_partition_ranges(_owned_ranges, utils::can_yield::yes);
+        auto owned_ranges = dht::to_partition_ranges(*_owned_ranges, utils::can_yield::yes);
 
         auto non_owned_ranges = boost::copy_range<dht::partition_range_vector>(sstables
                 | boost::adaptors::transformed([] (const shared_sstable& sst) {
@@ -1132,10 +1132,10 @@ protected:
     }
 
 private:
-    cleanup_compaction(table_state& table_s, compaction_descriptor descriptor, compaction_data& cdata, dht::token_range_vector owned_ranges)
+    cleanup_compaction(table_state& table_s, compaction_descriptor descriptor, compaction_data& cdata, owned_ranges_ptr owned_ranges)
         : regular_compaction(table_s, std::move(descriptor), cdata)
         , _owned_ranges(std::move(owned_ranges))
-        , _owned_ranges_checker(_owned_ranges)
+        , _owned_ranges_checker(*_owned_ranges)
     {
     }
 

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -20,6 +20,16 @@
 #include "dht/i_partitioner.hh"
 #include "compaction_weight_registration.hh"
 
+namespace compaction {
+
+using owned_ranges_ptr = lw_shared_ptr<const dht::token_range_vector>;
+
+inline owned_ranges_ptr make_owned_ranges_ptr(dht::token_range_vector&& ranges) {
+    return make_lw_shared<const dht::token_range_vector>(std::move(ranges));
+}
+
+} // namespace compaction
+
 namespace sstables {
 
 enum class compaction_type {
@@ -54,10 +64,10 @@ public:
     struct regular {
     };
     struct cleanup {
-        dht::token_range_vector owned_ranges;
+        compaction::owned_ranges_ptr owned_ranges;
     };
     struct upgrade {
-        dht::token_range_vector owned_ranges;
+        compaction::owned_ranges_ptr owned_ranges;
     };
     struct scrub {
         enum class mode {
@@ -102,11 +112,11 @@ public:
         return compaction_type_options(regular{});
     }
 
-    static compaction_type_options make_cleanup(dht::token_range_vector&& owned_ranges) {
+    static compaction_type_options make_cleanup(compaction::owned_ranges_ptr owned_ranges) {
         return compaction_type_options(cleanup{std::move(owned_ranges)});
     }
 
-    static compaction_type_options make_upgrade(dht::token_range_vector&& owned_ranges) {
+    static compaction_type_options make_upgrade(compaction::owned_ranges_ptr owned_ranges) {
         return compaction_type_options(upgrade{std::move(owned_ranges)});
     }
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -673,8 +673,8 @@ compaction_manager::compaction_manager(config cfg, abort_source& as)
 }
 
 compaction_manager::compaction_manager()
-    : _compaction_sg(scheduling_group{default_scheduling_group(), default_priority_class()})
-    , _maintenance_sg(scheduling_group{default_scheduling_group(), default_priority_class()})
+    : _compaction_sg()
+    , _maintenance_sg()
     , _compaction_controller(make_compaction_controller(_compaction_sg, 1, [] () -> float { return 1.0; }))
     , _backlog_manager(_compaction_controller)
     , _available_memory(1)

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -421,10 +421,10 @@ public:
     // Cleanup is about discarding keys that are no longer relevant for a
     // given sstable, e.g. after node loses part of its token range because
     // of a newly added node.
-    future<> perform_cleanup(replica::database& db, compaction::table_state& t);
+    future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t);
 
     // Submit a table to be upgraded and wait for its termination.
-    future<> perform_sstable_upgrade(replica::database& db, compaction::table_state& t, bool exclude_current_version);
+    future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, bool exclude_current_version);
 
     // Submit a table to be scrubbed and wait for its termination.
     future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -51,7 +51,7 @@ public:
     struct config {
         scheduling_group compaction_sched_group;
         scheduling_group maintenance_sched_group;
-        size_t available_memory;
+        size_t available_memory = 0;
         utils::updateable_value<float> static_shares = utils::updateable_value<float>(0);
         utils::updateable_value<uint32_t> throughput_mb_per_sec = utils::updateable_value<uint32_t>(0);
     };

--- a/main.cc
+++ b/main.cc
@@ -514,6 +514,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     sharded<locator::effective_replication_map_factory> erm_factory;
     sharded<service::migration_notifier> mm_notifier;
     sharded<service::endpoint_lifecycle_notifier> lifecycle_notifier;
+    sharded<compaction_manager> cm;
     distributed<replica::database> db;
     seastar::sharded<service::cache_hitrate_calculator> cf_cache_hitrate_calculator;
     service::load_meter load_meter;
@@ -562,7 +563,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
         tcp_syncookies_sanity();
 
-        return seastar::async([&app, cfg, ext, &db, &qp, &bm, &proxy, &forward_service, &mm, &mm_notifier, &ctx, &opts, &dirs,
+        return seastar::async([&app, cfg, ext, &cm, &db, &qp, &bm, &proxy, &forward_service, &mm, &mm_notifier, &ctx, &opts, &dirs,
                 &prometheus_server, &cf_cache_hitrate_calculator, &load_meter, &feature_service, &gossiper,
                 &token_metadata, &erm_factory, &snapshot_ctl, &messaging, &sst_dir_semaphore, &raft_gr, &service_memory_limiter,
                 &repair, &sst_loader, &ss, &lifecycle_notifier, &stream_manager] {
@@ -947,10 +948,25 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
             view_hints_dir_initializer.ensure_created_and_verified().get();
 
+            supervisor::notify("starting compaction_manager");
+            // get_cm_cfg is called on each shard when starting a sharded<compaction_manager>
+            // we need the getter since updateable_value is not shard-safe (#7316)
+            auto get_cm_cfg = sharded_parameter([&] {
+                return compaction_manager::config {
+                    .compaction_sched_group = compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group, service::get_local_compaction_priority()},
+                    .maintenance_sched_group = compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group, service::get_local_streaming_priority()},
+                    .available_memory = dbcfg.available_memory,
+                    .static_shares = cfg->compaction_static_shares,
+                    .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
+                };
+            });
+            cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source())).get();
+            auto stop_cm = deferred_stop(cm);
+
             supervisor::notify("starting database");
             debug::the_database = &db;
             db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
-                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+                    std::ref(cm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
             auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
                 // #293 - do not stop anything - not even db (for real)
                 //return db.stop();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1327,7 +1327,7 @@ private:
     utils::updateable_value_source<utils::UUID> _version;
     uint32_t _schema_change_count = 0;
     // compaction_manager object is referenced by all column families of a database.
-    std::unique_ptr<compaction_manager> _compaction_manager;
+    compaction_manager& _compaction_manager;
     seastar::metrics::metric_groups _metrics;
     bool _enable_incremental_backups = false;
     bool _shutdown = false;
@@ -1432,7 +1432,7 @@ public:
 
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            compaction_manager& cm, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 
@@ -1458,10 +1458,10 @@ public:
     seastar::scheduling_group get_streaming_scheduling_group() const { return _dbcfg.streaming_scheduling_group; }
 
     compaction_manager& get_compaction_manager() {
-        return *_compaction_manager;
+        return _compaction_manager;
     }
     const compaction_manager& get_compaction_manager() const {
-        return *_compaction_manager;
+        return _compaction_manager;
     }
 
     const locator::shared_token_metadata& get_shared_token_metadata() const { return _shared_token_metadata; }

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4624,7 +4624,12 @@ class scylla_compaction_tasks(gdb.Command):
 
     def invoke(self, arg, from_tty):
         db = find_db()
-        cm = std_unique_ptr(db['_compaction_manager']).get().dereference()
+        cm = db['_compaction_manager']
+        try:
+            aux = std_unique_ptr(db['_compaction_manager']).get().dereference()
+            cm = aux
+        except:
+            pass
         task_hist = histogram(print_indicators=False)
 
         task_list = list(std_list(cm['_tasks']))

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2178,7 +2178,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             cf->mark_ready_for_writes();
             cf->start();
 
-            dht::token_range_vector local_ranges = db.get_keyspace_local_ranges(ks_name);
+            auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(ks_name));
             auto descriptor = sstables::compaction_descriptor({std::move(sst)}, default_priority_class(), compaction_descriptor::default_level,
                 compaction_descriptor::default_max_sstable_bytes, run_identifier, compaction_type_options::make_cleanup(std::move(local_ranges)));
             auto ret = compact_sstables(db.get_compaction_manager(), std::move(descriptor), *cf, sst_gen).get0();


### PR DESCRIPTION
Start compaction_manager as a sharded service
and pass a reference to it to the database rather
than having the database construct its own compaction_manager.

This is part of the wider scope effort to decouple compaction from replica database and table.
