### PR TITLE
Add support for TRUNCATE USING TIMEOUT

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -44,7 +44,7 @@ options {
 #include "cql3/statements/drop_aggregate_statement.hh"
 #include "cql3/statements/drop_service_level_statement.hh"
 #include "cql3/statements/detach_service_level_statement.hh"
-#include "cql3/statements/truncate_statement.hh"
+#include "cql3/statements/raw/truncate_statement.hh"
 #include "cql3/statements/raw/update_statement.hh"
 #include "cql3/statements/raw/insert_statement.hh"
 #include "cql3/statements/raw/delete_statement.hh"
@@ -1072,10 +1072,18 @@ dropIndexStatement returns [std::unique_ptr<drop_index_statement> expr]
     ;
 
 /**
-  * TRUNCATE <CF>;
+  * TRUNCATE [TABLE] <CF>
+  * [USING TIMEOUT <duration>];
   */
-truncateStatement returns [std::unique_ptr<truncate_statement> stmt]
-    : K_TRUNCATE (K_COLUMNFAMILY)? cf=columnFamilyName { $stmt = std::make_unique<truncate_statement>(cf); }
+truncateStatement returns [std::unique_ptr<raw::truncate_statement> stmt]
+    @init {
+        auto attrs = std::make_unique<cql3::attributes::raw>();
+    }
+    : K_TRUNCATE (K_COLUMNFAMILY)? cf=columnFamilyName
+      ( usingTimeoutClause[attrs] )?
+      {
+        $stmt = std::make_unique<raw::truncate_statement>(std::move(cf), std::move(attrs));
+      }
     ;
 
 /**

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -371,7 +371,8 @@ useStatement returns [std::unique_ptr<raw::use_statement> stmt]
  * SELECT [JSON] <expression>
  * FROM <CF>
  * WHERE KEY = "key1" AND COL > 1 AND COL < 100
- * LIMIT <NUMBER>;
+ * LIMIT <NUMBER>
+ * [USING TIMEOUT <duration>];
  */
 selectStatement returns [std::unique_ptr<raw::select_statement> expr]
     @init {
@@ -398,7 +399,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
       ( K_LIMIT rows=intValue { limit = rows; } )?
       ( K_ALLOW K_FILTERING  { allow_filtering = true; } )?
       ( K_BYPASS K_CACHE { bypass_cache = true; })?
-      ( usingClause[attrs] )?
+      ( usingTimeoutClause[attrs] )?
       {
           auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
           $expr = std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
@@ -525,6 +526,10 @@ usingTimestampTimeoutClause[std::unique_ptr<cql3::attributes::raw>& attrs]
 usingTimestampTimeoutClauseObjective[std::unique_ptr<cql3::attributes::raw>& attrs]
     : K_TIMESTAMP ts=intValue { attrs->timestamp = ts; }
     | K_TIMEOUT to=term { attrs->timeout = to; }
+    ;
+
+usingTimeoutClause[std::unique_ptr<cql3::attributes::raw>& attrs]
+    : K_USING K_TIMEOUT to=term { attrs->timeout = to; }
     ;
 
 /**

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -99,9 +99,7 @@ delete_statement::delete_statement(cf_name name,
     , _deletions(std::move(deletions))
     , _where_clause(std::move(where_clause))
 {
-    if (_attrs->time_to_live) {
-        throw exceptions::invalid_request_exception("TTL attribute is not allowed for deletes");
-    }
+    assert(!_attrs->time_to_live.has_value());
 }
 
 }

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -39,7 +39,7 @@ private:
     const bool _if_not_exists;
     const bool _if_exists;
 protected:
-    modification_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, conditions_vector conditions, bool if_not_exists, bool if_exists);
+    modification_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, conditions_vector conditions = {}, bool if_not_exists = false, bool if_exists = false);
 
 public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/raw/truncate_statement.hh
+++ b/cql3/statements/raw/truncate_statement.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include "cql3/statements/raw/cf_statement.hh"
+#include "cql3/attributes.hh"
+
+namespace cql3 {
+
+namespace statements {
+
+namespace raw {
+
+class truncate_statement : public raw::cf_statement {
+private:
+    std::unique_ptr<attributes::raw> _attrs;
+public:
+    /**
+     * Creates a new truncate_statement from a column family name, and attributes.
+     *
+     * @param name column family being operated on
+     * @param attrs additional attributes for statement (timeout)
+     */
+    truncate_statement(cf_name name, std::unique_ptr<attributes::raw> attrs);
+
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+};
+
+} // namespace raw
+
+} // namespace statements
+
+} // namespace cql3

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1573,12 +1573,8 @@ parallelized_select_statement::do_execute(
 namespace raw {
 
 static void validate_attrs(const cql3::attributes::raw& attrs) {
-    if (attrs.timestamp) {
-        throw exceptions::invalid_request_exception("Specifying TIMESTAMP is not legal for SELECT statement");
-    }
-    if (attrs.time_to_live) {
-        throw exceptions::invalid_request_exception("Specifying TTL is not legal for SELECT statement");
-    }
+    assert(!attrs.timestamp.has_value());
+    assert(!attrs.time_to_live.has_value());
 }
 
 select_statement::select_statement(cf_name cf_name,

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "cql3/statements/raw/truncate_statement.hh"
 #include "cql3/statements/truncate_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/cql_statement.hh"
@@ -15,25 +16,59 @@
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 #include <optional>
+#include "validation.hh"
 
 namespace cql3 {
 
 namespace statements {
 
-truncate_statement::truncate_statement(cf_name name)
-    : cf_statement{std::move(name)}
-    , cql_statement_no_metadata(&timeout_config::truncate_timeout)
+namespace raw {
+
+truncate_statement::truncate_statement(cf_name name, std::unique_ptr<attributes::raw> attrs)
+        : cf_statement(std::move(name))
+        , _attrs(std::move(attrs))
 {
+    // Validate the attributes.
+    // Currently, TRUNCATE supports only USING TIMEOUT
+    assert(!_attrs->timestamp.has_value());
+    assert(!_attrs->time_to_live.has_value());
+}
+
+std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+    schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
+    auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());
+    auto ctx = get_prepare_context();
+    prepared_attributes->fill_prepare_context(ctx);
+    auto stmt = ::make_shared<cql3::statements::truncate_statement>(std::move(schema), std::move(prepared_attributes));
+    return std::make_unique<prepared_statement>(std::move(stmt));
+}
+
+} // namespace raw
+
+truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs)
+    : cql_statement_no_metadata(&timeout_config::truncate_timeout)
+    , _schema{std::move(schema)}
+    , _attrs(std::move(prepared_attrs))
+{
+}
+
+truncate_statement::truncate_statement(const truncate_statement& ts)
+    : cql_statement_no_metadata(ts)
+    , _schema(ts._schema)
+    , _attrs(std::make_unique<attributes>(*ts._attrs))
+{ }
+
+const sstring& truncate_statement::keyspace() const {
+    return _schema->ks_name();
+}
+
+const sstring& truncate_statement::column_family() const {
+    return _schema->cf_name();
 }
 
 uint32_t truncate_statement::get_bound_terms() const
 {
     return 0;
-}
-
-std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db,cql_stats& stats)
-{
-    return std::make_unique<prepared_statement>(::make_shared<truncate_statement>(*this));
 }
 
 bool truncate_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
@@ -60,11 +95,16 @@ truncate_statement::execute(query_processor& qp, service::query_state& state, co
     if (qp.db().find_schema(keyspace(), column_family())->is_view()) {
         throw exceptions::invalid_request_exception("Cannot TRUNCATE materialized view directly; must truncate base table instead");
     }
-    return qp.proxy().truncate_blocking(keyspace(), column_family()).handle_exception([](auto ep) {
+    auto timeout_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(get_timeout(state.get_client_state(), options));
+    return qp.proxy().truncate_blocking(keyspace(), column_family(), timeout_in_ms).handle_exception([](auto ep) {
         throw exceptions::truncate_exception(ep);
     }).then([] {
         return ::shared_ptr<cql_transport::messages::result_message>{};
     });
+}
+
+db::timeout_clock::duration truncate_statement::get_timeout(const service::client_state& state, const query_options& options) const {
+    return _attrs->is_timeout_set() ? _attrs->get_timeout(options) : state.get_timeout_config().truncate_timeout;
 }
 
 }

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -50,8 +50,7 @@ duration and applies it as a timeout specific to a single particular query.
 The parameter is supported for prepared statements as well.
 The parameter acts as part of the USING clause, and thus can be combined with other
 parameters - like timestamps and time-to-live.
-In order for this parameter to be effective for read operations as well, it's possible
-to attach USING clause to SELECT statements.
+For example, one can use ``USING TIMEOUT ... and TTL ...`` to specify both a non-default timeout and a ttl.
 
 Examples:
 ```cql
@@ -59,6 +58,9 @@ Examples:
 ```
 ```cql
 	INSERT INTO t(a,b,c) VALUES (1,2,3) USING TIMESTAMP 42 AND TIMEOUT 50ms;
+```
+```cql
+	TRUNCATE TABLE t USING TIMEOUT 5m;
 ```
 
 Working with prepared statements works as usual - the timeout parameter can be
@@ -70,6 +72,12 @@ explicitly defined or provided as a marker:
 ```cql
 	INSERT INTO t(a,b,c) VALUES (?,?,?) USING TIMESTAMP 42 AND TIMEOUT 50ms;
 ```
+
+The timeout parameter can be applied to the following data modification queries:
+INSERT, UPDATE, DELETE, PRUNE MATERIALIZED VIEW, BATCH,
+and to the TRUNCATE data definition query.
+
+In addition, the timeout parameter can be applied to SELECT queries as well.
 
 ## Keyspace storage options
 

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -958,11 +958,19 @@ A table can be truncated using the ``TRUNCATE`` statement:
 .. code-block::
    
    truncate_statement: TRUNCATE [ TABLE ] `table_name`
+                     : [ USING TIMEOUT `timeout` ]
+   timeout: `duration`
 
 Note that ``TRUNCATE TABLE foo`` is allowed for consistency with other DDL statements, but tables are the only object
 that can be truncated currently and so the ``TABLE`` keyword can be omitted.
 
 Truncating a table permanently removes all existing data from the table, but without removing the table itself.
+
+The ``USING TIMEOUT`` clause allows specifying a timeout for a specific request.
+
+For example::
+
+  TRUNCATE TABLE users USING TIMEOUT 5m;
 
 .. caution:: Do not run any operation on a table that is being truncated. Truncate operation is an administrative operation, and running any other operation on the same table in parallel may cause the truncating table's data to end up in an undefined state.
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -585,8 +585,9 @@ public:
      * the column family cfname
      * @param keyspace
      * @param cfname
+     * @param timeout (default: use truncate_request_timeout_in_ms config)
      */
-    future<> truncate_blocking(sstring keyspace, sstring cfname);
+    future<> truncate_blocking(sstring keyspace, sstring cfname, std::optional<std::chrono::milliseconds> timeout_in_ms = std::nullopt);
 
     /*
      * Executes data query on the whole cluster.

--- a/test/cql-pytest/test_using_timeout.py
+++ b/test/cql-pytest/test_using_timeout.py
@@ -153,7 +153,7 @@ def test_invalid_timeout(scylla_only, cql, table1):
 
     # For select statements, it's not allowed to specify timestamp or ttl,
     # since they bear no meaning
-    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TIMESTAMP 42")
-    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 10000")
-    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 123 AND TIMESTAMP 911")
+    invalid_syntax(f"SELECT * FROM {table} USING TIMEOUT 60s AND TIMESTAMP 42")
+    invalid_syntax(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 10000")
+    invalid_syntax(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 123 AND TIMESTAMP 911")
     invalid_syntax(f"DELETE FROM {table} USING TIMEOUT 60s AND TTL 42 WHERE p = 42")


### PR DESCRIPTION
Extend the cql3 truncate statement to accept attributes,
similar to modification statements.

To achieve that we define cql3::statements::raw::truncate_statement
derived from raw::cf_statement, and implement its pure virtual
prepare() method to make a prepared truncate_statement.

The latter is no longer derived from raw::cf_statement,
and just stores a schema_ptr to get to the keyspace and column_family.

`test_truncate_using_timeout` cql-pytest was added to test
the new USING TIMEOUT feature.
    
Fixes #11408

Also, update docs/cql/ddl.rst truncate-statement section respectively.