### PR TITLE
release: define SCYLLA_BUILD_MODE_STR by stringifying SCYLLA_BUILD_MODE

### DIFF
--- a/build_mode.hh
+++ b/build_mode.hh
@@ -1,0 +1,59 @@
+
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#ifndef SCYLLA_BUILD_MODE
+#error SCYLLA_BUILD_MODE must be defined
+#endif
+
+#ifndef STRINGIFY
+// We need to levels of indirection
+// to make a string out of the macro name.
+// The outer level expands the macro
+// and the inner level makes a string out of the expanded macro.
+#define STRINGIFY_VALUE(x) #x
+#define STRINGIFY_MACRO(x) STRINGIFY_VALUE(x)
+#endif
+
+#define SCYLLA_BUILD_MODE_STR STRINGIFY_MACRO(SCYLLA_BUILD_MODE)
+
+// We use plain macro definitions
+// so the preprocessor can expand them
+// inline in the #if directives below
+#define SCYLLA_BUILD_MODE_CODE_debug 0
+#define SCYLLA_BUILD_MODE_CODE_release 1
+#define SCYLLA_BUILD_MODE_CODE_dev 2
+#define SCYLLA_BUILD_MODE_CODE_sanitize 3
+#define SCYLLA_BUILD_MODE_CODE_coverage 4
+
+#define _SCYLLA_BUILD_MODE_CODE(sbm) SCYLLA_BUILD_MODE_CODE_ ## sbm
+#define SCYLLA_BUILD_MODE_CODE(sbm) _SCYLLA_BUILD_MODE_CODE(sbm)
+
+#if SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_debug
+#define SCYLLA_BUILD_MODE_DEBUG
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_release
+#define SCYLLA_BUILD_MODE_RELEASE
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_dev
+#define SCYLLA_BUILD_MODE_DEV
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_sanitize
+#define SCYLLA_BUILD_MODE_SANITIZE
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_coverage
+#define SCYLLA_BUILD_MODE_COVERAGE
+#else
+#error unrecognized SCYLLA_BUILD_MODE
+#endif
+
+#if (defined(SCYLLA_BUILD_MODE_RELEASE) || defined(SCYLLA_BUILD_MODE_DEV)) && defined(SEASTAR_DEBUG)
+#error SEASTAR_DEBUG is not expected to be defined when SCYLLA_BUILD_MODE is "release" or "dev"
+#endif
+
+#if (defined(SCYLLA_BUILD_MODE_DEBUG) || defined(SCYLLA_BUILD_MODE_SANITIZE)) && !defined(SEASTAR_DEBUG)
+#error SEASTAR_DEBUG is expected to be defined when SCYLLA_BUILD_MODE is "debug" or "sanitize"
+#endif

--- a/configure.py
+++ b/configure.py
@@ -1557,7 +1557,8 @@ scylla_product = file.read().strip()
 arch = platform.machine()
 
 for m, mode_config in modes.items():
-    cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\" -DSCYLLA_BUILD_MODE=\"\\\"" + m + "\\\"\""
+    mode_config['cxxflags'] += f" -DSCYLLA_BUILD_MODE={m}"
+    cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\""
     mode_config["per_src_extra_cxxflags"]["release.cc"] = cxxflags
     if mode_config["can_have_debug_info"]:
         mode_config['cxxflags'] += ' ' + dbgflag

--- a/release.cc
+++ b/release.cc
@@ -7,12 +7,13 @@
  */
 
 #include "version.hh"
+#include "build_mode.hh"
 
 #include <seastar/core/print.hh>
 
 static const char scylla_version_str[] = SCYLLA_VERSION;
 static const char scylla_release_str[] = SCYLLA_RELEASE;
-static const char scylla_build_mode_str[] = SCYLLA_BUILD_MODE;
+static const char scylla_build_mode_str[] = SCYLLA_BUILD_MODE_STR;
 
 std::string scylla_version()
 {

--- a/release.hh
+++ b/release.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include "build_mode.hh"
 
 std::string scylla_version();
 


### PR DESCRIPTION
Currently SCYLLA_BULD_MODE is defined as a string by the cxxflags
generated by configure.py.  This is not very useful since one cannot use
it in a @if preprocessor directive.

Instead, use -DSCYLLA_BULD_MODE=release, for example, and define a
SCYLLA_BULD_MODE_STR as the dtirng representation of it.

In addition define the respective
SCYLLA_BUILD_MODE_{RELEASE,DEV,DEBUG,SANITIZE} macros that can be easily
used in @ifdef (or #ifndef :)) for conditional compilation.

The planned use case for it is to enable a task_manager test module only
in non-release modes.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>