### PR TITLE
cdc: generation: silence `sleep_aborted` in background streams table update loop

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -455,7 +455,12 @@ static future<> update_streams_description(
                     noncopyable_function<unsigned()> get_num_token_owners,
                     abort_source& abort_src) -> future<> {
             while (true) {
-                co_await sleep_abortable(std::chrono::seconds(60), abort_src);
+                try {
+                    co_await sleep_abortable(std::chrono::seconds(60), abort_src);
+                } catch (const sleep_aborted&) {
+                    co_return;
+                }
+
                 try {
                     co_await do_update_streams_description(gen_id, *sys_dist_ks, { get_num_token_owners() });
                     co_return;


### PR DESCRIPTION
If we shutdown while the loop is sleeping we don't want seastar to
complain about abandoned exceptional futures.

Fixes #11192.