### PR TITLE
Optimize mutation consume of range tombstones in reverse

### DIFF
--- a/mutation.hh
+++ b/mutation.hh
@@ -35,8 +35,8 @@ struct mutation_consume_cookie {
         rts_iterator_type rts_end;
         range_tombstone_change_generator rt_gen;
 
-        clustering_iterators(const schema& s, mutation_partition::rows_type& crs, range_tombstone_list& rts)
-            : crs_begin(crs.begin()), crs_end(crs.end()), rts_begin(rts.begin()), rts_end(rts.end()), rt_gen(s) { }
+        clustering_iterators(const schema& s, crs_iterator_type crs_b, crs_iterator_type crs_e, rts_iterator_type rts_b, rts_iterator_type rts_e)
+            : crs_begin(std::move(crs_b)), crs_end(std::move(crs_e)), rts_begin(std::move(rts_b)), rts_end(std::move(rts_e)), rt_gen(s) { }
     };
 
     schema_ptr schema;
@@ -233,7 +233,9 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
     }
 
     if (!cookie.iterators) {
-        cookie.iterators = std::make_unique<mutation_consume_cookie::clustering_iterators>(*s, partition.mutable_clustered_rows(), *rt_list);
+        auto& crs = partition.mutable_clustered_rows();
+        auto& rts = *rt_list;
+        cookie.iterators = std::make_unique<mutation_consume_cookie::clustering_iterators>(*s, crs.begin(), crs.end(), rts.begin(), rts.end());
     }
 
     crs_iterator_type crs_it, crs_end;

--- a/mutation.hh
+++ b/mutation.hh
@@ -274,16 +274,16 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
             ++crs_it;
             continue;
         }
