### PR TITLE
scripts: introduce script to apply email, working around google groups brokeness

### DIFF
--- a/docs/dev/maintainer.md
+++ b/docs/dev/maintainer.md
@@ -75,9 +75,11 @@ to see if you forgot to push a previously applied patch.
 
 Save the patch(es) to some directory, and use the command
 
-    git am -im3 /path/to/patches/*.eml
+    ./scripts/apply-mail.py /path/to/patches/*.eml
 
-to apply the patches. `-i` makes the process interactive and
+to apply the patches. This fixes up From: headers corrupted
+by Google Groups and calls `git am -3mi` on the result.
+`-i` makes the process interactive and
 lets you edit the commit message, `-m` sets the Message-Id
 tag (which is used by Commit Bot to set the Reply-To header,
 so that the commit acknowledgement appears as a response to

--- a/scripts/apply-mail.py
+++ b/scripts/apply-mail.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import email
+import argparse
+import re
+import tempfile
+import os
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('emails', metavar='FILE', nargs='+',
+                            help='Files with email message containing a patch')
+
+
+args = argparser.parse_args()
+
+bad_google = re.compile(r'".* via .*" <.*@googlegroups.com>')
+
+temps = []
+
+for email_file in args.emails:
+    e = email.message_from_file(open(email_file))
+    author = e.get('From')
+    m = re.fullmatch(bad_google, author)
+    if m:
+        e.replace_header('From', e.get('Reply-To'))
+    o = tempfile.NamedTemporaryFile()
+    o.write(bytes(e))
+    temps.append(o)
+
+names = str.join(' ', [f.name for f in temps])
+
+os.system(f'git am -3mi {names}')
+
+    
+    


### PR DESCRIPTION
Google Groups recently started rewriting the From: header, garbaging
our git log. This script rewrites it back, using the Reply-To header
as a still working source.