### PR TITLE
Fix undefined behavior during eviction

### DIFF
--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -605,8 +605,8 @@ public:
         auto latest_i = get_iterator_in_latest_version();
         auto e = alloc_strategy_unique_ptr<rows_entry>(current_allocator().construct<rows_entry>(_schema, pos, is_dummy(!pos.is_clustering_row()),
             is_continuous(latest_i && latest_i->continuous())));
-        _snp.tracker()->insert(*e);
         auto e_i = rows.insert_before(latest_i, std::move(e));
+        _snp.tracker()->insert(*e_i);
         return ensure_result{*e_i, true};
     }
 

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -155,6 +155,9 @@ void cache_tracker::clear() {
         _memtable_cleaner.clear();
         current_tracker = this;
         _lru.evict_all();
+        // Eviction could have produced garbage.
+        _garbage.clear();
+        _memtable_cleaner.clear();
     });
     _stats.partition_removals += partitions_before;
     _stats.row_removals += rows_before;


### PR DESCRIPTION
When the last non-dummy row is evicted from a partition, the partition
entry is evicted as well. The existing logic in on_evicted() leaves
the last dummy row in the partition version before evicting the
partition entry. This row may still be attached to the LRU. Eviction
of partition entry goes through mutation_cleaner::clear_gently(). If
this is preempted, the destruction may proceed in the background. If
evicition happens on the remaining row in that entry before it's
destroyed, the code will hit undefined behavior. on_evicted() calls
partition_version::is_referenced_from_entry(), which is unspecified
when the version is enqueued in the mutation_cleaner. It returns
incorrect value for the last item remaining in the LRU (middle entires evict fine).
In that case, eviction will try to access non-existent containing partition_entry,
causing undefined behavior.

Caught by debug-mode cql_query_test.test_clustering_filtering with
raft enabled. Where it manifested like this:

  partition_version.hh:328:16: runtime error: load of value 7, which is not a valid value for type 'bool'
  SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior partition_version.hh:328:16 in
  Aborting on shard 0.

Instances of this issue outside of the unit test environment are not
known as of yet.

This change makes is_referenced_from_entry() return the correct value
even for versions which are queued in the mutation cleaner.

Fixes https://github.com/scylladb/scylladb/issues/11140

The series also contains some related cleanups and minor fixes for issues which 
could come up later.