### PR TITLE
test.py: cluster manager fix api paths and fix driver logic for server restart

### DIFF
--- a/test.py
+++ b/test.py
@@ -660,13 +660,13 @@ class CQLApprovalTest(Test):
                 logging.info("Server log:\n%s", self.server_log)
 
         async with self.suite.clusters.instance() as cluster:
-            logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-            # FIXME: cluster should provide contact points
-            self.args.insert(1, "--host={}".format(cluster[0].host))
-            # If pre-check fails, e.g. because Scylla failed to start
-            # or crashed between two tests, fail entire test.py
             try:
                 cluster.before_test(self.uname)
+                logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
+                # FIXME: cluster should provide contact points
+                self.args.insert(1, "--host={}".format(cluster[0].host))
+                # If pre-check fails, e.g. because Scylla failed to start
+                # or crashed between two tests, fail entire test.py
                 self.is_before_test_ok = True
                 # FIXME: should be more comprehensive than checking the first server
                 cluster[0].take_log_savepoint()
@@ -806,11 +806,11 @@ class PythonTest(Test):
     async def run(self, options: argparse.Namespace) -> Test:
 
         async with self.suite.clusters.instance() as cluster:
-            logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-            # FIXME: cluster should provide contact points
-            self.args.insert(0, "--host={}".format(cluster[0].host))
             try:
                 cluster.before_test(self.uname)
+                logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
+                # FIXME: cluster should provide contact points
+                self.args.insert(0, "--host={}".format(cluster[0].host))
                 self.is_before_test_ok = True
                 # FIXME: should be more comprehensive than checking the first server
                 cluster[0].take_log_savepoint()

--- a/test.py
+++ b/test.py
@@ -663,8 +663,7 @@ class CQLApprovalTest(Test):
             try:
                 cluster.before_test(self.uname)
                 logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-                # FIXME: cluster should provide contact points
-                self.args.insert(1, "--host={}".format(cluster[0].host))
+                self.args.insert(1, "--host={}".format(cluster.endpoint()))
                 # If pre-check fails, e.g. because Scylla failed to start
                 # or crashed between two tests, fail entire test.py
                 self.is_before_test_ok = True
@@ -809,8 +808,7 @@ class PythonTest(Test):
             try:
                 cluster.before_test(self.uname)
                 logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-                # FIXME: cluster should provide contact points
-                self.args.insert(0, "--host={}".format(cluster[0].host))
+                self.args.insert(0, "--host={}".format(cluster.endpoint()))
                 self.is_before_test_ok = True
                 # FIXME: should be more comprehensive than checking the first server
                 cluster[0].take_log_savepoint()

--- a/test.py
+++ b/test.py
@@ -696,8 +696,7 @@ Check test log at {}.""".format(self.log_filename))
                 # 1) failed pre-check, e.g. start failure
                 # 2) failed test execution.
                 if self.is_executed_ok is False:
-                    # FIXME: why only logs of the first server?
-                    self.server_log = cluster[0].read_log()
+                    self.server_log = cluster.read_server_log()
                     self.server_log_filename = cluster[0].log_filename
                     if self.is_before_test_ok is False:
                         set_summary("pre-check failed: {}".format(e))
@@ -815,8 +814,7 @@ class PythonTest(Test):
                 self.is_after_test_ok = True
                 self.success = status
             except Exception as e:
-                # FIXME: why only logs of the first server?
-                self.server_log = cluster[0].read_log()
+                self.server_log = cluster.read_server_log()
                 self.server_log_filename = cluster[0].log_filename
                 if self.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
@@ -849,7 +847,7 @@ class TopologyTest(PythonTest):
             try:
                 self.success = await run_test(self, options)
             except Exception as e:
-                self.server_log = manager.cluster[0].read_log()
+                self.server_log = manager.cluster.read_server_log()
                 self.server_log_filename = manager.cluster[0].log_filename
                 if manager.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))

--- a/test.py
+++ b/test.py
@@ -667,8 +667,7 @@ class CQLApprovalTest(Test):
                 # If pre-check fails, e.g. because Scylla failed to start
                 # or crashed between two tests, fail entire test.py
                 self.is_before_test_ok = True
-                # FIXME: should be more comprehensive than checking the first server
-                cluster[0].take_log_savepoint()
+                cluster.take_log_savepoint()
                 self.is_executed_ok = await run_test(self, options, env=self.env)
                 cluster.after_test(self.uname)
                 self.is_after_test_ok = True
@@ -810,8 +809,7 @@ class PythonTest(Test):
                 logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
                 self.args.insert(0, "--host={}".format(cluster.endpoint()))
                 self.is_before_test_ok = True
-                # FIXME: should be more comprehensive than checking the first server
-                cluster[0].take_log_savepoint()
+                cluster.take_log_savepoint()
                 status = await run_test(self, options)
                 cluster.after_test(self.uname)
                 self.is_after_test_ok = True

--- a/test.py
+++ b/test.py
@@ -624,7 +624,7 @@ class CQLApprovalTest(Test):
         self.tmpfile = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".reject")
         self.reject = suite.suite_path / (self.shortname + ".reject")
         self.server_log: Optional[str] = None
-        self.server_log_filename: Optional[str] = None
+        self.server_log_filename: Optional[pathlib.Path] = None
         CQLApprovalTest._reset(self)
 
     def _reset(self) -> None:
@@ -697,7 +697,7 @@ Check test log at {}.""".format(self.log_filename))
                 # 2) failed test execution.
                 if self.is_executed_ok is False:
                     self.server_log = cluster.read_server_log()
