### PR TITLE
docs: mention the new synchronous_updates option in mv docs

### DIFF
--- a/docs/cql/mv.rst
+++ b/docs/cql/mv.rst
@@ -150,6 +150,20 @@ MV Options
 A materialized view is internally implemented by a table, and as such, creating a MV allows the :ref:`same options than
 creating a table <create-table-options>`.
 
+Additionally, the following Scylla-specific options are supported:
+
+.. list-table::
+   :widths: 20 10 10 60
+   :header-rows: 1
+
+   * - Option
+     - Kind
+     - Default
+     - Description
+   * - ``synchronous_updates``
+     - simple
+     - false
+     - When true, view updates are applied synchronously; otherwise, view updates may be applied in the background
 
 .. _alter-materialized-view-statement:
 


### PR DESCRIPTION
This commit adds a table (with 1 row) explaining Scylla-specific
materialized view options - which now consists just of
synchronous_updates.

Tested manually by running `make preview` from docs/ directory.