### PR TITLE
Introduce Compaction Groups

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -792,27 +792,26 @@ future<> compaction_manager::stop_tasks(std::vector<shared_ptr<task>> tasks, sst
 }
 
 future<> compaction_manager::stop_ongoing_compactions(sstring reason, compaction::table_state* t, std::optional<sstables::compaction_type> type_opt) noexcept {
-  // FIXME: restore indentation
-  try {
-    auto ongoing_compactions = get_compactions(t).size();
-    auto tasks = boost::copy_range<std::vector<shared_ptr<task>>>(_tasks | boost::adaptors::filtered([t, type_opt] (auto& task) {
-        return (!t || task->compacting_table() == t) && (!type_opt || task->type() == *type_opt);
-    }));
-    logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
-    if (cmlog.is_enabled(level)) {
-        std::string scope = "";
-        if (t) {
-            scope = fmt::format(" for table {}.{}", t->schema()->ks_name(), t->schema()->cf_name());
+    try {
+        auto ongoing_compactions = get_compactions(t).size();
+        auto tasks = boost::copy_range<std::vector<shared_ptr<task>>>(_tasks | boost::adaptors::filtered([t, type_opt] (auto& task) {
+            return (!t || task->compacting_table() == t) && (!type_opt || task->type() == *type_opt);
+        }));
+        logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
+        if (cmlog.is_enabled(level)) {
+            std::string scope = "";
+            if (t) {
+                scope = fmt::format(" for table {}.{}", t->schema()->ks_name(), t->schema()->cf_name());
+            }
+            if (type_opt) {
+                scope += fmt::format(" {} type={}", scope.size() ? "and" : "for", *type_opt);
+            }
+            cmlog.log(level, "Stopping {} tasks for {} ongoing compactions{} due to {}", tasks.size(), ongoing_compactions, scope, reason);
         }
-        if (type_opt) {
-            scope += fmt::format(" {} type={}", scope.size() ? "and" : "for", *type_opt);
-        }
-        cmlog.log(level, "Stopping {} tasks for {} ongoing compactions{} due to {}", tasks.size(), ongoing_compactions, scope, reason);
+        return stop_tasks(std::move(tasks), std::move(reason));
+    } catch (...) {
+        return current_exception_as_future<>();
     }
-    return stop_tasks(std::move(tasks), std::move(reason));
-  } catch (...) {
-    return current_exception_as_future<>();
-  }
 }
 
 future<> compaction_manager::drain() {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -489,7 +489,7 @@ public:
 
     // Remove a table from the compaction manager.
     // Cancel requests on table and wait for possible ongoing compactions.
-    future<> remove(compaction::table_state& t);
+    future<> remove(compaction::table_state& t) noexcept;
 
     const stats& get_stats() const {
         return _stats;
@@ -506,7 +506,7 @@ public:
     future<> stop_compaction(sstring type, compaction::table_state* table = nullptr);
 
     // Stops ongoing compaction of a given table and/or compaction_type.
-    future<> stop_ongoing_compactions(sstring reason, compaction::table_state* t = nullptr, std::optional<sstables::compaction_type> type_opt = {});
+    future<> stop_ongoing_compactions(sstring reason, compaction::table_state* t = nullptr, std::optional<sstables::compaction_type> type_opt = {}) noexcept;
 
     double backlog() {
         return _backlog_manager.backlog();

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -64,6 +64,9 @@ public:
     const lw_shared_ptr<sstables::sstable_set>& maintenance_sstables() const noexcept;
     void set_maintenance_sstables(lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables);
 
+    // Makes a compound set, which includes main and maintenance sets
+    lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
+
     compaction::table_state& as_table_state() const noexcept;
 };
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -30,6 +30,8 @@ class compaction_group {
     table& _t;
     class table_state;
     std::unique_ptr<table_state> _table_state;
+    // Holds list of memtables for this group
+    lw_shared_ptr<memtable_list> _memtables;
     // SSTable set which contains all non-maintenance sstables
     lw_shared_ptr<sstables::sstable_set> _main_sstables;
     // Holds SSTables created by maintenance operations, which need reshaping before integration into the main set
@@ -42,6 +44,15 @@ public:
 
     // Clear sstable sets
     void clear_sstables();
+
+    // Clear memtable(s) content
+    future<> clear_memtables();
+
+    future<> flush();
+    bool can_flush() const;
+    lw_shared_ptr<memtable_list>& memtables() noexcept;
+    // Returns minimum timestamp from memtable list
+    api::timestamp_type min_memtable_timestamp() const;
 
     // Add sstable to main set
     void add_sstable(sstables::shared_sstable sstable);

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "database_fwd.hh"
+
+#pragma once
+
+namespace compaction {
+class table_state;
+}
+
+namespace replica {
+
+// Compaction group is a set of SSTables which are eligible to be compacted together.
+// By this definition, we can say:
+//      - A group contains SSTables that are owned by the same shard.
+//      - Also, a group will be owned by a single table. Different tables own different groups.
+//      - Each group can be thought of an isolated LSM tree, where Memtable(s) and SSTable(s) are
+//          isolated from other groups.
+// Usually, a table T in shard S will own a single compaction group. With compaction_group, a
+// table T will be able to own as many groups as it wishes.
+class compaction_group {
+    table& _t;
+    class table_state;
+    std::unique_ptr<table_state> _table_state;
+public:
+    compaction_group(table& t);
+
+    // Will stop ongoing compaction on behalf of this group, etc.
+    future<> stop() noexcept;
+
+    compaction::table_state& as_table_state() const noexcept;
+};
+
+}

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -412,8 +412,6 @@ private:
 
     compaction_manager& _compaction_manager;
     sstables::compaction_strategy _compaction_strategy;
-    // Holds SSTables created by maintenance operations, which need reshaping before integration into the main set
-    lw_shared_ptr<sstables::sstable_set> _maintenance_sstables;
     // TODO: Still holds a single compaction group, meaning all sstables are eligible to be compacted with one another. Soon, a table
     //  will be able to hold more than one group.
     std::unique_ptr<compaction_group> _compaction_group;
@@ -552,9 +550,9 @@ private:
     lw_shared_ptr<sstables::sstable_set>
     do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, sstables::shared_sstable sstable,
         enable_backlog_tracker backlog_tracker);
-    // Helper which adds sstable on behalf of a compaction group and refreshes compound set.
+    // Helpers which add sstable on behalf of a compaction group and refreshes compound set.
     void add_sstable(compaction_group& cg, sstables::shared_sstable sstable);
-    void add_maintenance_sstable(sstables::shared_sstable sst);
+    void add_maintenance_sstable(compaction_group& cg, sstables::shared_sstable sst);
     static void add_sstable_to_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable);
     static void remove_sstable_from_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable);
     // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
@@ -585,11 +583,6 @@ private:
     static seastar::shard_id calculate_shard_from_sstable_generation(sstables::generation_type sstable_generation) {
         return sstables::generation_value(sstable_generation) % smp::count;
     }
-    // This will update sstable lists on behalf of off-strategy compaction, where
-    // input files will be removed from the maintenance set and output files will
-    // be inserted into the main set.
-    future<>
-    update_sstable_lists_on_off_strategy_completion(sstables::compaction_completion_desc desc);
 private:
     void rebuild_statistics();
 
@@ -892,7 +885,6 @@ public:
     future<std::unordered_set<sstring>> get_sstables_by_partition_key(const sstring& key) const;
 
     const sstables::sstable_set& get_sstable_set() const;
-    const sstables::sstable_set& maintenance_sstable_set() const;
     lw_shared_ptr<const sstable_list> get_sstables() const;
     lw_shared_ptr<const sstable_list> get_sstables_including_compacted_undeleted() const;
     const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -415,7 +415,7 @@ private:
     // TODO: Still holds a single compaction group, meaning all sstables are eligible to be compacted with one another. Soon, a table
     //  will be able to hold more than one group.
     std::unique_ptr<compaction_group> _compaction_group;
-    // Compound set which manages all the SSTable sets (e.g. main, etc) and allow their operations to be combined
+    // Compound SSTable set for all the compaction groups, which is useful for operations spanning all of them.
     lw_shared_ptr<sstables::sstable_set> _sstables;
     // sstables that have been compacted (so don't look up in query) but
     // have not been deleted yet, so must not GC any tombstones in other sstables

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -92,10 +92,12 @@ table::make_sstable_reader(schema_ptr s,
     }
 }
 
+lw_shared_ptr<sstables::sstable_set> compaction_group::make_compound_sstable_set() {
+    return make_lw_shared(sstables::make_compound_sstable_set(_t.schema(), { _main_sstables, _maintenance_sstables }));
+}
+
 lw_shared_ptr<sstables::sstable_set> table::make_compound_sstable_set() {
-    // FIXME: once _maintenance_sstables goes to compaction_group, then table::make_compound_sstable_set()
-    // will call compaction_group::make_compound_sstable_set().
-    return make_lw_shared(sstables::make_compound_sstable_set(_schema, { _compaction_group->main_sstables(), _compaction_group->maintenance_sstables() }));
+    return _compaction_group->make_compound_sstable_set();
 }
 
 lw_shared_ptr<sstables::sstable_set> table::make_maintenance_sstable_set() const {

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4056,7 +4056,8 @@ class scylla_memtables(gdb.Command):
         region_ptr_type = gdb.lookup_type('logalloc::region').pointer()
         for table in all_tables(db):
             gdb.write('table %s:\n' % schema_ptr(table['_schema']).table_name())
-            memtable_list = seastar_lw_shared_ptr(table['_memtables']).get()
+            compaction_group = std_unique_ptr(table["_compaction_group"]).get()
+            memtable_list = seastar_lw_shared_ptr(compaction_group['_memtables']).get()
             for mt_ptr in std_vector(memtable_list['_memtables']):
                 mt = seastar_lw_shared_ptr(mt_ptr).get()
                 reg = lsa_region(mt.cast(region_ptr_type))

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -145,7 +145,7 @@ public:
         return _t->get_sstable_set();
     }
     const sstables::sstable_set& maintenance_sstable_set() const override {
-        return _t->maintenance_sstable_set();
+        return _t->as_table_state().maintenance_sstable_set();
     }
     std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
         return sstables::get_fully_expired_sstables(_t->as_table_state(), sstables, query_time);

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -55,7 +55,8 @@ public:
     }
 
     auto try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
