### PR TITLE
logalloc: region: properly track listeners when moved

### DIFF
--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -72,7 +72,8 @@ region_group::del(region_group* child) {
 void
 region_group::add(region* child_r) {
     auto child = static_cast<size_tracked_region*>(child_r);
-    child->_heap_handle = _regions.push(child);
+    assert(!child->_heap_handle);
+    child->_heap_handle = std::make_optional(_regions.push(child));
     region_group_binomial_group_sanity_check(_regions);
     update(child_r->occupancy().total_space());
 }
@@ -80,13 +81,27 @@ region_group::add(region* child_r) {
 void
 region_group::del(region* child_r) {
     auto child = static_cast<size_tracked_region*>(child_r);
-    _regions.erase(child->_heap_handle);
-    region_group_binomial_group_sanity_check(_regions);
-    update(-child_r->occupancy().total_space());
+    if (child->_heap_handle) {
+        _regions.erase(*std::exchange(child->_heap_handle, std::nullopt));
+        region_group_binomial_group_sanity_check(_regions);
+        update(-child_r->occupancy().total_space());
+    }
 }
 
 void
 region_group::moved(region* old_address, region* new_address) {
+    auto old_child = static_cast<size_tracked_region*>(old_address);
+    if (old_child->_heap_handle) {
+        _regions.erase(*std::exchange(old_child->_heap_handle, std::nullopt));
+    }
+
+    auto new_child = static_cast<size_tracked_region*>(new_address);
+
+    // set the old child handle since it's going to be moved
+    // to the new child's handle by the respective move constructor /
+    // assignment operator.
+    old_child->_heap_handle = std::make_optional(_regions.push(new_child));
+    region_group_binomial_group_sanity_check(_regions);
 }
 
 bool

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -36,7 +36,7 @@ using region_heap = boost::heap::binomial_heap<size_tracked_region*,
 
 class size_tracked_region : public logalloc::region {
 public:
-    region_heap::handle_type _heap_handle;
+    std::optional<region_heap::handle_type> _heap_handle;
 };
 
 //
@@ -272,12 +272,12 @@ public:
     //    evictable / non-evictable. Because the evictable occupancy changes, we would like to call
     //    the full update cycle even then.
     virtual void increase_usage(region* r, ssize_t delta) override { // From region_listener
-        _regions.increase(static_cast<size_tracked_region*>(r)->_heap_handle);
+        _regions.increase(*static_cast<size_tracked_region*>(r)->_heap_handle);
         update(delta);
     }
 
     virtual void decrease_evictable_usage(region* r) override { // From region_listener
-        _regions.decrease(static_cast<size_tracked_region*>(r)->_heap_handle);
+        _regions.decrease(*static_cast<size_tracked_region*>(r)->_heap_handle);
     }
 
     virtual void decrease_usage(region* r, ssize_t delta) override { // From region_listener
@@ -401,6 +401,8 @@ private:
     void del(region_group* child);
     virtual void add(region* child) override; // from region_listener
     virtual void del(region* child) override; // from region_listener
+
+    friend class test_region_group;
 };
 
 }

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -342,6 +342,18 @@ SEASTAR_TEST_CASE(test_merging) {
     });
 }
 
