### PR TITLE
raft server, log size limit in bytes

### DIFF
--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -400,7 +400,7 @@ public:
     // go below max_log_size.
     // Can only be called on a leader.
     // On abort throws `semaphore_aborted`.
-    future<> consume_memory(seastar::abort_source* as, size_t size);
+    future<semaphore_units<>> wait_for_memory_permit(seastar::abort_source* as, size_t size);
 
     // Return current configuration.
     const configuration& get_configuration() const;

--- a/raft/log.cc
+++ b/raft/log.cc
@@ -66,6 +66,7 @@ void log::truncate_uncommitted(index_t idx) {
     auto it = _log.begin() + (idx - _first_idx);
     const auto released_memory = range_memory_usage(it, _log.end());
     _log.erase(it, _log.end());
+    _log.shrink_to_fit();
     _memory_usage -= released_memory;
     stable_to(std::min(_stable_idx, last_idx()));
     if (_last_conf_idx > last_idx()) {
@@ -238,6 +239,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
         // entries and the next entry index.
         released_memory = std::exchange(_memory_usage, 0);
         _log.clear();
+        _log.shrink_to_fit();
         _first_idx = idx + index_t{1};
     } else {
         auto entries_to_remove = _log.size() - (last_idx() - idx);
@@ -251,6 +253,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
         }
         released_memory = range_memory_usage(_log.begin(), _log.begin() + entries_to_remove);
         _log.erase(_log.begin(), _log.begin() + entries_to_remove);
+        _log.shrink_to_fit();
         _memory_usage -= released_memory;
         _first_idx = _first_idx + index_t{entries_to_remove};
     }

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -471,8 +471,10 @@ using rpc_message = std::variant<append_request,
       read_quorum,
       read_quorum_reply>;
 
-// we need something that can be truncated form both sides.
+// we need something that can be truncated from both sides.
 // std::deque move constructor is not nothrow hence cannot be used
+// also, boost::deque deallocates blocks when items are removed,
+// we don't want to hold on to memory we don't use.
 using log_entries = boost::container::deque<log_entry_ptr>;
 
 // 3.4 Leader election

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -472,16 +472,23 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
 
 future<entry_id> server_impl::add_entry_on_leader(command cmd, seastar::abort_source* as) {
     // Wait for sufficient memory to become available
+    semaphore_units<> memory_permit;
     try {
-        co_await _fsm->consume_memory(as, log::memory_usage_of(cmd, _config.max_command_size));
+        memory_permit = co_await _fsm->wait_for_memory_permit(as, log::memory_usage_of(cmd, _config.max_command_size));
     } catch (semaphore_aborted&) {
         throw request_aborted();
     }
-    logger.trace("[{}] adding entry after log size limit check", id());
+    logger.trace("[{}] adding entry after waiting for memory permit", id());
 
-    const log_entry& e = _fsm->add_entry(std::move(cmd));
-
-    co_return entry_id{.term = e.term, .idx = e.idx};
+    try {
+        const log_entry& e = _fsm->add_entry(std::move(cmd));
+        memory_permit.release();
+        co_return entry_id{.term = e.term, .idx = e.idx};
+    } catch (const not_a_leader&) {
+        // the semaphore is already destroyed, prevent memory_permit from accessing it
+        memory_permit.release();
+        throw;
+    }
 }
 
 future<add_entry_reply> server_impl::execute_add_entry(server_id from, command cmd, seastar::abort_source* as) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -175,18 +175,23 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto storage = std::make_unique<raft_sys_table_storage>(_qp, gid, my_addr.id);
     auto& persistence_ref = *storage;
     auto* cl = _qp.proxy().get_db().local().commitlog();
