### PR TITLE
Revert "test: move scylla_inject_error from alternator/ to cql-pytest/"

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import boto3
 import requests
 import re
-from alternator_util import create_test_table, is_aws
+from util import create_test_table, is_aws
 
 # When tests are run with HTTPS, the server often won't have its SSL
 # certificate signed by a known authority. So we will disable certificate

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -8,12 +8,8 @@
 
 import pytest
 import random
-import sys
 from botocore.exceptions import ClientError
-from alternator_util import random_string, full_scan, full_query, multiset
-
-sys.path.insert(1, sys.path[0] + '/../cql-pytest')
-from util import scylla_inject_error
+from util import random_string, full_scan, full_query, multiset, scylla_inject_error
 
 # Test ensuring that items inserted by a batched statement can be properly extracted
 # via GetItem. Schema has both hash and sort keys.

--- a/test/alternator/test_condition_expression.py
+++ b/test/alternator/test_condition_expression.py
@@ -19,7 +19,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string
+from util import random_string
 from sys import version_info
 
 # A helper function for changing write isolation policies

--- a/test/alternator/test_describe_table.py
+++ b/test/alternator/test_describe_table.py
@@ -18,7 +18,7 @@ import pytest
 from botocore.exceptions import ClientError
 import re
 import time
-from alternator_util import multiset
+from util import multiset
 
 # Test that DescribeTable correctly returns the table's name and state
 def test_describe_table_basic(test_table):

--- a/test/alternator/test_expected.py
+++ b/test/alternator/test_expected.py
@@ -9,7 +9,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string
+from util import random_string
 
 # Most of the tests in this file check that the "Expected" parameter works for
 # the UpdateItem operation. It should also work the same for the PutItem and

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from alternator_util import full_query, full_query_and_counts, full_scan, random_string, random_bytes, multiset
+from util import full_query, full_query_and_counts, full_scan, random_string, random_bytes, multiset
 
 # The test_table_sn_with_data fixture is the regular test_table_sn fixture
 # with a partition inserted with many items. The sort key 'c' of the items

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -11,7 +11,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from alternator_util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table
+from util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table
 
 # GSIs only support eventually consistent reads, so tests that involve
 # writing to a table and then expect to read something from it cannot be

--- a/test/alternator/test_item.py
+++ b/test/alternator/test_item.py
@@ -7,7 +7,7 @@
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from alternator_util import random_string, random_bytes
+from util import random_string, random_bytes
 
 # Basic test for creating a new item with a random name, and reading it back
 # with strong consistency.

--- a/test/alternator/test_key_condition_expression.py
+++ b/test/alternator/test_key_condition_expression.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from alternator_util import random_string, full_query, multiset
+from util import random_string, full_query, multiset
 
 # The test_table_{sn,ss,sb}_with_sorted_partition fixtures are the regular
 # test_table_{sn,ss,sb} fixture with a partition inserted with many items.

--- a/test/alternator/test_key_conditions.py
+++ b/test/alternator/test_key_conditions.py
@@ -9,7 +9,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string, random_bytes, full_query, multiset
+from util import random_string, random_bytes, full_query, multiset
 
 # The test_table_{sn,ss,sb}_with_sorted_partition fixtures are the regular
 # test_table_{sn,ss,sb} fixture with a partition inserted with many items.

--- a/test/alternator/test_limits.py
+++ b/test/alternator/test_limits.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from alternator_util import random_string, new_test_table, full_query
+from util import random_string, new_test_table, full_query
 from botocore.exceptions import ClientError
 from test_gsi import assert_index_query
 

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -11,7 +11,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from alternator_util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, list_tables
+from util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, list_tables
 
 # LSIs support strongly-consistent reads, so the following functions do not
 # need to retry like we did in test_gsi.py for GSIs:

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -28,7 +28,7 @@ import re
 from contextlib import contextmanager
 from botocore.exceptions import ClientError
 
-from alternator_util import random_string, new_test_table
+from util import random_string, new_test_table
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for

--- a/test/alternator/test_nested.py
+++ b/test/alternator/test_nested.py
@@ -6,7 +6,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string
+from util import random_string
 
 # Test that we can write a top-level attribute that is a nested document, and
 # read it back correctly.

