### PR TITLE
Fix frozen mutation consume ordering

### DIFF
--- a/canonical_mutation.cc
+++ b/canonical_mutation.cc
@@ -113,17 +113,19 @@ std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm) {
             auto&& entry = _cm.static_column_at(id);
             fmt::print(_os, "static column {} {}", bytes_to_text(entry.name()), collection_mutation_view::printer(*entry.type(), cmv));
         }
-        virtual void accept_row_tombstone(range_tombstone rt) override {
+        virtual stop_iteration accept_row_tombstone(range_tombstone rt) override {
             print_separator();
             fmt::print(_os, "row tombstone {}", rt);
+            return stop_iteration::no;
         }
-        virtual void accept_row(position_in_partition_view pipv, row_tombstone rt, row_marker rm, is_dummy, is_continuous) override {
+        virtual stop_iteration accept_row(position_in_partition_view pipv, row_tombstone rt, row_marker rm, is_dummy, is_continuous) override {
             if (_in_row) {
                 fmt::print(_os, "}}, ");
             }
             fmt::print(_os, "{{row {} tombstone {} marker {}", pipv, rt, rm);
             _in_row = true;
             _first = false;
+            return stop_iteration::no;
         }
         virtual void accept_row_cell(column_id id, atomic_cell ac) override {
             print_separator();

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -55,11 +55,6 @@ private:
                 _stop_consuming = _consumer.consume(static_row(std::move(row)));
             }
         }
-        _rt_gen.flush(pos, [this] (range_tombstone_change rt) {
-            if (!_stop_consuming) {
-                _stop_consuming = _consumer.consume(std::move(rt));
-            }
-        });
         if (_current_row) {
             auto row_entry = std::move(_current_row_entry);
             _current_row = nullptr;
@@ -67,6 +62,11 @@ private:
                 _stop_consuming = _consumer.consume(clustering_row(std::move(*row_entry)));
             }
         }
+        _rt_gen.flush(pos, [this] (range_tombstone_change rt) {
+            if (!_stop_consuming) {
+                _stop_consuming = _consumer.consume(std::move(rt));
+            }
+        });
     }
 
 public:

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -64,8 +64,8 @@ private:
                 return _stop_consuming;
             }
         }
