### PR TITLE
doc: change the tool names to "Scylla SStable" and "Scylla Types"

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -3,7 +3,7 @@
 * :doc:`REST - Scylla REST/HTTP Admin API</operating-scylla/rest>`.
 * :doc:`Tracing </using-scylla/tracing>` - a ScyllaDB tool for debugging and analyzing internal flows in the server. 
 * :doc:`SSTableloader </operating-scylla/admin-tools/sstableloader>` - Bulk load the sstables found in the directory to a Scylla cluster
-* :doc:`scylla-sstable </operating-scylla/admin-tools/scylla-sstable>` - Validates and dumps the content of SStables, generates a histogram, dumps the content of the SStable index.
+* :doc:`Scylla SStable </operating-scylla/admin-tools/scylla-sstable>` - Validates and dumps the content of SStables, generates a histogram, dumps the content of the SStable index.
 * :doc:`scylla-types </operating-scylla/admin-tools/scylla-types/>` - Examines raw values obtained from SStables, logs, coredumps, etc.
 * :doc:`cassandra-stress </operating-scylla/admin-tools/cassandra-stress/>` A tool for benchmarking and load testing a Scylla and Cassandra clusters.
 * :doc:`SSTabledump - Scylla 3.0, Scylla Enterprise 2019.1 and newer versions </operating-scylla/admin-tools/sstabledump>`

--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -4,7 +4,7 @@
 * :doc:`Tracing </using-scylla/tracing>` - a ScyllaDB tool for debugging and analyzing internal flows in the server. 
 * :doc:`SSTableloader </operating-scylla/admin-tools/sstableloader>` - Bulk load the sstables found in the directory to a Scylla cluster
 * :doc:`Scylla SStable </operating-scylla/admin-tools/scylla-sstable>` - Validates and dumps the content of SStables, generates a histogram, dumps the content of the SStable index.
-* :doc:`scylla-types </operating-scylla/admin-tools/scylla-types/>` - Examines raw values obtained from SStables, logs, coredumps, etc.
+* :doc:`Scylla Types </operating-scylla/admin-tools/scylla-types/>` - Examines raw values obtained from SStables, logs, coredumps, etc.
 * :doc:`cassandra-stress </operating-scylla/admin-tools/cassandra-stress/>` A tool for benchmarking and load testing a Scylla and Cassandra clusters.
 * :doc:`SSTabledump - Scylla 3.0, Scylla Enterprise 2019.1 and newer versions </operating-scylla/admin-tools/sstabledump>`
 * :doc:`SSTable2JSON - Scylla 2.3 and older </operating-scylla/admin-tools/sstable2json>`

--- a/docs/operating-scylla/admin-tools/index.rst
+++ b/docs/operating-scylla/admin-tools/index.rst
@@ -9,8 +9,8 @@ Admin Tools
    CQLSh </cql/cqlsh>
    REST </operating-scylla/rest>
    Tracing </using-scylla/tracing>
-   scylla-sstable
-   scylla-types </operating-scylla/admin-tools/scylla-types/>
+   Scylla SStable </operating-scylla/admin-tools/scylla-sstable/>
+   Scylla Types </operating-scylla/admin-tools/scylla-types/>
    sstableloader
    cassandra-stress </operating-scylla/admin-tools/cassandra-stress/>
    sstabledump

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -1,4 +1,4 @@
-scylla-sstable
+Scylla SStable
 ==============
 
 .. versionadded:: 5.0
@@ -9,15 +9,15 @@ Introduction
 This tool allows you to examine the content of SStables by performing operations such as dumping the content of SStables,
 generating a histogram, validating the content of SStables, and more. See `Supported Operations`_ for the list of available operations.
 
-Run ``scylla-sstable --help`` for additional information about the tool and the operations.
+Run ``scylla sstable --help`` for additional information about the tool and the operations.
 
 This tool is similar to SStableDump_, with notable differences:
 
 * Built on the ScyllaDB C++ codebase, it supports all SStable formats and components that ScyllaDB supports.
 * Expanded scope: this tool supports much more than dumping SStable data components (see `Supported Operations`_).
-* More flexible on how schema is obtained and where SStables are located: SStableDump_ only supports dumping SStables located in their native data directory. To dump an SStable, one has to clone the entire ScyllaDB data directory tree, including system table directories and even config files. scylla-sstable can dump sstables from any path with multiple choices on how to obtain the schema, see Schema_.
+* More flexible on how schema is obtained and where SStables are located: SStableDump_ only supports dumping SStables located in their native data directory. To dump an SStable, one has to clone the entire ScyllaDB data directory tree, including system table directories and even config files. ``scylla sstable`` can dump sstables from any path with multiple choices on how to obtain the schema, see Schema_.
 