-                    self.server_log_filename = cluster[0].log_filename
+                    self.server_log_filename = cluster.server_log_filename()
                     if self.is_before_test_ok is False:
                         set_summary("pre-check failed: {}".format(e))
                         print("Test {} {}".format(self.name, self.summary))
@@ -777,7 +777,7 @@ class PythonTest(Test):
         self.path = "pytest"
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         self.server_log: Optional[str] = None
-        self.server_log_filename: Optional[str] = None
+        self.server_log_filename: Optional[pathlib.Path] = None
         PythonTest._reset(self)
 
     def _reset(self) -> None:
@@ -815,7 +815,7 @@ class PythonTest(Test):
                 self.success = status
             except Exception as e:
                 self.server_log = cluster.read_server_log()
-                self.server_log_filename = cluster[0].log_filename
+                self.server_log_filename = cluster.server_log_filename()
                 if self.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))
@@ -848,7 +848,7 @@ class TopologyTest(PythonTest):
                 self.success = await run_test(self, options)
             except Exception as e:
                 self.server_log = manager.cluster.read_server_log()
-                self.server_log_filename = manager.cluster[0].log_filename
+                self.server_log_filename = manager.cluster.server_log_filename()
                 if manager.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,6 +63,13 @@ def cql(request):
                       # Use the default superuser credentials, which work for both Scylla and Cassandra
                       auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
                       ssl_context=ssl_context,
+                      # The default timeout for new connections is 5 seconds, and for
+                      # requests made by the control connection is 2 seconds. These should
+                      # have been more than enough, but in some extreme cases with a very
+                      # slow debug build running on a very busy machine, they may not be.
+                      # so let's increase them to 60 seconds. See issue #11289.
+                      connect_timeout = 60,
+                      control_connection_timeout = 60,
                       )
     yield cluster.connect()
     cluster.shutdown()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -113,34 +113,34 @@ class ManagerClient():
         await self._request("/cluster/mark-dirty")
 
     async def server_stop(self, server_id: str) -> bool:
-        """Stop specified node"""
-        ret = await self._request(f"/cluster/node/{server_id}/stop")
+        """Stop specified server"""
+        ret = await self._request(f"/cluster/server/{server_id}/stop")
         return ret == "OK"
 
     async def server_stop_gracefully(self, server_id: str) -> bool:
-        """Stop specified node gracefully"""
-        ret = await self._request(f"/cluster/node/{server_id}/stop_gracefully")
+        """Stop specified server gracefully"""
+        ret = await self._request(f"/cluster/server/{server_id}/stop_gracefully")
         return ret == "OK"
 
     async def server_start(self, server_id: str) -> bool:
-        """Start specified node"""
-        ret = await self._request(f"/cluster/node/{server_id}/start")
+        """Start specified server"""
+        ret = await self._request(f"/cluster/server/{server_id}/start")
         self._driver_update()
         return ret == "OK"
 
     async def server_restart(self, server_id: str) -> bool:
-        """Restart specified node"""
-        ret = await self._request(f"/cluster/node/{server_id}/restart")
+        """Restart specified server"""
+        ret = await self._request(f"/cluster/server/{server_id}/restart")
         self._driver_update()
         return ret == "OK"
 
     async def server_add(self) -> str:
-        """Add a new node"""
-        server_id = await self._request("/cluster/addnode")
+        """Add a new server"""
+        server_id = await self._request("/cluster/addserver")
         self._driver_update()
         return server_id
 
     async def server_remove(self, server_id: str) -> None:
-        """Remove a specified node"""
-        await self._request(f"/cluster/removenode/{server_id}")
+        """Remove a specified server"""
+        await self._request(f"/cluster/removeserver/{server_id}")
         self._driver_update()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -13,8 +13,8 @@ import os.path
 from typing import List, Optional, Callable
 import aiohttp                                                             # type: ignore
 import aiohttp.web                                                         # type: ignore
