### PR TITLE
test/alternator: fix a flaky test for full-table scan page size

### DIFF
--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -432,12 +432,12 @@ def test_scan_paging_missing_limit(dynamodb):
             KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
             AttributeDefinitions=[
                 { 'AttributeName': 'p', 'AttributeType': 'N' }]) as table:
-        # Insert a 4 MB of data in multiple smaller partitions.
+        # Insert a 6 MB of data in multiple smaller partitions.
         # Because of issue #10327 when the table is *small* Alternator may
-        # return significantly more than 1 MB - sometimes even 3 MB. This
-        # is why we need to use 4 MB of data here and 2 MB is not enough.
+        # return significantly more than 1 MB - sometimes even 4 MB. This
+        # is why we need to use 6 MB of data here and 2 MB is not enough.
         str = 'x' * 10240
-        N = 400
+        N = 600
         with table.batch_writer() as batch:
             for i in range(N):
                 batch.put_item({'p': i, 's': str})


### PR DESCRIPTION
This patch fixes the test test_scan.py::test_scan_paging_missing_limit
which failed in a Jenkins run once (that we know of).

That test verifies that an Alternator Scan operation *without* an explicit
"Limit" is nevertheless paged: DynamoDB (and also Scylla) wanted this page
size to be 1 MB, but it turns out (see #10327) that because of the details
of how Scylla's scan works, the page size can be larger than 1 MB. How much
larger? I ran this test hundreds of times and never saw it exceed a 3 MB
page - so the test asserted the page must be smaller than 4 MB. But now
in one run - we got to this 4 MB and failed the test.

So in this patch we increase the table to be scanned from 4 MB to 6 MB,
and assert the page size isn't the full 6 MB. The chance that this size will
eventually fail as well should be (famous last words...) very small for
two reasons: First because 6 MB is even higher than I the maximum I saw
in practice, and second because empirically I noticed that adding more
data to the table reduces the variance of the page size, so it should
become closer to 1 MB and reduce the chance of it reaching 6 MB.

Refs #10327

Signed-off-by: Nadav Har'El <nyh@scylladb.com>