### PR TITLE
doc: describe specifying workload attributes with service levels

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -176,3 +176,7 @@ Glossary
 
     Dummy Rows
        Cache dummy rows are entries in the row set, which have a clustering position, although they do not represent CQL rows written by users.  Scylla cache uses them to mark boundaries of population ranges, to represent the information that the whole range is complete, and there is no need to go to sstables to read the gaps between existing row entries when scanning.
+      
+    Workload
+      A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By creating workloads, you can specify how ScyllaDB will process those activities. For example, you can prioritize one workload over another (e.g., user requests over administrative activities). See :doc:`Workload Prioritization </using-scylla/workload-prioritization>`.
+

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -178,5 +178,5 @@ Glossary
        Cache dummy rows are entries in the row set, which have a clustering position, although they do not represent CQL rows written by users.  Scylla cache uses them to mark boundaries of population ranges, to represent the information that the whole range is complete, and there is no need to go to sstables to read the gaps between existing row entries when scanning.
       
     Workload
-      A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By creating workloads, you can specify how ScyllaDB will process those activities. For example, you can prioritize one workload over another (e.g., user requests over administrative activities). See :doc:`Workload Prioritization </using-scylla/workload-prioritization>`.
+      A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By defining workloads, you can specify how ScyllaDB will process those activities. For example, you can prioritize one workload over another (e.g., user requests over administrative activities). See :doc:`Workload Prioritization </using-scylla/workload-prioritization>`.
 

--- a/docs/operating-scylla/index.rst
+++ b/docs/operating-scylla/index.rst
@@ -9,12 +9,10 @@ Scylla for Administrators
    Procedures <procedures/index>
    security/index
    admin-tools/index
-   manager/index
    ScyllaDB Monitoring Stack <https://monitoring.docs.scylladb.com/>
    ScyllaDB Operator <https://operator.docs.scylladb.com/>
    ScyllaDB Manager <https://manager.docs.scylladb.com/>
-   Scylla Monitoring Stack <monitoring/index>
-   Scylla Operator <scylla-operator/index>
+
    Upgrade Procedures </upgrade/index>
    System Configuration <system-configuration/index>
    benchmarking-scylla
@@ -36,15 +34,9 @@ Scylla for Administrators
   :class: my-panel
     
   * :doc:`Scylla Tools </operating-scylla/admin-tools/index>` - Tools for Administrating and integrating with Scylla
-<<<<<<< HEAD
-  * :doc:`Scylla Manager </operating-scylla/manager/index>` - Tool for cluster administration and automation
   * `ScyllaDB Monitoring Stack <https://monitoring.docs.scylladb.com/stable/>`_ - Tool for cluster monitoring and alerting
   * `ScyllaDB Operator <https://operator.docs.scylladb.com>`_ - Tool to run Scylla on Kubernetes
