### PR TITLE
locator: token_metadata: drop unused and dangerous accessors

### DIFF
--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -65,23 +65,10 @@ public:
      */
     bool has_endpoint(inet_address) const;
 
-    std::unordered_map<sstring,
-                       std::unordered_set<inet_address>>&
-    get_datacenter_endpoints() {
-        return _dc_endpoints;
-    }
-
     const std::unordered_map<sstring,
                            std::unordered_set<inet_address>>&
     get_datacenter_endpoints() const {
         return _dc_endpoints;
-    }
-
-    std::unordered_map<sstring,
-                       std::unordered_map<sstring,
-                                          std::unordered_set<inet_address>>>&
-    get_datacenter_racks() {
-        return _dc_racks;
     }
 
     const std::unordered_map<sstring,


### PR DESCRIPTION
The mutable get_datacenter_endpoints() and get_datacenter_racks() are
dangerous since they expose internal members without enforcing class
invariants. Fortunately they are unused, so delete them.