### PR TITLE
systemd: drop StandardOutput=syslog

### DIFF
--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -23,8 +23,6 @@ KillMode=process
 Restart=on-abnormal
 User=scylla
 OOMScoreAdjust=-950
-StandardOutput=syslog
-StandardError=syslog
 SyslogLevelPrefix=false
 Slice=scylla-server.slice
 


### PR DESCRIPTION
On recent version of systemd, StandardOutput=syslog is obsolete.
We should use StandardOutput=journal instead, but since it's default value,
so we can just drop it.

Fixes #11322