### PR TITLE
Alternator: Run more TTL tests by default (and add a test for metrics)

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -776,6 +776,8 @@ future<> expiration_service::run() {
                 tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count()/1000.0);
                 co_await seastar::sleep_abortable(period - scan_duration, _abort_source);
             } catch(seastar::sleep_aborted&) {}
+        } else {
+                tlogger.warn("scan took {} seconds, longer than period - not sleeping", scan_duration.count()/1000.0);
         }
     }
 }

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -769,11 +769,11 @@ future<> expiration_service::run() {
         // in the next iteration by reducing the scanner's scheduling-group
         // share (if using a separate scheduling group), or introduce
         // finer-grain sleeps into the scanning code.
-        std::chrono::seconds scan_duration(std::chrono::duration_cast<std::chrono::seconds>(lowres_clock::now() - start));
-        std::chrono::seconds period(_db.get_config().alternator_ttl_period_in_seconds());
+        std::chrono::milliseconds scan_duration(std::chrono::duration_cast<std::chrono::milliseconds>(lowres_clock::now() - start));
+        std::chrono::milliseconds period(long(_db.get_config().alternator_ttl_period_in_seconds() * 1000));
         if (scan_duration < period) {
             try {
-                tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count());
+                tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count()/1000.0);
                 co_await seastar::sleep_abortable(period - scan_duration, _abort_source);
             } catch(seastar::sleep_aborted&) {}
         }