--- a/test/alternator/test_number.py
+++ b/test/alternator/test_number.py
@@ -28,7 +28,7 @@
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from alternator_util import random_string, client_no_transform
+from util import random_string, client_no_transform
 
 # Monkey-patch the boto3 library to stop doing its own error-checking on
 # numbers. This works around a bug https://github.com/boto/boto3/issues/2500

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -13,7 +13,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string, full_scan, full_query, multiset
+from util import random_string, full_scan, full_query, multiset
 
 # Basic test for ProjectionExpression, requesting only top-level attributes.
 # Result should include the selected attributes only - if one wants the key

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -14,7 +14,7 @@ import random
 import pytest
 from botocore.exceptions import ClientError
 from decimal import Decimal
-from alternator_util import random_string, random_bytes, full_query, multiset
+from util import random_string, random_bytes, full_query, multiset
 from boto3.dynamodb.conditions import Key, Attr
 
 def test_query_nonexistent_table(dynamodb):

--- a/test/alternator/test_query_filter.py
+++ b/test/alternator/test_query_filter.py
@@ -9,7 +9,7 @@
 import pytest
 from botocore.exceptions import ClientError
 import random
-from alternator_util import full_query, full_query_and_counts, random_string, random_bytes
+from util import full_query, full_query_and_counts, random_string, random_bytes
 
 # The test_table_sn_with_data fixture is the regular test_table_sn fixture
 # with a partition inserted with 20 items. The sort key 'c' of the items

--- a/test/alternator/test_returnvalues.py
+++ b/test/alternator/test_returnvalues.py
@@ -7,7 +7,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string
+from util import random_string
 
 # Test trivial support for the ReturnValues parameter in PutItem, UpdateItem
 # and DeleteItem - test that "NONE" works (and changes nothing), while a

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -7,7 +7,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from alternator_util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table
+from util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table
 from boto3.dynamodb.conditions import Attr
 
 # Test that scanning works fine with/without pagination

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -10,7 +10,7 @@ import time
 import urllib.request
 
 from botocore.exceptions import ClientError
-from alternator_util import list_tables, unique_table_name, create_test_table, random_string, freeze
+from util import list_tables, unique_table_name, create_test_table, random_string, freeze
 from contextlib import contextmanager
 from urllib.error import URLError
 from boto3.dynamodb.types import TypeDeserializer

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -11,7 +11,7 @@ import pytest
 import time
 import threading
 from botocore.exceptions import ClientError
-from alternator_util import list_tables, unique_table_name, create_test_table, random_string
+from util import list_tables, unique_table_name, create_test_table, random_string
 
 # Utility function for create a table with a given name and some valid
 # schema.. This function initiates the table's creation, but doesn't
@@ -326,7 +326,7 @@ def test_update_table_non_existent(dynamodb, test_table):
 # default, this fixture can be removed.
 @pytest.fixture(scope="session")
 def check_pre_raft(dynamodb):
-    from alternator_util import is_aws
+    from util import is_aws
     # If not running on Scylla, return false.
     if is_aws(dynamodb):
         return false

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -12,7 +12,7 @@ import pytest
 from botocore.exceptions import ClientError
 import re
 import time
-from alternator_util import multiset, create_test_table, unique_table_name, random_string
+from util import multiset, create_test_table, unique_table_name, random_string
 from packaging.version import Version
 
 def delete_tags(table, arn):

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -19,7 +19,7 @@ import requests
 import time
 import json
 from botocore.exceptions import ClientError
-from alternator_util import random_string, full_scan, full_query, create_test_table
+from util import random_string, full_scan, full_query, create_test_table
 
 # The "with_tracing" fixture ensures that tracing is enabled throughout
 # the run of a test function, and disabled when it ends. If tracing cannot be

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -9,7 +9,7 @@ import time
 import re
 import math
 from botocore.exceptions import ClientError
-from alternator_util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform
+from util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform
 from contextlib import contextmanager
 from decimal import Decimal
 

--- a/test/alternator/test_update_expression.py
+++ b/test/alternator/test_update_expression.py
@@ -8,7 +8,7 @@ import random
 import string
 import pytest
 from botocore.exceptions import ClientError
-from alternator_util import random_string
+from util import random_string
 
 # The simplest test of using UpdateExpression to set a top-level attribute,
 # instead of the older AttributeUpdates parameter.

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -8,6 +8,9 @@ import string
 import random
 import collections
 import time
