### PR TITLE
raft server, abort on background errors

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -562,6 +562,7 @@ raft_tests = set([
     'test/raft/replication_test',
     'test/raft/randomized_nemesis_test',
     'test/raft/many_test',
+    'test/raft/raft_server_test',
     'test/raft/fsm_test',
     'test/raft/etcd_test',
     'test/raft/raft_sys_table_storage_test',
@@ -1312,6 +1313,7 @@ deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']
 deps['test/boost/rust_test'] += rusts
 
 deps['test/raft/replication_test'] = ['test/raft/replication_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
+deps['test/raft/raft_server_test'] = ['test/raft/raft_server_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/failure_detector_test'] = ['test/raft/failure_detector_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies

--- a/configure.py
+++ b/configure.py
@@ -1179,7 +1179,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
     'test/lib/random_schema.cc',
 ]
 
-scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc']
+scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
 
 scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc']
 

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -269,7 +269,10 @@ struct commit_status_unknown : public error {
 };
 
 struct stopped_error : public error {
-    stopped_error() : error("Raft instance is stopped") {}
+    explicit stopped_error(const sstring& reason = "")
+            : error(!reason.empty()
+                    ? fmt::format("Raft instance is stopped, reason: \"{}\"", reason)
+                    : std::string("Raft instance is stopped")) {}
 };
 
 struct conf_change_in_progress : public error {

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -7,6 +7,7 @@
  */
 #include "server.hh"
 
+#include "utils/error_injection.hh"
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
@@ -854,6 +855,9 @@ future<> server_impl::io_fiber(index_t last_stable) {
                     co_await _persistence->truncate_log(entries[0]->idx);
                     _stats.truncate_persisted_log++;
                 }
+
+                utils::get_local_injector().inject("store_log_entries/test-failure",
+                    [] { throw std::runtime_error("store_log_entries/test-failure"); });
 
                 // Combine saving and truncating into one call?
                 // will require persistence to keep track of last idx

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -136,7 +136,7 @@ public:
     // to know if they succeeded or not. If this server was
     // a leader it will relinquish its leadership and cease
     // replication.
-    virtual future<> abort() = 0;
+    virtual future<> abort(sstring reason = "") = 0;
 
     // Return Raft protocol current term.
     virtual term_t get_current_term() const = 0;

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -45,6 +45,9 @@ public:
         // Max size of a single command, add_entry with a bigger command will throw command_is_too_big_error.
         // The value of zero means no limit.
         size_t max_command_size = 0;
+        // A callback to invoke if one of internal server
+        // background activities has stopped because of an error.
+        std::function<void(std::exception_ptr e)> on_background_error;
     };
 
     virtual ~server() {}

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -179,7 +179,10 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
                 // Dividing by two is to protect against paddings that the
                 // commit log can add for each mutation, as well as
                 // against different commit log limits on different nodes.
-                .max_command_size = cl ? cl->max_record_size() / 2 : 0
+                .max_command_size = cl ? cl->max_record_size() / 2 : 0,
+                .on_background_error = [gid, this](std::exception_ptr e) {
+                    _raft_gr.abort_server(gid, fmt::format("background error, {}", e));
+                }
             });
 
     // initialize the corresponding timer to tick the raft server instance

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -82,6 +82,17 @@ class raft_group0 {
 
     gms::feature::listener_registration _raft_support_listener;
 
+    seastar::metrics::metric_groups _metrics;
+    void register_metrics();
+
+    // Status of the raft group0 for monitoring.
+    enum class status_for_monitoring : uint8_t {
+        // Raft is disabled.
+        disabled = 0,
+        normal = 1,
+        aborted = 2
+    } _status_for_monitoring;
+
 public:
     // Assumes that the provided services are fully started.
     raft_group0(seastar::abort_source& abort_source,

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -39,6 +39,7 @@ struct raft_server_for_group {
     std::unique_ptr<raft_ticker_type> ticker;
     raft_rpc& rpc;
     raft_sys_table_storage& persistence;
+    std::optional<seastar::future<>> aborted;
 };
 
 // This class is responsible for creating, storing and accessing raft servers.
@@ -102,6 +103,7 @@ public:
     // Start raft server instance, store in the map of raft servers and
     // arm the associated timer to tick the server.
     future<> start_server_for_group(raft_server_for_group grp);
+    void abort_server(raft::group_id gid, sstring reason = "");
     unsigned shard_for_group(const raft::group_id& gid) const;
     shared_ptr<raft::failure_detector> failure_detector();
     raft_address_map<>& address_map() { return _srv_address_mappings; }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -135,6 +135,7 @@ private:
     sharded<db::batchlog_manager>& _batchlog_manager;
     sharded<gms::gossiper>& _gossiper;
     service::raft_group0_client& _group0_client;
+    sharded<service::raft_group_registry>& _group0_registry;
 
 private:
     struct core_local_state {
@@ -186,7 +187,8 @@ public:
             sharded<qos::service_level_controller> &sl_controller,
             sharded<db::batchlog_manager>& batchlog_manager,
             sharded<gms::gossiper>& gossiper,
-            service::raft_group0_client& client)
+            service::raft_group0_client& client,
+            sharded<service::raft_group_registry>& group0_registry)
             : _db(db)
             , _qp(qp)
             , _auth_service(auth_service)
@@ -198,6 +200,7 @@ public:
             , _batchlog_manager(batchlog_manager)
             , _gossiper(gossiper)
             , _group0_client(client)
+            , _group0_registry(group0_registry)
     {
         adjust_rlimit();
     }
@@ -415,6 +418,10 @@ public:
 
     virtual service::raft_group0_client& get_raft_group0_client() override {
         return _group0_client;
+    }
+
+    virtual sharded<service::raft_group_registry>& get_raft_group_registry() override {
+        return _group0_registry;
     }
 
     virtual future<> refresh_client_state() override {
@@ -872,7 +879,7 @@ public:
                 // The default user may already exist if this `cql_test_env` is starting with previously populated data.
             }
 
-            single_node_cql_env env(db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, group0_client);
+            single_node_cql_env env(db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, group0_client, raft_gr);
             env.start().get();
             auto stop_env = defer([&env] { env.stop().get(); });
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -51,6 +51,7 @@ namespace service {
 class client_state;
 class migration_manager;
 class raft_group0_client;
+class raft_group_registry;
 
 }
 
@@ -165,6 +166,8 @@ public:
     virtual future<> refresh_client_state() = 0;
 
     virtual service::raft_group0_client& get_raft_group0_client() = 0;
+
+    virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
     data_dictionary::database data_dictionary();
 };

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -1,0 +1,30 @@
+#include "replication.hh"
+
+#ifdef SEASTAR_DEBUG
+// Increase tick time to allow debug to process messages
+const auto tick_delay = 200ms;
+#else
+const auto tick_delay = 100ms;
+#endif
+
+SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
+    raft_cluster<std::chrono::steady_clock> cluster(
+        test_case { .nodes = 1 },
+        [](raft::server_id id, const std::vector<raft::command_cref>& commands, lw_shared_ptr<hasher_int> hasher) {
+            return 0;
+        },
+        0,
+        0,
+        0, false, tick_delay, rpc_config{});
+    cluster.start_all().get0();
+
+    cluster.stop_server(0, "test crash").get0();
+
+    auto check_error = [](const raft::stopped_error& e) {
+        return e.what() == sstring("Raft instance is stopped, reason: \"test crash\"");
+    };
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).modify_config({}, {to_raft_id(0)}).get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).read_barrier().get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).set_configuration({}).get0(), raft::stopped_error, check_error);
+}


### PR DESCRIPTION
Halted background fibers render raft server
effectively unusable, so report this
explicitly to the clients.

Fix: #11352