-Currently, SStableDump_ works better on production systems as it automatically loads the schema from the system tables, unlike scylla-sstable, which has to be provided with the schema explicitly. On the other hand scylla-sstable works better for off-line investigations, as it can be used with as little as just a schema definition file and a single sstable. In the future we plan on closing this gap -- adding support for automatic schema-loading for scylla-sstable too -- and completely supplant SStableDump_ with scylla-sstable.
+Currently, SStableDump_ works better on production systems as it automatically loads the schema from the system tables, unlike ``scylla sstable``, which has to be provided with the schema explicitly. On the other hand ``scylla sstable`` works better for off-line investigations, as it can be used with as little as just a schema definition file and a single sstable. In the future we plan on closing this gap -- adding support for automatic schema-loading for ``scylla sstable`` too -- and completely supplant SStableDump_ with ``scylla sstable``.
 
 .. _SStableDump: /operating-scylla/admin-tools/sstabledump
 
@@ -31,7 +31,7 @@ The command syntax is as follows:
 
 .. code-block:: console
 
-   scylla-sstable <operation> <path to SStable>
+   scylla sstable <operation> <path to SStable>
 
 
 You can specify more than one SStable.
@@ -105,7 +105,7 @@ If the examined table is a system table -- it belongs to one of the system keysp
 
 .. code-block:: console
 
-    scylla-sstable dump-data --system-schema system.local ./path/to/md-123456-big-Data.db
+    scylla sstable dump-data --system-schema system.local ./path/to/md-123456-big-Data.db
 
 Supported Operations
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,17 +137,17 @@ Dumping the content of the SStable:
 
 .. code-block:: console
 
-   scylla-sstable dump-data /path/to/md-123456-big-Data.db
+   scylla sstable dump-data /path/to/md-123456-big-Data.db
 
 Dumping the content of two SStables as a unified stream:
 
 .. code-block:: console
 
-   scylla-sstable dump-data --merge /path/to/md-123456-big-Data.db /path/to/md-123457-big-Data.db
+   scylla sstable dump-data --merge /path/to/md-123456-big-Data.db /path/to/md-123457-big-Data.db
 
 
 Validating the specified SStables:
 
 .. code-block:: console
 
-   scylla-sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-Data.db
+   scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-Data.db

--- a/docs/operating-scylla/admin-tools/scylla-types.rst
+++ b/docs/operating-scylla/admin-tools/scylla-types.rst
@@ -1,4 +1,4 @@
-scylla-types
+Scylla Types
 ==============
 
 .. versionadded:: 5.0
@@ -26,7 +26,7 @@ The command syntax is as follows:
 * Provide the values in the hex form without a leading 0x prefix.
 * You must specify the type of the provided values. See :ref:`Specifying the Value Type <scylla-types-type>`.
 * The number of provided values depends on the operation. See :ref:`Supported Operations <scylla-types-operations>` for details.
-* The scylla-types operations come with additional options. See :ref:`Additional Options <scylla-types-options>` for the list of options.
+* The ``scylla types`` operations come with additional options. See :ref:`Additional Options <scylla-types-options>` for the list of options.
 
 .. _scylla-types-type:
 

--- a/docs/using-scylla/features-open-source.rst
+++ b/docs/using-scylla/features-open-source.rst
@@ -25,8 +25,8 @@ Scylla Open Source Features
     the implementation of Raft, schema changes in ScyllaDB are safe, including concurrent schema updates. 
     This feature is experimental in version 5.0 and needs to be explicitly enabled.
 
-  * :doc:`scylla-sstable tool </operating-scylla/admin-tools/scylla-sstable/>` - An admin tool that allows you to examine the content of SStables by performing operations such as dumping the content of SStables, generating a histogram, validating the content of SStables, and more.
-  * :doc:`scylla-types tool </operating-scylla/admin-tools/scylla-types/>` - An admin tool that allows you to examine raw values obtained from SStables, logs, coredumps, etc., by printing, validating or comparing the values.
+  * :doc:`Scylla SStable tool </operating-scylla/admin-tools/scylla-sstable/>` - An admin tool that allows you to examine the content of SStables by performing operations such as dumping the content of SStables, generating a histogram, validating the content of SStables, and more.
+  * :doc:`Scylla Types tool </operating-scylla/admin-tools/scylla-types/>` - An admin tool that allows you to examine raw values obtained from SStables, logs, coredumps, etc., by printing, validating or comparing the values.
   * :doc:`Virtual Tables </operating-scylla/admin-tools/virtual-tables/>` - Tables that retrieve system-level information by generating their contents on-the-fly when queried.
 
 		* Virtual table for configuration - ``system.config``, allows you to query and update configuration over CQL.


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11393

- Rename the tool names across the docs.
- Update the examples to replace `scylla-sstable` and `scylla-types` with `scylla sstable` and `scylla types`, respectively.