### PR TITLE
Associate alternator user with its service level configuration

### DIFF
--- a/alternator/controller.hh
+++ b/alternator/controller.hh
@@ -34,6 +34,14 @@ class gossiper;
 
 }
 
+namespace auth {
+class service;
+}
+
+namespace qos {
+class service_level_controller;
+}
+
 namespace alternator {
 
 // This is the official DynamoDB API version.
@@ -53,6 +61,8 @@ class controller : public protocol_server {
     sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     sharded<cdc::generation_service>& _cdc_gen_svc;
     sharded<service::memory_limiter>& _memory_limiter;
+    sharded<auth::service>& _auth_service;
+    sharded<qos::service_level_controller>& _sl_controller;
     const db::config& _config;
 
     std::vector<socket_address> _listen_addresses;
@@ -68,6 +78,8 @@ public:
         sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<cdc::generation_service>& cdc_gen_svc,
         sharded<service::memory_limiter>& memory_limiter,
+        sharded<auth::service>& auth_service,
+        sharded<qos::service_level_controller>& sl_controller,
         const db::config& config);
 
     virtual sstring name() const override;

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -235,7 +235,7 @@ protected:
 future<std::string> server::verify_signature(const request& req, const chunked_content& content) {
     if (!_enforce_authorization) {
         slogger.debug("Skipping authorization");
-        return make_ready_future<std::string>("<unauthenticated request>");
+        return make_ready_future<std::string>();
     }
     auto host_it = req._headers.find("Host");
     if (host_it == req._headers.end()) {
@@ -365,7 +365,9 @@ static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_
         tracing::add_session_param(trace_state, "alternator_op", op);
         tracing::add_query(trace_state, truncated_content_view(query, buf));
         tracing::begin(trace_state, format("Alternator {}", op), client_state.get_client_address());
-        tracing::set_username(trace_state, auth::authenticated_user(username));
+        if (!username.empty()) {
+            tracing::set_username(trace_state, auth::authenticated_user(username));
+        }
     }
     return trace_state;
 }
@@ -408,7 +410,11 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     auto leave = defer([this] () noexcept { _pending_requests.leave(); });
     //FIXME: Client state can provide more context, e.g. client's endpoint address
     // We use unique_ptr because client_state cannot be moved or copied
-    executor::client_state client_state{executor::client_state::internal_tag()};
+    executor::client_state client_state = username.empty()
+        ? service::client_state{service::client_state::internal_tag()}
+        : service::client_state{service::client_state::internal_tag(), _auth_service, _sl_controller, username};
+    co_await client_state.maybe_update_per_service_level_params();
+
     tracing::trace_state_ptr trace_state = maybe_trace_query(client_state, username, op, content);
     tracing::trace(trace_state, op);
     rjson::value json_request = co_await _json_parser.parse(std::move(content));

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -16,6 +16,7 @@
 #include <seastar/util/short_streams.hh>
 #include "seastarx.hh"
 #include "error.hh"
+#include "service/qos/service_level_controller.hh"
 #include "utils/rjson.hh"
 #include "auth.hh"
 #include <cctype>
@@ -440,12 +441,14 @@ void server::set_routes(routes& r) {
 //FIXME: A way to immediately invalidate the cache should be considered,
 // e.g. when the system table which stores the keys is changed.
 // For now, this propagation may take up to 1 minute.
-server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gossiper)
+server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& auth_service, qos::service_level_controller& sl_controller)
         : _http_server("http-alternator")
         , _https_server("https-alternator")
         , _executor(exec)
         , _proxy(proxy)
         , _gossiper(gossiper)
+        , _auth_service(auth_service)
+        , _sl_controller(sl_controller)
         , _key_cache(1024, 1min, slogger)
         , _enforce_authorization(false)
         , _enabled_servers{}

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -15,6 +15,7 @@
 #include <seastar/net/tls.hh>
 #include <optional>
 #include "alternator/auth.hh"
+#include "service/qos/service_level_controller.hh"
 #include "utils/small_vector.hh"
 #include "utils/updateable_value.hh"
 #include <seastar/core/units.hh>
@@ -34,6 +35,8 @@ class server {
     executor& _executor;
     service::storage_proxy& _proxy;
     gms::gossiper& _gossiper;
+    auth::service& _auth_service;
+    qos::service_level_controller& _sl_controller;
 
     key_cache _key_cache;
     bool _enforce_authorization;
@@ -65,7 +68,7 @@ class server {
     json_parser _json_parser;
 
 public:
-    server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper);
+    server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
             bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);

--- a/main.cc
+++ b/main.cc
@@ -1545,7 +1545,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_rpc_controller(ctx).get();
             });
 
-            alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, *cfg);
+            alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, auth_service, sl_controller, *cfg);
             sharded<alternator::expiration_service> es;
             std::any stop_expiration_service;
 

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -196,6 +196,15 @@ public:
             , _timeout_config(config)
     {}
 
+    client_state(internal_tag, auth::service& auth_service, qos::service_level_controller& sl_controller, sstring username)
+        : _user(auth::authenticated_user(username))
+        , _auth_state(auth_state::READY)
+        , _is_internal(true)
+        , _is_thrift(false)
+        , _auth_service(&auth_service)
+        , _sl_controller(&sl_controller)
+    {}
+
     client_state(const client_state&) = delete;
     client_state(client_state&&) = default;
 


### PR DESCRIPTION
Until now, authentication in alternator served only two purposes:
 - refusing clients without proper credentials
 - printing user information with logs

After this series, this user information is passed to lower layers, which also means that users are capable of attaching service levels to roles, and this service level configuration will be effective with alternator requests.

tests: manually by adding more debug logs and inspecting that per-service-level timeout value was properly applied for an authenticated alternator user

Fixes #11379