### PR TITLE
Raft test topology part 1

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -240,6 +240,8 @@ class RandomTables():
         self.keyspace = keyspace
         self.tables: List[RandomTable] = []
         self.removed_tables: List[RandomTable] = []
+        cql.execute(f"CREATE KEYSPACE {keyspace} WITH REPLICATION = "
+                     "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
 
     async def add_tables(self, ntables: int = 1, ncolumns: int = 5) -> None:
         """Add random tables to the list.
@@ -278,11 +280,9 @@ class RandomTables():
         self.removed_tables.append(table)
         return table
 
-    async def drop_all_tables(self) -> None:
-        """Drop all active managed tables"""
-        tables, self.tables = self.tables, []
-        await asyncio.gather(*(t.drop() for t in tables))
-        self.removed_tables.extend(tables)
+    def drop_all(self) -> None:
+        """Drop keyspace (and tables)"""
+        self.cql.execute(f"DROP KEYSPACE {self.keyspace}")
 
     async def verify_schema(self, table: Union[RandomTable, str] = None) -> None:
         """Verify schema of all active managed random tables"""

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -280,8 +280,9 @@ class RandomTables():
 
     async def drop_all_tables(self) -> None:
         """Drop all active managed tables"""
-        await asyncio.gather(*(t.drop() for t in self.tables))
-        self.removed_tables.extend(self.tables)
+        tables, self.tables = self.tables, []
+        await asyncio.gather(*(t.drop() for t in tables))
+        self.removed_tables.extend(tables)
 
     async def verify_schema(self, table: Union[RandomTable, str] = None) -> None:
         """Verify schema of all active managed random tables"""

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -105,7 +105,7 @@ class ScyllaServer:
 
     def __init__(self, exe: str, vardir: str,
                  host_registry,
-                 cluster_name: str, seed: str,
+                 cluster_name: str, seed: Optional[str],
                  cmdline_options: List[str]) -> None:
         self.exe = pathlib.Path(exe).resolve()
         self.vardir = pathlib.Path(vardir)

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -6,10 +6,75 @@
 # This file configures pytest for all tests in this directory, and also
 # defines common test fixtures for all of them to use
 
+import asyncio
 import pathlib
 import sys
+from typing import AsyncGenerator
+from test.pylib.random_tables import RandomTables                        # type: ignore
+import pytest
+from cassandra.cluster import Session, ResponseFuture                    # type: ignore
 
 # Add test.pylib to the search path
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 
+def _wrap_future(f: ResponseFuture) -> asyncio.Future:
+    """Wrap a cassandra Future into an asyncio.Future object.
+
+    Args:
+        f: future to wrap
+
+    Returns:
+        And asyncio.Future object which can be awaited.
+    """
+    loop = asyncio.get_event_loop()
+    aio_future = loop.create_future()
+
+    def on_result(result):
+        loop.call_soon_threadsafe(aio_future.set_result, result)
+
+    def on_error(exception, *_):
+        loop.call_soon_threadsafe(aio_future.set_exception, exception)
+
+    f.add_callback(on_result)
+    f.add_errback(on_error)
+    return aio_future
+
+
+def run_async(self, *args, **kwargs) -> asyncio.Future:
+    return _wrap_future(self.execute_async(*args, **kwargs))
+
+
+Session.run_async = run_async
+
+
+# While the raft-based schema modifications are still experimental and only
+# optionally enabled some tests are expected to fail on Scylla without this
+# option enabled, and pass with it enabled (and also pass on Cassandra).
+# These tests should use the "fails_without_raft" fixture. When Raft mode
+# becomes the default, this fixture can be removed.
+@pytest.fixture(scope="session")
+def check_pre_raft(cql):
+    # If not running on Scylla, return false.
+    names = [row.table_name for row in cql.execute("SELECT * FROM system_schema.tables WHERE keyspace_name = 'system'")]
+    if not any('scylla' in name for name in names):
+        return False
+    # In Scylla, we check Raft mode by inspecting the configuration via CQL.
+    experimental_features = list(cql.execute("SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
+    return not '"raft"' in experimental_features
+
+
+@pytest.fixture(scope="function")
+def fails_without_raft(request, check_pre_raft):
+    if check_pre_raft:
+        request.node.add_marker(pytest.mark.xfail(reason='Test expected to fail without Raft experimental feature on'))
+
+
+# "random_tables" fixture: Creates and returns a temporary RandomTables object
+# used in tests to make schema changes. Tables are dropped after finished.
+@pytest.mark.asyncio
+@pytest.fixture(scope="function")
+async def random_tables(request, cql, keyspace) -> AsyncGenerator:
+    tables = RandomTables(request.node.name, cql, keyspace)
+    yield tables
+    await tables.drop_all_tables()

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -9,8 +9,8 @@
 import asyncio
 import pathlib
 import sys
-from typing import AsyncGenerator
 from test.pylib.random_tables import RandomTables                        # type: ignore
+from test.pylib.util import unique_name                                  # type: ignore
 import pytest
 from cassandra.cluster import Session, ResponseFuture                    # type: ignore
 
@@ -72,9 +72,8 @@ def fails_without_raft(request, check_pre_raft):
 
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
 # used in tests to make schema changes. Tables are dropped after finished.
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
-async def random_tables(request, cql, keyspace) -> AsyncGenerator:
-    tables = RandomTables(request.node.name, cql, keyspace)
+def random_tables(request, cql):
+    tables = RandomTables(request.node.name, cql, unique_name())
     yield tables
-    await tables.drop_all_tables()
+    tables.drop_all()

--- a/test/topology/pytest.ini
+++ b/test/topology/pytest.ini
@@ -4,3 +4,4 @@
 [pytest]
 # Use shared fixtures from the parent dir
 addopts = --confcutdir ..
+asyncio_mode = auto


### PR DESCRIPTION
These are the first commits out of #10815 and is itself based on #11193 .

It starts by moving pytest logic out of the common `test/conftest.py` and into `test/topology/conftest.py`, including removing the async support as it's not used anywhere else.

There's a fix of a bug of leaving tables in `RandomTables.tables` after dropping all of them.

Keyspace creation is moved out of `conftest.py` into `RandomTables` as it makes more sense and this way topology tests avoid all the workarounds for old version (topology needs ScyllaDB 5+ for Raft, anyway).

And a minor fix.

