### PR TITLE
build_docker.sh: Build docker based on Ubuntu:22.04

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -40,7 +40,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-container="$(buildah from docker.io/ubuntu:20.04)"
+container="$(buildah from docker.io/ubuntu:22.04)"
 
 packages=(
     "build/dist/$mode/debian/${product}_$version-$release-1_$arch.deb"
@@ -76,7 +76,7 @@ run apt-get -y update
 run apt-get -y install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 run bash -ec "rm -rf /etc/rsyslog.conf"
-run apt-get -y install hostname supervisor openssh-server openssh-client openjdk-11-jre-headless python python-yaml curl rsyslog locales sudo
+run apt-get -y install hostname supervisor openssh-server openssh-client openjdk-11-jre-headless python2.7 python3 python3-yaml curl rsyslog locales sudo
 run locale-gen en_US.UTF-8
 run update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 run bash -ec "dpkg -i packages/*.deb"


### PR DESCRIPTION
Ubuntu 20.04 has less than 3 years of OS support remaining.

We should switch to Ubuntu 22.04 to reduce the need for OS upgrades in newly installed clusters.