### PR TITLE
db: schema_tables: Make table creation shadow earlier concurrent changes

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2222,11 +2222,54 @@ std::vector<mutation> make_drop_aggregate_mutations(schema_features features, sh
  * Table metadata serialization/deserialization.
  */
 
+/// Returns mutations which when applied to the database will cause all schema changes
+/// which create or alter the table with a given name, made with timestamps smaller than t,
+/// have no effect. Used when overriding schema to shadow concurrent conflicting schema changes.
+/// Shouldn't be needed if schema changes are serialized with RAFT.
+static schema_mutations make_table_deleting_mutations(const sstring& ks, const sstring& table, bool is_view, api::timestamp_type t) {
+    tombstone tomb;
+
+    // Generate neutral mutations if t == api::min_timestamp
+    if (t > api::min_timestamp) {
+        tomb = tombstone(t - 1, gc_clock::now());
+    }
+
+    auto tables_m_s = is_view ? views() : tables();
+    mutation tables_m{tables_m_s, partition_key::from_singular(*tables_m_s, ks)};
+    {
+        auto ckey = clustering_key::from_singular(*tables_m_s, table);
+        tables_m.partition().apply_delete(*tables_m_s, ckey, tomb);
+    }
+
+    mutation scylla_tables_m{scylla_tables(), partition_key::from_singular(*scylla_tables(), ks)};
+    {
+        auto ckey = clustering_key::from_singular(*scylla_tables(), table);
+        scylla_tables_m.partition().apply_delete(*scylla_tables(), ckey, tomb);
+    }
+
+    auto make_drop_columns = [&] (const schema_ptr& s) {
+        mutation m{s, partition_key::from_singular(*s, ks)};
+        auto ckey = clustering_key::from_exploded(*s, {utf8_type->decompose(table)});
+        m.partition().apply_delete(*s, ckey, tomb);
+        return m;
+    };
+
+    return schema_mutations(std::move(tables_m),
+                            make_drop_columns(columns()),
+                            make_drop_columns(view_virtual_columns()),
+                            make_drop_columns(computed_columns()),
+                            mutation(indexes(), partition_key::from_singular(*indexes(), ks)),
+                            make_drop_columns(dropped_columns()),
+                            std::move(scylla_tables_m)
+    );
+}
+
 std::vector<mutation> make_create_table_mutations(schema_ptr table, api::timestamp_type timestamp)
 {
     std::vector<mutation> mutations;
     add_table_or_view_to_schema_mutation(table, timestamp, true, mutations);
-
+    make_table_deleting_mutations(table->ks_name(), table->cf_name(), table->is_view(), timestamp)
+        .copy_to(mutations);
     return mutations;
 }
 
@@ -3223,6 +3266,8 @@ std::vector<mutation> make_create_view_mutations(lw_shared_ptr<keyspace_metadata
     auto base = keyspace->cf_meta_data().at(view->view_info()->base_name());
     add_table_or_view_to_schema_mutation(base, timestamp, true, mutations);
     add_table_or_view_to_schema_mutation(view, timestamp, true, mutations);
+    make_table_deleting_mutations(view->ks_name(), view->cf_name(), view->is_view(), timestamp)
+        .copy_to(mutations);
     return mutations;
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2415,8 +2415,12 @@ static schema_mutations make_table_mutations(schema_ptr table, api::timestamp_ty
         }
     }
 
-    return schema_mutations{std::move(m), std::move(columns_mutation), std::nullopt, std::move(computed_columns_mutation),
-                            std::move(indices_mutation), std::move(dropped_columns_mutation),
+    return schema_mutations{std::move(m),
+                            std::move(columns_mutation),
+                            std::nullopt,
+                            std::move(computed_columns_mutation),
+                            std::move(indices_mutation),
+                            std::move(dropped_columns_mutation),
                             std::move(scylla_tables_mutation)};
 }
 
@@ -3198,8 +3202,12 @@ static schema_mutations make_view_mutations(view_ptr view, api::timestamp_type t
 
     auto scylla_tables_mutation = make_scylla_tables_mutation(view, timestamp);
 
-    return schema_mutations{std::move(m), std::move(columns_mutation), std::move(view_virtual_columns_mutation), std::move(computed_columns_mutation),
-                            std::move(indices_mutation), std::move(dropped_columns_mutation),
+    return schema_mutations{std::move(m),
+                            std::move(columns_mutation),
+                            std::move(view_virtual_columns_mutation),
+                            std::move(computed_columns_mutation),
+                            std::move(indices_mutation),
+                            std::move(dropped_columns_mutation),
                             std::move(scylla_tables_mutation)};
 }
 

--- a/mutation.hh
+++ b/mutation.hh
@@ -458,6 +458,20 @@ void apply(mutation_opt& dst, mutation_opt&& src) {
     }
 }
 
+inline
+void apply(mutation& dst, mutation_opt&& src) {
+    if (src) {
+        dst.apply(std::move(*src));
+    }
+}
+
+inline
+void apply(mutation& dst, const mutation_opt& src) {
+    if (src) {
+        dst.apply(*src);
+    }
+}
+
 // Returns a range into partitions containing mutations covered by the range.
 // partitions must be sorted according to decorated key.
 // range must not wrap around.

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -149,3 +149,14 @@ std::ostream& operator<<(std::ostream& out, const schema_mutations& sm) {
     out << "}";
     return out;
 }
+
+schema_mutations& schema_mutations::operator+=(schema_mutations&& sm) {
+    _columnfamilies += std::move(sm._columnfamilies);
+    _columns += std::move(sm._columns);
+    apply(_computed_columns, std::move(sm._computed_columns));
+    apply(_view_virtual_columns, std::move(sm._view_virtual_columns));
+    apply(_indices, std::move(sm._indices));
+    apply(_dropped_columns, std::move(sm._dropped_columns));
+    apply(_scylla_tables, std::move(sm._scylla_tables));
+    return *this;
+}

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -145,7 +145,9 @@ std::ostream& operator<<(std::ostream& out, const schema_mutations& sm) {
     out << " scylla_tables=" << sm.scylla_tables() << ",\n";
     out << " columns=" << sm.columns_mutation() << ",\n";
     out << " dropped_columns=" << sm.dropped_columns_mutation() << ",\n";
-    out << " indices=" << sm.indices_mutation() << "\n";
+    out << " indices=" << sm.indices_mutation() << ",\n";
+    out << " computed_columns=" << sm.computed_columns_mutation() << ",\n";
+    out << " view_virtual_columns=" << sm.view_virtual_columns_mutation() << "\n";
     out << "}";
     return out;
 }

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -129,6 +129,7 @@ public:
 
     bool operator==(const schema_mutations&) const;
     bool operator!=(const schema_mutations&) const;
+    schema_mutations& operator+=(schema_mutations&&);
 
     // Returns true iff any mutations contain any live cells
     bool live() const;


### PR DESCRIPTION
Issuing two CREATE TABLE statements with a different name for one of
the partition key columns leads to the following assertion failure on
all replicas:

scylla: schema.cc:363: schema::schema(const schema::raw_schema&, std::optional<raw_view_info>): Assertion `!def.id || def.id == id - column_offset(def.kind)' failed.

The reason is that once the create table mutations are merged, the
columns table contains two entries for the same position in the
partition key tuple.

If the schemas were the same, or not conflicting in a way which leads
to abort, the current behavior would be to drop the older table as if
the last CREATE TABLE was preceded by a DROP TABLE.

The proposed fix is to make CREATE TABLE mutation include a tombstone
for all older schema changes of this table, effectively overriding
them. The behavior will be the same as if the schemas were not
different, older table will be dropped.

Fixes #11396