-        return _cf->try_flush_memtable_to_sstable(mt, sstable_write_permit::unconditional());
+        // FIXME: for multiple groups, rewrite this without directly referencing replica::table::_compaction_group.
+        return _cf->try_flush_memtable_to_sstable(*_cf->_compaction_group, mt, sstable_write_permit::unconditional());
     }
 };
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -32,18 +32,14 @@ class column_family_test {
 public:
     column_family_test(lw_shared_ptr<replica::column_family> cf) : _cf(cf) {}
 
-    void add_sstable(sstables::shared_sstable sstable) {
-        _cf->_main_sstables->insert(std::move(sstable));
-        _cf->refresh_compound_sstable_set();
+    future<> add_sstable(sstables::shared_sstable sstable) {
+        auto new_sstables = { sstable };
+        return _cf->as_table_state().on_compaction_completion(sstables::compaction_completion_desc{ .new_sstables = new_sstables }, sstables::offstrategy::no);
     }
 
-    // NOTE: must run in a thread
-    void rebuild_sstable_list(const std::vector<sstables::shared_sstable>& new_sstables,
+    future<> rebuild_sstable_list(const std::vector<sstables::shared_sstable>& new_sstables,
             const std::vector<sstables::shared_sstable>& sstables_to_remove) {
-        auto permit = seastar::get_units(_cf->_sstable_set_mutation_sem, 1).get0();
-        auto builder = replica::table::sstable_list_builder(std::move(permit));
-        _cf->_main_sstables = builder.build_new_list(*_cf->_main_sstables, _cf->_compaction_strategy.make_sstable_set(_cf->schema()), new_sstables, sstables_to_remove).get0();
-        _cf->refresh_compound_sstable_set();
+        return _cf->as_table_state().on_compaction_completion(sstables::compaction_completion_desc{ .old_sstables = sstables_to_remove, .new_sstables = new_sstables }, sstables::offstrategy::no);
     }
 
     static void update_sstables_known_generation(replica::column_family& cf, unsigned generation) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -213,6 +213,8 @@ public:
     }
 
     void set_values(sstring first_key, sstring last_key, stats_metadata stats) {
+        _sst->_data_file_size = 1;
+        _sst->_bytes_on_disk = 1;
         // scylla component must be present for a sstable to be considered fully expired.
         _sst->_recognized_components.insert(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));


### PR DESCRIPTION
Compaction group can be defined as a set of files that can be compacted together. Today, all sstables belonging to a table in a given shard belong to the same group. So we can say there's one group per table per shard. As we want to eventually allow isolation of data that shouldn't be mixed, e.g. data from different vnodes, then we want to have more than one group per table per shard. That's why compaction groups is being introduced here.

Today, all memtables and sstables are stored in a single structure per table. After compaction groups, there will be memtables and sstables for each group in the table.

As we're taking an incremental approach, table still supports a single group. But work was done on preparing table for supporting multiple groups. Completing that work is actually the next step. Also, a procedure for deriving the group from token is introduced, but today it always return the single group owned by the table. Once multiple groups are supported, then that procedure should be implemented to map a token to a group.

No semantics was changed by this series.