### PR TITLE
mutation_partition: add apply_gently methods

### DIFF
--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1259,6 +1259,21 @@ public:
     // Same guarantees and constraints as for apply(const schema&, const mutation_partition&, const schema&).
     void apply(const schema& this_schema, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
+    //
+    // Applies p to current object using async functions.
+    //
+    // Commutative when this_schema == p_schema. If schemas differ, data in p which
+    // is not representable in this_schema is dropped, thus apply() loses commutativity.
+    //
+    // Weak exception guarantees.
+    future<> apply_gently(const schema& this_schema, const mutation_partition& p, const schema& p_schema,
+            mutation_application_stats& app_stats);
+    // Use in case this instance and p share the same schema.
+    // Same guarantees as apply(const schema&, mutation_partition&&, const schema&);
+    future<> apply_gently(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
+    // Same guarantees and constraints as for apply(const schema&, const mutation_partition&, const schema&).
+    future<> apply_gently(const schema& this_schema, mutation_partition_view p, const schema& p_schema,
+            mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -1297,6 +1312,12 @@ public:
     void apply_weak(const schema& s, mutation_partition&&,
             mutation_application_stats& app_stats);
     void apply_weak(const schema& s, mutation_partition_view p, const schema& p_schema,
+            mutation_application_stats& app_stats);
+    future<> apply_weak_gently(const schema& s, const mutation_partition& p, const schema& p_schema,
+            mutation_application_stats& app_stats);
+    future<> apply_weak_gently(const schema& s, mutation_partition&&,
+            mutation_application_stats& app_stats);
+    future<> apply_weak_gently(const schema& s, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4360,8 +4360,7 @@ public:
             for (const version& ver : v) {
                 if (ver.par) {
                     mutation_application_stats app_stats;
-                    m.partition().apply(*schema, ver.par->mut().partition(), *schema, app_stats);
-                    co_await coroutine::maybe_yield();
+                    co_await m.partition().apply_gently(*schema, ver.par->mut().partition(), *schema, app_stats);
                 }
             }
             auto live_row_count = m.live_row_count();

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -160,6 +160,30 @@ SEASTAR_TEST_CASE(test_range_tombstone_slicing) {
             check_range(*snap2, table.make_ckey_range(8, 10), {rt3, rt5});
             check_range(*snap2, table.make_ckey_range(10, 10), {});
             check_range(*snap2, table.make_ckey_range(0, 10), {rt4, rt2, rt3, rt5});
+
+            auto rt6 = table.make_range_tombstone(table.make_ckey_range(9, 10));
+
+            mutation_partition m3(s);
+            m3.apply_delete(*s, rt6);
+
+            auto&& v3 = e.add_version(*s, no_cache_tracker);
+            v3.partition().apply_weak_gently(*s, m3, *s, app_stats).get();
+            auto snap3 = e.read(r, cleaner, s, no_cache_tracker);
+
+            check_range(*snap3, table.make_ckey_range(0, 0), {});
+            check_range(*snap3, table.make_ckey_range(1, 1), {rt4});
+            check_range(*snap3, table.make_ckey_range(3, 4), {rt2});
+            check_range(*snap3, table.make_ckey_range(3, 5), {rt2, rt5});
+            check_range(*snap3, table.make_ckey_range(3, 6), {rt2, rt3, rt5});
+            check_range(*snap3, table.make_ckey_range(4, 4), {rt2});
+            check_range(*snap3, table.make_ckey_range(5, 5), {rt2, rt5});
+            check_range(*snap3, table.make_ckey_range(6, 6), {rt2, rt3, rt5});
+            check_range(*snap3, table.make_ckey_range(7, 10), {rt2, rt3, rt5, rt6});
+            check_range(*snap3, table.make_ckey_range(8, 8), {rt3, rt5});
+            check_range(*snap3, table.make_ckey_range(9, 9), {rt3, rt6});
+            check_range(*snap3, table.make_ckey_range(8, 10), {rt3, rt5, rt6});
+            check_range(*snap3, table.make_ckey_range(10, 10), {rt6});
+            check_range(*snap3, table.make_ckey_range(0, 10), {rt4, rt2, rt3, rt5, rt6});
         });
     });
 


### PR DESCRIPTION
and use from storage_proxy data_read_resolver::resolve.

This prevents stalls when reconciling a large number of range
tombstoneas as seen in #10315 and
https://github.com/scylladb/scylladb/issues/10303#issuecomment-1087480452

Fixes #10315

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>