### PR TITLE
Minimal implementation of Broadcast Tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,8 @@ set(scylla_sources
     cql3/statements/sl_prop_defs.cc
     cql3/statements/truncate_statement.cc
     cql3/statements/update_statement.cc
+    cql3/statements/strongly_consistent_modification_statement.cc
+    cql3/statements/strongly_consistent_select_statement.cc
     cql3/statements/use_statement.cc
     cql3/type_json.cc
     cql3/untyped_result_set.cc
@@ -533,6 +535,7 @@ set(scylla_sources
     raft/raft.cc
     raft/server.cc
     raft/tracker.cc
+    service/broadcast_tables/experimental/lang.cc
     range_tombstone.cc
     range_tombstone_list.cc
     tombstone_gc_options.cc

--- a/configure.py
+++ b/configure.py
@@ -804,6 +804,8 @@ scylla_core = (['message/messaging_service.cc',
                 'cql3/statements/raw/parsed_statement.cc',
                 'cql3/statements/property_definitions.cc',
                 'cql3/statements/update_statement.cc',
+                'cql3/statements/strongly_consistent_modification_statement.cc',
+                'cql3/statements/strongly_consistent_select_statement.cc',
                 'cql3/statements/delete_statement.cc',
                 'cql3/statements/prune_materialized_view_statement.cc',
                 'cql3/statements/batch_statement.cc',
@@ -1041,6 +1043,7 @@ scylla_core = (['message/messaging_service.cc',
                 'service/raft/raft_group0.cc',
                 'direct_failure_detector/failure_detector.cc',
                 'service/raft/raft_group0_client.cc',
+                'service/broadcast_tables/experimental/lang.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] + [Thrift('interface/cassandra.thrift', 'Cassandra')] \
                   + scylla_raft_core
                )

--- a/configure.py
+++ b/configure.py
@@ -1151,6 +1151,7 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/replica_exception.idl.hh',
         'idl/per_partition_rate_limit_info.idl.hh',
         'idl/position_in_partition.idl.hh',
+        'idl/experimental/broadcast_tables_lang.idl.hh',
         ]
 
 rusts = [

--- a/cql3/column_condition.hh
+++ b/cql3/column_condition.hh
@@ -73,6 +73,14 @@ public:
             std::move(in_values), nullptr, expr::oper_t::IN);
     }
 
+    const std::optional<expr::expression>& get_value() const {
+        return _value;
+    }
+
+    expr::oper_t get_operation() const {
+        return _op;
+    }
+
     class raw final {
     private:
         std::optional<cql3::expr::expression> _value;

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -10,6 +10,7 @@
 
 #include "cql3/constants.hh"
 #include "cql3/cql3_type.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
 
 namespace cql3 {
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
@@ -21,5 +22,10 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
     } else {
         m.set_cell(prefix, column, params.make_dead_cell());
     }
+}
+
+void constants::setter::prepare_for_broadcast_tables(service::broadcast_tables::update_query& query) const {
+    // FIXME: this works only for constants and bind markers are unimplemented at this point.
+    query.new_value = expr::evaluate(*_e, query_options::DEFAULT).to_bytes();
 }
 }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -11,11 +11,16 @@
 #pragma once
 
 #include "cql3/abstract_marker.hh"
+#include "cql3/query_options.hh"
 #include "cql3/update_parameters.hh"
 #include "cql3/operation.hh"
 #include "cql3/values.hh"
 #include "mutation.hh"
 #include <seastar/core/shared_ptr.hh>
+
+namespace service::broadcast_tables {
+    class update_query;
+}
 
 namespace cql3 {
 
@@ -44,6 +49,8 @@ public:
                 m.set_cell(prefix, column, params.make_cell(*column.type, value));
             }
         }
+
+        virtual void prepare_for_broadcast_tables(service::broadcast_tables::update_query& query) const override;
     };
 
     struct adder final : operation {

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -18,6 +18,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include "types/user.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
 
 namespace cql3 {
 
@@ -355,6 +356,12 @@ operation::element_deletion::prepare(data_dictionary::database db, const sstring
         return make_shared<maps::discarder_by_key>(receiver, std::move(key));
     }
     abort();
+}
+
+void
+operation::prepare_for_broadcast_tables(service::broadcast_tables::update_query&) const {
+    // FIXME: implement for every type of `operation`.
+    throw service::broadcast_tables::unsupported_operation_error{};
 }
 
 }

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -19,6 +19,10 @@
 
 #include <optional>
 
+namespace service::broadcast_tables {
+    class update_query;
+}
+
 namespace cql3 {
 
 class update_parameters;
@@ -85,6 +89,8 @@ public:
      * Execute the operation.
      */
     virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) = 0;
