### PR TITLE
Merge tokens during range scans with EverywhereStrategy

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5440,9 +5440,11 @@ storage_proxy::query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
     schema_ptr schema = local_schema_registry().get(cmd->schema_version);
     replica::keyspace& ks = _db.local().find_keyspace(schema->ks_name());
 
-    // when dealing with LocalStrategy keyspaces, we can skip the range splitting and merging (which can be
-    // expensive in clusters with vnodes)
-    query_ranges_to_vnodes_generator ranges_to_vnodes(get_token_metadata_ptr(), schema, std::move(partition_ranges), ks.get_replication_strategy().get_type() == locator::replication_strategy_type::local);
+    // when dealing with LocalStrategy and EverywhereStrategy keyspaces, we can skip the range splitting and merging
+    // (which can be expensive in clusters with vnodes)
+    auto merge_tokens = !ks.get_replication_strategy().natural_endpoints_depend_on_token();
+
+    query_ranges_to_vnodes_generator ranges_to_vnodes(get_token_metadata_ptr(), schema, std::move(partition_ranges), merge_tokens);
 
     int result_rows_per_range = 0;
     int concurrency_factor = 1;


### PR DESCRIPTION
With EverywhereStrategy, we know that all tokens will be on the same node and the data is typically sparse like LocalStrategy.

Result of testing the feature:
Cluster: 2 DC, 2 nodes in each DC, 256 tokens per nodes, 14 shards per node

Before: 154 scanning operations
After: 14 scanning operations (~10x improvement)

On bigger cluster, it will probably be even more efficient.


Refs: #11306


