### PR TITLE
gms: gossiper: include nodes with empty feature sets when calculating…

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2435,9 +2435,8 @@ std::set<sstring> gossiper::get_supported_features(const std::unordered_map<gms:
         auto features = feature_service::to_feature_set(x.second);
         if (features.empty()) {
             logger.warn("Loaded empty features for peer node {}", x.first);
-        } else {
-            features_map.emplace(x.first, std::move(features));
         }
+        features_map.emplace(x.first, std::move(features));
     }
 
     for (auto& x : _endpoint_state_map) {
@@ -2451,8 +2450,11 @@ std::set<sstring> gossiper::get_supported_features(const std::unordered_map<gms:
             auto it = loaded_peer_features.find(endpoint);
             if (it != loaded_peer_features.end()) {
                 logger.info("Node {} does not contain SUPPORTED_FEATURES in gossip, using features saved in system table, features={}", endpoint, feature_service::to_feature_set(it->second));
+                // `features_map` was updated above for this case.
             } else {
                 logger.warn("Node {} does not contain SUPPORTED_FEATURES in gossip or system table", endpoint);
+                // The intersection (`common_features`) will be empty. We can return early.
+                return {};
             }
         } else {
             // Replace the features with live info


### PR DESCRIPTION
… enabled features

Right now, if there's a node for which we don't know the features
supported by this node (they are neither persisted locally, nor gossiped
by that node), we would skip this node in calculating the set
of enabled features and potentially enable a feature which shouldn't be
enabled - because that node may not know it. We should only enable a
feature when we know that all nodes have upgraded and know the feature.

This bug caused us problems when we tried to move RAFT out of
experimental. There are dtests such as `partitioner_tests.py` in which
nodes would enable features prematurely, which caused the Raft upgrade
procedure to break (the procedure starts only when all nodes upgrade
and announce that they know the SUPPORTS_RAFT cluster feature).