### PR TITLE
Initialize `storage_proxy` early, without `messaging_service` and `gossiper`

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1008,9 +1008,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_stats();
                 reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_split_metrics_local();
             };
-            proxy.start(std::ref(db), std::ref(gossiper), spcfg, std::ref(node_backlog),
+            proxy.start(std::ref(db), spcfg, std::ref(node_backlog),
                     scheduling_group_key_create(storage_proxy_stats_cfg).get0(),
-                    std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory), std::ref(messaging)).get();
+                    std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
             supervisor::notify("starting forward service");
             forward_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();
             auto stop_forward_service_handlers = defer_verbose_shutdown("forward service", [&forward_service] {
@@ -1214,8 +1214,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 mm.init_messaging_service();
             }).get();
             supervisor::notify("initializing storage proxy RPC verbs");
-            proxy.invoke_on_all([&mm] (service::storage_proxy& proxy) {
-                proxy.init_messaging_service(&mm.local());
+            proxy.invoke_on_all([&messaging, &gossiper, &mm] (service::storage_proxy& proxy) {
+                proxy.init_messaging_service(messaging.local(), gossiper.local(), mm.local());
             }).get();
             auto stop_proxy_handlers = defer_verbose_shutdown("storage proxy RPC verbs", [&proxy] {
                 proxy.invoke_on_all(&service::storage_proxy::uninit_messaging_service).get();

--- a/main.cc
+++ b/main.cc
@@ -728,6 +728,76 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 mm_notifier.stop().get();
             });
 
+            supervisor::notify("starting per-shard database core");
+
+            sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
+            auto stop_sst_dir_sem = defer_verbose_shutdown("sst_dir_semaphore", [&sst_dir_semaphore] {
+                sst_dir_semaphore.stop().get();
+            });
+
+            service_memory_limiter.start(memory::stats().total_memory()).get();
+            auto stop_mem_limiter = defer_verbose_shutdown("service_memory_limiter", [&service_memory_limiter] {
+                // Uncomment this once services release all the memory on stop
+                // service_memory_limiter.stop().get();
+            });
+
+            supervisor::notify("creating and verifying directories");
+            utils::directories::set dir_set;
+            dir_set.add(cfg->data_file_directories());
+            dir_set.add(cfg->commitlog_directory());
+            dirs.emplace(cfg->developer_mode());
+            dirs->create_and_verify(std::move(dir_set)).get();
+
+            auto hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->hints_directory()).get();
+            auto view_hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->view_hints_directory()).get();
+            if (!hinted_handoff_enabled.is_disabled_for_all()) {
+                hints_dir_initializer.ensure_created_and_verified().get();
+            }
+            view_hints_dir_initializer.ensure_created_and_verified().get();
+
+            // Note: changed from using a move here, because we want the config object intact.
+            replica::database_config dbcfg;
+            dbcfg.compaction_scheduling_group = make_sched_group("compaction", 1000);
+            dbcfg.memory_compaction_scheduling_group = make_sched_group("mem_compaction", 1000);
+            dbcfg.streaming_scheduling_group = maintenance_scheduling_group;
+            dbcfg.statement_scheduling_group = make_sched_group("statement", 1000);
+            dbcfg.memtable_scheduling_group = make_sched_group("memtable", 1000);
+            dbcfg.memtable_to_cache_scheduling_group = make_sched_group("memtable_to_cache", 200);
+            dbcfg.gossip_scheduling_group = make_sched_group("gossip", 1000);
+            dbcfg.available_memory = memory::stats().total_memory();
+
+            supervisor::notify("starting compaction_manager");
+            // get_cm_cfg is called on each shard when starting a sharded<compaction_manager>
+            // we need the getter since updateable_value is not shard-safe (#7316)
+            auto get_cm_cfg = sharded_parameter([&] {
+                return compaction_manager::config {
+                    .compaction_sched_group = compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group, service::get_local_compaction_priority()},
+                    .maintenance_sched_group = compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group, service::get_local_streaming_priority()},
+                    .available_memory = dbcfg.available_memory,
+                    .static_shares = cfg->compaction_static_shares,
+                    .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
+                };
+            });
+            cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source())).get();
+            auto stop_cm = deferred_stop(cm);
+
+            supervisor::notify("starting database");
+            debug::the_database = &db;
+            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
+                    std::ref(cm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+            auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
+                // #293 - do not stop anything - not even db (for real)
+                //return db.stop();
+                // call stop on each db instance, but leave the shareded<database> pointers alive.
+                db.invoke_on_all(&replica::database::stop).get();
+            });
+
+            // We need to init commitlog on shard0 before it is inited on other shards
+            // because it obtains the list of pre-existing segments for replay, which must
+            // not include reserve segments created by active commitlogs.
+            db.local().init_commitlog().get();
+            db.invoke_on_all(&replica::database::start).get();
+
             supervisor::notify("starting lifecycle notifier");
             lifecycle_notifier.start().get();
             // storage_service references this notifier and is not stopped yet
