### PR TITLE
Deglobalize repair history maps

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -684,7 +684,8 @@ private:
                 reader.consume_in_thread(std::move(cfc));
             });
         });
-        return consumer(make_compacting_reader(make_sstable_reader(), compaction_time, max_purgeable_func()));
+        const auto& gc_state = _table_s.get_tombstone_gc_state();
+        return consumer(make_compacting_reader(make_sstable_reader(), compaction_time, max_purgeable_func(), gc_state));
     }
 
     future<> consume() {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -705,6 +705,7 @@ private:
                     using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
                     auto cfc = compact_mutations(*schema(), now,
                         max_purgeable_func(),
+                        _table_s.get_tombstone_gc_state(),
                         get_compacted_fragments_writer(),
                         get_gc_compacted_fragments_writer());
 
@@ -714,6 +715,7 @@ private:
                 using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
                 auto cfc = compact_mutations(*schema(), now,
                     max_purgeable_func(),
+                    _table_s.get_tombstone_gc_state(),
                     get_compacted_fragments_writer(),
                     noop_compacted_fragments_consumer());
                 reader.consume_in_thread(std::move(cfc));

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1777,7 +1777,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
     int64_t min_timestamp = std::numeric_limits<int64_t>::max();
 
     for (auto& sstable : overlapping) {
-        auto gc_before = sstable->get_gc_before_for_fully_expire(compaction_time);
+        auto gc_before = sstable->get_gc_before_for_fully_expire(compaction_time, table_s.get_tombstone_gc_state());
         if (sstable->get_max_local_deletion_time() >= gc_before) {
             min_timestamp = std::min(min_timestamp, sstable->get_stats_metadata().min_timestamp);
         }
@@ -1796,7 +1796,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
 
     // SStables that do not contain live data is added to list of possibly expired sstables.
     for (auto& candidate : compacting) {
-        auto gc_before = candidate->get_gc_before_for_fully_expire(compaction_time);
+        auto gc_before = candidate->get_gc_before_for_fully_expire(compaction_time, table_s.get_tombstone_gc_state());
         clogger.debug("Checking if candidate of generation {} and max_deletion_time {} is expired, gc_before is {}",
                     candidate->generation(), candidate->get_stats_metadata().max_local_deletion_time, gc_before);
         // A fully expired sstable which has an ancestor undeleted shouldn't be compacted because

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -657,6 +657,7 @@ compaction_manager::compaction_manager(config cfg, abort_source& as)
     , _update_compaction_static_shares_action([this] { return update_static_shares(static_shares()); })
     , _compaction_static_shares_observer(_cfg.static_shares.observe(_update_compaction_static_shares_action.make_observer()))
     , _strategy_control(std::make_unique<strategy_control>(*this))
+    , _tombstone_gc_state(&_repair_history_maps)
 {
     register_metrics();
     // Bandwidth throttling is node-wide, updater is needed on single shard
@@ -676,6 +677,7 @@ compaction_manager::compaction_manager()
     , _update_compaction_static_shares_action([] { return make_ready_future<>(); })
     , _compaction_static_shares_observer(_cfg.static_shares.observe(_update_compaction_static_shares_action.make_observer()))
     , _strategy_control(std::make_unique<strategy_control>(*this))
+    , _tombstone_gc_state(&_repair_history_maps)
 {
     // No metric registration because this constructor is supposed to be used only by the testing
     // infrastructure.

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
+
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -36,6 +39,11 @@
 #include "tombstone_gc.hh"
 
 class compacting_sstable_registration;
+
+class repair_history_map {
+public:
+    boost::icl::interval_map<dht::token, gc_clock::time_point, boost::icl::partial_absorber, std::less, boost::icl::inplace_max> map;
+};
 
 // Compaction manager provides facilities to submit and track compaction jobs on
 // behalf of existing tables.
@@ -296,6 +304,7 @@ private:
     class strategy_control;
     std::unique_ptr<strategy_control> _strategy_control;
 
+    per_table_history_maps _repair_history_maps;
     tombstone_gc_state _tombstone_gc_state;
 private:
     future<compaction_stats_opt> perform_task(shared_ptr<task>);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -33,6 +33,7 @@
 #include "backlog_controller.hh"
 #include "seastarx.hh"
 #include "sstables/exceptions.hh"
+#include "tombstone_gc.hh"
 
 class compacting_sstable_registration;
 
@@ -294,6 +295,8 @@ private:
 
     class strategy_control;
     std::unique_ptr<strategy_control> _strategy_control;
+
+    tombstone_gc_state _tombstone_gc_state;
 private:
     future<compaction_stats_opt> perform_task(shared_ptr<task>);
 
@@ -507,6 +510,14 @@ public:
     static sstables::compaction_data create_compaction_data();
 
     compaction::strategy_control& get_strategy_control() const noexcept;
+
+    tombstone_gc_state& get_tombstone_gc_state() noexcept {
+        return _tombstone_gc_state;
+    };
+
+    const tombstone_gc_state& get_tombstone_gc_state() const noexcept {
+        return _tombstone_gc_state;
+    };
 
     friend class compacting_sstable_registration;
     friend class compaction_weight_registration;

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -13,6 +13,7 @@
 #include "compaction_strategy.hh"
 #include "db_clock.hh"
 #include "compaction_descriptor.hh"
+#include "tombstone_gc.hh"
 
 namespace compaction {
 class table_state;
@@ -67,7 +68,7 @@ public:
 
     // Check if a given sstable is entitled for tombstone compaction based on its
     // droppable tombstone histogram and gc_before.
-    bool worth_dropping_tombstones(const shared_sstable& sst, gc_clock::time_point compaction_time);
+    bool worth_dropping_tombstones(const shared_sstable& sst, gc_clock::time_point compaction_time, const tombstone_gc_state& gc_state);
 
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
 

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -39,16 +39,16 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
     for (auto level = int(manifest.get_level_count()); level >= 0; level--) {
         auto& sstables = manifest.get_level(level);
         // filter out sstables which droppable tombstone ratio isn't greater than the defined threshold.
-        auto e = boost::range::remove_if(sstables, [this, compaction_time] (const sstables::shared_sstable& sst) -> bool {
-            return !worth_dropping_tombstones(sst, compaction_time);
+        auto e = boost::range::remove_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
+            return !worth_dropping_tombstones(sst, compaction_time, table_s.get_tombstone_gc_state());
         });
         sstables.erase(e, sstables.end());
         if (sstables.empty()) {
             continue;
         }
         auto& sst = *std::max_element(sstables.begin(), sstables.end(), [&] (auto& i, auto& j) {
-            auto gc_before1 = i->get_gc_before_for_drop_estimation(compaction_time);
-            auto gc_before2 = j->get_gc_before_for_drop_estimation(compaction_time);
+            auto gc_before1 = i->get_gc_before_for_drop_estimation(compaction_time, table_s.get_tombstone_gc_state());
+            auto gc_before2 = j->get_gc_before_for_drop_estimation(compaction_time, table_s.get_tombstone_gc_state());
             return i->estimate_droppable_tombstone_ratio(gc_before1) < j->estimate_droppable_tombstone_ratio(gc_before2);
         });
         return sstables::compaction_descriptor({ sst }, service::get_local_compaction_priority(), sst->get_sstable_level());

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -169,8 +169,8 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
     // tombstone purge, i.e. less likely to shadow even older data.
     for (auto&& sstables : buckets | boost::adaptors::reversed) {
         // filter out sstables which droppable tombstone ratio isn't greater than the defined threshold.
-        auto e = boost::range::remove_if(sstables, [this, compaction_time] (const sstables::shared_sstable& sst) -> bool {
-            return !worth_dropping_tombstones(sst, compaction_time);
+        auto e = boost::range::remove_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
+            return !worth_dropping_tombstones(sst, compaction_time, table_s.get_tombstone_gc_state());
         });
         sstables.erase(e, sstables.end());
         if (sstables.empty()) {

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -43,6 +43,7 @@ public:
     virtual future<> update_compaction_history(utils::UUID compaction_id, sstring ks_name, sstring cf_name, std::chrono::milliseconds ended_at, int64_t bytes_in, int64_t bytes_out) = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
+    virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
 };
 
 }

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -270,8 +270,8 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
 
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
-    auto e = boost::range::remove_if(non_expiring_sstables, [this, compaction_time] (const shared_sstable& sst) -> bool {
-        return !worth_dropping_tombstones(sst, compaction_time);
+    auto e = boost::range::remove_if(non_expiring_sstables, [this, compaction_time, &table_s] (const shared_sstable& sst) -> bool {
+        return !worth_dropping_tombstones(sst, compaction_time, table_s.get_tombstone_gc_state());
     });
     non_expiring_sstables.erase(e, non_expiring_sstables.end());
     if (non_expiring_sstables.empty()) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1278,6 +1278,7 @@ future<stop_iteration> view_update_builder::on_results() {
 }
 
 view_update_builder make_view_update_builder(
+        const replica::table& base_table,
         const schema_ptr& base,
         std::vector<view_and_base>&& views_to_update,
         flat_mutation_reader_v2&& updates,
@@ -1291,7 +1292,7 @@ view_update_builder make_view_update_builder(
         }
         return view_updates(std::move(v));
     }));
-    return view_update_builder(base, std::move(vs), std::move(updates), std::move(existings), now);
+    return view_update_builder(base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
 }
 
 future<query::clustering_row_ranges> calculate_affected_clustering_ranges(const schema& base,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1169,7 +1169,7 @@ void view_update_builder::generate_update(clustering_row&& update, std::optional
     }
 
     auto dk = dht::decorate_key(*_schema, _key);
-    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    const auto& gc_state = _base.get_compaction_manager().get_tombstone_gc_state();
     auto gc_before = gc_state.get_gc_before_for_key(_schema, dk, _now);
 
     // We allow existing to be disengaged, which we treat the same as an empty row.

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1169,7 +1169,8 @@ void view_update_builder::generate_update(clustering_row&& update, std::optional
     }
 
     auto dk = dht::decorate_key(*_schema, _key);
-    auto gc_before = ::get_gc_before_for_key(_schema, dk, _now);
+    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    auto gc_before = gc_state.get_gc_before_for_key(_schema, dk, _now);
 
     // We allow existing to be disengaged, which we treat the same as an empty row.
     if (existing) {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -206,6 +206,10 @@ private:
 };
 
 class view_update_builder {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+    const replica::table& _base;
+#pragma GCC diagnostic pop
     schema_ptr _schema; // The base schema
     std::vector<view_updates> _view_updates;
     flat_mutation_reader_v2 _updates;
@@ -220,12 +224,13 @@ class view_update_builder {
     partition_key _key = partition_key::make_empty();
 public:
 
-    view_update_builder(schema_ptr s,
+    view_update_builder(const replica::table& base, schema_ptr s,
         std::vector<view_updates>&& views_to_update,
         flat_mutation_reader_v2&& updates,
         flat_mutation_reader_v2_opt&& existings,
         gc_clock::time_point now)
-            : _schema(std::move(s))
+            : _base(base)
+            , _schema(std::move(s))
             , _view_updates(std::move(views_to_update))
             , _updates(std::move(updates))
             , _existings(std::move(existings))
@@ -249,7 +254,8 @@ private:
 };
 
 view_update_builder make_view_update_builder(
-        const schema_ptr& base,
+        const replica::table& base_table,
+        const schema_ptr& base_schema,
         std::vector<view_and_base>&& views_to_update,
         flat_mutation_reader_v2&& updates,
         flat_mutation_reader_v2_opt&& existings,

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -206,10 +206,7 @@ private:
 };
 
 class view_update_builder {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-private-field"
     const replica::table& _base;
-#pragma GCC diagnostic pop
     schema_ptr _schema; // The base schema
     std::vector<view_updates> _view_updates;
     flat_mutation_reader_v2 _updates;

--- a/mutation.cc
+++ b/mutation.cc
@@ -174,7 +174,7 @@ mutation mutation::sliced(const query::clustering_row_ranges& ranges) const {
 
 mutation mutation::compacted() const {
     auto m = *this;
-    m.partition().compact_for_compaction(*schema(), always_gc, m.decorated_key(), gc_clock::time_point::min());
+    m.partition().compact_for_compaction(*schema(), always_gc, m.decorated_key(), gc_clock::time_point::min(), tombstone_gc_state(nullptr));
     return m;
 }
 

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -140,6 +140,7 @@ class compact_mutation_state {
     uint64_t _row_limit{};
     uint32_t _partition_limit{};
     uint64_t _partition_row_limit{};
+    tombstone_gc_state _tombstone_gc_state; // FIXME: default-constructed for now
 
     tombstone _partition_tombstone;
 
@@ -239,7 +240,7 @@ private:
             return _gc_before.value();
         } else {
             if (_dk) {
-                _gc_before = ::get_gc_before_for_key(_schema.shared_from_this(), *_dk, _query_time);
+                _gc_before = _tombstone_gc_state.get_gc_before_for_key(_schema.shared_from_this(), *_dk, _query_time);
                 return _gc_before.value();
             } else {
                 return gc_clock::time_point::min();

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -573,15 +573,20 @@ class compact_mutation_v2 {
     GCConsumer _gc_consumer;
 
 public:
+    // Can only be used for compact_for_sstables::no
     compact_mutation_v2(const schema& s, gc_clock::time_point query_time, const query::partition_slice& slice, uint64_t limit,
-              uint32_t partition_limit, Consumer consumer, GCConsumer gc_consumer = GCConsumer())
+              uint32_t partition_limit,
+              Consumer consumer, GCConsumer gc_consumer = GCConsumer())
         : _state(make_lw_shared<compact_mutation_state<SSTableCompaction>>(s, query_time, slice, limit, partition_limit))
         , _consumer(std::move(consumer))
         , _gc_consumer(std::move(gc_consumer)) {
     }
 
+    // Can only be used for compact_for_sstables::yes
     compact_mutation_v2(const schema& s, gc_clock::time_point compaction_time,
             std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+            // FIXME: pass to compact_mutation_state if compact_for_sstables
+            const tombstone_gc_state& gc_state,
             Consumer consumer, GCConsumer gc_consumer = GCConsumer())
         : _state(make_lw_shared<compact_mutation_state<SSTableCompaction>>(s, compaction_time, get_max_purgeable))
         , _consumer(std::move(consumer))

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1475,7 +1475,8 @@ mutation_partition::compact_for_query(
 }
 
 void mutation_partition::compact_for_compaction(const schema& s,
-    can_gc_fn& can_gc, const dht::decorated_key& dk, gc_clock::time_point compaction_time)
+    can_gc_fn& can_gc, const dht::decorated_key& dk, gc_clock::time_point compaction_time,
+    const tombstone_gc_state& gc_state)
 {
     check_schema(s);
     static const std::vector<query::clustering_range> all_rows = {
@@ -1483,7 +1484,6 @@ void mutation_partition::compact_for_compaction(const schema& s,
     };
 
     bool drop_tombstones_unconditionally = false;
-    auto gc_state = tombstone_gc_state(); // FIXME: for now
     do_compact(s, dk, compaction_time, all_rows, true, false, query::partition_max_rows, can_gc, drop_tombstones_unconditionally, gc_state);
 }
 

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1401,13 +1401,14 @@ uint32_t mutation_partition::do_compact(const schema& s,
     bool reverse,
     uint64_t row_limit,
     can_gc_fn& can_gc,
-    bool drop_tombstones_unconditionally)
+    bool drop_tombstones_unconditionally,
+    const tombstone_gc_state& gc_state)
 {
     check_schema(s);
     assert(row_limit > 0);
 
     auto gc_before = drop_tombstones_unconditionally ? gc_clock::time_point::max() :
-        ::get_gc_before_for_key(s.shared_from_this(), dk, query_time);
+        gc_state.get_gc_before_for_key(s.shared_from_this(), dk, query_time);
 
     auto should_purge_tombstone = [&] (const tombstone& t) {
         return t.deletion_time < gc_before && can_gc(t);
@@ -1468,7 +1469,9 @@ mutation_partition::compact_for_query(
 {
     check_schema(s);
     bool drop_tombstones_unconditionally = false;
-    return do_compact(s, dk, query_time, row_ranges, always_return_static_content, reverse, row_limit, always_gc, drop_tombstones_unconditionally);
+    // Replicas should only send non-purgeable tombstones already,
+    // so we can expect to not have to actually purge any tombstones here.
+    return do_compact(s, dk, query_time, row_ranges, always_return_static_content, reverse, row_limit, always_gc, drop_tombstones_unconditionally, tombstone_gc_state(nullptr));
 }
 
 void mutation_partition::compact_for_compaction(const schema& s,
@@ -1480,7 +1483,8 @@ void mutation_partition::compact_for_compaction(const schema& s,
     };
 
     bool drop_tombstones_unconditionally = false;
-    do_compact(s, dk, compaction_time, all_rows, true, false, query::partition_max_rows, can_gc, drop_tombstones_unconditionally);
+    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    do_compact(s, dk, compaction_time, all_rows, true, false, query::partition_max_rows, can_gc, drop_tombstones_unconditionally, gc_state);
 }
 
 void mutation_partition::compact_for_compaction_drop_tombstones_unconditionally(const schema& s, const dht::decorated_key& dk)
@@ -1491,7 +1495,7 @@ void mutation_partition::compact_for_compaction_drop_tombstones_unconditionally(
     };
     bool drop_tombstones_unconditionally = true;
     auto compaction_time = gc_clock::time_point::max();
-    do_compact(s, dk, compaction_time, all_rows, true, false, query::partition_max_rows, always_gc, drop_tombstones_unconditionally);
+    do_compact(s, dk, compaction_time, all_rows, true, false, query::partition_max_rows, always_gc, drop_tombstones_unconditionally, tombstone_gc_state(nullptr));
 }
 
 // Returns true if the mutation_partition represents no writes.

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -32,6 +32,7 @@
 #include "utils/managed_ref.hh"
 #include "utils/compact-radix-tree.hh"
 #include "utils/immutable-collection.hh"
+#include "tombstone_gc.hh"
 
 class mutation_fragment;
 class mutation_partition_view;
@@ -1317,7 +1318,8 @@ private:
         bool reverse,
         uint64_t row_limit,
         can_gc_fn&,
-        bool drop_tombstones_unconditionally);
+        bool drop_tombstones_unconditionally,
+        const tombstone_gc_state& gc_state);
 
     // Calls func for each row entry inside row_ranges until func returns stop_iteration::yes.
     // Removes all entries for which func didn't return stop_iteration::no or wasn't called at all.

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1358,7 +1358,8 @@ public:
     //   - drops expired tombstones which timestamp is before max_purgeable
     void compact_for_compaction(const schema& s, can_gc_fn&,
         const dht::decorated_key& dk,
-        gc_clock::time_point compaction_time);
+        gc_clock::time_point compaction_time,
+        const tombstone_gc_state& gc_state);
 
     // Like compact_for_compaction but drop tombstones unconditionally
     void compact_for_compaction_drop_tombstones_unconditionally(const schema& s,

--- a/readers/compacting.hh
+++ b/readers/compacting.hh
@@ -16,6 +16,8 @@ namespace dht {
 class decorated_key;
 }
 
+class tombstone_gc_state;
+
 /// Creates a compacting reader.
 ///
 /// The compaction is done with a \ref mutation_compactor, using compaction-type
@@ -33,4 +35,5 @@ class decorated_key;
 /// if the source reader supports it
 flat_mutation_reader_v2 make_compacting_reader(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
         std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+        const tombstone_gc_state& gc_state,
         streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1457,12 +1457,11 @@ private:
 public:
     compacting_reader(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
             std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
-            // FIXME: pass to _compactor
             const tombstone_gc_state& gc_state,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no)
         : impl(source.schema(), source.permit())
         , _reader(std::move(source))
-        , _compactor(*_schema, compaction_time, get_max_purgeable)
+        , _compactor(*_schema, compaction_time, get_max_purgeable, gc_state)
         , _last_uncompacted_partition_start(dht::decorated_key(dht::minimum_token(), partition_key::make_empty()), tombstone{})
         , _fwd(fwd) {
     }

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -28,6 +28,7 @@
 #include "readers/queue.hh"
 #include "readers/reversing_v2.hh"
 #include "readers/upgrading_consumer.hh"
+#include "tombstone_gc.hh"
 #include <seastar/core/coroutine.hh>
 #include <stack>
 
@@ -1456,6 +1457,8 @@ private:
 public:
     compacting_reader(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
             std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+            // FIXME: pass to _compactor
+            const tombstone_gc_state& gc_state,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no)
         : impl(source.schema(), source.permit())
         , _reader(std::move(source))
@@ -1541,6 +1544,7 @@ public:
 } // anonymous namespace
 
 flat_mutation_reader_v2 make_compacting_reader(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
-        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable, streamed_mutation::forwarding fwd) {
-    return make_flat_mutation_reader_v2<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, fwd);
+        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+        const tombstone_gc_state& gc_state, streamed_mutation::forwarding fwd) {
+    return make_flat_mutation_reader_v2<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, gc_state, fwd);
 }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2101,7 +2101,7 @@ future<repair_update_system_table_response> repair_service::repair_update_system
         throw std::runtime_error(format("repair[{}]: range {} is not in the format of (start, end]", req.repair_uuid, req.range));
     }
     co_await db.invoke_on_all([&req] (replica::database& local_db) {
-        auto gc_state = tombstone_gc_state(); // FIXME: for now
+        auto& gc_state = local_db.get_compaction_manager().get_tombstone_gc_state();
         return gc_state.update_repair_time(req.table_uuid, req.range, req.repair_time);
     });
     db::system_keyspace::repair_history_entry ent;
@@ -3010,7 +3010,7 @@ future<> repair_service::load_history() {
                     entry.ks, entry.cf, entry.table_uuid, entry.ts, range);
             try {
                 co_await get_db().invoke_on_all([table_uuid = entry.table_uuid, range, repair_time] (replica::database& local_db) {
-                    auto gc_state = tombstone_gc_state(); // FIXME: for now
+                    auto& gc_state = local_db.get_compaction_manager().get_tombstone_gc_state();
                     gc_state.update_repair_time(table_uuid, range, repair_time);
                 });
             } catch (...) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2497,7 +2497,7 @@ future<> database::truncate(column_family& cf, const table_truncate_state& st, d
     cf.cache_truncation_record(truncated_at);
     co_await db::system_keyspace::save_truncation_record(cf, truncated_at, rp);
 
-    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    auto& gc_state = get_compaction_manager().get_tombstone_gc_state();
     gc_state.drop_repair_history_map_for_table(uuid);
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1005,7 +1005,6 @@ void database::remove(const table& cf) noexcept {
 
 future<> database::detach_column_family(table& cf) {
     auto uuid = cf.schema()->id();
-    drop_repair_history_map_for_table(uuid);
     remove(cf);
     cf.clear_views();
     co_await cf.await_pending_ops();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2497,7 +2497,8 @@ future<> database::truncate(column_family& cf, const table_truncate_state& st, d
     cf.cache_truncation_record(truncated_at);
     co_await db::system_keyspace::save_truncation_record(cf, truncated_at, rp);
 
-    drop_repair_history_map_for_table(uuid);
+    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    gc_state.drop_repair_history_map_for_table(uuid);
 }
 
 const sstring& database::get_snitch_name() const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -919,6 +919,10 @@ public:
         return _compaction_strategy;
     }
 
+    const compaction_manager& get_compaction_manager() const {
+        return _compaction_manager;
+    }
+
     table_stats& get_stats() const {
         return _stats;
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2454,6 +2454,9 @@ public:
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return _t.is_auto_compaction_disabled_by_user();
     }
+    const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
+        return _t.get_compaction_manager().get_tombstone_gc_state();
+    }
 };
 
 compaction::table_state& table::as_table_state() const noexcept {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1284,6 +1284,7 @@ table::sstables_as_snapshot_source() {
                 std::move(reader),
                 gc_clock::now(),
                 [](const dht::decorated_key&) { return api::min_timestamp; },
+                _compaction_manager.get_tombstone_gc_state(),
                 fwd);
         }, [this, sst_set] {
             return make_partition_presence_checker(sst_set);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1696,6 +1696,7 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
         gc_clock::time_point now) const {
     auto base_token = m.token();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
+            *this,
             base,
             std::move(views),
             make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), std::move(m)),
@@ -1831,6 +1832,7 @@ future<> table::populate_views(
         gc_clock::time_point now) {
     auto schema = reader.schema();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
+            *this,
             schema,
             std::move(views),
             std::move(reader),

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3300,7 +3300,8 @@ gc_clock::time_point sstable::get_gc_before_for_drop_estimation(const gc_clock::
     auto end = get_last_decorated_key().token();
     auto range = dht::token_range(dht::token_range::bound(start, true), dht::token_range::bound(end, true));
     sstlog.trace("sstable={}, ks={}, cf={}, range={}, estimate", get_filename(), s->ks_name(), s->cf_name(), range);
-    return ::get_gc_before_for_range(s, range, compaction_time).max_gc_before;
+    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    return gc_state.get_gc_before_for_range(s, range, compaction_time).max_gc_before;
 }
 
 // If the sstable contains any regular live cells, we can not drop the sstable.
@@ -3325,7 +3326,8 @@ gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::tim
     auto range = dht::token_range(dht::token_range::bound(start, true), dht::token_range::bound(end, true));
     sstlog.trace("sstable={}, ks={}, cf={}, range={}, get_max_local_deletion_time={}, min_timestamp={}, gc_grace_seconds={}, query",
             get_filename(), s->ks_name(), s->cf_name(), range, deletion_time, get_stats_metadata().min_timestamp, s->gc_grace_seconds().count());
-    auto res = ::get_gc_before_for_range(s, range, compaction_time);
+    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    auto res = gc_state.get_gc_before_for_range(s, range, compaction_time);
     return res.knows_entire_range ? res.min_gc_before : gc_clock::time_point::min();
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3294,13 +3294,12 @@ std::optional<large_data_stats_entry> sstable::get_large_data_stat(large_data_ty
 // gc_before for all the partitions that have record in repair history map. It
 // is fine that some of the partitions inside the sstable does not have a
 // record.
-gc_clock::time_point sstable::get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time) const {
+gc_clock::time_point sstable::get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const {
     auto s = get_schema();
     auto start = get_first_decorated_key().token();
     auto end = get_last_decorated_key().token();
     auto range = dht::token_range(dht::token_range::bound(start, true), dht::token_range::bound(end, true));
-    sstlog.trace("sstable={}, ks={}, cf={}, range={}, estimate", get_filename(), s->ks_name(), s->cf_name(), range);
-    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    sstlog.trace("sstable={}, ks={}, cf={}, range={}, gc_state={}, estimate", get_filename(), s->ks_name(), s->cf_name(), range, bool(gc_state));
     return gc_state.get_gc_before_for_range(s, range, compaction_time).max_gc_before;
 }
 
@@ -3312,7 +3311,7 @@ gc_clock::time_point sstable::get_gc_before_for_drop_estimation(const gc_clock::
 // in the repair history map, we can not drop the sstable, in such case we
 // return gc_clock::time_point::min() as gc_before. Otherwise, return the
 // gc_before from the repair history map.
-gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time) const {
+gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const {
     auto deletion_time = get_max_local_deletion_time();
     auto s = get_schema();
     // No need to query gc_before for the sstable if the max_deletion_time is max()
@@ -3324,9 +3323,8 @@ gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::tim
     auto start = get_first_decorated_key().token();
     auto end = get_last_decorated_key().token();
     auto range = dht::token_range(dht::token_range::bound(start, true), dht::token_range::bound(end, true));
-    sstlog.trace("sstable={}, ks={}, cf={}, range={}, get_max_local_deletion_time={}, min_timestamp={}, gc_grace_seconds={}, query",
-            get_filename(), s->ks_name(), s->cf_name(), range, deletion_time, get_stats_metadata().min_timestamp, s->gc_grace_seconds().count());
-    auto gc_state = tombstone_gc_state(); // FIXME: for now
+    sstlog.trace("sstable={}, ks={}, cf={}, range={}, get_max_local_deletion_time={}, min_timestamp={}, gc_grace_seconds={}, gc_state={}, query",
+            get_filename(), s->ks_name(), s->cf_name(), range, deletion_time, get_stats_metadata().min_timestamp, s->gc_grace_seconds().count(), bool(gc_state));
     auto res = gc_state.get_gc_before_for_range(s, range, compaction_time);
     return res.knows_entire_range ? res.min_gc_before : gc_clock::time_point::min();
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -887,8 +887,8 @@ public:
     friend std::unique_ptr<DataConsumeRowsContext>
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&);
     friend void lw_shared_ptr_deleter<sstables::sstable>::dispose(sstable* s);
-    gc_clock::time_point get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time) const;
-    gc_clock::time_point get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time) const;
+    gc_clock::time_point get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const;
+    gc_clock::time_point get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const;
 };
 
 // When we compact sstables, we have to atomically instantiate the new

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -911,7 +911,8 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
     auto compacted = [] (flat_mutation_reader_v2 rd) {
         return make_compacting_reader(std::move(rd),
                                       gc_clock::time_point::max(),
-                                      [] (const dht::decorated_key&) { return api::max_timestamp; });
+                                      [] (const dht::decorated_key&) { return api::max_timestamp; },
+                                      tombstone_gc_state(nullptr));
     };
 
     auto reversed_forward_reader = assert_that(compacted(

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -150,7 +150,7 @@ SEASTAR_TEST_CASE(test_memtable_flush_reader) {
                 const auto now = gc_clock::now();
                 auto compacted_muts = muts;
                 for (auto& mut : compacted_muts) {
-                    mut.partition().compact_for_compaction(*mut.schema(), always_gc, mut.decorated_key(), now);
+                    mut.partition().compact_for_compaction(*mut.schema(), always_gc, mut.decorated_key(), now, tombstone_gc_state(nullptr));
                 }
 
                 testlog.info("Simple read");

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2585,7 +2585,8 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_as_mutation_source) {
                     source = make_forwardable(std::move(source));
                 }
                 auto mr = make_compacting_reader(std::move(source), query_time,
-                        [] (const dht::decorated_key&) { return api::min_timestamp; }, fwd_sm);
+                        [] (const dht::decorated_key&) { return api::min_timestamp; },
+                        tombstone_gc_state(nullptr), fwd_sm);
                 if (single_fragment_buffer) {
                     mr.set_max_buffer_size(1);
                 }
@@ -2640,7 +2641,8 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_next_partition) {
 
         auto mr = make_compacting_reader(make_flat_mutation_reader_from_fragments(ss.schema(), permit, std::move(mfs)),
                 gc_clock::now(),
-                [] (const dht::decorated_key&) { return api::min_timestamp; });
+                [] (const dht::decorated_key&) { return api::min_timestamp; },
+                tombstone_gc_state(nullptr));
         mr.set_max_buffer_size(buffer_size);
 
         return mr;
@@ -2685,7 +2687,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_is_consistent_with_compaction) {
         .produces_range_tombstone_change({position_in_partition::for_range_end(r), {}})
         .produces_partition_end();
 
-    assert_that(make_compacting_reader(read_m(), gc_clock::time_point::min(), [] (const dht::decorated_key&) { return api::min_timestamp; }))
+    assert_that(make_compacting_reader(read_m(), gc_clock::time_point::min(), [] (const dht::decorated_key&) { return api::min_timestamp; }, tombstone_gc_state(nullptr)))
             .exact()
             .produces_partition_start(m.decorated_key(), p_tomb)
             .produces_partition_end();

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1030,7 +1030,7 @@ sstables::shared_sstable create_sstable(sstables::test_env& env, schema_ptr s, s
 
 static mutation compacted(const mutation& m) {
     auto result = m;
-    result.partition().compact_for_compaction(*result.schema(), always_gc, result.decorated_key(), gc_clock::now());
+    result.partition().compact_for_compaction(*result.schema(), always_gc, result.decorated_key(), gc_clock::now(), tombstone_gc_state(nullptr));
     return result;
 }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2328,6 +2328,7 @@ void run_compaction_data_stream_split_test(const schema& schema, reader_permit p
             schema,
             query_time,
             get_max_purgeable,
+            tombstone_gc_state(nullptr),
             survived_compacted_fragments_consumer(schema, query_time, get_max_purgeable),
             purged_compacted_fragments_consumer(schema, query_time, get_max_purgeable));
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1238,7 +1238,7 @@ SEASTAR_TEST_CASE(test_mutation_hash) {
 
 static mutation compacted(const mutation& m, gc_clock::time_point now) {
     auto result = m;
-    result.partition().compact_for_compaction(*result.schema(), always_gc, result.decorated_key(), now);
+    result.partition().compact_for_compaction(*result.schema(), always_gc, result.decorated_key(), now, tombstone_gc_state(nullptr));
     return result;
 }
 
@@ -1632,7 +1632,7 @@ SEASTAR_TEST_CASE(test_tombstone_purge) {
     tombstone tomb(api::new_timestamp(), gc_clock::now() - std::chrono::seconds(1));
     m.partition().apply(tomb);
     BOOST_REQUIRE(!m.partition().empty());
-    m.partition().compact_for_compaction(*s, always_gc, m.decorated_key(), gc_clock::now());
+    m.partition().compact_for_compaction(*s, always_gc, m.decorated_key(), gc_clock::now(), tombstone_gc_state(nullptr));
     // Check that row was covered by tombstone.
     BOOST_REQUIRE(m.partition().empty());
     // Check that tombstone was purged after compact_for_compaction().
@@ -1824,8 +1824,8 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             if (s != m2.schema()) {
                 return;
             }
-            m1.partition().compact_for_compaction(*s, never_gc, m1.decorated_key(), now);
-            m2.partition().compact_for_compaction(*s, never_gc, m2.decorated_key(), now);
+            m1.partition().compact_for_compaction(*s, never_gc, m1.decorated_key(), now, tombstone_gc_state(nullptr));
+            m2.partition().compact_for_compaction(*s, never_gc, m2.decorated_key(), now, tombstone_gc_state(nullptr));
             auto m12 = m1;
             m12.apply(m2);
             auto m12_with_diff = m1;
@@ -2315,7 +2315,7 @@ void run_compaction_data_stream_split_test(const schema& schema, reader_permit p
         std::vector<mutation> mutations) {
     auto never_gc = std::function<bool(tombstone)>([] (tombstone) { return false; });
     for (auto& mut : mutations) {
-        mut.partition().compact_for_compaction(schema, never_gc, mut.decorated_key(), query_time);
+        mut.partition().compact_for_compaction(schema, never_gc, mut.decorated_key(), query_time, tombstone_gc_state(nullptr));
     }
 
     auto reader = make_flat_mutation_reader_from_mutations_v2(schema.shared_from_this(), std::move(permit), mutations);

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -373,12 +373,12 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer) {
 
     const auto now = gc_clock::now();
     for (auto& m : muts) {
-        m.partition().compact_for_compaction(*random_schema.schema(), always_gc, m.decorated_key(), now);
+        m.partition().compact_for_compaction(*random_schema.schema(), always_gc, m.decorated_key(), now, tombstone_gc_state(nullptr));
     }
 
     std::vector<mutation> combined_mutations;
     while (auto m = read_mutation_from_flat_mutation_reader(reader).get0()) {
-        m->partition().compact_for_compaction(*random_schema.schema(), always_gc, m->decorated_key(), now);
+        m->partition().compact_for_compaction(*random_schema.schema(), always_gc, m->decorated_key(), now, tombstone_gc_state(nullptr));
         combined_mutations.emplace_back(std::move(*m));
     }
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -682,8 +682,8 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging) {
 
                 // Drop empty rows
                 can_gc_fn never_gc = [] (tombstone) { return false; };
-                actual.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now());
-                expected.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now());
+                actual.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now(), tombstone_gc_state(nullptr));
+                expected.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now(), tombstone_gc_state(nullptr));
 
                 assert_that(s, actual).is_equal_to_compacted(expected);
             }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -124,10 +124,12 @@ class table_state_for_test : public table_state {
     column_family_for_tests& _t;
     test_env& _env;
     std::vector<sstables::shared_sstable> _compacted_undeleted;
+    tombstone_gc_state _tombstone_gc_state;
 public:
     explicit table_state_for_test(column_family_for_tests& t, test_env& env)
         : _t(t)
         , _env(env)
+        , _tombstone_gc_state(nullptr)
     {
     }
     const schema_ptr& schema() const noexcept override {
@@ -178,6 +180,9 @@ public:
     }
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return false;
+    }
+    const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
+        return _tombstone_gc_state;
     }
 };
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3406,7 +3406,7 @@ SEASTAR_TEST_CASE(purged_tombstone_consumer_sstable_test) {
             auto gc_grace_seconds = s->gc_grace_seconds();
 
             auto cfc = compact_for_compaction_v2<compacting_sstable_writer_test, compacting_sstable_writer_test>(
-                *s, gc_now, max_purgeable_func, std::move(cr), std::move(purged_cr));
+                *s, gc_now, max_purgeable_func, tombstone_gc_state(nullptr), std::move(cr), std::move(purged_cr));
 
             auto cs = sstables::make_compaction_strategy(sstables::compaction_strategy_type::size_tiered, s->compaction_strategy_options());
             auto compacting = make_lw_shared<sstables::sstable_set>(cs.make_sstable_set(s));

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -36,7 +36,7 @@ static inline void match_compacted_mutation(const mutation_opt& mo, const mutati
     BOOST_REQUIRE(bool(mo));
     memory::scoped_critical_alloc_section dfg;
     mutation got = *mo;
-    got.partition().compact_for_compaction(*m.schema(), always_gc, got.decorated_key(), query_time);
+    got.partition().compact_for_compaction(*m.schema(), always_gc, got.decorated_key(), query_time, tombstone_gc_state(nullptr));
     assert_that(got).is_equal_to(m, ck_ranges);
 }
 

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -23,7 +23,7 @@ private:
     static mutation_partition compacted(const schema& s, const mutation_partition& m) {
         mutation_partition res(s, m);
         auto key = dht::decorate_key(s, partition_key::make_empty());
-        res.compact_for_compaction(s, always_gc, key, gc_clock::time_point::min());
+        res.compact_for_compaction(s, always_gc, key, gc_clock::time_point::min(), tombstone_gc_state(nullptr));
         return res;
     }
 public:

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -953,7 +953,7 @@ void test_all_data_is_read_back(tests::reader_concurrency_semaphore_wrapper& sem
     for_each_mutation([&semaphore, &populate, query_time] (const mutation& m) mutable {
         auto ms = populate(m.schema(), {m}, query_time);
         mutation copy(m);
-        copy.partition().compact_for_compaction(*copy.schema(), always_gc, copy.decorated_key(), query_time);
+        copy.partition().compact_for_compaction(*copy.schema(), always_gc, copy.decorated_key(), query_time, tombstone_gc_state(nullptr));
         assert_that(ms.make_reader_v2(m.schema(), semaphore.make_permit())).produces_compacted(copy, query_time);
     });
 }
@@ -1584,7 +1584,7 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
         const auto query_time = gc_clock::now();
 
         mutation m_compacted(m);
-        m_compacted.partition().compact_for_compaction(*m_compacted.schema(), always_gc, m_compacted.decorated_key(), query_time);
+        m_compacted.partition().compact_for_compaction(*m_compacted.schema(), always_gc, m_compacted.decorated_key(), query_time, tombstone_gc_state(nullptr));
 
         {
             auto rd = ms.make_fragment_v1_stream(m.schema(), semaphore.make_permit());

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -22,17 +22,6 @@
 
 extern logging::logger dblog;
 
-class repair_history_map {
-public:
-    boost::icl::interval_map<dht::token, gc_clock::time_point, boost::icl::partial_absorber, std::less, boost::icl::inplace_max> map;
-};
-
-thread_local std::unordered_map<table_id, seastar::lw_shared_ptr<repair_history_map>> repair_history_maps;
-
-tombstone_gc_state::tombstone_gc_state() noexcept
-    : _repair_history_maps(&repair_history_maps)
-{ }
-
 seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_or_create_repair_history_map_for_table(const table_id& id) {
     if (!_repair_history_maps) {
         return {};

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -29,7 +29,15 @@ public:
 
 thread_local std::unordered_map<table_id, seastar::lw_shared_ptr<repair_history_map>> repair_history_maps;
 
-static seastar::lw_shared_ptr<repair_history_map> get_or_create_repair_history_map_for_table(const table_id& id) {
+tombstone_gc_state::tombstone_gc_state() noexcept
+    : _repair_history_maps(&repair_history_maps)
+{ }
+
+seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_or_create_repair_history_map_for_table(const table_id& id) {
+    if (!_repair_history_maps) {
+        return {};
+    }
+    auto& repair_history_maps = *_repair_history_maps;
     auto it = repair_history_maps.find(id);
     if (it != repair_history_maps.end()) {
         return it->second;
@@ -39,7 +47,11 @@ static seastar::lw_shared_ptr<repair_history_map> get_or_create_repair_history_m
     }
 }
 
-seastar::lw_shared_ptr<repair_history_map> get_repair_history_map_for_table(const table_id& id) {
+seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_repair_history_map_for_table(const table_id& id) const {
+    if (!_repair_history_maps) {
+        return {};
+    }
+    auto& repair_history_maps = *_repair_history_maps;
     auto it = repair_history_maps.find(id);
     if (it != repair_history_maps.end()) {
         return it->second;
@@ -48,8 +60,8 @@ seastar::lw_shared_ptr<repair_history_map> get_repair_history_map_for_table(cons
     }
 }
 
-void drop_repair_history_map_for_table(const table_id& id) {
-    repair_history_maps.erase(id);
+void tombstone_gc_state::drop_repair_history_map_for_table(const table_id& id) {
+    _repair_history_maps->erase(id);
 }
 
 // This is useful for a sstable to query a gc_before for a range. The range is
@@ -60,7 +72,7 @@ void drop_repair_history_map_for_table(const table_id& id) {
 // The knows_entire_range is set to true:
 // 1) if the tombstone_gc_mode is not repair, since we have the same value for all the keys in the ranges.
 // 2) if the tombstone_gc_mode is repair, and the range is a sub range of a range in the repair history map.
-get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::token_range& range, const gc_clock::time_point& query_time) {
+tombstone_gc_state::get_gc_before_for_range_result tombstone_gc_state::get_gc_before_for_range(schema_ptr s, const dht::token_range& range, const gc_clock::time_point& query_time) const {
     bool knows_entire_range = true;
     const auto& options = s->tombstone_gc_options();
     switch (options.mode()) {
@@ -118,7 +130,7 @@ get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::
     std::abort();
 }
 
-gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) {
+gc_clock::time_point tombstone_gc_state::get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) const {
     // if mode = timeout    // default option, if user does not specify tombstone_gc options
     // if mode = disabled   // never gc tombstone
     // if mode = immediate  // can gc tombstone immediately
@@ -155,7 +167,7 @@ gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_ke
     std::abort();
 }
 
-void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time) {
+void tombstone_gc_state::update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time) {
     auto m = get_or_create_repair_history_map_for_table(id);
     m->map += std::make_pair(locator::token_metadata::range_to_interval(range), repair_time);
 }

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -155,8 +155,8 @@ gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_ke
     std::abort();
 }
 
-void update_repair_time(schema_ptr s, const dht::token_range& range, gc_clock::time_point repair_time) {
-    auto m = get_or_create_repair_history_map_for_table(s->id());
+void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time) {
+    auto m = get_or_create_repair_history_map_for_table(id);
     m->map += std::make_pair(locator::token_metadata::range_to_interval(range), repair_time);
 }
 

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -37,7 +37,7 @@ class tombstone_gc_options;
 class tombstone_gc_state {
     per_table_history_maps* _repair_history_maps;
 public:
-    tombstone_gc_state() noexcept;
+    tombstone_gc_state() = delete;
     tombstone_gc_state(per_table_history_maps* maps) noexcept : _repair_history_maps(maps) {}
 
     explicit operator bool() const noexcept {

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -37,10 +37,6 @@ struct get_gc_before_for_range_result {
     bool knows_entire_range;
 };
 
-namespace replica {
-    class database;
-}
-
 void drop_repair_history_map_for_table(const table_id& id);
 
 get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::token_range& range, const gc_clock::time_point& query_time);

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -29,20 +29,36 @@ class database;
 
 }
 
+class repair_history_map;
+using per_table_history_maps = std::unordered_map<table_id, seastar::lw_shared_ptr<repair_history_map>>;
+
 class tombstone_gc_options;
 
-struct get_gc_before_for_range_result {
-    gc_clock::time_point min_gc_before;
-    gc_clock::time_point max_gc_before;
-    bool knows_entire_range;
+class tombstone_gc_state {
+    per_table_history_maps* _repair_history_maps;
+public:
+    tombstone_gc_state() noexcept;
+    tombstone_gc_state(per_table_history_maps* maps) noexcept : _repair_history_maps(maps) {}
+
+    explicit operator bool() const noexcept {
+        return _repair_history_maps != nullptr;
+    }
+
+    seastar::lw_shared_ptr<repair_history_map> get_repair_history_map_for_table(const table_id& id) const;
+    seastar::lw_shared_ptr<repair_history_map> get_or_create_repair_history_map_for_table(const table_id& id);
+    void drop_repair_history_map_for_table(const table_id& id);
+
+    struct get_gc_before_for_range_result {
+        gc_clock::time_point min_gc_before;
+        gc_clock::time_point max_gc_before;
+        bool knows_entire_range;
+    };
+
+    get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::token_range& range, const gc_clock::time_point& query_time) const;
+
+    gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) const;
+
+    void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
 };
-
-void drop_repair_history_map_for_table(const table_id& id);
-
-get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::token_range& range, const gc_clock::time_point& query_time);
-
-gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time);
-
-void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
 
 void validate_tombstone_gc_options(const tombstone_gc_options* options, data_dictionary::database db, sstring ks_name);

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -43,6 +43,6 @@ get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::
 
 gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time);
 
-void update_repair_time(schema_ptr s, const dht::token_range& range, gc_clock::time_point repair_time);
+void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
 
 void validate_tombstone_gc_options(const tombstone_gc_options* options, data_dictionary::database db, sstring ks_name);


### PR DESCRIPTION
Change a8ad385ecd3 introduced
```
thread_local std::unordered_map<utils::UUID, seastar::lw_shared_ptr<repair_history_map>> repair_history_maps;
```

We're trying to avoid global scoped variables as much as we can so this should probably be embedded in some sharded service.

This series moves the thread-local `repair_history_maps` instances to `compaction_manager`
and passes a reference to the shard compaction_manager to functions that need it for compact_for_query
and compact_for_compaction.

Since some paths don't need it and don't have access to the compactio_manager,
the series introduced `utils::optional_reference<T>` that allows to pass nullopt.
In this case, `get_gc_before_for_key` behaves in `tombstone_gc_mode::repair` as if the table wasn't repaired and tombstones are not garbage-collected.

Fixes #11208