-=======
   * `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_ - Tool for cluster administration and automation
-  * :doc:`Scylla Monitoring Stack </operating-scylla/monitoring/index>` - Tool for cluster monitoring and alerting
-  * :doc:`Scylla Operator </operating-scylla/scylla-operator/index>` - Tool to run Scylla on Kubernetes
->>>>>>> 40050f951 (doc: add the link to manager.docs.scylladb.com to the toctree)
   * :doc:`Scylla Logs </getting-started/logging/>`
 
 .. panel-box::

--- a/docs/operating-scylla/index.rst
+++ b/docs/operating-scylla/index.rst
@@ -12,7 +12,6 @@ Scylla for Administrators
    ScyllaDB Monitoring Stack <https://monitoring.docs.scylladb.com/>
    ScyllaDB Operator <https://operator.docs.scylladb.com/>
    ScyllaDB Manager <https://manager.docs.scylladb.com/>
-
    Upgrade Procedures </upgrade/index>
    System Configuration <system-configuration/index>
    benchmarking-scylla

--- a/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
@@ -30,7 +30,7 @@ Apply the following procedure **serially** on each node. Do not move to the next
 **During** the rolling upgrade, it is highly recommended:
 
 * Not to use new 2022.1 features.
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending Scylla Manager's scheduled or running repairs.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending Scylla Manager's scheduled or running repairs.
 * Not to apply schema changes.
 
 

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -33,7 +33,7 @@ Apply the following procedure **serially** on each node. Do not move to the next
 **During** the rolling upgrade, it is highly recommended:
 
 * Not to use new 2022.1 features.
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending Scylla Manager scheduled or running repairs.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending Scylla Manager scheduled or running repairs.
 * Not to apply schema changes.
 
 Upgrade Steps

--- a/docs/using-scylla/index.rst
+++ b/docs/using-scylla/index.rst
@@ -9,6 +9,7 @@ Scylla for Developers
    Scylla Alternator <alternator/index>
    Scylla Features <features>
    Scylla Drivers <drivers/index>
+   Workload Attributes <workload-attributes>
 
 
 .. panel-box::
@@ -19,6 +20,14 @@ Scylla for Developers
   * :doc:`Scylla Drivers </using-scylla/drivers/index>` - Scylla and third-party drivers for CQL and DynamoDB
   * :doc:`Scylla Alternator </using-scylla/alternator/index>` - The Open Source DynamoDB-compatible API
   * :doc:`CQL Reference </cql/index>` - Reference for the Apache Cassandra Query Language (CQL) and its ScyllaDB extensions
+
+.. panel-box::
+  :title: Features
+  :id: "getting-started"
+  :class: my-panel
+
+  * :doc:`Workload Attributes </using-scylla/workload-attributes/>`
+
   
   
 .. panel-box::

--- a/docs/using-scylla/workload-attributes.rst
+++ b/docs/using-scylla/workload-attributes.rst
@@ -34,13 +34,13 @@ Procedure
 
     .. code-block:: cql
 
-	   CREATE SERVICE LEVEL <service_level_name> <attribute>
+     CREATE SERVICE LEVEL <service_level_name> WITH <attribute> [ AND <attribute>];
 	
     For example:
 
     .. code-block:: cql
 
-	   CREATE SERVICE LEVEL sl2 WITH timeout = 500ms;
+	   CREATE SERVICE LEVEL sl2 WITH timeout = 500ms AND workload_type=interactive;
 	
 	
     See :ref:`Available Attributes <workload-attributes-available-attributes>`.
@@ -58,7 +58,13 @@ Procedure
 	   ATTACH SERVICE LEVEL sl2 TO scylla;
 
 
-You can modify the service level attributes with the ``ALTER SERVICE LEVEL`` command. For example:
+You can modify the service level attributes with the ``ALTER SERVICE LEVEL`` command:
+
+    .. code-block:: cql
+
+     ALTER SERVICE LEVEL <service_level_name> WITH <attribute> [ AND <attribute>];
+
+ For example:
 
 .. code-block:: cql
 

--- a/docs/using-scylla/workload-attributes.rst
+++ b/docs/using-scylla/workload-attributes.rst
@@ -1,0 +1,132 @@
+=============================
+Defining Workload Attributes
+=============================
+
+.. versionadded:: 2022.1 ScyllaDB Enterprise
+
+
+.. versionadded:: 5.0 ScyllaDB Open Source
+
+
+Introduction
+-------------
+
+A typical database has more than one :term:`workload <workload>` running simultaneously with a different acceptable level of latency and 
+throughput. By defining the attributes of each workload, you can specify how ScyllaDB will handle requests depending on 
+the workload to which they are assigned.
+
+You can define a workload's attribute using the *service level* concept. The service level CQL commands allow you to attach 
+attributes to users and roles. When a user logs into the system, all of the attributes attached to that user and to the roles 
+granted to that user are combined and become a set of workload attributes.
+
+See :ref:`Service Level Management <workload-priorization-service-level-management>` for more information about service levels.
+
+Prerequisites
+---------------
+
+* An :doc:`authenticated </operating-scylla/security/runtime-authentication>` and :doc:`authorized </operating-scylla/security/enable-authorization>` user 
+* At least one :ref:`role created <create-role-statement>`.
+
+Procedure
+------------
+
+#. Create a service level with the desired attribute.
+
+    .. code-block:: cql
+
+	   CREATE SERVICE LEVEL <service_level_name> <attribute>
+	
+    For example:
+
+    .. code-block:: cql
+
+	   CREATE SERVICE LEVEL sl2 WITH timeout = 500ms;
+	
+	
+    See :ref:`Available Attributes <workload-attributes-available-attributes>`.
+
+#. Assign a service level to a role or user:
+
+    .. code-block:: cql
+
+	   ATTACH SERVICE_LEVEL <service_level_name> TO <role_name|user_name>;
+	
+    For example:
+
+    .. code-block:: cql
+
+	   ATTACH SERVICE LEVEL sl2 TO scylla;
+
+
+You can modify the service level attributes with the ``ALTER SERVICE LEVEL`` command. For example:
+
+.. code-block:: cql
+
+     ALTER SERVICE LEVEL sl2 WITH timeout = null;
+
+
+.. _workload-attributes-available-attributes:
+
+Available Attributes
+-----------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Attribute
+     - Details
+   * - ``timeout``
+     - :ref:`Specifying Service Level Timeout <workload-attributes-timeout>`
+   * - ``workload_type``
+     - :ref:`Specifying Workload Type<workload-attributes-workload-type>`
+
+
+.. _workload-attributes-timeout:
+
+Specifying Service Level Timeout
+-----------------------------------
+
+You can specify the timeout for a service level (in milliseconds or seconds) with the ``timeout`` attribute. 
+
+For example:
+
+.. code-block:: cql
+
+   CREATE SERVICE LEVEL primary WITH timeout = 30ms;
+
+Specifying the timeout value is useful when your workloads have different acceptable latency levels.
+
+.. _workload-attributes-workload-type:
+
+Specifying Workload Type
+----------------------------
+
+You can specify the workload type for a service level with the ``workload_type`` attribute. 
+
+For example:
+
+.. code-block:: cql
+
+   CREATE SERVICE LEVEL secondary WITH workload_type = 'batch';
+
+Specifying the workload type allows ScyllaDB to handle sessions more efficiently (for example, depending on whether the workload is 
+sensitive to latency).
+
+
+Available Workload Types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Workload type
+     - Description
+   * - ``unspecified``
+     - A generic workload without any specific characteristics (default).
+   * - ``interactive``
+     - A workload sensitive to latency, expected to have high/unbounded concurrency, with dynamic characteristics, :doc:`OLTP </using-scylla/workload-prioritization>`. For example, a workload assigned to users clicking on a website and generating events with their clicks.
+   * -  ``batch``
+     - A workload for processing large amounts of data, not sensitive to latency, expected to have fixed concurrency, :doc:`OLAP </using-scylla/workload-prioritization>`. For example, a workload assigned to processing billions of historical sales records to generate statistics.
+


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11197

This PR adds a new page where specifying workload attributes with service levels is described and adds it to the menu.

Also, I had to fix some links because of the warnings.