### PR TITLE
repair: Yield in repair_service::do_decommission_removenode_with_repair

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1579,6 +1579,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             auto local_dc = topology.get_datacenter();
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
             for (auto&r : ranges) {
+                seastar::thread::maybe_yield();
                 if (ops) {
                     ops->check_abort();
                 }


### PR DESCRIPTION
When walking through the ranges, we should yield to prevent stalls. We
do similar yield in other node operations.

Fix a stall in 5.1.dev.20220724.f46b207472a3 with build-id
d947aaccafa94647f71c1c79326eb88840c5b6d2

```
!INFO | scylla[6551]: Reactor stalled for 10 ms on shard 0. Backtrace:
0x4bbb9d2 0x4bba630 0x4bbb8e0 0x7fd365262a1f 0x2face49 0x2f5caff
0x36ca29f 0x36c89c3 0x4e3a0e1
````

Fixes #11146