### PR TITLE
test/alternator: improve tests for DescribeTable for indexes

### DIFF
--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -168,7 +168,7 @@ def test_gsi_empty_value(test_table_gsi_2):
         test_table_gsi_2.put_item(Item={'p': random_string(), 'x': ''})
 
 # Verify that a GSI is correctly listed in describe_table
-@pytest.mark.xfail(reason="DescribeTable for GSI misses IndexSizeBytes, ItemCount, Projection, IndexStatus")
+@pytest.mark.xfail(reason="issues #7550, #11466, #11470, #11471")
 def test_gsi_describe(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
     assert 'Table' in desc

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -242,8 +242,32 @@ def test_lsi_describe(test_table_lsi_4):
     assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_x1', 'hello_x2', 'hello_x3', 'hello_x4'])
     for lsi in lsis:
         assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/' + lsi['IndexName']
-    # TODO: check projection and key params
-    # TODO: check also ProvisionedThroughput
+
+# In addition to the basic listing of an LSI in DescribeTable tested above,
+# in this test we check additional fields that should appear in each LSI's
+# description.
+# Note that whereas GSIs also have IndexStatus and ProvisionedThroughput
+# fields, LSIs do not. IndexStatus is not needed because LSIs cannot be
+# added after the base table is created, and ProvisionedThroughput isn't
+# needed because an LSI shares its provisioning with the base table.
+@pytest.mark.xfail(reason="issues #7550, #11466, #11470")
+def test_lsi_describe_fields(test_table_lsi_1):
+    desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
+    assert 'Table' in desc
+    assert 'LocalSecondaryIndexes' in desc['Table']
+    lsis = desc['Table']['LocalSecondaryIndexes']
+    assert len(lsis) == 1
+    lsi = lsis[0]
+    assert lsi['IndexName'] == 'hello'
+    assert 'IndexSizeBytes' in lsi     # actual size depends on content
+    assert 'ItemCount' in lsi
+    assert not 'IndexStatus' in lsi
+    assert not 'ProvisionedThroughput' in lsi
+    assert lsi['Projection'] == {'ProjectionType': 'ALL'}
+    assert lsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'p'},
+                                {'KeyType': 'RANGE', 'AttributeName': 'b'}]
+    # The index's ARN should look like the table's ARN followed by /index/<indexname>.
+    assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/hello'
 
 # A table with selective projection - only keys are projected into the index
 @pytest.fixture(scope="module")


### PR DESCRIPTION
I created new issues for each missing field in DescribeTable's response for GSIs and LSIs, so in this patch we edit the xfail messages in the test to refer to these issues.

Additionally, we only had a test for these fields for GSIs, so this patch also adds a similar test for LSIs. I turns out there is a difference between the two tests -  the two fields IndexStatus and ProvisionedThroughput are returned for GSIs, but not for LSIs.

Refs #7750
Refs #11466
Refs #11470
Refs #11471

Signed-off-by: Nadav Har'El <nyh@scylladb.com>