### PR TITLE
install.sh: add --without-systemd option

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -107,9 +107,9 @@ have_gnutls = any([lib.startswith('libgnutls.so')
 gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.PIPE)
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
-# relocatable package format version = 2.1
+# relocatable package format version = 2.2
 with open('build/.relocatable_package_version', 'w') as f:
-    f.write('2.1\n')
+    f.write('2.2\n')
 ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
 
 for exe in executables:

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -71,5 +71,7 @@ for pkg in $PKGS; do
 done
 ln -f unified/install.sh build/"$MODE"/unified/
 ln -f unified/uninstall.sh build/"$MODE"/unified/
+# relocatable package format version = 2.2
+echo "2.2" > build/"$MODE"/unified/.relocatable_package_version
 cd build/"$MODE"/unified
 tar cpf "$UNIFIED_PKG" --use-compress-program=pigz * .relocatable_package_version

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -27,6 +27,7 @@ Options:
   --sysconfdir /etc/sysconfig   specify sysconfig directory name
   --supervisor             enable supervisor to manage scylla processes
   --supervisor-log-to-stdout logging to stdout on supervisor
+  --without-systemd         skip installing systemd units
   --help                   this helpful message
 EOF
     exit 1
@@ -42,6 +43,7 @@ housekeeping=false
 nonroot=false
 supervisor=false
 supervisor_log_to_stdout=false
+without_systemd=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -75,6 +77,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--supervisor-log-to-stdout")
             supervisor_log_to_stdout=true
+            shift 1
+            ;;
+        "--without-systemd")
+            without_systemd=true
             shift 1
             ;;
         "--help")
@@ -148,6 +154,10 @@ if $supervisor; then
 fi
 if $supervisor_log_to_stdout; then
     scylla_args+=(--supervisor-log-to-stdout)
+fi
+if $without_systemd; then
+    scylla_args+=(--without-systemd)
+    jmx_args+=(--without-systemd)
 fi
 
 (cd $(readlink -f scylla); ./install.sh --root "$root" --prefix "$prefix" --python3 "$python3" --sysconfdir "$sysconfdir" ${scylla_args[@]})


### PR DESCRIPTION
Since we fail to write files to $USER/.config on Jenkins jobs, we need
an option to skip installing systemd units.
Let's add --without-systemd to do that.

See scylladb/scylla-dtest#2819

----

Please merge jmx part of patch first, otherwise unified installer will fail: scylladb/scylla-jmx#186
