### PR TITLE
Fix nodetool flush example

### DIFF
--- a/docs/kb/tombstones-flush.rst
+++ b/docs/kb/tombstones-flush.rst
@@ -34,7 +34,7 @@ Steps:
 
 .. code-block:: sh
 
-   nodetool flush <keyspace>.<mytable>;
+   nodetool flush <keyspace> <mytable>;
 
 4. Run compaction (this will remove big partitions with tombstones from specified table)
 


### PR DESCRIPTION
`nodetool flush` have a space between *keyspace* and *table* names

See https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/flush for the right syntax.

Fix https://github.com/scylladb/scylladb/issues/11314