### PR TITLE
log query id when a memory limit is exceeded

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -781,7 +781,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
 
     try {
-        auto accounter = co_await local_db.get_result_memory_limiter().new_mutation_read(*cmd.max_result_size, short_read_allowed);
+        auto accounter = co_await local_db.get_result_memory_limiter().new_mutation_read(*cmd.max_result_size, short_read_allowed, cmd.query_uuid);
 
         auto result = co_await do_query<ResultBuilder>(db, s, cmd, ranges, std::move(trace_state), timeout,
                 [result_builder_factory, accounter = std::move(accounter)] (const compact_for_query_state_v2& compaction_state) mutable {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2109,13 +2109,13 @@ stop_iteration query::result_memory_accounter::check_local_limit() const {
     } else {
         if (_total_used_memory > _maximum_result_size.hard_limit) {
             throw std::runtime_error(fmt::format(
-                    "Memory usage of unpaged query exceeds hard limit of {} (configured via max_memory_for_unlimited_query_hard_limit)",
-                    _maximum_result_size.hard_limit));
+                    "Memory usage of unpaged query {} exceeds hard limit of {} (configured via max_memory_for_unlimited_query_hard_limit)",
+                    _query_id, _maximum_result_size.hard_limit));
         }
         if (_below_soft_limit && _total_used_memory > _maximum_result_size.soft_limit) {
             mplog.warn(
-                    "Memory usage of unpaged query exceeds soft limit of {} (configured via max_memory_for_unlimited_query_soft_limit)",
-                    _maximum_result_size.soft_limit);
+                    "Memory usage of unpaged query {} exceeds soft limit of {} (configured via max_memory_for_unlimited_query_soft_limit)",
+                    _query_id, _maximum_result_size.soft_limit);
             _below_soft_limit = false;
         }
     }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1567,7 +1567,7 @@ database::query_mutations(schema_ptr s, const query::read_command& cmd, const dh
     const auto short_read_allwoed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     auto& semaphore = get_reader_concurrency_semaphore();
     auto max_result_size = cmd.max_result_size ? *cmd.max_result_size : get_unlimited_query_max_result_size();
-    auto accounter = co_await get_result_memory_limiter().new_mutation_read(max_result_size, short_read_allwoed);
+    auto accounter = co_await get_result_memory_limiter().new_mutation_read(max_result_size, short_read_allwoed, cmd.query_uuid);
     column_family& cf = find_column_family(cmd.cf_id);
 
     std::optional<query::querier> querier_opt;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2053,8 +2053,8 @@ table::query(schema_ptr s,
 
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     auto accounter = co_await (opts.request == query::result_request::only_digest
-             ? memory_limiter.new_digest_read(permit.max_result_size(), short_read_allowed)
-             : memory_limiter.new_data_read(permit.max_result_size(), short_read_allowed));
+             ? memory_limiter.new_digest_read(permit.max_result_size(), short_read_allowed, cmd.query_uuid)
+             : memory_limiter.new_data_read(permit.max_result_size(), short_read_allowed, cmd.query_uuid));
 
     query_state qs(s, cmd, opts, partition_ranges, std::move(accounter));
 

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -550,11 +550,11 @@ SEASTAR_THREAD_TEST_CASE(test_result_size_calculation) {
     slice.options.set<query::partition_slice::option::allow_short_read>();
 
     query::result::builder digest_only_builder(slice, query::result_options{query::result_request::only_digest, query::digest_algorithm::xxHash},
-            l.new_digest_read(query::max_result_size(query::result_memory_limiter::maximum_result_size), query::short_read::yes).get0(), query::max_tombstones);
+            l.new_digest_read(query::max_result_size(query::result_memory_limiter::maximum_result_size), query::short_read::yes, query_id::create_null_id()).get0(), query::max_tombstones);
     data_query(s, semaphore.make_permit(), source, query::full_partition_range, slice, digest_only_builder);
 
     query::result::builder result_and_digest_builder(slice, query::result_options{query::result_request::result_and_digest, query::digest_algorithm::xxHash},
-            l.new_data_read(query::max_result_size(query::result_memory_limiter::maximum_result_size), query::short_read::yes).get0(), query::max_tombstones);
+            l.new_data_read(query::max_result_size(query::result_memory_limiter::maximum_result_size), query::short_read::yes, query_id::create_null_id()).get0(), query::max_tombstones);
     data_query(s, semaphore.make_permit(), source, query::full_partition_range, slice, result_and_digest_builder);
 
     BOOST_REQUIRE_EQUAL(digest_only_builder.memory_accounter().used_memory(), result_and_digest_builder.memory_accounter().used_memory());


### PR DESCRIPTION
`max_memory_for_unlimited_query_{soft,hard}_limit` are exceeded by replicas, and at the point of such failure the replica does not know anything user-legible about the query that caused the limit to be exceeded.

This change tries to help somewhat by storing the query id in the accounter object, so the user can correlate replica and coordinator logs using the query id and in that way find the actual offending query.

Fixes #11478.

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>