### PR TITLE
functions: fix dropping of a keyspace with an aggregate in it

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1829,8 +1829,10 @@ static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, sch
             cql3::functions::functions::add_function(create_aggregate(db, *val.first, val.second));
         }
         for (const auto& val : diff.dropped) {
-            auto func = create_aggregate(db, *val.first, val.second);
-            cql3::functions::functions::remove_function(func->name(), func->arg_types());
+            cql3::functions::function_name name{
+                val.first->get_nonnull<sstring>("keyspace_name"), val.first->get_nonnull<sstring>("aggregate_name")};
+            auto arg_types = read_arg_types(db, *val.first, name.keyspace);
+            cql3::functions::functions::remove_function(name, arg_types);
         }
     });
 }


### PR DESCRIPTION
Currently, if a keyspace has an aggregate and the keyspace
is dropped, the keyspace becomes corrupted and another keyspace
with the same name cannot be created again

This is caused by the fact that when removing an aggregate, we
call create_aggregate() to get values for its name and signature.
In the create_aggregate(), we check whether the row and final
functions for the aggregate exist.
Normally, that's not an issue, because when dropping an existing
aggregate alone, we know that its UDFs also exist. But when dropping
and entire keyspace, we first drop the UDFs, making us unable to drop
the aggregate afterwards.

This patch fixes this behavior by removing the create_aggregate()
from the aggregate dropping implementation and replacing it with
specific calls for getting the aggregate name and signature.

Additionally, a test that would previously fail is added to
cql-pytest/test_uda.py where we drop a keyspace with an aggregate.

Fixes #11327