@@ -756,17 +826,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             startlog.info("Scylla API server listening on {}:{} ...", api_addr, cfg->api_port());
 
             api::set_server_config(ctx, *cfg).get();
-
-            // Note: changed from using a move here, because we want the config object intact.
-            replica::database_config dbcfg;
-            dbcfg.compaction_scheduling_group = make_sched_group("compaction", 1000);
-            dbcfg.memory_compaction_scheduling_group = make_sched_group("mem_compaction", 1000);
-            dbcfg.streaming_scheduling_group = maintenance_scheduling_group;
-            dbcfg.statement_scheduling_group = make_sched_group("statement", 1000);
-            dbcfg.memtable_scheduling_group = make_sched_group("memtable", 1000);
-            dbcfg.memtable_to_cache_scheduling_group = make_sched_group("memtable_to_cache", 200);
-            dbcfg.gossip_scheduling_group = make_sched_group("gossip", 1000);
-            dbcfg.available_memory = memory::stats().total_memory();
 
             netw::messaging_service::config mscfg;
 
@@ -902,33 +961,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.stop().get();
             });
 
-            supervisor::notify("starting per-shard database core");
-
-            sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
-            auto stop_sst_dir_sem = defer_verbose_shutdown("sst_dir_semaphore", [&sst_dir_semaphore] {
-                sst_dir_semaphore.stop().get();
-            });
-
-            service_memory_limiter.start(memory::stats().total_memory()).get();
-            auto stop_mem_limiter = defer_verbose_shutdown("service_memory_limiter", [&service_memory_limiter] {
-                // Uncomment this once services release all the memory on stop
-                // service_memory_limiter.stop().get();
-            });
-
-            supervisor::notify("creating and verifying directories");
-            utils::directories::set dir_set;
-            dir_set.add(cfg->data_file_directories());
-            dir_set.add(cfg->commitlog_directory());
-            dirs.emplace(cfg->developer_mode());
-            dirs->create_and_verify(std::move(dir_set)).get();
-
-            auto hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->hints_directory()).get();
-            auto view_hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->view_hints_directory()).get();
-            if (!hinted_handoff_enabled.is_disabled_for_all()) {
-                hints_dir_initializer.ensure_created_and_verified().get();
-            }
-            view_hints_dir_initializer.ensure_created_and_verified().get();
-
             static sharded<wasm::instance_cache> wasm_instance_cache;
             auto udf_enabled = cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF);
             std::any stop_udf_cache_handlers;
@@ -939,38 +971,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     wasm_instance_cache.stop().get();
                 });
             }
-
-            supervisor::notify("starting compaction_manager");
-            // get_cm_cfg is called on each shard when starting a sharded<compaction_manager>
-            // we need the getter since updateable_value is not shard-safe (#7316)
-            auto get_cm_cfg = sharded_parameter([&] {
-                return compaction_manager::config {
-                    .compaction_sched_group = compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group, service::get_local_compaction_priority()},
-                    .maintenance_sched_group = compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group, service::get_local_streaming_priority()},
-                    .available_memory = dbcfg.available_memory,
-                    .static_shares = cfg->compaction_static_shares,
-                    .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
-                };
-            });
-            cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source())).get();
-            auto stop_cm = deferred_stop(cm);
-
-            supervisor::notify("starting database");
-            debug::the_database = &db;
-            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
-                    std::ref(cm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
-            auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
-                // #293 - do not stop anything - not even db (for real)
-                //return db.stop();
-                // call stop on each db instance, but leave the shareded<database> pointers alive.
-                db.invoke_on_all(&replica::database::stop).get();
-            });
-
-            // We need to init commitlog on shard0 before it is inited on other shards
-            // because it obtains the list of pre-existing segments for replay, which must
-            // not include reserve segments created by active commitlogs.
-            db.local().init_commitlog().get();
-            db.invoke_on_all(&replica::database::start).get();
 
             // Initialization of a keyspace is done by shard 0 only. For system
             // keyspace, the procedure  will go through the hardcoded column

