### PR TITLE
Add cassandra functional - show warn/err when tombstone threshold reached.

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -557,7 +557,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Tombstone settings */
     /* When executing a scan, within or across a partition, tombstones must be kept in memory to allow returning them to the coordinator. The coordinator uses them to ensure other replicas know about the deleted rows. Workloads that generate numerous tombstones may cause performance problems and exhaust the server heap. See Cassandra anti-patterns: Queues and queue-like datasets. Adjust these thresholds only if you understand the impact and want to scan more tombstones. Additionally, you can adjust these thresholds at runtime using the StorageServiceMBean. */
     /* Related information: Cassandra anti-patterns: Queues and queue-like datasets */
-    , tombstone_warn_threshold(this, "tombstone_warn_threshold", value_status::Unused, 1000,
+    , tombstone_warn_threshold(this, "tombstone_warn_threshold", value_status::Used, 1000,
         "The maximum number of tombstones a query can scan before warning.")
     , tombstone_failure_threshold(this, "tombstone_failure_threshold", value_status::Unused, 100000,
         "The maximum number of tombstones a query can scan before aborting.")

--- a/querier.cc
+++ b/querier.cc
@@ -18,6 +18,7 @@
 namespace query {
 
 logging::logger qlogger("querier_cache");
+logging::logger qrlogger("querier");
 
 enum class can_use {
     yes,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1252,6 +1252,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
     cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
+    cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_concurrency_semaphore = _config.view_update_concurrency_semaphore;
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -382,6 +382,7 @@ public:
         utils::updateable_value<bool> enable_optimized_reversed_reads{true};
         // Can be updated by a schema change:
         bool enable_optimized_twcs_queries{true};
+        uint32_t tombstone_warn_threshold{0};
     };
     struct no_commitlog {};
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2166,8 +2166,9 @@ table::query(schema_ptr s,
         auto&& range = *qs.current_partition_range++;
 
         if (!querier_opt) {
+            query::querier_base::querier_config conf(_config.tombstone_warn_threshold);
             querier_opt = query::querier(as_mutation_source(), s, permit, range, qs.cmd.slice,
-                    service::get_local_sstable_query_read_priority(), trace_state);
+                    service::get_local_sstable_query_read_priority(), trace_state, conf);
         }
         auto& q = *querier_opt;
 
@@ -2220,8 +2221,9 @@ table::mutation_query(schema_ptr s,
         querier_opt = std::move(*saved_querier);
     }
     if (!querier_opt) {
+        query::querier_base::querier_config conf(_config.tombstone_warn_threshold);
         querier_opt = query::querier(as_mutation_source(), s, permit, range, cmd.slice,
-                service::get_local_sstable_query_read_priority(), trace_state);
+                service::get_local_sstable_query_read_priority(), trace_state, conf);
     }
     auto& q = *querier_opt;
 


### PR DESCRIPTION
Add cassandra functional - show warn/err when tombstone_warn_threshold/tombstone_failure_threshold reached on select, by partitions. Propagate raw query_string from coordinator to replicas.