### PR TITLE
 sstables: add options for disabling long-term index caching 

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -905,6 +905,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,
         "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
     , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 10, "Time for which information about finished task stays in memory.")
+    , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,
+        "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions.")
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)
     , log_to_stdout(this, "log_to_stdout", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -385,6 +385,8 @@ public:
 
     named_value<uint32_t> task_ttl_seconds;
 
+    named_value<bool> cache_index_pages;
+
     seastar::logging_settings logging_settings(const log_cli::options&) const;
 
     const db::extensions& extensions() const;

--- a/main.cc
+++ b/main.cc
@@ -569,6 +569,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             cfg->broadcast_to_all_shards().get();
 
+            // We pass this piece of config through a global as a temporary hack.
+            // See the comment at the definition of sstables::global_cache_index_pages.
+            smp::invoke_on_all([&cfg] {
+                sstables::global_cache_index_pages = cfg->cache_index_pages.operator utils::updateable_value<bool>();
+            }).get();
+
             ::sighup_handler sighup_handler(opts, *cfg);
             auto stop_sighup_handler = defer_verbose_shutdown("sighup", [&] {
                 sighup_handler.stop().get();

--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -201,6 +201,7 @@ public:
 
 // Allocated inside LSA.
 class promoted_index {
+    friend class index_reader;
     deletion_time _del_time;
     uint64_t _promoted_index_start;
     uint32_t _promoted_index_size;
@@ -219,14 +220,6 @@ public:
 
     [[nodiscard]] deletion_time get_deletion_time() const { return _del_time; }
     [[nodiscard]] uint32_t get_promoted_index_size() const { return _promoted_index_size; }
-
-    // Call under allocating_section.
-    // For sstable versions >= mc the returned cursor will be of type `bsearch_clustered_cursor`.
-    std::unique_ptr<clustered_index_cursor> make_cursor(shared_sstable,
-        reader_permit,
-        tracing::trace_state_ptr,
-        file_input_stream_options,
-        use_caching);
 };
 
 // A partition index element.

--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -25,7 +25,10 @@
 
 namespace sstables {
 
-using use_caching = bool_class<struct use_caching_tag>;
+enum class use_caching {
+    cache_globally,
+    bypass_cache,
+};
 using promoted_index_block_position_view = std::variant<composite_view, position_in_partition_view>;
 using promoted_index_block_position = std::variant<composite, position_in_partition>;
 

--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -25,10 +25,14 @@
 
 namespace sstables {
 
+// See the comment at the definition of sstables::global_cache_index_pages
+// for a discussion of these caching modes.
 enum class use_caching {
     cache_globally,
+    cache_locally,
     bypass_cache,
 };
+
 using promoted_index_block_position_view = std::variant<composite_view, position_in_partition_view>;
 using promoted_index_block_position = std::variant<composite, position_in_partition>;
 

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1189,7 +1189,7 @@ private:
     }
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(!_slice.options.contains(query::partition_slice::option::bypass_cache));
+            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(), _consumer.io_priority(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1189,7 +1189,12 @@ private:
     }
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
+            use_caching caching;
+            if (!global_cache_index_pages || _slice.options.contains(query::partition_slice::option::bypass_cache)) {
+                caching = use_caching::bypass_cache;
+            } else {
+                caching = use_caching::cache_globally;
+            }
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(), _consumer.io_priority(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1190,8 +1190,10 @@ private:
     index_reader& get_index_reader() {
         if (!_index_reader) {
             use_caching caching;
-            if (!global_cache_index_pages || _slice.options.contains(query::partition_slice::option::bypass_cache)) {
+            if (_slice.options.contains(query::partition_slice::option::bypass_cache)) {
                 caching = use_caching::bypass_cache;
+            } else if (!global_cache_index_pages) {
+                caching = use_caching::cache_locally;
             } else {
                 caching = use_caching::cache_globally;
             }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1320,8 +1320,10 @@ private:
     index_reader& get_index_reader() {
         if (!_index_reader) {
             use_caching caching;
-            if (!global_cache_index_pages || _slice.options.contains(query::partition_slice::option::bypass_cache)) {
+            if (_slice.options.contains(query::partition_slice::option::bypass_cache)) {
                 caching = use_caching::bypass_cache;
+            } else if (!global_cache_index_pages) {
+                caching = use_caching::cache_locally;
             } else {
                 caching = use_caching::cache_globally;
             }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1319,7 +1319,7 @@ private:
     }
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(!_slice.options.contains(query::partition_slice::option::bypass_cache));
+            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(), _consumer.io_priority(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1319,7 +1319,12 @@ private:
     }
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
+            use_caching caching;
+            if (!global_cache_index_pages || _slice.options.contains(query::partition_slice::option::bypass_cache)) {
+                caching = use_caching::bypass_cache;
+            } else {
+                caching = use_caching::cache_globally;
+            }
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(), _consumer.io_priority(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -87,6 +87,18 @@ thread_local disk_error_signal_type sstable_write_error;
 
 namespace sstables {
 
+// The below flag governs the mode of index file page caching used by the index
+// reader.
+//
+// If set to true, the reader will read and/or populate a common global cache,
+// which shares its capacity with the row cache. If false, the reader will use
+// BYPASS CACHE semantics for index caching.
+//
+// This flag is intended to be a temporary hack. The goal is to eventually
+// solve index caching problems via a smart cache replacement policy.
+//
+thread_local utils::updateable_value<bool> global_cache_index_pages(false);
+
 logging::logger sstlog("sstable");
 
 // Because this is a noop and won't hold any state, it is better to use a global than a

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2916,7 +2916,7 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
     std::exception_ptr ex;
     auto sem = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::has_partition_key()");
     try {
-        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), s->get_filename(), db::no_timeout), default_priority_class(), tracing::trace_state_ptr(), use_caching::yes);
+        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), s->get_filename(), db::no_timeout), default_priority_class(), tracing::trace_state_ptr(), use_caching::cache_globally);
         present = co_await lh_index_ptr->advance_lower_and_check_if_present(dk);
     } catch (...) {
         ex = std::current_exception();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -50,6 +50,7 @@
 #include "mutation_fragment_stream_validator.hh"
 #include "readers/flat_mutation_reader_fwd.hh"
 #include "tracing/trace_state.hh"
+#include "utils/updateable_value.hh"
 
 #include <seastar/util/optimized_optional.hh>
 
@@ -57,6 +58,8 @@ class sstable_assertions;
 class cached_file;
 
 namespace sstables {
+
+extern thread_local utils::updateable_value<bool> global_cache_index_pages;
 
 namespace mc {
 class writer;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -4578,7 +4578,7 @@ static sstring get_read_index_test_path(sstring table_name) {
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
     return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+                                          tracing::trace_state_ptr(), use_caching::cache_globally);
 }
 
 shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name, int64_t gen = 1) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2484,7 +2484,7 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
     return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+                                          tracing::trace_state_ptr(), use_caching::cache_globally);
 }
 
 SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -918,7 +918,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
     return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+                                          tracing::trace_state_ptr(), use_caching::cache_globally);
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -90,7 +90,7 @@ public:
 
     std::unique_ptr<index_reader> make_index_reader(reader_permit permit) {
         return std::make_unique<index_reader>(_sst, std::move(permit), default_priority_class(),
-                                              tracing::trace_state_ptr(), use_caching::yes);
+                                              tracing::trace_state_ptr(), use_caching::cache_globally);
     }
 
     struct index_entry {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -929,7 +929,7 @@ void dump_index_operation(schema_ptr schema, reader_permit permit, const std::ve
     json_writer writer;
     writer.StartStream();
     for (auto& sst : sstables) {
-        sstables::index_reader idx_reader(sst, permit, default_priority_class(), {}, sstables::use_caching::yes);
+        sstables::index_reader idx_reader(sst, permit, default_priority_class(), {}, sstables::use_caching::cache_globally);
         auto close_idx_reader = deferred_close(idx_reader);
 
         writer.SstableKey(*sst);


### PR DESCRIPTION
A draft of a potential fix for #11202. See that issue and commit messages `sstables: add a flag for disabling long-term index caching` and `sstables: index_entry: add use_caching::cache_locally` for some discussion.

`sstables: add a flag for disabling long-term index caching` alone is enough as a band-aid fix. If I understood the history of this code correctly, enabling the flag added in that patch should revert index caching to it's state at 4.5.

But since in some cases (partitions with promoted index, especially if it fits on a single page with the partition index entry) disabling index file caching is likely to lead to additional disk reads or (w.r.t. 4.6), I also added a mode in between full caching and BYPASS CACHE, which caches index file pages only for the lifetime of the index reader. It didn't come out that small, though, so I'm not sure if it's a good fit for backporting.

Passing the flag around in this series is hacked in with a global variable. But there is no obstacle to passing it around normally or making it per-table, if needed.