### PR TITLE
scylla-gdb.py: bring scylla reads-stats up-to-date

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -833,7 +833,8 @@ class string_view_printer(gdb.printing.PrettyPrinter):
         self.val = val
 
     def to_string(self):
-        return str(self.val['_M_str'])[0:int(self.val['_M_len'])]
+        inf = gdb.selected_inferior()
+        return str(inf.read_memory(self.val['_M_str'], self.val['_M_len']), encoding='utf-8')
 
     def display_hint(self):
         return 'string'

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4910,7 +4910,9 @@ class scylla_read_stats(gdb.Command):
             gdb.write("Scylla version doesn't seem to have the permits linked yet, cannot list reads.")
             raise
 
-        permit_list = std_unique_ptr(permit_list).get().dereference()['permits']
+        if not permit_list.type.strip_typedefs().name.startswith('boost::intrusive::list'):
+            # 4.5 compatibility
+            permit_list = std_unique_ptr(permit_list).get().dereference()['permits']
 
         state_prefix_len = len('reader_permit::state::')
 

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -156,4 +156,7 @@ def test_sstable_summary(gdb, sstable):
 def test_sstable_summary(gdb, sstable):
     scylla(gdb, f'sstable-index-cache {sstable}')
 
+def test_read_stats(gdb, sstable):
+    scylla(gdb, f'read-stats')
+
 # FIXME: need a simple test for lsa-segment


### PR DESCRIPTION
Said command is broken since 4.6, as the type of `reader_concurrency_semaphore::_permit_list` was changed without an accompanying update to this command. This series updates said command and adds it to the list of tested commands so we notice if it breaks in the future.