### PR TITLE
release: properly evaluate SCYLLA_BUILD_MODE_* macros

### DIFF
--- a/build_mode.hh
+++ b/build_mode.hh
@@ -9,6 +9,10 @@
 
 #pragma once
 
+#ifndef SCYLLA_BUILD_MODE
+#error SCYLLA_BUILD_MODE must be defined
+#endif
+
 #ifndef STRINGIFY
 // We need to levels of indirection
 // to make a string out of the macro name.
@@ -20,12 +24,36 @@
 
 #define SCYLLA_BUILD_MODE_STR STRINGIFY_MACRO(SCYLLA_BUILD_MODE)
 
-#if SCYLLA_BUILD_MODE == release
-#define SCYLLA_BUILD_MODE_RELEASE
-#elif SCYLLA_BUILD_MODE == dev
-#define SCYLLA_BUILD_MODE_DEV
-#elif SCYLLA_BUILD_MODE == debug
+// We use plain macro definitions
+// so the preprocessor can expand them
+// inline in the #if directives below
+#define SCYLLA_BUILD_MODE_CODE_debug 0
+#define SCYLLA_BUILD_MODE_CODE_release 1
+#define SCYLLA_BUILD_MODE_CODE_dev 2
+#define SCYLLA_BUILD_MODE_CODE_sanitize 3
+#define SCYLLA_BUILD_MODE_CODE_coverage 4
+
+#define _SCYLLA_BUILD_MODE_CODE(sbm) SCYLLA_BUILD_MODE_CODE_ ## sbm
+#define SCYLLA_BUILD_MODE_CODE(sbm) _SCYLLA_BUILD_MODE_CODE(sbm)
+
+#if SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_debug
 #define SCYLLA_BUILD_MODE_DEBUG
-#elif SCYLLA_BUILD_MODE == sanitize
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_release
+#define SCYLLA_BUILD_MODE_RELEASE
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_dev
+#define SCYLLA_BUILD_MODE_DEV
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_sanitize
 #define SCYLLA_BUILD_MODE_SANITIZE
+#elif SCYLLA_BUILD_MODE_CODE(SCYLLA_BUILD_MODE) == SCYLLA_BUILD_MODE_CODE_coverage
+#define SCYLLA_BUILD_MODE_COVERAGE
+#else
+#error unrecognized SCYLLA_BUILD_MODE
+#endif
+
+#if (defined(SCYLLA_BUILD_MODE_RELEASE) || defined(SCYLLA_BUILD_MODE_DEV)) && defined(SEASTAR_DEBUG)
+#error SEASTAR_DEBUG is not expected to be defined when SCYLLA_BUILD_MODE is "release" or "dev"
+#endif
+
+#if (defined(SCYLLA_BUILD_MODE_DEBUG) || defined(SCYLLA_BUILD_MODE_SANITIZE)) && !defined(SEASTAR_DEBUG)
+#error SEASTAR_DEBUG is expected to be defined when SCYLLA_BUILD_MODE is "debug" or "sanitize"
 #endif

--- a/configure.py
+++ b/configure.py
@@ -1557,7 +1557,8 @@ scylla_product = file.read().strip()
 arch = platform.machine()
 
 for m, mode_config in modes.items():
-    cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\" -DSCYLLA_BUILD_MODE=" + m
+    mode_config['cxxflags'] += f" -DSCYLLA_BUILD_MODE={m}"
+    cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\""
     mode_config["per_src_extra_cxxflags"]["release.cc"] = cxxflags
     if mode_config["can_have_debug_info"]:
         mode_config['cxxflags'] += ' ' + dbgflag


### PR DESCRIPTION
Patch 765d2f5e4699dc148977d83bd84bae9aab3ee670 did not
evaluate the #if SCYLLA_BUILD_MODE directives properly
and it always matched SCYLLA_BULD_MODE == release.

This change fixes that by defining numerical codes
for each build mode and using macro expansion to match
the define SCYLLA_BUILD_MODE against these codes.

Also, ./configure.py was changes to pass SCYLLA_BUILD_MODE
to all .cc source files, and makes sure it is defined
in build_mode.hh.

Support was added for coverage build mode,
and an #error was added if SCYLLA_BUILD_MODE
was not recognized by the #if ladder directives.

Additional checks verifying the expected SEASTAR_DEBUG
against SCYLLA_BUILD_MODE were added as well,

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>