### PR TITLE
alternator - Doc - Update DescribeTable response and introduce hashing function differences

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -16,7 +16,21 @@ provision that - Scylla requires you to provision your cluster. You need
 to reason about the number and size of your nodes - not the throughput.
 
 When creating a table, the BillingMode and ProvisionedThroughput options
-are ignored by Scylla.
+are ignored by Scylla. Tables default to a Billing mode of `PAY_PER_REQUEST`
+and `DescribeTable` API calls will return a value of 0 for the RCUs, WCUs
+and NumberOfDecreasesToday within the response.
+
+## Scan ordering
+
+In DynamoDB, the Hash key (or partition key) determines where the item will
+be stored within DynamoDB's internal storage. Another notable difference between
+DynamoDB and Scylla comes down to the underlying hashing algorithm.
+While DynamoDB uses a proprietary hashing function, ScyllaDB implements the well-known
+[Murmur3](https://docs.scylladb.com/stable/glossary.html#term-Partitioner) algorithm.
+
+Even though regular users should not typically care about the underlying
+implementation details, particularly such difference causes Scan operations
+to return results in a different order between DynamoDB and Alternator.
 
 ## Load balancing
 
@@ -251,7 +265,7 @@ they should be easy to detect. Here is a list of these unimplemented features:
   <https://github.com/scylladb/scylla/issues/5013>
   <https://github.com/scylladb/scylla/issues/5026>
   <https://github.com/scylladb/scylla/issues/7550>
-  <https://github.com/scylladb/scylla/issues/7551 >
+  <https://github.com/scylladb/scylla/issues/7551>
 
 * The recently-added PartiQL syntax (SQL-like SELECT/UPDATE/INSERT/DELETE
   expressions) and the new operations ExecuteStatement, BatchExecuteStatement


### PR DESCRIPTION
This commit introduces the following changes to Alternator compability doc:

* As of https://github.com/scylladb/scylladb/pull/11298 Alternator will return ProvisionedThroughput in DescribeTable API calls. We add the fact that tables will default to a BillingMode of PAY_PER_REQUEST (this wasn't made explicit anywhere in the docs), and that the values for RCUs/WCUs are hardcoded to 0.
* Mention the fact that ScyllaDB (thus Alternator) hashing function is different than AWS proprietary implementation for DynamoDB. This is mostly of an implementation aspect rather than a bug, but it may cause user confusion when/if comparing the ResultSet between DynamoDB and Alternator returned from Table Scans.
* Finally, it corrects an annoying reading typo under the Unimplemented API features section

Refs: https://github.com/scylladb/scylladb/issues/11222
Fixes: https://github.com/scylladb/scylladb/issues/11315