### PR TITLE
test.py simplify cql test search

### DIFF
--- a/test.py
+++ b/test.py
@@ -395,10 +395,7 @@ class CQLApprovalTestSuite(PythonTestSuite):
         super().__init__(path, cfg, options, mode)
 
     def build_test_list(self) -> List[str]:
-        """For CQL tests, search for directories recursively"""
-        path = self.suite_path
-        cqltests = itertools.chain(path.rglob("*_test.cql"), path.rglob("test_*.cql"))
-        return [os.path.splitext(t.relative_to(self.suite_path))[0] for t in cqltests]
+        return TestSuite.build_test_list(self)
 
     async def add_test(self, shortname: str) -> None:
         test = CQLApprovalTest(self.next_id, shortname, self)


### PR DESCRIPTION
Use a base class method available instead of hand-coded recursive lookup. Don't lookup for cql tests recursively, there is no need to.