### PR TITLE
Untangle `snitch_ptr` from `gossiper` a bit

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -810,10 +810,10 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         return map_keys(ctx.db.local().get_keyspaces());
     });
 
-    ss::update_snitch.set(r, [](std::unique_ptr<request> req) {
+    ss::update_snitch.set(r, [&g = g.container()](std::unique_ptr<request> req) {
         locator::snitch_config cfg;
         cfg.name = req->get_query_param("ep_snitch_class_name");
-        return locator::i_endpoint_snitch::reset_snitch(cfg).then([] {
+        return locator::i_endpoint_snitch::reset_snitch(cfg, std::ref(g)).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });

--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -24,7 +24,7 @@ namespace locator {
 const std::string azure_snitch::REGION_NAME_QUERY_PATH = fmt::format(AZURE_QUERY_PATH_TEMPLATE, "location");
 const std::string azure_snitch::ZONE_NAME_QUERY_PATH = fmt::format(AZURE_QUERY_PATH_TEMPLATE, "zone");
 
-azure_snitch::azure_snitch(const snitch_config& cfg) : production_snitch_base(cfg) {
+azure_snitch::azure_snitch(const snitch_config& cfg, gms::gossiper& g) : production_snitch_base(cfg, g) {
     if (this_shard_id() == cfg.io_cpu_id) {
         io_cpu_id() = cfg.io_cpu_id;
     }
@@ -115,7 +115,7 @@ future<sstring> azure_snitch::read_property_file() {
     });
 }
 
-using registry_default = class_registrator<i_endpoint_snitch, azure_snitch, const snitch_config&>;
+using registry_default = class_registrator<i_endpoint_snitch, azure_snitch, const snitch_config&, gms::gossiper&>;
 static registry_default registrator_default("org.apache.cassandra.locator.AzureSnitch");
 static registry_default registrator_default_short_name("AzureSnitch");
 

--- a/locator/azure_snitch.hh
+++ b/locator/azure_snitch.hh
@@ -20,7 +20,7 @@ public:
     static const std::string REGION_NAME_QUERY_PATH;
     static const std::string ZONE_NAME_QUERY_PATH;
 
-    explicit azure_snitch(const snitch_config&);
+    explicit azure_snitch(const snitch_config&, gms::gossiper&);
     virtual future<> start() override;
     virtual sstring get_name() const override {
         return "org.apache.cassandra.locator.AzureSnitch";

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -77,15 +77,15 @@ future<> ec2_multi_region_snitch::start() {
             // set on the shard0 so that it may be used when Gossiper is
             // going to invoke gossiper_starting() method.
             //
-            container().invoke_on(0, [this] (snitch_ptr& local_s) {
+            container().invoke_on(0, [addr = _local_private_address, my_dc = _my_dc] (snitch_ptr& local_s) {
                 if (this_shard_id() != io_cpu_id()) {
-                    local_s->set_local_private_addr(_local_private_address);
+                    local_s->set_local_private_addr(addr);
                 }
 
                 // this invoke_on() was done from the io_cpu_id() which had
                 // already passed through ec2_snitch::load_config() which, in
                 // turn, had already spread the _my_dc accross shards
-                local_s.get_local_gossiper().register_(::make_shared<reconnectable_snitch_helper>(_my_dc));
+                local_s.get_local_gossiper().register_(::make_shared<reconnectable_snitch_helper>(my_dc));
             }).get();
 
             set_snitch_ready();

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -19,8 +19,8 @@ static constexpr const char* PUBLIC_IPV6_QUERY_REQ  = "/latest/meta-data/network
 static constexpr const char* PRIVATE_MAC_QUERY = "/latest/meta-data/network/interfaces/macs";
 
 namespace locator {
-ec2_multi_region_snitch::ec2_multi_region_snitch(const snitch_config& cfg)
-    : ec2_snitch(cfg)
+ec2_multi_region_snitch::ec2_multi_region_snitch(const snitch_config& cfg, gms::gossiper& g)
+    : ec2_snitch(cfg, g)
     , _broadcast_rpc_address_specified_by_user(cfg.broadcast_rpc_address_specified_by_user) {}
 
 future<> ec2_multi_region_snitch::start() {
@@ -108,7 +108,7 @@ std::list<std::pair<gms::application_state, gms::versioned_value>> ec2_multi_reg
     };
 }
 
-using registry_default = class_registrator<i_endpoint_snitch, ec2_multi_region_snitch, const snitch_config&>;
+using registry_default = class_registrator<i_endpoint_snitch, ec2_multi_region_snitch, const snitch_config&, gms::gossiper&>;
 static registry_default registrator_default("org.apache.cassandra.locator.Ec2MultiRegionSnitch");
 static registry_default registrator_default_short_name("Ec2MultiRegionSnitch");
 

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -86,7 +86,7 @@ future<> ec2_multi_region_snitch::start() {
                 // already passed through ec2_snitch::load_config() which, in
                 // turn, had already spread the _my_dc accross shards
                 auto& self = dynamic_cast<ec2_multi_region_snitch&>(local_s.get());
-                self._reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(my_dc);
+                self._reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(my_dc, self, local_s.get_local_gossiper().get_local_messaging());
                 local_s.get_local_gossiper().register_(self._reconnectable_helper);
             }).get();
 

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -86,8 +86,8 @@ future<> ec2_multi_region_snitch::start() {
                 // already passed through ec2_snitch::load_config() which, in
                 // turn, had already spread the _my_dc accross shards
                 auto& self = dynamic_cast<ec2_multi_region_snitch&>(local_s.get());
-                self._reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(my_dc, self, local_s.get_local_gossiper().get_local_messaging());
-                local_s.get_local_gossiper().register_(self._reconnectable_helper);
+                self._reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(my_dc, self, self._gossiper.get_local_messaging());
+                self._gossiper.register_(self._reconnectable_helper);
             }).get();
 
             set_snitch_ready();
@@ -100,7 +100,7 @@ future<> ec2_multi_region_snitch::start() {
 
 future<> ec2_multi_region_snitch::stop() {
     if (_reconnectable_helper) {
-        return local().get_local_gossiper().unregister_(_reconnectable_helper);
+        return _gossiper.unregister_(_reconnectable_helper);
     }
     return make_ready_future<>();
 }

--- a/locator/ec2_multi_region_snitch.hh
+++ b/locator/ec2_multi_region_snitch.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "locator/ec2_snitch.hh"
+#include "locator/reconnectable_snitch_helper.hh"
 
 namespace locator {
 class ec2_multi_region_snitch : public ec2_snitch {
@@ -18,6 +19,7 @@ public:
     ec2_multi_region_snitch(const snitch_config&, gms::gossiper&);
     virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const override;
     virtual future<> start() override;
+    virtual future<> stop() override;
     virtual void set_local_private_addr(const sstring& addr_str) override;
     virtual sstring get_name() const override {
         return "org.apache.cassandra.locator.Ec2MultiRegionSnitch";
@@ -25,5 +27,6 @@ public:
 private:
     sstring _local_private_address;
     bool _broadcast_rpc_address_specified_by_user;
+    shared_ptr<reconnectable_snitch_helper> _reconnectable_helper;
 };
 } // namespace locator

--- a/locator/ec2_multi_region_snitch.hh
+++ b/locator/ec2_multi_region_snitch.hh
@@ -15,7 +15,7 @@
 namespace locator {
 class ec2_multi_region_snitch : public ec2_snitch {
 public:
-    ec2_multi_region_snitch(const snitch_config&);
+    ec2_multi_region_snitch(const snitch_config&, gms::gossiper&);
     virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const override;
     virtual future<> start() override;
     virtual void set_local_private_addr(const sstring& addr_str) override;

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -6,7 +6,7 @@
 
 namespace locator {
 
-ec2_snitch::ec2_snitch(const snitch_config& cfg) : production_snitch_base(cfg) {
+ec2_snitch::ec2_snitch(const snitch_config& cfg, gms::gossiper& g) : production_snitch_base(cfg, g) {
     if (this_shard_id() == cfg.io_cpu_id) {
         io_cpu_id() = cfg.io_cpu_id;
     }
@@ -111,7 +111,7 @@ future<sstring> ec2_snitch::read_property_file() {
     });
 }
 
-using registry_default = class_registrator<i_endpoint_snitch, ec2_snitch, const snitch_config&>;
+using registry_default = class_registrator<i_endpoint_snitch, ec2_snitch, const snitch_config&, gms::gossiper&>;
 static registry_default registrator_default("org.apache.cassandra.locator.Ec2Snitch");
 static registry_default registrator_default_short_name("Ec2Snitch");
 } // namespace locator

--- a/locator/ec2_snitch.hh
+++ b/locator/ec2_snitch.hh
@@ -17,7 +17,7 @@ public:
     static constexpr const char* AWS_QUERY_SERVER_ADDR = "169.254.169.254";
     static constexpr uint16_t AWS_QUERY_SERVER_PORT = 80;
 
-    ec2_snitch(const snitch_config&);
+    ec2_snitch(const snitch_config&, gms::gossiper&);
     virtual future<> start() override;
     virtual sstring get_name() const override {
         return "org.apache.cassandra.locator.Ec2Snitch";

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -17,7 +17,7 @@
 
 namespace locator {
 
-gce_snitch::gce_snitch(const snitch_config& cfg) : production_snitch_base(cfg) {
+gce_snitch::gce_snitch(const snitch_config& cfg, gms::gossiper& g) : production_snitch_base(cfg, g) {
     if (this_shard_id() == cfg.io_cpu_id) {
         io_cpu_id() = cfg.io_cpu_id;
         _meta_server_url = cfg.gce_meta_server_url;
@@ -133,7 +133,7 @@ future<sstring> gce_snitch::read_property_file() {
     });
 }
 
-using registry_default = class_registrator<i_endpoint_snitch, gce_snitch, const snitch_config&>;
+using registry_default = class_registrator<i_endpoint_snitch, gce_snitch, const snitch_config&, gms::gossiper&>;
 static registry_default registrator_default("org.apache.cassandra.locator.GoogleCloudSnitch");
 static registry_default registrator_default_short_name("GoogleCloudSnitch");
 

--- a/locator/gce_snitch.hh
+++ b/locator/gce_snitch.hh
@@ -18,7 +18,7 @@ public:
     static constexpr const char* ZONE_NAME_QUERY_REQ = "/computeMetadata/v1/instance/zone";
     static constexpr const char* GCE_QUERY_SERVER_ADDR = "metadata.google.internal";
 
-    explicit gce_snitch(const snitch_config&);
+    explicit gce_snitch(const snitch_config&, gms::gossiper&);
     virtual future<> start() override;
     virtual sstring get_name() const override {
         return "org.apache.cassandra.locator.GoogleCloudSnitch";

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -239,13 +239,18 @@ void gossiping_property_file_snitch::start_io() {
 }
 
 future<> gossiping_property_file_snitch::stop() {
+    future<> ret = make_ready_future<>();
+    if (_reconnectable_helper) {
+        ret = local().get_local_gossiper().unregister_(_reconnectable_helper);
+    }
+
     if (_state == snitch_state::stopped || _state == snitch_state::io_paused) {
-        return make_ready_future<>();
+        return ret;
     }
 
     _state = snitch_state::stopping;
 
-    return stop_io();
+    return ret.then(std::bind_front(&gossiping_property_file_snitch::stop_io, this));
 }
 
 future<> gossiping_property_file_snitch::pause_io() {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -275,7 +275,7 @@ future<> gossiping_property_file_snitch::reload_gossiper_state() {
     }
 
     return ret.then([this] {
-        _reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(_my_dc);
+        _reconnectable_helper = ::make_shared<reconnectable_snitch_helper>(_my_dc, *this, local().get_local_gossiper().get_local_messaging());
         local().get_local_gossiper().register_(_reconnectable_helper);
     });
 }

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -39,8 +39,8 @@ future<bool> gossiping_property_file_snitch::property_file_was_modified() {
     });
 }
 
-gossiping_property_file_snitch::gossiping_property_file_snitch(const snitch_config& cfg)
-        : production_snitch_base(cfg), _file_reader_cpu_id(cfg.io_cpu_id) {
+gossiping_property_file_snitch::gossiping_property_file_snitch(const snitch_config& cfg, gms::gossiper& g)
+        : production_snitch_base(cfg, g), _file_reader_cpu_id(cfg.io_cpu_id) {
     if (this_shard_id() == _file_reader_cpu_id) {
         io_cpu_id() = _file_reader_cpu_id;
     }
@@ -275,7 +275,7 @@ future<> gossiping_property_file_snitch::reload_gossiper_state() {
     });
 }
 
-using registry_default = class_registrator<i_endpoint_snitch, gossiping_property_file_snitch, const snitch_config&>;
+using registry_default = class_registrator<i_endpoint_snitch, gossiping_property_file_snitch, const snitch_config&, gms::gossiper&>;
 static registry_default registrator_default("org.apache.cassandra.locator.GossipingPropertyFileSnitch");
 static registry_default registrator_default_short_name("GossipingPropertyFileSnitch");
 } // namespace locator

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -179,7 +179,8 @@ future<> gossiping_property_file_snitch::reload_configuration() {
             return seastar::async([this] {
                 // reload Gossiper state (executed on CPU0 only)
                 container().invoke_on(0, [] (snitch_ptr& local_snitch_ptr) {
-                    return local_snitch_ptr->reload_gossiper_state();
+                    auto& self = dynamic_cast<gossiping_property_file_snitch&>(local_snitch_ptr.get());
+                    return self.reload_gossiper_state();
                 }).get();
 
                 _reconfigured();

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -54,6 +54,7 @@ public:
         });
     }
 
+private:
     /**
      * This function register a Gossiper subscriber to reconnect according to
      * the new "prefer_local" value, namely use either an internal or extenal IP
@@ -73,9 +74,8 @@ public:
      *
      * This is currently relevant to EC2/GCE(?) only.
      */
-    virtual future<> reload_gossiper_state() override;
+    future<> reload_gossiper_state();
 
-private:
     void periodic_reader_callback();
 
     /**

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -45,7 +45,7 @@ public:
         return "org.apache.cassandra.locator.GossipingPropertyFileSnitch";
     }
 
-    gossiping_property_file_snitch(const snitch_config&);
+    gossiping_property_file_snitch(const snitch_config&, gms::gossiper&);
 
     virtual snitch_signal_connection_t when_reconfigured(snitch_signal_slot_t& slot) override {
         return _reconfigured.connect([slot = std::move(slot)] () mutable {

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -21,11 +21,12 @@
 
 namespace locator {
 
-production_snitch_base::production_snitch_base(snitch_config cfg)
+production_snitch_base::production_snitch_base(snitch_config cfg, gms::gossiper& g)
         : allowed_property_keys({ dc_property_key,
                           rack_property_key,
                           prefer_local_property_key,
-                          dc_suffix_property_key }) {
+                          dc_suffix_property_key })
+        , _gossiper(g) {
     if (!cfg.properties_file_name.empty()) {
         _prop_file_name = cfg.properties_file_name;
     } else {

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -20,6 +20,10 @@
 #include <seastar/core/sstring.hh>
 #include "snitch_base.hh"
 
+namespace gms {
+class gossiper;
+}
+
 namespace locator {
 
 class bad_property_file_error : public std::exception {};
@@ -40,7 +44,7 @@ public:
     static constexpr const char* dc_suffix_property_key    = "dc_suffix";
     const std::unordered_set<sstring> allowed_property_keys;
 
-    explicit production_snitch_base(snitch_config);
+    explicit production_snitch_base(snitch_config, gms::gossiper&);
 
     virtual sstring get_rack(inet_address endpoint) override;
     virtual sstring get_datacenter(inet_address endpoint) override;
@@ -72,6 +76,8 @@ protected:
     void throw_incomplete_file() const;
 
 protected:
+    gms::gossiper& _gossiper;
+
     std::optional<addr2dc_rack_map> _saved_endpoints;
     std::string _prop_file_contents;
     sstring _prop_file_name;

--- a/locator/reconnectable_snitch_helper.hh
+++ b/locator/reconnectable_snitch_helper.hh
@@ -12,18 +12,27 @@
 
 #include "gms/i_endpoint_state_change_subscriber.hh"
 
+namespace netw {
+class messaging_service;
+}
+
 namespace locator {
+
+class i_endpoint_snitch;
 
 // @note all callbacks should be called in seastar::async() context
 class reconnectable_snitch_helper : public  gms::i_endpoint_state_change_subscriber {
 private:
+    i_endpoint_snitch& _snitch;
+    netw::messaging_service& _ms;
+
     static logging::logger& logger();
     sstring _local_dc;
 private:
     future<> reconnect(gms::inet_address public_address, const gms::versioned_value& local_address_value);
     future<> reconnect(gms::inet_address public_address, gms::inet_address local_address);
 public:
-    reconnectable_snitch_helper(sstring local_dc);
+    reconnectable_snitch_helper(sstring local_dc, i_endpoint_snitch&, netw::messaging_service&);
     future<> before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
     future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
     future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override;

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -117,8 +117,7 @@ std::list<std::pair<gms::application_state, gms::versioned_value>> snitch_base::
     };
 }
 
-snitch_ptr::snitch_ptr(const snitch_config cfg, sharded<gms::gossiper>& g)
-        : _gossiper(g) {
+snitch_ptr::snitch_ptr(const snitch_config cfg, sharded<gms::gossiper>& g) {
     i_endpoint_snitch::ptr_type s;
 
     // Production snitches take a `gms::gossiper&` argument, non-production snitches don't.

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -230,15 +230,8 @@ struct snitch_ptr : public peering_sharded_service<snitch_ptr> {
 
     snitch_ptr(const snitch_config cfg, sharded<gms::gossiper>&);
 
-    gms::gossiper& get_local_gossiper() noexcept { return _gossiper.local(); }
-    const gms::gossiper& get_local_gossiper() const noexcept { return _gossiper.local(); }
-
-    sharded<gms::gossiper>& get_gossiper() noexcept { return _gossiper; }
-    const sharded<gms::gossiper>& get_gossiper() const noexcept { return _gossiper; }
-
 private:
     ptr_type _ptr;
-    sharded<gms::gossiper>& _gossiper;
 };
 
 /**

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -159,11 +159,6 @@ public:
         //noop by default
     }
 
-    virtual future<> reload_gossiper_state() {
-        // noop by default
-        return make_ready_future<>();
-    }
-
     virtual snitch_signal_connection_t when_reconfigured(snitch_signal_slot_t& slot) {
         // no updates by default
         return snitch_signal_connection_t();
@@ -207,6 +202,10 @@ struct snitch_ptr : public peering_sharded_service<snitch_ptr> {
         } else {
             return make_ready_future<>();
         }
+    }
+
+    i_endpoint_snitch& get() {
+        return *_ptr;
     }
 
     i_endpoint_snitch* operator->() {

--- a/test/boost/snitch_reset_test.cc
+++ b/test/boost/snitch_reset_test.cc
@@ -71,7 +71,7 @@ future<> one_test(const std::string& property_fname1,
             snitch_config cfg;
             cfg.name = "org.apache.cassandra.locator.GossipingPropertyFileSnitch";
             cfg.properties_file_name = fname2.string();
-            i_endpoint_snitch::reset_snitch(cfg).get();
+            i_endpoint_snitch::reset_snitch(cfg, std::ref(g)).get();
 
             if (!exp_result) {
                 BOOST_ERROR("Failed to catch an error in a malformed "


### PR DESCRIPTION
`snitch_ptr` stored a reference to `shared<gossiper>`. But not every snitch implementation requires a gossiper, only "production snitches" do.

After this PR, production snitches store a `gossiper&` internally.
We also remove an access to global snitch instance variable.

Note: the snitch tests are not passing because they don't start `gossiper` before starting the snitches and we fail on `local_is_initialized()` assertion.
I'm considering one of the following approaches:
- store `sharded<gossiper>&` - but this is kind of sweeping problems under the rug
- fix the tests, e.g. reuse `cql_test_env`