### PR TITLE
db: range_tombstone_list: Avoid quadratic behavior when applying

### DIFF
--- a/range_tombstone_list.cc
+++ b/range_tombstone_list.cc
@@ -9,6 +9,7 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include "range_tombstone_list.hh"
 #include "utils/allocation_strategy.hh"
+#include "utils/amortized_reserve.hh"
 #include <seastar/util/variant_utils.hh>
 
 range_tombstone_list::range_tombstone_list(const range_tombstone_list& x)
@@ -375,13 +376,13 @@ range_tombstone_list::reverter::insert(range_tombstones_type::iterator it, range
 
 range_tombstone_list::range_tombstones_type::iterator
 range_tombstone_list::reverter::erase(range_tombstones_type::iterator it) {
-    _ops.reserve(_ops.size() + 1);
+    amortized_reserve(_ops, _ops.size() + 1);
     _ops.emplace_back(erase_undo_op(*it));
     return _dst._tombstones.erase(it);
 }
 
 void range_tombstone_list::reverter::update(range_tombstones_type::iterator it, range_tombstone&& new_rt) {
-    _ops.reserve(_ops.size() + 1);
+    amortized_reserve(_ops, _ops.size() + 1);
     swap(it->tombstone(), new_rt);
     _ops.emplace_back(update_undo_op(std::move(new_rt), *it));
 }

--- a/range_tombstone_list.hh
+++ b/range_tombstone_list.hh
@@ -12,6 +12,7 @@
 #include "range_tombstone.hh"
 #include "query-request.hh"
 #include "utils/preempt.hh"
+#include "utils/chunked_vector.hh"
 #include <iosfwd>
 #include <variant>
 
@@ -106,7 +107,7 @@ class range_tombstone_list final {
     class reverter {
     private:
         using op = std::variant<erase_undo_op, insert_undo_op, update_undo_op>;
-        std::vector<op> _ops;
+        utils::chunked_vector<op> _ops;
         const schema& _s;
     protected:
         range_tombstone_list& _dst;

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -12,6 +12,7 @@
 #include <deque>
 #include <random>
 #include "utils/chunked_vector.hh"
+#include "utils/amortized_reserve.hh"
 
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/equal.hpp>
@@ -206,4 +207,38 @@ BOOST_AUTO_TEST_CASE(test_shrinking_and_expansion_involving_chunk_boundary) {
     for (uint64_t i = 0; i < vector_type::max_chunk_capacity() * 2; ++i) {
         v.emplace_back(std::make_unique<uint64_t>(i));
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_amoritzed_reserve) {
+    utils::chunked_vector<int> v;
+
+    v.reserve(10);
+    amortized_reserve(v, 1);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 10);
+    BOOST_REQUIRE_EQUAL(v.size(), 0);
+
+    v = {};
+    amortized_reserve(v, 1);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 1);
+    BOOST_REQUIRE_EQUAL(v.size(), 0);
+
+    v = {};
+    amortized_reserve(v, 1);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 1);
+    amortized_reserve(v, 2);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 2);
+    amortized_reserve(v, 3);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 4);
+    amortized_reserve(v, 4);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 4);
+    amortized_reserve(v, 5);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 8);
+    amortized_reserve(v, 6);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 8);
+    amortized_reserve(v, 7);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 8);
+    amortized_reserve(v, 7);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 8);
+    amortized_reserve(v, 1);
+    BOOST_REQUIRE_EQUAL(v.capacity(), 8);
 }

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -43,6 +43,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
         auto prefill_compacted = logalloc::memory_compacted();
         auto prefill_allocated = logalloc::memory_allocated();
 
+        scheduling_latency_measurer memtable_slm;
+        memtable_slm.start();
+
         auto mt = make_lw_shared<replica::memtable>(s);
         auto fill_d = duration_in_seconds([&] {
             while (mt->occupancy().total_space() < memtable_size) {
@@ -54,7 +57,8 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
                 }
             }
         });
-        std::cout << format("Memtable fill took {:.6f} [ms]", fill_d.count() * 1000) << std::endl;
+        memtable_slm.stop();
+        std::cout << format("Memtable fill took {:.6f} [ms], {}", fill_d.count() * 1000, memtable_slm) << std::endl;
 
         std::cout << "Draining..." << std::endl;
         auto drain_d = duration_in_seconds([&] {
@@ -223,6 +227,40 @@ void test_partition_with_lots_of_range_tombstones() {
     });
 }
 
