### PR TITLE
storage_service: Prevent removed node to rejoin in handle_state_normal

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -399,6 +399,8 @@ public:
 
     locator::host_id get_host_id(inet_address endpoint) const;
 
+    std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;
+
     std::optional<endpoint_state> get_state_for_version_bigger_than(inet_address for_endpoint, int version);
 
     /**


### PR DESCRIPTION
- Start n1, n2, n3 (127.0.0.3)
- Stop n3
- Change ip address of n3 to 127.0.0.33 and restart n3
- Decommission n3
- Start new node n4

The node n4 will learn from the gossip entry for 127.0.0.3 that node
127.0.0.3 is in shutdown status which means 127.0.0.3 is still part of
the ring.

This patch prevents this by checking the status for the host id on all
the entries. If any of the entries shows the node with the host id is in
LEFT status, reject to put the node in NORMAL status.

Fixes #11355