### PR TITLE
Update Alternator Markdown file to use automatic link notation

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -134,7 +134,7 @@ isolation policy for a specific table can be overridden by tagging the table
 This section provides only a very brief introduction to Alternator's
 design. A much more detailed document about the features of the DynamoDB
 API and how they are, or could be, implemented in Scylla can be found in:
-https://docs.google.com/document/d/1i4yjF5OSAazAY_-T8CBce9-2ykW4twx_E_Nt2zDoOVs
+<https://docs.google.com/document/d/1i4yjF5OSAazAY_-T8CBce9-2ykW4twx_E_Nt2zDoOVs>
 
 Almost all of Alternator's source code (except some initialization code)
 can be found in the alternator/ subdirectory of Scylla's source code.

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -26,7 +26,7 @@ request for this single URL to many different backend nodes. Such a
 load-balancing setup is *not* included inside Alternator. You should either
 set one up, or configure the client library to do the load balancing itself.
 Instructions for doing this can be found in:
-https://github.com/scylladb/alternator-load-balancing/
+<https://github.com/scylladb/alternator-load-balancing/>
 
 ## Write isolation policies
 
@@ -125,7 +125,7 @@ All of this is not yet implemented in Alternator.
 Scylla has an advanced and extensive monitoring framework for inspecting
 and graphing hundreds of different metrics of Scylla's usage and performance.
 Scylla's monitoring stack, based on Grafana and Prometheus, is described in
-https://docs.scylladb.com/operating-scylla/monitoring/.
+<https://docs.scylladb.com/operating-scylla/monitoring/>.
 This monitoring stack is different from DynamoDB's offering - but Scylla's
 is significantly more powerful and gives the user better insights on
 the internals of the database and its performance.
@@ -160,7 +160,7 @@ experimental:
   One thing that this implementation is still missing is that expiration
   events appear in the Streams API as normal deletions - without the
   distinctive marker on deletions which are really expirations.
-  https://github.com/scylladb/scylla/issues/5060
+  <https://github.com/scylladb/scylla/issues/5060>
 
 * The DynamoDB Streams API for capturing change is supported, but still
   considered experimental so needs to be enabled explicitly with the
@@ -172,12 +172,12 @@ experimental:
   * While in DynamoDB data usually appears in the stream less than a second
     after it was written, in Alternator Streams there is currently a 10
     second delay by default.
-    https://github.com/scylladb/scylla/issues/6929
+    <https://github.com/scylladb/scylla/issues/6929>
   * Some events are represented differently in Alternator Streams. For
     example, a single PutItem is represented by a REMOVE + MODIFY event,
     instead of just a single MODIFY or INSERT.
-    https://github.com/scylladb/scylla/issues/6930
-    https://github.com/scylladb/scylla/issues/6918
+    <https://github.com/scylladb/scylla/issues/6930>
+    <https://github.com/scylladb/scylla/issues/6918>
 
 ## Unimplemented API features
 
@@ -189,18 +189,18 @@ they should be easy to detect. Here is a list of these unimplemented features:
 * Currently in Alternator, a GSI (Global Secondary Index) can only be added
   to a table at table creation time. Unlike DynamoDB which also allows adding
   a GSI (but not an LSI) to an existing table using an UpdateTable operation.
-  https://github.com/scylladb/scylla/issues/5022
+  <https://github.com/scylladb/scylla/issues/5022>
 
 * GSI (Global Secondary Index) and LSI (Local Secondary Index) may be
   configured to project only a subset of the base-table attributes to the
   index. This option is not yet respected by Alternator - all attributes
   are projected. This wastes some disk space when it is not needed.
-  https://github.com/scylladb/scylla/issues/5036
+  <https://github.com/scylladb/scylla/issues/5036>
 
 * DynamoDB's new multi-item transaction feature (TransactWriteItems,
   TransactGetItems) is not supported. Note that the older single-item
   conditional updates feature are fully supported.
-  https://github.com/scylladb/scylla/issues/5064
+  <https://github.com/scylladb/scylla/issues/5064>
 
 * Alternator does not yet support the DynamoDB API calls that control which
   table is available in which data center (DC): CreateGlobalTable,
