### PR TITLE
multishard_mutation_query: don't unpop partition header of spent partition

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -205,7 +205,7 @@ class read_context : public reader_lifecycle_policy_v2 {
 
     dismantle_buffer_stats dismantle_combined_buffer(flat_mutation_reader_v2::tracked_buffer combined_buffer, const dht::decorated_key& pkey);
     dismantle_buffer_stats dismantle_compaction_state(detached_compaction_state compaction_state);
-    future<> save_reader(shard_id shard, const dht::decorated_key& last_pkey, position_in_partition_view last_pos);
+    future<> save_reader(shard_id shard, full_position_view last_pos);
 
 public:
     read_context(distributed<replica::database>& db, schema_ptr s, const query::read_command& cmd, const dht::partition_range_vector& ranges,
@@ -275,7 +275,7 @@ public:
     future<> lookup_readers(db::timeout_clock::time_point timeout) noexcept;
 
     future<> save_readers(flat_mutation_reader_v2::tracked_buffer unconsumed_buffer, detached_compaction_state compaction_state,
-            position_in_partition last_pos) noexcept;
+            full_position last_pos) noexcept;
 
     future<> stop();
 };
@@ -474,10 +474,10 @@ read_context::dismantle_buffer_stats read_context::dismantle_compaction_state(de
     return stats;
 }
 
