### PR TITLE
Secondary indexes on static columns

### DIFF
--- a/column_computation.hh
+++ b/column_computation.hh
@@ -12,11 +12,11 @@
 
 class schema;
 class partition_key;
-class clustering_row;
 struct atomic_cell_view;
 struct tombstone;
 
 namespace db::view {
+struct clustering_or_static_row;
 struct view_key_and_action;
 }
 
@@ -118,7 +118,7 @@ class collection_column_computation final : public column_computation {
     using collection_kv = std::pair<bytes_view, atomic_cell_view>;
     void operate_on_collection_entries(
             std::invocable<collection_kv*, collection_kv*, tombstone> auto&& old_and_new_row_func, const schema& schema,
-            const partition_key& key, const clustering_row& update, const std::optional<clustering_row>& existing) const;
+            const partition_key& key, const db::view::clustering_or_static_row& update, const std::optional<db::view::clustering_or_static_row>& existing) const;
 
 public:
     static collection_column_computation for_keys(const bytes& collection_name) {
@@ -141,5 +141,6 @@ public:
         return true;
     }
 
-    std::vector<db::view::view_key_and_action> compute_values_with_action(const schema& schema, const partition_key& key, const clustering_row& row, const std::optional<clustering_row>& existing) const;
+    std::vector<db::view::view_key_and_action> compute_values_with_action(const schema& schema, const partition_key& key,
+            const db::view::clustering_or_static_row& row, const std::optional<db::view::clustering_or_static_row>& existing) const;
 };

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -114,9 +114,9 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
                     format("No column definition found for column {}", target->column_name()));
         }
 