@@ -211,19 +211,19 @@ they should be easy to detect. Here is a list of these unimplemented features:
   If a DC is added after a table is created, the table won't be visible from
   the new DC and changing that requires a CQL "ALTER TABLE" statement to
   modify the table's replication strategy.
-  https://github.com/scylladb/scylla/issues/5062
+  <https://github.com/scylladb/scylla/issues/5062>
 
 * Recently DynamoDB added support, in addition to the DynamoDB Streams API,
   also for the similar Kinesis Streams. Alternator doesn't support this yet,
   and the related operations DescribeKinesisStreamingDestination,
   DisableKinesisStreamingDestination, and EnableKinesisStreamingDestination.
-  https://github.com/scylladb/scylla/issues/8786
+  <https://github.com/scylladb/scylla/issues/8786>
 
 * The on-demand backup APIs are not supported: CreateBackup, DescribeBackup,
   DeleteBackup, ListBackups, RestoreTableFromBackup.
   For now, users can use Scylla's existing backup solutions such as snapshots
   or Scylla Manager.
-  https://github.com/scylladb/scylla/issues/5063
+  <https://github.com/scylladb/scylla/issues/5063>
 
 * Continuous backup (the ability to restore any point in time) is also not
   supported: UpdateContinuousBackups, DescribeContinuousBackups,
@@ -237,28 +237,28 @@ they should be easy to detect. Here is a list of these unimplemented features:
   BillingMode option is ignored by Alternator, and if a provisioned throughput
   is specified, it is ignored. Requests which are asked to return the amount
   of provisioned throughput used by the request do not return it in Alternator.
-  https://github.com/scylladb/scylla/issues/5068
+  <https://github.com/scylladb/scylla/issues/5068>
 
 * DAX (DynamoDB Accelerator), an in-memory cache for DynamoDB, is not
   available in for Alternator. Anyway, it should not be necessary - Scylla's
   internal cache is already rather advanced and there is no need to place
   another cache in front of the it. We wrote more about this here:
-  https://www.scylladb.com/2017/07/31/database-caches-not-good/
+  <https://www.scylladb.com/2017/07/31/database-caches-not-good/>
 
 * The DescribeTable is missing information about creation data and size
   estimates, and also part of the information about indexes enabled on 
   the table.
-  https://github.com/scylladb/scylla/issues/5013
-  https://github.com/scylladb/scylla/issues/5026
-  https://github.com/scylladb/scylla/issues/7550
-  https://github.com/scylladb/scylla/issues/7551 
+  <https://github.com/scylladb/scylla/issues/5013>
+  <https://github.com/scylladb/scylla/issues/5026>
+  <https://github.com/scylladb/scylla/issues/7550>
+  <https://github.com/scylladb/scylla/issues/7551 >
 
 * The recently-added PartiQL syntax (SQL-like SELECT/UPDATE/INSERT/DELETE
   expressions) and the new operations ExecuteStatement, BatchExecuteStatement
   and ExecuteTransaction is not yet supported.
   A user that is interested in an SQL-like syntax can consider using Scylla's
   CQL protocol instead.
-  https://github.com/scylladb/scylla/issues/8787
+  <https://github.com/scylladb/scylla/issues/8787>
 
 * As mentioned above, Alternator has its own powerful monitoring framework,
   which is different from AWS's. In particular, the operations
@@ -266,8 +266,8 @@ they should be easy to detect. Here is a list of these unimplemented features:
   UpdateContributorInsights that configure Amazon's "CloudWatch Contributor
   Insights" are not yet supported. Scylla has different ways to retrieve the
   same information, such as which items were accessed most often.
-  https://github.com/scylladb/scylla/issues/8788
+  <https://github.com/scylladb/scylla/issues/8788>
 
 * Alternator does not support the new DynamoDB feature "export to S3",
   and its operations DescribeExport, ExportTableToPointInTime, ListExports.
-  https://github.com/scylladb/scylla/issues/8789
+  <https://github.com/scylladb/scylla/issues/8789>


### PR DESCRIPTION
We use Sphinx to generate docs from Markdown.
Unlike Github, Sphinx does not generate a link from *any* URL.
Instead, it requires a link notation, for example, the "automatic link" notion, using `<URL>`.
This notation works in Sphinx as well as Github.

Fix https://github.com/scylladb/scylladb/issues/11333
