### PR TITLE
storage_service: Prevent removed node to restart and join the cluster

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -364,6 +364,7 @@ public:
 
     bool is_gossip_only_member(inet_address endpoint);
     bool is_safe_for_bootstrap(inet_address endpoint);
+    bool is_safe_for_restart(inet_address endpoint, utils::UUID host_id);
 private:
     /**
      * Returns true if the chosen target was also a seed. False otherwise


### PR DESCRIPTION
1) Start node1,2,3
2) Stop node3
3) Run nodetool removenode $host_id_of_node3
4) Restart node3

Step 4 is wrong and not allowed. If it happens it will bring back node3
to the cluster.

This patch adds a check during node restart to detect such operation
error and reject the restart.

With this patch, we would see the following in step 4.

```
init - Startup failed: std::runtime_error (The node 127.0.0.3 with
host_id fa7e500a-8617-4de4-8efd-a0e177218ee8 is removed from the
cluster. Can not restart the removed node to join the cluster again!)
```

Refs #11217