--- a/main.cc
+++ b/main.cc
@@ -798,6 +798,37 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             db.local().init_commitlog().get();
             db.invoke_on_all(&replica::database::start).get();
 
+            smp::invoke_on_all([blocked_reactor_notify_ms] {
+                engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
+            }).get();
+
+            supervisor::notify("starting storage proxy");
+            service::storage_proxy::config spcfg {
+                .hints_directory_initializer = hints_dir_initializer,
+            };
+            spcfg.hinted_handoff_enabled = hinted_handoff_enabled;
+            spcfg.available_memory = memory::stats().total_memory();
+            smp_service_group_config storage_proxy_smp_service_group_config;
+            // Assuming less than 1kB per queued request, this limits storage_proxy submit_to() queues to 5MB or less
+            storage_proxy_smp_service_group_config.max_nonlocal_requests = 5000;
+            spcfg.read_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
+            spcfg.write_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
+            spcfg.hints_write_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
+            spcfg.write_ack_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
+            static db::view::node_update_backlog node_backlog(smp::count, 10ms);
+            scheduling_group_key_config storage_proxy_stats_cfg =
+                    make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
+            storage_proxy_stats_cfg.constructor = [plain_constructor = storage_proxy_stats_cfg.constructor] (void* ptr) {
+                plain_constructor(ptr);
+                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_stats();
+                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_split_metrics_local();
+            };
+            proxy.start(std::ref(db), spcfg, std::ref(node_backlog),
+                    scheduling_group_key_create(storage_proxy_stats_cfg).get0(),
+                    std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
+            // #293 - do not stop anything
+            // engine().at_exit([&proxy] { return proxy.stop(); });
+
             supervisor::notify("starting lifecycle notifier");
             lifecycle_notifier.start().get();
             // storage_service references this notifier and is not stopped yet
@@ -983,42 +1014,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto system_keyspace_sel = db::table_selector::all_in_keyspace(db::system_keyspace::NAME);
             replica::distributed_loader::init_system_keyspace(db, ss, gossiper, *cfg, *system_keyspace_sel).get();
 
-            smp::invoke_on_all([blocked_reactor_notify_ms] {
-                engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
-            }).get();
-
-            supervisor::notify("starting storage proxy");
-            service::storage_proxy::config spcfg {
-                .hints_directory_initializer = hints_dir_initializer,
-            };
-            spcfg.hinted_handoff_enabled = hinted_handoff_enabled;
-            spcfg.available_memory = memory::stats().total_memory();
-            smp_service_group_config storage_proxy_smp_service_group_config;
-            // Assuming less than 1kB per queued request, this limits storage_proxy submit_to() queues to 5MB or less
-            storage_proxy_smp_service_group_config.max_nonlocal_requests = 5000;
-            spcfg.read_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
-            spcfg.write_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
-            spcfg.hints_write_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
-            spcfg.write_ack_smp_service_group = create_smp_service_group(storage_proxy_smp_service_group_config).get0();
-            static db::view::node_update_backlog node_backlog(smp::count, 10ms);
-            scheduling_group_key_config storage_proxy_stats_cfg =
-                    make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
-            storage_proxy_stats_cfg.constructor = [plain_constructor = storage_proxy_stats_cfg.constructor] (void* ptr) {
-                plain_constructor(ptr);
-                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_stats();
-                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_split_metrics_local();
-            };
-            proxy.start(std::ref(db), spcfg, std::ref(node_backlog),
-                    scheduling_group_key_create(storage_proxy_stats_cfg).get0(),
-                    std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
             supervisor::notify("starting forward service");
             forward_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();
             auto stop_forward_service_handlers = defer_verbose_shutdown("forward service", [&forward_service] {
                 forward_service.stop().get();
             });
-
-            // #293 - do not stop anything
-            // engine().at_exit([&proxy] { return proxy.stop(); });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
                 std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -955,6 +955,7 @@ public:
     }
 
     void set_hit_rate(gms::inet_address addr, cache_temperature rate);
+    cache_hit_rate get_my_hit_rate() const;
     cache_hit_rate get_hit_rate(const gms::gossiper& g, gms::inet_address addr);
     void drop_hit_rate(gms::inet_address addr);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1895,9 +1895,13 @@ void table::set_hit_rate(gms::inet_address addr, cache_temperature rate) {
     e.last_updated = lowres_clock::now();
 }
 
+table::cache_hit_rate table::get_my_hit_rate() const {
+    return cache_hit_rate { _global_cache_hit_rate, lowres_clock::now()};
+}
+
 table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, gms::inet_address addr) {
     if (utils::fb_utilities::get_broadcast_address() == addr) {
-        return cache_hit_rate { _global_cache_hit_rate, lowres_clock::now()};
+        return get_my_hit_rate();
     }
     auto it = _cluster_cache_hit_rates.find(addr);
     if (it == _cluster_cache_hit_rates.end()) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2573,7 +2573,7 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, gms::gossiper& 
     _hints_for_views_manager.register_metrics("hints_for_views_manager");
 }
 
