### PR TITLE
configure.py: add date-stamp parameter

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 USAGE=$(cat <<-END
-Usage: $(basename "$0") [-h|--help] [-o|--output-dir PATH] -- generate Scylla version and build information files.
+Usage: $(basename "$0") [-h|--help] [-o|--output-dir PATH] [--date-stamp DATE] -- generate Scylla version and build information files.
 
 Options:
   -h|--help show this help message.
   -o|--output-dir PATH specify destination path at which the version files are to be created.
+  -d|--date-stamp DATE manually set date for release parameter
 
 By default, the script will attempt to parse 'version' file
 in the current directory, which should contain a string of
@@ -31,6 +32,8 @@ using '-o PATH' option.
 END
 )
 
+DATE=""
+
 while [[ $# -gt 0 ]]; do
 	opt="$1"
 	case $opt in
@@ -40,6 +43,11 @@ while [[ $# -gt 0 ]]; do
 			;;
 		-o|--output-dir)
 			OUTPUT_DIR="$2"
+			shift
+			shift
+			;;
+		--date-stamp)
+			DATE="$2"
 			shift
 			shift
 			;;
@@ -58,6 +66,10 @@ if [ -z "$OUTPUT_DIR" ]; then
 	OUTPUT_DIR="$SCRIPT_DIR/build"
 fi
 
+if [ -z "$DATE" ]; then
+  DATE=$(date --utc +%Y%m%d)
+fi
+
 # Default scylla product/version tags
 PRODUCT=scylla
 VERSION=5.2.0-dev
@@ -67,7 +79,6 @@ then
 	SCYLLA_VERSION=$(cat version | awk -F'-' '{print $1}')
 	SCYLLA_RELEASE=$(cat version | awk -F'-' '{print $2}')
 else
-	DATE=$(date --utc +%Y%m%d)
 	GIT_COMMIT=$(git -C "$SCRIPT_DIR" log --pretty=format:'%h' -n 1 --abbrev=12)
 	SCYLLA_VERSION=$VERSION
 	# For custom package builds, replace "0" with "counter.your_name",

--- a/configure.py
+++ b/configure.py
@@ -652,6 +652,8 @@ arg_parser.add_argument('--clang-inline-threshold', action='store', type=int, de
                         help="LLVM-specific inline threshold compilation parameter")
 arg_parser.add_argument('--list-artifacts', dest='list_artifacts', action='store_true', default=False,
                         help='List all available build artifacts, that can be passed to --with')
+arg_parser.add_argument('--date-stamp', dest='date_stamp', type=str,
+                        help='Set datestamp for SCYLLA-VERSION-GEN')
 args = arg_parser.parse_args()
 
 if args.list_artifacts:
@@ -1536,7 +1538,8 @@ if args.artifacts:
 else:
     build_artifacts = all_artifacts
 
-status = subprocess.call("./SCYLLA-VERSION-GEN")
+date_stamp = f"--date-stamp {args.date_stamp}" if args.date_stamp else ""
+status = subprocess.call(f"./SCYLLA-VERSION-GEN {date_stamp}", shell=True)
 if status != 0:
     print('Version file generation failed')
     sys.exit(1)


### PR DESCRIPTION
When starting `Build` job we have a situation when `x86` and `arm` starting in different dates causing the all process to fail

As suggested by @avikivity , adding a date-stamp parameter and will pass it through downstream jobs to get one release for each job

Ref: https://github.com/scylladb/scylla-pkg/pull/3008