### PR TITLE
raft, limit for command size

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -294,6 +294,16 @@ struct intermittent_connection_error: public error {
     intermittent_connection_error() : error("Intermittent connection error") {}
 };
 
+struct command_is_too_big_error: public error {
+    size_t command_size;
+    size_t limit;
+
+    command_is_too_big_error(size_t command_size, size_t limit)
+        : error(fmt::format("Command size {} is greater than the configured limit {}", command_size, limit))
+        , command_size(command_size)
+        , limit(limit) {}
+};
+
 struct no_other_voting_member : public error {
     no_other_voting_member() : error("Cannot stepdown because there is no other voting member") {}
 };

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -471,6 +471,11 @@ future<add_entry_reply> server_impl::execute_add_entry(server_id from, command c
 }
 
 future<> server_impl::add_entry(command command, wait_type type, seastar::abort_source* as) {
+    if (_config.max_command_size > 0 && command.size() > _config.max_command_size) {
+        logger.trace("[{}] add_entry command size exceeds the limit: {} > {}",
+                     id(), command.size(), _config.max_command_size);
+        throw command_is_too_big_error(command.size(), _config.max_command_size);
+    }
     _stats.add_command++;
     server_id leader = _fsm->current_leader();
     logger.trace("[{}] an entry is submitted", id());

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -41,6 +41,10 @@ public:
         // add_entry()/modify_config() never throws not_a_leader,
         // but makes timed_out_error more likely.
         bool enable_forwarding = true;
+
+        // Max size of a single command, add_entry with a bigger command will throw command_is_too_big_error.
+        // The value of zero means no limit.
+        size_t max_command_size = 0;
     };
 
     virtual ~server() {}

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -18,6 +18,7 @@
 #include "direct_failure_detector/failure_detector.hh"
 #include "gms/gossiper.hh"
 #include "db/system_keyspace.hh"
+#include "replica/database.hh"
 
 #include <seastar/core/smp.hh>
 #include <seastar/core/sleep.hh>
@@ -101,8 +102,15 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto& rpc_ref = *rpc;
     auto storage = std::make_unique<raft_sys_table_storage>(_qp, gid, my_addr.id);
     auto& persistence_ref = *storage;
+    auto* cl = _qp.proxy().get_db().local().commitlog();
     auto server = raft::create_server(my_addr.id, std::move(rpc), std::move(state_machine),
-            std::move(storage), _raft_gr.failure_detector(), raft::server::configuration());
+            std::move(storage), _raft_gr.failure_detector(),
+            raft::server::configuration {
+                // Dividing by two is to protect against paddings that the
+                // commit log can add for each mutation, as well as
+                // against different commit log limits on different nodes.
+                .max_command_size = cl ? cl->max_record_size() / 2 : 0
+            });
 
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });


### PR DESCRIPTION
Commitlog imposes a limit on the size of mutations
and throws an exception if it's exceeded. In case of
schema changes before raft this exception was delivered
to the client. Now it happens while saving the raft
command in io_fiber in persistence->store_log_entries
and what the client gets is just a timeout exception,
which doesn't say much about the cause of the problem.
This patch introduces an explicit command size limit
and provides a clear error message in this case.