+    auto config = raft::server::configuration {
+        .on_background_error = [gid, this](std::exception_ptr e) {
+            _raft_gr.abort_server(gid, fmt::format("background error, {}", e));
+            _status_for_monitoring = status_for_monitoring::aborted;
+        }
+    };
+    if (cl) {
+        // Dividing by two is to protect against paddings that the
+        // commit log can add for each mutation, as well as
+        // against different commit log limits on different nodes.
+        config.max_command_size = cl->max_record_size() / 2;
+        config.max_log_size = 3 * config.max_command_size;
+        config.snapshot_threshold_log_size = config.max_log_size / 2;
+        config.snapshot_trailing_size = config.snapshot_threshold_log_size / 2;
+    };
     auto server = raft::create_server(my_addr.id, std::move(rpc), std::move(state_machine),
-            std::move(storage), _raft_gr.failure_detector(),
-            raft::server::configuration {
-                // Dividing by two is to protect against paddings that the
-                // commit log can add for each mutation, as well as
-                // against different commit log limits on different nodes.
-                .max_command_size = cl ? cl->max_record_size() / 2 : 0,
-                .on_background_error = [gid, this](std::exception_ptr e) {
-                    _raft_gr.abort_server(gid, fmt::format("background error, {}", e));
-                    _status_for_monitoring = status_for_monitoring::aborted;
-                }
-            });
+            std::move(storage), _raft_gr.failure_detector(), config);
 
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -41,7 +41,8 @@ SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
                 .nodes = 1,
                 .config = std::vector<raft::server::configuration>({
                     raft::server::configuration {
-                        .max_snapshot_trailing_bytes = 1,
+                        .snapshot_threshold_log_size = 0,
+                        .snapshot_trailing_size = 0,
                         .max_log_size = command_size,
                         .max_command_size = command_size
                     }

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -1,21 +1,23 @@
 #include "replication.hh"
+#include "utils/error_injection.hh"
+#include <seastar/util/defer.hh>
 
 #ifdef SEASTAR_DEBUG
 // Increase tick time to allow debug to process messages
-const auto tick_delay = 200ms;
+ const auto tick_delay = 200ms;
 #else
 const auto tick_delay = 100ms;
 #endif
 
 SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
     raft_cluster<std::chrono::steady_clock> cluster(
-        test_case { .nodes = 1 },
-        [](raft::server_id id, const std::vector<raft::command_cref>& commands, lw_shared_ptr<hasher_int> hasher) {
-            return 0;
-        },
-        0,
-        0,
-        0, false, tick_delay, rpc_config{});
+            test_case { .nodes = 1 },
+            [](raft::server_id id, const std::vector<raft::command_cref>& commands, lw_shared_ptr<hasher_int> hasher) {
+                return 0;
+            },
+            0,
+            0,
+            0, false, tick_delay, rpc_config{});
     cluster.start_all().get0();
 
     cluster.stop_server(0, "test crash").get0();
@@ -27,4 +29,40 @@ SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
     BOOST_CHECK_EXCEPTION(cluster.get_server(0).modify_config({}, {to_raft_id(0)}).get0(), raft::stopped_error, check_error);
     BOOST_CHECK_EXCEPTION(cluster.get_server(0).read_barrier().get0(), raft::stopped_error, check_error);
     BOOST_CHECK_EXCEPTION(cluster.get_server(0).set_configuration({}).get0(), raft::stopped_error, check_error);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+#else
+    const size_t command_size = sizeof(size_t);
+    raft_cluster<std::chrono::steady_clock> cluster(
+            test_case {
+                .nodes = 1,
+                .config = std::vector<raft::server::configuration>({
+                    raft::server::configuration {
+                        .max_snapshot_trailing_bytes = 1,
+                        .max_log_size = command_size,
+                        .max_command_size = command_size
+                    }
+                })
+            },
+            ::apply_changes,
+            0,
+            0,
+            0, false, tick_delay, rpc_config{});
+    cluster.start_all().get0();
+    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+
+    utils::get_local_injector().enable("fsm::add_entry/test-failure", true);
+    auto check_error = [](const std::runtime_error& e) {
+        return e.what() == sstring("fsm::add_entry/test-failure");
+    };
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), std::runtime_error, check_error);
+
+    // we would block forever if the memory wasn't released
+    // when the exception was thrown from the first add_entry
+    cluster.add_entries(1, 0).get0();
+    cluster.read(read_value{0, 1}).get();
+#endif
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2216,9 +2216,12 @@ SEASTAR_TEST_CASE(test_frequent_snapshotting) {
         }, 10'000);
         const auto server_config = raft::server::configuration {
             .snapshot_threshold{1},
+            .snapshot_threshold_log_size{150},
             .snapshot_trailing{5},
-            .max_log_size{20},
-            .enable_forwarding{true}
+            .snapshot_trailing_size{75},
+            .max_log_size{300},
+            .enable_forwarding{true},
+            .max_command_size{30}
         };
 
         auto leader_id = co_await env.new_server(true, server_config);
