### PR TITLE
Calculate effective_replication_map: prevent stalls with everywhere_replication_strategy

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -78,6 +78,10 @@ public:
         const replication_strategy_config_options& config_options,
         replication_strategy_type my_type);
 
+    // Evaluates to true iff calculate_natural_endpoints
+    // returns different results for different tokens.
+    virtual bool natural_endpoints_depend_on_token() const noexcept { return true; }
+
     // The returned vector has size O(number of normal token owners), which is O(number of nodes in the cluster).
     // Note: it is not guaranteed that the function will actually yield. If the complexity of a particular implementation
     // is small, that implementation may not yield since by itself it won't cause a reactor stall (assuming practical

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -18,6 +18,8 @@ class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
     everywhere_replication_strategy(const replication_strategy_config_options& config_options);
 
+    virtual bool natural_endpoints_depend_on_token() const noexcept override { return false; }
+
     virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options() const override { /* noop */ }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -27,6 +27,8 @@ public:
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 
+    virtual bool natural_endpoints_depend_on_token() const noexcept override { return false; }
+
     virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options() const override;


### PR DESCRIPTION
For replication strategies like "everywhere"
and "local" that return the same set of endpoints
for all tokens, we can call rs->calculate_natural_endpoints
one once and reuse the result for all token.

Note that ideally the replication_map could contain only
a single token range for this case, but that does't seem to work yet.

Add `maybe_yield()` calls to the tight loop
to prevent reactor stalls on large clusters when copying
a long vector returned by everywhere_replication_strategy
to potentially 1000's of tokens in the map.

Nicholas Peshek wrote in
https://github.com/scylladb/scylladb/issues/10337#issuecomment-1211152370

about similar patch by Geoffrey Beausire:
https://github.com/criteo-forks/scylla/commit/994c6ecf3c4edd151cd1db2ed0c92f32dc832cbb

> Yep. That dropped our startup from 3000+ seconds to about 40.

Fixes #10337