-struct storage_proxy::remote& storage_proxy::remote() {
+struct storage_proxy::remote& storage_proxy::remote() const {
     return *_remote;
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -147,26 +147,24 @@ static future<rpc::tuple<Elements..., replica::exception_variant>> encode_replic
 // Without it only local queries are available.
 class storage_proxy::remote {
     storage_proxy& _sp;
-    migration_manager* _mm;
     netw::messaging_service& _ms;
     const gms::gossiper& _gossiper;
+    migration_manager& _mm;
 
     netw::connection_drop_slot_t _connection_dropped;
     netw::connection_drop_registration_t _condrop_registration;
 
+    bool _stopped{false};
+
 public:
-    remote(storage_proxy& sp, netw::messaging_service& ms, gms::gossiper& g)
-        : _sp(sp), _ms(ms), _gossiper(g)
-        , _connection_dropped(std::bind_front(&remote::connection_dropped, this))
-        , _condrop_registration(_ms.when_connection_drops(_connection_dropped))
-    {}
-
-    void init_messaging_service(migration_manager* mm, storage_proxy* sp) {
-        _mm = mm;
-
+    remote(storage_proxy& sp, netw::messaging_service& ms, gms::gossiper& g, migration_manager& mm)
+            : _sp(sp), _ms(ms), _gossiper(g), _mm(mm)
+            , _connection_dropped(std::bind_front(&remote::connection_dropped, this))
+            , _condrop_registration(_ms.when_connection_drops(_connection_dropped))
+    {
         ser::storage_proxy_rpc_verbs::register_counter_mutation(&_ms, std::bind_front(&remote::handle_counter_mutation, this));
-        ser::storage_proxy_rpc_verbs::register_mutation(&_ms, std::bind_front(&remote::receive_mutation_handler, this, sp->_write_smp_service_group));
-        ser::storage_proxy_rpc_verbs::register_hint_mutation(&_ms, [this, sp] <typename... Args>(Args&&... args) { return receive_mutation_handler(sp->_hints_write_smp_service_group, std::forward<Args>(args)..., std::monostate()); });
+        ser::storage_proxy_rpc_verbs::register_mutation(&_ms, std::bind_front(&remote::receive_mutation_handler, this, _sp._write_smp_service_group));
+        ser::storage_proxy_rpc_verbs::register_hint_mutation(&_ms, [this] <typename... Args>(Args&&... args) { return receive_mutation_handler(_sp._hints_write_smp_service_group, std::forward<Args>(args)..., std::monostate()); });
         ser::storage_proxy_rpc_verbs::register_paxos_learn(&_ms, std::bind_front(&remote::handle_paxos_learn, this));
         ser::storage_proxy_rpc_verbs::register_mutation_done(&_ms, std::bind_front(&remote::handle_mutation_done, this));
         ser::storage_proxy_rpc_verbs::register_mutation_failed(&_ms, std::bind_front(&remote::handle_mutation_failed, this));
@@ -180,10 +178,14 @@ public:
         ser::storage_proxy_rpc_verbs::register_paxos_prune(&_ms, std::bind_front(&remote::handle_paxos_prune, this));
     }
 
+    ~remote() {
+        assert(_stopped);
+    }
+
     // Must call before destroying the `remote` object.
     future<> stop() {
         co_await ser::storage_proxy_rpc_verbs::unregister(&_ms);
-        _mm = nullptr;
+        _stopped = true;
     }
 
     const gms::gossiper& gossiper() const {
@@ -366,11 +368,11 @@ public:
 
 private:
     future<schema_ptr> get_schema_for_read(table_schema_version v, netw::msg_addr from) {
-        return _mm->get_schema_for_read(std::move(v), std::move(from), _ms);
+        return _mm.get_schema_for_read(std::move(v), std::move(from), _ms);
     }
 
     future<schema_ptr> get_schema_for_write(table_schema_version v, netw::msg_addr from) {
-        return _mm->get_schema_for_write(std::move(v), std::move(from), _ms);
+        return _mm.get_schema_for_write(std::move(v), std::move(from), _ms);
     }
 
     future<> handle_counter_mutation(
@@ -2548,9 +2550,12 @@ inline std::ostream& operator<<(std::ostream& os, const hint_wrapper& h) {
 
 using namespace std::literals::chrono_literals;
 
-storage_proxy::~storage_proxy() {}
-storage_proxy::storage_proxy(distributed<replica::database>& db, gms::gossiper& gossiper, storage_proxy::config cfg, db::view::node_update_backlog& max_view_update_backlog,
-        scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms)
+storage_proxy::~storage_proxy() {
+    assert(!_remote);
+}
+
+storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::config cfg, db::view::node_update_backlog& max_view_update_backlog,
+        scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory)
     : _db(db)
     , _shared_token_metadata(stm)
     , _erm_factory(erm_factory)
@@ -2565,7 +2570,6 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, gms::gossiper& 
     , _hints_for_views_manager(_db.local().get_config().view_hints_directory(), {}, _db.local().get_config().max_hint_window_in_ms(), _hints_resource_manager, _db)
     , _stats_key(stats_key)
     , _features(feat)
-    , _remote(std::make_unique<struct remote>(*this, ms, gossiper))
     , _background_write_throttle_threahsold(cfg.available_memory / 10)
     , _mutate_stage{"storage_proxy_mutate", &storage_proxy::do_mutate}
     , _max_view_update_backlog(max_view_update_backlog)
@@ -5848,12 +5852,13 @@ future<> storage_proxy::truncate_blocking(sstring keyspace, sstring cfname) {
     return remote().send_truncate_blocking(std::move(keyspace), std::move(cfname));
 }
 
-void storage_proxy::init_messaging_service(migration_manager* mm) {
-    _remote->init_messaging_service(mm, this);
+void storage_proxy::init_messaging_service(netw::messaging_service& ms, gms::gossiper& g, migration_manager& mm) {
+    _remote = std::make_unique<struct remote>(*this, ms, g, mm);
 }
 
 future<> storage_proxy::uninit_messaging_service() {
-    return _remote->stop();
+    co_await _remote->stop();
+    _remote = nullptr;
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3194,7 +3194,9 @@ storage_proxy::mutate_atomically(std::vector<mutation> mutations, db::consistenc
             .then(utils::result_into_future<result<>>);
 }
 
-static inet_address_vector_replica_set endpoint_filter(const gms::gossiper& g, const sstring& local_rack, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>& endpoints) {
+static inet_address_vector_replica_set endpoint_filter(
+        const noncopyable_function<bool(const gms::inet_address&)>& is_alive,
+        const sstring& local_rack, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>& endpoints) {
     // special case for single-node data centers
     if (endpoints.size() == 1 && endpoints.begin()->second.size() == 1) {
         return boost::copy_range<inet_address_vector_replica_set>(endpoints.begin()->second);
@@ -3203,9 +3205,8 @@ static inet_address_vector_replica_set endpoint_filter(const gms::gossiper& g, c
     // strip out dead endpoints and localhost
     std::unordered_multimap<sstring, gms::inet_address> validated;
 
-    auto is_valid = [&g] (gms::inet_address input) {
-        return input != utils::fb_utilities::get_broadcast_address()
-            && g.is_alive(input);
+    auto is_valid = [&is_alive] (gms::inet_address input) {
+        return input != utils::fb_utilities::get_broadcast_address() && is_alive(input);
     };
 
     for (auto& e : endpoints) {
@@ -3299,8 +3300,7 @@ storage_proxy::mutate_atomically_result(std::vector<mutation> mutations, db::con
                             auto local_dc = topology.get_datacenter();
                             auto& local_endpoints = topology.get_datacenter_racks().at(local_dc);
                             auto local_rack = topology.get_rack();
-                            auto& gossiper = _p._remote->gossiper();
-                            auto chosen_endpoints = endpoint_filter(gossiper, local_rack, local_endpoints);
+                            auto chosen_endpoints = endpoint_filter(std::bind_front(&storage_proxy::is_alive, &_p), local_rack, local_endpoints);
 
                             if (chosen_endpoints.empty()) {
                                 if (_cl == db::consistency_level::ANY) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -432,8 +432,8 @@ private:
     void retire_view_response_handlers(noncopyable_function<bool(const abstract_write_response_handler&)> filter_fun);
 
 public:
-    storage_proxy(distributed<replica::database>& db, gms::gossiper& gossiper, config cfg, db::view::node_update_backlog& max_view_update_backlog,
-            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
+    storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
+            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory);
     ~storage_proxy();
 
     const distributed<replica::database>& get_db() const {
@@ -470,7 +470,7 @@ public:
         }
         return next;
     }
-    void init_messaging_service(migration_manager*);
+    void init_messaging_service(netw::messaging_service&, gms::gossiper&, migration_manager&);
     future<> uninit_messaging_service();
 
 private:

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -433,7 +433,7 @@ public:
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
     ~storage_proxy();
 
-    remote& remote();
+    remote& remote() const;
 
     const distributed<replica::database>& get_db() const {
         return _db;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -436,8 +436,6 @@ public:
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
     ~storage_proxy();
 
-    remote& remote() const;
-
     const distributed<replica::database>& get_db() const {
         return _db;
     }
@@ -476,6 +474,9 @@ public:
     future<> uninit_messaging_service();
 
 private:
+    // Throws an error if remote is not initialized.
+    remote& remote() const;
+
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
     future<> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -332,6 +332,9 @@ private:
     db::hints::manager& hints_manager_for(db::write_type type);
     static void sort_endpoints_by_proximity(inet_address_vector_replica_set& eps);
     inet_address_vector_replica_set get_live_sorted_endpoints(replica::keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set calculate_target_replicas(db::consistency_level, replica::keyspace&, inet_address_vector_replica_set live_endpoints, const inet_address_vector_replica_set& preferred_endpoints, db::read_repair_decision, gms::inet_address* extra, replica::column_family*) const;
+    // As above with read_repair_decision=NONE, extra=nullptr.
+    inet_address_vector_replica_set calculate_target_replicas(db::consistency_level, replica::keyspace&, const inet_address_vector_replica_set& live_endpoints, const inet_address_vector_replica_set& preferred_endpoints, replica::column_family*) const;
     bool is_alive(const gms::inet_address&) const;
     db::read_repair_decision new_read_repair_decision(const schema& s);
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -686,7 +686,7 @@ public:
             db::view::node_update_backlog b(smp::count, 10ms);
             scheduling_group_key_config sg_conf =
                     make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
-            proxy.start(std::ref(db), std::ref(gossiper), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory), std::ref(ms)).get();
+            proxy.start(std::ref(db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
             auto stop_proxy = defer([&proxy] { proxy.stop().get(); });
 
             forward_service.start(std::ref(ms), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();


### PR DESCRIPTION
The refactors from #11088 allow us to easily move the initialization
of `storage_proxy` early in the startup procedure, before starting
`system_keyspace`, `messaging_service`, `gossiper`, `storage_service` and more.

Eventually we should be able to move initialization of `query_processor` right
after `storage_proxy` (but this requires a bit of refactoring in
`query_processor` too).

Note: local queries are unavailable yet by this point because all queries
access the global snitch instance, and snitch is not started yet by this point.

There's an orthogonal effort to remove the snitch->gossiper dependency (from @xemul).
This would allow us to initialize snitch early and perform local queries before
gossiper is available.
