### PR TITLE
db/virtual_table: add virtual destructor to virtual_table

### DIFF
--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -38,6 +38,7 @@ public:
     };
 
     explicit virtual_table(schema_ptr s) : _s(std::move(s)) {}
+    virtual ~virtual_table() = default;
 
     const schema_ptr& schema() const { return _s; }
 


### PR DESCRIPTION
It should have had one, derived instances are stored and destroyed via
the base-class. The only reason this haven't caused bugs yet is that
derived instances happen to not have any non-trivial members yet.