### PR TITLE
storage_proxy: use consistent topology, prepare for fencing

### DIFF
--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -69,8 +69,8 @@ size_t block_for_each_quorum(replica::keyspace& ks) {
     auto& rs = ks.get_replication_strategy();
 
     if (rs.get_type() == replication_strategy_type::network_topology) {
-        network_topology_strategy* nrs =
-            static_cast<network_topology_strategy*>(&rs);
+        const network_topology_strategy* nrs =
+            static_cast<const network_topology_strategy*>(&rs);
         size_t n = 0;
 
         for (auto& dc : nrs->get_datacenters()) {
@@ -123,8 +123,8 @@ std::unordered_map<sstring, dc_node_count> count_per_dc_endpoints(
     auto& rs = ks.get_replication_strategy();
     const auto& topo = ks.get_effective_replication_map()->get_topology();
 
-    network_topology_strategy* nrs =
-            static_cast<network_topology_strategy*>(&rs);
+    const network_topology_strategy* nrs =
+            static_cast<const network_topology_strategy*>(&rs);
 
     std::unordered_map<sstring, dc_node_count> dc_endpoints;
     for (auto& dc : nrs->get_datacenters()) {

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -26,25 +26,29 @@ namespace gms {
 class gossiper;
 };
 
+namespace locator {
+class effective_replication_map;
+}
+
 namespace db {
 
 extern logging::logger cl_logger;
 
-size_t quorum_for(const replica::keyspace& ks);
+size_t quorum_for(const locator::effective_replication_map& erm);
 
-size_t local_quorum_for(const replica::keyspace& ks, const sstring& dc);
+size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc);
 
-size_t block_for_local_serial(replica::keyspace& ks);
+size_t block_for_local_serial(const locator::effective_replication_map& erm);
 
-size_t block_for_each_quorum(replica::keyspace& ks);
+size_t block_for_each_quorum(const locator::effective_replication_map& erm);
 
-size_t block_for(replica::keyspace& ks, consistency_level cl);
+size_t block_for(const locator::effective_replication_map& erm, consistency_level cl);
 
 bool is_datacenter_local(consistency_level l);
 
 inet_address_vector_replica_set
 filter_for_query(consistency_level cl,
-                 replica::keyspace& ks,
+                 const locator::effective_replication_map& erm,
                  inet_address_vector_replica_set live_endpoints,
                  const inet_address_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
@@ -53,7 +57,7 @@ filter_for_query(consistency_level cl,
                  replica::column_family* cf);
 
 inet_address_vector_replica_set filter_for_query(consistency_level cl,
-        replica::keyspace& ks,
+        const locator::effective_replication_map& erm,
         inet_address_vector_replica_set& live_endpoints,
         const inet_address_vector_replica_set& preferred_endpoints,
         const gms::gossiper& g,
@@ -66,17 +70,17 @@ struct dc_node_count {
 
 bool
 is_sufficient_live_nodes(consistency_level cl,
-                         replica::keyspace& ks,
+                         const locator::effective_replication_map& erm,
                          const inet_address_vector_replica_set& live_endpoints);
 
 template<typename Range, typename PendingRange = std::array<gms::inet_address, 0>>
 void assure_sufficient_live_nodes(
         consistency_level cl,
-        replica::keyspace& ks,
+        const locator::effective_replication_map& erm,
         const Range& live_endpoints,
         const PendingRange& pending_endpoints = std::array<gms::inet_address, 0>());
 
-extern template void assure_sufficient_live_nodes(consistency_level, replica::keyspace&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
-extern template void assure_sufficient_live_nodes(db::consistency_level, replica::keyspace&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
+extern template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
+extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
 
 }

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -493,7 +493,8 @@ future<query::forward_result> forward_service::dispatch(query::forward_request r
     std::map<netw::messaging_service::msg_addr, dht::partition_range_vector> vnodes_per_addr;
     const auto& topo = get_token_metadata_ptr()->get_topology();
     while (std::optional<dht::partition_range> vnode = next_vnode()) {
-        inet_address_vector_replica_set live_endpoints = _proxy.get_live_endpoints(ks, end_token(*vnode));
+        auto erm = ks.get_effective_replication_map();
+        inet_address_vector_replica_set live_endpoints = _proxy.get_live_endpoints(*erm, end_token(*vnode));
         // Do not choose an endpoint outside the current datacenter if a request has a local consistency
         if (db::is_datacenter_local(req.cl)) {
             retain_local_endpoints(topo, live_endpoints);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -226,7 +226,7 @@ public:
 
     query::max_result_size get_max_result_size(const query::partition_slice& slice) const;
     query::tombstone_limit get_tombstone_limit() const;
-    inet_address_vector_replica_set get_live_endpoints(replica::keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set get_live_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
 
 private:
     distributed<replica::database>& _db;
@@ -332,7 +332,7 @@ private:
     bool hints_enabled(db::write_type type) const noexcept;
     db::hints::manager& hints_manager_for(db::write_type type);
     static void sort_endpoints_by_proximity(inet_address_vector_replica_set& eps);
-    inet_address_vector_replica_set get_live_sorted_endpoints(replica::keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set get_live_sorted_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
     bool is_alive(const gms::inet_address&) const;
     db::read_repair_decision new_read_repair_decision(const schema& s);
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -313,7 +313,7 @@ private:
     result<response_id_type> create_write_response_handler_helper(schema_ptr s, const dht::token& token,
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
             service_permit permit, db::allow_per_partition_rate_limit allow_limit);
-    result<response_id_type> create_write_response_handler(replica::keyspace& ks, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, inet_address_vector_replica_set targets,
+    result<response_id_type> create_write_response_handler(locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, inet_address_vector_replica_set targets,
             const inet_address_vector_topology_change& pending_endpoints, inet_address_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info);
     result<response_id_type> create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);


### PR DESCRIPTION
Replication is a mix of several inputs: tokens and token->node mappings (topology),
the replication strategy, replication strategy parameters. These are all captured
in effective_replication_map.

However, if we use effective_replication_map:s captured at different times in a single
query, then different uses may see different inputs to effective_replication_map.

This series protects against that by capturing an effective_replication_map just
once in a query, and then using it. Furthermore, the captured effective_replication_map
is held until the query completes, so topology code can know when a topology is no
longer is use (although this isn't exploited in this series).

Only the simple read and write paths are covered. Counters and paxos are left for
later.

I don't think the series fixes any bugs - as far as I could tell everything was happening
in the same continuation. But this series ensures it.