-        //NOTICE(sarna): Should be lifted after resolving issue #2963
-        if (cd->is_static()) {
-            throw exceptions::invalid_request_exception("Indexing static columns is not implemented yet.");
+        if (!db.features().secondary_indexes_on_static_columns && cd->is_static()) {
+            throw exceptions::invalid_request_exception("Cluster does not support secondary indexes on static columns yet,"
+                    " upgrade the whole cluster first in order to be able to create them");
         }
 
         if (cd->type->references_duration()) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -567,6 +567,11 @@ indexed_table_select_statement::do_execute_base_query(
         base_query_state(const base_query_state&) = delete;
     };
 
+    const column_definition* target_cdef = _schema->get_column_definition(to_bytes(_index.target_column()));
+    if (!target_cdef) {
+        throw exceptions::invalid_request_exception("Indexed column not found in schema");
+    }
+
     const bool is_paged = bool(paging_state);
     base_query_state query_state{cmd->get_row_limit() * queried_ranges_count, std::move(ranges_to_vnodes)};
     {
@@ -586,7 +591,7 @@ indexed_table_select_statement::do_execute_base_query(
                 auto base_pk = generate_base_key_from_index_pk<partition_key>(old_paging_state->get_partition_key(),
                         old_paging_state->get_clustering_key(), *_schema, *_view_schema);
                 auto row_ranges = command->slice.default_row_ranges();
-                if (old_paging_state->get_clustering_key() && _schema->clustering_key_size() > 0) {
+                if (old_paging_state->get_clustering_key() && _schema->clustering_key_size() > 0 && !target_cdef->is_static()) {
                     auto base_ck = generate_base_key_from_index_pk<clustering_key>(old_paging_state->get_partition_key(),
                             old_paging_state->get_clustering_key(), *_schema, *_view_schema);
 
@@ -1013,7 +1018,7 @@ lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement
         exploded_index_ck.push_back(bytes_view(token_bytes));
         append_base_key_to_index_ck<partition_key>(exploded_index_ck, last_base_pk, *cdef);
     }
-    if (last_base_ck) {
+    if (last_base_ck && !cdef->is_static()) {
         append_base_key_to_index_ck<clustering_key>(exploded_index_ck, *last_base_ck, *cdef);
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1068,6 +1068,10 @@ indexed_table_select_statement::do_execute(query_processor& qp,
         // Obviously, if there are no clustering columns, then we can work at
         // the granularity of whole partitions.
         whole_partitions = true;
+    } else if (_schema->get_column_definition(to_bytes(_index.target_column()))->is_static()) {
+        // Index table for a static index does not have the original tables'
+        // clustering key columns, so we must not fetch them.
+        whole_partitions = true;
     } else {
         if (_index.depends_on(*(_schema->clustering_key_columns().begin()))) {
             // Searching on the *first* clustering column means in each of

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1510,6 +1510,12 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(const 
 
 }
 
+bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views) {
+    // TODO: We could also check whether any of the views need static rows
+    // and return false if none of them do
+    return mp.partition_tombstone() || !mp.static_row().empty();
+}
+
 // Calculate the node ("natural endpoint") to which this node should send
 // a view update.
 //

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -233,6 +233,20 @@ bool view_info::has_base_non_pk_columns_in_view_pk() const {
     return _base_info->has_base_non_pk_columns_in_view_pk;
 }
 
+clustering_row db::view::clustering_or_static_row::as_clustering_row(const schema& s) const {
+    if (!is_clustering_row()) {
+        on_internal_error(vlogger, "Tried to interpret a static row as a clustering row");
+    }
+    return clustering_row(*_key, tomb(), marker(), row(s, column_kind::regular_column, cells()));
+}
+
+static_row db::view::clustering_or_static_row::as_static_row(const schema& s) const {
+    if (!is_static_row()) {
+        on_internal_error(vlogger, "Tried to interpret a clustering row as a static row");
+    }
+    return static_row(s, cells());
+}
+
 namespace db {
 
 namespace view {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -620,7 +620,13 @@ private:
         }
         collection_column_position = column_position - 1;
 
-        for (auto& bwa : collection_computation->compute_values_with_action(_base, _base_key, _update, _existing)) {
+        // TODO: Introduced just for the sake of clear commit history, will be removed in following commits
+        const auto update = clustering_or_static_row(clustering_row(_base, _update));
+        const auto existing = _existing
+                ? std::make_optional<clustering_or_static_row>(clustering_row(_base, *_existing))
+                : std::nullopt;
+
+        for (auto& bwa : collection_computation->compute_values_with_action(_base, _base_key, update, existing)) {
             ret.push_back({std::move(bwa), linearized_values});
         }
         return ret;

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -163,7 +163,7 @@ bool may_be_affected_by(const schema& base, const view_info& view, const dht::de
  * @param now the current time in seconds (to decide what is live and what isn't).
  * @return whether the base row matches the view filter.
  */
-bool matches_view_filter(const schema& base, const view_info& view, const partition_key& key, const clustering_row& update, gc_clock::time_point now);
+bool matches_view_filter(const schema& base, const view_info& view, const partition_key& key, const clustering_or_static_row& update, gc_clock::time_point now);
 
 bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck);
 
@@ -225,24 +225,24 @@ public:
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
-    void generate_update(const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing, gc_clock::time_point now);
+    void generate_update(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
 
     size_t op_count() const;
 
 private:
     mutation_partition& partition_for(partition_key&& key);
-    row_marker compute_row_marker(const clustering_row& base_row) const;
+    row_marker compute_row_marker(const clustering_or_static_row& base_row) const;
     struct view_row_entry {
         deletable_row* _row;
         view_key_and_action::action _action;
     };
-    std::vector<view_row_entry> get_view_rows(const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing);
-    bool can_skip_view_updates(const clustering_row& update, const clustering_row& existing) const;
-    void create_entry(const partition_key& base_key, const clustering_row& update, gc_clock::time_point now);
-    void delete_old_entry(const partition_key& base_key, const clustering_row& existing, const clustering_row& update, gc_clock::time_point now);
-    void do_delete_old_entry(const partition_key& base_key, const clustering_row& existing, const clustering_row& update, gc_clock::time_point now);
-    void update_entry(const partition_key& base_key, const clustering_row& update, const clustering_row& existing, gc_clock::time_point now);
-    void update_entry_for_computed_column(const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing, gc_clock::time_point now);
+    std::vector<view_row_entry> get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing);
+    bool can_skip_view_updates(const clustering_or_static_row& update, const clustering_or_static_row& existing) const;
+    void create_entry(const partition_key& base_key, const clustering_or_static_row& update, gc_clock::time_point now);
+    void delete_old_entry(const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);
+    void do_delete_old_entry(const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);
+    void update_entry(const partition_key& base_key, const clustering_or_static_row& update, const clustering_or_static_row& existing, gc_clock::time_point now);
+    void update_entry_for_computed_column(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
 };
 
 class view_update_builder {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -41,13 +41,15 @@ private:
     schema_ptr _base_schema;
     // Id of a regular base table column included in the view's PK, if any.
     // Scylla views only allow one such column, alternator can have up to two.
-    std::vector<column_id> _base_non_pk_columns_in_view_pk;
+    std::vector<column_id> _base_regular_columns_in_view_pk;
+    std::vector<column_id> _base_static_columns_in_view_pk;
     // For tracing purposes, if the view is out of sync with its base table
     // and there exists a column which is not in base, its name is stored
     // and added to debug messages.
     std::optional<bytes> _column_missing_in_base = {};
 public:
-    const std::vector<column_id>& base_non_pk_columns_in_view_pk() const;
+    const std::vector<column_id>& base_regular_columns_in_view_pk() const;
+    const std::vector<column_id>& base_static_columns_in_view_pk() const;
     const schema_ptr& base_schema() const;
 
     // Indicates if the view hase pk columns which are not part of the base
@@ -62,7 +64,9 @@ public:
     const bool use_only_for_reads;
 
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
-    base_dependent_view_info(schema_ptr base_schema, std::vector<column_id>&& base_non_pk_columns_in_view_pk);
+    base_dependent_view_info(schema_ptr base_schema,
+            std::vector<column_id>&& base_regular_columns_in_view_pk,
+            std::vector<column_id>&& base_static_columns_in_view_pk);
     // A constructor for a base info that can facilitate only reads from the materialized view.
     base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk, std::optional<bytes>&& column_missing_in_base);
 };

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -305,6 +305,8 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const mutation_partition& mp,
         const std::vector<view_and_base>& views);
 
+bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views);
+
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 future<> mutate_MV(

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -281,6 +281,7 @@ public:
 
 private:
     void generate_update(clustering_row&& update, std::optional<clustering_row>&& existing);
+    void generate_update(static_row&& update, const tombstone& update_tomb, std::optional<static_row>&& existing, const tombstone& existing_tomb);
     future<stop_iteration> on_results();
 
     future<stop_iteration> advance_all();

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -112,6 +112,7 @@ public:
     gms::feature aggregate_storage_options { *this, "AGGREGATE_STORAGE_OPTIONS"sv };
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
     gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
+    gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
 
 public:
 

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -249,11 +249,13 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
         }
     }
 
-    for (auto& col : schema->clustering_key_columns()) {
-        if (col == *index_target) {
-            continue;
+    if (!index_target->is_static()) {
+        for (auto& col : schema->clustering_key_columns()) {
+            if (col == *index_target) {
+                continue;
+            }
+            builder.with_column(col.name(), col.type, column_kind::clustering_key);
         }
-        builder.with_column(col.name(), col.type, column_kind::clustering_key);
     }
 
     // This column needs to be after the base clustering key.

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -63,7 +63,7 @@ public:
     bool empty() const { return _row.empty(); }
 
     bool is_live(const schema& s, tombstone base_tombstone = tombstone(), gc_clock::time_point now = gc_clock::time_point::min()) const {
-        return _row.is_live(s, std::move(base_tombstone), std::move(now));
+        return _row.is_live(s, column_kind::regular_column, std::move(base_tombstone), std::move(now));
     }
 
     void apply(const schema& s, clustering_row&& cr) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1505,13 +1505,13 @@ bool mutation_partition::empty() const
 }
 
 bool
-deletable_row::is_live(const schema& s, tombstone base_tombstone, gc_clock::time_point query_time) const {
+deletable_row::is_live(const schema& s, column_kind kind, tombstone base_tombstone, gc_clock::time_point query_time) const {
     // _created_at corresponds to the row marker cell, present for rows
     // created with the 'insert' statement. If row marker is live, we know the
     // row is live. Otherwise, a row is considered live if it has any cell
     // which is live.
     base_tombstone.apply(_deleted_at.tomb());
-    return _marker.is_live(base_tombstone, query_time) || _cells.is_live(s, column_kind::regular_column, base_tombstone, query_time);
+    return _marker.is_live(base_tombstone, query_time) || _cells.is_live(s, kind, base_tombstone, query_time);
 }
 
 bool
@@ -1532,7 +1532,7 @@ mutation_partition::live_row_count(const schema& s, gc_clock::time_point query_t
 
     for (const rows_entry& e : non_dummy_rows()) {
         tombstone base_tombstone = range_tombstone_for_row(s, e.key());
-        if (e.row().is_live(s, base_tombstone, query_time)) {
+        if (e.row().is_live(s, column_kind::regular_column, base_tombstone, query_time)) {
             ++count;
         }
     }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -866,7 +866,7 @@ public:
     const row& cells() const { return _cells; }
     row& cells() { return _cells; }
     bool equal(column_kind, const schema& s, const deletable_row& other, const schema& other_schema) const;
-    bool is_live(const schema& s, tombstone base_tombstone = tombstone(), gc_clock::time_point query_time = gc_clock::time_point::min()) const;
+    bool is_live(const schema& s, column_kind kind, tombstone base_tombstone = tombstone(), gc_clock::time_point query_time = gc_clock::time_point::min()) const;
     bool empty() const { return !_deleted_at && _marker.is_missing() && !_cells.size(); }
     deletable_row difference(const schema&, column_kind, const deletable_row& other) const;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2428,26 +2428,36 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
         co_return row_locker::lock_holder();
     }
     auto cr_ranges = co_await db::view::calculate_affected_clustering_ranges(*base, m.decorated_key(), m.partition(), views);
-    if (cr_ranges.empty()) {
+    const bool need_regular = !cr_ranges.empty();
+    const bool need_static = db::view::needs_static_row(m.partition(), views);
+    if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
         co_await generate_and_propagate_view_updates(base, sem.make_tracking_only_permit(s.get(), "push-view-updates-1", timeout), std::move(views), std::move(m), { }, std::move(tr_state), now);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
     }
-    // We read the whole set of regular columns in case the update now causes a base row to pass
+    // We read whole sets of regular and/or static columns in case the update now causes a base row to pass
     // a view's filters, and a view happens to include columns that have no value in this update.
     // Also, one of those columns can determine the lifetime of the base row, if it has a TTL.
-    auto columns = boost::copy_range<query::column_id_vector>(
-            base->regular_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)));
+    query::column_id_vector static_columns;
+    query::column_id_vector regular_columns;
+    if (need_regular) {
+        boost::copy(base->regular_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)), std::back_inserter(regular_columns));
+    }
+    if (need_static) {
+        boost::copy(base->static_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)), std::back_inserter(static_columns));
+    }
     query::partition_slice::option_set opts;
     opts.set(query::partition_slice::option::send_partition_key);
-    opts.set(query::partition_slice::option::send_clustering_key);
+    opts.set_if<query::partition_slice::option::send_clustering_key>(need_regular);
+    opts.set_if<query::partition_slice::option::distinct>(need_static && !need_regular);
+    opts.set_if<query::partition_slice::option::always_return_static_content>(need_static);
     opts.set(query::partition_slice::option::send_timestamp);
     opts.set(query::partition_slice::option::send_ttl);
     opts.add(custom_opts);
     auto slice = query::partition_slice(
-            std::move(cr_ranges), { }, std::move(columns), std::move(opts), { }, cql_serialization_format::internal(), query::max_rows);
+            std::move(cr_ranges), std::move(static_columns), std::move(regular_columns), std::move(opts), { }, cql_serialization_format::internal(), query::max_rows);
     // Take the shard-local lock on the base-table row or partition as needed.
     // We'll return this lock to the caller, which will release it after
     // writing the base-table update.

--- a/schema.cc
+++ b/schema.cc
@@ -1770,7 +1770,7 @@ column_computation_ptr collection_column_computation::for_target_type(std::strin
 
 void collection_column_computation::operate_on_collection_entries(
         std::invocable<collection_kv*, collection_kv*, tombstone> auto&& old_and_new_row_func, const schema& schema,
-        const partition_key& key, const clustering_row& update, const std::optional<clustering_row>& existing) const {
+        const partition_key& key, const db::view::clustering_or_static_row& update, const std::optional<db::view::clustering_or_static_row>& existing) const {
 
     const column_definition* cdef = schema.get_column_definition(_collection_name);
 
@@ -1840,7 +1840,8 @@ bytes collection_column_computation::compute_value(const schema&, const partitio
     throw std::runtime_error(fmt::format("{}: not supported", __PRETTY_FUNCTION__));
 }
 
-std::vector<db::view::view_key_and_action> collection_column_computation::compute_values_with_action(const schema& schema, const partition_key& key, const clustering_row& update, const std::optional<clustering_row>& existing) const {
+std::vector<db::view::view_key_and_action> collection_column_computation::compute_values_with_action(const schema& schema, const partition_key& key,
+        const db::view::clustering_or_static_row& update, const std::optional<db::view::clustering_or_static_row>& existing) const {
     using collection_kv = std::pair<bytes_view, atomic_cell_view>;
     auto serialize_cell = [_kind = _kind](const collection_kv& kv) -> bytes {
         using kind = collection_column_computation::kind;

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -1115,7 +1115,7 @@ static void validate_result(size_t i, const mutation& result_mut, const expected
     const auto exp_dead_end = expected_part.dead_rows.cend();
 
     for (; res_it != res_end && (exp_live_it != exp_live_end || exp_dead_it != exp_dead_end); ++res_it) {
-        const bool is_live = res_it->row().is_live(schema);
+        const bool is_live = res_it->row().is_live(schema, column_kind::regular_column);
 
         // Check that we have remaining expected rows of the respective liveness.
         if (is_live) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3180,7 +3180,7 @@ SEASTAR_TEST_CASE(compact_deleted_cell) {
     auto rows = m->partition().clustered_rows();
     BOOST_REQUIRE(rows.calculate_size() == 1);
     auto& row = rows.begin()->row();
-    BOOST_REQUIRE(row.is_live(*s));
+    BOOST_REQUIRE(row.is_live(*s, column_kind::regular_column));
     auto& cells = row.cells();
     BOOST_REQUIRE(cells.size() == 1);
   });

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
@@ -8,7 +8,6 @@
 from cassandra_tests.porting import *
 
 
-@pytest.mark.xfail(reason="issues #2963")
 def testSimpleStaticColumn(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, name text, age int static, PRIMARY KEY (id, name))") as table:
         cql.execute(f"CREATE INDEX static_age on {table}(age)")
@@ -39,7 +38,6 @@ def testSimpleStaticColumn(cql, test_keyspace):
         assert_empty(execute(cql, table, "SELECT id, name, age FROM %s WHERE age=?", age2))
 
 
-@pytest.mark.xfail(reason="issues #2963")
 def testIndexOnCompoundRowKey(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(interval text, seq int, id int, severity int static, PRIMARY KEY ((interval, seq), id) ) WITH CLUSTERING ORDER BY (id DESC)") as table:
         execute(cql, table, "CREATE INDEX ON %s (severity)")
@@ -56,7 +54,6 @@ def testIndexOnCompoundRowKey(cql, test_keyspace):
         assert_rows(execute(cql, table, "select * from %s where severity = 10 and interval = 't' and seq = 1"),
                    ["t", 1, 4, 10], ["t", 1, 3, 10])
 
-@pytest.mark.xfail(reason="issues #2963")
 def testIndexOnCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, v int, l list<int> static, s set<text> static, m map<text, int> static, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s (l)")
@@ -108,7 +105,6 @@ def testIndexOnCollections(cql, test_keyspace):
         execute(cql, table, "DELETE m['a'] FROM %s WHERE k = 0")
         assert_empty(execute(cql, table, "SELECT k, v FROM %s  WHERE m CONTAINS KEY 'a'"))
 
-@pytest.mark.xfail(reason="issues #2963")
 def testIndexOnFrozenCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, v int, l frozen<list<int>> static, s frozen<set<text>> static, m frozen<map<text, int>> static, PRIMARY KEY (k, v))") as table:
         execute(cql, table, "CREATE INDEX ON %s (FULL(l))")
@@ -154,7 +150,6 @@ def testIndexOnFrozenCollections(cql, test_keyspace):
         assert_empty(execute(cql, table, "SELECT k, v FROM %s WHERE m = {'a': 1, 'b': 2}"))
         assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE m = {'a': 2, 'b': 3}"), [0, 0], [0, 1])
 
-@pytest.mark.xfail(reason="issues #2963")
 def testStaticIndexAndNonStaticIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, company text, age int static, salary int, PRIMARY KEY(id, company))") as table:
         execute(cql, table, "CREATE INDEX on %s(age)")
@@ -170,7 +165,6 @@ def testStaticIndexAndNonStaticIndex(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT id, company, age, salary FROM %s WHERE age = 20 AND salary = 2000 ALLOW FILTERING"),
                    [1, company2, 20, 2000])
 
-@pytest.mark.xfail(reason="issues #2963")
 def testIndexOnUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(street text, city text)") as type_name:
         with create_table(cql, test_keyspace, f"(id int, company text, home frozen<{type_name}> static, price int, PRIMARY KEY(id, company))") as table:

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -856,7 +856,6 @@ def testAllowFilteringOnPartitionKeyWithIndexForContains(cql, test_keyspace):
                        [1, 1, {4, 5, 6}])
             assert_empty(execute(cql, table, "SELECT * FROM %s WHERE k2 < ? AND v CONTAINS ? ALLOW FILTERING", 0, 7))
 
-@pytest.mark.xfail(reason="issues #2963")
 def testIndexOnStaticColumnWithPartitionWithoutRows(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))") as table:
         execute(cql, table, "CREATE INDEX ON %s (s)")

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -1269,3 +1269,210 @@ def test_index_paging_group_by(cql, test_keyspace, use_group_by):
             all_rows.extend(results.current_rows)
             # Finally check that altogether, we read the right rows.
             assert sorted(all_rows) == [(i,) for i in range(10)]
+
+# Tests basic operations on a static column index.
+def test_static_column_index(cql, test_keyspace):
+    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'CREATE INDEX ON {table}(s)')
+
+        # Insert
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (0, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (1, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (2, 1)')
+
+        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+
+        # Update
+        cql.execute(f'UPDATE {table} SET s = 1 WHERE pk = 1')
+
+        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(1,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+
+        # Partition delete
+        cql.execute(f'DELETE FROM {table} WHERE pk = 2')
+
+        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+
+# Tests that building static indexes from a non-empty state works.
+def test_static_column_index_build(cql, test_keyspace):
+    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (0, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (1, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (2, 0)')
+        cql.execute(f'CREATE INDEX ON {table}(s)')
+
+        # Indexes are created in the background, so we should wait here.
+        # I don't know how to get information about secondary index build
+        # status on C*, so we'll just wait until 30 seconds elapse or
+        # the index appears to be properly built.
+        start_time = time.time()
+        rows = None
+        while time.time() < start_time + 30:
+            rows = sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+            if len(rows) == 3:
+                break
+
+        assert [(0,),(1,),(2,)] == rows
+
+# Checks that clustering row deletions do not affect static columns.
+def test_static_column_index_unaffected_by_clustering_row_ops(cql, test_keyspace):
+    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'CREATE INDEX ON {table}(s)')
+
+        cql.execute(f'INSERT INTO {table} (pk, c, s, v) VALUES (0, 0, 42, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 1, 10)')
+        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 2, 20)')
+        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 3, 30)')
+        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 4, 40)')
+
+        # We are not using SELECT DISTINCT because it is not implemented yet
+        # for queries that restrict a non-pk column. Therefore, `pk` appears
+        # multiple times in the result.
+
+        assert [(0,)]*5 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+
+        # Row delete
+        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c = 4')
+        assert [(0,)]*4 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+
+        # Range delete
+        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c >= 1 AND c < 3')
+        assert [(0,)]*2 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+
+        # Range delete, but this time get rid of all rows (static row should stay)
+        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c >= 0 AND c <= 4')
+        assert [(0,)]*1 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+
+        # Finally, perform a partition delete and get rid of the row
+        cql.execute(f'DELETE FROM {table} WHERE pk = 0')
+        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+
+# Checks that changing a static column's value is correctly reflected by queries
+# accelerated by a secondary index.
+def test_static_column_index_all_clustering_rows_moved_by_static_column_update(cql, test_keyspace):
+    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        rows_for_pk = [
+            [(0, 0, 0), (0, 1, 10), (0, 2, 20)],
+            [(1, 0, 0), (1, 1, 10), (1, 2, 20)],
+        ]
+
+        cql.execute(f'CREATE INDEX ON {table}(s)')
+
+        for pk in range(2):
+            cql.execute(f'INSERT INTO {table} (pk, c, s, v) VALUES ({pk}, 0, 0, 0)')
+            cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES ({pk}, 1, 10)')
+            cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES ({pk}, 2, 20)')
+
+        assert rows_for_pk[0] + rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
+        assert [] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+
+        cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 1")
+
+        assert rows_for_pk[0] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
+        assert rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+
+        cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 0")
+
+        assert [] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
+        assert rows_for_pk[0] + rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+
+
+# Tests operations on tables which have both static column and regular column indexes.
+# Checks that one does not interfere with the other.
+def test_static_and_regular_index_operations(cql, test_keyspace):
+    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f'CREATE INDEX ON {table}(v)')
+
+        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (0, 0, 0, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (1, 0, 0, 1)')
+        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (2, 1, 0, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (3, 1, 0, 1)')
+
+        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
+        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+
+        cql.execute(f'UPDATE {table} SET s = 1 WHERE pk = 1')
+
+        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
+        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+
+        cql.execute(f'UPDATE {table} SET v = 0 WHERE pk = 1 AND c = 0')
+
+        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,),(1,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
+        assert [(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+
+        # There are separate codepaths for processing static column addition/removal
+        # in case the static row isn't the last element of the mutation.
+        # The operations below allow us to test those cases
+
+        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (4, 0, 4)')
+        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
+        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 4'))
+
+        # Static column is set on a partition which didn't have a static row yet
+        cql.execute(f'BEGIN BATCH \
+                      UPDATE {table} SET s = 2 WHERE pk = 4; \
+                      UPDATE {table} SET v = 5 WHERE pk = 4 AND c = 0; \
+                      APPLY BATCH')
+        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
+        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 4'))
+        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 5'))
+
+        # Static column is removed from a partition
+        # In order to construct the batch, we need the write timestamp
+        timestamp = list(cql.execute(f'SELECT writetime(v) FROM {table} WHERE pk = 4 AND c = 0'))[0][0]
+        cql.execute(f'BEGIN BATCH \
+                      DELETE FROM {table} USING TIMESTAMP {timestamp} WHERE pk = 4; \
+                      UPDATE {table} USING TIMESTAMP {timestamp+1} SET v = 6 WHERE pk = 4 AND c = 0; \
+                      APPLY BATCH')
+        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
+        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 5'))
+        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 6'))
+
+# Make sure that, when there are multiple static column indexes and only one
+# column is modified, only the index relevant to that column is modified.
+def test_multiple_static_column_indexes(cql, test_keyspace):
+    schema = 'pk int, c int, s1 int STATIC, s2 int STATIC, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'CREATE INDEX ON {table}(s1)')
+        cql.execute(f'CREATE INDEX ON {table}(s2)')
+
+        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (0, 0, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (1, 0, 1)')
+        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (2, 1, 0)')
+        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (3, 1, 1)')
+
+        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 0'))
+        assert [(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 1'))
+        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 0'))
+        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 1'))
+
+        cql.execute(f'UPDATE {table} SET s1 = 1 WHERE pk = 1')
+
+        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 0'))
+        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 1'))
+        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 0'))
+        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 1'))
+
+# Test that creating a local index on a static column is disallowed.
+# Local static indexes are not useful because there is only one value
+# of a static column allowed for a given partition.
+def test_disallow_local_indexes_on_static_columns(scylla_only, cql, test_keyspace):
+    schema = 'pk int, c int, s int static, PRIMARY KEY(pk, c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="Local indexes containing static columns are not supported"):
+            cql.execute(f'CREATE INDEX ON {table}((pk), s)')

--- a/view_info.hh
+++ b/view_info.hh
@@ -50,7 +50,7 @@ public:
 
     cql3::statements::select_statement& select_statement() const;
     const query::partition_slice& partition_slice() const;
-    const column_definition* view_column(const schema& base, column_id base_id) const;
+    const column_definition* view_column(const schema& base, column_kind kind, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;
     bool has_base_non_pk_columns_in_view_pk() const;
     bool has_computed_column_depending_on_base_non_primary_key() const {


### PR DESCRIPTION
This pull request introduces support for global secondary indexes based on static columns.

Local secondary indexes based on secondary columns are not planned to be supported and are explicitly forbidden. Because there is only one static row per partition and local indexes require full partition key when querying, such indexes wouldn't be very useful and would only waste resources.

The index table for secondary indexes on static columns, unlike other secondary indexes, do not contain clustering keys from the base table. A static column's value determines a set of full partitions, so the clustering keys would only be unnecessary.

The already existing logic for querying using secondary indexes works after introducing minimal notifications. The view update generation path now works on a common representation of static and clustering rows, but the new representation allowed to keep most of the logic intact.

New cql-pytests are added. All but one of the existing tests for secondary indexes on static columns - ported from Cassandra - now work and have their `xfail` marks lifted; the remaining test requires support for collection indexing, so it will start working only after #2962 is fixed.

Materialized view with static rows as a key are __not__ implemented in this PR.

Fixes: #2963