### PR TITLE
doc: add the upgrade guide for ScyllaDB image from 2021.1 to 2022.1

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
@@ -1,0 +1,104 @@
+=============================================================================
+Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION| for |OS|
+=============================================================================
+
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2021.1 to ScyllaDB Enterprise 2022.1, and rollback to 2021.1 if required.
+
+
+Applicable Versions
+===================
+This guide covers upgrading ScyllaDB Enterprise from version 2021.1.x to ScyllaDB Enterprise version 2022.1.y on |OS|.
+
+Upgrade Procedure
+=================
+.. include:: /upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
+
+A ScyllaDB upgrade is a rolling procedure that does **not** require a full cluster shutdown.
+For each of the nodes in the cluster, you will:
+
+* Check the cluster schema
+* Drain the node and backup the data
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install the new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node that you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use new 2022.1 features.
+* Not to run administration functions, like repairs, refresh, rebuild, or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/index.html>`_ for suspending ScyllaDB Manager's scheduled or running repairs.
+* Not to apply schema changes.
+
+.. include:: /upgrade/_common/upgrade_to_2022_warning.rst
+  
+Upgrade Steps
+=============
+Check the cluster schema
+-------------------------
+Make sure that all nodes have the schema synched before the upgrade. The upgrade will fail if there is a schema disagreement between nodes.
+
+.. code:: sh
+
+       nodetool describecluster
+
+Drain the nodes and backup the data
+-------------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In ScyllaDB, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
+
+Backup the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-2021.1
+
+Gracefully stop the node
+------------------------
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server stop
+
+Download and install the new release
+------------------------------------
+Before upgrading, check what version you are running now using ``dpkg -l scylla\*server``. You should use the same version in case you want to |ROLLBACK|_ the upgrade. If you are not running a 2021.1.x version, stop right here! This guide only covers 2021.1.x to 2022.1.y upgrades.
+
+**To upgrade ScyllaDB:**
+
+#. Update the |APT|_ to **2022.1** and enable scylla/ppa repo.
+
+   .. code:: sh
+
+       Ubuntu 16:
+       sudo add-apt-repository -y ppa:scylladb/ppa
+
+#. Configure Java 1.8, which is requested by ScyllaDB Enterprise 2022.1.
+
+   .. code:: sh
+ 
+      sudo apt-get update
+      sudo apt-get install -y openjdk-8-jre-headless
+      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+#. Install:
+
+   .. code:: sh
+
+      sudo apt-get clean all
+      sudo apt-get update
+      sudo apt-get dist-upgrade scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
@@ -7,7 +7,7 @@ This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise
 
 Applicable Versions
 ===================
-This guide covers upgrading ScyllaDB Enterprise from version 2021.1.x to ScyllaDB Enterprise version 2022.1.y on |OS|.
+This guide covers upgrading ScyllaDB Enterprise from version 2021.1.x to ScyllaDB Enterprise version 2022.1.y on |OS|. See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
 
 Upgrade Procedure
 =================

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
@@ -75,30 +75,5 @@ Download and install the new release
 ------------------------------------
 Before upgrading, check what version you are running now using ``dpkg -l scylla\*server``. You should use the same version in case you want to |ROLLBACK|_ the upgrade. If you are not running a 2021.1.x version, stop right here! This guide only covers 2021.1.x to 2022.1.y upgrades.
 
-**To upgrade ScyllaDB:**
 
-#. Update the |APT|_ to **2022.1** and enable scylla/ppa repo.
-
-   .. code:: sh
-
-       Ubuntu 16:
-       sudo add-apt-repository -y ppa:scylladb/ppa
-
-#. Configure Java 1.8, which is requested by ScyllaDB Enterprise 2022.1.
-
-   .. code:: sh
- 
-      sudo apt-get update
-      sudo apt-get install -y openjdk-8-jre-headless
-      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-
-#. Install:
-
-   .. code:: sh
-
-      sudo apt-get clean all
-      sudo apt-get update
-      sudo apt-get dist-upgrade scylla-enterprise
-
-Answer ‘y’ to the first two questions.
 

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
@@ -1,3 +1,30 @@
+**To upgrade ScyllaDB:**
+
+#. Update the |APT|_ to **2022.1** and enable scylla/ppa repo.
+
+   .. code:: sh
+
+       Ubuntu 16:
+       sudo add-apt-repository -y ppa:scylladb/ppa
+
+#. Configure Java 1.8, which is requested by ScyllaDB Enterprise 2022.1.
+
+   .. code:: sh
+ 
+      sudo apt-get update
+      sudo apt-get install -y openjdk-8-jre-headless
+      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+#. Install:
+
+   .. code:: sh
+
+      sudo apt-get clean all
+      sudo apt-get update
+      sudo apt-get dist-upgrade scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+
 Start the node
 --------------
 

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
@@ -1,0 +1,100 @@
+Start the node
+--------------
+
+A new io.conf format was introduced in Scylla 2.3 and 2019.1. If your io.conf doesn't contain `--io-properties-file` option, then it's still the old format. You need to re-run the io setup to generate new io.conf.
+
+.. code:: sh
+
+    sudo scylla_io_setup
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server start
+
+Validate
+--------
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
+#. Check scylla-enterprise-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+#. Check again after two minutes to validate no new issues are introduced.
+
+Once you are sure the node upgrade is successful, move to the next node in the cluster.
+
+See :doc:`Scylla Metrics Update - Scylla Enterprise 2021.1 to 2022.1<metric-update-2021.1-to-2022.1>` for more information.
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from ScyllaDB Enterprise release 2022.1.x to 2022.1.y. Apply this procedure if an upgrade from 2021.1 to 2022.1 failed before completing on all nodes. Use this procedure only for nodes you upgraded to 2022.1
+
+ScyllaDB rollback is a rolling procedure that does **not** require a full cluster shutdown.
+For each of the nodes you rollback to 2021.1, you will:
+
+* Drain the node and stop ScyllaDB
+* Retrieve the old Scylla packages
+* Restore the configuration file
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running with the new version.
+
+Rollback Steps
+==============
+Gracefully shutdown ScyllaDB
+----------------------------
+
+.. code:: sh
+
+   nodetool drain
+   sudo service scylla-enterprise-server stop
+
+Download and install the old release
+------------------------------------
+#. Remove the old repo file.
+
+    .. code:: sh
+
+       sudo rm -rf /etc/apt/sources.list.d/scylla.list
+
+#. Update the |APT|_ to **2021.1**.
+#. Install:
+
+    .. code:: sh
+
+       sudo apt-get clean all
+       sudo apt-get update
+       sudo apt-get remove scylla\* -y
+       sudo apt-get install scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+
+Restore the configuration file
+------------------------------
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-2021.1 /etc/scylla/scylla.yaml
+
+Restore system tables
+---------------------
+
+Restore all tables of **system** and **system_schema** from the previous snapshot - 2022.1 uses a different set of system tables. Reference doc: :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`.
+
+.. code:: sh
+
+    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
+    sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
+    sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server start
+
+Validate
+--------
+Check the upgrade instructions above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
@@ -80,7 +80,7 @@ Restore the configuration file
 Restore system tables
 ---------------------
 
