### PR TITLE
doc: remove Drivers from getting startded index

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -8,7 +8,6 @@ Getting Started
    install-scylla/index
    configure
    requirements
-   Scylla Drivers </using-scylla/drivers/index>
    Migrate to Scylla </using-scylla/migrate-scylla>
    Integration Solutions </using-scylla/integrations/index>
    tutorials


### PR DESCRIPTION
The Drivers' docs were displayed in the menu under Getting Started and Scylla for Developers.
This PR removes them from the Getting Started index to avoid duplication and follow the structure of the project (the pages about drivers are in the `using-scylla `directory i.e. Scylla for Developers section.