--- a/api/api-doc/system.json
+++ b/api/api-doc/system.json
@@ -53,6 +53,45 @@
          ]
       },
       {
+         "path":"/system/log",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Write a message to the Scylla log",
+               "type":"void",
+               "nickname":"write_log_message",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"message",
+                     "description":"The message to write to the log",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"level",
+                     "description":"The logging level to use",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "enum":[
+                        "error",
+                        "warn",
+                        "info",
+                        "debug",
+                        "trace"
+                     ],
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/system/drop_sstable_caches",
          "operations":[
             {

--- a/api/system.cc
+++ b/api/system.cc
@@ -61,6 +61,16 @@ void set_system(http_context& ctx, routes& r) {
         return json::json_void();
     });
 
+    hs::write_log_message.set(r, [](const_req req) {
+        try {
+            logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
+            apilog.log(level, "/system/log: {}", std::string(req.get_query_param("message")));
+        } catch (boost::bad_lexical_cast& e) {
+            throw bad_param_exception("Unknown logging level " + req.get_query_param("level"));
+        }
+        return json::json_void();
+    });
+
     hs::drop_sstable_caches.set(r, [&ctx](std::unique_ptr<request> req) {
         apilog.info("Dropping sstable caches");
         return ctx.db.invoke_on_all([] (replica::database& db) {

--- a/db/config.hh
+++ b/db/config.hh
@@ -358,7 +358,7 @@ public:
     named_value<sstring> alternator_write_isolation;
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;
-    named_value<uint32_t> alternator_ttl_period_in_seconds;
+    named_value<double> alternator_ttl_period_in_seconds;
 
     named_value<bool> abort_on_ebadf;
 

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import boto3
 import requests
 import re
-from util import create_test_table, is_aws
+from util import create_test_table, is_aws, scylla_log
 
 # When tests are run with HTTPS, the server often won't have its SSL
 # certificate signed by a known authority. So we will disable certificate
@@ -112,7 +112,8 @@ def dynamodbstreams(request):
 # that the server is still alive - and if not report the test which crashed
 # it and stop running any more tests.
 @pytest.fixture(scope="function", autouse=True)
-def dynamodb_test_connection(dynamodb, request):
+def dynamodb_test_connection(dynamodb, request, optional_rest_api):
+    scylla_log(optional_rest_api, f'test/alternator: Starting {request.node.parent.name}::{request.node.name}', 'info')
     yield
     try:
         # We want to run a do-nothing DynamoDB command. The health-check
@@ -122,6 +123,7 @@ def dynamodb_test_connection(dynamodb, request):
         assert response.ok
     except:
         pytest.exit(f"Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}")
+    scylla_log(optional_rest_api, f'test/alternator: Ended {request.node.parent.name}::{request.node.name}', 'info')
 
 
 # "test_table" fixture: Create and return a temporary table to be used in tests
@@ -275,9 +277,14 @@ def test_table_s_forbid_rmw(dynamodb, scylla_only):
 # the test using this fixture will be skipped with a message about the REST
 # API not being available.
 @pytest.fixture(scope="session")
-def rest_api(dynamodb):
+def rest_api(dynamodb, optional_rest_api):
+    if optional_rest_api is None:
+        pytest.skip('Cannot connect to Scylla REST API')
+    return optional_rest_api
+@pytest.fixture(scope="session")
+def optional_rest_api(dynamodb):
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only REST API not supported by AWS')
+        return None
     url = dynamodb.meta.client._endpoint.host
     # The REST API is on port 10000, and always http, not https.
     url = re.sub(r':[0-9]+(/|$)', ':10000', url)
@@ -287,5 +294,5 @@ def rest_api(dynamodb):
     try:
         requests.get(f'{url}/column_family/name/keyspace', timeout=1).raise_for_status()
     except:
-        pytest.skip('Cannot connect to Scylla REST API')
+        return None
     return url

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -43,7 +43,7 @@ def run_alternator_cmd(pid, dir):
         '--alternator-write-isolation', 'always_use_lwt',
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
-        '--alternator-ttl-period-in-seconds', '1',
+        '--alternator-ttl-period-in-seconds', '0.5',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # We only list here Alternator-specific experimental features - CQL

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -25,10 +25,11 @@
 import pytest
 import requests
 import re
+import time
 from contextlib import contextmanager
 from botocore.exceptions import ClientError
 
-from util import random_string, new_test_table
+from util import random_string, new_test_table, is_aws
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for
@@ -96,7 +97,7 @@ def check_increases_metric(metrics, metric_names):
     yield
     the_metrics = get_metrics(metrics)
     for n in metric_names:
-        assert saved_metrics[n] < get_metric(metrics, n, None, the_metrics)
+        assert saved_metrics[n] < get_metric(metrics, n, None, the_metrics), f'metric {n} did not increase'
 
 @contextmanager
 def check_increases_operation(metrics, operation_names):
@@ -225,6 +226,64 @@ def test_unsupported_operation(dynamodb, metrics):
 def test_total_operations(dynamodb, metrics):
     with check_increases_metric(metrics, ['scylla_alternator_total_operations']):
         dynamodb.meta.client.describe_endpoints()
+
+# A fixture to read alternator-ttl-period-in-seconds from Scylla's
+# configuration. If we're testing something which isn't Scylla, or
+# this configuration does not exist, skip this test. If the configuration
+# isn't low enough (it is more than one second), skip this test unless
+# the "--runveryslow" option is used.
+@pytest.fixture(scope="session")
+def alternator_ttl_period_in_seconds(dynamodb, request):
+    # If not running on Scylla, skip the test
+    if is_aws(dynamodb):
+        pytest.skip('Scylla-only test skipped')
+    # In Scylla, we can inspect the configuration via a system table
+    # (which is also visible in Alternator)
+    config_table = dynamodb.Table('.scylla.alternator.system.config')
+    resp = config_table.query(
+            KeyConditionExpression='#key=:val',
+            ExpressionAttributeNames={'#key': 'name'},
+            ExpressionAttributeValues={':val': 'alternator_ttl_period_in_seconds'})
+    if not 'Items' in resp:
+        pytest.skip('missing TTL feature, skipping test')
+    period = float(resp['Items'][0]['value'])
+    if period > 1 and not request.config.getoption('runveryslow'):
+        pytest.skip('need --runveryslow option to run')
+    return period
+
+# Test metrics of the background expiration thread run for Alternator's TTL
+# feature. The metrics tested in this test are scylla_expiration_scan_passes,
+# scylla_expiration_scan_table and scylla_expiration_items_deleted. The
+# metric scylla_expiration_secondary_ranges_scanned is not tested in this
+# test - testing it requires a multi-node cluster because it counts the
+# number of times that this node took over another node's expiration duty.
+#
+# Unfortunately, to see TTL expiration in action this test may need to wait
+# up to the setting of alternator_ttl_period_in_seconds. test/alternator/run
+# sets this to 1 second, which becomes the maximum delay of this test, but
+# if it is set higher we skip this test unless --runveryslow is enabled.
+def test_ttl_stats(dynamodb, metrics, alternator_ttl_period_in_seconds):
+    print(alternator_ttl_period_in_seconds)
+    with check_increases_metric(metrics, ['scylla_expiration_scan_passes', 'scylla_expiration_scan_table', 'scylla_expiration_items_deleted']):
+        with new_test_table(dynamodb,
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
+            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+            # Insert one already-expired item, and then enable TTL:
+            p0 = random_string()
+            table.put_item(Item={'p': p0, 'expiration': int(time.time())-60})
+            assert 'Item' in table.get_item(Key={'p': p0})
+            client = table.meta.client
+            client.update_time_to_live(TableName=table.name,
+                TimeToLiveSpecification= {'AttributeName': 'expiration', 'Enabled': True})
+            # After alternator_ttl_period_in_seconds, we expect the metrics
+            # to have increased. Add some time to that, to account for
+            # extremely overloaded test machines.
+            start_time = time.time()
+            while time.time() < start_time + alternator_ttl_period_in_seconds + 60:
+                if not 'Item' in table.get_item(Key={'p': p0}):
+                    break
+                time.sleep(0.1)
+            assert not 'Item' in table.get_item(Key={'p': p0})
 
 # TODO: there are additional metrics which we don't yet test here. At the
 # time of this writing they are: latency histograms

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -231,3 +231,10 @@ def scylla_inject_error(rest_api, err, one_shot=False):
     finally:
         print("Disabling error injection", err)
         response = requests.delete(f'{rest_api}/v2/error_injection/injection/{err}')
+
+# Send a message to the Scylla log. E.g., we can write a message to the log
+# indicating that a test has started, which will make it easier to see which
+# test caused which errors in the log.
+def scylla_log(optional_rest_api, message, level):
+    if optional_rest_api:
+        requests.post(f'{optional_rest_api}/system/log?message={requests.utils.quote(message)}&level={level}')


### PR DESCRIPTION
We had quite a few tests for Alternator TTL in test/alternator, but most of them did not run as part of the usual Jenkins test suite, because they were considered "very slow" (and require a special "--runveryslow" flag to run). 

In this series we enable six tests which run quickly enough to run by default, without an additional flag. We also make them even quicker - the six tests now take around 2.5 seconds.

I also noticed that we don't have a test for the Alternator TTL metrics - and added one.

Fixes #11374.
Refs https://github.com/scylladb/scylla-monitoring/issues/1783