### PR TITLE
compaction: validate: validate the index too

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1236,62 +1236,8 @@ public:
 
 class scrub_compaction final : public regular_compaction {
 public:
-    static void report_invalid_partition(compaction_type type, mutation_fragment_stream_validator& validator, const dht::decorated_key& new_key,
-            std::string_view action = "") {
-        const auto& schema = validator.schema();
-        const auto& current_key = validator.previous_partition_key();
-        clogger.error("[{} compaction {}.{}] Invalid partition {} ({}), partition is out-of-order compared to previous partition {} ({}){}{}",
-                type,
-                schema.ks_name(),
-                schema.cf_name(),
-                new_key.key().with_schema(schema),
-                new_key,
-                current_key.key().with_schema(schema),
-                current_key,
-                action.empty() ? "" : "; ",
-                action);
-    }
-    static void report_invalid_partition_start(compaction_type type, mutation_fragment_stream_validator& validator, const dht::decorated_key& new_key,
-            std::string_view action = "") {
-        const auto& schema = validator.schema();
-        const auto& current_key = validator.previous_partition_key();
-        clogger.error("[{} compaction {}.{}] Invalid partition start for partition {} ({}), previous partition {} ({}) didn't end with a partition-end fragment{}{}",
-                type,
-                schema.ks_name(),
-                schema.cf_name(),
-                new_key.key().with_schema(schema),
-                new_key,
-                current_key.key().with_schema(schema),
-                current_key,
-                action.empty() ? "" : "; ",
-                action);
-    }
-    static void report_invalid_mutation_fragment(compaction_type type, mutation_fragment_stream_validator& validator, const mutation_fragment_v2& mf,
-            std::string_view action = "") {
-        const auto& schema = validator.schema();
-        const auto& key = validator.previous_partition_key();
-        const auto prev_pos = validator.previous_position();
-        clogger.error("[{} compaction {}.{}] Invalid {} fragment{} ({}) in partition {} ({}),"
-                " fragment is out-of-order compared to previous {} fragment{} ({}){}{}",
-                type,
-                schema.ks_name(),
-                schema.cf_name(),
-                mf.mutation_fragment_kind(),
-                mf.has_key() ? format(" with key {}", mf.key().with_schema(schema)) : "",
-                mf.position(),
-                key.key().with_schema(schema),
-                key,
-                prev_pos.region(),
-                prev_pos.has_key() ? format(" with key {}", prev_pos.key().with_schema(schema)) : "",
-                prev_pos,
-                action.empty() ? "" : "; ",
-                action);
-    }
-    static void report_invalid_end_of_stream(compaction_type type, mutation_fragment_stream_validator& validator, std::string_view action = "") {
-        const auto& schema = validator.schema();
-        const auto& key = validator.previous_partition_key();
-        clogger.error("[{} compaction {}.{}] Invalid end-of-stream, last partition {} ({}) didn't end with a partition-end fragment{}{}",
-                type, schema.ks_name(), schema.cf_name(), key.key().with_schema(schema), key, action.empty() ? "" : "; ", action);
+    static void report_validation_error(compaction_type type, const ::schema& schema, sstring what, std::string_view action = "") {
+        clogger.error("[{} compaction {}.{}] {}{}{}", type, schema.ks_name(), schema.cf_name(), what, action.empty() ? "" : "; ", action);
     }
 
 private:
@@ -1314,9 +1260,9 @@ private:
             ++_validation_errors;
         }
 
-        void on_unexpected_partition_start(const mutation_fragment_v2& ps) {
-            auto report_fn = [this, &ps] (std::string_view action = "") {
-                report_invalid_partition_start(compaction_type::Scrub, _validator, ps.as_partition_start().key(), action);
+        void on_unexpected_partition_start(const mutation_fragment_v2& ps, sstring error) {
+            auto report_fn = [this, error] (std::string_view action = "") {
+                report_validation_error(compaction_type::Scrub, *_schema, error, action);
             };
             maybe_abort_scrub(report_fn);
             report_fn("Rectifying by adding assumed missing partition-end");
@@ -1338,9 +1284,9 @@ private:
             }
         }
 
-        skip on_invalid_partition(const dht::decorated_key& new_key) {
-            auto report_fn = [this, &new_key] (std::string_view action = "") {
-                report_invalid_partition(compaction_type::Scrub, _validator, new_key, action);
+        skip on_invalid_partition(const dht::decorated_key& new_key, sstring error) {
+            auto report_fn = [this, error] (std::string_view action = "") {
+                report_validation_error(compaction_type::Scrub, *_schema, error, action);
             };
             maybe_abort_scrub(report_fn);
             if (_scrub_mode == compaction_type_options::scrub::mode::segregate) {
@@ -1354,9 +1300,9 @@ private:
             return skip::yes;
         }
 
-        skip on_invalid_mutation_fragment(const mutation_fragment_v2& mf) {
-            auto report_fn = [this, &mf] (std::string_view action = "") {
-                report_invalid_mutation_fragment(compaction_type::Scrub, _validator, mf, "");
+        skip on_invalid_mutation_fragment(const mutation_fragment_v2& mf, sstring error) {
+            auto report_fn = [this, error] (std::string_view action = "") {
+                report_validation_error(compaction_type::Scrub, *_schema, error, action);
             };
             maybe_abort_scrub(report_fn);
 
@@ -1391,9 +1337,9 @@ private:
             return skip::yes;
         }
 
-        void on_invalid_end_of_stream() {
-            auto report_fn = [this] (std::string_view action = "") {
-                report_invalid_end_of_stream(compaction_type::Scrub, _validator, action);
+        void on_invalid_end_of_stream(sstring error) {
+            auto report_fn = [this, error] (std::string_view action = "") {
+                report_validation_error(compaction_type::Scrub, *_schema, error, action);
             };
             maybe_abort_scrub(report_fn);
             // Handle missing partition_end
@@ -1412,21 +1358,27 @@ private:
                     // and shouldn't be verified. We know the last fragment the
                     // validator saw is a partition-start, passing it another one
                     // will confuse it.
-                    if (!_skip_to_next_partition && !_validator(mf)) {
-                        on_unexpected_partition_start(mf);
+                    if (!_skip_to_next_partition) {
+                        if (auto res = _validator(mf); !res) {
+                            on_unexpected_partition_start(mf, res.what());
+                        }
                         // Continue processing this partition start.
                     }
                     _skip_to_next_partition = false;
                     // Then check that the partition monotonicity stands.
                     const auto& dk = mf.as_partition_start().key();
-                    if (!_validator(dk) && on_invalid_partition(dk) == skip::yes) {
-                        continue;
+                    if (auto res = _validator(dk); !res) {
+                        if (on_invalid_partition(dk, res.what()) == skip::yes) {
+                            continue;
+                        }
                     }
                 } else if (_skip_to_next_partition) {
                     continue;
                 } else {
-                    if (!_validator(mf) && on_invalid_mutation_fragment(mf) == skip::yes) {
-                        continue;
+                    if (auto res = _validator(mf); !res) {
+                        if (on_invalid_mutation_fragment(mf, res.what()) == skip::yes) {
+                            continue;
+                        }
                     }
                 }
                 push_mutation_fragment(std::move(mf));
@@ -1435,8 +1387,8 @@ private:
             _end_of_stream = _reader.is_end_of_stream() && _reader.is_buffer_empty();
 
             if (_end_of_stream) {
-                if (!_validator.on_end_of_stream()) {
-                    on_invalid_end_of_stream();
+                if (auto res = _validator.on_end_of_stream(); !res) {
+                    on_invalid_end_of_stream(res.what());
                 }
             }
         }
@@ -1734,28 +1686,22 @@ future<uint64_t> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 rea
 
             const auto& mf = *mf_opt;
 
+            if (auto res = validator(mf); !res) {
+                scrub_compaction::report_validation_error(compaction_type::Scrub, *schema, res.what());
+                validator.reset(mf);
+                ++errors;
+            }
             if (mf.is_partition_start()) {
                 const auto& ps = mf.as_partition_start();
-                if (!validator(mf)) {
-                    scrub_compaction::report_invalid_partition_start(compaction_type::Scrub, validator, ps.key());
-                    validator.reset(mf);
-                    ++errors;
-                }
-                if (!validator(ps.key())) {
-                    scrub_compaction::report_invalid_partition(compaction_type::Scrub, validator, ps.key());
+                if (auto res = validator(ps.key()); !res) {
+                    scrub_compaction::report_validation_error(compaction_type::Scrub, *schema, res.what());
                     validator.reset(ps.key());
-                    ++errors;
-                }
-            } else {
-                if (!validator(mf)) {
-                    scrub_compaction::report_invalid_mutation_fragment(compaction_type::Scrub, validator, mf);
-                    validator.reset(mf);
                     ++errors;
                 }
             }
         }
-        if (!validator.on_end_of_stream()) {
-            scrub_compaction::report_invalid_end_of_stream(compaction_type::Scrub, validator);
+        if (auto res = validator.on_end_of_stream(); !res) {
+            scrub_compaction::report_validation_error(compaction_type::Scrub, *schema, res.what());
             ++errors;
         }
     } catch (...) {

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -130,7 +130,4 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
 // For tests, can drop after we virtualize sstables.
 flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors);
 
-// For tests, can drop after we virtualize sstables.
-future<uint64_t> scrub_validate_mode_validate_reader(flat_mutation_reader_v2 rd, const compaction_data& info);
-
 }

--- a/mutation/mutation_fragment_stream_validator.hh
+++ b/mutation/mutation_fragment_stream_validator.hh
@@ -214,4 +214,5 @@ public:
     /// Equivalent to `operator()(partition_end{})`
     bool on_end_of_partition();
     void on_end_of_stream();
+    mutation_fragment_stream_validator& validator() { return _validator; }
 };

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -8,6 +8,7 @@
 
 #include "reader.hh"
 #include "concrete_types.hh"
+#include "mutation/mutation_fragment_stream_validator.hh"
 #include "sstables/liveness_info.hh"
 #include "sstables/mutation_fragment_filter.hh"
 #include "sstables/sstable_mutation_reader.hh"
@@ -1844,6 +1845,338 @@ void mp_row_consumer_reader_mx::on_next_partition(dht::decorated_key key, tombst
     push_mutation_fragment(
             mutation_fragment_v2(*_schema, _permit, partition_start(*_current_partition_key, tomb)));
     _sst->get_stats().on_partition_read();
+}
+
+// A validating consumer implementing the Consumer concept of data_consume_rows_context_m.
+//
+// It consumes the atoms coming from the parser and validates that the mutation
+// fragment stream they form is valid, namely it checks:
+// * partition ordering
+// * mutation fragment kind ordering
+// * clustering element ordering
+// * partitions being ended properly (before EOS)
+// * range tombstones being ended properly (before end-of-partition)
+//
+// For this, it relies on the mutation_fragment_stream_validator.
+//
+// It also allows for checking that partitions and clustering keys are laid out
+// as expected by the index and promoted index respectively.
+class validating_consumer {
+public:
+    struct clustering_block {
+        position_in_partition start;
+        position_in_partition end;
+        bool done = false;
+
+        clustering_block(position_in_partition_view start, position_in_partition_view end) : start(start), end(end) {
+        }
+    };
+
+private:
+    schema_ptr _schema;
+    reader_permit _permit;
+    const io_priority_class& _pc;
+    std::function<void(sstring)> _error_handler;
+    // For static-compact tables C* stores the only row in the static row but in our representation they're regular rows.
+    const bool _treat_static_row_as_regular;
+    mutation_fragment_stream_validator _validator;
+    uint64_t _error_count = 0;
+    std::optional<partition_key> _expected_pkey;
+    std::optional<clustering_block> _expected_clustering_block;
+    position_in_partition _current_pos;
+    bool _stop_after_partition_header = false;
+
+private:
+    clustering_key from_fragmented_buffer(const std::vector<fragmented_temporary_buffer>& ecp) {
+        return clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
+                [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
+    }
+    void validate_fragment_order(mutation_fragment_v2::kind kind, std::optional<tombstone> new_current_tombstone) {
+        if (auto res = _validator(kind, _current_pos, new_current_tombstone); !res) {
+            report_error(res.what());
+            _validator.reset(kind, _current_pos, new_current_tombstone);
+        }
+        if (_current_pos.region() != partition_region::clustered) {
+            return;
+        }
+        if (_expected_clustering_block) {
+            auto cmp = position_in_partition::tri_compare(*_schema);
+            const auto cmp_start = cmp(_expected_clustering_block->start, _current_pos);
+            const auto cmp_end = cmp(_expected_clustering_block->end, _current_pos);
+            if (cmp_start > 0 || cmp_end < 0) {
+                if (_expected_clustering_block->done) {
+                    report_error(format("mismatching index/data: promoted index has no more blocks, but partition {} ({}) has more rows",
+                            _validator.previous_partition_key().key().with_schema(*_schema),
+                            _validator.previous_partition_key().key()));
+                } else {
+                    report_error(format("mismatching index/data: clustering element {} is outside of current promoted-index block [{}, {}]",
+                            _current_pos,
+                            _expected_clustering_block->start,
+                            _expected_clustering_block->end));
+                }
+            }
+            if (cmp_end == 0) {
+                _expected_clustering_block->done = true;
+            }
+        }
+    }
+
+public:
+    validating_consumer(const schema_ptr schema, reader_permit permit, const io_priority_class& pc, const shared_sstable& sst, std::function<void(sstring)> error_handler)
+        : _schema(schema)
+        , _permit(std::move(permit))
+        , _pc(pc)
+        , _error_handler(std::move(error_handler))
+        , _treat_static_row_as_regular(_schema->is_static_compact_table()
+            && (!sst->has_scylla_component() || sst->features().is_enabled(sstable_feature::CorrectStaticCompact))) // See #4139
+        , _validator(*_schema)
+        , _current_pos(position_in_partition::end_of_partition_tag_t{})
+    {
+    }
+
+    const reader_permit& permit() const { return _permit; }
+    const io_priority_class& io_priority() const { return _pc; }
+    tracing::trace_state_ptr trace_state() { return {}; }
+    uint64_t error_count() const { return _error_count; }
+    position_in_partition_view current_position() const { return _current_pos; }
+
+    void set_stop_after_partition_header() {
+        _stop_after_partition_header = true;
+    }
+
+    void set_index_expected_partition(partition_key pkey) {
+        _expected_pkey.emplace(std::move(pkey));
+    }
+    void reset_index_expected_partition() {
+        _expected_pkey.reset();
+    }
+    void set_index_expected_clustering_block(position_in_partition_view start, position_in_partition_view end) {
+        _expected_clustering_block.emplace(start, end);
+    }
+
+    void report_error(sstring what) {
+        ++_error_count;
+        _error_handler(what);
+    }
+
+    data_consumer::proceed consume_partition_start(sstables::key_view key, sstables::deletion_time deltime) {
+        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto dk = dht::decorate_key(*_schema, pk);
+        _current_pos = position_in_partition(position_in_partition::partition_start_tag_t{});
+        sstlog.trace("validating_consumer {}: {}({}) _expected_pkey={}", fmt::ptr(this), __FUNCTION__, pk, _expected_pkey);
+        validate_fragment_order(mutation_fragment_v2::kind::partition_start, {});
+        if (_expected_pkey && !_expected_pkey->equal(*_schema, dk.key())) {
+            report_error(format("mismatching index/data: partition mismatch: index: {}, data: {}", *_expected_pkey, dk.key()));
+        }
+        if (auto res = _validator(dk); !res) {
+            report_error(res.what());
+            _validator.reset(dk);
+        }
+        if (_stop_after_partition_header) {
+            _stop_after_partition_header = false;
+            return data_consumer::proceed::no;
+        }
+        return data_consumer::proceed::yes;
+    }
+
+    row_processing_result consume_row_start(const std::vector<fragmented_temporary_buffer>& ecp) {
+        auto ck = from_fragmented_buffer(ecp);
+        _current_pos = position_in_partition::for_key(std::move(ck));
+        sstlog.trace("validating_consumer {}: {}({})", fmt::ptr(this), __FUNCTION__, _current_pos);
+        validate_fragment_order(mutation_fragment_v2::kind::clustering_row, {});
+        return row_processing_result::do_proceed;
+    }
+
+    data_consumer::proceed consume_row_marker_and_tombstone(const liveness_info& info, tombstone tomb, tombstone shadowable_tomb) {
+        return data_consumer::proceed::yes;
+    }
+
+    row_processing_result consume_static_row_start() {
+        sstlog.trace("validating_consumer {}: {}()", fmt::ptr(this), __FUNCTION__);
+        if (_treat_static_row_as_regular) {
+            return consume_row_start({});
+        }
+        _current_pos = position_in_partition(position_in_partition::static_row_tag_t{});
+        validate_fragment_order(mutation_fragment_v2::kind::static_row, {});
+        return row_processing_result::do_proceed;
+    }
+
+    data_consumer::proceed consume_column(const column_translation::column_info& column_info, bytes_view cell_path, fragmented_temporary_buffer::view value,
+            api::timestamp_type timestamp, gc_clock::duration ttl, gc_clock::time_point local_deletion_time, bool is_deleted) {
+        return data_consumer::proceed::yes;
+    }
+
+    data_consumer::proceed consume_complex_column_start(const sstables::column_translation::column_info& column_info, tombstone tomb) {
+        return data_consumer::proceed::yes;
+    }
+
+    data_consumer::proceed consume_complex_column_end(const sstables::column_translation::column_info& column_info) {
+        return data_consumer::proceed::yes;
+    }
+
+    data_consumer::proceed consume_counter_column(const column_translation::column_info& column_info, fragmented_temporary_buffer::view value, api::timestamp_type timestamp) {
+        return data_consumer::proceed::yes;
+    }
+
+    data_consumer::proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp, bound_kind kind, tombstone tomb) {
+        auto ck = from_fragmented_buffer(ecp);
+        _current_pos = position_in_partition(position_in_partition::range_tag_t(), kind, std::move(ck));
+        std::optional<tombstone> new_current_tomb;
+        if (kind == bound_kind::incl_start || kind == bound_kind::excl_start) {
+            new_current_tomb = tomb;
+        }
+        sstlog.trace("validating_consumer {}: {}({}, {})", fmt::ptr(this), __FUNCTION__, _current_pos, tomb);
+        validate_fragment_order(mutation_fragment_v2::kind::range_tombstone_change, new_current_tomb);
+        return data_consumer::proceed(!need_preempt());
+    }
+
+    data_consumer::proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp, sstables::bound_kind_m kind, tombstone end_tombstone, tombstone start_tombstone) {
+        sstlog.trace("validating_consumer {}: {}()", fmt::ptr(this), __FUNCTION__);
+        switch (kind) {
+        case bound_kind_m::incl_end_excl_start:
+            return consume_range_tombstone(ecp, bound_kind::excl_start, start_tombstone);
+        case bound_kind_m::excl_end_incl_start:
+            return consume_range_tombstone(ecp, bound_kind::incl_start, start_tombstone);
+        default:
+            assert(false && "Invalid boundary type");
+        }
+    }
+
+    data_consumer::proceed consume_row_end() {
+        sstlog.trace("validating_consumer {}: {}()", fmt::ptr(this), __FUNCTION__);
+        if (_expected_clustering_block) {
+            return data_consumer::proceed(!_expected_clustering_block->done);
+        } else {
+            return data_consumer::proceed(!need_preempt());
+        }
+    }
+
+    void on_end_of_stream() {
+        if (auto res = _validator.on_end_of_stream(); !res) {
+            report_error(res.what());
+        }
+        sstlog.trace("validating_consumer {}: {}()", fmt::ptr(this), __FUNCTION__);
+    }
+
+    data_consumer::proceed consume_partition_end() {
+        sstlog.trace("validating_consumer {}: {}()", fmt::ptr(this), __FUNCTION__);
+        _current_pos = position_in_partition(position_in_partition::end_of_partition_tag_t{});
+        validate_fragment_order(mutation_fragment_v2::kind::partition_end, {});
+        return data_consumer::proceed::no;
+    }
+};
+
+future<uint64_t> validate(
+        shared_sstable sstable,
+        reader_permit permit,
+        const io_priority_class& pc,
+        abort_source& abort,
+        std::function<void(sstring)> error_handler) {
+    auto schema = sstable->get_schema();
+    validating_consumer consumer(schema, permit, pc, sstable, std::move(error_handler));
+    auto context = data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer);
+
+    std::optional<sstables::index_reader> idx_reader;
+    idx_reader.emplace(sstable, permit, pc, tracing::trace_state_ptr{}, sstables::use_caching::no, false);
+
+    try {
+        while (!context->eof() && !abort.abort_requested()) {
+            uint64_t current_partition_pos = 0;
+            clustered_index_cursor* idx_cursor = nullptr;
+
+            if (idx_reader && idx_reader->eof()) {
+                consumer.report_error("mismatching index/data: index is at EOF, but data file has more data");
+                co_await idx_reader->close();
+                idx_reader.reset();
+            }
+
+            if (idx_reader) {
+                co_await idx_reader->read_partition_data();
+
+                idx_cursor = idx_reader->current_clustered_cursor();
+
+                const auto index_pos = idx_reader->get_data_file_position();
+                const auto data_pos = context->position();
+                sstlog.trace("validate(): index-data position check for partition {}: {} == {}", idx_reader->get_partition_key(), data_pos, index_pos);
+                if (index_pos != data_pos) {
+                    consumer.report_error(format("mismatching index/data: position mismatch: index: {}, data: {}", index_pos, data_pos));
+                }
+                current_partition_pos = data_pos;
+
+                consumer.set_index_expected_partition(idx_reader->get_partition_key());
+            } else {
+                consumer.reset_index_expected_partition();
+            }
+
+            std::optional<clustered_index_cursor::entry_info> current_pi_block;
+
+            if (idx_cursor) {
+                consumer.set_stop_after_partition_header();
+                co_await context->consume_input();
+            }
+            bool first_block = true;
+
+            do {
+                if (idx_cursor && (current_pi_block = co_await idx_cursor->next_entry())) {
+                    // The mx format always has position-in-partition in the variant.
+                    const auto start = std::get<position_in_partition_view>(current_pi_block->start);
+                    const auto end = std::get<position_in_partition_view>(current_pi_block->end);
+                    const auto index_pos = current_partition_pos + current_pi_block->offset;
+                    const auto data_pos = context->position();
+                    sstlog.trace("validate(): index-data position check for clustering block (first={}) [{}, {}]: {} == {}", first_block, start, end, data_pos, index_pos);
+                    // We cannot reliably position the parser at the start of
+                    // the first block, because there is no way to check what
+                    // the next element is (static row or clustering row)
+                    // without reading its header. And once read, we cannot
+                    // rewind the parser.
+                    // So we do a best-effort here: we ask the consumer to stop
+                    // after consuming the partition-start. For schemas without
+                    // static row this should result in the exact position, but
+                    // even then it is not guaranteed if the schema has a dropped
+                    // static column.
+                    if (first_block) {
+                        first_block = false;
+                        if (data_pos > index_pos) {
+                            consumer.report_error(format("mismatching index/data: position mismatch: first promoted index block: {}, data: {}", index_pos, data_pos));
+                        }
+                    } else {
+                        if (data_pos != index_pos) {
+                            consumer.report_error(format("mismatching index/data: position mismatch: promoted index: {}, data: {}", index_pos, data_pos));
+                        }
+                    }
+
+                    consumer.set_index_expected_clustering_block(start, end);
+                }
+                co_await context->consume_input();
+
+                co_await coroutine::maybe_yield();
+            } while (consumer.current_position().region() != partition_region::partition_end && !abort.abort_requested());
+
+            if (abort.abort_requested()) {
+                // Prevent fall-through to the post-checks below if the the loop above was broken due to abort.
+                break;
+            }
+
+            // Check if promoted index still has more entries.
+            if (idx_cursor && (current_pi_block = co_await idx_cursor->next_entry())) {
+                consumer.report_error(format("mismatching index/data: promoted index has more blocks, but it is end of partition {} ({})",
+                        idx_reader->get_partition_key().with_schema(*schema),
+                        idx_reader->get_partition_key()));
+            }
+
+            if (idx_reader) {
+                co_await idx_reader->advance_to_next_partition();
+            }
+        }
+    } catch (...) {
+        consumer.report_error(format("unexpected exception: {}", std::current_exception()));
+    }
+
+    if (idx_reader) {
+        co_await idx_reader->close();
+    }
+
+    co_return consumer.error_count();
 }
 
 } // namespace mx

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1801,9 +1801,7 @@ flat_mutation_reader_v2 make_crawling_reader(
             std::move(trace_state), monitor);
 }
 
-} // namespace mx
-
-void mx::mp_row_consumer_reader_mx::on_next_partition(dht::decorated_key key, tombstone tomb) {
+void mp_row_consumer_reader_mx::on_next_partition(dht::decorated_key key, tombstone tomb) {
     _partition_finished = false;
     _before_partition = false;
     _end_of_stream = false;
@@ -1813,4 +1811,5 @@ void mx::mp_row_consumer_reader_mx::on_next_partition(dht::decorated_key key, to
     _sst->get_stats().on_partition_read();
 }
 
+} // namespace mx
 } // namespace sstables

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -56,5 +56,15 @@ flat_mutation_reader_v2 make_crawling_reader(
         tracing::trace_state_ptr trace_state,
         read_monitor& monitor);
 
+// Validate the content of the sstable with the mutation_fragment_stream_valdiator,
+// additionally cross checking that the content is laid out as expected by the
+// index and promoted index respectively.
+future<uint64_t> validate(
+        shared_sstable sstable,
+        reader_permit permit,
+        const io_priority_class& pc,
+        abort_source& abort,
+        std::function<void(sstring)> error_handler);
+
 } // namespace mx
 } // namespace sstables

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1841,6 +1841,10 @@ sstable_writer sstable::get_writer(const schema& s, uint64_t estimated_partition
 
 future<uint64_t> sstable::validate(reader_permit permit, const io_priority_class& pc, abort_source& abort,
         std::function<void(sstring)> error_handler) {
+    if (_version >= sstable_version_types::mc) {
+        co_return co_await mx::validate(shared_from_this(), std::move(permit), pc, abort, std::move(error_handler));
+    }
+
     auto reader = make_crawling_reader(_schema, permit, pc, nullptr);
 
     uint64_t errors = 0;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -263,6 +263,16 @@ public:
         const io_priority_class& pc = default_priority_class(),
         shard_id shard = this_shard_id());
 
+    // Validates the content of the sstable.
+    // Reports all errors via the provided error handler.
+    // Returns the count of all validation errors found.
+    // Can be aborted via the abort-source parameter.
+    // If aborted, either via the abort-source or via unrecoverable errors
+    // (e.g. parse error), it will return with validation error count seen up to
+    // the abort. In the latter case it will call the error-handler before doing so.
+    future<uint64_t> validate(reader_permit permit, const io_priority_class& pc, abort_source& abort,
+            std::function<void(sstring)> error_handler);
+
     encoding_stats get_encoding_stats_for_compaction() const;
 
     future<> seal_sstable(bool backup);

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -457,7 +457,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_fragment_stream_validator) {
             bool valid = true;
             for (const auto& mf : mfs) {
                 testlog.trace("validate fragment [{}] {} @ {}", i, mf.mutation_fragment_kind(), mf.position());
-                valid &= validator(mf);
+                valid &= bool(validator(mf));
                 if (expect_valid) {
                     if (!valid) {
                         BOOST_FAIL(fmt::format("Unexpected invalid fragment {} @ {}", mf.mutation_fragment_kind(), mf.position()));
@@ -470,7 +470,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_fragment_stream_validator) {
                 ++i;
             }
             if (expect_valid || i <= at) {
-                valid &= validator.on_end_of_stream();
+                valid &= bool(validator.on_end_of_stream());
                 BOOST_REQUIRE(valid == expect_valid);
             }
         }

--- a/test/cql-pytest/test_sstable_validation.py
+++ b/test/cql-pytest/test_sstable_validation.py
@@ -1,0 +1,313 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Tests for sstable validation.
+#
+# Namely, detecting discrepancies between index and data files.
+# These tests produce pairs of sstables, that differ only slightly, mixes the
+# index/data from the two of them, then runs `sstable validate` expecting it to
+# find the discrepancies.
+#############################################################################
+
+
+import glob
+import json
+import os
+import pytest
+import shutil
+import subprocess
+import tempfile
+
+
+@pytest.fixture(scope="module")
+def schema1_file():
+    """Create a schema.cql for the schema1"""
+    with tempfile.NamedTemporaryFile("w+t") as f:
+        f.write("CREATE TABLE ks.tbl (pk int, ck int, v text, PRIMARY KEY (pk, ck))")
+        f.flush()
+        yield f.name
+
+
+@pytest.fixture(scope="module")
+def schema2_file():
+    """Create a schema.cql for the schema2"""
+    with tempfile.NamedTemporaryFile("w+t") as f:
+        f.write("CREATE TABLE ks.tbl (pk int, ck int, v text, s text STATIC, PRIMARY KEY (pk, ck))")
+        f.flush()
+        yield f.name
+
+
+@pytest.fixture(scope="module")
+def large_rows():
+    """Create a set of large rows"""
+    rows = []
+    v_1k = 'v' * 1024
+    for ck in range(128):
+        ck_raw = "0004{:08x}".format(ck)
+        rows.append({ "type": "clustering-row", "key": { "raw": ck_raw }, "columns": { "v": { "is_live": True, "type": "regular", "timestamp": 1680263186359882, "value": v_1k } } })
+    return rows
+
+
+def find_component(generation, component_type, sst_dir):
+    comps = glob.glob(os.path.join(sst_dir, f"*-{str(generation)}-big-{component_type}.db"))
+    assert len(comps) == 1
+    return comps[0]
+
+
+@pytest.fixture(scope="module")
+def sstable_cache(scylla_path):
+    """Content-addressable sstable cache"""
+    class cache:
+        def __init__(self, scylla_path, workdir):
+            self._scylla_path = scylla_path
+            self._in_json = os.path.join(workdir, "input.json")
+            self._store_dir = os.path.join(workdir, "sst_store_dir")
+            self._cache = {}
+            self._next_generation = 0
+
+            os.mkdir(self._store_dir)
+
+        @property
+        def dir(self):
+            return self._store_dir
+
+        def get_generation(self, sst, schema_file):
+            json_str = json.dumps(sst)
+            generation = self._cache.get(json_str)
+            if not generation is None:
+                return generation
+            with open(self._in_json, "w") as f:
+                f.write(json_str)
+            generation = self._next_generation
+            self._cache[json_str] = generation
+            self._next_generation = self._next_generation + 1
+            subprocess.check_call([self._scylla_path, "sstable", "write", "--schema-file", schema_file, "--output-dir", self._store_dir, "--generation", str(generation), "--input-file", self._in_json])
+            return generation
+
+        def copy_sstable_to(self, generation, target_dir):
+            for f in glob.glob(os.path.join(self._store_dir, f"*-{str(generation)}-big-*.*")):
+                shutil.copy(f, target_dir)
+
+    with tempfile.TemporaryDirectory() as workdir:
+        yield cache(scylla_path, workdir)
+
+
+def validate_mixed_sstable_pair(ssta, sstb, scylla_path, sst_cache, sst_work_dir, schema_file, error_message):
+    """Validate an sstable, created by mixing the index and data from two different sstables.
+
+    Check that the validation has the expected result (`error_message`).
+    """
+    generation_a = sst_cache.get_generation(ssta, schema_file)
+    generation_b = sst_cache.get_generation(sstb, schema_file)
+    shutil.rmtree(sst_work_dir)
+    os.mkdir(sst_work_dir)
+    sst_cache.copy_sstable_to(generation_a, sst_work_dir)
+    shutil.copyfile(find_component(generation_b, "Index", sst_cache.dir), find_component(generation_a, "Index", sst_work_dir))
+
+    res = subprocess.run([scylla_path, "sstable", "validate", "--schema-file", schema_file, find_component(generation_a, "Data", sst_work_dir)],
+                         check=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    out = res.stdout.decode('utf-8')
+    err = res.stderr.decode('utf-8')
+    valid = out.split(":")[1].strip() == "valid"
+    if error_message:
+        assert not valid
+        assert error_message in err
+    else:
+        print(err)
+        assert valid
+
+
+def make_partition(pk, ck, v):
+    pks = [ "000400000001", "000400000000", "000400000002", "000400000003" ]
+    r = { "type": "clustering-row", "key": { "raw": "0004{:08x}".format(ck) }, "columns": { "v": { "is_live": True, "type": "regular", "timestamp": 1680263186359882, "value": v } } }
+    return { "key": { "raw": pks[pk] }, "clustering_elements": [ r ] }
+
+
+def make_large_partition(pk, rows, with_static_row = False):
+    pks = [ "000400000001", "000400000000", "000400000002", "000400000003" ]
+    if with_static_row:
+        return {
+             "key": { "raw": pks[pk] },
+             "static_row": { "s": { "is_live": True, "type": "regular", "timestamp": 1680263186359882, "value": "s" * 128 } },
+             "clustering_elements": rows
+             }
+    else:
+        return { "key": { "raw": pks[pk] }, "clustering_elements": rows }
+
+
+def test_scylla_sstable_validate_ok1(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v')],
+            [make_partition(0, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "")
+
+
+def test_scylla_sstable_validate_ok2(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v'), make_partition(1, 0, 'v'), make_partition(2, 0, 'v')],
+            [make_partition(0, 0, 'v'), make_partition(1, 0, 'v'), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "")
+
+
+def test_scylla_sstable_validate_mismatching_partition(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v')],
+            [make_partition(1, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: partition mismatch")
+
+
+def test_scylla_sstable_validate_mismatching_position(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v'), make_partition(2, 0, 'v')],
+            [make_partition(0, 0, 'vv'), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: position mismatch")
+
+
+def test_scylla_sstable_validate_index_ends_before_data(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v'), make_partition(2, 0, 'v')],
+            [make_partition(0, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: index is at EOF, but data file has more data")
+
+
+@pytest.mark.xfail(reason="index's EOF definition depends on data file size")
+def test_scylla_sstable_validate_index_ends_before_data1(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v')],
+            [make_partition(0, 0, 'vvvvvvvvvvvvvvvvvvvvvv'), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: data is at EOF, but index has more data")
+
+
+@pytest.mark.xfail(reason="index's EOF definition depends on data file size")
+def test_scylla_sstable_validate_index_ends_before_data2(cql, scylla_path, temp_workdir, schema1_file, sstable_cache):
+    validate_mixed_sstable_pair(
+            [make_partition(0, 0, 'v')],
+            [make_partition(0, 0, 'v'), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: data is at EOF, but index has more data")
+
+def test_scylla_sstable_validate_large_rows_ok1(cql, scylla_path, temp_workdir, schema1_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows)],
+            [make_large_partition(0, large_rows)],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "")
+
+def test_scylla_sstable_validate_large_rows_ok2(cql, scylla_path, temp_workdir, schema2_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows)],
+            [make_large_partition(0, large_rows)],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema2_file,
+            error_message = "")
+
+def test_scylla_sstable_validate_large_rows_ok3(cql, scylla_path, temp_workdir, schema2_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows, True)],
+            [make_large_partition(0, large_rows, True)],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema2_file,
+            error_message = "")
+
+
+def test_scylla_sstable_validate_large_rows_mismatching_position1(cql, scylla_path, temp_workdir, schema1_file, sstable_cache, large_rows):
+    row_0x = { "type": "clustering-row", "key": { "raw": "000400000000" }, "columns": { "v": { "is_live": True, "type": "regular", "timestamp": 1680263186359882, "value": "v" } } }
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows)],
+            [make_large_partition(0, [row_0x] + large_rows[1:])],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: position mismatch: promoted index:")
+
+
+def test_scylla_sstable_validate_large_rows_mismatching_position2(cql, scylla_path, temp_workdir, schema2_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows, True)],
+            [make_large_partition(0, large_rows)],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema2_file,
+            error_message = "mismatching index/data: position mismatch: promoted index:")
+
+
+def test_scylla_sstable_validate_large_rows_mismatching_position3(cql, scylla_path, temp_workdir, schema2_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows)],
+            [make_large_partition(0, large_rows, True)],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema2_file,
+            error_message = "mismatching index/data: position mismatch: promoted index:")
+
+def test_scylla_sstable_validate_large_rows_mismathing_row(cql, scylla_path, temp_workdir, schema1_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, [large_rows[1]] + large_rows[4:])],
+            [make_large_partition(0, [large_rows[2]] + large_rows[4:])],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: clustering element")
+
+def test_scylla_sstable_validate_large_rows_end_of_pi_not_end_of_rows(cql, scylla_path, temp_workdir, schema1_file, sstable_cache, large_rows):
+    row_0x = { "type": "clustering-row", "key": { "raw": "000400000000" }, "columns": { "v": { "is_live": True, "type": "regular", "timestamp": 1680263186359882, "value": "v" } } }
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, [row_0x]), make_partition(2, 0, 'v')],
+            [make_large_partition(0, large_rows), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: promoted index has more blocks, but it is end of partition")
+
+def test_scylla_sstable_validate_large_rows_end_of_rows_not_end_of_pi(cql, scylla_path, temp_workdir, schema1_file, sstable_cache, large_rows):
+    validate_mixed_sstable_pair(
+            [make_large_partition(0, large_rows), make_partition(2, 0, 'v')],
+            [make_large_partition(0, large_rows[:96]), make_partition(2, 0, 'v')],
+            scylla_path,
+            sstable_cache,
+            temp_workdir,
+            schema_file = schema1_file,
+            error_message = "mismatching index/data: promoted index has no more blocks, but partition")

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -18,30 +18,6 @@ import random
 import shutil
 import util
 
-# To run the Scylla tools, we need to run Scylla executable itself, so we
-# need to find the path of the executable that was used to run Scylla for
-# this test. We do this by trying to find a local process which is listening
-# to the address and port to which our our CQL connection is connected.
-# If such a process exists, we verify that it is Scylla, and return the
-# executable's path. If we can't find the Scylla executable we use
-# pytest.skip() to skip tests relying on this executable.
-@pytest.fixture(scope="module")
-def scylla_path(cql):
-    pid = util.local_process_id(cql)
-    if not pid:
-        pytest.skip("Can't find local Scylla process")
-    # Now that we know the process id, use /proc to find the executable.
-    try:
-        path = os.readlink(f'/proc/{pid}/exe')
-    except:
-        pytest.skip("Can't find local Scylla executable")
-    # Confirm that this executable is a real tool-providing Scylla by trying
-    # to run it with the "--list-tools" option
-    try:
-        subprocess.check_output([path, '--list-tools'])
-    except:
-        pytest.skip("Local server isn't Scylla")
-    return path
 
 # A fixture for finding Scylla's data directory. We get it using the CQL
 # interface to Scylla's configuration. Note that if the server is remote,
@@ -539,13 +515,6 @@ def test_scylla_sstable_script(cql, test_keyspace, scylla_path, scylla_data_dir,
 
         assert dump_lua_json == cxx_json
         assert slice_lua_json == cxx_json
-
-
-@pytest.fixture(scope="function")
-def temp_workdir():
-    """ Creates a temporary work directory, for the scope of a single test. """
-    with tempfile.TemporaryDirectory() as workdir:
-        yield workdir
 
 
 @pytest.fixture(scope="class")

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -948,9 +948,8 @@ void validate_operation(schema_ptr schema, reader_permit permit, const std::vect
 
     abort_source abort;
     for (const auto& sst : sstables) {
-        sst_log.info("validating {}", sst->get_filename());
         const auto errors = sst->validate(permit, default_priority_class(), abort, [] (sstring what) { sst_log.info("{}", what); }).get();
-        sst_log.info("validated {}: {}", sst->get_filename(), errors == 0 ? "valid" : "invalid");
+        fmt::print("{}: {}\n", sst->get_filename(), errors == 0 ? "valid" : "invalid");
     }
 }
 


### PR DESCRIPTION
In addition to the data file itself. Currently validation avoids the
index altogether, using the crawling reader which only relies on the
data file and ignores the index+summary. This is because a corrupt
sstable usually has a corrupt index too and using both at the same time
might hide the corruption. This patch adds targeted validation of the
index, independent of and in addition to the already existing data
validation: it validates the order of index entries as well as whether
the entry points to a complete partition in the data file.
This will usually result in duplicate errors for out-of-order
partitions: one for the data file and one for the index file.

Fixes: #9611