### PR TITLE
Raft test topology start stopped servers

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -144,3 +144,8 @@ class ManagerClient():
         """Remove a specified node"""
         await self._request(f"/cluster/removenode/{server_id}")
         self._driver_update()
+
+    async def start_stopped(self) -> None:
+        """Start all previously stopped servers"""
+        await self._request(f"/cluster/start_stopped")
+        self._driver_update()

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -176,7 +176,7 @@ class RandomTable():
             ctype = ctype if ctype is not None else TextType
             column = Column(name, ctype=ctype)
         self.columns.append(column)
-        self.cql.execute(f"ALTER TABLE {self.full_name} ADD {column.name} {column.ctype.name}")
+        await self.cql.run_async(f"ALTER TABLE {self.full_name} ADD {column.name} {column.ctype.name}")
 
     async def drop_column(self, column: Union[Column, str] = None):
         if column is None:
@@ -196,7 +196,7 @@ class RandomTable():
         assert len(self.columns) - 1 > self.pks, f"Cannot remove last value column {col.name} from {self.name}"
         self.columns.remove(col)
         self.removed_columns.append(col)
-        self.cql.execute(f"ALTER TABLE {self.full_name} DROP {col.name}")
+        await self.cql.run_async(f"ALTER TABLE {self.full_name} DROP {col.name}")
 
     async def insert_seq(self) -> asyncio.Future:
         """Insert a row of next sequential values"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -652,6 +652,17 @@ class ScyllaCluster:
         self.removed.add(server_id)
         return ScyllaCluster.ActionReturn(success=True, msg=f"Server {server_id} removed")
 
+    async def start_stopped(self) -> ActionReturn:
+        """Start a stopped server"""
+        logging.info("Cluster %s starting all stopped servers", self)
+        if not self.stopped:
+            return ScyllaCluster.ActionReturn(success=True, msg=f"No stopped servers")
+        ids = list(self.stopped.keys())
+        await asyncio.gather(*(server.start() for server in self.stopped.values()))
+        self.running.update(self.stopped)
+        self.stopped.clear()
+        return ScyllaCluster.ActionReturn(success=True, msg=f"Re-started servers {','.join(ids)}")
+
 
 class ScyllaClusterManager:
     """Manages a Scylla cluster for running test cases
@@ -728,6 +739,7 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
         self.app.router.add_get('/cluster/addserver', self._cluster_server_add)
         self.app.router.add_get('/cluster/removeserver/{id}', self._cluster_server_remove)
+        self.app.router.add_get('/cluster/start_stopped', self._cluster_start_stopped)
 
     async def _manager_up(self, _request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -811,6 +823,15 @@ class ScyllaClusterManager:
         if not await self.cluster.server_remove(server_id):
             return aiohttp.web.Response(status=500, text=f"Host {server_id} not found")
         return aiohttp.web.Response(text="OK")
+
+    async def _cluster_start_stopped(self, _request) -> aiohttp.web.Response:
+        """Start all previously stopped servers"""
+        assert self.cluster
+        resp = await self.cluster.start_stopped()
+        if not resp.success:
+            return aiohttp.web.Response(status=500, text="Error")
+        return aiohttp.web.Response(status=200, text="OK")
+
 
 @asynccontextmanager
 async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -169,7 +169,9 @@ def fails_without_raft(request, check_pre_raft):
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
 # used in tests to make schema changes. Tables are dropped after finished.
 @pytest.fixture(scope="function")
-def random_tables(request, cql):
+async def random_tables(request, cql, manager):
     tables = RandomTables(request.node.name, cql, unique_name())
     yield tables
+    # NOTE: to avoid occasional timeouts on keyspace teardown, start stopped servers
+    await manager.start_stopped()
     tables.drop_all()


### PR DESCRIPTION
Test teardown involves dropping the test keyspace. If there are stopped servers occasionally we would see timeouts.

Start stopped servers after a test is finished (and passed).

Revert previous commit making teardown async again.