### PR TITLE
Add support to split large partitions across SSTables

### DIFF
--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -153,6 +153,8 @@ struct compaction_descriptor {
     int level;
     // Threshold size for sstable(s) to be created.
     uint64_t max_sstable_bytes;
+    // Can split large partitions at clustering boundary.
+    bool can_split_large_partition = false;
     // Run identifier of output sstables.
     sstables::run_id run_identifier;
     // The options passed down to the compaction code.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -353,8 +353,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_large_cell_warning_threshold_mb()*1024*1024,
               _cfg.compaction_rows_count_warning_threshold()))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker))
-    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
+    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1284,7 +1284,27 @@ stop_iteration writer::consume(clustering_row&& cr) {
     ensure_tombstone_is_written();
     ensure_static_row_is_written_if_needed();
     write_clustered(cr);
-    return stop_iteration::no;
+
+    auto can_split_partition_at_clustering_boundary = [this] {
+        // will allow size limit to be exceeded for 10%, so we won't perform unnecessary split
+        // of a partition which crossed the limit by a small margin.
+        uint64_t size_threshold = [this] {
+            const uint64_t max_size = std::numeric_limits<uint64_t>::max();
+            if (_cfg.max_sstable_size == max_size) {
+                return max_size;
+            }
+            uint64_t threshold_goal = _cfg.max_sstable_size * 1.1;
+            // handle overflow.
+            return threshold_goal < _cfg.max_sstable_size ? max_size : threshold_goal;
+        }();
+        // Check there are enough promoted index entries, meaning that current fragment won't
+        // unnecessarily cut the current partition in the middle.
+        bool has_enough_promoted_index_entries = _pi_write_m.promoted_index_size >= 2;
+
+        return get_data_offset() > size_threshold && has_enough_promoted_index_entries;
+    };
+
+    return stop_iteration(can_split_partition_at_clustering_boundary());
 }
 
 // Write clustering prefix along with its bound kind and, if not full, its size

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -40,8 +40,7 @@ bool sstable_run::will_introduce_overlapping(const shared_sstable& sst) const {
         auto less_cmp = [s = s1->get_schema()] (const dht::decorated_key& k1, const dht::decorated_key& k2) {
             return k1.less_compare(*s, k2);
         };
-        return less_cmp(s1->get_first_decorated_key(), s2->get_first_decorated_key()) &&
-               less_cmp(s1->get_last_decorated_key(), s2->get_first_decorated_key());
+        return less_cmp(s1->get_last_decorated_key(), s2->get_first_decorated_key());
     };
     // lower bound will be the 1st element which is not *all* before the candidate sstable.
     // upper bound will be the 1st element which the candidate sstable is *all* before.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1183,6 +1183,86 @@ void sstable::set_position_range() {
     _position_range = position_range(pip(min_elements, bound_kind::incl_start), pip(max_elements, bound_kind::incl_end));
 }
 
