### PR TITLE
docs: update theme 1.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,6 @@ html_theme_options = {
     "hide_edit_this_page_button": "false",
     "github_issues_repository": "scylladb/scylladb",
     "github_repository": "scylladb/scylladb",
-    "hide_version_dropdown": ["master"],
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
     'banner_button_text': 'Learn More',

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,13 +9,13 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.2.0"
 recommonmark = "0.7.1"
-sphinx-scylladb-theme = "~1.2.1"
+sphinx-scylladb-theme = "~1.3.1"
 sphinx-sitemap = "2.2.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.10"
 sphinx-markdown-tables = "0.0.15"
-redirects_cli ="0.1.0"
+redirects_cli ="~0.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/548

ScyllaDB Sphinx Theme 1.3 is now released 🥳 

We’ve added better redirects support and introduced numerous UI updates.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/stable/upgrade/CHANGELOG.html#aug-2022).


## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

4. Open  http://localhost:5500 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.3.x``:

![image](https://user-images.githubusercontent.com/9107969/185590281-c79c5278-36d1-4bca-8197-e94824be1759.png)
