### PR TITLE
Raft test topology part 3

### DIFF
--- a/test.py
+++ b/test.py
@@ -410,7 +410,11 @@ class CQLApprovalTestSuite(PythonTestSuite):
 
 
 class TopologyTestSuite(PythonTestSuite):
-    """A collection of Python pytests against Scylla instances dealing with topology changes"""
+    """A collection of Python pytests against Scylla instances dealing with topology changes.
+       Instead of using a single Scylla cluster directly, there is a cluster manager handling
+       the lifecycle of clusters and bringing up new ones as needed. The cluster health checks
+       are done per test case.
+    """
 
     def build_test_list(self) -> List[str]:
         """Build list of Topology python tests"""

--- a/test.py
+++ b/test.py
@@ -848,9 +848,10 @@ class TopologyTest(PythonTest):
 
     async def run(self, options: argparse.Namespace) -> Test:
 
-        async with get_cluster_manager(self.shortname, self.suite.clusters) as manager:
-            self.args.insert(0, "--host={}".format(manager.cluster[0].host))
+        test_path = os.path.join(self.suite.options.tmpdir, self.mode)
+        async with get_cluster_manager(self.shortname, self.suite.clusters, test_path) as manager:
             logging.info("Leasing Scylla cluster %s for test %s", manager.cluster, self.uname)
+            self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
                 manager.cluster.before_test(self.uname)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -102,3 +102,8 @@ class ManagerClient():
         """Get list of running servers"""
         host_list = await self._request("http://localhost/cluster/servers")
         return host_list.split(',')
+
+    async def mark_dirty(self) -> None:
+        """Manually mark current cluster dirty.
+           To be used when a server was modified outside of this API."""
+        await self._request("http://localhost/cluster/mark-dirty", "Could not mark cluster dirty")

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""Manager client.
+   Communicates with Manager server via socket.
+   Provides helper methods to test cases.
+   Manages driver refresh when cluster is cycled.
+"""
+
+from typing import List
+import aiohttp                                                             # type: ignore
+import aiohttp.web                                                         # type: ignore
+
+
+class ManagerClient():
+    """Helper Manager API client
+    Args:
+        sock_path (str): path to an AF_UNIX socket where Manager server is listening
+    """
+    conn: aiohttp.UnixConnector
+    session: aiohttp.ClientSession
+
+    def __init__(self, sock_path: str) -> None:
+        self.sock_path = sock_path
+
+    async def start(self):
+        """Setup connection to Manager server"""
+        self.conn = aiohttp.UnixConnector(path=self.sock_path)
+        self.session = aiohttp.ClientSession(connector=self.conn)
+
+    async def _request(self, url: str) -> str:
+        # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html
+        resp = await self.session.get(url)
+        return await resp.text()
+
+    async def is_manager_up(self) -> bool:
+        """Check if Manager server is up"""
+        ret = await self._request("http://localhost/up")
+        return ret == "True"
+
+    async def is_cluster_up(self) -> bool:
+        """Check if cluster is up"""
+        ret = await self._request("http://localhost/cluster/up")
+        return ret == "True"
+
+    async def is_dirty(self) -> bool:
+        """Check if current cluster dirty."""
+        dirty = await self._request("http://localhost/cluster/is-dirty")
+        return dirty == "True"
+
+    async def replicas(self) -> int:
+        """Get number of configured replicas for the cluster (replication factor)"""
+        resp = await self._request("http://localhost/cluster/replicas")
+        return int(resp)
+
+    async def servers(self) -> List[str]:
+        """Get list of running servers"""
+        host_list = await self._request("http://localhost/cluster/servers")
+        return host_list.split(',')

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -106,4 +106,37 @@ class ManagerClient():
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
-        await self._request("http://localhost/cluster/mark-dirty", "Could not mark cluster dirty")
+        await self._request("http://localhost/cluster/mark-dirty")
+
+    async def server_stop(self, server_id: str) -> bool:
+        """Stop specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/stop")
+        return ret == "OK"
+
+    async def server_stop_gracefully(self, server_id: str) -> bool:
+        """Stop specified node gracefully"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/stop_gracefully")
+        return ret == "OK"
+
+    async def server_start(self, server_id: str) -> bool:
+        """Start specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/start")
+        self._driver_update()
+        return ret == "OK"
+
+    async def server_restart(self, server_id: str) -> bool:
+        """Restart specified node"""
+        ret = await self._request(f"http://localhost/cluster/node/{server_id}/restart")
+        self._driver_update()
+        return ret == "OK"
+
+    async def server_add(self) -> str:
+        """Add a new node"""
+        server_id = await self._request("http://localhost/cluster/addnode")
+        self._driver_update()
+        return server_id
+
+    async def server_remove(self, server_id: str) -> None:
+        """Remove a specified node"""
+        await self._request(f"http://localhost/cluster/removenode/{server_id}")
+        self._driver_update()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -611,6 +611,8 @@ class ScyllaClusterManager:
         self.test_name: str = test_name
         self.clusters: Pool[ScyllaCluster] = clusters
         self.is_running: bool = False
