### PR TITLE
wasm: Reuse instances across scheduling groups

### DIFF
--- a/lang/wasm_instance_cache.cc
+++ b/lang/wasm_instance_cache.cc
@@ -145,9 +145,11 @@ seastar::future<instance_cache::value_type> instance_cache::get(const db::functi
 
 void instance_cache::recycle(instance_cache::value_type val) noexcept {
     val->mutex.unlock();
-    size_t size;
+    size_t size = 0;
     try {
-        size = get_instance_size(val->instance.value());
+        if (val->instance) {
+            size = get_instance_size(val->instance.value());
+        }
         if (size > 1 * MB) {
             val->instance = std::nullopt;
             return;


### PR DESCRIPTION
This series improves the wasm instance cache so that it now can
reuse instances that originate from other scheduling groups. The
motivation for this change is included in the corresponding commit
message.

To test this, a change to the test cql environment was needed - now
 the wasm instance cache can be used in the boost tests.

This patch also includes a small fix for recycling invalidated instances 