+SEASTAR_THREAD_TEST_CASE(test_region_move) {
+    logalloc::region r0;
+    logalloc::region r1(std::move(r0)); // simple move
+    logalloc::region r2(std::move(r1)); // transitive move
+    logalloc::region r3(std::move(r0)); // moving a moved-from region (with disengaged impl)
+
+    logalloc::region r4;
+    r4 = std::move(r2); // simple move
+    r4 = std::move(r3); // moving a moved-from region (with disengaged impl)
+    auto r5 = std::move(r4);
+}
+
 #ifndef SEASTAR_DEFAULT_ALLOCATOR
 SEASTAR_TEST_CASE(test_region_lock) {
     return seastar::async([] {

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2201,13 +2201,10 @@ lsa_buffer region::alloc_buf(size_t buffer_size) {
 void region::merge(region& other) noexcept {
     if (_impl != other._impl) {
         auto other_impl = static_cast<region_impl*>(other._impl.get());
-        if (other_impl->_listener) {
-            // Not very generic, but we know that post-merge the caller
-            // (row_cache) isn't interested in listening, and one region
-            // can't have many listeners.
-            other_impl->_listener->del(&other);
-            other_impl->_listener = nullptr;
-        }
+        // Not very generic, but we know that post-merge the caller
+        // (row_cache) isn't interested in listening, and one region
+        // can't have many listeners.
+        other_impl->unlisten();
         get_impl().merge(other.get_impl());
         other._impl = _impl;
     }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2154,8 +2154,9 @@ const region_impl& region::get_impl() const noexcept {
     return *static_cast<const region_impl*>(_impl.get());
 }
 
-region::region(region&& other) noexcept {
-    this->_impl = std::move(other._impl);
+region::region(region&& other) noexcept
+    : _impl(std::move(other._impl))
+{
     if (_impl) {
         auto r_impl = static_cast<region_impl*>(_impl.get());
         r_impl->_region = this;

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1809,6 +1809,13 @@ public:
         }
     }
 
+    void moved(region* new_region) {
+        if (_listener) {
+            _listener->moved(_region, new_region);
+        }
+        _region = new_region;
+    }
+
     // Note: allocation is disallowed in this path
     // since we don't instantiate reclaiming_lock
     // while traversing _regions
@@ -2159,10 +2166,7 @@ region::region(region&& other) noexcept
 {
     if (_impl) {
         auto r_impl = static_cast<region_impl*>(_impl.get());
-        r_impl->_region = this;
-        if (r_impl->_listener) {
-            r_impl->_listener->moved(&other, this);
-        }
+        r_impl->moved(this);
     }
 }
 
@@ -2176,10 +2180,7 @@ region& region::operator=(region&& other) noexcept {
     this->_impl = std::move(other._impl);
     if (_impl) {
         auto r_impl = static_cast<region_impl*>(_impl.get());
-        r_impl->_region = this;
-        if (r_impl->_listener) {
-            r_impl->_listener->moved(&other, this);
-        }
+        r_impl->moved(this);
     }
     return *this;
 }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2171,12 +2171,7 @@ region& region::operator=(region&& other) noexcept {
         return *this;
     }
     if (_impl) {
-        auto r_impl = static_cast<region_impl*>(_impl.get());
-        if (r_impl->_listener) {
-            r_impl->_listener->del(this);
-            // Clear before region_impl destructor tries to access removed region
-            r_impl->_listener = nullptr;
-        }
+        unlisten();
     }
     this->_impl = std::move(other._impl);
     if (_impl) {
@@ -2191,12 +2186,7 @@ region& region::operator=(region&& other) noexcept {
 
 region::~region() {
     if (_impl) {
-        auto impl = static_cast<region_impl*>(_impl.get());
-        if (impl->_listener) {
-            impl->_listener->del(this);
-            // Clear before region_impl destructor tries to access removed region
-            impl->_listener = nullptr;
-        }
+        unlisten();
     }
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2200,12 +2200,12 @@ lsa_buffer region::alloc_buf(size_t buffer_size) {
 
 void region::merge(region& other) noexcept {
     if (_impl != other._impl) {
-        auto other_impl = static_cast<region_impl*>(other._impl.get());
+        auto& other_impl = other.get_impl();
         // Not very generic, but we know that post-merge the caller
         // (row_cache) isn't interested in listening, and one region
         // can't have many listeners.
-        other_impl->unlisten();
-        get_impl().merge(other.get_impl());
+        other_impl.unlisten();
+        get_impl().merge(other_impl);
         other._impl = _impl;
     }
 }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2156,9 +2156,9 @@ const region_impl& region::get_impl() const noexcept {
 
 region::region(region&& other) noexcept {
     this->_impl = std::move(other._impl);
-    get_impl()._region = this;
     if (_impl) {
         auto r_impl = static_cast<region_impl*>(_impl.get());
+        r_impl->_region = this;
         if (r_impl->_listener) {
             r_impl->_listener->moved(&other, this);
         }
@@ -2180,11 +2180,11 @@ region& region::operator=(region&& other) noexcept {
     this->_impl = std::move(other._impl);
     if (_impl) {
         auto r_impl = static_cast<region_impl*>(_impl.get());
+        r_impl->_region = this;
         if (r_impl->_listener) {
             r_impl->_listener->moved(&other, this);
         }
     }
-    get_impl()._region = this;
     return *this;
 }
 


### PR DESCRIPTION
Currently logalloc::region is relying on boost binomial_heap handle to properly move listeners registration when the region (when derived from dirty_memory_manager_logalloc::size_tracked_region) is moved, like boost::intrusive link hooks do -
hence https://github.com/scylladb/scylla/blob/81e20ceaab8f54938aa77842ee5c9d9e62639432/dirty_memory_manager.cc#L89-L90 does nothing.

Unfortunately, this doesn't work as expected.

This series adds a unit test that verifies the move semantics
and a fix to size_tracked_region and region_group code to make it pass.

Also "logalloc: region: get_impl might be called on disengaged _impl when moved"
fixes a couple corner cases where the shared _impl could be dereferenced when disengaged, and
the change also adds a unit test for that too.