### PR TITLE
ninja: add ci-build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2144,7 +2144,7 @@ with open(buildfile, 'w') as f:
     f.write(
             'build check: phony {}\n'.format(' '.join(['{mode}-check'.format(mode=mode) for mode in default_modes]))
     )
-    f.write('build ci-build: phony debug release dev\n')
+    f.write('build ci-build: phony debug release dev dev-headers\n')
 
     f.write(textwrap.dedent(f'''\
         build dist-unified-tar: phony {' '.join([f'$builddir/{mode}/dist/tar/{scylla_product}-unified-{scylla_version}-{scylla_release}.{arch}.tar.gz' for mode in default_modes])}

--- a/configure.py
+++ b/configure.py
@@ -2144,6 +2144,7 @@ with open(buildfile, 'w') as f:
     f.write(
             'build check: phony {}\n'.format(' '.join(['{mode}-check'.format(mode=mode) for mode in default_modes]))
     )
+    f.write('build ci-build: phony debug release dev\n')
 
     f.write(textwrap.dedent(f'''\
         build dist-unified-tar: phony {' '.join([f'$builddir/{mode}/dist/tar/{scylla_product}-unified-{scylla_version}-{scylla_release}.{arch}.tar.gz' for mode in default_modes])}


### PR DESCRIPTION
This PR contains two commits for adding the `ci-build` build task to ninja
only the first commit 765cc56 should be merged to release branches (unless the dev-headers build fixed on the target release)

@nyh @avikivity 