### PR TITLE
doc: update the links to Manager and Operator

### DIFF
--- a/docs/operating-scylla/index.rst
+++ b/docs/operating-scylla/index.rst
@@ -9,12 +9,9 @@ Scylla for Administrators
    Procedures <procedures/index>
    security/index
    admin-tools/index
-   manager/index
    ScyllaDB Monitoring Stack <https://monitoring.docs.scylladb.com/>
    ScyllaDB Operator <https://operator.docs.scylladb.com/>
    ScyllaDB Manager <https://manager.docs.scylladb.com/>
-   Scylla Monitoring Stack <monitoring/index>
-   Scylla Operator <scylla-operator/index>
    Upgrade Procedures </upgrade/index>
    System Configuration <system-configuration/index>
    benchmarking-scylla
@@ -36,15 +33,9 @@ Scylla for Administrators
   :class: my-panel
     
   * :doc:`Scylla Tools </operating-scylla/admin-tools/index>` - Tools for Administrating and integrating with Scylla
-<<<<<<< HEAD
-  * :doc:`Scylla Manager </operating-scylla/manager/index>` - Tool for cluster administration and automation
   * `ScyllaDB Monitoring Stack <https://monitoring.docs.scylladb.com/stable/>`_ - Tool for cluster monitoring and alerting
   * `ScyllaDB Operator <https://operator.docs.scylladb.com>`_ - Tool to run Scylla on Kubernetes
-=======
   * `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_ - Tool for cluster administration and automation
-  * :doc:`Scylla Monitoring Stack </operating-scylla/monitoring/index>` - Tool for cluster monitoring and alerting
-  * :doc:`Scylla Operator </operating-scylla/scylla-operator/index>` - Tool to run Scylla on Kubernetes
->>>>>>> 40050f951 (doc: add the link to manager.docs.scylladb.com to the toctree)
   * :doc:`Scylla Logs </getting-started/logging/>`
 
 .. panel-box::

--- a/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
@@ -30,7 +30,7 @@ Apply the following procedure **serially** on each node. Do not move to the next
 **During** the rolling upgrade, it is highly recommended:
 
 * Not to use new 2022.1 features.
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending Scylla Manager's scheduled or running repairs.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending Scylla Manager's scheduled or running repairs.
 * Not to apply schema changes.
 
 

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -33,7 +33,7 @@ Apply the following procedure **serially** on each node. Do not move to the next
 **During** the rolling upgrade, it is highly recommended:
 
 * Not to use new 2022.1 features.
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending Scylla Manager scheduled or running repairs.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending Scylla Manager scheduled or running repairs.
 * Not to apply schema changes.
 
 Upgrade Steps


### PR DESCRIPTION
This PR fixes the links to Manager and Operator:
- I've re-added the changes that were added too late - after this PR was merged: https://github.com/scylladb/scylladb/pull/11162
- I've fixed two links to the Operator's school that were added with the upgrade guide from 5.0 to 2022.1.