### PR TITLE
Revert "Merge "memtable-sstable: Add compacting reader when flushing memtable." from Mikołaj"

### DIFF
--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1037,14 +1037,12 @@ struct mutation_application_stats {
     uint64_t row_writes = 0;
     uint64_t rows_compacted_with_tombstones = 0;
     uint64_t rows_dropped_by_tombstones = 0;
-    bool has_any_tombstones = false;
 
     mutation_application_stats& operator+=(const mutation_application_stats& other) {
         row_hits += other.row_hits;
         row_writes += other.row_writes;
         rows_compacted_with_tombstones += other.rows_compacted_with_tombstones;
         rows_dropped_by_tombstones += other.rows_dropped_by_tombstones;
-        has_any_tombstones |= other.has_any_tombstones;
         return *this;
     }
 };

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -839,10 +839,6 @@ bool memtable::is_flushed() const noexcept {
     return bool(_underlying);
 }
 
-bool memtable::has_any_tombstones() const noexcept {
-    return _table_stats.memtable_app_stats.has_any_tombstones;
-}
-
 void memtable_entry::upgrade_schema(const schema_ptr& s, mutation_cleaner& cleaner) {
     if (_schema != s) {
         partition().upgrade(_schema, s, cleaner, no_cache_tracker);

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -219,8 +219,6 @@ public:
     mutation_cleaner& cleaner() noexcept {
         return _cleaner;
     }
-    bool has_any_tombstones() const noexcept;
-
 public:
     memtable_list* get_memtable_list() noexcept {
         return _memtable_list;


### PR DESCRIPTION
This reverts commit bcadd8229b0345c50494e33ed4b3b7e3bd21cd85, reversing
changes made to cf528d7df96af1435f256fd6c35f0a94ba451508. Since
4bd4aa2e887278c4912f65b80548faaad4e05951 ("Merge 'memtable, cache: Eagerly
compact data with tombstones' from Tomasz Grabiec"), memtable is
self-compacting and the extra compaction step only reduces throughput.

The unit test in memtable_test.cc is not reverted as proof that the
revert does not cause a regression.