+// This test case stresses handling of overlapping range tombstones
+void test_partition_with_lots_of_range_tombstones_with_residuals() {
+    auto s = schema_builder("ks", "cf")
+        .with_column("pk", uuid_type, column_kind::partition_key)
+        .with_column("ck", int32_type, column_kind::clustering_key)
+        .with_column("v1", bytes_type, column_kind::regular_column)
+        .with_column("v2", bytes_type, column_kind::regular_column)
+        .with_column("v3", bytes_type, column_kind::regular_column)
+        .build();
+
+    auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
+        serialized(utils::UUID_gen::get_time_UUID())));
+    int ck_idx = 0;
+
+    run_test("Large partition, lots of range tombstones with residuals", s, [&] {
+        mutation m(s, pk);
+        auto val = data_value(bytes(bytes::initialized_later(), cell_size));
+        auto ck = clustering_key::from_single_value(*s, serialized(ck_idx++));
+        auto r = query::clustering_range::make({ck}, {ck});
+        tombstone tomb(api::new_timestamp(), gc_clock::now());
+        m.partition().apply_row_tombstone(*s, range_tombstone(bound_view::from_range_start(r), bound_view::top(), tomb));
+
+        // Stress range tombstone overlapping with lots of range tombstones
+        auto stride = 1'000'000;
+        if (ck_idx == stride) {
+            ck = clustering_key::from_single_value(*s, serialized(ck_idx - stride));
+            r = query::clustering_range::make({ck}, {ck});
+            m.partition().apply_row_tombstone(*s, range_tombstone(bound_view::from_range_start(r), bound_view::top(), tomb));
+        }
+
+        return m;
+    });
+}
+
 int main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [&app] {
@@ -236,6 +274,7 @@ int main(int argc, char** argv) {
             test_partition_with_few_small_rows();
             test_partition_with_lots_of_small_rows();
             test_partition_with_lots_of_range_tombstones();
+            test_partition_with_lots_of_range_tombstones_with_residuals();
         });
     });
 }

--- a/utils/amortized_reserve.hh
+++ b/utils/amortized_reserve.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <concepts>
+#include <vector>
+#include <memory>
+
+/// Represents a container which can preallocate space for future insertions
+/// which can be used to reduce the number of overall memory re-allocation and item movement.
+///
+/// The number of items for which space is currently reserved is returned by capacity().
+/// This includes items currently present in the container.
+///
+/// The number of items currently present is returned by size().
+///
+/// Invariant:
+///
+///   size() <= capacity()
+///
+/// Space is reserved by calling reserve(desired_capacity).
+/// The post-condition of calling reserve() is:
+///
+///   capacity() >= desired_capacity
+///
+/// It is guaranteed insertion of (capacity() - size()) items does not
+/// throw if T::value_type constructor and move constructor do not throw.
+template <typename T>
+concept ContainerWithCapacity = requires (T x, size_t desired_capacity, typename T::value_type e) {
+    { x.reserve(desired_capacity) } -> std::same_as<void>;
+    { x.capacity() } -> std::same_as<size_t>;
+    { x.size() } -> std::same_as<size_t>;
+};
+
+static_assert(ContainerWithCapacity<std::vector<int>>);
+
+/// Reserves space for at least desired_capacity - v.size() elements.
+///
+/// Amortizes space expansion so that a series of N calls to amortized_reserve(v, v.size() + 1)
+/// starting from an empty container takes O(N) time overall.
+///
+/// Post-condition: v.capacity() >= desired_capacity
+template <ContainerWithCapacity T>
+void amortized_reserve(T& v, size_t desired_capacity) {
+    if (desired_capacity > v.capacity()) {
+        v.reserve(std::max(desired_capacity, v.capacity() * 2));
+    }
+}


### PR DESCRIPTION
Range tombstones are kept in memory (cache/memtable) in
range_tombstone_list. It keeps them deoverlapped, so applying a range
tombstone which covers many range tombstones will erase existing range
tombstones from the list. This operation needs to be exception-safe,
so range_tombstone_list maintains an undo log. This undo log will
receive a record for each range tombstone which is removed. For
exception safety reasons, before pushing an undo log entry, we reserve
space in the log by calling std::vector::reserve(size() + 1). This is
O(N) where N is the number of undo log entries. Therefore, the whole
application is O(N^2).

This can cause reactor stalls and availability issues when replicas
apply such deletions.

This patch avoids the problem by reserving exponentially increasing
amount of space. Also, to avoid large allocations, switches the
container to chunked_vector.

Fixes #11211