-future<> read_context::save_reader(shard_id shard, const dht::decorated_key& last_pkey, position_in_partition_view last_pos) {
-  return do_with(std::exchange(_readers[shard], {}), [this, shard, &last_pkey, last_pos] (reader_meta& rm) mutable {
+future<> read_context::save_reader(shard_id shard, full_position_view last_pos) {
+  return do_with(std::exchange(_readers[shard], {}), [this, shard, last_pos] (reader_meta& rm) mutable {
     return _db.invoke_on(shard, [this, query_uuid = _cmd.query_uuid, query_ranges = _ranges, &rm,
-            &last_pkey, last_pos, gts = tracing::global_trace_state_ptr(_trace_state)] (replica::database& db) mutable {
+            last_pos, gts = tracing::global_trace_state_ptr(_trace_state)] (replica::database& db) mutable {
         try {
             auto rparts = rm.rparts.release(); // avoid another round-trip when destroying rparts
             auto reader_opt = rparts->permit.semaphore().unregister_inactive_read(std::move(*rparts->handle));
@@ -517,8 +517,7 @@ future<> read_context::save_reader(shard_id shard, const dht::decorated_key& las
                     std::move(rparts->slice),
                     std::move(*reader),
                     std::move(rparts->permit),
-                    last_pkey,
-                    position_in_partition(last_pos));
+                    last_pos);
 
             db.get_querier_cache().insert_shard_querier(query_uuid, std::move(querier), gts.get());
 
@@ -584,23 +583,21 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
 }
 
 future<> read_context::save_readers(flat_mutation_reader_v2::tracked_buffer unconsumed_buffer, detached_compaction_state compaction_state,
-            position_in_partition last_pos) noexcept {
+            full_position last_pos) noexcept {
     if (_cmd.query_uuid == utils::UUID{}) {
         co_return;
     }
 
-    auto last_pkey = compaction_state.partition_start.key();
-
-    const auto cb_stats = dismantle_combined_buffer(std::move(unconsumed_buffer), last_pkey);
+    const auto cb_stats = dismantle_combined_buffer(std::move(unconsumed_buffer), dht::decorate_key(*_schema, last_pos.partition));
     tracing::trace(_trace_state, "Dismantled combined buffer: {}", cb_stats);
 
     const auto cs_stats = dismantle_compaction_state(std::move(compaction_state));
     tracing::trace(_trace_state, "Dismantled compaction state: {}", cs_stats);
 
-    co_await parallel_for_each(boost::irange(0u, smp::count), [this, &last_pkey, &last_pos] (shard_id shard) {
+    co_await parallel_for_each(boost::irange(0u, smp::count), [this, &last_pos] (shard_id shard) {
         auto& rm = _readers[shard];
         if (rm.state == reader_state::successful_lookup || rm.state == reader_state::saving) {
-            return save_reader(shard, last_pkey, last_pos);
+            return save_reader(shard, last_pos);
         }
 
         return make_ready_future<>();
@@ -746,8 +743,9 @@ future<typename ResultBuilder::result_type> do_query(
         return read_page<ResultBuilder>(ctx, s, cmd, ranges, trace_state, std::move(result_builder_factory));
     }).then([&] (page_consume_result<ResultBuilder> r) -> future<typename ResultBuilder::result_type> {
         if (r.compaction_state->are_limits_reached() || r.result.is_short_read()) {
-            co_await ctx->save_readers(std::move(r.unconsumed_fragments), std::move(*r.compaction_state).detach_state(),
-                    position_in_partition(r.compaction_state->current_position()));
+            // Must call before calling `detach_state()`.
+            auto last_pos = *r.compaction_state->current_full_position();
+            co_await ctx->save_readers(std::move(r.unconsumed_fragments), std::move(*r.compaction_state).detach_state(), std::move(last_pos));
         }
         co_return std::move(r.result);
     }));

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -166,6 +166,9 @@ class compact_mutation_state {
     std::unique_ptr<mutation_compactor_garbage_collector> _collector;
 
     compaction_stats _stats;
+
+    // Remember if we requested to stop mid-partition.
+    stop_iteration _stop = stop_iteration::no;
 private:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
@@ -290,6 +293,7 @@ public:
     }
 
     void consume_new_partition(const dht::decorated_key& dk) {
+        _stop = stop_iteration::no;
         auto& pk = dk.key();
         _dk = &dk;
         _return_static_content_on_partition_with_no_rows =
@@ -354,9 +358,9 @@ public:
         _static_row_live = is_live;
         if (is_live || !sr.empty()) {
             partition_is_not_empty(consumer);
-            return consumer.consume(std::move(sr), current_tombstone, is_live);
+            _stop = consumer.consume(std::move(sr), current_tombstone, is_live);
         }
-        return stop_iteration::no;
+        return _stop;
     }
 
     template <typename Consumer, typename GCConsumer>
@@ -402,15 +406,14 @@ public:
             }
         }
 
-        auto stop = stop_iteration::no;
         if (!cr.empty()) {
             partition_is_not_empty(consumer);
-            stop = consumer.consume(std::move(cr), t, is_live);
+            _stop = consumer.consume(std::move(cr), t, is_live);
         }
         if (!sstable_compaction() && is_live && ++_rows_in_current_partition == _current_partition_limit) {
-            return stop_iteration::yes;
+            _stop = stop_iteration::yes;
         }
-        return stop;
+        return _stop;
     }
 
     template <typename Consumer, typename GCConsumer>
@@ -420,7 +423,8 @@ public:
             _last_pos = rtc.position();
         }
         ++_stats.range_tombstones;
-        return do_consume(std::move(rtc), consumer, gc_consumer);
+        _stop = do_consume(std::move(rtc), consumer, gc_consumer);
+        return _stop;
     }
 
     template <typename Consumer, typename GCConsumer>
@@ -531,12 +535,28 @@ public:
     /// compactor will result in the new compactor being in the same state *this
     /// is (given the same outside parameters of course). Practically this
     /// allows the compaction state to be stored in the compacted reader.
-    detached_compaction_state detach_state() && {
+    /// If the currently compacted partition is exhausted a disengaged optional
+    /// is returned -- in this case there is no state to detach.
+    std::optional<detached_compaction_state> detach_state() && {
+        // If we exhausted the partition, there is no need to detach-restore the
+        // compaction state.
+        // We exhausted the partition if `consume_partition_end()` was called
+        // without us requesting the consumption to stop (remembered in _stop)
+        // from one of the consume() overloads.
+        // The consume algorithm calls `consume_partition_end()` in two cases:
+        // * on a partition-end fragment
+        // * consume() requested to stop
+        // In the latter case, the partition is not exhausted. Even if the next
+        // fragment to process is a partition-end, it will not be consumed.
+        if (!_stop) {
+            return {};
+        }
         partition_start ps(std::move(_last_dk), _partition_tombstone);
         if (_effective_tombstone) {
-            return {std::move(ps), std::move(_last_static_row), range_tombstone_change(position_in_partition_view::after_key(_last_pos), _effective_tombstone)};
+            return detached_compaction_state{std::move(ps), std::move(_last_static_row),
+                    range_tombstone_change(position_in_partition_view::after_key(_last_pos), _effective_tombstone)};
         } else {
-            return {std::move(ps), std::move(_last_static_row), std::optional<range_tombstone_change>{}};
+            return detached_compaction_state{std::move(ps), std::move(_last_static_row), std::optional<range_tombstone_change>{}};
         }
     }
 

--- a/querier.hh
+++ b/querier.hh
@@ -193,8 +193,7 @@ public:
 /// considered to be the same as that of the query.
 class shard_mutation_querier : public querier_base {
     std::unique_ptr<const dht::partition_range_vector> _query_ranges;
-    dht::decorated_key _nominal_pkey;
-    position_in_partition _nominal_pos;
+    full_position _nominal_pos;
 
 private:
     shard_mutation_querier(
@@ -203,11 +202,9 @@ private:
             std::unique_ptr<const query::partition_slice> reader_slice,
             flat_mutation_reader_v2 reader,
             reader_permit permit,
-            dht::decorated_key nominal_pkey,
-            position_in_partition nominal_pos)
+            full_position nominal_pos)
         : querier_base(permit, std::move(reader_range), std::move(reader_slice), std::move(reader), *query_ranges)
         , _query_ranges(std::move(query_ranges))
-        , _nominal_pkey(std::move(nominal_pkey))
         , _nominal_pos(std::move(nominal_pos)) {
     }
 
@@ -219,14 +216,13 @@ public:
             std::unique_ptr<const query::partition_slice> reader_slice,
             flat_mutation_reader_v2 reader,
             reader_permit permit,
-            dht::decorated_key nominal_pkey,
-            position_in_partition nominal_pos)
+            full_position nominal_pos)
         : shard_mutation_querier(std::make_unique<const dht::partition_range_vector>(std::move(query_ranges)), std::move(reader_range),
-                std::move(reader_slice), std::move(reader), std::move(permit), std::move(nominal_pkey), std::move(nominal_pos)) {
+                std::move(reader_slice), std::move(reader), std::move(permit), std::move(nominal_pos)) {
     }
 
     virtual std::optional<full_position_view> current_position() const override {
-        return full_position_view(_nominal_pkey.key(), _nominal_pos);
+        return _nominal_pos;
     }
 
     lw_shared_ptr<const dht::partition_range> reader_range() && {

--- a/test/cql-pytest/test_scan.py
+++ b/test/cql-pytest/test_scan.py
@@ -14,6 +14,7 @@
 import pytest
 from util import new_test_table, new_type, user_type
 from cassandra.protocol import InvalidRequest
+from cassandra.query import SimpleStatement
 
 # Test that in a table with multiple clustering-key columns, we can have
 # multi-column restrictions on involving various legal combinations of
@@ -154,3 +155,17 @@ def test_restriction_token_and_nontoken(cql, test_keyspace):
         # This reproduces issue #4244.
         result = list(cql.execute(f"SELECT p,c FROM {table} WHERE token(p) <= {sometoken} AND p = {somep}"))
         assert result == [(somep,0), (somep,1)]
+
+
+# Regression test for #9482
+def test_scan_ending_with_static_row(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int, ck int, s int STATIC, v int, PRIMARY KEY (pk, ck)") as table:
+        stmt = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
+        for pk in range(100):
+            cql.execute(stmt, (0, pk))
+
+        statement = SimpleStatement(f"SELECT * FROM {table}", fetch_size=10)
+        # This will trigger an error in either processing or building the query
+        # results. The success criteria for this test is the query finishing
+        # without errors.
+        res = list(cql.execute(statement))


### PR DESCRIPTION
When stopping the read, the multishard reader will dismantle the
compaction state, pushing back (unpopping) the currently processed
partition's header to its originating reader. This ensures that if the
reader stops in the middle of a partition, on the next page the
partition-header is re-emitted as the compactor (and everything
downstream from it) expects.
It can happen however that there is nothing more for the current
partition in the reader and the next fragment is another partition.
Since we only push back the partition header (without a partition-end)
this can result in two partitions being emitted without being separated
by a partition end.
We could just add the missing partition-end when needed but it is
pointless, if the partition has no more data, just drop the header, we
won't need it on the next page.

The missing partition-end can generate an "IDL frame truncated" message
as it ends up causing the query result writer to create a corrupt
partition entry.

Fixes: https://github.com/scylladb/scylladb/issues/9482