@@ -3257,12 +3260,16 @@ SEASTAR_TEST_CASE(basic_generator_test) {
         bool nemesis_crashes = true;
 
         // TODO: randomize the snapshot thresholds between different servers for more chaos.
+        const auto max_command_size = 2 * sizeof(raft::log_entry);
         auto srv_cfg = frequent_snapshotting
             ? raft::server::configuration {
                 .snapshot_threshold{10},
+                .snapshot_threshold_log_size{3 * (max_command_size + sizeof(raft::log_entry))},
                 .snapshot_trailing{5},
-                .max_log_size{20},
+                .snapshot_trailing_size{max_command_size + sizeof(raft::log_entry)},
+                .max_log_size{5 * (max_command_size + sizeof(raft::log_entry))},
                 .enable_forwarding{forwarding},
+                .max_command_size{max_command_size}
             }
             : raft::server::configuration {
                 .enable_forwarding{forwarding},

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -158,7 +158,20 @@ RAFT_TEST_CASE(take_snapshot, (test_case{
 // 2 nodes doing simple replication/snapshoting while leader's log size is limited
 RAFT_TEST_CASE(backpressure, (test_case{
          .nodes = 2,
-         .config = {{.snapshot_threshold = 10, .snapshot_trailing = 5, .max_log_size = 20}, {.snapshot_threshold = 20, .snapshot_trailing = 10}},
+         .config = {
+             {
+                 .snapshot_threshold = 10,
+                 .snapshot_threshold_log_size = 200,
+                 .snapshot_trailing = 5,
+                 .snapshot_trailing_size = 100,
+                 .max_log_size = 450,
+                 .max_command_size = 150
+             },
+             {
+                 .snapshot_threshold = 20,
+                 .snapshot_trailing = 10
+            }
+         },
          .updates = {entries{100}}}));
 
 // 3 nodes, add entries, drop leader 0, add entries [implicit re-join all]

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -159,20 +159,25 @@ RAFT_TEST_CASE(take_snapshot, (test_case{
 RAFT_TEST_CASE(backpressure, (test_case{
          .nodes = 2,
          .config = {
-             {
-                 .snapshot_threshold = 10,
-                 .snapshot_threshold_log_size = 200,
-                 .snapshot_trailing = 5,
-                 .snapshot_trailing_size = 100,
-                 .max_log_size = 450,
-                 .max_command_size = 150
-             },
+             []() {
+                 const auto max_command_size = sizeof(size_t);
+                 return raft::server::configuration {
+                     .snapshot_threshold = 10,
+                     .snapshot_threshold_log_size = 2 * (max_command_size + sizeof(raft::log_entry)),
+                     .snapshot_trailing = 5,
+                     .snapshot_trailing_size = 1 * (max_command_size + sizeof(raft::log_entry)),
+                     .max_log_size = 5 * (max_command_size + sizeof(raft::log_entry)),
+                     .max_command_size = max_command_size
+                 };
+             }(),
              {
                  .snapshot_threshold = 20,
                  .snapshot_trailing = 10
-            }
+             }
          },
-         .updates = {entries{100}}}));
+         .updates = {entries{100, {}, true}},
+         .commutative_hash = true,
+         .verify_persisted_snapshots = false}));
 
 // 3 nodes, add entries, drop leader 0, add entries [implicit re-join all]
 RAFT_TEST_CASE(drops_01, (test_case{


### PR DESCRIPTION
Before this patch we could get an OOM if we
received several big commands. The number of
commands was small, but their total size
in bytes was large.

snapshot_trailing_size is needed to guarantee
progress. Without this limit the fsm could
get stuck if the size of the next item is greater than
 max_log_size - (size of trailing entries).