### PR TITLE
raft read_barrier, retry over intermittent rpc failures

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -290,6 +290,10 @@ struct state_machine_error: public error {
         : error(fmt::format("State machine error at {}:{}", l.file_name(), l.line())) {}
 };
 
+struct intermittent_connection_error: public error {
+    intermittent_connection_error() : error("Intermittent connection error") {}
+};
+
 struct no_other_voting_member : public error {
     no_other_voting_member() : error("Cannot stepdown because there is no other voting member") {}
 };
@@ -559,6 +563,9 @@ public:
     virtual void send_read_quorum_reply(server_id id, const read_quorum_reply& read_quorum_reply) = 0;
 
     // Forward a read barrier request to the leader.
+    // Should throw a raft::intermittent_connection_error if the target host is unreachable.
+    // In this case, the call will be retried after some time,
+    // possibly with a different server_id if the leader has changed by then.
     virtual future<read_barrier_reply> execute_read_barrier_on_leader(server_id id) = 0;
 
     // Two-way RPC for adding an entry on the leader


### PR DESCRIPTION
If the leader was unavailable during read_barrier,
closed_error occurs, which was not handled in any way
and eventually reached the client. This patch adds retries in this case.

This is not a full-blown solution to the problem, as we
may enter a busy loop until the leader changes. The solution
to the issue and a separate focused test for it will follow later.
This patch is needed to not block on the dtests failures
because of this problem.

Fix: #11262