### PR TITLE
replica/table: eliminate _async_gate

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1857,15 +1857,15 @@ future<> database::do_apply_in_memory(const mutation& m, table& tbl, db::rp_hand
 }
 
 future<> database::apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&& h, db::timeout_clock::time_point timeout) {
-    auto& cf = find_column_family(m.column_family_id());
-    return with_gate(cf.async_gate(), [this, &m, h = std::move(h), &cf, timeout] () mutable -> future<> {
-        return do_apply_in_memory(m, cf, std::move(h), timeout);
+    auto& tbl = find_column_family(m.column_family_id());
+    return with_gate(tbl.async_gate(), [this, &m, h = std::move(h), &tbl, timeout] () mutable -> future<> {
+        return do_apply_in_memory(m, tbl, std::move(h), timeout);
     });
 }
 
-future<> database::apply_in_memory(const mutation& m, column_family& cf, db::rp_handle&& h, db::timeout_clock::time_point timeout) {
-    return with_gate(cf.async_gate(), [this, &m, h = std::move(h), &cf, timeout]() mutable -> future<> {
-        return do_apply_in_memory(m, cf, std::move(h), timeout);
+future<> database::apply_in_memory(const mutation& m, table& tbl, db::rp_handle&& h, db::timeout_clock::time_point timeout) {
+    return with_gate(tbl.async_gate(), [this, &m, h = std::move(h), &tbl, timeout]() mutable -> future<> {
+        return do_apply_in_memory(m, tbl, std::move(h), timeout);
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2830,7 +2830,7 @@ flat_mutation_reader_v2 make_multishard_streaming_reader(distributed<replica::da
             auto& cf = _db.local().find_column_family(schema);
 
             _contexts[shard].range = make_foreign(make_lw_shared<const dht::partition_range>(range));
-            _contexts[shard].read_operation = make_foreign(std::make_unique<utils::phased_barrier::operation>(cf.read_in_progress()));
+            _contexts[shard].read_operation = make_foreign(std::make_unique<utils::phased_barrier::operation>(cf.stream_in_progress()));
             _contexts[shard].semaphore = &cf.streaming_read_concurrency_semaphore();
 
             return cf.make_streaming_reader(std::move(schema), std::move(permit), *_contexts[shard].range, slice, fwd_mr);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1011,7 +1011,8 @@ future<> database::detach_column_family(table& cf) {
     auto uuid = cf.schema()->id();
     remove(cf);
     cf.clear_views();
-    co_await cf.await_pending_ops();
+    co_await cf.close_for_read_write_ops();
+    co_await cf.await_pending_flushes();
     for (auto* sem : {&_read_concurrency_sem, &_streaming_concurrency_sem, &_compaction_concurrency_sem, &_system_read_concurrency_sem}) {
         co_await sem->evict_inactive_reads_for_table(uuid);
     }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1012,7 +1012,7 @@ future<> database::detach_column_family(table& cf) {
     remove(cf);
     cf.clear_views();
     co_await cf.close_for_read_write_ops();
-    co_await cf.await_pending_flushes();
+    co_await cf.await_generic_ops();
     for (auto* sem : {&_read_concurrency_sem, &_streaming_concurrency_sem, &_compaction_concurrency_sem, &_system_read_concurrency_sem}) {
         co_await sem->evict_inactive_reads_for_table(uuid);
     }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2006,9 +2006,6 @@ future<> database::do_apply(schema_ptr s, const frozen_mutation& m, tracing::tra
     // assume failure until proven otherwise
     auto update_writes_failed = defer([&] { ++_stats->total_writes_failed; });
 
-    // I'm doing a nullcheck here since the init code path for db etc
-    // is a little in flux and commitlog is created only when db is
-    // initied from datadir.
     auto uuid = m.column_family_id();
     auto& cf = find_column_family(uuid);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2431,7 +2431,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, c
             auto& cf = *table_shards[this_shard_id()];
             auto st = std::make_unique<table_truncate_state>();
 
-            st->holder = cf.async_gate().hold();
+            st->op = cf.generic_op_in_progress();
 
             // Force mutations coming in to re-acquire higher rp:s
             // This creates a "soft" ordering, in that we will guarantee that

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -992,8 +992,8 @@ public:
         return _pending_flushes_phaser.advance_and_await();
     }
 
-    future<> await_pending_ops() noexcept {
-        return when_all(await_pending_reads(), await_pending_writes(), await_pending_streams(), await_pending_flushes()).discard_result();
+    future<> close_for_read_write_ops() noexcept {
+        return when_all(_pending_reads_phaser.close(), _pending_writes_phaser.close(), _pending_streams_phaser.close()).discard_result();
     }
 
     void add_or_update_view(view_ptr v);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1651,7 +1651,7 @@ private:
     static future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& db, table_id uuid);
 
     struct table_truncate_state {
-        gate::holder holder;
+        utils::phased_barrier::operation op;
         db_clock::time_point low_mark_at;
         db::replay_position low_mark;
         std::vector<compaction_manager::compaction_reenabler> cres;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -477,6 +477,7 @@ private:
     utils::phased_barrier _pending_streams_phaser;
     // Phaser for generic operations
     utils::phased_barrier _pending_generic_ops_phaser;
+    bool _stopped = false;
 
     // This field cashes the last truncation time for the table.
     // The master resides in system.truncated table

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -475,8 +475,8 @@ private:
     utils::phased_barrier _pending_reads_phaser;
     // Corresponding phaser for in-progress streams
     utils::phased_barrier _pending_streams_phaser;
-    // Corresponding phaser for in-progress flushes
-    utils::phased_barrier _pending_flushes_phaser;
+    // Phaser for generic operations
+    utils::phased_barrier _pending_generic_ops_phaser;
 
     // This field cashes the last truncation time for the table.
     // The master resides in system.truncated table
@@ -988,8 +988,12 @@ public:
         return _pending_streams_phaser.operations_in_progress();
     }
 
-    future<> await_pending_flushes() noexcept {
-        return _pending_flushes_phaser.advance_and_await();
+    utils::phased_barrier::operation generic_op_in_progress() {
+        return _pending_generic_ops_phaser.start();
+    }
+
+    future<> await_generic_ops() noexcept {
+        return _pending_generic_ops_phaser.advance_and_await();
     }
 
     future<> close_for_read_write_ops() noexcept {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1366,7 +1366,7 @@ public:
     future<> init_commitlog();
     const gms::feature_service& features() const { return _feat; }
     future<> apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&&, db::timeout_clock::time_point timeout);
-    future<> apply_in_memory(const mutation& m, column_family& cf, db::rp_handle&&, db::timeout_clock::time_point timeout);
+    future<> apply_in_memory(const mutation& m, table& tbl, db::rp_handle&&, db::timeout_clock::time_point timeout);
 
     wasm::engine* wasm_engine() {
         return _wasm_engine.get();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1356,6 +1356,9 @@ private:
     serialized_action _update_memtable_flush_static_shares_action;
     utils::observer<float> _memtable_flush_static_shares_observer;
 
+private:
+    future<> do_apply_in_memory(const frozen_mutation& m, table& cf, db::rp_handle&&, db::timeout_clock::time_point timeout);
+    future<> do_apply_in_memory(const mutation& m, table& tbl, db::rp_handle&&, db::timeout_clock::time_point timeout);
 public:
     data_dictionary::database as_data_dictionary() const;
     std::shared_ptr<data_dictionary::user_types_storage> as_user_types_storage() const noexcept;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -766,6 +766,8 @@ public:
         do_apply(compaction_group_for_token(m.token()), std::move(h), m);
     }
 
+    // Note: caller is required to take write_in_progress() right after looking up
+    // table object and keep it alive until query is over.
     future<> apply(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&& h, db::timeout_clock::time_point tmo);
     future<> apply(const mutation& m, db::rp_handle&& h, db::timeout_clock::time_point tmo);
 
@@ -774,6 +776,9 @@ public:
     // the saved querier from the previous page (if there was one) and after
     // completion it contains the to-be saved querier for the next page (if
     // there is one). Pass nullptr when queriers are not saved.
+    //
+    // Note: caller is required to take read_in_progress() right after looking up
+    // table object and keep it alive until query is over.
     future<lw_shared_ptr<query::result>>
     query(schema_ptr,
         reader_permit permit,
@@ -801,6 +806,9 @@ public:
     // the saved querier from the previous page (if there was one) and after
     // completion it contains the to-be saved querier for the next page (if
     // there is one). Pass nullptr when queriers are not saved.
+    //
+    // Note: caller is required to take read_in_progress() right after looking up
+    // table object and keep it alive until query is over.
     future<reconcilable_result>
     mutation_query(schema_ptr s,
             reader_permit permit,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -455,14 +455,6 @@ private:
     // in dynamically
     std::unordered_map<gms::inet_address, cache_hit_rate> _cluster_cache_hit_rates;
 
-    // Operations like truncate, flush, query, etc, may depend on a column family being alive to
-    // complete.  Some of them have their own gate already (like flush), used in specialized wait
-    // logic. That is particularly useful if there is a particular
-    // order in which we need to close those gates. For all the others operations that don't have
-    // such needs, we have this generic _async_gate, which all potentially asynchronous operations
-    // have to get.  It will be closed by stop().
-    seastar::gate _async_gate;
-
     double _cached_percentile = -1;
     lowres_clock::time_point _percentile_cache_timestamp;
     std::chrono::milliseconds _percentile_cache_value;
@@ -612,8 +604,6 @@ public:
     sstring dir() const {
         return _config.datadir;
     }
-
-    seastar::gate& async_gate() { return _async_gate; }
 
     uint64_t failed_counter_applies_to_memtable() const {
         return _failed_counter_applies_to_memtable;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2155,13 +2155,11 @@ table::query(schema_ptr s,
         co_return make_lw_shared<query::result>();
     }
 
-    _async_gate.enter();
     utils::latency_counter lc;
     _stats.reads.set_latency(lc);
 
     auto finally = defer([&] () noexcept {
         _stats.reads.mark(lc);
-        _async_gate.leave();
     });
 
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());


### PR DESCRIPTION
The existence of `table::_async_gate` together with the various specialized phasers causes a lot of confusion:
* Is it supposed to be used by internal operations?
* Is it supposed to be used internally by the table while external users use the phasers?
* Is it supposed to be used in tandem with the phasers?

It appears that the answer is a a little bit of all three, at least after going through the code. Internal operations (compaction, flush) do seem to use the async gate, but memtable flushes also take the flush phaser (but not always). The read path (query()) uses both the read phaser and the async gate, but mutation_query() and the range scan code only uses the read phaser. The write path, depending on the exact call path uses either both or just the async gate. This is a confusing mess and as recently we've seen a crash with inactive reader still being around after the plug has been pulled on the table I decided to attempt to clean this up.
This series eliminates the _async_gate internally. In its stead it introduces a generic phaser (also replacing the flush phaser). The read/write/stream path now only use the respective specific phasers. Other external users and internal users use the new generic phaser. `phased_barrier` gets `close()` and `is_closed()` methods. This means reads/writes/streams will now fail after detaching the table from the database, unlike before, where new ones could still slip in if they had a pre-existing table reference.