### PR TITLE
Docs: fix wrong manifest file for enterprise releases

### DIFF
--- a/docs/upgrade/_common/upgrade-image.rst
+++ b/docs/upgrade/_common/upgrade-image.rst
@@ -20,7 +20,7 @@ This installation upgrade method allows you to upgrade your ScyllaDB version and
     
     The file is included in the ScyllaDB packages downloaded in the previous step. The file location is:
 
-     * ScyllaDB Enterprise: ``http://downloads.scylladb.com/downloads/scylla-enterprise/aws/manifest/scylla-packages-<version>-<arch>.txt``
+     * ScyllaDB Enterprise: ``http://downloads.scylladb.com/downloads/scylla-enterprise/aws/manifest/scylla-enterprise-packages-<version>-<arch>.txt``
      * ScyllaDB Open Source: ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
 
     Example:


### PR DESCRIPTION
In https://docs.scylladb.com/stable/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2022.1-to-2022.1-image.html, manifest file location is pointing the wrong filename for enterprise

Fixing