+    
+    virtual void prepare_for_broadcast_tables(service::broadcast_tables::update_query&) const;
 
     /**
      * A parsed raw UPDATE operation.

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -55,7 +55,7 @@ public:
     }
 };
 
-query_processor::query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg)
+query_processor::query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client)
         : _migration_subscriber{std::make_unique<migration_subscriber>(this)}
         , _proxy(proxy)
         , _forwarder(forwarder)
@@ -64,6 +64,7 @@ query_processor::query_processor(service::storage_proxy& proxy, service::forward
         , _mm(mm)
         , _mcfg(mcfg)
         , _cql_config(cql_cfg)
+        , _group0_client(group0_client)
         , _internal_state(new internal_state())
         , _prepared_cache(prep_cache_log, _mcfg.prepared_statment_cache_size)
         , _authorized_prepared_cache(std::move(auth_prep_cache_cfg), authorized_prepared_statements_cache_log)

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -23,6 +23,7 @@
 #include "exceptions/exceptions.hh"
 #include "lang/wasm_instance_cache.hh"
 #include "service/migration_listener.hh"
+#include "service/raft/raft_group0_client.hh"
 #include "transport/messages/result_message.hh"
 #include "service/qos/service_level_controller.hh"
 #include "service/client_state.hh"
@@ -98,6 +99,7 @@ private:
     service::migration_manager& _mm;
     memory_config _mcfg;
     const cql_config& _cql_config;
+    service::raft_group0_client& _group0_client;
 
     struct stats {
         uint64_t prepare_invocations = 0;
@@ -138,7 +140,7 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries);
 
-    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg);
+    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client);
 
     ~query_processor();
 
@@ -200,6 +202,10 @@ public:
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const prepared_cache_key_type& key) {
         return _prepared_cache.find(key);
+    }
+
+    service::raft_group0_client& get_group0_client() {
+        return _group0_client;
     }
 
     inline

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -8,8 +8,10 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "cql3/cql_statement.hh"
 #include "types/map.hh"
 #include "cql3/statements/modification_statement.hh"
+#include "cql3/statements/strongly_consistent_modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/util.hh"
@@ -28,6 +30,7 @@
 #include "cas_request.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
 
 template<typename T = void>
 using coordinator_result = exceptions::coordinator_result<T>;
@@ -439,13 +442,30 @@ modification_statement::process_where_clause(data_dictionary::database db, expr:
     }
 }
 
+::shared_ptr<strongly_consistent_modification_statement>
+modification_statement::prepare_for_broadcast_tables() const {
+    // FIXME: implement for every type of `modification_statement`.
+    throw service::broadcast_tables::unsupported_operation_error{};
+}
+
 namespace raw {
+
+::shared_ptr<cql_statement_opt_metadata>
+modification_statement::prepare_statement(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) {
+    ::shared_ptr<cql3::statements::modification_statement> statement = prepare(db, ctx, stats);
+
+    if (service::broadcast_tables::is_broadcast_table_statement(keyspace(), column_family())) {
+        return statement->prepare_for_broadcast_tables();
+    } else {
+        return statement;
+    }
+}
 
 std::unique_ptr<prepared_statement>
 modification_statement::prepare(data_dictionary::database db, cql_stats& stats) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto meta = get_prepare_context();
-    auto statement = prepare(db, meta, stats);
+    auto statement = prepare_statement(db, meta, stats);
     auto partition_key_bind_indices = meta.get_partition_key_bind_indexes(*schema);
     return std::make_unique<prepared_statement>(std::move(statement), meta, std::move(partition_key_bind_indices));
 }

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -33,6 +33,7 @@ class operation;
 
 namespace statements {
 
+class strongly_consistent_modification_statement;
 
 namespace raw { class modification_statement; }
 
@@ -69,10 +70,11 @@ public:
 protected:
     std::vector<::shared_ptr<operation>> _column_operations;
     cql_stats& _stats;
-private:
+
     // Separating normal and static conditions makes things somewhat easier
     std::vector<lw_shared_ptr<column_condition>> _regular_conditions;
     std::vector<lw_shared_ptr<column_condition>> _static_conditions;
+private:
     const ks_selector _ks_sel;
 
     // True if this statement has _if_exists or _if_not_exists or other
@@ -256,6 +258,9 @@ public:
     future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs) const;
 
     virtual json_cache_opt maybe_prepare_json_cache(const query_options& options) const;
+
+    virtual ::shared_ptr<strongly_consistent_modification_statement> prepare_for_broadcast_tables() const;
+
 protected:
     /**
      * If there are conditions on the statement, this is called after the where clause and conditions have been

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -14,6 +14,7 @@
 #include "cql3/column_identifier.hh"
 #include "cql3/column_condition.hh"
 #include "cql3/attributes.hh"
+#include "cql3/cql_statement.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -42,6 +43,7 @@ protected:
 
 public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    ::shared_ptr<cql_statement_opt_metadata> prepare_statement(data_dictionary::database db, prepare_context& ctx, cql_stats& stats);
     ::shared_ptr<cql3::statements::modification_statement> prepare(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const;
 protected:
     virtual ::shared_ptr<cql3::statements::modification_statement> prepare_internal(data_dictionary::database db, schema_ptr schema,

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+
+#include "cql3/statements/strongly_consistent_modification_statement.hh"
+
+#include <boost/range/adaptors.hpp>
+#include <optional>
+
+#include <seastar/core/future.hh>
+
+#include "cql3/attributes.hh"
+#include "cql3/operation.hh"
+#include "cql3/query_processor.hh"
+#include "timeout_config.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
+
+namespace cql3 {
+
+namespace statements {
+
+strongly_consistent_modification_statement::strongly_consistent_modification_statement(
+    uint32_t bound_terms,
+    schema_ptr schema,
+    service::broadcast_tables::update_query query)
+    : cql_statement_opt_metadata{&timeout_config::write_timeout}
+    , _bound_terms{bound_terms}
+    , _schema{schema}
+    , _query{std::move(query)}
+{ }
+
+future<::shared_ptr<cql_transport::messages::result_message>>
+strongly_consistent_modification_statement::execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    return execute_without_checking_exception_message(qp, qs, options)
+            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<cql_transport::messages::result_message>>);
+}
+    
+future<::shared_ptr<cql_transport::messages::result_message>>
+strongly_consistent_modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    return service::broadcast_tables::execute(qp.get_group0_client(), { _query })
+        .then(make_ready_future<::shared_ptr<cql_transport::messages::result_message>>);
+}
+
+uint32_t strongly_consistent_modification_statement::get_bound_terms() const {
+    return _bound_terms;
+}
+
+future<> strongly_consistent_modification_statement::check_access(query_processor& qp, const service::client_state& state) const {
+    const data_dictionary::database db = qp.db();
+    auto f = state.has_column_family_access(db, _schema->ks_name(), _schema->cf_name(), auth::permission::MODIFY);
+    if (_query.value_condition->has_value()) {
+        f = f.then([this, &state, db] {
+           return state.has_column_family_access(db, _schema->ks_name(), _schema->cf_name(), auth::permission::SELECT);
+        });
+    }
+    return f;
+}
+
+void strongly_consistent_modification_statement::validate(query_processor&, const service::client_state& state) const {
+    // Nothing to do, all validation has been done by prepare().
+}
+
+bool strongly_consistent_modification_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
+    return _schema->ks_name() == ks_name && (!cf_name || _schema->cf_name() == *cf_name);
+}
+
+}
+
+}

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -44,6 +44,11 @@ strongly_consistent_modification_statement::execute(query_processor& qp, service
     
 future<::shared_ptr<cql_transport::messages::result_message>>
 strongly_consistent_modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    if (this_shard_id() != 0) {
+        return make_ready_future<::shared_ptr<cql_transport::messages::result_message>>(
+            ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0, cql3::computed_function_values{}));
+    }
+
     return service::broadcast_tables::execute(qp.get_group0_client(), { _query })
         .then(make_ready_future<::shared_ptr<cql_transport::messages::result_message>>);
 }

--- a/cql3/statements/strongly_consistent_modification_statement.hh
+++ b/cql3/statements/strongly_consistent_modification_statement.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include "cql3/cql_statement.hh"
+#include "cql3/statements/modification_statement.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
+
+namespace cql3 {
+
+namespace statements {
+
+class strongly_consistent_modification_statement : public cql_statement_opt_metadata {
+    const uint32_t _bound_terms;
+    const schema_ptr _schema;
+    const service::broadcast_tables::update_query _query;
+
+public:
+    strongly_consistent_modification_statement(uint32_t bound_terms, schema_ptr schema, service::broadcast_tables::update_query query);
+
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+    execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;
+
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+    execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const override;
+
+    virtual uint32_t get_bound_terms() const override;
+
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
+
+    // Validate before execute, using client state and current schema
+    void validate(query_processor&, const service::client_state& state) const override;
+
+    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+};
+
+
+}
+
+}

--- a/cql3/statements/strongly_consistent_select_statement.cc
+++ b/cql3/statements/strongly_consistent_select_statement.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+
+#include "cql3/statements/strongly_consistent_select_statement.hh"
+
+#include <seastar/core/future.hh>
+
+#include "cql3/restrictions/statement_restrictions.hh"
+#include "cql3/query_processor.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
+
+namespace cql3 {
+
+namespace statements {
+
+static
+bytes get_key(const cql3::expr::expression& partition_key_restrictions) {
+    const auto* conjunction = cql3::expr::as_if<cql3::expr::conjunction>(&partition_key_restrictions);
+
+    if (!conjunction || conjunction->children.size() != 1) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format(
+            "partition key restriction: {}", partition_key_restrictions));
+    }
+
+    const auto* key_restriction = cql3::expr::as_if<cql3::expr::binary_operator>(&conjunction->children[0]);
+
+    if (!key_restriction) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format("partition key restriction: {}", *conjunction));
+    }
+
+    // FIXME: add support for bind variables
+    const auto* column = cql3::expr::as_if<cql3::expr::column_value>(&key_restriction->lhs);
+    const auto* value = cql3::expr::as_if<cql3::expr::constant>(&key_restriction->rhs);
+
+    if (!column || column->col->kind != column_kind::partition_key ||
+        !value || key_restriction->op != cql3::expr::oper_t::EQ) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format("key restriction: {}", *key_restriction));
+    }
+
+    return to_bytes(value->view());
+}
+
+static
+bool is_selecting_only_value(const cql3::selection::selection& selection) {
+    return selection.is_trivial() &&
+           selection.get_column_count() == 1 &&
+           selection.get_columns()[0]->name() == "value";
+}
+
+strongly_consistent_select_statement::strongly_consistent_select_statement(schema_ptr schema, uint32_t bound_terms,
+                                                                           lw_shared_ptr<const parameters> parameters,
+                                                                           ::shared_ptr<selection::selection> selection,
+                                                                           ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+                                                                           ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
+                                                                           bool is_reversed,
+                                                                           ordering_comparator_type ordering_comparator,
+                                                                           std::optional<expr::expression> limit,
+                                                                           std::optional<expr::expression> per_partition_limit,
+                                                                           cql_stats &stats,
+                                                                           std::unique_ptr<attributes> attrs)
+    : select_statement{schema, bound_terms, parameters, selection, restrictions, group_by_cell_indices, is_reversed, ordering_comparator, std::move(limit), std::move(per_partition_limit), stats, std::move(attrs)},
+      _query{prepare_query()}
+{ }
+
+service::broadcast_tables::select_query strongly_consistent_select_statement::prepare_query() const {
+    if (!is_selecting_only_value(*_selection)) {
+        throw service::broadcast_tables::unsupported_operation_error("only 'value' selector is allowed");
+    }
+
+    return {
+        .key = get_key(_restrictions->get_partition_key_restrictions())
+    };
+}
+
+future<::shared_ptr<cql_transport::messages::result_message>>
+strongly_consistent_select_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    return service::broadcast_tables::execute(qp.get_group0_client(), { _query })
+        .then(make_ready_future<::shared_ptr<cql_transport::messages::result_message>>);
+}
+
+}
+
+}

--- a/cql3/statements/strongly_consistent_select_statement.cc
+++ b/cql3/statements/strongly_consistent_select_statement.cc
@@ -82,6 +82,11 @@ service::broadcast_tables::select_query strongly_consistent_select_statement::pr
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 strongly_consistent_select_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    if (this_shard_id() != 0) {
+        return make_ready_future<::shared_ptr<cql_transport::messages::result_message>>(
+            ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0, cql3::computed_function_values{}));
+    }
+
     return service::broadcast_tables::execute(qp.get_group0_client(), { _query })
         .then(make_ready_future<::shared_ptr<cql_transport::messages::result_message>>);
 }

--- a/cql3/statements/strongly_consistent_select_statement.hh
+++ b/cql3/statements/strongly_consistent_select_statement.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include "cql3/statements/select_statement.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
+
+namespace cql3 {
+
+namespace statements {
+
+class strongly_consistent_select_statement : public select_statement {
+    const service::broadcast_tables::select_query _query;
+
+    service::broadcast_tables::select_query prepare_query() const;
+public:
+    strongly_consistent_select_statement(schema_ptr schema,
+                     uint32_t bound_terms,
+                     lw_shared_ptr<const parameters> parameters,
+                     ::shared_ptr<selection::selection> selection,
+                     ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+                     ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
+                     bool is_reversed,
+                     ordering_comparator_type ordering_comparator,
+                     std::optional<expr::expression> limit,
+                     std::optional<expr::expression> per_partition_limit,
+                     cql_stats &stats,
+                     std::unique_ptr<cql3::attributes> attrs);
+
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+        execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const override;
+};
+
+}
+
+}

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -9,6 +9,8 @@
  */
 
 #include "update_statement.hh"
