### PR TITLE
db/system_keyspace: in system.local, use broadcast_rpc_address in rpc_address column

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1243,22 +1243,22 @@ schema_ptr system_keyspace::legacy::aggregates() {
 
 future<> system_keyspace::setup_version(sharded<netw::messaging_service>& ms) {
     auto& cfg = _db.local().get_config();
-        sstring req = fmt::format("INSERT INTO system.{} (key, release_version, cql_version, thrift_version, native_protocol_version, data_center, rack, partitioner, rpc_address, broadcast_address, listen_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-                        , db::system_keyspace::LOCAL);
-        auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
+    sstring req = fmt::format("INSERT INTO system.{} (key, release_version, cql_version, thrift_version, native_protocol_version, data_center, rack, partitioner, rpc_address, broadcast_address, listen_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    , db::system_keyspace::LOCAL);
+    auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
 
-        return execute_cql(req, sstring(db::system_keyspace::LOCAL),
-                             version::release(),
-                             cql3::query_processor::CQL_VERSION,
-                             ::cassandra::thrift_version,
-                             to_sstring(cql_serialization_format::latest_version),
-                             snitch->get_datacenter(utils::fb_utilities::get_broadcast_address()),
-                             snitch->get_rack(utils::fb_utilities::get_broadcast_address()),
-                             sstring(cfg.partitioner()),
-                             utils::fb_utilities::get_broadcast_rpc_address().addr(),
-                             utils::fb_utilities::get_broadcast_address().addr(),
-                             ms.local().listen_address().addr()
-        ).discard_result();
+    return execute_cql(req, sstring(db::system_keyspace::LOCAL),
+                            version::release(),
+                            cql3::query_processor::CQL_VERSION,
+                            ::cassandra::thrift_version,
+                            to_sstring(cql_serialization_format::latest_version),
+                            snitch->get_datacenter(utils::fb_utilities::get_broadcast_address()),
+                            snitch->get_rack(utils::fb_utilities::get_broadcast_address()),
+                            sstring(cfg.partitioner()),
+                            utils::fb_utilities::get_broadcast_rpc_address().addr(),
+                            utils::fb_utilities::get_broadcast_address().addr(),
+                            ms.local().listen_address().addr()
+    ).discard_result();
 }
 
 future<> system_keyspace::save_local_supported_features(const std::set<std::string_view>& feats) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1243,7 +1243,6 @@ schema_ptr system_keyspace::legacy::aggregates() {
 
 future<> system_keyspace::setup_version(sharded<netw::messaging_service>& ms) {
     auto& cfg = _db.local().get_config();
-    return utils::resolve(cfg.rpc_address).then([this, &cfg, &ms](gms::inet_address a) {
         sstring req = fmt::format("INSERT INTO system.{} (key, release_version, cql_version, thrift_version, native_protocol_version, data_center, rack, partitioner, rpc_address, broadcast_address, listen_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                         , db::system_keyspace::LOCAL);
         auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
@@ -1256,11 +1255,10 @@ future<> system_keyspace::setup_version(sharded<netw::messaging_service>& ms) {
                              snitch->get_datacenter(utils::fb_utilities::get_broadcast_address()),
                              snitch->get_rack(utils::fb_utilities::get_broadcast_address()),
                              sstring(cfg.partitioner()),
-                             a.addr(),
+                             utils::fb_utilities::get_broadcast_rpc_address().addr(),
                              utils::fb_utilities::get_broadcast_address().addr(),
                              ms.local().listen_address().addr()
         ).discard_result();
-    });
 }
 
 future<> system_keyspace::save_local_supported_features(const std::set<std::string_view>& feats) {


### PR DESCRIPTION
Previously, the `system.local`'s `rpc_address` column kept local node's
`rpc_address` from the scylla.yaml configuration. Although it sounds
like it makes sense, there are a few reasons to change it to the value
of scylla.yaml's `broadcast_rpc_address`:

- The `broadcast_rpc_address` is the address that the drivers are
  supposed to connect to. `rpc_address` is the address that the node
  binds to - it can be set for example to 0.0.0.0 so that Scylla listens
  on all addresses, however this gives no useful information to the
  driver.
- The `system.peers` table also has the `rpc_address` column and it
  already keeps other nodes' `broadcast_rpc_address`es.
- Cassandra is going to do the same change in the upcoming version 4.1.

Fixes: #11201