### PR TITLE
doc: update the "Counting all rows in a table is slow" page

### DIFF
--- a/docs/cql/dml.rst
+++ b/docs/cql/dml.rst
@@ -99,11 +99,12 @@ alternatively, of the wildcard character (``*``) to select all the columns defin
 Selectors
 `````````
 
-A :token:`selector` can be one of:
+A :token:`selector` can be one of the following:
 
 - A column name of the table selected to retrieve the values for that column.
 - A casting, which allows you to convert a nested selector to a (compatible) type.
 - A function call, where the arguments are selector themselves.
+- A call to the :ref:`COUNT function <count-function>`, which counts all non-null results.
 
 Aliases
 ```````

--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -261,6 +261,10 @@ It also can be used to count the non-null value of a given column::
 
     SELECT COUNT (scores) FROM plays;
 
+.. note::
+    Counting all rows in a table may be time-consuming and exceed the default timeout. In such a case, 
+    see :doc:`Counting all rows in a table is slow </kb/count-all-rows>` for instructions.
+
 Max and Min
 ```````````
 

--- a/docs/kb/count-all-rows.rst
+++ b/docs/kb/count-all-rows.rst
@@ -2,7 +2,7 @@
 Counting all rows in a table is slow
 ====================================
 
-**Audience: Scylla users**
+**Audience: ScyllaDB users**
 
 Trying to count all rows in a table using
 
@@ -10,14 +10,19 @@ Trying to count all rows in a table using
 
    SELECT COUNT(1) FROM ks.table;
 
-often fails with **ReadTimeout** error.
+may fail with the **ReadTimeout** error.
 
-COUNT() is running a full-scan query on all nodes, which might take a long time to finish. Often the time is greater than Scylla query timeout. 
-One way to bypass this in Scylla 4.4 or later is increasing the timeout for this query using the :ref:`USING TIMEOUT <using-timeout>` directive, for example:
+COUNT() runs a full-scan query on all nodes, which might take a long time to finish. As a result, the count time may be greater than the ScyllaDB query timeout. 
+One way to prevent that issue in Scylla 4.4 or later is to increase the timeout for the query using the :ref:`USING TIMEOUT <using-timeout>` directive, for example:
 
 
 .. code-block:: cql
 
    SELECT COUNT(1) FROM ks.table USING TIMEOUT 120s;
 
-You can also get an *estimation* of the number **of partitions** (not rows) with :doc:`nodetool tablestats </operating-scylla/nodetool-commands/tablestats>`
+You can also get an *estimation* of the number **of partitions** (not rows) with :doc:`nodetool tablestats </operating-scylla/nodetool-commands/tablestats>`.
+
+.. note::
+    ScyllaDB 5.1 includes improvements to speed up the execution of SELECT COUNT(*) queries. 
+    To increase the count speed, we recommend upgrading to ScyllaDB 5.1 or later. 
+ 

--- a/docs/kb/count-all-rows.rst
+++ b/docs/kb/count-all-rows.rst
@@ -26,3 +26,5 @@ You can also get an *estimation* of the number **of partitions** (not rows) with
     ScyllaDB 5.1 includes improvements to speed up the execution of SELECT COUNT(*) queries. 
     To increase the count speed, we recommend upgrading to ScyllaDB 5.1 or later. 
  
+
+ .. REMOVE IN FUTURE VERSIONS - Remove the note above in version 5.1.


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11373

- Updated the information on the "Counting all rows in a table is slow" page.
- Added COUNT to the list of selectors of the SELECT statement (somehow it was missing).
- Added the note to the description of the COUNT() function with a link to the KB page for troubleshooting if necessary. This will allow the users to easily find the KB page.