### PR TITLE
test: topology: make imports friendlier for tools (such as `mypy`)

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -11,19 +11,14 @@ import pathlib
 import ssl
 import sys
 from typing import List
-# Also pylib modules
-sys.path.append(sys.path[0] + '/../pylib')
-from random_tables import RandomTables       # type: ignore # pylint: disable=import-error
-from util import unique_name                 # type: ignore # pylint: disable=import-error
-from manager_client import ManagerClient     # type: ignore # pylint: disable=import-error
+from test.pylib.random_tables import RandomTables
+from test.pylib.util import unique_name
+from test.pylib.manager_client import ManagerClient
 import pytest
 from cassandra.cluster import Session, ResponseFuture                    # type: ignore
 from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore
 from cassandra.policies import RoundRobinPolicy                          # type: ignore
-
-# Add test.pylib to the search path
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 def pytest_addoption(parser):
     parser.addoption('--manager-api', action='store', required=True,

--- a/test/topology/test_concurrent_schema.py
+++ b/test/topology/test_concurrent_schema.py
@@ -6,7 +6,7 @@
 import asyncio
 import logging
 import pytest
-from pylib.random_tables import Column, UUIDType, IntType         # type: ignore
+from test.pylib.random_tables import Column, UUIDType, IntType
 
 
 logger = logging.getLogger('schema-test')


### PR DESCRIPTION
When importing from `pylib`, don't modify `sys.path` but use the fact
that both `test/` and `test/pylib/` directories contain an `__init__.py`
file, so `test.pylib` is a valid module if we start with `test/` as the
Python package root.

Both `pytest` and `mypy` (and I guess other tools) understand this
setup.

Also add an `__init__.py` to `test/topology/` so other modules under the
`test/` directory will be able to import stuff from `test/topology/`
(i.e. from `test.topology.X import Y`).