### PR TITLE
Safemode - Introduce TimeWindowCompactionStrategy Guardrails

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -43,6 +43,10 @@ time_window_compaction_strategy_options::time_window_compaction_strategy_options
         }
     }
 
+    if (window_size <= 0) {
+        throw exceptions::configuration_exception(fmt::format("{} must be greater than 1 for compaction_window_size", window_size));
+    }
+
     sstable_window_size = window_size * window_unit;
 
     it = options.find(EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_KEY);

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -409,7 +409,8 @@ cql3::statements::alter_table_statement::prepare(data_dictionary::database db, c
 
 future<::shared_ptr<messages::result_message>>
 alter_table_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
-    std::optional<sstring> warning = check_restricted_table_properties(qp, keyspace(), column_family(), *_properties);
+    auto s = validation::validate_column_family(qp.db(), keyspace(), column_family());
+    std::optional<sstring> warning = check_restricted_table_properties(qp, s, keyspace(), column_family(), *_properties);
     return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -30,6 +30,7 @@
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "db/config.hh"
+#include "compaction/time_window_compaction_strategy.hh"
 
 namespace cql3 {
 
@@ -435,6 +436,19 @@ std::optional<sstring> check_restricted_table_properties(
     // function before cfprops.validate() (there, validate() is only called
     // in prepare_schema_mutations(), in the middle of execute).
     auto strategy = cfprops.get_compaction_strategy_class();
+    sstables::compaction_strategy_type current_strategy = sstables::compaction_strategy_type::null;
+    gc_clock::duration current_ttl = gc_clock::duration::zero();
+    // cfprops doesn't return any of the table attributes unless the attribute
+    // has been specified in the CQL statement. If a schema is defined, then
+    // this was an ALTER TABLE statement.
+    if (schema) {
+        current_strategy = (*schema)->compaction_strategy();
+        current_ttl = (*schema)->default_time_to_live();
+    }
+
+    // Evaluate whether the strategy to evaluate was explicitly passed
+    auto cs = (strategy) ? strategy : current_strategy;
+
     if (strategy && *strategy == sstables::compaction_strategy_type::date_tiered) {
         switch(qp.db().get_config().restrict_dtcs()) {
         case db::tri_mode_restriction_t::mode::TRUE:
@@ -453,6 +467,31 @@ std::optional<sstring> check_restricted_table_properties(
             break;
         }
     }
+    if (cs == sstables::compaction_strategy_type::time_window) {
+        std::map<sstring, sstring> options = (strategy) ? cfprops.get_compaction_type_options() : (*schema)->compaction_strategy_options();
+        sstables::time_window_compaction_strategy_options twcs_options(options);
+        long ttl = (cfprops.has_property(cf_prop_defs::KW_DEFAULT_TIME_TO_LIVE)) ? cfprops.get_default_time_to_live() : current_ttl.count();
+        auto max_windows = qp.db().get_config().twcs_max_window_count();
+
+        // It may happen that an user tries to update an unrelated table property. Allow the request through.
+        if (!cfprops.has_property(cf_prop_defs::KW_DEFAULT_TIME_TO_LIVE) && !strategy) {
+            return std::nullopt;
+        }
+
+        if (ttl > 0) {
+            // Ideally we should not need the window_size check below. However, given #2336 it may happen that some incorrectly
+            // table created with a window_size=0 may exist, which would cause a division by zero (eg: in an ALTER statement).
+            // Given that, an invalid window size is treated as 1 minute, which is the smaller "supported" window size for TWCS.
+            auto window_size = twcs_options.get_sstable_window_size() > std::chrono::seconds::zero() ? twcs_options.get_sstable_window_size() : std::chrono::seconds(60);
+            auto window_count = std::chrono::seconds(ttl) / window_size;
+            if (max_windows > 0 && window_count > max_windows) {
+                throw exceptions::configuration_exception(fmt::format("The setting of default_time_to_live={} and compaction window={}(s) "
+                                                   "can lead to {} windows, which is larger than the allowed number of windows specified "
+                                                   "by the twcs_max_window_count ({}) parameter. Note that default_time_to_live=0 is also "
+                                                   "highly discouraged.", ttl, twcs_options.get_sstable_window_size().count(), window_count, max_windows));
+            }
+        }
+   }
     return std::nullopt;
 }
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -426,6 +426,7 @@ void create_table_statement::raw_statement::add_column_alias(::shared_ptr<column
 // in the table's options are done elsewhere.
 std::optional<sstring> check_restricted_table_properties(
     query_processor& qp,
+    std::optional<schema_ptr> schema,
     const sstring& keyspace, const sstring& table,
     const cf_prop_defs& cfprops)
 {
@@ -457,7 +458,7 @@ std::optional<sstring> check_restricted_table_properties(
 
 future<::shared_ptr<messages::result_message>>
 create_table_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
-    std::optional<sstring> warning = check_restricted_table_properties(qp, keyspace(), column_family(), *_properties);
+    std::optional<sstring> warning = check_restricted_table_properties(qp, std::nullopt, keyspace(), column_family(), *_properties);
     return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -130,6 +130,7 @@ public:
 
 std::optional<sstring> check_restricted_table_properties(
     query_processor& qp,
+    std::optional<schema_ptr> schema,
     const sstring& keyspace, const sstring& table,
     const cf_prop_defs& cfprops);
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -840,6 +840,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , max_memory_for_unlimited_query_hard_limit(this, "max_memory_for_unlimited_query_hard_limit", "max_memory_for_unlimited_query", liveness::LiveUpdate, value_status::Used, (uint64_t(100) << 20),
             "Maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g. non-paged and reverse queries. "
             "This is the hard limit, queries violating this limit will be aborted.")
+    , twcs_max_window_count(this, "twcs_max_window_count", liveness::LiveUpdate, value_status::Used, 50,
+            "The maximum number of compaction windows allowed when making use of TimeWindowCompactionStrategy. A setting of 0 effectively disables the restriction.")
     , initial_sstable_loading_concurrency(this, "initial_sstable_loading_concurrency", value_status::Used, 4u,
             "Maximum amount of sstables to load in parallel during initialization. A higher number can lead to more memory consumption. You should not need to touch this")
     , enable_3_1_0_compatibility_mode(this, "enable_3_1_0_compatibility_mode", value_status::Used, false,

--- a/db/config.cc
+++ b/db/config.cc
@@ -899,6 +899,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Flush tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them")
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
+    , restrict_twcs_without_default_ttl(this, "restrict_twcs_without_default_ttl", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent creating TimeWindowCompactionStrategy tables without a default TTL. Can be true, false, or warn.")
     , ignore_truncation_record(this, "unsafe_ignore_truncation_record", value_status::Used, false,
         "Ignore truncation record stored in system tables as if tables were never truncated.")
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,

--- a/db/config.hh
+++ b/db/config.hh
@@ -377,6 +377,7 @@ public:
     // enjoy:
     named_value<tri_mode_restriction> restrict_replication_simplestrategy;
     named_value<tri_mode_restriction> restrict_dtcs;
+    named_value<tri_mode_restriction> restrict_twcs_without_default_ttl;
 
     named_value<bool> ignore_truncation_record;
     named_value<bool> force_schema_commit_log;

--- a/db/config.hh
+++ b/db/config.hh
@@ -335,6 +335,7 @@ public:
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
     named_value<uint64_t> max_memory_for_unlimited_query_soft_limit;
     named_value<uint64_t> max_memory_for_unlimited_query_hard_limit;
+    named_value<uint32_t> twcs_max_window_count;
     named_value<unsigned> initial_sstable_loading_concurrency;
     named_value<bool> enable_3_1_0_compatibility_mode;
     named_value<bool> enable_user_defined_functions;


### PR DESCRIPTION
This series introduces two configurable options when working with TWCS tables: 

- `restrict_twcs_default_ttl` - a LiveUpdate-able tri_mode_restriction which defaults to WARN and will notify the user whenever a TWCS table is created without a `default_time_to_live` setting
- `twcs_max_window_count` - Which forbids the user from creating TWCS tables whose window count (buckets) are past a certain threshold. We default to 50, which should be enough for most use cases, and a setting of 0 effectively disables the check.

Refs: #6923
Fixes: #9029