### PR TITLE
cross-tree: fix header file self-sufficiency

### DIFF
--- a/alternator/ttl.hh
+++ b/alternator/ttl.hh
@@ -12,6 +12,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/semaphore.hh>
+#include "data_dictionary/data_dictionary.hh"
 
 namespace replica {
 class database;

--- a/cql3/statements/cf_properties.hh
+++ b/cql3/statements/cf_properties.hh
@@ -13,6 +13,7 @@
 
 #include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/column_identifier.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 namespace cql3 {
 

--- a/db/system_keyspace_view_types.hh
+++ b/db/system_keyspace_view_types.hh
@@ -10,6 +10,7 @@
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/reactor.hh>
 #include <utility>
 #include <optional>
 #include "dht/token.hh"

--- a/db/view/view_updating_consumer.hh
+++ b/db/view/view_updating_consumer.hh
@@ -16,6 +16,7 @@
 #include "db/view/row_locking.hh"
 #include <seastar/core/abort_source.hh>
 #include "mutation.hh"
+#include <seastar/core/circular_buffer.hh>
 
 class evictable_reader_handle;
 

--- a/memtable-sstable.hh
+++ b/memtable-sstable.hh
@@ -15,6 +15,7 @@
 #include "sstables/shared_sstable.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/io_priority_class.hh>
+#include "reader_permit.hh"
 
 class memtable;
 class flat_mutation_reader;

--- a/protocol_server.hh
+++ b/protocol_server.hh
@@ -10,6 +10,7 @@
 
 #include "seastarx.hh"
 #include <seastar/core/future.hh>
+#include <seastar/net/socket_defs.hh>
 #include <vector>
 
 // Abstraction for a server serving some kind of user-facing protocol.

--- a/schema_upgrader.hh
+++ b/schema_upgrader.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "mutation_fragment.hh"
+#include "mutation_fragment_v2.hh"
 #include "converting_mutation_partition_applier.hh"
 
 // A StreamedMutationTransformer which transforms the stream to a different schema

--- a/service/paxos/cas_request.hh
+++ b/service/paxos/cas_request.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <optional>
+#include <seastar/core/sharded.hh>
 
 #include "timestamp.hh"
 

--- a/sstables/downsampling.hh
+++ b/sstables/downsampling.hh
@@ -16,6 +16,7 @@
 #include <list>
 #include <map>
 #include <vector>
+#include <array>
 #include <algorithm>
 #include <iterator>
 #include <cassert>

--- a/sstables/promoted_index_blocks_reader.hh
+++ b/sstables/promoted_index_blocks_reader.hh
@@ -14,6 +14,7 @@
 #include "m_format_read_helpers.hh"
 #include "sstables/mx/parsers.hh"
 #include "sstables/index_entry.hh"
+#include <seastar/core/circular_buffer.hh>
 
 namespace sstables {
 

--- a/test/raft/future_set.hh
+++ b/test/raft/future_set.hh
@@ -11,6 +11,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/condition-variable.hh>
+#include "raft/raft.hh"
+#include "test/raft/logical_timer.hh"
 
 using namespace seastar;
 

--- a/test/raft/logical_timer.hh
+++ b/test/raft/logical_timer.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/future-util.hh>
 
 #include "raft/logical_clock.hh"
+#include "raft/raft.hh"
 
 using namespace seastar;
 

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -12,6 +12,9 @@
 #include "gc_clock.hh"
 #include "dht/token.hh"
 #include "schema_fwd.hh"
+#include "range.hh"
+#include "tombstone_gc_options.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 namespace dht {
 

--- a/utils/entangled.hh
+++ b/utils/entangled.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <boost/intrusive/parent_from_member.hpp>
+#include <cassert>
 
 //  A movable pointer-like object paired with exactly one other object of the same type. 
 //  The two objects which are paired with each other point at each other.

--- a/utils/immutable-collection.hh
+++ b/utils/immutable-collection.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <type_traits>
+#include <utility>
 #include <seastar/util/concepts.hh>
 
 namespace utils {

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <unordered_set>
+#include <cstddef>
 
 namespace utils {
 /**


### PR DESCRIPTION
Scylla's coding standard requires that each header is self-sufficient,
i.e., it includes whatever other headers it needs - so it can be included
without having to include any other header before it.

We have a test for this, "ninja dev-headers", but it isn't run very
frequently, and it turns out our code deviated from this requirement
in a few places. This patch fixes those places, and after it
"ninja dev-headers" succeeds again.

This is needed because our CI runs "ninja dev-headers".

Fixes #10995

Signed-off-by: Nadav Har'El <nyh@scylladb.com>