+#include "cql3/statements/strongly_consistent_modification_statement.hh"
+#include "service/broadcast_tables/experimental/lang.hh"
 #include "raw/update_statement.hh"
 
 #include "raw/insert_statement.hh"
@@ -252,6 +254,107 @@ void insert_prepared_json_statement::execute_operations_for_key(mutation& m, con
             execute_set_value(m, prefix, params, def, bytes_opt{});
         }
     }
+}
+
+
+static
+bytes get_key(const cql3::expr::expression& partition_key_restrictions) {
+    const auto* conjunction = cql3::expr::as_if<cql3::expr::conjunction>(&partition_key_restrictions);
+
+    if (!conjunction || conjunction->children.size() != 1) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format(
+            "partition key restriction: {}", partition_key_restrictions));
+    }
+
+    const auto* key_restriction = cql3::expr::as_if<cql3::expr::binary_operator>(&conjunction->children[0]);
+
+    if (!key_restriction) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format("partition key restriction: {}", *conjunction));
+    }
+
+    // FIXME: add support for bind variables
+    const auto* column = cql3::expr::as_if<cql3::expr::column_value>(&key_restriction->lhs);
+    const auto* value = cql3::expr::as_if<cql3::expr::constant>(&key_restriction->rhs);
+
+    if (!column || column->col->kind != column_kind::partition_key ||
+        !value || key_restriction->op != cql3::expr::oper_t::EQ) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format("key restriction: {}", *key_restriction));
+    }
+
+    return to_bytes(value->view());
+}
+
+static
+void prepare_new_value(service::broadcast_tables::update_query& query, const std::vector<::shared_ptr<operation>>& operations) {
+    if (operations.size() != 1) {
+        throw service::broadcast_tables::unsupported_operation_error("only one operation is allowed and must be of the form \"value = X\"");
+    }
+
+    operations[0]->prepare_for_broadcast_tables(query);
+}
+
+static
+std::optional<bytes_opt> get_value_condition(const std::vector<lw_shared_ptr<column_condition>>& conditions) {
+    if (conditions.size() == 0) {
+        return std::nullopt;
+    }
+
+    if (conditions.size() > 1) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format("conditions: {}", fmt::join(
+            conditions | boost::adaptors::transformed([] (const auto& cond) {
+                return fmt::format("{}{}", cond->get_operation(), cond->get_value());
+            }), ", ")));
+    }
+
+    const auto& condition = conditions[0];
+
+    if (!condition->get_value() || condition->get_operation() != cql3::expr::oper_t::EQ) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format(
+            "condition: {}{}", condition->get_operation(), condition->get_value()));
+    }
+
+    const auto* value = cql3::expr::as_if<cql3::expr::constant>(&*condition->get_value());
+
+    if (!value) {
+        throw service::broadcast_tables::unsupported_operation_error(fmt::format(
+            "condition: {}{}", condition->get_operation(), condition->get_value()));
+    }
+
+    if (value->is_null()) {
+        return bytes_opt{};
+    }
+
+    return to_bytes(value->view());
+}
+
+::shared_ptr<strongly_consistent_modification_statement>
+update_statement::prepare_for_broadcast_tables() const {
+    if (attrs) {
+        if (attrs->is_time_to_live_set()) {
+            throw service::broadcast_tables::unsupported_operation_error{"USING TTL"};
+        }
+
+        if (attrs->is_timestamp_set()) {
+            throw service::broadcast_tables::unsupported_operation_error{"USING TIMESTAMP"};
+        }
+
+        if (attrs->is_timeout_set()) {
+            throw service::broadcast_tables::unsupported_operation_error{"USING TIMEOUT"};
+        }
+    }
+
+    service::broadcast_tables::update_query query = {
+        .key = get_key(restrictions().get_partition_key_restrictions()),
+        .value_condition = get_value_condition(_regular_conditions),
+    };
+
+    prepare_new_value(query, _column_operations);
+
+    return ::make_shared<strongly_consistent_modification_statement>(
+        get_bound_terms(),
+        s,
+        query
+    );
 }
 
 namespace raw {

--- a/cql3/statements/update_statement.hh
+++ b/cql3/statements/update_statement.hh
@@ -42,6 +42,9 @@ private:
     virtual void add_update_for_key(mutation& m, const query::clustering_range& range, const update_parameters& params, const json_cache_opt& json_cache) const override;
 
     virtual void execute_operations_for_key(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const json_cache_opt& json_cache) const;
+
+public:
+    virtual ::shared_ptr<strongly_consistent_modification_statement> prepare_for_broadcast_tables() const override;
 };
 
 /*

--- a/db/config.cc
+++ b/db/config.cc
@@ -1014,7 +1014,8 @@ db::fs::path db::config::get_conf_sub(db::fs::path sub) {
 bool db::config::check_experimental(experimental_features_t::feature f) const {
     if (experimental()
         && f != experimental_features_t::feature::UNUSED
-        && f != experimental_features_t::feature::RAFT) {
+        && f != experimental_features_t::feature::RAFT
+        && f != experimental_features_t::feature::BROADCAST_TABLES) {
             return true;
     }
     const auto& optval = experimental_features();
@@ -1058,6 +1059,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"alternator-streams", feature::ALTERNATOR_STREAMS},
         {"alternator-ttl", feature::ALTERNATOR_TTL},
         {"raft", feature::RAFT},
+        {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
     };
 }

--- a/db/config.hh
+++ b/db/config.hh
@@ -81,10 +81,11 @@ namespace db {
 
 /// Enumeration of all valid values for the `experimental` config entry.
 struct experimental_features_t {
-    // NOTE: RAFT feature is not enabled via `experimental` umbrella flag.
-    // This option should be enabled explicitly.
+    // NOTE: RAFT and BROADCAST_TABLES features are not enabled via `experimental` umbrella flag.
+    // These options should be enabled explicitly.
+    // RAFT feature has to be enabled if BROADCAST_TABLES is enabled.
     enum class feature { UNUSED, UDF, ALTERNATOR_STREAMS, ALTERNATOR_TTL, RAFT,
-            KEYSPACE_STORAGE_OPTIONS };
+            BROADCAST_TABLES, KEYSPACE_STORAGE_OPTIONS };
     static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();
 };

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2850,6 +2850,7 @@ static const std::unordered_set<sstring>& system_ks_null_shard_tables() {
         db::system_keyspace::RAFT_CONFIG,
         db::system_keyspace::GROUP0_HISTORY,
         db::system_keyspace::DISCOVERY,
+        db::system_keyspace::BROADCAST_KV_STORE,
     };
     return tables;
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -952,6 +952,20 @@ schema_ptr system_keyspace::discovery() {
     return schema;
 }
 
+schema_ptr system_keyspace::broadcast_kv_store() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(NAME, BROADCAST_KV_STORE);
+        return schema_builder(NAME, BROADCAST_KV_STORE, id)
+            .with_column("key", utf8_type, column_kind::partition_key)
+            .with_column("value", utf8_type)
+            .with_version(generate_schema_version(id))
+            .set_wait_for_sync_to_commitlog(true)
+            .with_null_sharder()
+            .build();
+    }();
+    return schema;
+}
+
 schema_ptr system_keyspace::legacy::hints() {
     static thread_local auto schema = [] {
         schema_builder builder(generate_legacy_id(NAME, HINTS), NAME, HINTS,
@@ -2682,6 +2696,10 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
     });
     if (cfg.check_experimental(db::experimental_features_t::feature::RAFT)) {
         r.insert(r.end(), {raft(), raft_snapshots(), raft_config(), group0_history(), discovery()});
+
+        if (cfg.check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {
+            r.insert(r.end(), {broadcast_kv_store()});
+        }
     }
     // legacy schema
     r.insert(r.end(), {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -138,6 +138,7 @@ public:
     static constexpr auto REPAIR_HISTORY = "repair_history";
     static constexpr auto GROUP0_HISTORY = "group0_history";
     static constexpr auto DISCOVERY = "discovery";
+    static constexpr auto BROADCAST_KV_STORE = "broadcast_kv_store";
 
     struct v3 {
         static constexpr auto BATCHES = "batches";
@@ -196,7 +197,7 @@ public:
         static schema_ptr batchlog();
     };
 
-    static constexpr const char* extra_durable_tables[] = { PAXOS, SCYLLA_LOCAL, RAFT, RAFT_SNAPSHOTS, RAFT_CONFIG, DISCOVERY };
+    static constexpr const char* extra_durable_tables[] = { PAXOS, SCYLLA_LOCAL, RAFT, RAFT_SNAPSHOTS, RAFT_CONFIG, DISCOVERY, BROADCAST_KV_STORE };
 
     static bool is_extra_durable(const sstring& name);
 
@@ -221,6 +222,7 @@ public:
     static schema_ptr repair_history();
     static schema_ptr group0_history();
     static schema_ptr discovery();
+    static schema_ptr broadcast_kv_store();
 
     static table_schema_version generate_schema_version(table_id table_id, uint16_t offset = 0);
 

--- a/idl/experimental/broadcast_tables_lang.idl.hh
+++ b/idl/experimental/broadcast_tables_lang.idl.hh
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace service {
+namespace broadcast_tables {
+
+struct select_query {
+    bytes key;
+};
+
+struct update_query {
+    bytes key;
+    bytes new_value;
+    std::optional<bytes_opt> value_condition;
+};
+
+struct query {
+    std::variant<service::broadcast_tables::select_query, service::broadcast_tables::update_query> q;
+};
+
+} // namespace broadcast_tables
+} // namespace service

--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -19,8 +19,12 @@ struct schema_change {
     std::vector<canonical_mutation> mutations;
 };
 
+struct broadcast_table_query {
+    service::broadcast_tables::query query;
+};
+
 struct group0_command {
-    std::variant<service::schema_change> change;
+    std::variant<service::schema_change, service::broadcast_table_query> change;
     canonical_mutation history_append;
 
     std::optional<utils::UUID> prev_state_id;

--- a/main.cc
+++ b/main.cc
@@ -1060,7 +1060,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                                                      std::chrono::duration_cast<std::chrono::milliseconds>(cql3::prepared_statements_cache::entry_expiry));
             auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
 
-            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notifier), std::ref(mm), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config)).get();
+            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notifier), std::ref(mm), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::ref(group0_client)).get();
             // #293 - do not stop anything
             // engine().at_exit([&qp] { return qp.stop(); });
             if (udf_enabled) {

--- a/main.cc
+++ b/main.cc
@@ -1041,6 +1041,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
             if (cfg->check_experimental(db::experimental_features_t::feature::RAFT)) {
                 supervisor::notify("starting Raft Group Registry service");
+            } else {
+                if (cfg->check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {
+                    startlog.error("Bad configuration: RAFT feature has to be enabled if BROADCAST_TABLES is enabled");
+                    throw bad_configuration_error();
+                }
             }
             raft_gr.invoke_on_all(&service::raft_group_registry::start).get();
 

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -15,6 +15,8 @@
 #include "db/system_keyspace.hh"
 #include "exceptions/exceptions.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "partition_slice_builder.hh"
+#include "query-request.hh"
 
 
 namespace service::broadcast_tables {
@@ -24,7 +26,98 @@ bool is_broadcast_table_statement(const sstring& keyspace, const sstring& column
 }
 
 future<> execute(service::raft_group0_client& group0_client, const query& query) {
-    throw exceptions::invalid_request_exception{"executing queries on broadcast_kv_store is currently not implemented"};
+    auto group0_cmd = group0_client.prepare_command(broadcast_table_query{query});
+    return group0_client.add_entry_unguarded(std::move(group0_cmd));
+}
+
+
+static
+std::pair<lw_shared_ptr<::query::read_command>, dht::partition_range>
+prepare_read_command(storage_proxy& proxy, const schema& schema, const bytes& key) {
+    auto slice = partition_slice_builder(schema).build();
+    auto partition_key = partition_key::from_single_value(schema, key);
+    dht::ring_position ring_position(dht::get_token(schema, partition_key), partition_key);
+    auto range = dht::partition_range::make_singular(ring_position);
+    return {make_lw_shared<::query::read_command>(
+            schema.id(),
+            schema.version(),
+            slice,
+            proxy.get_max_result_size(slice),
+            ::query::tombstone_limit(proxy.get_tombstone_limit())
+        ), range};
+}
+
+static
+const atomic_cell_view
+get_atomic_cell(const schema_ptr& schema, mutation& mutation, const bytes& name) {
+    const auto* column_definition = schema->get_column_definition(name);
+    return mutation.partition().clustered_row(*schema, clustering_key::make_empty()).cells().cell_at(column_definition->id).as_atomic_cell(*column_definition);
+}
+
+future<> execute_broadcast_table_query(
+    storage_proxy& proxy,
+    const query& query,
+    utils::UUID cmd_id) {
+    // std::bind_front is used to avoid losing the captures in coroutines.
+    return std::visit(make_visitor(
+        std::bind_front([] (storage_proxy& proxy, const service::broadcast_tables::select_query& q) -> future<> {
+            const auto schema = db::system_keyspace::broadcast_kv_store();
+            const auto* column_definition = schema->get_column_definition("value");
+
+            // Read mutations
+            const auto [read_cmd, range] = prepare_read_command(proxy, *schema, q.key);
+            auto [rs, _] = co_await proxy.query_mutations_locally(schema, read_cmd, range, db::no_timeout);
+
+            if (rs->partitions().empty()) {
+                co_return;
+            }
+
+            assert(rs->partitions().size() == 1); // In this version only one value per partition key is allowed.
+
+            const auto& p = rs->partitions()[0];
+            auto mutation = p.mut().unfreeze(schema);
+            const auto cell = get_atomic_cell(schema, mutation, "value");
+
+            // TODO return result
+        }, std::ref(proxy)),
+        std::bind_front([] (storage_proxy& proxy, utils::UUID cmd_id, const broadcast_tables::update_query& q) -> future<> {
+            const auto schema = db::system_keyspace::broadcast_kv_store();
+
+            // Read mutations
+            const auto [read_cmd, range] = prepare_read_command(proxy, *schema, q.key);
+            auto [rs, _] = co_await proxy.query_mutations_locally(schema, read_cmd, range, db::no_timeout);
+
+            bool found = !rs->partitions().empty();
+
+            assert(!found || rs->partitions().size() == 1); // In this version at most one value per partition key is allowed.
+
+            auto new_mutation = found
+                ? rs->partitions()[0].mut().unfreeze(schema)
+                : mutation(schema, partition_key::from_single_value(*schema, to_bytes(q.key)));
+
+            const auto cell = found
+                ? std::optional<atomic_cell_view>{get_atomic_cell(schema, new_mutation, "value")}
+                : std::nullopt;
+
+            const auto previous_value = found
+                ? bytes_opt{cell->value().linearize()}
+                : std::nullopt;
+
+            bool is_conditional = q.value_condition.has_value();
+            bool is_applied = !is_conditional || *q.value_condition == previous_value;
+
+            if (is_applied) {
+                auto old_ts = found ? cell->timestamp() : api::min_timestamp;
+                auto from_state_id = utils::UUID_gen::micros_timestamp(cmd_id);
+                auto ts = std::max(from_state_id, old_ts + 1);
+
+                auto value = utf8_type->deserialize(q.new_value);
+                new_mutation.set_clustered_cell(clustering_key::make_empty(), "value", std::move(value), ts);
+                co_await proxy.mutate_locally(new_mutation, {}, {});
+            }
+        }, std::ref(proxy), cmd_id)),
+        query.q
+    );
 }
 
 }

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "lang.hh"
+
+#include <seastar/core/future.hh>
+
+#include "data_dictionary/data_dictionary.hh"
+#include "db/config.hh"
+#include "db/system_keyspace.hh"
+#include "exceptions/exceptions.hh"
+#include "service/raft/raft_group0_client.hh"
+
+
+namespace service::broadcast_tables {
+
+bool is_broadcast_table_statement(const sstring& keyspace, const sstring& column_family) {
+    return keyspace == db::system_keyspace::NAME && column_family == db::system_keyspace::BROADCAST_KV_STORE;
+}
+
+future<> execute(service::raft_group0_client& group0_client, const query& query) {
+    throw exceptions::invalid_request_exception{"executing queries on broadcast_kv_store is currently not implemented"};
+}
+
+}

--- a/service/broadcast_tables/experimental/lang.hh
+++ b/service/broadcast_tables/experimental/lang.hh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "bytes.hh"
+
+
+namespace service::broadcast_tables {
+
+using namespace std::string_literals;
+
+// Represents 'SELECT value WHERE key = {key} FROM system.broadcast_kv_store;'.
+struct select_query {
+    bytes key;
+};
+
+// Represents 'UPDATE system.broadcast_kv_store SET value = {new_value} WHERE key = {key} [IF value = {value_condition}];'.
+// If value_condition is nullopt, the update is unconditional.
+struct update_query {
+    bytes key;
+    bytes new_value;
+    std::optional<bytes_opt> value_condition;
+};
+
+struct query {
+    std::variant<select_query, update_query> q;
+};
+
+} // namespace service::broadcast_tables

--- a/service/broadcast_tables/experimental/lang.hh
+++ b/service/broadcast_tables/experimental/lang.hh
@@ -15,6 +15,7 @@
 #include "bytes.hh"
 #include "exceptions/exceptions.hh"
 #include "service/storage_proxy.hh"
+#include "service/broadcast_tables/experimental/query_result.hh"
 
 
 namespace service {
@@ -49,9 +50,9 @@ struct query {
 // For now it returns true if and only if target table is system.broadcast_kv_store.
 bool is_broadcast_table_statement(const sstring& keyspace, const sstring& column_family);
 
-future<> execute(service::raft_group0_client& group0_client, const query& query);
+future<query_result> execute(service::raft_group0_client& group0_client, const query& query);
 
-future<> execute_broadcast_table_query(service::storage_proxy& proxy, const query& query, utils::UUID cmd_id);
+future<query_result> execute_broadcast_table_query(service::storage_proxy& proxy, const query& query, utils::UUID cmd_id);
 
 class unsupported_operation_error : public exceptions::invalid_request_exception {
 public:

--- a/service/broadcast_tables/experimental/lang.hh
+++ b/service/broadcast_tables/experimental/lang.hh
@@ -16,9 +16,11 @@
 #include "exceptions/exceptions.hh"
 #include "service/storage_proxy.hh"
 
+
 namespace service {
 
 class raft_group0_client;
+class group0_command;
 
 }
 
@@ -48,6 +50,8 @@ struct query {
 bool is_broadcast_table_statement(const sstring& keyspace, const sstring& column_family);
 
 future<> execute(service::raft_group0_client& group0_client, const query& query);
+
+future<> execute_broadcast_table_query(service::storage_proxy& proxy, const query& query, utils::UUID cmd_id);
 
 class unsupported_operation_error : public exceptions::invalid_request_exception {
 public:

--- a/service/broadcast_tables/experimental/query_result.hh
+++ b/service/broadcast_tables/experimental/query_result.hh
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#pragma once
+
+#include <variant>
+
+#include "bytes.hh"
+
+namespace service::broadcast_tables {
+
+// Represents result of single cell query.
+struct query_result_select {
+    bytes_opt value;
+};
+
+// Represents result of conditional update query.
+struct query_result_conditional_update {
+    bool is_applied;
+    bytes_opt previous_value;
+};
+
+struct query_result_none {};
+
+using query_result = std::variant<query_result_select, query_result_conditional_update, query_result_none>;
+
+} // namespace service::broadcast_tables

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "service/broadcast_tables/experimental/lang.hh"
 #include "raft/raft.hh"
 #include "utils/UUID_gen.hh"
 #include "canonical_mutation.hh"
@@ -23,8 +24,12 @@ struct schema_change {
     std::vector<canonical_mutation> mutations;
 };
 
+struct broadcast_table_query {
+    service::broadcast_tables::query query;
+};
+
 struct group0_command {
-    std::variant<schema_change> change;
+    std::variant<schema_change, broadcast_table_query> change;
 
     // Mutation of group0 history table, appending a new state ID and optionally a description.
     canonical_mutation history_append;

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -85,6 +85,8 @@ public:
 
     future<> add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as = nullptr);
 
+    future<> add_entry_unguarded(group0_command group0_cmd, seastar::abort_source* as = nullptr);
+
     // Ensures that all previously finished operations on group 0 are visible on this node;
     // in particular, performs a Raft read barrier on group 0.
     //
@@ -108,6 +110,7 @@ public:
     future<group0_guard> start_operation(seastar::abort_source* as = nullptr);
 
     group0_command prepare_command(schema_change change, group0_guard& guard, std::string_view description);
+    group0_command prepare_command(broadcast_table_query query);
 
     // Returns the current group 0 upgrade state.
     //

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -975,6 +975,21 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_raft) {
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(cfg.check_experimental(ef::RAFT));
+    BOOST_CHECK(!cfg.check_experimental(ef::BROADCAST_TABLES));
+    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
+    return make_ready_future();
+}
+
+SEASTAR_TEST_CASE(test_parse_experimental_features_broadcast_tables) {
+    auto cfg_ptr = std::make_unique<config>();
+    config& cfg = *cfg_ptr;
+    cfg.read_from_yaml("experimental_features:\n    - broadcast-tables\n", throw_on_error);
+    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::BROADCAST_TABLES});
+    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
+    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
+    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
+    BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
+    BOOST_CHECK(cfg.check_experimental(ef::BROADCAST_TABLES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }

--- a/test/broadcast_tables/pytest.ini
+++ b/test/broadcast_tables/pytest.ini
@@ -1,0 +1,6 @@
+# Pytest configuration file. If we don't have one in this directory,
+# pytest will look for one in our ancestor directories, and may find
+# something irrelevant. So we should have one here, even if empty.
+[pytest]
+# Use shared fixtures from the parent dir
+addopts = --confcutdir ..

--- a/test/broadcast_tables/suite.yaml
+++ b/test/broadcast_tables/suite.yaml
@@ -1,0 +1,2 @@
+type: Python
+extra_scylla_cmdline_options: ["--experimental-features=raft", "--experimental-features=broadcast-tables"]

--- a/test/broadcast_tables/test_broadcast_tables.py
+++ b/test/broadcast_tables/test_broadcast_tables.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import random
+import string
+from typing import Dict, List, Optional, Tuple
+import pytest
+import enum
+
+
+def random_string(size=10) -> str:
+    """Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for _ in range(size))
+
+
+def select(cql, key: str) -> Optional[str]:
+    result = list(cql.execute(f"SELECT value FROM system.broadcast_kv_store WHERE key = '{key}';"))
+
+    if len(result) == 0:
+        return None
+
+    assert len(result) == 1
+    return result[0].value
+
+def update(cql, key: str, new_value: str) -> None:
+    cql.execute(f"UPDATE system.broadcast_kv_store SET value = '{new_value}' WHERE key = '{key}';")
+
+def update_conditional(cql, key: str, new_value: str, value_condition: Optional[str]) -> Tuple[bool, Optional[str]]:
+    condition = "null" if value_condition is None else f"'{value_condition}'"
+    result = list(cql.execute(f"UPDATE system.broadcast_kv_store SET value = '{new_value}' WHERE key = '{key}' IF value = {condition};"))
+
+    assert len(result) == 1
+    return (result[0].applied, result[0].value)
+
+
+# For now, only the following types of statements can be compiled:
+# * select value where key = CONST from system.broadcast_kv_store;
+# * update system.broadcast_kv_store set value = CONST where key = CONST;
+# * update system.broadcast_kv_store set value = CONST where key = CONST if value = CONST;
+# where CONST is string literal.
+class QueryType(enum.Enum):
+    SELECT = enum.auto()
+    UPDATE = enum.auto()
+    CONDITIONAL_UPDATE = enum.auto()
+
+class ConditionType(enum.Enum):
+    EXISTING_KEY_PASS = enum.auto()
+    EXISTING_KEY_FAIL = enum.auto()
+    NEW_KEY = enum.auto()
+
+@pytest.mark.asyncio
+async def test_broadcast_kv_store(cql) -> None:
+    seed = random.randint(0, 2 ** 64)
+    print(f"Seed: {seed}")
+    random.seed(seed)
+
+    experimental_features = list(cql.execute("SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
+    assert "broadcast-tables" in experimental_features
+
+    random_strings: List[str] = [random_string() for _ in range(42)]
+    remaining_strings = random_strings.copy()
+    kv_store: Dict[str, str] = {}
+
+    query_types = random.choices(
+            [QueryType.SELECT, QueryType.UPDATE, QueryType.CONDITIONAL_UPDATE],
+            weights=[0.3, 0.2, 0.5], k=3721
+        )
+    for query_type in query_types:
+        key = random.choice(random_strings)
+
+        if query_type == QueryType.SELECT:
+            value = select(cql, key)
+            assert value == kv_store.get(key)
+        else:
+            new_value = random.choice(random_strings)
+
+            if query_type == QueryType.UPDATE:
+                update(cql, key, new_value)
+                kv_store[key] = new_value
+            elif query_type == QueryType.CONDITIONAL_UPDATE:
+                condition_type: ConditionType
+                if len(kv_store) == 0:
+                    condition_type = ConditionType.NEW_KEY
+                elif len(remaining_strings) == 0:
+                    condition_type = random.choice([ConditionType.EXISTING_KEY_PASS, ConditionType.EXISTING_KEY_FAIL])
+                else:
+                    condition_type = random.choices(
+                            [ConditionType.NEW_KEY, ConditionType.EXISTING_KEY_PASS, ConditionType.EXISTING_KEY_FAIL],
+                            weights=[0.2, 0.4, 0.4], k=1
+                        )[0]
+
+                value_condition: Optional[str]
+                if condition_type == ConditionType.EXISTING_KEY_FAIL:
+                    value_condition = random.choice(list[Optional[str]](random_strings) + [None])
+                elif condition_type == ConditionType.EXISTING_KEY_PASS:
+                    value_condition = kv_store.get(key)
+                elif condition_type == ConditionType.NEW_KEY:
+                    key = remaining_strings.pop()
+                    value_condition = None
+
+                result = update_conditional(cql, key, new_value, value_condition)
+                applied = False
+                previous_value = kv_store.get(key)
+                if previous_value == value_condition:
+                    applied = True
+                    kv_store[key] = new_value
+                assert (applied, previous_value) == result

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -714,7 +714,7 @@ public:
             auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
 
 
-            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notif), std::ref(mm), qp_mcfg, std::ref(cql_config), auth_prep_cache_config).get();
+            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notif), std::ref(mm), qp_mcfg, std::ref(cql_config), auth_prep_cache_config, std::ref(group0_client)).get();
             auto stop_qp = defer([&qp] { qp.stop().get(); });
 
             sys_ks.invoke_on_all(&db::system_keyspace::start).get();


### PR DESCRIPTION
Broadcast tables are tables for which all statements are strongly consistent (linearizable), replicated to every node in the cluster and available as long as a majority of the cluster is available. If a user wants to store a “small” volume of metadata that is not modified “too often” but provides high resiliency against failures and strong consistency of operations, they can use broadcast tables.

The main goal of the broadcast tables project is to solve problems which need to be solved when we eventually implement general-purpose strongly consistent tables: designing the data structure for the Raft command, ensuring that the commands are idempotent, handling snapshots correctly, and so on.

In this MVP (Minimum Viable Product), statements are limited to simple SELECT and UPDATE operations on the built-in table. In the future, other statements and data types will be available but with this PR we can already work on features like idempotent commands or snapshotting.  Snapshotting is not handled yet which means that restarting a node or performing too many operations (which would cause a snapshot to be created) will give incorrect results.

In a follow-up, we plan to add end-to-end Jepsen tests (https://jepsen.io/). With this PR we can already simulate operations on lists and test linearizability in linear complexity. This can also test Scylla's implementation of persistent storage, failure detector, RPC, etc.

Design doc: https://docs.google.com/document/d/1m1IW320hXtsGulzSTSHXkfcBKaG5UlsxOpm6LN7vWOc/edit?usp=sharing