### PR TITLE
raft: server: drop waiters in `applier_fiber` instead of `io_fiber`

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -115,7 +115,13 @@ private:
     condition_variable _applied_index_changed;
 
     struct stop_apply_fiber{}; // exception to send when apply fiber is needs to be stopepd
-    queue<std::variant<std::vector<log_entry_ptr>, snapshot_descriptor>> _apply_entries = queue<std::variant<std::vector<log_entry_ptr>, snapshot_descriptor>>(10);
+
+    struct removed_from_config{}; // sent to applier_fiber when we're not a leader and we're outside the current configuration
+    using applier_fiber_message = std::variant<
+        std::vector<log_entry_ptr>,
+        snapshot_descriptor,
+        removed_from_config>;
+    queue<applier_fiber_message> _apply_entries = queue<applier_fiber_message>(10);
 
     struct stats {
         uint64_t add_command = 0;
@@ -905,9 +911,13 @@ future<> server_impl::io_fiber(index_t last_stable) {
                     std::exchange(_stepdown_promise, std::nullopt)->set_value();
                 }
                 if (!_current_rpc_config.contains(_id)) {
-                    // If the node is no longer part of a config and no longer the leader
-                    // it will never know the status of entries it submitted
-                    drop_waiters();
+                    // - It's important we push this after we pushed committed entries above. It
+                    // will cause `applier_fiber` to drop waiters, which should be done after we
+                    // notify all waiters for entries committed in this batch.
+                    // - This may happen multiple times if `io_fiber` gets multiple batches when
+                    // we're outside the configuration, but it should eventually (and generally
+                    // quickly) stop happening (we're outside the config after all).
+                    co_await _apply_entries.push_eventually(removed_from_config{});
                 }
                 // request aborts of snapshot transfers
                 abort_snapshot_transfers();
@@ -1059,6 +1069,12 @@ future<> server_impl::applier_fiber() {
                 _applied_idx = snp.idx;
                 _applied_index_changed.broadcast();
                 _stats.sm_load_snapshot++;
+            },
+            [this] (const removed_from_config&) -> future<> {
+                // If the node is no longer part of a config and no longer the leader
+                // it may never know the status of entries it submitted.
+                drop_waiters();
+                co_return;
             }
             ), v);
 


### PR DESCRIPTION
When `io_fiber` fetched a batch with a configuration that does not
contain this node, it would send the entries committed in this batch to
`applier_fiber` and proceed by any remaining entry dropping waiters (if
the node was no longer a leader).

If there were waiters for entries committed in this batch, it could
either happen that `applier_fiber` received and processed those entries
first, notifying the waiters that the entries were committed and/or
applied, or it could happen that `io_fiber` reaches the dropping waiters
code first, causing the waiters to be resolved with
`commit_status_unknown`.

The second scenario is undesirable. For example, when a follower tries
to remove the current leader from the configuration using
`modify_config`, if the second scenario happens, the follower will get
`commit_status_unknown` - this can happen even though there are no node
or network failures. In particular, this caused
`randomized_nemesis_test.remove_leader_with_forwarding_finishes` to fail
from time to time.

Fix it by serializing the notifying and dropping of waiters in a single
fiber - `applier_fiber`. We decided to move all management of waiters
into `applier_fiber`, because most of that management was already there
(there was already one `drop_waiters` call, and two `notify_waiters`
calls). Now, when `io_fiber` observes that we've been removed from the
config and no longer a leader, instead of dropping waiters, it sends a
message to `applier_fiber`. `applier_fiber` will drop waiters when
receiving that message.

Improve an existing test to reproduce this scenario more frequently.

Fixes #11235.