+import re
+import requests
+import pytest
 from contextlib import contextmanager
 from botocore.hooks import HierarchicalEmitter
 
@@ -212,3 +215,19 @@ def client_no_transform(client):
 
 def is_aws(dynamodb):
     return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
+
+# Tries to inject an error via Scylla REST API. It only works on Scylla,
+# and only in specific build modes (dev, debug, sanitize), so this function
+# will trigger a test to be skipped if it cannot be executed.
+@contextmanager
+def scylla_inject_error(rest_api, err, one_shot=False):
+    response = requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}')
+    response = requests.get(f'{rest_api}/v2/error_injection/injection')
+    print("Enabled error injections:", response.content.decode('utf-8'))
+    if response.content.decode('utf-8') == "[]":
+        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+    try:
+        yield
+    finally:
+        print("Disabling error injection", err)
+        response = requests.delete(f'{rest_api}/v2/error_injection/injection/{err}')

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -12,8 +12,6 @@ import time
 import socket
 import os
 import collections
-import requests
-import pytest
 from contextlib import contextmanager
 
 from cassandra.auth import PlainTextAuthProvider
@@ -250,23 +248,6 @@ def local_process_id(cql):
 # The number of arguments is assumed to be even.
 def user_type(*args):
     return collections.namedtuple('user_type', args[::2])(*args[1::2])
-
-# Tries to inject an error via Scylla REST API. It only works on Scylla,
-# and only in specific build modes (dev, debug, sanitize), so this function
-# will trigger a test to be skipped if it cannot be executed.
-@contextmanager
-def scylla_inject_error(rest_api, err, one_shot=False):
-    response = requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}')
-    response = requests.get(f'{rest_api}/v2/error_injection/injection')
-    print("Enabled error injections:", response.content.decode('utf-8'))
-    if response.content.decode('utf-8') == "[]":
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
-    try:
-        yield
-    finally:
-        print("Disabling error injection", err)
-        response = requests.delete(f'{rest_api}/v2/error_injection/injection/{err}')
-
 
 class config_value_context:
     """Change the value of a config item while the context is active.

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -10,8 +10,8 @@ import time
 
 # Use the util.py library from ../cql-pytest:
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
-from util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index, scylla_inject_error
-from rest_util import new_test_snapshot
+from util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index
+from rest_util import new_test_snapshot, scylla_inject_error
 
 # "keyspace" function: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
@@ -142,8 +142,7 @@ def test_storage_service_keyspace_scrub(cql, this_dc, rest_api):
 def test_storage_service_keyspace_scrub_abort(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t0:
-            url = f"http://{rest_api.host}:{rest_api.port}"
-            with scylla_inject_error(url, "rest_api_keyspace_scrub_abort"):
+            with scylla_inject_error(rest_api, "rest_api_keyspace_scrub_abort"):
                 cql.execute(f"INSERT INTO {t0} (a) VALUES (42)")
                 resp = rest_api.send("POST", f"storage_service/keyspace_flush/{keyspace}")
                 resp.raise_for_status()


### PR DESCRIPTION
This reverts commit 8e892426e2e85c0e752c996cf3714401e8b3013f and fixes
the code in a different way:

That commit moved the scylla_inject_error function from
test/alternator/util.py to test/cql-pytest/util.py and renamed
test/alternator/util.py. I found the rename confusing and unnecessary.
Moreover, the moved function isn't even usable today by the test suite
that includes it, cql-pytest, because it lacks the "rest_api" fixture :-)
so test/cql-pytest/util.py wasn't the right place for it anyway.
test/rest_api/rest_util.py could have been a good place for this function,
but there is another complication: Although the Alternator and rest_api
tests both had a "rest_api" fixture, it has a different type, which led
to the code in rest_api which used the moved function to have to jump
through hoops to call it instead of just passing "rest_api".

I think the best solution is to revert the above commit, and duplicate
the short scylla_inject_error() function. The duplication isn't an
exact copy - the test/rest_api/rest_util.py version now accepts the
"rest_api" fixture instead of the URL that the Alternator version used.

In the future we can remove some of this duplication by having some
shared "library" code but we should do it carefully and starting with
agreeing on the basic fixtures like "rest_api" and "cql", without that
it's not useful to share small functions that operate on them.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>