### PR TITLE
everywhere: define locator::host_id as a strong tagged_uuid type

### DIFF
--- a/counters.cc
+++ b/counters.cc
@@ -170,8 +170,10 @@ std::optional<atomic_cell> counter_cell_view::difference(atomic_cell_view a, ato
 }
 
 
-void transform_counter_updates_to_shards(mutation& m, const mutation* current_state, uint64_t clock_offset, utils::UUID local_id) {
+void transform_counter_updates_to_shards(mutation& m, const mutation* current_state, uint64_t clock_offset, locator::host_id local_host_id) {
     // FIXME: allow current_state to be frozen_mutation
+
+    utils::UUID local_id = local_host_id.uuid();
 
     auto transform_new_row_to_shards = [&s = *m.schema(), clock_offset, local_id] (column_kind kind, auto& cells) {
         cells.for_each_cell([&] (column_id id, atomic_cell_or_collection& ac_o_c) {

--- a/counters.hh
+++ b/counters.hh
@@ -14,6 +14,7 @@
 
 #include "atomic_cell.hh"
 #include "types.hh"
+#include "locator/host_id.hh"
 
 class mutation;
 class atomic_cell_or_collection;
@@ -366,7 +367,7 @@ struct counter_cell_mutable_view : basic_counter_cell_view<mutable_view::yes> {
 // Transforms mutation dst from counter updates to counter shards using state
 // stored in current_state.
 // If current_state is present it has to be in the same schema as dst.
-void transform_counter_updates_to_shards(mutation& dst, const mutation* current_state, uint64_t clock_offset, utils::UUID local_id);
+void transform_counter_updates_to_shards(mutation& dst, const mutation* current_state, uint64_t clock_offset, locator::host_id local_id);
 
 template<>
 struct appending_hash<counter_shard_view> {

--- a/db/config.hh
+++ b/db/config.hh
@@ -20,7 +20,7 @@
 #include "seastarx.hh"
 #include "utils/config_file.hh"
 #include "utils/enum_option.hh"
-#include "utils/UUID.hh"
+#include "locator/host_id.hh"
 #include "gms/inet_address.hh"
 #include "db/hints/host_filter.hh"
 
@@ -383,7 +383,7 @@ public:
 
     const db::extensions& extensions() const;
 
-    utils::UUID host_id;
+    locator::host_id host_id;
 
     static const sstring default_tls_priority;
 private:

--- a/db/hints/sync_point.hh
+++ b/db/hints/sync_point.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/sstring.hh>
 #include "gms/inet_address.hh"
 #include "db/commitlog/replay_position.hh"
+#include "locator/host_id.hh"
 
 namespace db {
 namespace hints {
@@ -24,7 +25,7 @@ namespace hints {
 struct sync_point {
     using shard_rps = std::unordered_map<gms::inet_address, db::replay_position>;
     // ID of the host which created this sync point
-    utils::UUID host_id;
+    locator::host_id host_id;
     std::vector<shard_rps> regular_per_shard_rps;
     std::vector<shard_rps> mv_per_shard_rps;
 
@@ -49,7 +50,7 @@ struct per_manager_sync_point_v1 {
 
 // IDL type
 struct sync_point_v1 {
-    utils::UUID host_id;
+    locator::host_id host_id;
     uint16_t shard_count;
 
     // Sync point information for regular mutation hints

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -13,6 +13,7 @@
 #include "service/qos/qos_common.hh"
 #include "utils/UUID.hh"
 #include "cdc/generation_id.hh"
+#include "locator/host_id.hh"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -90,7 +91,7 @@ public:
 
     bool started() const { return _started; }
 
-    future<std::unordered_map<utils::UUID, sstring>> view_status(sstring ks_name, sstring view_name) const;
+    future<std::unordered_map<locator::host_id, sstring>> view_status(sstring ks_name, sstring view_name) const;
     future<> start_view_build(sstring ks_name, sstring view_name) const;
     future<> finish_view_build(sstring ks_name, sstring view_name) const;
     future<> remove_view(sstring ks_name, sstring view_name) const;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -24,6 +24,7 @@
 #include <map>
 #include <seastar/core/distributed.hh>
 #include "cdc/generation_id.hh"
+#include "locator/host_id.hh"
 
 namespace service {
 
@@ -339,7 +340,7 @@ public:
      * Return a map of store host_ids to IP addresses
      *
      */
-    future<std::unordered_map<gms::inet_address, utils::UUID>> load_host_ids();
+    future<std::unordered_map<gms::inet_address, locator::host_id>> load_host_ids();
 
     /*
      * Read this node's tokens stored in the LOCAL table.
@@ -367,12 +368,12 @@ public:
      * Read the host ID from the system keyspace, creating (and storing) one if
      * none exists.
      */
-    future<utils::UUID> load_local_host_id();
+    future<locator::host_id> load_local_host_id();
 
     /**
      * Sets the local host ID explicitly.  Should only be called outside of SystemTable when replacing a node.
      */
-    future<utils::UUID> set_local_host_id(utils::UUID host_id);
+    future<locator::host_id> set_local_host_id(locator::host_id host_id);
 
     static api::timestamp_type schema_creation_timestamp();
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -333,7 +333,7 @@ public:
      * @param host_id      - the ID of the host being removed
      * @param local_host_id - my own host ID for replication coordination
      */
-    future<> advertise_removing(inet_address endpoint, utils::UUID host_id, utils::UUID local_host_id);
+    future<> advertise_removing(inet_address endpoint, locator::host_id host_id, locator::host_id local_host_id);
 
     /**
      * Handles switching the endpoint's state from REMOVING_TOKEN to REMOVED_TOKEN
@@ -342,7 +342,7 @@ public:
      * @param endpoint
      * @param host_id
      */
-    future<> advertise_token_removed(inet_address endpoint, utils::UUID host_id);
+    future<> advertise_token_removed(inet_address endpoint, locator::host_id host_id);
 
     future<> unsafe_assassinate_endpoint(sstring address);
 
@@ -362,7 +362,7 @@ public:
 
     bool is_gossip_only_member(inet_address endpoint);
     bool is_safe_for_bootstrap(inet_address endpoint);
-    bool is_safe_for_restart(inet_address endpoint, utils::UUID host_id);
+    bool is_safe_for_restart(inet_address endpoint, locator::host_id host_id);
 private:
     /**
      * Returns true if the chosen target was also a seed. False otherwise
@@ -399,7 +399,7 @@ public:
 
     bool uses_host_id(inet_address endpoint) const;
 
-    utils::UUID get_host_id(inet_address endpoint) const;
+    locator::host_id get_host_id(inet_address endpoint) const;
 
     std::optional<endpoint_state> get_state_for_version_bigger_than(inet_address for_endpoint, int version);
 

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -12,7 +12,7 @@
 
 #include <seastar/core/sstring.hh>
 #include "utils/serialization.hh"
-#include "utils/UUID.hh"
+#include "locator/host_id.hh"
 #include "version_generator.hh"
 #include "gms/inet_address.hh"
 #include "dht/i_partitioner.hh"
@@ -147,7 +147,7 @@ public:
                                                make_token_string(tokens)}));
     }
 
-    static versioned_value host_id(const utils::UUID& host_id) {
+    static versioned_value host_id(const locator::host_id& host_id) {
         return versioned_value(host_id.to_sstring());
     }
 
@@ -159,17 +159,17 @@ public:
         return versioned_value(make_cdc_generation_id_string(gen_id));
     }
 
-    static versioned_value removing_nonlocal(const utils::UUID& host_id) {
+    static versioned_value removing_nonlocal(const locator::host_id& host_id) {
         return versioned_value(sstring(REMOVING_TOKEN) +
             sstring(DELIMITER_STR) + host_id.to_sstring());
     }
 
-    static versioned_value removed_nonlocal(const utils::UUID& host_id, int64_t expire_time) {
+    static versioned_value removed_nonlocal(const locator::host_id& host_id, int64_t expire_time) {
         return versioned_value(sstring(REMOVED_TOKEN) + sstring(DELIMITER_STR) +
             host_id.to_sstring() + sstring(DELIMITER_STR) + to_sstring(expire_time));
     }
 
-    static versioned_value removal_coordinator(const utils::UUID& host_id) {
+    static versioned_value removal_coordinator(const locator::host_id& host_id) {
         return versioned_value(sstring(REMOVAL_COORDINATOR) +
             sstring(DELIMITER_STR) + host_id.to_sstring());
     }

--- a/idl/hinted_handoff.idl.hh
+++ b/idl/hinted_handoff.idl.hh
@@ -24,7 +24,7 @@ struct per_manager_sync_point_v1 {
 };
 
 struct sync_point_v1 {
-    utils::UUID host_id;
+    locator::host_id host_id;
     uint16_t shard_count;
 
     // Sync point information for regular mutation hints

--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -42,7 +42,7 @@ class paging_state {
     std::optional<clustering_key> get_clustering_key();
     uint32_t get_remaining_low_bits();
     query_id get_query_uuid() [[version 2.2]] = query_id::create_null_id();
-    std::unordered_map<dht::token_range, std::vector<utils::UUID>> get_last_replicas() [[version 2.2]] = std::unordered_map<dht::token_range, std::vector<utils::UUID>>();
+    std::unordered_map<dht::token_range, std::vector<locator::host_id>> get_last_replicas() [[version 2.2]] = std::unordered_map<dht::token_range, std::vector<locator::host_id>>();
     std::optional<db::read_repair_decision> get_query_read_repair_decision() [[version 2.3]] = std::nullopt;
     uint32_t get_rows_fetched_for_last_partition_low_bits() [[version 3.1]] = 0;
     uint32_t get_remaining_high_bits() [[version 4.3]] = 0;

--- a/idl/uuid.idl.hh
+++ b/idl/uuid.idl.hh
@@ -9,6 +9,7 @@
 #include "utils/UUID.hh"
 #include "schema_fwd.hh"
 #include "query-request.hh"
+#include "locator/host_id.hh"
 
 namespace utils {
 class UUID final {
@@ -28,3 +29,12 @@ class table_schema_version final {
 class query_id final {
     utils::UUID uuid();
 };
+
+namespace locator {
+
+class host_id final {
+    utils::UUID uuid();
+};
+
+} // namespace locator
+

--- a/locator/host_id.hh
+++ b/locator/host_id.hh
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "utils/UUID.hh"
+
+namespace locator {
+
+using host_id = utils::tagged_uuid<struct host_id_tag>;
+
+}
+

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -16,7 +16,7 @@
 #include "gms/inet_address.hh"
 #include "dht/i_partitioner.hh"
 #include "inet_address_vectors.hh"
-#include "utils/UUID.hh"
+#include "locator/host_id.hh"
 #include <optional>
 #include <memory>
 #include <boost/range/iterator_range.hpp>
@@ -132,7 +132,6 @@ class token_metadata_impl;
 class token_metadata final {
     std::unique_ptr<token_metadata_impl> _impl;
 public:
-    using UUID = utils::UUID;
     using inet_address = gms::inet_address;
 private:
     class tokens_iterator {
@@ -205,19 +204,19 @@ public:
      * @param hostId
      * @param endpoint
      */
-    void update_host_id(const UUID& host_id, inet_address endpoint);
+    void update_host_id(const locator::host_id& host_id, inet_address endpoint);
 
     /** Return the unique host ID for an end-point. */
-    UUID get_host_id(inet_address endpoint) const;
+    host_id get_host_id(inet_address endpoint) const;
 
     /// Return the unique host ID for an end-point or nullopt if not found.
-    std::optional<UUID> get_host_id_if_known(inet_address endpoint) const;
+    std::optional<host_id> get_host_id_if_known(inet_address endpoint) const;
 
     /** Return the end-point for a unique host ID */
-    std::optional<inet_address> get_endpoint_for_host_id(UUID host_id) const;
+    std::optional<inet_address> get_endpoint_for_host_id(locator::host_id host_id) const;
 
     /** @return a copy of the endpoint-to-id map for read-only operations */
-    const std::unordered_map<inet_address, utils::UUID>& get_endpoint_to_host_id_map_for_reading() const;
+    const std::unordered_map<inet_address, host_id>& get_endpoint_to_host_id_map_for_reading() const;
 
     void add_bootstrap_token(token t, inet_address endpoint);
 

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -18,6 +18,7 @@
 #include "dht/i_partitioner.hh"
 #include "db/read_repair_decision.hh"
 #include "position_in_partition.hh"
+#include "locator/host_id.hh"
 
 namespace service {
 
@@ -25,7 +26,7 @@ namespace pager {
 
 class paging_state final {
 public:
-    using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<utils::UUID>>;
+    using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<locator::host_id>>;
 
 private:
     partition_key _partition_key;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2031,7 +2031,7 @@ bool paxos_response_handler::learned(gms::inet_address ep) {
 }
 
 static inet_address_vector_replica_set
-replica_ids_to_endpoints(const locator::token_metadata& tm, const std::vector<utils::UUID>& replica_ids) {
+replica_ids_to_endpoints(const locator::token_metadata& tm, const std::vector<locator::host_id>& replica_ids) {
     inet_address_vector_replica_set endpoints;
     endpoints.reserve(replica_ids.size());
 
@@ -2044,9 +2044,9 @@ replica_ids_to_endpoints(const locator::token_metadata& tm, const std::vector<ut
     return endpoints;
 }
 
-static std::vector<utils::UUID>
+static std::vector<locator::host_id>
 endpoints_to_replica_ids(const locator::token_metadata& tm, const inet_address_vector_replica_set& endpoints) {
-    std::vector<utils::UUID> replica_ids;
+    std::vector<locator::host_id> replica_ids;
     replica_ids.reserve(endpoints.size());
 
     for (const auto& endpoint : endpoints) {
@@ -5911,7 +5911,7 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(const std::v
 }
 
 future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spoint, clock_type::time_point deadline) {
-    const utils::UUID my_host_id = _db.local().get_config().host_id;
+    const auto my_host_id = _db.local().get_config().host_id;
     if (spoint.host_id != my_host_id) {
         throw std::runtime_error(format("The hint sync point was created on another node, with host ID {}. This node's host ID is {}",
                 spoint.host_id, my_host_id));

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -48,6 +48,7 @@
 #include "exceptions/coordinator_result.hh"
 #include "replica/exceptions.hh"
 #include "db/per_partition_rate_limit_info.hh"
+#include "locator/host_id.hh"
 
 class reconcilable_result;
 class frozen_mutation_and_schema;
@@ -91,7 +92,7 @@ class mutation_holder;
 class view_update_write_response_handler;
 struct hint_wrapper;
 
-using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<utils::UUID>>;
+using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<locator::host_id>>;
 
 struct query_partition_key_range_concurrent_result {
     std::vector<foreign_ptr<lw_shared_ptr<query::result>>> result;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1098,7 +1098,7 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
                 slogger.warn("{}", err);
                 throw std::runtime_error(err);
             }
-            UUID host_id(coordinator[1]);
+            auto host_id = locator::host_id(utils::UUID(coordinator[1]));
             // grab any data we are now responsible for and notify responsible node
             auto ep = get_token_metadata().get_endpoint_for_host_id(host_id);
             if (!ep) {
@@ -2270,7 +2270,7 @@ future<> storage_service::removenode(sstring host_id_string, std::list<gms::inet
         return seastar::async([&ss, host_id_string, ignore_nodes = std::move(ignore_nodes)] {
             auto uuid = utils::make_random_uuid();
             auto tmptr = ss.get_token_metadata_ptr();
-            auto host_id = utils::UUID(host_id_string);
+            auto host_id = locator::host_id(utils::UUID(host_id_string));
             auto endpoint_opt = tmptr->get_endpoint_for_host_id(host_id);
             if (!endpoint_opt) {
                 throw std::runtime_error(format("removenode[{}]: Host ID not found in the cluster", uuid));
@@ -3298,7 +3298,7 @@ future<> storage_service::force_remove_completion() {
                 auto leaving = tm.get_leaving_endpoints();
                 slogger.warn("Removal not confirmed, Leaving={}", leaving);
                 for (auto endpoint : leaving) {
-                    utils::UUID host_id;
+                    locator::host_id host_id;
                     auto tokens = tm.get_tokens(endpoint);
                     try {
                         host_id = tm.get_host_id(endpoint);

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -17,6 +17,8 @@
 #include "db/commitlog/replay_position.hh"
 #include "clustering_bounds_comparator.hh"
 #include "position_in_partition.hh"
+#include "db/cache_tracker.hh"
+#include "locator/host_id.hh"
 
 #include <algorithm>
 
@@ -119,7 +121,7 @@ public:
 private:
     const schema& _schema;
     sstring _name;
-    utils::UUID _host_id;
+    locator::host_id _host_id;
     // EH of 150 can track a max value of 1697806495183, i.e., > 1.5PB
     utils::estimated_histogram _estimated_partition_size{150};
     // EH of 114 can track a max value of 2395318855, i.e., > 2B cells
@@ -148,7 +150,7 @@ private:
 private:
     void convert(disk_array<uint32_t, disk_string<uint16_t>>&to, const std::optional<position_in_partition>& from);
 public:
-    explicit metadata_collector(const schema& schema, sstring name, const utils::UUID& host_id)
+    explicit metadata_collector(const schema& schema, sstring name, const locator::host_id& host_id)
         : _schema(schema)
         , _name(name)
         , _host_id(host_id)

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -29,7 +29,7 @@ sstables_manager::~sstables_manager() {
     assert(_undergoing_close.empty());
 }
 
-const utils::UUID& sstables_manager::get_local_host_id() const {
+const locator::host_id& sstables_manager::get_local_host_id() const {
     return _db_config.host_id;
 }
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -21,6 +21,7 @@
 #include "sstables/version.hh"
 #include "sstables/component_type.hh"
 #include "db/cache_tracker.hh"
+#include "locator/host_id.hh"
 
 #include <boost/intrusive/list.hpp>
 
@@ -86,7 +87,7 @@ public:
     void set_format(sstable_version_types format) noexcept { _format = format; }
     sstables::sstable::version_types get_highest_supported_format() const noexcept { return _format; }
 
-    const utils::UUID& get_local_host_id() const;
+    const locator::host_id& get_local_host_id() const;
 
     // Wait until all sstables managed by this sstables_manager instance
     // (previously created by make_sstable()) have been disposed of:

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -25,6 +25,7 @@
 #include "version.hh"
 #include "encoding_stats.hh"
 #include "utils/UUID.hh"
+#include "locator/host_id.hh"
 
 // While the sstable code works with char, bytes_view works with int8_t
 // (signed char). Rather than change all the code, let's do a cast.
@@ -313,7 +314,7 @@ struct stats_metadata : public metadata_base<stats_metadata> {
     int64_t rows_count; // 3_x only
     db::replay_position commitlog_lower_bound; // 3_x only
     disk_array<uint32_t, commitlog_interval> commitlog_intervals; // 3_x only
-    std::optional<utils::UUID> originating_host_id; // 3_11_11 and later (me format)
+    std::optional<locator::host_id> originating_host_id; // 3_11_11 and later (me format)
 
     template <typename Describer>
     auto describe_type(sstable_version_types v, Describer f) {

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -278,6 +278,11 @@ inline void write(sstable_version_types v, file_writer& out, const utils::UUID& 
     out.write(uuid.serialize());
 }
 
+template <typename Tag>
+inline void write(sstable_version_types v, file_writer& out, const utils::tagged_uuid<Tag>& id) {
+    write(v, out, id.uuid());
+}
+
 template <typename W>
 requires Writer<W>
 inline void write(sstable_version_types v, W& out, const bytes& s) {

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -417,11 +417,11 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
         m3.set_static_cell(scol, std::move(c3));
 
         auto m0 = m1;
-        transform_counter_updates_to_shards(m0, nullptr, 0, utils::UUID{});
+        transform_counter_updates_to_shards(m0, nullptr, 0, locator::host_id::create_null_id());
 
         auto empty = mutation(s, pk);
         auto m = m1;
-        transform_counter_updates_to_shards(m, &empty, 0, utils::UUID{});
+        transform_counter_updates_to_shards(m, &empty, 0, locator::host_id::create_null_id());
         BOOST_REQUIRE_EQUAL(m, m0);
 
         auto ac = get_counter_cell(m);
@@ -441,7 +441,7 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
       }
 
         m = m2;
-        transform_counter_updates_to_shards(m, &m0, 0, utils::UUID{});
+        transform_counter_updates_to_shards(m, &m0, 0, locator::host_id::create_null_id());
 
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
@@ -460,7 +460,7 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
       }
 
         m = m3;
-        transform_counter_updates_to_shards(m, &m0, 0, utils::UUID{});
+        transform_counter_updates_to_shards(m, &m0, 0, locator::host_id::create_null_id());
         ac = get_counter_cell(m);
         BOOST_REQUIRE(!ac.is_live());
         ac = get_static_counter_cell(m);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1089,7 +1089,7 @@ SEASTAR_TEST_CASE(populate_from_quarantine_works) {
     auto tmpdir_for_data = make_lw_shared<tmpdir>();
     auto db_cfg_ptr = make_shared<db::config>();
     db_cfg_ptr->data_file_directories(std::vector<sstring>({ tmpdir_for_data->path().string() }));
-    utils::UUID host_id;
+    locator::host_id host_id;
 
     // populate tmpdir_for_data and
     // move a random sstable to quarantine

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5189,7 +5189,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
 
     large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
-    test_db_config.host_id = ::utils::make_random_uuid();
+    test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker);
     auto stop_manager = defer([&] { manager.close().get(); });
     tmpdir dir;
@@ -5249,7 +5249,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, f);
     cache_tracker tracker;
-    test_db_config.host_id = ::utils::make_random_uuid();
+    test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker);
     auto close_manager = defer([&] { manager.close().get(); });
     tmpdir dir;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -491,8 +491,8 @@ public:
             cfg->ring_delay_ms.set(500);
             cfg->shutdown_announce_in_ms.set(0);
             cfg->broadcast_to_all_shards().get();
-            if (cfg->host_id == utils::UUID{}) {
-                cfg->host_id = utils::make_random_uuid();
+            if (!cfg->host_id) {
+                cfg->host_id = locator::host_id::create_random_id();
             }
             create_directories((data_dir_path + "/system").c_str());
             create_directories(cfg->commitlog_directory().c_str());

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -31,6 +31,7 @@
 #include "tools/schema_loader.hh"
 #include "tools/utils.hh"
 #include "utils/rjson.hh"
+#include "locator/host_id.hh"
 
 // has to be below the utils/rjson.hh include
 #include <rapidjson/ostreamwrapper.h>
@@ -1158,6 +1159,11 @@ private:
 
     void visit(const utils::UUID& uuid) {
         _writer.String(uuid.to_sstring());
+    }
+
+    template <typename Tag>
+    void visit(const utils::tagged_uuid<Tag>& id) {
+        visit(id.uuid());
     }
 
     template <typename Integer>
@@ -3193,7 +3199,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             db::config dbcfg;
             gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
             cache_tracker tracker;
-            dbcfg.host_id = ::utils::make_random_uuid();
+            dbcfg.host_id = locator::host_id::create_random_id();
             sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker);
             auto close_sst_man = deferred_close(sst_man);
 


### PR DESCRIPTION
So it can be distinguished from other uuid-based identifiers in the system.