### PR TITLE
raft: server: handle aborts when waiting for config entry to commit

### DIFF
--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -369,6 +369,9 @@ public:
     index_t log_last_snapshot_idx() const {
         return _log.get_snapshot().idx;
     }
+    index_t log_last_conf_idx() const {
+        return _log.last_conf_idx();
+    }
 
     // Return the last configuration entry with index smaller than or equal to `idx`.
     // Precondition: `log_last_idx()` >= `idx` >= `log_last_snapshot_idx()`.

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -41,6 +41,11 @@ struct awaited_index {
     optimized_optional<abort_source::subscription> abort;
 };
 
+struct awaited_conf_change {
+    promise<> promise;
+    optimized_optional<abort_source::subscription> abort;
+};
+
 static const seastar::metrics::label server_id_label("id");
 static const seastar::metrics::label log_entry_type("log_entry_type");
 static const seastar::metrics::label message_type("message_type");
@@ -102,7 +107,7 @@ private:
     server::configuration _config;
     std::optional<promise<>> _stepdown_promise;
     std::optional<shared_promise<>> _leader_promise;
-    std::optional<promise<>> _non_joint_conf_commit_promise;
+    std::optional<awaited_conf_change> _non_joint_conf_commit_promise;
     // Index of the last entry applied to `_state_machine`.
     index_t _applied_idx;
     std::list<active_read> _reads;
