### PR TITLE
Streaming: define plan_id as a strong tagged_uuid type

### DIFF
--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -12,6 +12,10 @@
 
 namespace streaming {
 
+class plan_id final {
+    utils::UUID uuid();
+};
+
 class stream_request {
     sstring keyspace;
     // For compatibility with <= 1.5, we use wrapping ranges

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -823,14 +823,14 @@ rpc::sink<int32_t> messaging_service::make_sink_for_stream_mutation_fragments(rp
 }
 
 future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>>
-messaging_service::make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, utils::UUID plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id) {
+messaging_service::make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, streaming::plan_id plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id) {
     using value_type = std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>;
     if (is_shutting_down()) {
         return make_exception_future<value_type>(rpc::closed_error());
     }
     auto rpc_client = get_rpc_client(messaging_verb::STREAM_MUTATION_FRAGMENTS, id);
     return rpc_client->make_stream_sink<netw::serializer, frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>().then([this, plan_id, schema_id, cf_id, estimated_partitions, reason, rpc_client] (rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd> sink) mutable {
-        auto rpc_handler = rpc()->make_client<rpc::source<int32_t> (utils::UUID, table_schema_version, table_id, uint64_t, streaming::stream_reason, rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>)>(messaging_verb::STREAM_MUTATION_FRAGMENTS);
+        auto rpc_handler = rpc()->make_client<rpc::source<int32_t> (streaming::plan_id, table_schema_version, table_id, uint64_t, streaming::stream_reason, rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>)>(messaging_verb::STREAM_MUTATION_FRAGMENTS);
         return rpc_handler(*rpc_client , plan_id, schema_id, cf_id, estimated_partitions, reason, sink).then_wrapped([sink, rpc_client] (future<rpc::source<int32_t>> source) mutable {
             return (source.failed() ? sink.close() : make_ready_future<>()).then([sink = std::move(sink), source = std::move(source)] () mutable {
                 return make_ready_future<value_type>(value_type(std::move(sink), source.get0()));
@@ -839,7 +839,7 @@ messaging_service::make_sink_and_source_for_stream_mutation_fragments(table_sche
     });
 }
 
-void messaging_service::register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, UUID plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason>, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func) {
+void messaging_service::register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason>, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func) {
     register_handler(this, messaging_verb::STREAM_MUTATION_FRAGMENTS, std::move(func));
 }
 
@@ -936,10 +936,10 @@ future<> messaging_service::unregister_repair_get_full_row_hashes_with_rpc_strea
 
 // PREPARE_MESSAGE
 void messaging_service::register_prepare_message(std::function<future<streaming::prepare_message> (const rpc::client_info& cinfo,
-        streaming::prepare_message msg, UUID plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func) {
+        streaming::prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func) {
     register_handler(this, messaging_verb::PREPARE_MESSAGE, std::move(func));
 }
-future<streaming::prepare_message> messaging_service::send_prepare_message(msg_addr id, streaming::prepare_message msg, UUID plan_id,
+future<streaming::prepare_message> messaging_service::send_prepare_message(msg_addr id, streaming::prepare_message msg, streaming::plan_id plan_id,
         sstring description, streaming::stream_reason reason) {
     return send_message<streaming::prepare_message>(this, messaging_verb::PREPARE_MESSAGE, id,
         std::move(msg), plan_id, std::move(description), reason);
@@ -949,10 +949,10 @@ future<> messaging_service::unregister_prepare_message() {
 }
 
 // PREPARE_DONE_MESSAGE
-void messaging_service::register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id)>&& func) {
+void messaging_service::register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id)>&& func) {
     register_handler(this, messaging_verb::PREPARE_DONE_MESSAGE, std::move(func));
 }
-future<> messaging_service::send_prepare_done_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id) {
+future<> messaging_service::send_prepare_done_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id) {
     return send_message<void>(this, messaging_verb::PREPARE_DONE_MESSAGE, id,
         plan_id, dst_cpu_id);
 }
@@ -962,15 +962,15 @@ future<> messaging_service::unregister_prepare_done_message() {
 
 // STREAM_MUTATION_DONE
 void messaging_service::register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo,
-        UUID plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id)>&& func) {
+        streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id)>&& func) {
     register_handler(this, messaging_verb::STREAM_MUTATION_DONE,
             [func = std::move(func)] (const rpc::client_info& cinfo,
-                    UUID plan_id, std::vector<wrapping_range<dht::token>> ranges,
+                    streaming::plan_id plan_id, std::vector<wrapping_range<dht::token>> ranges,
                     table_id cf_id, unsigned dst_cpu_id) mutable {
         return func(cinfo, plan_id, ::compat::unwrap(std::move(ranges)), cf_id, dst_cpu_id);
     });
 }
-future<> messaging_service::send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
+future<> messaging_service::send_stream_mutation_done(msg_addr id, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
     return send_message<void>(this, messaging_verb::STREAM_MUTATION_DONE, id,
         plan_id, std::move(ranges), cf_id, dst_cpu_id);
 }
@@ -979,10 +979,10 @@ future<> messaging_service::unregister_stream_mutation_done() {
 }
 
 // COMPLETE_MESSAGE
-void messaging_service::register_complete_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func) {
+void messaging_service::register_complete_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func) {
     register_handler(this, messaging_verb::COMPLETE_MESSAGE, std::move(func));
 }
-future<> messaging_service::send_complete_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id, bool failed) {
+future<> messaging_service::send_complete_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id, bool failed) {
     return send_message<void>(this, messaging_verb::COMPLETE_MESSAGE, id,
         plan_id, dst_cpu_id, failed);
 }

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -20,6 +20,7 @@
 #include "range.hh"
 #include "tracing/tracing.hh"
 #include "schema_fwd.hh"