-        _rt_gen.flush(pos, [this] (range_tombstone_change rt) {
-            _stop_consuming = _consumer.consume(std::move(rt));
+        _rt_gen.flush(pos, [this] (range_tombstone_change rtc) {
+            _stop_consuming = _consumer.consume(std::move(rtc));
         });
         return _stop_consuming;
     }

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -51,9 +51,7 @@ private:
     void flush_rows_and_tombstones(position_in_partition_view pos) {
         if (!_static_row.empty()) {
             auto row = std::move(_static_row.get_existing());
-            if (!_stop_consuming) {
-                _stop_consuming = _consumer.consume(static_row(std::move(row)));
-            }
+            _stop_consuming = _consumer.consume(static_row(std::move(row)));
         }
         if (_current_row) {
             auto row_entry = std::move(_current_row_entry);

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -23,9 +23,6 @@
 #include "concrete_types.hh"
 #include "types/user.hh"
 
-#include "idl/mutation.dist.hh"
-#include "idl/mutation.dist.impl.hh"
-
 using namespace db;
 
 static_assert(MutationViewVisitor<mutation_partition_view_virtual_visitor>);
@@ -276,6 +273,113 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
     }
 }
 
+template <bool is_preemptible>
+mutation_partition_view::accept_ordered_result mutation_partition_view::do_accept_ordered(const schema& s, mutation_partition_view_virtual_visitor& visitor, accept_ordered_cookie cookie) const {
+    auto in = _in;
+    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    const column_mapping& cm = s.get_column_mapping();
+
+    if (!cookie.accepted_partition_tombstone) {
+        visitor.accept_partition_tombstone(mpv.tomb());
+        cookie.accepted_partition_tombstone = true;
+    }
+
+    if (!cookie.accepted_static_row) {
+        struct static_row_cell_visitor {
+            mutation_partition_view_virtual_visitor& _visitor;
+
+            void accept_atomic_cell(column_id id, atomic_cell ac) const {
+                _visitor.accept_static_cell(id, std::move(ac));
+            }
+            void accept_collection(column_id id, const collection_mutation& cm) const {
+                _visitor.accept_static_cell(id, cm);
+            }
+        };
+        read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
+        cookie.accepted_static_row = true;
+    }
+
+    if (!cookie.iterators) {
+        cookie.iterators.emplace(accept_ordered_cookie::rts_crs_iterators{
+            .rts_begin = mpv.range_tombstones().cbegin(),
+            .rts_end = mpv.range_tombstones().cend(),
+            .crs_begin = mpv.rows().cbegin(),
+            .crs_end = mpv.rows().cend(),
+        });
+    }
+
+    auto rt_it = cookie.iterators->rts_begin;
+    const auto& rt_e = cookie.iterators->rts_end;
+    auto cr_it = cookie.iterators->crs_begin;
+    const auto& cr_e = cookie.iterators->crs_end;
+
+    auto consume_rt = [&] (range_tombstone&& rt) {
+        cookie.iterators->rts_begin = rt_it;
+        visitor.accept_row_tombstone(std::move(rt));
+    };
+    auto consume_cr = [&] (ser::deletable_row_view&& cr, clustering_key_prefix&& cr_key) {
+        cookie.iterators->crs_begin = cr_it;
+        auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
+        visitor.accept_row(position_in_partition_view::for_key(cr_key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
+
+        struct cell_visitor {
+            mutation_partition_view_virtual_visitor& _visitor;
+
+            void accept_atomic_cell(column_id id, atomic_cell ac) const {
+                _visitor.accept_row_cell(id, std::move(ac));
+            }
+            void accept_collection(column_id id, const collection_mutation& cm) const {
+                _visitor.accept_row_cell(id, cm);
+            }
+        };
+        read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
+    };
+
+    std::optional<range_tombstone> rt;
+    auto next_rt = [&] {
+        if (rt || rt_it == rt_e) {
+            return;
+        }
+        rt = *rt_it;
+        ++rt_it;
+    };
+
+    std::optional<ser::deletable_row_view> cr;
+    std::optional<clustering_key_prefix> cr_key;
+    auto next_cr = [&] {
+        if (cr || cr_it == cr_e) {
+            return;
+        }
+        cr = *cr_it;
+        cr_key = cr->key();
+        ++cr_it;
+    };
+
+    position_in_partition::tri_compare cmp{s};
+
+    for (;;) {
+        next_rt();
+        next_cr();
+        bool emit_rt = bool(rt);
+        if (rt && cr) {
+            auto rt_pos = rt->position();
+            auto cr_pos = position_in_partition_view::for_key(*cr_key);
+            emit_rt = (cmp(rt_pos, cr_pos) < 0);
+        }
+        // FIXME: allow visitor to return stop_iteration
+        if (emit_rt) {
+            consume_rt(std::move(*std::exchange(rt, std::nullopt)));
+        } else if (cr) {
+            consume_cr(std::move(*std::exchange(cr, std::nullopt)), std::move(*cr_key));
+        } else {
+            return accept_ordered_result{stop_iteration::yes, accept_ordered_cookie{}};
+        }
+        if (is_preemptible && need_preempt()) {
+            return accept_ordered_result{stop_iteration::no, std::move(cookie)};
+        }
+    }
+}
+
 void mutation_partition_view::accept(const schema& s, partition_builder& visitor) const
 {
     do_accept(s.get_column_mapping(), visitor);
@@ -298,8 +402,16 @@ void mutation_partition_view::accept(const column_mapping& cm, mutation_partitio
     do_accept(cm, visitor);
 }
 
-future<> mutation_partition_view::accept_gently(const column_mapping& cm, mutation_partition_view_virtual_visitor& visitor) const {
-    return do_accept_gently(cm, visitor);
+void mutation_partition_view::accept_ordered(const schema& s, mutation_partition_view_virtual_visitor& visitor) const {
+    do_accept_ordered<false>(s, visitor, accept_ordered_cookie{});
+}
+
+future<> mutation_partition_view::accept_gently_ordered(const schema& s, mutation_partition_view_virtual_visitor& visitor) const {
+    accept_ordered_result res;
+    do {
+        res = do_accept_ordered<true>(s, visitor, std::move(res.cookie));
+        co_await coroutine::maybe_yield();
+    } while (!res.stop);
 }
 
 std::optional<clustering_key> mutation_partition_view::first_row_key() const

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -12,6 +12,8 @@
 #include "mutation_partition_visitor.hh"
 #include "utils/input_stream.hh"
 #include "atomic_cell.hh"
+#include "idl/mutation.dist.hh"
+#include "idl/mutation.dist.impl.hh"
 
 namespace ser {
 class mutation_partition_view;
@@ -62,6 +64,28 @@ private:
     template<typename Visitor>
     requires MutationViewVisitor<Visitor>
     future<> do_accept_gently(const column_mapping&, Visitor& visitor) const;
+
+    struct accept_ordered_cookie {
+        bool accepted_partition_tombstone = false;
+        bool accepted_static_row = false;
+
+        struct rts_crs_iterators {
+            ser::vector_deserializer<ser::range_tombstone_view>::const_iterator rts_begin;
+            ser::vector_deserializer<ser::range_tombstone_view>::const_iterator rts_end;
+            ser::vector_deserializer<ser::deletable_row_view>::const_iterator crs_begin;
+            ser::vector_deserializer<ser::deletable_row_view>::const_iterator crs_end;
+        };
+        std::optional<rts_crs_iterators> iterators;
+    };
+
+    struct accept_ordered_result {
+        stop_iteration stop = stop_iteration::no;
+        accept_ordered_cookie cookie;
+    };
+
+    template <bool is_preemptible>
+    accept_ordered_result do_accept_ordered(const schema& schema, mutation_partition_view_virtual_visitor& mpvvv, accept_ordered_cookie cookie) const;
+
 public:
     static mutation_partition_view from_stream(utils::input_stream v) {
         return { v };
@@ -72,7 +96,8 @@ public:
     void accept(const column_mapping&, converting_mutation_partition_applier& visitor) const;
     future<> accept_gently(const column_mapping&, converting_mutation_partition_applier& visitor) const;
     void accept(const column_mapping&, mutation_partition_view_virtual_visitor& mpvvv) const;
-    future<> accept_gently(const column_mapping&, mutation_partition_view_virtual_visitor& mpvvv) const;
+    void accept_ordered(const schema& schema, mutation_partition_view_virtual_visitor& mpvvv) const;
+    future<> accept_gently_ordered(const schema&, mutation_partition_view_virtual_visitor& mpvvv) const;
 
     std::optional<clustering_key> first_row_key() const;
     std::optional<clustering_key> last_row_key() const;

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -43,8 +43,8 @@ public:
     virtual void accept_partition_tombstone(tombstone t) = 0;
     virtual void accept_static_cell(column_id, atomic_cell ac) = 0;
     virtual void accept_static_cell(column_id, collection_mutation_view cmv) = 0;
-    virtual void accept_row_tombstone(range_tombstone rt) = 0;
-    virtual void accept_row(position_in_partition_view pipv, row_tombstone rt, row_marker rm, is_dummy, is_continuous) = 0;
+    virtual stop_iteration accept_row_tombstone(range_tombstone rt) = 0;
+    virtual stop_iteration accept_row(position_in_partition_view pipv, row_tombstone rt, row_marker rm, is_dummy, is_continuous) = 0;
     virtual void accept_row_cell(column_id, atomic_cell ac) = 0;
     virtual void accept_row_cell(column_id, collection_mutation_view cmv) = 0;
 };

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -12,6 +12,9 @@
 
 #include "mutation.hh"
 #include "mutation_fragment_stream_validator.hh"
+#include "log.hh"
+
+extern logging::logger testlog;
 
 class mutation_partition_assertion {
     schema_ptr _schema;
@@ -200,27 +203,33 @@ class validating_consumer {
 public:
     explicit validating_consumer(const schema& s) : _validator(s) { }
 
-    void consume_new_partition(const dht::decorated_key&) {
+    void consume_new_partition(const dht::decorated_key& dk) {
+        testlog.debug("consume new partition: {}", dk);
         BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{})));
     }
     void consume(tombstone) { }
     stop_iteration consume(static_row&& sr) {
+        testlog.debug("consume static_row");
         BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::static_row, sr.position()));
         return stop_iteration::no;
     }
     stop_iteration consume(clustering_row&& cr) {
+        testlog.debug("consume clustering_row: {}", cr.key());
         BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::clustering_row, cr.position()));
         return stop_iteration::no;
     }
     stop_iteration consume(range_tombstone_change&& rtc) {
+        testlog.debug("consume range_tombstone_change: {} {}", rtc.position(), rtc.tombstone());
         BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position()));
         return stop_iteration::no;
     }
     stop_iteration consume_end_of_partition() {
+        testlog.debug("consume end of partition");
         BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{})));
         return stop_iteration::no;
     }
     void consume_end_of_stream() {
+        testlog.debug("consume end of stream");
         BOOST_REQUIRE(_validator.on_end_of_stream());
     }
 };


### PR DESCRIPTION
Currently, frozen_mutation is not consumed in position_in_partition
order as all range tombstones are consumed before all rows.
    
This violates the range_tombstone_generator invariants
as its lower_bound needs to be monotonically increasing.
    
Fix this by adding mutation_partition_view::accept_ordered
and rewriting do_accept_gently to do the same,
both making sure to consume the range tombstones
and clustering rows in position_in_partition order,
similar to the mutation consume_clustering_fragments function.
    
Add a unit test that verifies that.
    
Fixes #11198