@@ -884,7 +889,7 @@ future<> server_impl::io_fiber(index_t last_stable) {
                     for (const auto& e: batch.committed) {
                         const auto* cfg = get_if<raft::configuration>(&e->data);
                         if (cfg != nullptr && !cfg->is_joint()) {
-                            std::exchange(_non_joint_conf_commit_promise, std::nullopt)->set_value();
+                            std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_value();
                             break;
                         }
                     }
@@ -1237,7 +1242,7 @@ future<> server_impl::abort() {
     _awaited_commits.clear();
     _awaited_applies.clear();
     if (_non_joint_conf_commit_promise) {
-        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->set_exception(stopped_error());
+        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(stopped_error());
     }
 
     // Complete all read attempts with not_a_leader
@@ -1282,6 +1287,13 @@ future<> server_impl::set_configuration(config_member_set c_new, seastar::abort_
     }
 
     _stats.add_config++;
+
+    if (_non_joint_conf_commit_promise) {
+        logger.warn("[{}] set_configuration: a configuration change is still in progress (at index: {}, config: {})",
+            _id, _fsm->log_last_conf_idx(), cfg);
+        throw conf_change_in_progress{};
+    }
+
     const auto& e = _fsm->add_entry(raft::configuration{std::move(c_new)});
 
     // We've just submitted a joint configuration to be committed.
@@ -1292,10 +1304,21 @@ future<> server_impl::set_configuration(config_member_set c_new, seastar::abort_
     // would be the one corresponding to our joint configuration,
     // no matter if the leader changed in the meantime.
 
-    auto f = _non_joint_conf_commit_promise.emplace().get_future();
+    auto f = _non_joint_conf_commit_promise.emplace().promise.get_future();
+    if (as) {
+        _non_joint_conf_commit_promise->abort = as->subscribe([this] () noexcept {
+            // If we're inside this callback, the subscription wasn't destroyed yet.
+            // The subscription is destroyed when the field is reset, so if we're here, the field must be engaged.
+            assert(_non_joint_conf_commit_promise);
+            // Whoever resolves the promise must reset the field. Thus, if we're here, the promise is not resolved.
+            std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(request_aborted{});
+        });
+    }
+
     try {
         co_await wait_for_entry({.term = e.term, .idx = e.idx}, wait_type::committed, as);
     } catch (...) {
+        _non_joint_conf_commit_promise.reset();
         // We need to 'observe' possible exceptions in f, otherwise they will be
         // considered unhandled and cause a warning.
         (void)f.handle_exception([id = _id] (auto e) {

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2433,18 +2433,20 @@ struct bouncing {
                 if (n_a_l->leader) {
                     if (n_a_l->leader == srv_id || !tried.contains(n_a_l->leader)) {
                         co_await timer.sleep(known_leader_delay);
+                        tlogger.trace("bouncing call: got `not_a_leader` from {}, rerouting to {}", srv_id, n_a_l->leader);
                         srv_id = n_a_l->leader;
-                        tlogger.trace("bouncing call: got `not_a_leader`, rerouted to {}", srv_id);
                         continue;
                     }
                 }
 
                 if (!known.empty()) {
+                    auto prev = srv_id;
                     srv_id = *known.begin();
                     if (n_a_l->leader) {
-                        tlogger.trace("bouncing call: got `not_a_leader`, rerouted to {}, but already tried it; trying {}", n_a_l->leader, srv_id);
+                        tlogger.trace("bouncing call: got `not_a_leader` from {}, rerouted to {}, but already tried it; trying {}",
+                                prev, n_a_l->leader, srv_id);
                     } else {
-                        tlogger.trace("bouncing call: got `not_a_leader`, no reroute, trying {}", srv_id);
+                        tlogger.trace("bouncing call: got `not_a_leader` from {}, no reroute, trying {}", prev, srv_id);
                     }
                     continue;
                 }
@@ -2623,7 +2625,8 @@ struct reconfiguration {
 
     using result_type = reconfigure_result_t;
 
-    future<result_type> execute_modify_config(state_type& s, std::vector<raft::server_id> nodes, size_t members_end, size_t voters_end) {
+    future<result_type> execute_modify_config(
+            state_type& s, const operation::context& ctx, std::vector<raft::server_id> nodes, size_t members_end, size_t voters_end) {
         std::vector<std::pair<raft::server_id, bool>> added;
         for (size_t i = 0; i < voters_end; ++i) {
             added.emplace_back(nodes[i], true);
@@ -2633,12 +2636,16 @@ struct reconfiguration {
         }
 
         std::vector<raft::server_id> removed {nodes.begin() + members_end, nodes.end()};
+        auto contact = *s.known.begin();
+
+        tlogger.debug("reconfig modify_config start add {} remove {} start tid {} start time {} current time {} contact {}",
+                added, removed, ctx.thread, ctx.start, s.timer.now(), contact);
 
         assert(s.known.size() > 0);
         auto [res, last] = co_await bouncing{
                 [&added, &removed, timeout = s.timer.now() + timeout, &timer = s.timer, &env = s.env] (raft::server_id id) {
             return env.modify_config(id, added, removed, timeout, timer);
-        }}(s.timer, s.known, *s.known.begin(), 10, 10_t, 10_t);
+        }}(s.timer, s.known, contact, 10, 10_t, 10_t);
 
         std::visit(make_visitor(
         [&, last = last] (std::monostate) {
@@ -2657,10 +2664,14 @@ struct reconfiguration {
         }
         ), res);
 
+        tlogger.debug("reconfig modify_config end add {} remove {} start tid {} start time {} current time {} last contact {}",
+                added, removed, ctx.thread, ctx.start, s.timer.now(), last);
+
         co_return res;
     }
 
-    future<result_type> execute_reconfigure(state_type& s, std::vector<raft::server_id> nodes, size_t members_end, size_t voters_end) {
+    future<result_type> execute_reconfigure(
+            state_type& s, const operation::context& ctx, std::vector<raft::server_id> nodes, size_t members_end, size_t voters_end) {
         std::vector<std::pair<raft::server_id, bool>> nodes_voters;
         nodes_voters.reserve(members_end);
         for (size_t i = 0; i < voters_end; ++i) {
@@ -2670,10 +2681,15 @@ struct reconfiguration {
             nodes_voters.emplace_back(nodes[i], false);
         }
 
+        auto contact = *s.known.begin();
+
+        tlogger.debug("reconfig set_configuration start nodes {} start tid {} start time {} current time {} contact {}",
+                nodes_voters, ctx.thread, ctx.start, s.timer.now(), contact);
+
         assert(s.known.size() > 0);
         auto [res, last] = co_await bouncing{[&nodes_voters, timeout = s.timer.now() + timeout, &timer = s.timer, &env = s.env] (raft::server_id id) {
             return env.reconfigure(id, nodes_voters, timeout, timer);
-        }}(s.timer, s.known, *s.known.begin(), 10, 10_t, 10_t);
+        }}(s.timer, s.known, contact, 10, 10_t, 10_t);
 
         std::visit(make_visitor(
         [&, last = last] (std::monostate) {
@@ -2691,6 +2707,9 @@ struct reconfiguration {
         }
         ), res);
 
+        tlogger.debug("reconfig set_configuration end nodes {} start tid {} start time {} current time {} last contact {}",
+                nodes_voters, ctx.thread, ctx.start, s.timer.now(), last);
+
         co_return res;
     }
 
@@ -2705,9 +2724,9 @@ struct reconfiguration {
         size_t voters_end = std::uniform_int_distribution<size_t>{1, members_end}(s.rnd);
 
         if (bdist(s.rnd)) {
-            return execute_modify_config(s, std::move(nodes), members_end, voters_end);
+            return execute_modify_config(s, ctx, std::move(nodes), members_end, voters_end);
         } else {
-            return execute_reconfigure(s, std::move(nodes), members_end, voters_end);
+            return execute_reconfigure(s, ctx, std::move(nodes), members_end, voters_end);
         }
     }
 


### PR DESCRIPTION
Changing configuration involves two entries in the log: a 'joint
configuration entry' and a 'non-joint configuration entry'. We use
`wait_for_entry` to wait on the joint one. To wait on the non-joint one,
we use a separate promise field in `server`. This promise wasn't
connected to the `abort_source` passed into `set_configuration`.

The call could get stuck if the server got removed from the
configuration and lost leadership after committing the joint entry but
before committing the non-joint one, waiting on the promise. Aborting
wouldn't help. Fix this by subscribing to the `abort_source` in
resolving the promise exceptionally.

Furthermore, make sure that two `set_configuration` calls don't step on
each other's toes by one setting the other's promise. To do that, reset
the promise field at the end of `set_configuration` and check that it's
not engaged at the beginning.

Fixes #11288.

