### PR TITLE
wasm: fix compilation without libwasmtime

### DIFF
--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -43,8 +43,6 @@ struct context {
 
 void compile(context& ctx, const std::vector<sstring>& arg_names, std::string script);
 
-seastar::future<bytes_opt> run_script(context& ctx, wasmtime::Store& store, wasmtime::Instance& instance, wasmtime::Func& func, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input);
-
 seastar::future<bytes_opt> run_script(context& ctx, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input);
 
 seastar::future<bytes_opt> run_script(const db::functions::function_name& name, context& ctx, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input);
@@ -58,10 +56,6 @@ struct context {
 };
 
 inline void compile(context&, const std::vector<sstring>&, std::string) {
-    throw wasm::exception("WASM support was not enabled during compilation!");
-}
-
-inline seastar::future<bytes_opt> run_script(context& ctx, wasmtime::Store& store, wasmtime::Instance& instance, wasmtime::Func& func, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input) {
     throw wasm::exception("WASM support was not enabled during compilation!");
 }
 

--- a/lang/wasm_instance_cache.cc
+++ b/lang/wasm_instance_cache.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#ifdef SCYLLA_ENABLE_WASMTIME
+
 #include "lang/wasm_instance_cache.hh"
 #include "seastar/core/metrics.hh"
 #include "seastar/core/scheduling.hh"
@@ -220,3 +222,5 @@ struct equal_to<seastar::scheduling_group> {
 };
 
 }
+
+#endif

--- a/lang/wasm_instance_cache.hh
+++ b/lang/wasm_instance_cache.hh
@@ -8,6 +8,30 @@
 
 #pragma once
 
+#ifndef SCYLLA_ENABLE_WASMTIME
+
+#include <cstddef>
+#include <seastar/core/lowres_clock.hh>
+#include "lang/wasm.hh"
+
+namespace wasm {
+
+struct instance_cache {
+    explicit instance_cache(size_t size, seastar::lowres_clock::duration timer_period) {}
+
+    void remove(const db::functions::function_name& name, const std::vector<data_type>& arg_types) {
+        throw wasm::exception("WASM support was not enabled during compilation!");
+    }
+
+    future<> stop() {
+        return seastar::make_ready_future<>();
+    }
+};
+
+}
+
+#else
+
 #include "db/functions/function_name.hh"
 #include <list>
 #include <seastar/core/metrics_registration.hh>
@@ -121,3 +145,5 @@ public:
 };
 
 }
+
+#endif


### PR DESCRIPTION
Some segments of code using wasmtime were not under an
ifdef SCYLLA_ENABLE_WASMTIME, making Scylla unable to compile
on machines without wasmtime. This patch adds the ifdef where
needed.
Additionally a run_script() method that is used only internally is removed
from wasm.hh