### PR TITLE
test: row_cache: Use more narrow key range to stress overlapping reads more

### DIFF
--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -3352,6 +3352,7 @@ SEASTAR_TEST_CASE(test_tombstone_merging_of_overlapping_tombstones_in_many_versi
 SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
     return seastar::async([] {
         random_mutation_generator gen(random_mutation_generator::generate_counters::no);
+        gen.set_key_cardinality(16);
         memtable_snapshot_source underlying(gen.schema());
         schema_ptr s = gen.schema();
         schema_ptr rev_s = s->make_reversed();

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2013,6 +2013,11 @@ public:
         _blobs =  boost::copy_range<std::vector<bytes>>(keys | boost::adaptors::transformed([this] (sstring& k) { return to_bytes(k); }));
     }
 
+    void set_key_cardinality(size_t n_keys) {
+        assert(n_keys <= n_blobs);
+        _ck_index_dist = std::uniform_int_distribution<size_t>{0, n_keys - 1};
+    }
+
     bytes random_blob() {
         return _blobs[std::min(_blobs.size() - 1, std::max<size_t>(0, _ck_index_dist(_gen)))];
     }
@@ -2330,6 +2335,10 @@ clustering_key random_mutation_generator::make_random_key() {
 
 std::vector<query::clustering_range> random_mutation_generator::make_random_ranges(unsigned n_ranges) {
     return _impl->make_random_ranges(n_ranges);
+}
+
+void random_mutation_generator::set_key_cardinality(size_t n_keys) {
+    _impl->set_key_cardinality(n_keys);
 }
 
 void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mutation>&,

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -64,6 +64,8 @@ public:
     range_tombstone make_random_range_tombstone();
     std::vector<dht::decorated_key> make_partition_keys(size_t n);
     std::vector<query::clustering_range> make_random_ranges(unsigned n_ranges);
+    // Sets the number of distinct clustering keys which will be used in generated mutations.
+    void set_key_cardinality(size_t);
 };
 
 bytes make_blob(size_t blob_size);


### PR DESCRIPTION
This makes catching issues related to concurrent access of same or
adjacent entries more likely. 

For example, catches #11239.