### PR TITLE
doc: fix the architecture type on the upgrade page

### DIFF
--- a/docs/upgrade/_common/upgrade-image.rst
+++ b/docs/upgrade/_common/upgrade-image.rst
@@ -16,7 +16,7 @@ This installation upgrade method allows you to upgrade your ScyllaDB version and
     Where:
 
       * ``<version>`` - The Scylla version to which you are upgrading ( |NEW_VERSION| ).
-      * ``<arch>`` - Architecture type: ``x86`` or ``aarch644``.
+      * ``<arch>`` - Architecture type: ``x86_64`` or ``aarch64``.
     
     The file is included in the ScyllaDB packages downloaded in the previous step. The file location is:
 


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11429 