### PR TITLE
Backport a few Alternator TTL patches to 5.0

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -504,6 +504,8 @@ struct scan_ranges_context {
         selection = cql3::selection::selection::wildcard(s);
         query::partition_slice::option_set opts = selection->get_query_options();
         opts.set<query::partition_slice::option::allow_short_read>();
+        // It is important that the scan bypass cache to avoid polluting it:
+        opts.set<query::partition_slice::option::bypass_cache>();
         std::vector<query::clustering_range> ck_bounds{query::clustering_range::make_open_ended_both_sides()};
         auto partition_slice = query::partition_slice(std::move(ck_bounds), {}, std::move(regular_columns), opts);
         command = ::make_lw_shared<query::read_command>(s->id(), s->version(), partition_slice, proxy.get_max_result_size(partition_slice));

--- a/db/config.cc
+++ b/db/config.cc
@@ -860,6 +860,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", value_status::Used, 10000,
         "The server-side timeout for completing Alternator API requests.")
+    , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
+        60*60*24,
+        "The default period for Alternator's expiration scan. Alternator attempts to scan every table within that period.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -346,6 +346,7 @@ public:
     named_value<sstring> alternator_write_isolation;
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;
+    named_value<uint32_t> alternator_ttl_period_in_seconds;
 
     named_value<bool> abort_on_ebadf;
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -108,8 +108,21 @@ they should be easy to detect. Here is a list of these unimplemented features:
   are projected. This wastes some disk space when it is not needed.
   https://github.com/scylladb/scylla/issues/5036
 
-* DynamoDB's TTL (per-item expiration) feature is not supported. Note that
-  this is a different feature from Scylla's feature with the same name.
+* DynamoDB's TTL (item expiration) feature is supported, but in this release
+  still considered experimental and needs to be enabled explicitly with the
+  `--experimental-features=alternator-ttl` configuration option.
+  The experimental implementation is mostly complete, but not throughly
+  tested or optimized.
+  Like in DynamoDB, Alternator items which are set to expire at a certain
+  time will not disappear exactly at that time, but only after some delay.
+  DynamoDB guarantees that the expiration delay will be less than 48 hours
+  (though for small tables the delay is often much shorter). In Alternator,
+  the expiration delay is configurable - it defaults to 24 hours but can
+  be set with the `--alternator-ttl-period-in-seconds` configuration option.
+
+  One thing that this implementation is still missing is that expiration
+  events appear in the Streams API as normal deletions - without the
+  distinctive marker on deletions which are really expirations.
   https://github.com/scylladb/scylla/issues/5060
 
 * DynamoDB's new multi-item transaction feature (TransactWriteItems,

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -35,6 +35,7 @@ def run_alternator_cmd(pid, dir):
         '--alternator-write-isolation', 'always_use_lwt',
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
+        '--alternator-ttl-period-in-seconds', '1',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # We only list here Alternator-specific experimental features - CQL


### PR DESCRIPTION
Although branch 5.0 has most of the Alternator TTL feature, it was missing a few important patches. These are:

* c26230943b882f2d3e0654345043ef507e280c5b: alternator ttl: add metrics
* db7b11cfc49145fc4f84427d6b28c517f842f811: alternator: make TTL expiration scanner bypass cache
* e06b5d9306446a4956feec9dd6d7a80f51866388: alternator: updated compatibility.md about TTL feature
* 49a8164fb7e6741049e7417c3d446558192f61e6: alternator: add configurable scan period to TTL expiration

Although none of these patches fix regressions, arguably the feature is broken without the configurable scan period (before it, the scan happened all the time at full speed), and without bypassing cache (because scan could significantly hurt regular read performance). The metrics is also something we need for debugging this feature in real deployments.

I propose backporting these patches to next-5.0 (and from it to other branches which are based on branch-5.0).
branch-5.1 already has all these patches.