-Restore all tables of **system** and **system_schema** from the previous snapshot - 2022.1 uses a different set of system tables. Reference doc: :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`.
+Restore all tables of **system** and **system_schema** from the previous snapshot - 2022.1 uses a different set of system tables. Refer to :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`.
 
 .. code:: sh
 

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian.rst
@@ -1,0 +1,2 @@
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
@@ -96,11 +96,6 @@ Before upgrading, check what version you are running now using ``dpkg -s scylla-
 
 Answer ‘y’ to the first two questions.
 
-**To upgrade ScyllaDB and update 3rd party and OS packages:**
-
-.. include:: /upgrade/_common/upgrade-image.rst
-
-
 .. note::
 
    Alternator users upgrading from Scylla 4.0 to 4.1 need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`.

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
@@ -81,22 +81,4 @@ Download and install the new release
 ------------------------------------
 Before upgrading, check what version you are running now using ``dpkg -s scylla-server``. You should use the same version in case you want to |ROLLBACK|_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
-**To upgrade ScyllaDB:**
-
-1. Update the |SCYLLA_REPO|_ to |NEW_VERSION|
-
-2. Install
-
-.. code-block::
-   
-   sudo apt-get clean all
-   sudo apt-get update
-   sudo apt-get dist-upgrade |PKG_NAME|
-
-
-Answer ‘y’ to the first two questions.
-
-.. note::
-
-   Alternator users upgrading from Scylla 4.0 to 4.1 need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`.
 

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p2.rst
@@ -1,3 +1,23 @@
+**To upgrade ScyllaDB:**
+
+1. Update the |SCYLLA_REPO|_ to |NEW_VERSION|
+
+2. Install
+
+.. code-block::
+   
+   sudo apt-get clean all
+   sudo apt-get update
+   sudo apt-get dist-upgrade |PKG_NAME|
+
+
+Answer ‘y’ to the first two questions.
+
+.. note::
+
+   Alternator users upgrading from Scylla 4.0 to 4.1 need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`.
+
+
 Start the node
 --------------
 

--- a/docs/upgrade/_common/upgrade-image.rst
+++ b/docs/upgrade/_common/upgrade-image.rst
@@ -7,16 +7,23 @@ This installation upgrade method allows you to upgrade your ScyllaDB version and
 
 #. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.
 
-#. Run the following command:
+#. Run the following command to update the manifest file:
     
     .. code:: sh 
     
-       cat scylla-packages-xxx-x86_64.txt | sudo xargs -n1 apt-get -y
+       cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get -y
     
+    Where:
+
+      * ``<version>`` - The Scylla version to which you are upgrading ( |NEW_VERSION| ).
+      * ``<arch>`` - Architecture type: ``x86`` or ``aarch644``.
     
-    Where xxx is the relevant Scylla version ( |NEW_VERSION| ). The file is included in the Scylla packages downloaded in the previous step.
-    
-    For example
+    The file is included in the ScyllaDB packages downloaded in the previous step. The file location is:
+
+     * ScyllaDB Enterprise: ``http://downloads.scylladb.com/downloads/scylla-enterprise/aws/manifest/scylla-packages-<version>-<arch>.txt``
+     * ScyllaDB Open Source: ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
+
+    Example:
     
         .. code:: sh 
            

--- a/docs/upgrade/_common/upgrade-image.rst
+++ b/docs/upgrade/_common/upgrade-image.rst
@@ -1,7 +1,9 @@
+**To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
+
 .. versionadded:: Scylla 5.0
 .. versionadded:: Scylla Enterprise 2021.1.10
 
-This alternative installation upgrade method allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command. This method is recommended if you run a ScyllaDB official image (EC2 AMI, GCP, and Azure images) based on Ubuntu 20.04.
+This installation upgrade method allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command. This method is recommended if you run a ScyllaDB official image (EC2 AMI, GCP, and Azure images), which is based on Ubuntu 20.04.
 
 #. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.
 

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
@@ -7,9 +7,9 @@ Upgrade from ScyllaDB Enterprise 2021.1 to 2022.1
    :titlesonly:
 
    Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>
-   Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>
-   Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>
+   Ubuntu <upgrade-guide-from-2021.1-to-2022.1-ubuntu>
    Debian <upgrade-guide-from-2021.1-to-2022.1-debian>
+   ScyllaDB Image <upgrade-guide-from-2022.1-to-2022.1-image>
    Metrics <metric-update-2021.1-to-2022.1>
 
 .. raw:: html
@@ -25,9 +25,9 @@ Upgrade from ScyllaDB Enterprise 2021.1 to 2022.1
 Upgrade guides are available for:
 
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>`
-* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>`
-* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu <upgrade-guide-from-2021.1-to-2022.1-ubuntu>`
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Debian <upgrade-guide-from-2021.1-to-2022.1-debian>`
+* :doc:`Upgrade ScyllaDB Enterprise Image (EC2, GCP, and Azure) from 2021.1.x to 2022.1.y <upgrade-guide-from-2022.1-to-2022.1-image>`
 * :doc:`ScyllaDB Enterprise Metrics Update - Scylla 2021.1 to 2022.1<metric-update-2021.1-to-2022.1>`
 
 

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian.rst
@@ -1,7 +1,13 @@
-.. |OS| replace:: Debian 9
+.. |OS| replace:: Debian
 .. |ROLLBACK| replace:: rollback
-.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian/#rollback-procedure
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1/#rollback-procedure
+.. |SRC_VERSION| replace:: 2021.1
+.. |NEW_VERSION| replace:: 2022.1
+.. |SCYLLA_NAME| replace:: ScyllaDB Enterprise
+.. |PKG_NAME| replace:: scylla
 .. |APT| replace:: ScyllaDB Enterprise Deb repo
 .. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=debian-9&version=stable-release-2022.1
+.. |SCYLLA_REPO| replace:: ScyllaDB Enterprise Deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/customer-portal/?product=ent&platform=debian-9&version=stable-release-2022.1
 .. |OPENJDK| replace:: openjdk-8-jre-headless
-.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04.rst
@@ -1,7 +1,0 @@
-.. |OS| replace:: 18.04
-.. |ROLLBACK| replace:: rollback
-.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04/#rollback-procedure
-.. |APT| replace:: ScyllaDB Enterprise Deb repo
-.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-18.04&version=stable-release-2022.1
-.. |OPENJDK| replace:: openjdk-8-jre-headless
-.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04.rst
@@ -1,7 +1,0 @@
-.. |OS| replace:: 20.04
-.. |ROLLBACK| replace:: rollback
-.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04/#rollback-procedure
-.. |APT| replace:: ScyllaDB Enterprise Deb repo
-.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
-.. |OPENJDK| replace:: openjdk-8-jre-headless
-.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu.rst
@@ -1,0 +1,13 @@
+.. |OS| replace:: Ubuntu
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu/#rollback-procedure
+.. |SRC_VERSION| replace:: 2021.1
+.. |NEW_VERSION| replace:: 2022.1
+.. |SCYLLA_NAME| replace:: ScyllaDB Enterprise
+.. |PKG_NAME| replace:: scylla
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. |SCYLLA_REPO| replace:: ScyllaDB Enterprise Deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2022.1-to-2022.1-image.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2022.1-to-2022.1-image.rst
@@ -1,0 +1,18 @@
+.. |OS| replace:: EC2, GCP, and Azure
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-image/#rollback-procedure
+.. |SRC_VERSION| replace:: 2021.1
+.. |NEW_VERSION| replace:: 2022.1
+.. |SCYLLA_NAME| replace:: ScyllaDB Image
+.. |PKG_NAME| replace:: scylla
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. |SCYLLA_REPO| replace:: ScyllaDB Enterprise Deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. |SCYLLA_METRICS| replace:: Scylla Metrics Update - Scylla 2021.1 to 2022.1
+.. _SCYLLA_METRICS: ../metric-update-2021.1-to-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+.. include:: /upgrade/_common/upgrade-image.rst
+.. include:: /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
+


### PR DESCRIPTION
This PR is related to  https://github.com/scylladb/scylla-docs/issues/4124 and https://github.com/scylladb/scylla-docs/issues/4123.

**New Enterprise Upgrade Guide from 2021.1 to 2022.2** 
I've added the upgrade guide for ScyllaDB Enterprise image. In consists of 3 files:
/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
upgrade/_common/upgrade-image.rst
 /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst

**Modified Enterprise Upgrade Guides 2021.1 to 2022.2**
I've modified the existing guides for Ubuntu and Debian to use the same files as above, but exclude the image-related information:
/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst + /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst = /upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian.rst

To make things simpler and remove duplication, I've replaced the guides for Ubuntu 18 and 20 with a generic Ubuntu guide.

**Modified Enterprise Upgrade Guides from 4.6 to 5.0**
These guides included a bug: they included the image-related information (about updating OS packages), because a file that includes that information was included by mistake. What's worse, it was duplicated. After the includes were removed, image-related information is no longer included in the Ubuntu and Debian guides (this fixes https://github.com/scylladb/scylla-docs/issues/4123).


I've modified the index file to be in sync with the updates.