### PR TITLE
test.py: bump timeout of async requests for topology

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -63,6 +63,7 @@ def _wrap_future(f: ResponseFuture) -> asyncio.Future:
 
 
 def run_async(self, *args, **kwargs) -> asyncio.Future:
+    kwargs.setdefault("timeout", 60.0)
     return _wrap_future(self.execute_async(*args, **kwargs))
 
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -98,17 +98,17 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
                    # different versions. If we drop this setting completely, it will
                    # mean pick the latest version supported by the client and the server.
                    protocol_version=4,
-                      # NOTE: No auth provider as auth keysppace has RF=1 and topology will take
-                      # down nodes, causing errors. If auth is needed in the future for topology
-                      # tests, they should bump up auth RF and run repair.
-                      ssl_context=ssl_context,
-                      # The default timeout for new connections is 5 seconds, and for
-                      # requests made by the control connection is 2 seconds. These should
-                      # have been more than enough, but in some extreme cases with a very
-                      # slow debug build running on a very busy machine, they may not be.
-                      # so let's increase them to 60 seconds. See issue #11289.
-                      connect_timeout = 60,
-                      control_connection_timeout = 60,
+                   # NOTE: No auth provider as auth keysppace has RF=1 and topology will take
+                   # down nodes, causing errors. If auth is needed in the future for topology
+                   # tests, they should bump up auth RF and run repair.
+                   ssl_context=ssl_context,
+                   # The default timeout for new connections is 5 seconds, and for
+                   # requests made by the control connection is 2 seconds. These should
+                   # have been more than enough, but in some extreme cases with a very
+                   # slow debug build running on a very busy machine, they may not be.
+                   # so let's increase them to 60 seconds. See issue #11289.
+                   connect_timeout = 60,
+                   control_connection_timeout = 60,
                    )
 
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -110,6 +110,7 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
                    # so let's increase them to 60 seconds. See issue #11289.
                    connect_timeout = 60,
                    control_connection_timeout = 60,
+                   max_schema_agreement_wait=60,
                    )
 
 


### PR DESCRIPTION
Topology tests do async requests using the Python driver. The driver's
API for async doesn't use the session timeout.

Pass 60 seconds timeout (default is 10) to match the session's.

Fixes https://github.com/scylladb/scylladb/issues/11289