### PR TITLE
utils/logalloc: consolidate lsa state in shard tracker

### DIFF
--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -128,7 +128,7 @@ region_group::start_releaser(scheduling_group deferred_work_sg) {
                 } else {
                     // Block reclaiming to prevent signal() from being called by reclaimer inside wait()
                     // FIXME: handle allocation failures (not very likely) like allocating_section does
-                    tracker_reclaimer_lock rl;
+                    tracker_reclaimer_lock rl(logalloc::shard_tracker());
                     return _relief.wait().then([] {
                         return stop_iteration::no;
                     });

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -236,7 +236,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader_v2::impl, pub
 
         template<typename Function>
         decltype(auto) with_reserve(Function&& fn) {
-            return _read_section.with_reserve(std::forward<Function>(fn));
+            return _read_section.with_reserve(_region, std::forward<Function>(fn));
         }
 
         tombstone partition_tombstone() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -191,7 +191,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
     memory::set_additional_diagnostics_producer([this] (memory::memory_diagnostics_writer wr) {
         auto writeln = memory_diagnostics_line_writer(std::move(wr));
 
-        const auto lsa_occupancy_stats = logalloc::lsa_global_occupancy_stats();
+        const auto lsa_occupancy_stats = logalloc::shard_tracker().global_occupancy();
         writeln("LSA\n");
         writeln("  allocated: {}\n", utils::to_hr_size(lsa_occupancy_stats.total_space()));
         writeln("  used:      {}\n", utils::to_hr_size(lsa_occupancy_stats.used_space()));

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -748,10 +748,10 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
     std::vector<managed_bytes> std_allocs;
     size_t std_alloc_size = 1000000; // note that managed_bytes fragments these, even in std
     for (int i = 0; i < 50; ++i) {
-        auto compacted_pre = logalloc::memory_compacted();
+        auto compacted_pre = logalloc::shard_tracker().statistics().memory_compacted;
         fmt::print("compacted {} items {} (pre)\n", compacted_pre, evictable_allocs.size());
         std_allocs.emplace_back(managed_bytes::initialized_later(), std_alloc_size);
-        auto compacted_post = logalloc::memory_compacted();
+        auto compacted_post = logalloc::shard_tracker().statistics().memory_compacted;
         fmt::print("compacted {} items {} (post)\n", compacted_post, evictable_allocs.size());
         BOOST_REQUIRE_EQUAL(compacted_pre, compacted_post);
     

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -40,8 +40,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 
     for (int i = 0; i < update_iterations; ++i) {
         auto MB = 1024 * 1024;
-        auto prefill_compacted = logalloc::memory_compacted();
-        auto prefill_allocated = logalloc::memory_allocated();
+        const auto prefill_stats = logalloc::shard_tracker().statistics();
+        auto prefill_compacted = prefill_stats.memory_compacted;
+        auto prefill_allocated = prefill_stats.memory_allocated;
 
         scheduling_latency_measurer memtable_slm;
         memtable_slm.start();
@@ -66,8 +67,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
         });
         std::cout << format("took {:.6f} [ms]", drain_d.count() * 1000) << std::endl;
 
-        auto prev_compacted = logalloc::memory_compacted();
-        auto prev_allocated = logalloc::memory_allocated();
+        const auto prev_stats = logalloc::shard_tracker().statistics();
+        auto prev_compacted = prev_stats.memory_compacted;
+        auto prev_allocated = prev_stats.memory_allocated;
         auto prev_rows_processed_from_memtable = tracker.get_stats().rows_processed_from_memtable;
         auto prev_rows_merged_from_memtable = tracker.get_stats().rows_merged_from_memtable;
         auto prev_rows_dropped_from_memtable = tracker.get_stats().rows_dropped_from_memtable;
@@ -109,8 +111,9 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 
         slm.stop();
 
-        auto compacted = logalloc::memory_compacted() - prev_compacted;
-        auto allocated = logalloc::memory_allocated() - prev_allocated;
+        const auto stats = logalloc::shard_tracker().statistics();
+        auto compacted = stats.memory_compacted - prev_compacted;
+        auto allocated = stats.memory_allocated - prev_allocated;
 
         std::cout << format("update: {:.6f} [ms], preemption: {}, cache: {:d}/{:d} [MB], alloc/comp: {:d}/{:d} [MB] (amp: {:.3f}), pr/me/dr {:d}/{:d}/{:d}\n",
             d.count() * 1000,

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1732,8 +1732,8 @@ private:
     };
 
 public:
-    explicit region_impl(region* region)
-        : _region(region), _id(next_id())
+    explicit region_impl(tracker& tracker, region* region)
+        : basic_region_impl(tracker), _region(region), _id(next_id())
     {
         _buf_ptrs_for_compact_segment.reserve(segment::size / buf_align);
         _preferred_max_contiguous_allocation = max_managed_object_size;
@@ -1743,7 +1743,7 @@ public:
     virtual ~region_impl() {
         _sanitizer.on_region_destruction();
 
-        tracker_instance._impl->unregister_region(this);
+        _tracker.get_impl().unregister_region(this);
 
         while (!_segment_descs.empty()) {
             auto& desc = _segment_descs.one_of_largest();
@@ -2118,7 +2118,7 @@ memory::reclaiming_result tracker::reclaim(seastar::memory::reclaimer::request r
 }
 
 region::region()
-    : _impl(make_shared<impl>(this))
+    : _impl(make_shared<impl>(shard_tracker(), this))
 { }
 
 void

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -512,7 +512,7 @@ private:
     size_t reclaim_locked(size_t bytes, is_preemptible p);
 };
 
-tracker_reclaimer_lock::tracker_reclaimer_lock() noexcept : _tracker_impl(shard_tracker().get_impl()) {
+tracker_reclaimer_lock::tracker_reclaimer_lock(tracker::impl& impl) noexcept : _tracker_impl(impl) {
     _tracker_impl.disable_reclaim();
 }
 
@@ -1074,7 +1074,7 @@ segment* segment_pool::allocate_segment(size_t reserve)
     //    memory in order to reclaim enough segments.
     //
     do {
-        tracker_reclaimer_lock rl;
+        tracker_reclaimer_lock rl(_tracker);
         if (_free_segments > reserve) {
             auto free_idx = _lsa_free_segments_bitmap.find_last_set();
             _lsa_free_segments_bitmap.clear(free_idx);
@@ -2609,7 +2609,7 @@ bool segment_pool::compact_segment(segment* seg) {
     // one more segment
     reservation_goal open_emergency_pool(*this, 0);
     allocation_lock no_alloc(*this);
-    tracker_reclaimer_lock no_reclaim;
+    tracker_reclaimer_lock no_reclaim(_tracker);
 
     desc._region->compact_segment(seg, desc);
     return true;

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -574,11 +574,6 @@ struct alignas(segment_size) segment {
         return reinterpret_cast<T*>(data + offset);
     }
 
-    bool is_empty() const noexcept;
-    void record_alloc(size_type size) noexcept;
-    void record_free(size_type size) noexcept;
-    occupancy_stats occupancy() const noexcept;
-
     static void* operator new(size_t size) = delete;
     static void* operator new(size_t, void* ptr) noexcept { return ptr; }
     static void operator delete(void* ptr) = delete;
@@ -1258,26 +1253,6 @@ static segment_pool& get_shard_segment_pool() noexcept {
 
 static thread_local segment_pool& shard_segment_pool = get_shard_segment_pool();
 
-void segment::record_alloc(segment::size_type size) noexcept {
-    shard_segment_pool.descriptor(this).record_alloc(size);
-}
-
-void segment::record_free(segment::size_type size) noexcept {
-    shard_segment_pool.descriptor(this).record_free(size);
-}
-
-bool segment::is_empty() const noexcept {
-    return shard_segment_pool.descriptor(this).is_empty();
-}
-
-// Note: allocation is disallowed in this path
-// since we don't instantiate reclaiming_lock
-// while traversing _regions
-occupancy_stats
-segment::occupancy() const noexcept {
-    return { shard_segment_pool.descriptor(this).free_space(), segment::size };
-}
-
 thread_local reclaim_timer* reclaim_timer::_active_timer;
 thread_local clock::duration reclaim_timer::_duration_threshold = clock::duration::zero();
 
@@ -1535,7 +1510,7 @@ private:
 
         // Align the end of the value so that the next descriptor is aligned
         _active_offset = align_up_for_asan(_active_offset);
-        _active->record_alloc(_active_offset - old_active_offset);
+        shard_segment_pool.descriptor(_active).record_alloc(_active_offset - old_active_offset);
         return pos;
     }
 
@@ -1567,10 +1542,11 @@ private:
             auto pos =_active->at<char>(_active_offset);
             desc.encode(pos);
         }
-        llogger.trace("Closing segment {}, used={}, waste={} [B]", fmt::ptr(_active), _active->occupancy(), segment::size - _active_offset);
-        _closed_occupancy += _active->occupancy();
+        auto& desc = shard_segment_pool.descriptor(_active);
+        llogger.trace("Closing segment {}, used={}, waste={} [B]", fmt::ptr(_active), desc.occupancy(), segment::size - _active_offset);
+        _closed_occupancy += desc.occupancy();
 
-        _segment_descs.push(shard_segment_pool.descriptor(_active));
+        _segment_descs.push(desc);
         _active = nullptr;
     }
 
@@ -1578,10 +1554,11 @@ private:
         if (!_buf_active) {
             return;
         }
-        llogger.trace("Closing buf segment {}, used={}, waste={} [B]", fmt::ptr(_buf_active), _buf_active->occupancy(), segment::size - _buf_active_offset);
-        _closed_occupancy += _buf_active->occupancy();
+        auto& desc = shard_segment_pool.descriptor(_buf_active);
+        llogger.trace("Closing buf segment {}, used={}, waste={} [B]", fmt::ptr(_buf_active), desc.occupancy(), segment::size - _buf_active_offset);
+        _closed_occupancy += desc.occupancy();
 
-        _segment_descs.push(shard_segment_pool.descriptor(_buf_active));
+        _segment_descs.push(desc);
         _buf_active = nullptr;
     }
 
@@ -1646,7 +1623,7 @@ private:
         segment *seg = shard_segment_pool.segment_from(desc);
 
         if (seg != _buf_active) {
-            _closed_occupancy -= seg->occupancy();
+            _closed_occupancy -= desc.occupancy();
         }
 
         auto alloc_size = align_up(buf._size, buf_align);
@@ -1776,12 +1753,12 @@ public:
         }
         _closed_occupancy = {};
         if (_active) {
-            assert(_active->is_empty());
+            assert(shard_segment_pool.descriptor(_active).is_empty());
             free_segment(_active);
             _active = nullptr;
         }
         if (_buf_active) {
-            assert(_buf_active->is_empty());
+            assert(shard_segment_pool.descriptor(_buf_active).is_empty());
             free_segment(_buf_active);
             _buf_active = nullptr;
         }
@@ -1823,10 +1800,10 @@ public:
         occupancy_stats total = _non_lsa_occupancy;
         total += _closed_occupancy;
         if (_active) {
-            total += _active->occupancy();
+            total += shard_segment_pool.descriptor(_active).occupancy();
         }
         if (_buf_active) {
-            total += _buf_active->occupancy();
+            total += shard_segment_pool.descriptor(_buf_active).occupancy();
         }
         return total;
     }
@@ -1940,7 +1917,7 @@ public:
         poison(pos, dead_size);
 
         if (seg != _active) {
-            _closed_occupancy -= seg->occupancy();
+            _closed_occupancy -= seg_desc.occupancy();
         }
 
         seg_desc.record_free(dead_size);
@@ -1983,7 +1960,7 @@ public:
         unlisten_temporarily ult1(this);
         unlisten_temporarily ult2(&other);
 
-        if (_active && _active->is_empty()) {
+        if (_active && shard_segment_pool.descriptor(_active).is_empty()) {
             shard_segment_pool.free_segment(_active);
             _active = nullptr;
         }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -158,7 +158,8 @@ public:
 class tracker_reclaimer_lock {
     tracker::impl& _tracker_impl;
 public:
-    tracker_reclaimer_lock() noexcept;
+    tracker_reclaimer_lock(tracker::impl& impl) noexcept;
+    tracker_reclaimer_lock(tracker& t) noexcept : tracker_reclaimer_lock(t.get_impl()) { }
     ~tracker_reclaimer_lock();
 };
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -249,9 +249,15 @@ public:
 
 class basic_region_impl : public allocation_strategy {
 protected:
+    tracker& _tracker;
     bool _reclaiming_enabled = true;
     seastar::shard_id _cpu = this_shard_id();
 public:
+    basic_region_impl(tracker& tracker) : _tracker(tracker)
+    { }
+
+    tracker& get_tracker() { return _tracker; }
+
     void set_reclaiming_enabled(bool enabled) noexcept {
         assert(this_shard_id() == _cpu);
         _reclaiming_enabled = enabled;
@@ -296,6 +302,10 @@ public:
     void unlisten();
 
     occupancy_stats occupancy() const noexcept;
+
+    tracker& get_tracker() const {
+        return _impl->get_tracker();
+    }
 
     allocation_strategy& allocator() noexcept {
         return *_impl;

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -65,6 +65,44 @@ public:
         scheduling_group background_reclaim_sched_group;
     };
 
+    struct stats {
+        size_t segments_compacted;
+        size_t lsa_buffer_segments;
+        uint64_t memory_allocated;
+        uint64_t memory_freed;
+        uint64_t memory_compacted;
+        uint64_t memory_evicted;
+
+        friend stats operator+(const stats& s1, const stats& s2) {
+            stats result(s1);
+            result += s2;
+            return result;
+        }
+        friend stats operator-(const stats& s1, const stats& s2) {
+            stats result(s1);
+            result -= s2;
+            return result;
+        }
+        stats& operator+=(const stats& other) {
+            segments_compacted += other.segments_compacted;
+            lsa_buffer_segments += other.lsa_buffer_segments;
+            memory_allocated += other.memory_allocated;
+            memory_freed += other.memory_freed;
+            memory_compacted += other.memory_compacted;
+            memory_evicted += other.memory_evicted;
+            return *this;
+        }
+        stats& operator-=(const stats& other) {
+            segments_compacted -= other.segments_compacted;
+            lsa_buffer_segments -= other.lsa_buffer_segments;
+            memory_allocated -= other.memory_allocated;
+            memory_freed -= other.memory_freed;
+            memory_compacted -= other.memory_compacted;
+            memory_evicted -= other.memory_evicted;
+            return *this;
+        }
+    };
+
     void configure(const config& cfg);
     future<> stop();
 
@@ -78,6 +116,8 @@ private:
 public:
     tracker();
     ~tracker();
+
+    stats statistics() const;
 
     //
     // Tries to reclaim given amount of bytes in total using all compactible
@@ -95,6 +135,8 @@ public:
     void full_compaction();
 
     void reclaim_all_free_segments();
+
+    occupancy_stats global_occupancy() const noexcept;
 
     // Returns aggregate statistics for all pools.
     occupancy_stats region_occupancy() const noexcept;
@@ -481,12 +523,5 @@ public:
 };
 
 future<> prime_segment_pool(size_t available_memory, size_t min_free_memory);
-
-uint64_t memory_allocated() noexcept;
-uint64_t memory_freed() noexcept;
-uint64_t memory_compacted() noexcept;
-uint64_t memory_evicted() noexcept;
-
-occupancy_stats lsa_global_occupancy_stats() noexcept;
 
 }


### PR DESCRIPTION
Currently the state of LSA is scattered across a handful of global variables. This series consolidates all these into a single one: the shard tracker. Beyond reducing the number of globals (the less globals, the better) this paves the way for a planned de-globalization of the shard tracker itself.
There is one separate global left, the static migrators registry. This is left as-is for now.