### PR TITLE
docs: debugging: mention use of release number on backtrace.scylladb.com

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -327,8 +327,11 @@ Or from the executable like this:
 
     $ eu-unstrip -n --exec $executable
 
-With the build-id you can find the relocatable using the
-http://backtrace.scylladb.com/index.html search form.
+You can find the relocatable using the
+http://backtrace.scylladb.com/index.html search form
+using either the scylla Build ID or the Release number (e.g. 5.0.0 or 2022.1)
+to search the packages.
+
 The form can also be used to decode backtraces generated
 by the corresponding scylla binary.
 


### PR DESCRIPTION
Following scylladb/scylla_s3_reloc_server@af17e4ffcde211bfd91ce7b14ea9165b25d608ee
(scylladb/scylla_s3_reloc_server#28), the release number can
be used to search the relcatable package and/or decode a respective
backtrace.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>