-from cassandra.cluster import Session as CassandraSession                  # type: ignore
-from cassandra.cluster import Cluster as CassandraCluster                  # type: ignore
+from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 
 
 class ManagerClient():
@@ -23,6 +23,7 @@ class ManagerClient():
         sock_path (str): path to an AF_UNIX socket where Manager server is listening
         con_gen (Callable): generator function for CQL driver connection to a cluster
     """
+    # pylint: disable=too-many-instance-attributes
     conn: aiohttp.UnixConnector
     session: aiohttp.ClientSession
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -534,6 +534,10 @@ class ScyllaCluster:
         self.running[server.host] = server
         return server.host
 
+    def endpoint(self) -> str:
+        """Get a server id (IP) from running servers"""
+        return next(iter(self.running))
+
     def __getitem__(self, i: int) -> ScyllaServer:
         assert i >= 0, "ScyllaCluster: cluster sub-index must be positive"
         return list(self.running.values())[i]

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -543,6 +543,14 @@ class ScyllaCluster:
         for server in self.running.values():
             server.take_log_savepoint()
 
+    def read_server_log(self) -> str:
+        """Read log data of failed server"""
+        # FIXME: pick failed server
+        if self.running:
+            return next(iter(self.running.values())).read_log()
+        else:
+            return ""
+
     def __getitem__(self, i: int) -> ScyllaServer:
         assert i >= 0, "ScyllaCluster: cluster sub-index must be positive"
         return list(self.running.values())[i]

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -559,10 +559,6 @@ class ScyllaCluster:
         else:
             return None
 
-    def __getitem__(self, i: int) -> ScyllaServer:
-        assert i >= 0, "ScyllaCluster: cluster sub-index must be positive"
-        return list(self.running.values())[i]
-
     def __str__(self):
         return f"{{{', '.join(str(c) for c in self.running)}}}"
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -551,6 +551,14 @@ class ScyllaCluster:
         else:
             return ""
 
+    def server_log_filename(self) -> Optional[pathlib.Path]:
+        """The log file name of the failed server"""
+        # FIXME: pick failed server
+        if self.running:
+            return next(iter(self.running.values())).log_filename
+        else:
+            return None
+
     def __getitem__(self, i: int) -> ScyllaServer:
         assert i >= 0, "ScyllaCluster: cluster sub-index must be positive"
         return list(self.running.values())[i]

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -569,8 +569,9 @@ class ScyllaCluster:
     def _get_keyspace_count(self) -> int:
         """Get the current keyspace count"""
         assert self.start_exception is None
-        assert self[0].control_connection is not None
-        rows = self[0].control_connection.execute(
+        server = next(iter(self.running.values()))
+        assert server.control_connection is not None
+        rows = server.control_connection.execute(
                "select count(*) as c from system_schema.keyspaces")
         keyspace_count = int(rows.one()[0])
         return keyspace_count

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -538,6 +538,11 @@ class ScyllaCluster:
         """Get a server id (IP) from running servers"""
         return next(iter(self.running))
 
+    def take_log_savepoint(self) -> None:
+        """Save the log size on all running servers"""
+        for server in self.running.values():
+            server.take_log_savepoint()
+
     def __getitem__(self, i: int) -> ScyllaServer:
         assert i >= 0, "ScyllaCluster: cluster sub-index must be positive"
         return list(self.running.values())[i]
@@ -674,8 +679,7 @@ class ScyllaClusterManager:
         logging.info("Leasing Scylla cluster %s for test %s", self.cluster, test_name)
         self.cluster.before_test(self.test_name)
         self.is_before_test_ok = True
-        # FIXME: savepoint for all servers
-        self.cluster[0].take_log_savepoint()
+        self.cluster.take_log_savepoint()
 
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -100,6 +100,13 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
                       # down nodes, causing errors. If auth is needed in the future for topology
                       # tests, they should bump up auth RF and run repair.
                       ssl_context=ssl_context,
+                      # The default timeout for new connections is 5 seconds, and for
+                      # requests made by the control connection is 2 seconds. These should
+                      # have been more than enough, but in some extreme cases with a very
+                      # slow debug build running on a very busy machine, they may not be.
+                      # so let's increase them to 60 seconds. See issue #11289.
+                      connect_timeout = 60,
+                      control_connection_timeout = 60,
                    )
 
 


### PR DESCRIPTION
- Fix old paths using `/node` instead of `/server` on client side
- Fix logic for handling driver connection for restart, with consideration of single running server in the cluster

Both reported by @wmitros .

This pull request is based on top of #11305 currently being merged. It has only 2 commits.