### PR TITLE
Update auditing.rst

### DIFF
--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -14,8 +14,8 @@ Enabling Audit
 Enabling auditing is controlled by the ``audit:`` parameter in the ``scylla.yaml`` file. 
 You can set the following options:
 
-* ``none`` - Audit is disabled (default).
-* ``table`` - Audit is enabled, and messages are stored in a Scylla table.
+* ``none`` - Audit is disabled.
+* ``table`` - Audit is enabled, and messages are stored in a Scylla table (default).
 * ``syslog`` - Audit is enabled, and messages are sent to Syslog.
 
 Configuring any other value results in an error at Scylla startup.
@@ -28,7 +28,7 @@ The audit can be tuned using the following flags or ``scylla.yaml`` entries:
 ==================  ==================================  ========================================================================================================================
 Flag                Default Value                       Description
 ==================  ==================================  ========================================================================================================================
-audit_categories    ""                                  Comma-separated list of statement categories that should be audited
+audit_categories    "DCL,DDL,AUTH,ADMIN"                                  Comma-separated list of statement categories that should be audited
 ------------------  ----------------------------------  ------------------------------------------------------------------------------------------------------------------------
 audit_tables        “”                                  Comma-separated list of table names that should be audited, in the format of <keyspacename>.<tablename>
 ------------------  ----------------------------------  ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/11341

"audit" default parameter value is 'table' by default (not 'none')

"audit_categories" default value is 'DCL,DDL,AUTH,ADMIN' (not an empty string)