+#include "streaming/stream_fwd.hh"
 
 #include <list>
 #include <vector>
@@ -39,10 +40,6 @@ namespace gms {
     class gossip_digest_ack2;
     class gossip_get_endpoint_states_request;
     class gossip_get_endpoint_states_response;
-}
-
-namespace utils {
-    class UUID;
 }
 
 namespace db {
@@ -214,7 +211,6 @@ public:
 
     using msg_addr = netw::msg_addr;
     using inet_address = gms::inet_address;
-    using UUID = utils::UUID;
     using clients_map = std::unordered_map<msg_addr, shard_info, msg_addr::hash>;
 
     // This should change only if serialization format changes
@@ -336,22 +332,22 @@ public:
 
     // Wrapper for PREPARE_MESSAGE verb
     void register_prepare_message(std::function<future<streaming::prepare_message> (const rpc::client_info& cinfo,
-            streaming::prepare_message msg, UUID plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func);
-    future<streaming::prepare_message> send_prepare_message(msg_addr id, streaming::prepare_message msg, UUID plan_id,
+            streaming::prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func);
+    future<streaming::prepare_message> send_prepare_message(msg_addr id, streaming::prepare_message msg, streaming::plan_id plan_id,
             sstring description, streaming::stream_reason);
     future<> unregister_prepare_message();
 
     // Wrapper for PREPARE_DONE_MESSAGE verb
-    void register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id)>&& func);
-    future<> send_prepare_done_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id);
+    void register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id)>&& func);
+    future<> send_prepare_done_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id);
     future<> unregister_prepare_done_message();
 
     // Wrapper for STREAM_MUTATION_FRAGMENTS
     // The receiver of STREAM_MUTATION_FRAGMENTS sends status code to the sender to notify any error on the receiver side. The status code is of type int32_t. 0 means successful, -1 means error, other status code value are reserved for future use.
-    void register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, UUID plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func);
+    void register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func);
     future<> unregister_stream_mutation_fragments();
     rpc::sink<int32_t> make_sink_for_stream_mutation_fragments(rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>>& source);
-    future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>> make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, utils::UUID plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id);
+    future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>> make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, streaming::plan_id plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id);
 
     // Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM
     future<std::tuple<rpc::sink<repair_hash_with_cmd>, rpc::source<repair_row_on_wire_with_cmd>>> make_sink_and_source_for_repair_get_row_diff_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
@@ -371,12 +367,12 @@ public:
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
 
-    void register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id)>&& func);
-    future<> send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id);
+    void register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id)>&& func);
+    future<> send_stream_mutation_done(msg_addr id, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id);
     future<> unregister_stream_mutation_done();
 
