### PR TITLE
config: use ordered map for experimental features

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1042,7 +1042,7 @@ const db::extensions& db::config::extensions() const {
     return *_extensions;
 }
 
-std::unordered_map<sstring, db::experimental_features_t::feature> db::experimental_features_t::map() {
+std::map<sstring, db::experimental_features_t::feature> db::experimental_features_t::map() {
     // We decided against using the construct-on-first-use idiom here:
     // https://github.com/scylladb/scylla/pull/5369#discussion_r353614807
     // Features which are no longer experimental are mapped

--- a/db/config.hh
+++ b/db/config.hh
@@ -85,7 +85,7 @@ struct experimental_features_t {
     // This option should be enabled explicitly.
     enum class feature { UNUSED, UDF, ALTERNATOR_STREAMS, ALTERNATOR_TTL, RAFT,
             KEYSPACE_STORAGE_OPTIONS };
-    static std::unordered_map<sstring, feature> map(); // See enum_option.
+    static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();
 };
 


### PR DESCRIPTION
So that the help string will be sorted lexicographically.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>