-        bool emit_rt;
-        if (crs_it != crs_end && rts_it != rts_end) {
+        bool emit_rt = rts_it != rts_end;
+        if (rts_it != rts_end) {
+          if (crs_it != crs_end) {
             const auto cmp_res = cmp(rts_it->position(), crs_it->position());
             if constexpr (reverse == consume_in_reverse::legacy_half_reverse) {
                 emit_rt = cmp_res > 0;
             } else {
                 emit_rt = cmp_res < 0;
             }
-        } else {
-            emit_rt = rts_it != rts_end;
+          }
         }
         if (emit_rt) {
             flush_tombstones(rts_it->position());

--- a/mutation.hh
+++ b/mutation.hh
@@ -276,14 +276,14 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
         }
         bool emit_rt = rts_it != rts_end;
         if (rts_it != rts_end) {
-          if (crs_it != crs_end) {
-            const auto cmp_res = cmp(rts_it->position(), crs_it->position());
-            if constexpr (reverse == consume_in_reverse::legacy_half_reverse) {
-                emit_rt = cmp_res > 0;
-            } else {
-                emit_rt = cmp_res < 0;
+            if (crs_it != crs_end) {
+                const auto cmp_res = cmp(rts_it->position(), crs_it->position());
+                if constexpr (reverse == consume_in_reverse::legacy_half_reverse) {
+                    emit_rt = cmp_res > 0;
+                } else {
+                    emit_rt = cmp_res < 0;
+                }
             }
-          }
         }
         if (emit_rt) {
             flush_tombstones(rts_it->position());

--- a/mutation.hh
+++ b/mutation.hh
@@ -212,13 +212,14 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
     using rts_type = range_tombstone_list;
     using rts_iterator_type = std::conditional_t<rts_in_reverse, std::reverse_iterator<rts_type::iterator>, rts_type::iterator>;
 
-    if constexpr (reverse == consume_in_reverse::yes) {
-        s = s->make_reversed();
-    }
-
     if (!cookie.schema) {
-        cookie.schema = s;
+        if constexpr (reverse == consume_in_reverse::yes) {
+            cookie.schema = s->make_reversed();
+        } else {
+            cookie.schema = s;
+        }
     }
+    s = cookie.schema;
 
     auto* rt_list = &partition.mutable_row_tombstones();
     if (reverse == consume_in_reverse::yes && !cookie.reversed_range_tombstones) {

--- a/mutation.hh
+++ b/mutation.hh
@@ -34,7 +34,6 @@ struct mutation_consume_cookie {
         rts_iterator_type rts_begin;
         rts_iterator_type rts_end;
         range_tombstone_change_generator rt_gen;
-        tombstone current_rt;
 
         clustering_iterators(const schema& s, mutation_partition::rows_type& crs, range_tombstone_list& rts)
             : crs_begin(crs.begin()), crs_end(crs.end()), rts_begin(rts.begin()), rts_end(rts.end()), rt_gen(s) { }
@@ -257,7 +256,6 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
 
     auto flush_tombstones = [&] (position_in_partition_view pos) {
         cookie.iterators->rt_gen.flush(pos, [&] (range_tombstone_change rt) {
-            cookie.iterators->current_rt = rt.tombstone();
             consumer.consume(std::move(rt));
         });
     };

--- a/mutation.hh
+++ b/mutation.hh
@@ -332,17 +332,15 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
 template<FlattenedConsumerV2 Consumer>
 auto mutation::consume(Consumer& consumer, consume_in_reverse reverse, mutation_consume_cookie cookie) &&
         -> mutation_consume_result<decltype(consumer.consume_end_of_stream())> {
-    if (!cookie.partition_start_consumed) {
-        consumer.consume_new_partition(_ptr->_dk);
-    }
-
     auto& partition = _ptr->_p;
 
-    if (!cookie.partition_start_consumed && partition.partition_tombstone()) {
-        consumer.consume(partition.partition_tombstone());
+    if (!cookie.partition_start_consumed) {
+        consumer.consume_new_partition(_ptr->_dk);
+        if (partition.partition_tombstone()) {
+            consumer.consume(partition.partition_tombstone());
+        }
+        cookie.partition_start_consumed = true;
     }
-
-    cookie.partition_start_consumed = true;
 
     stop_iteration stop = stop_iteration::no;
     if (!cookie.static_row_consumed && !partition.static_row().empty()) {
@@ -372,17 +370,15 @@ auto mutation::consume(Consumer& consumer, consume_in_reverse reverse, mutation_
 template<FlattenedConsumerV2 Consumer>
 auto mutation::consume_gently(Consumer& consumer, consume_in_reverse reverse, mutation_consume_cookie cookie) &&
         -> future<mutation_consume_result<decltype(consumer.consume_end_of_stream())>> {
-    if (!cookie.partition_start_consumed) {
-        consumer.consume_new_partition(_ptr->_dk);
-    }
-
     auto& partition = _ptr->_p;
 
-    if (!cookie.partition_start_consumed && partition.partition_tombstone()) {
-        consumer.consume(partition.partition_tombstone());
+    if (!cookie.partition_start_consumed) {
+        consumer.consume_new_partition(_ptr->_dk);
+        if (partition.partition_tombstone()) {
+            consumer.consume(partition.partition_tombstone());
+        }
+        cookie.partition_start_consumed = true;
     }
-
-    cookie.partition_start_consumed = true;
 
     stop_iteration stop = stop_iteration::no;
     if (!cookie.static_row_consumed && !partition.static_row().empty()) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2565,6 +2565,19 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume_position_monotonicity) {
         validating_consumer consumer(*reverse_schema);
         std::move(mut).consume(consumer, consume_in_reverse::yes);
     }
+
+    BOOST_TEST_MESSAGE("Forward gently");
+    {
+        auto mut = muts.front();
+        validating_consumer consumer(*forward_schema);
+        std::move(mut).consume_gently(consumer, consume_in_reverse::no).get();
+    }
+    BOOST_TEST_MESSAGE("Reverse gently");
+    {
+        auto mut = muts.front();
+        validating_consumer consumer(*reverse_schema);
+        std::move(mut).consume_gently(consumer, consume_in_reverse::yes).get();
+    }
 }
 
 SEASTAR_TEST_CASE(mutation_with_dummy_clustering_row_is_consumed_monotonically) {


### PR DESCRIPTION
Reversing the whole range_tombstone_list
into reversed_range_tombstones is inefficient
and can lead to reactor stalls with a large number of
range tombstones.
    
Instead, iterate over the range_tombsotne_list in reverse
direction and reverse each range_tombstone as we go,
keeping the result in the optional cookie.reversed_rt member.

While at it, this series contains some other cleanups on this path
to improve the code readability and maybe make the compiler's life
easier as for optimizing the cleaned-up code.