### PR TITLE
Fix mutation commutativity with shadowable tombstone

### DIFF
--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -831,7 +831,6 @@ public:
 
     void apply(shadowable_tombstone deleted_at) {
         _deleted_at.apply(deleted_at, _marker);
-        maybe_shadow();
     }
 
     void apply(row_tombstone deleted_at) {

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -826,6 +826,7 @@ public:
 
     void apply(tombstone deleted_at) {
         _deleted_at.apply(deleted_at);
+        maybe_shadow();
     }
 
     void apply(shadowable_tombstone deleted_at) {

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -830,6 +830,7 @@ public:
 
     void apply(shadowable_tombstone deleted_at) {
         _deleted_at.apply(deleted_at, _marker);
+        maybe_shadow();
     }
 
     void apply(row_tombstone deleted_at) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1852,6 +1852,29 @@ SEASTAR_TEST_CASE(test_continuity_merging_of_complete_mutations) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_commutativity_and_associativity) {
+    random_mutation_generator gen(random_mutation_generator::generate_counters::no);
+    gen.set_key_cardinality(7);
+
+    for (int i = 0; i < 10; ++i) {
+        mutation m1 = gen();
+        m1.partition().make_fully_continuous();
+        mutation m2 = gen();
+        m2.partition().make_fully_continuous();
+        mutation m3 = gen();
+        m3.partition().make_fully_continuous();
+
+        assert_that(m1 + m2 + m3)
+            .is_equal_to(m1 + m3 + m2)
+            .is_equal_to(m2 + m1 + m3)
+            .is_equal_to(m2 + m3 + m1)
+            .is_equal_to(m3 + m1 + m2)
+            .is_equal_to(m3 + m2 + m1);
+    }
+
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_continuity_merging) {
     return seastar::async([] {
         simple_schema table;


### PR DESCRIPTION
This series fixes lack of mutation associativity which manifests as sporadic failures in row_cache_test.cc::test_concurrent_reads_and_eviction due to differences in mutations applied and read. 

No known production impact.

Refs https://github.com/scylladb/scylladb/issues/11307