-    void register_complete_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func);
-    future<> send_complete_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id, bool failed = false);
+    void register_complete_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func);
+    future<> send_complete_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id, bool failed = false);
     future<> unregister_complete_message();
 
     // Wrapper for REPAIR_GET_FULL_ROW_HASHES

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -127,7 +127,7 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
     size_t nr_sst_total = sstables.size();
     size_t nr_sst_current = 0;
     while (!sstables.empty()) {
-        auto ops_uuid = utils::make_random_uuid();
+        auto ops_uuid = streaming::plan_id{utils::make_random_uuid()};
         auto sst_set = make_lw_shared<sstables::sstable_set>(sstables::make_partitioned_sstable_set(s, false));
         size_t batch_sst_nr = 16;
         std::vector<sstring> sst_names;

--- a/streaming/stream_coordinator.hh
+++ b/streaming/stream_coordinator.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "gms/inet_address.hh"
+#include "streaming/stream_fwd.hh"
 #include "streaming/stream_session.hh"
 #include "streaming/session_info.hh"
 #include <map>

--- a/streaming/stream_event.hh
+++ b/streaming/stream_event.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "utils/UUID.hh"
 #include "gms/inet_address.hh"
 #include "streaming/stream_session.hh"
 #include "streaming/session_info.hh"
@@ -20,7 +19,6 @@ namespace streaming {
 
 class stream_event {
 public:
-    using UUID = utils::UUID;
     enum class type {
         STREAM_PREPARED,
         STREAM_COMPLETE,
@@ -28,9 +26,9 @@ public:
     };
 
     type event_type;
-    UUID plan_id;
+    streaming::plan_id plan_id;
 
-    stream_event(type event_type_, UUID plan_id_)
+    stream_event(type event_type_, streaming::plan_id plan_id_)
         : event_type(event_type_)
         , plan_id(plan_id_) {
     }
@@ -49,18 +47,16 @@ struct session_complete_event : public stream_event {
 };
 
 struct progress_event : public stream_event {
-    using UUID = utils::UUID;
     progress_info progress;
-    progress_event(UUID plan_id_, progress_info progress_)
+    progress_event(streaming::plan_id plan_id_, progress_info progress_)
         : stream_event(stream_event::type::FILE_PROGRESS, plan_id_)
         , progress(std::move(progress_)) {
     }
 };
 
 struct session_prepared_event : public stream_event {
-    using UUID = utils::UUID;
     session_info session;
-    session_prepared_event(UUID plan_id_, session_info session_)
+    session_prepared_event(streaming::plan_id plan_id_, session_info session_)
         : stream_event(stream_event::type::STREAM_PREPARED, plan_id_)
         , session(std::move(session_)) {
     }

--- a/streaming/stream_fwd.hh
+++ b/streaming/stream_fwd.hh
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+namespace streaming {
+
+class stream_event_handler;
+class stream_manager;
+class stream_result_future;
+class stream_session;
+class stream_state;
+
+} // namespace streaming

--- a/streaming/stream_fwd.hh
+++ b/streaming/stream_fwd.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/UUID.hh"
+
 namespace streaming {
 
 class stream_event_handler;
@@ -15,5 +17,7 @@ class stream_manager;
 class stream_result_future;
 class stream_session;
 class stream_state;
+
+using plan_id = utils::tagged_uuid<struct plan_id_tag>;
 
 } // namespace streaming

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -155,8 +155,8 @@ std::vector<shared_ptr<stream_result_future>> stream_manager::get_all_streams() 
     return result;
 }
 
-void stream_manager::update_progress(UUID cf_id, gms::inet_address peer, progress_info::direction dir, size_t fm_size) {
-    auto& sbytes = _stream_bytes[cf_id];
+void stream_manager::update_progress(UUID plan_id, gms::inet_address peer, progress_info::direction dir, size_t fm_size) {
+    auto& sbytes = _stream_bytes[plan_id];
     if (dir == progress_info::direction::OUT) {
         sbytes[peer].bytes_sent += fm_size;
         _total_outgoing_bytes += fm_size;

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -146,7 +146,7 @@ public:
         return make_ready_future<>();
     }
 
-    void update_progress(UUID cf_id, gms::inet_address peer, progress_info::direction dir, size_t fm_size);
+    void update_progress(UUID plan_id, gms::inet_address peer, progress_info::direction dir, size_t fm_size);
     future<> update_all_progress_info();
 
     void remove_progress(UUID plan_id);

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#include "streaming/stream_fwd.hh"
 #include "streaming/progress_info.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/distributed.hh>
@@ -44,9 +45,6 @@ class gossiper;
 }
 
 namespace streaming {
-
-class stream_session;
-class stream_result_future;
 
 struct stream_bytes {
     int64_t bytes_sent = 0;

--- a/streaming/stream_plan.hh
+++ b/streaming/stream_plan.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "utils/UUID.hh"
 #include "utils/UUID_gen.hh"
 #include <seastar/core/sstring.hh>
 #include "gms/inet_address.hh"
@@ -32,10 +31,9 @@ namespace streaming {
 class stream_plan {
 private:
     using inet_address = gms::inet_address;
-    using UUID = utils::UUID;
     using token = dht::token;
     stream_manager& _mgr;
-    UUID _plan_id;
+    plan_id _plan_id;
     sstring _description;
     stream_reason _reason;
     std::vector<stream_event_handler*> _handlers;
@@ -51,7 +49,7 @@ public:
      */
     stream_plan(stream_manager& mgr, sstring description, stream_reason reason = stream_reason::unspecified)
         : _mgr(mgr)
-        , _plan_id(utils::UUID_gen::get_time_UUID())
+        , _plan_id(plan_id{utils::UUID_gen::get_time_UUID()})
         , _description(description)
         , _reason(reason)
         , _coordinator(make_shared<stream_coordinator>())

--- a/streaming/stream_plan.hh
+++ b/streaming/stream_plan.hh
@@ -16,15 +16,13 @@
 #include "gms/inet_address.hh"
 #include "query-request.hh"
 #include "dht/i_partitioner.hh"
+#include "streaming/stream_fwd.hh"
 #include "streaming/stream_coordinator.hh"
 #include "streaming/stream_detail.hh"
 #include "streaming/stream_reason.hh"
 #include <vector>
 
 namespace streaming {
-
-class stream_state;
-class stream_event_handler;
 
 /**
  * {@link StreamPlan} is a helper class that builds StreamOperation of given configuration.

--- a/streaming/stream_receive_task.hh
+++ b/streaming/stream_receive_task.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "utils/UUID.hh"
 #include "streaming/stream_fwd.hh"
 #include "streaming/stream_task.hh"
 #include <memory>

--- a/streaming/stream_receive_task.hh
+++ b/streaming/stream_receive_task.hh
@@ -11,12 +11,11 @@
 #pragma once
 
 #include "utils/UUID.hh"
+#include "streaming/stream_fwd.hh"
 #include "streaming/stream_task.hh"
 #include <memory>
 
 namespace streaming {
-
-class stream_session;
 
 /**
  * Task that manages receiving files for the session for certain ColumnFamily.

--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -17,7 +17,7 @@ namespace streaming {
 
 extern logging::logger sslog;
 
-future<stream_state> stream_result_future::init_sending_side(stream_manager& mgr, UUID plan_id_, sstring description_,
+future<stream_state> stream_result_future::init_sending_side(stream_manager& mgr, streaming::plan_id plan_id_, sstring description_,
         std::vector<stream_event_handler*> listeners_, shared_ptr<stream_coordinator> coordinator_) {
     auto sr = ::make_shared<stream_result_future>(mgr, plan_id_, description_, coordinator_);
     mgr.register_sending(sr);
@@ -37,7 +37,7 @@ future<stream_state> stream_result_future::init_sending_side(stream_manager& mgr
     return sr->_done.get_future();
 }
 
-shared_ptr<stream_result_future> stream_result_future::init_receiving_side(stream_manager& mgr, UUID plan_id, sstring description, inet_address from) {
+shared_ptr<stream_result_future> stream_result_future::init_receiving_side(stream_manager& mgr, streaming::plan_id plan_id, sstring description, inet_address from) {
     auto sr = mgr.get_receiving_stream(plan_id);
     if (sr) {
         auto err = fmt::format("[Stream #{}] GOT PREPARE_MESSAGE from {}, description={},"

--- a/streaming/stream_result_future.hh
+++ b/streaming/stream_result_future.hh
@@ -11,7 +11,6 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
-#include "utils/UUID.hh"
 #include "gms/inet_address.hh"
 #include "streaming/stream_coordinator.hh"
 #include "streaming/stream_event_handler.hh"
@@ -20,7 +19,6 @@
 #include <vector>
 
 namespace streaming {
-    using UUID = utils::UUID;
     using inet_address = gms::inet_address;
 /**
  * A future on the result ({@link StreamState}) of a streaming plan.
@@ -37,8 +35,7 @@ namespace streaming {
  */
 class stream_result_future {
 public:
-    using UUID = utils::UUID;
-    UUID plan_id;
+    streaming::plan_id plan_id;
     sstring description;
 private:
     stream_manager& _mgr;
@@ -47,7 +44,7 @@ private:
     promise<stream_state> _done;
     lowres_clock::time_point _start_time;
 public:
-    stream_result_future(stream_manager& mgr, UUID plan_id_, sstring description_, bool is_receiving)
+    stream_result_future(stream_manager& mgr, streaming::plan_id plan_id_, sstring description_, bool is_receiving)
         : stream_result_future(mgr, plan_id_, description_, make_shared<stream_coordinator>(is_receiving)) {
         // Note: Origin sets connections_per_host = 0 on receiving side, We set 1 to
         // refelct the fact that we actaully create one conncetion to the initiator.
@@ -61,7 +58,7 @@ public:
      * @param planId Stream plan ID
      * @param description Stream description
      */
-    stream_result_future(stream_manager& mgr, UUID plan_id_, sstring description_, shared_ptr<stream_coordinator> coordinator_)
+    stream_result_future(stream_manager& mgr, streaming::plan_id plan_id_, sstring description_, shared_ptr<stream_coordinator> coordinator_)
         : plan_id(std::move(plan_id_))
         , description(std::move(description_))
         , _mgr(mgr)
@@ -77,8 +74,8 @@ public:
     shared_ptr<stream_coordinator> get_coordinator() { return _coordinator; };
 
 public:
-    static future<stream_state> init_sending_side(stream_manager& mgr, UUID plan_id_, sstring description_, std::vector<stream_event_handler*> listeners_, shared_ptr<stream_coordinator> coordinator_);
-    static shared_ptr<stream_result_future> init_receiving_side(stream_manager& mgr, UUID plan_id, sstring description, inet_address from);
+    static future<stream_state> init_sending_side(stream_manager& mgr, streaming::plan_id plan_id_, sstring description_, std::vector<stream_event_handler*> listeners_, shared_ptr<stream_coordinator> coordinator_);
+    static shared_ptr<stream_result_future> init_receiving_side(stream_manager& mgr, streaming::plan_id plan_id, sstring description, inet_address from);
 
 public:
     void add_event_listener(stream_event_handler* listener) {

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -52,7 +52,7 @@ static sstables::offstrategy is_offstrategy_supported(streaming::stream_reason r
 void stream_manager::init_messaging_service_handler() {
     auto& ms = _ms.local();
 
-    ms.register_prepare_message([this] (const rpc::client_info& cinfo, prepare_message msg, UUID plan_id, sstring description, rpc::optional<stream_reason> reason_opt) {
+    ms.register_prepare_message([this] (const rpc::client_info& cinfo, prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<stream_reason> reason_opt) {
         const auto& src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
         const auto& from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         auto dst_cpu_id = this_shard_id();
@@ -66,7 +66,7 @@ void stream_manager::init_messaging_service_handler() {
             return session->prepare(std::move(msg.requests), std::move(msg.summaries));
         });
     });
-    ms.register_prepare_done_message([this] (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id) {
+    ms.register_prepare_done_message([this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id) {
         const auto& from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         return container().invoke_on(dst_cpu_id, [plan_id, from] (auto& sm) mutable {
             auto session = sm.get_session(plan_id, from, "PREPARE_DONE_MESSAGE");
@@ -74,7 +74,7 @@ void stream_manager::init_messaging_service_handler() {
             return make_ready_future<>();
         });
     });
-    ms.register_stream_mutation_fragments([this] (const rpc::client_info& cinfo, UUID plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source) {
+    ms.register_stream_mutation_fragments([this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source) {
         auto from = netw::messaging_service::get_source(cinfo);
         auto reason = reason_opt ? *reason_opt: stream_reason::unspecified;
         sslog.trace("Got stream_mutation_fragments from {} reason {}", from, int(reason));
@@ -163,14 +163,14 @@ void stream_manager::init_messaging_service_handler() {
         });
       });
     });
-    ms.register_stream_mutation_done([this] (const rpc::client_info& cinfo, UUID plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
+    ms.register_stream_mutation_done([this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
         const auto& from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         return container().invoke_on(dst_cpu_id, [ranges = std::move(ranges), plan_id, cf_id, from] (auto& sm) mutable {
             auto session = sm.get_session(plan_id, from, "STREAM_MUTATION_DONE", cf_id);
             session->receive_task_completed(cf_id);
         });
     });
-    ms.register_complete_message([this] (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed) {
+    ms.register_complete_message([this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed) {
         const auto& from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         if (failed && *failed) {
             return container().invoke_on(dst_cpu_id, [plan_id, from, dst_cpu_id] (auto& sm) {
@@ -524,8 +524,8 @@ void stream_session::init(shared_ptr<stream_result_future> stream_result_) {
     _stream_result = stream_result_;
 }
 
-utils::UUID stream_session::plan_id() const {
-    return _stream_result ? _stream_result->plan_id : UUID();
+streaming::plan_id stream_session::plan_id() const {
+    return _stream_result ? _stream_result->plan_id : streaming::plan_id::create_null_id();
 }
 
 sstring stream_session::description() const {

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -13,7 +13,6 @@
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include <seastar/core/distributed.hh>
 #include "message/messaging_service_fwd.hh"
-#include "utils/UUID.hh"
 #include "streaming/stream_session_state.hh"
 #include "streaming/stream_transfer_task.hh"
 #include "streaming/stream_receive_task.hh"
@@ -119,7 +118,6 @@ private:
     using messaging_service = netw::messaging_service;
     using msg_addr = netw::msg_addr;
     using inet_address = gms::inet_address;
-    using UUID = utils::UUID;
     using token = dht::token;
     using ring_position = dht::ring_position;
 
@@ -193,7 +191,7 @@ public:
     stream_session(stream_manager& mgr, inet_address peer_);
     ~stream_session();
 
-    UUID plan_id() const;
+    streaming::plan_id plan_id() const;
 
     sstring description() const;
 

--- a/streaming/stream_state.hh
+++ b/streaming/stream_state.hh
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "utils/UUID.hh"
 #include "streaming/session_info.hh"
+#include "streaming/stream_plan.hh"
 #include <vector>
 
 namespace streaming {
@@ -21,12 +21,11 @@ namespace streaming {
  */
 class stream_state {
 public:
-    using UUID = utils::UUID;
-    UUID plan_id;
+    streaming::plan_id plan_id;
     sstring description;
     std::vector<session_info> sessions;
 
-    stream_state(UUID plan_id_, sstring description_, std::vector<session_info> sessions_)
+    stream_state(streaming::plan_id plan_id_, sstring description_, std::vector<session_info> sessions_)
         : plan_id(std::move(plan_id_))
         , description(std::move(description_))
         , sessions(std::move(sessions_)) {

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -9,6 +9,7 @@
  */
 
 #include "log.hh"
+#include "streaming/stream_fwd.hh"
 #include "streaming/stream_detail.hh"
 #include "streaming/stream_transfer_task.hh"
 #include "streaming/stream_session.hh"
@@ -45,7 +46,7 @@ stream_transfer_task::~stream_transfer_task() = default;
 
 struct send_info {
     netw::messaging_service& ms;
-    utils::UUID plan_id;
+    streaming::plan_id plan_id;
     table_id cf_id;
     netw::messaging_service::msg_addr id;
     uint32_t dst_cpu_id;
@@ -58,7 +59,7 @@ struct send_info {
     dht::partition_range_vector prs;
     mutation_fragment_v1_stream reader;
     noncopyable_function<void(size_t)> update;
-    send_info(netw::messaging_service& ms_, utils::UUID plan_id_, replica::table& tbl_, reader_permit permit_,
+    send_info(netw::messaging_service& ms_, streaming::plan_id plan_id_, replica::table& tbl_, reader_permit permit_,
               dht::token_range_vector ranges_, netw::messaging_service::msg_addr id_,
               uint32_t dst_cpu_id_, stream_reason reason_, noncopyable_function<void(size_t)> update_fn)
         : ms(ms_)

--- a/streaming/stream_transfer_task.hh
+++ b/streaming/stream_transfer_task.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "utils/UUID.hh"
 #include "streaming/stream_fwd.hh"
 #include "streaming/stream_task.hh"
 #include "streaming/stream_detail.hh"

--- a/streaming/stream_transfer_task.hh
+++ b/streaming/stream_transfer_task.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "utils/UUID.hh"
+#include "streaming/stream_fwd.hh"
 #include "streaming/stream_task.hh"
 #include "streaming/stream_detail.hh"
 #include <map>
@@ -18,7 +19,6 @@
 
 namespace streaming {
 
-class stream_session;
 class send_info;
 
 /**


### PR DESCRIPTION
This series turns plan_id from a generic UUID into a strong type so it can't be used interchangeably with other uuid's.
While at it, streaming/stream_fwd.hh was added for forward declarations and the definition of plan_id.
Also, `stream_manager::update_progress` parameter name was renamed to plan_id to represent its assumed content, before changing its type to `streaming::plan_id`.