+future<std::optional<position_in_partition>>
+sstable::find_first_position_in_partition(reader_permit permit, const dht::decorated_key& key, bool reversed, const io_priority_class& pc) {
+    using position_in_partition_opt = std::optional<position_in_partition>;
+    class position_finder {
+        position_in_partition_opt& _pos;
+        bool _reversed;
+    private:
+        // If consuming in reversed mode, range_tombstone_change or clustering_row will have
+        // its bound weight reversed, so we need to revert it here so the returned position
+        // can be correctly used to mark the end bound.
+        void on_position_found(position_in_partition&& pos, bool reverse_pos = false) {
+            _pos = reverse_pos ? std::move(pos).reversed() : std::move(pos);
+        }
+    public:
+        position_finder(position_in_partition_opt& pos, bool reversed) noexcept : _pos(pos), _reversed(reversed) {}
+
+        void consume_new_partition(const dht::decorated_key& dk) {}
+
+        stop_iteration consume(tombstone t) {
+            // Handle case partition contains only a partition_tombstone, so position_in_partition
+            // for this key should be before all rows.
+            on_position_found(position_in_partition::before_all_clustered_rows());
+            return stop_iteration::no;
+        }
+
+        stop_iteration consume(range_tombstone_change&& rt) {
+            on_position_found(std::move(std::move(rt)).position(), _reversed);
+            return stop_iteration::yes;
+        }
+
+        stop_iteration consume(clustering_row&& cr) {
+            on_position_found(position_in_partition::for_key(std::move(cr.key())), _reversed);
+            return stop_iteration::yes;
+        }
+
+        stop_iteration consume(static_row&& sr) {
+            on_position_found(position_in_partition(sr.position()));
+            // If reversed == true, we shouldn't stop at static row as we want to find the last row.
+            // We don't want to ignore its position, to handle the case where partition contains only static row.
+            return stop_iteration(!_reversed);
+        }
+
+        stop_iteration consume_end_of_partition() {
+            // Handle case where partition has no rows.
+            if (!_pos) {
+                on_position_found(_reversed ? position_in_partition::after_all_clustered_rows() : position_in_partition::before_all_clustered_rows());
+            }
+            return stop_iteration::yes;
+        }
+
+        mutation_opt consume_end_of_stream() {
+            return std::nullopt;
+        }
+    };
+
+    auto pr = dht::partition_range::make_singular(key);
+    auto s = get_schema();
+    auto full_slice = s->full_slice();
+    if (reversed) {
+        s = s->make_reversed();
+        full_slice.options.set(query::partition_slice::option::reversed);
+    }
+    auto r = make_reader(s, std::move(permit), pr, full_slice, pc, {}, streamed_mutation::forwarding::no,
+                         mutation_reader::forwarding::no /* to avoid reading past the partition end */);
+
+    position_in_partition_opt ret = std::nullopt;
+    position_finder finder(ret, reversed);
+    std::exception_ptr ex;
+    try {
+        co_await r.consume(finder);
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await r.close();
+    if (ex) {
+        co_await coroutine::exception(std::move(ex));
+    }
+    co_return std::move(ret);
+}
+
 double sstable::estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const {
     auto& st = get_stats_metadata();
     auto estimated_count = st.estimated_cells_count.mean() * st.estimated_cells_count.count();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -462,7 +462,7 @@ public:
      * The lower bound is inclusive: there might be a clustering row with position equal to min_position.
      */
     const position_in_partition& min_position() const {
-        return _position_range.start();
+        return _min_max_position_range.start();
     }
 
     /* Similar to min_position, but returns an upper-bound.
@@ -473,7 +473,7 @@ public:
      * occuring in the sstable (across all partitions).
      */
     const position_in_partition& max_position() const {
-        return _position_range.end();
+        return _min_max_position_range.end();
     }
 
 private:
@@ -499,7 +499,7 @@ private:
     uint64_t _filter_file_size = 0;
     uint64_t _bytes_on_disk = 0;
     db_clock::time_point _data_file_write_time;
-    position_range _position_range = position_range::all_clustered_rows();
+    position_range _min_max_position_range = position_range::all_clustered_rows();
     std::vector<unsigned> _shards;
     std::optional<dht::decorated_key> _first;
     std::optional<dht::decorated_key> _last;
@@ -620,7 +620,7 @@ private:
     // Create a position range based on the min/max_column_names metadata of this sstable.
     // It does nothing if schema defines no clustering key, and it's supposed
     // to be called when loading an existing sstable or after writing a new one.
-    void set_position_range();
+    void set_min_max_position_range();
 
     future<> create_data() noexcept;
 
@@ -856,7 +856,7 @@ public:
     // false => there are no partition tombstones, true => we don't know
     bool may_have_partition_tombstones() const {
         return !has_correct_min_max_column_names()
-            || _position_range.is_all_clustered_rows(*_schema);
+            || _min_max_position_range.is_all_clustered_rows(*_schema);
     }
 
     // Return the large_data_stats_entry identified by large_data_type

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -476,6 +476,13 @@ public:
         return _min_max_position_range.end();
     }
 
+    const position_in_partition& first_partition_first_position() const noexcept {
+        return _first_partition_first_position;
+    }
+
+    const position_in_partition& last_partition_last_position() const noexcept {
+        return _last_partition_last_position;
+    }
 private:
     size_t sstable_buffer_size;
 
@@ -500,6 +507,8 @@ private:
     uint64_t _bytes_on_disk = 0;
     db_clock::time_point _data_file_write_time;
     position_range _min_max_position_range = position_range::all_clustered_rows();
+    position_in_partition _first_partition_first_position = position_in_partition::before_all_clustered_rows();
+    position_in_partition _last_partition_last_position = position_in_partition::after_all_clustered_rows();
     std::vector<unsigned> _shards;
     std::optional<dht::decorated_key> _first;
     std::optional<dht::decorated_key> _last;
@@ -621,6 +630,10 @@ private:
     // It does nothing if schema defines no clustering key, and it's supposed
     // to be called when loading an existing sstable or after writing a new one.
     void set_min_max_position_range();
+
+    // Loads first position of the first partition, and last position of the last
+    // partition. Does nothing if schema defines no clustering key.
+    future<> load_first_and_last_position_in_partition();
 
     future<> create_data() noexcept;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -625,6 +625,13 @@ private:
     future<> create_data() noexcept;
 
 public:
+    // Finds first position_in_partition in a given partition.
+    // If reversed is false, then the first position is actually the first row (can be the static one).
+    // If reversed is true, then the first position is the last row (can be static if partition has a single static row).
+    future<std::optional<position_in_partition>>
+    find_first_position_in_partition(reader_permit permit, const dht::decorated_key& key, bool reversed,
+            const io_priority_class& pc = default_priority_class());
+
     // Return an input_stream which reads exactly the specified byte range
     // from the data file (after uncompression, if the file is compressed).
     // Unlike data_read() below, this method does not read the entire byte

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -19,8 +19,13 @@ namespace sstables {
 logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
-    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct)
-    : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct) {
+    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory)
+    : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
+    , _sstable_metadata_concurrency_sem(
+        max_count_sstable_metadata_concurrent_reads,
+        max_memory_sstable_metadata_concurrent_reads(available_memory),
+        "sstable_metadata_concurrency_sem",
+        std::numeric_limits<size_t>::max()) {
 }
 
 sstables_manager::~sstables_manager() {
@@ -94,7 +99,8 @@ void sstables_manager::maybe_done() {
 future<> sstables_manager::close() {
     _closing = true;
     maybe_done();
-    return _done.get_future();
+    co_await _done.get_future();
+    co_await _sstable_metadata_concurrency_sem.stop();
 }
 
 }   // namespace sstables

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -61,9 +61,8 @@ SEASTAR_TEST_CASE(test_empty_index) {
                  .with_column("val", int32_type)
                  .set_compressor_params(compression_parameters::no_compression())
                  .build();
-    sstable_ptr sstp = env.reusable_sst(s, "test/resource/sstables/empty_index", 36, sstable_version_types::mc).get0();
-    auto fut = sstables::test(sstp).read_indexes(env.make_reader_permit());
-    BOOST_REQUIRE_EXCEPTION(fut.get(), malformed_sstable_exception, exception_predicate::message_matches(
+    future<sstable_ptr> fut = env.reusable_sst(s, "test/resource/sstables/empty_index", 36, sstable_version_types::mc);
+    BOOST_REQUIRE_EXCEPTION(fut.get0(), malformed_sstable_exception, exception_predicate::message_matches(
         "index_consume_entry_context \\(state=.*\\): cannot finish parsing current entry, no more data in sstable test/resource/sstables/empty_index/mc-36-big-Index.db"));
   });
 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5190,7 +5190,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
-    sstables_manager manager(handler, test_db_config, test_feature_service, tracker);
+    sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
     auto stop_manager = defer([&] { manager.close().get(); });
     tmpdir dir;
     auto sst = manager.make_sstable(
@@ -5250,7 +5250,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
-    sstables_manager manager(handler, test_db_config, test_feature_service, tracker);
+    sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
     auto close_manager = defer([&] { manager.close().get(); });
     tmpdir dir;
     auto sst = manager.make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1064,42 +1064,6 @@ SEASTAR_TEST_CASE(check_overlapping) {
   });
 }
 
-SEASTAR_TEST_CASE(sstable_run_disjoint_invariant_test) {
-    return test_env::do_with([] (test_env& env) {
-        simple_schema ss;
-        auto s = ss.schema();
-
-        auto key_and_token_pair = token_generation_for_current_shard(6);
-        auto next_gen = [gen = make_lw_shared<unsigned>(1)] { return (*gen)++; };
-
-        sstables::sstable_run run;
-
-        auto insert = [&] (int first_key_idx, int last_key_idx) {
-            auto sst = sstable_for_overlapping_test(env, s, next_gen(),
-                key_and_token_pair[first_key_idx].first, key_and_token_pair[last_key_idx].first);
-            return run.insert(sst);
-        };
-
-        // insert ranges [0, 0], [1, 1], [3, 4]
-        BOOST_REQUIRE(insert(0, 0) == true);
-        BOOST_REQUIRE(insert(1, 1) == true);
-        BOOST_REQUIRE(insert(3, 4) == true);
-        BOOST_REQUIRE(run.all().size() == 3);
-
-        // check overlapping candidates won't be inserted
-        BOOST_REQUIRE(insert(0, 4) == false);
-        BOOST_REQUIRE(insert(4, 5) == false);
-        BOOST_REQUIRE(run.all().size() == 3);
-
-        // check non-overlapping candidates will be inserted
-        BOOST_REQUIRE(insert(2, 2) == true);
-        BOOST_REQUIRE(insert(5, 5) == true);
-        BOOST_REQUIRE(run.all().size() == 5);
-
-        return make_ready_future<>();
-    });
-}
-
 SEASTAR_TEST_CASE(tombstone_purge_test) {
     BOOST_REQUIRE(smp::count == 1);
     return test_env::do_with_async([] (test_env& env) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5072,3 +5072,140 @@ SEASTAR_TEST_CASE(test_compaction_strategy_cleanup_method) {
         run_cleanup_strategy_test(sstables::compaction_strategy_type::leveled, 64, empty_opts, 0ms, 1);
     });
 }
+
+SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
+    return test_env::do_with_async([] (test_env& env) {
+        auto builder = schema_builder("tests", "test_large_partition_splitting_on_compaction")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("cl", int32_type, column_kind::clustering_key)
+                .with_column("value", int32_type);
+        builder.set_compressor_params(compression_parameters::no_compression());
+        builder.set_gc_grace_seconds(0); // Don't purge any tombstone
+        auto s = builder.build();
+
+        using namespace std::chrono;
+        auto next_timestamp = [] (std::chrono::seconds step = 0s) {
+            return (gc_clock::now().time_since_epoch() + duration_cast<microseconds>(step)).count();
+        };
+        auto tmp = tmpdir();
+        auto sst_gen = [&env, s, &tmp, gen = make_lw_shared<unsigned>(1)] () mutable {
+            return env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
+        };
+        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto pkey = partition_key::from_exploded(*s, {to_bytes(tokens[0].first)});
+        column_family_for_tests cf(env.manager(), s);
+        auto close_cf = deferred_stop(cf);
+
+        auto get_next_ckey = [&] {
+            static thread_local int32_t row_value = 1;
+            return clustering_key::from_exploded(*s, {int32_type->decompose(row_value++)});
+        };
+
+        auto make_row = [&] () {
+            mutation m(s, pkey);
+            auto c_key = get_next_ckey();
+            // Use a step to make sure that rows aren't covered by tombstone.
+            m.set_clustered_cell(c_key, bytes("value"), data_value(int32_t(0)), next_timestamp(seconds(3600)));
+            return m;
+        };
+
+        auto make_open_ended_range_tombstone = [&] () {
+            mutation m(s, pkey);
+            tombstone tomb(api::new_timestamp(), gc_clock::now());
+            auto start_key = get_next_ckey();
+            auto start_bound = bound_view(start_key, bound_kind::incl_start);
+            auto end_bound = bound_view::top();
+            range_tombstone rt(start_bound,
+                    end_bound,
+                    tomb);
+            m.partition().apply_delete(*s, std::move(rt));
+            return m;
+        };
+
+        auto deletion_mut = [&] () {
+            mutation m(s, pkey);
+            tombstone tomb(next_timestamp(), gc_clock::now());
+            m.partition().apply(tomb);
+            return m;
+        }();
+
+        std::vector<mutation> mutations;
+        static constexpr size_t rows = 20;
+        mutations.reserve(1 + rows);
+        mutations.push_back(std::move(deletion_mut));
+
+        for (size_t i = 0; i < rows; i++) {
+            mutations.push_back(make_row());
+            mutations.push_back(make_open_ended_range_tombstone());
+        }
+
+        auto sst = make_sstable_containing(sst_gen, std::move(mutations));
+
+        auto desc = sstables::compaction_descriptor({ sst }, default_priority_class());
+        // With max_sstable_bytes of 1, we'll perform the splitting of the partition as soon as possible.
+        desc.max_sstable_bytes = 1;
+        desc.can_split_large_partition = true;
+        // Set block size to 1, so promoted index is generated for every row written, allowing the split to happen as soon as possible.
+        env.manager().set_promoted_index_block_size(1);
+
+        auto ret = compact_sstables(cf.get_compaction_manager(), std::move(desc), *cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get0();
+
+        testlog.info("Large partition splitting on compaction created {} sstables", ret.new_sstables.size());
+        BOOST_REQUIRE(ret.new_sstables.size() > 1);
+
+        sstable_run sst_run;
+
+        std::optional<range_tombstone_entry> last_rt;
+        std::optional<position_in_partition> last_pos;
+        position_in_partition::tri_compare pos_tri_cmp(*s);
+
+        for (auto& sst : ret.new_sstables) {
+            BOOST_REQUIRE(sst->may_have_partition_tombstones());
+
+            auto reader = sstable_reader(sst, s, env.make_reader_permit());
+
+            mutation_opt m = read_mutation_from_flat_mutation_reader(reader).get0();
+            BOOST_REQUIRE(m);
+            BOOST_REQUIRE(m->key().equal(*s, pkey));
+            // ASSERT that partition tobmstone is replicated to every fragment.
+            BOOST_REQUIRE(m->partition().partition_tombstone());
+            auto rows = m->partition().clustered_rows();
+            BOOST_REQUIRE(rows.calculate_size() >= 1);
+            auto& row = rows.begin()->row();
+            auto& cells = row.cells();
+            BOOST_REQUIRE_EQUAL(cells.size(), 1);
+            auto& cdef = *s->get_column_definition("value");
+            BOOST_REQUIRE(cells.cell_at(cdef.id).as_atomic_cell(cdef).is_live());
+
+            testlog.info("SSTable of generation {} has position range [{}, {}]", sst->generation(), sst->first_partition_first_position(), sst->last_partition_last_position());
+
+            // Check that if we split partition with active range tombstone, check we will issue properly
+            // the end bound in fragment A and re-emit it as start bound in fragment B.
+            // Fragment A will contain range [r1, r2]
+            // And fragment B will contain range (r2, ...]
+            // assuming the split happened when last position was r2.
+            auto& current_first_rt = *m->partition().row_tombstones().begin();
+            if (auto previous_last_rt = std::exchange(last_rt, *m->partition().row_tombstones().rbegin())) {
+                testlog.info("\tprevious last rt's end bound: {}", previous_last_rt->end_bound());
+                testlog.info("\tcurrent first rt's start bound: {}", current_first_rt.start_bound());
+                BOOST_REQUIRE(previous_last_rt->end_bound().prefix() == current_first_rt.start_bound().prefix());
+                BOOST_REQUIRE(previous_last_rt->end_bound().kind() == bound_kind::incl_end);
+                BOOST_REQUIRE(current_first_rt.start_bound().kind() == bound_kind::excl_start);
+            }
+            const auto& current_first_pos = sst->first_partition_first_position();
+            if (auto previous_last_pos = std::exchange(last_pos, sst->last_partition_last_position())) {
+                testlog.info("\tprevious last pos: {}", previous_last_pos);
+                testlog.info("\tcurrent first pos: {}", current_first_pos);
+                BOOST_REQUIRE(pos_tri_cmp(*previous_last_pos, current_first_pos) == 0);
+            }
+
+            BOOST_REQUIRE(!(reader)().get0());
+
+            reader.close().get();
+
+            // CHECK that all fragments generated by compaction are disjoint.
+            BOOST_REQUIRE(sst_run.insert(sst) == true);
+        }
+
+    });
+}

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -35,7 +35,7 @@ class test_env {
         reader_concurrency_semaphore semaphore;
 
         impl()
-            : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker)
+            : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
             , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
         { }
         impl(impl&&) = delete;

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -22,9 +22,18 @@ namespace sstables {
 
 class test_env_sstables_manager : public sstables_manager {
     using sstables_manager::sstables_manager;
+    std::optional<size_t> _promoted_index_block_size;
 public:
     virtual sstable_writer_config configure_writer(sstring origin = "test") const override {
-        return sstables_manager::configure_writer(std::move(origin));
+        auto ret = sstables_manager::configure_writer(std::move(origin));
+        if (_promoted_index_block_size) {
+            ret.promoted_index_block_size = *_promoted_index_block_size;
+        }
+        return ret;
+    }
+
+    void set_promoted_index_block_size(size_t promoted_index_block_size) {
+        _promoted_index_block_size = promoted_index_block_size;
     }
 };
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3200,7 +3200,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
             cache_tracker tracker;
             dbcfg.host_id = locator::host_id::create_random_id();
-            sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker);
+            sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory());
             auto close_sst_man = deferred_close(sst_man);
 
             std::vector<sstables::shared_sstable> sstables;


### PR DESCRIPTION
Introduces support to split large partitions during compaction. Today, compaction can only split input data at partition boundary, so a large partition is stored in a single file. But that can cause many problems, like memory pressure (e.g.: https://github.com/scylladb/scylladb/issues/4217), and incremental compaction can also not fulfill its promise as the file storing the large partition can only be released once exhausted.

The first step was to add clustering range metadata for first and last partition keys (retrieved from promoted index), which is crucial to determine disjointness at clustering level, and also the order at which the disjoint files should be opened for incremental reading.

The second step was to extend sstable_run to look at clustering dimension, so a set of files storing disjoint ranges for the same partition can live in the same sstable run.

The final step was to introduce the option for compaction to split large partition being written if it has exceeded the size threshold.

What's next? Following this series, a reader will be implemented for sstable_run that will incrementally open the readers. It can be safely built on the assumption of the disjoint invariant after the second step aforementioned.