+        self.is_before_test_ok: bool = False
+        self.is_after_test_ok: bool = False
         # API
         # NOTE: need to make a safe temp dir as tempfile can't make a safe temp sock name
         self.manager_dir: str = tempfile.mkdtemp(prefix="manager-", dir=base_dir)
@@ -627,11 +629,26 @@ class ScyllaClusterManager:
         await self.site.start()
         self.is_running = True
 
+    async def _before_test(self, test_name: str) -> None:
+        if self.cluster.is_dirty:
+            await self.cluster.stop()
+            await self._get_cluster()
+        logging.info("Leasing Scylla cluster %s for test %s", self.cluster, test_name)
+        self.cluster.before_test(self.test_name)
+        self.is_before_test_ok = True
+        # FIXME: savepoint for all servers
+        self.cluster[0].take_log_savepoint()
+
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
         await self.site.stop()
         self.cluster.after_test(self.test_name)
-        await self._return_cluster()
+        if not self.cluster.is_dirty:
+            logging.info("Returning Scylla cluster %s", self.cluster)
+            await self.clusters.put(self.cluster)
+        else:
+            await self.cluster.stop()
+        del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)
 
@@ -639,10 +656,6 @@ class ScyllaClusterManager:
         self.cluster = await self.clusters.get()
         logging.info("Getting new Scylla cluster %s", self.cluster)
 
-    async def _return_cluster(self) -> None:
-        logging.info("Returning Scylla cluster %s", self.cluster)
-        await self.clusters.put(self.cluster)
-        del self.cluster
 
     def _setup_routes(self) -> None:
         self.app.router.add_get('/up', self._manager_up)
@@ -650,6 +663,8 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/is-dirty', self._is_dirty)
         self.app.router.add_get('/cluster/replicas', self._cluster_replicas)
         self.app.router.add_get('/cluster/servers', self._cluster_servers)
+        self.app.router.add_get('/cluster/before-test/{test_name}', self._before_test_req)
+        self.app.router.add_get('/cluster/after-test/{test_name}', self._after_test)
 
     async def _manager_up(self, request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -673,6 +688,18 @@ class ScyllaClusterManager:
     async def _cluster_servers(self, request) -> aiohttp.web.Response:
         """Return a list of active server ids (IPs)"""
         return aiohttp.web.Response(text=f"{','.join(sorted(self.cluster.running.keys()))}")
+
+    async def _before_test_req(self, request) -> aiohttp.web.Response:
+        await self._before_test(request.match_info['test_name'])
+        return aiohttp.web.Response(text="OK")
+
+    async def _after_test(self, request) -> aiohttp.web.Response:
+        test_name = request.match_info['test_name']
+        assert self.cluster is not None
+        self.cluster.after_test(test_name)
+        self.is_after_test_ok = True
+        return aiohttp.web.Response(text="True")
+
 
 @asynccontextmanager
 async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -665,6 +665,7 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/servers', self._cluster_servers)
         self.app.router.add_get('/cluster/before-test/{test_name}', self._before_test_req)
         self.app.router.add_get('/cluster/after-test/{test_name}', self._after_test)
+        self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
 
     async def _manager_up(self, request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -700,6 +701,11 @@ class ScyllaClusterManager:
         self.is_after_test_ok = True
         return aiohttp.web.Response(text="True")
 
+    async def _mark_dirty(self, request) -> aiohttp.web.Response:
+        """Mark current cluster dirty"""
+        assert self.cluster
+        self.cluster.is_dirty = True
+        return aiohttp.web.Response(text="OK")
 
 @asynccontextmanager
 async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Test consistency of schema changes with topology changes.
+"""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_add_server_add_column(manager, random_tables):
+    """Add a node and then add a column to a table and verify"""
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_stop_server_add_column(manager, random_tables):
+    """Add a node, stop an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await manager.server_stop(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_restart_server_add_column(manager, random_tables):
+    """Add a node, stop an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    ret = await manager.server_restart(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_remove_server_add_column(manager, random_tables):
+    """Add a node, remove an original node, add a column"""
+    servers = await manager.servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await manager.server_remove(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()


### PR DESCRIPTION
Test schema changes when there was an underlying topology change.

- per test case checks of cluster health and cycling
- helper class to do cluster manager API requests
- tests can perform topology changes: stop/start/restart servers
- modified clusters are marked dirty and discarded after the test case
- cql connection is updated per topology change and per cluster change