### PR TITLE
Make error message on expression validation more friendly

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -12,6 +12,7 @@
 #include "cql3/constants.hh"
 #include "cql3/abstract_marker.hh"
 #include "cql3/lists.hh"
+#include "cql3/expr/restrictions.hh"
 #include "cql3/sets.hh"
 #include "cql3/user_types.hh"
 #include "types/list.hh"
@@ -1183,6 +1184,8 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
     }
     auto& prepared_lhs = *prepared_lhs_opt;
     lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, *schema);
+
+    validate_collection_column_relation(prepared_lhs, binop.op);
 
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
     expression prepared_rhs = prepare_expression(binop.rhs, db, schema->ks_name(), schema.get(), rhs_receiver);

--- a/cql3/expr/restrictions.hh
+++ b/cql3/expr/restrictions.hh
@@ -17,5 +17,8 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
                                                      data_dictionary::database db,
                                                      schema_ptr schema,
                                                      prepare_context& ctx);
+
+void validate_collection_column_relation(const expression& col_expr,
+                                         oper_t oper);
 } // namespace expr
 } // namespace cql3

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -20,6 +20,33 @@ def testInvalidCollectionEqualityRelation(cql, test_keyspace):
         assert_invalid_message(cql, table, "Collection column 'd' (map<int, int>) cannot be restricted by a '=' relation",
                              "SELECT * FROM %s WHERE a = 0 AND d=?", {0: 0})
 
+def testInvalidCollectionIntegerArgumentEqualityRelation(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)") as table:
+        execute(cql, table, "CREATE INDEX ON %s (b)")
+        execute(cql, table, "CREATE INDEX ON %s (c)")
+        execute(cql, table, "CREATE INDEX ON %s (d)")
+        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '=' relation",
+                             "SELECT * FROM %s WHERE a = 0 AND b=?", 1)
+        assert_invalid_message(cql, table, "Collection column 'c' (list<int>) cannot be restricted by a '=' relation",
+                             "SELECT * FROM %s WHERE a = 0 AND c=?", 1)
+        assert_invalid_message(cql, table, "Collection column 'd' (map<int, int>) cannot be restricted by a '=' relation",
+                             "SELECT * FROM %s WHERE a = 0 AND d=?", 1)
+
+def testInvalidCollectionIntegerArgumentNonEQRelation(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c int)") as table:
+        execute(cql, table, "CREATE INDEX ON %s (c)")
+        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, {0}, 0)")
+
+        # non-EQ operators
+        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '>' relation",
+                             "SELECT * FROM %s WHERE c = 0 AND b > ?", 1)
+        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '>=' relation",
+                             "SELECT * FROM %s WHERE c = 0 AND b >= ?", 1)
+        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '<' relation",
+                             "SELECT * FROM %s WHERE c = 0 AND b < ?", 1)
+        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '<=' relation",
+                             "SELECT * FROM %s WHERE c = 0 AND b <= ?", 1)
+
 def testInvalidCollectionNonEQRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c int)") as table:
         execute(cql, table, "CREATE INDEX ON %s (c)")


### PR DESCRIPTION
If one attempts the expression x<1 where x is a collection (e.g., list<int>), Scylla's error message should look like Cassandra's one: Collection column 'x' (list) cannot be restricted by a '<' relation

Refs scylladb#11061