### PR TITLE
raft, take a snapshot if memory limit deadlock detected

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -562,6 +562,7 @@ raft_tests = set([
     'test/raft/replication_test',
     'test/raft/randomized_nemesis_test',
     'test/raft/many_test',
+    'test/raft/raft_server_test',
     'test/raft/fsm_test',
     'test/raft/etcd_test',
     'test/raft/raft_sys_table_storage_test',
@@ -1178,7 +1179,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
     'test/lib/random_schema.cc',
 ]
 
-scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc']
+scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
 
 scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc']
 
@@ -1312,6 +1313,7 @@ deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']
 deps['test/boost/rust_test'] += rusts
 
 deps['test/raft/replication_test'] = ['test/raft/replication_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
+deps['test/raft/raft_server_test'] = ['test/raft/raft_server_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/failure_detector_test'] = ['test/raft/failure_detector_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -45,17 +45,9 @@ fsm::fsm(server_id id, term_t current_term, server_id voted_for, log log,
         failure_detector& failure_detector, fsm_config config) :
         fsm(id, current_term, voted_for, std::move(log), index_t{0}, failure_detector, config) {}
 
-future<> fsm::consume_memory(seastar::abort_source* as, size_t size) {
+seastar::semaphore& fsm::get_log_limiter_semaphore() {
     check_is_leader();
-
-    auto& sm = *leader_state().log_limiter_semaphore;
-    return as ? sm.wait(*as, size) : sm.wait(size);
-}
-
-void fsm::release_memory(size_t size) {
-    check_is_leader();
-
-    leader_state().log_limiter_semaphore->signal(size);
+    return *leader_state().log_limiter_semaphore;
 }
 
 const configuration& fsm::get_configuration() const {

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -44,10 +44,11 @@ fsm::fsm(server_id id, term_t current_term, server_id voted_for, log log,
         failure_detector& failure_detector, fsm_config config) :
         fsm(id, current_term, voted_for, std::move(log), index_t{0}, failure_detector, config) {}
 
-future<> fsm::wait_max_log_size(seastar::abort_source* as) {
+future<> fsm::consume_memory(seastar::abort_source* as, size_t size) {
     check_is_leader();
 
-    return as ? leader_state().log_limiter_semaphore->wait(*as) : leader_state().log_limiter_semaphore->wait();
+    auto& sm = *leader_state().log_limiter_semaphore;
+    return as ? sm.wait(*as, size) : sm.wait(size);
 }
 
 const configuration& fsm::get_configuration() const {
@@ -156,7 +157,20 @@ void fsm::reset_election_timeout() {
 void fsm::become_leader() {
     assert(!std::holds_alternative<leader>(_state));
     _state.emplace<leader>(_config.max_log_size, *this);
-    leader_state().log_limiter_semaphore->consume(_log.in_memory_size());
+
+    // The semaphore is not used on the follower, so the limit could
+    // be temporarily exceeded here, and the value of
+    // the counter in the semaphore could become negative.
+    // This is not a problem though as applier_fiber triggers a snapshot
+    // if memory usage approaches the limit.
+    // As _applied_idx moves forward, snapshots will eventually release
+    // sufficient memory for at least one waiter (add_entry) to proceed.
+    // The amount of memory used by log::apply_snapshot for trailing items
+    // is limited by the condition
+    // _config.max_snapshot_trailing_bytes <= _config.max_log_size - max_command_memory_usage(),
+    // which means that at least one command will eventually return from semaphore::wait.
+    leader_state().log_limiter_semaphore->consume(_log.memory_usage());
+
     _last_election_time = _clock.now();
     _ping_leader = false;
     // a new leader needs to commit at lease one entry to make sure that
@@ -976,7 +990,7 @@ void fsm::install_snapshot_reply(server_id from, snapshot_reply&& reply) {
     // again and snapshot transfer will be attempted one more time.
 }
 
-bool fsm::apply_snapshot(snapshot_descriptor snp, size_t trailing, bool local) {
+bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, size_t max_trailing_bytes, bool local) {
     logger.trace("apply_snapshot[{}]: current term: {}, term: {}, idx: {}, id: {}, local: {}",
             _my_id, _current_term, snp.term, snp.idx, snp.id, local);
     // If the snapshot is locally generated, all entries up to its index must have been locally applied,
@@ -998,7 +1012,7 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t trailing, bool local) {
     // Otherwise snp.idx becomes the new commit index.
     _commit_idx = std::max(_commit_idx, snp.idx);
     _output.snp.emplace(fsm_output::applied_snapshot{snp, local, current_snp.id});
-    size_t units = _log.apply_snapshot(std::move(snp), trailing);
+    size_t units = _log.apply_snapshot(std::move(snp), max_trailing_entries, max_trailing_bytes);
     if (is_leader()) {
         logger.trace("apply_snapshot[{}]: signal {} available units", _my_id, units);
         leader_state().log_limiter_semaphore->signal(units);

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -394,13 +394,9 @@ public:
         _ping_leader = true;
     }
 
-    // Call this function to wait for the total size in bytes of log entries to
-    // go below max_log_size.
+    // Returns the semaphore, which can be used to throttle incoming command entries.
     // Can only be called on a leader.
-    // On abort throws `semaphore_aborted`.
-    future<> consume_memory(seastar::abort_source* as, size_t size);
-
-    void release_memory(size_t size);
+    seastar::semaphore& get_log_limiter_semaphore();
 
     // Return current configuration.
     const configuration& get_configuration() const;

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -47,11 +47,10 @@ struct fsm_output {
 struct fsm_config {
     // max size of appended entries in bytes
     size_t append_request_threshold;
-    // Max number of entries of in-memory part of the log after
+    // Limit in bytes on the size of in-memory part of the log after
     // which requests are stopped to be admitted until the log
     // is shrunk back by a snapshot. Should be greater than
-    // whatever the default number of trailing log entries
-    // is configured by the snapshot, otherwise the state
+    // the sum of sizes of trailing log entries, otherwise the state
     // machine will deadlock.
     size_t max_log_size;
     // If set to true will enable prevoting stage during election
@@ -84,7 +83,7 @@ struct candidate {
 struct leader {
     // A state for each follower
     raft::tracker tracker;
-    // Used to acces new leader to set semaphore exception
+    // Used to access new leader to set semaphore exception
     const raft::fsm& fsm;
     // Used to limit log size
     std::unique_ptr<seastar::semaphore> log_limiter_semaphore;
@@ -395,10 +394,11 @@ public:
         _ping_leader = true;
     }
 
-    // Call this function to wait for the number of log entries to
-    // go below  max_log_size.
+    // Call this function to wait for the total size in bytes of log entries to
+    // go below max_log_size.
+    // Can only be called on a leader.
     // On abort throws `semaphore_aborted`.
-    future<> wait_max_log_size(seastar::abort_source* as);
+    future<> consume_memory(seastar::abort_source* as, size_t size);
 
     // Return current configuration.
     const configuration& get_configuration() const;
@@ -458,14 +458,19 @@ public:
     }
 
     // This call will update the log to point to the new snapshot
-    // and will truncate the log prefix up to (snp.idx - trailing)
-    // entry. Returns false if the snapshot is older than existing one.
-    bool apply_snapshot(snapshot_descriptor snp, size_t traling, bool local);
+    // and will truncate the log prefix so that the number of
+    // remaining applied entries is <= max_trailing_entries and their total size is <= max_trailing_bytes.
+    // Returns false if the snapshot is older than existing one.
+    bool apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, size_t max_trailing_bytes, bool local);
 
     std::optional<std::pair<read_id, index_t>> start_read_barrier(server_id requester);
 
     size_t in_memory_log_size() const {
         return _log.in_memory_size();
+    }
+
+    size_t log_memory_usage() const {
+        return _log.memory_usage();
     };
 
     server_id id() const { return _my_id; }
@@ -514,7 +519,7 @@ void fsm::step(server_id from, const follower& c, Message&& msg) {
         request_vote(from, std::move(msg));
     } else if constexpr (std::is_same_v<Message, install_snapshot>) {
         send_to(from, snapshot_reply{.current_term = _current_term,
-                    .success = apply_snapshot(std::move(msg.snp), 0, false)});
+                    .success = apply_snapshot(std::move(msg.snp), 0, 0, false)});
     } else if constexpr (std::is_same_v<Message, timeout_now>) {
         // Leadership transfers never use pre-vote; we know we are not
         // recovering from a partition so there is no need for the

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -400,6 +400,8 @@ public:
     // On abort throws `semaphore_aborted`.
     future<> consume_memory(seastar::abort_source* as, size_t size);
 
+    void release_memory(size_t size);
+
     // Return current configuration.
     const configuration& get_configuration() const;
 

--- a/raft/log.cc
+++ b/raft/log.cc
@@ -66,6 +66,7 @@ void log::truncate_uncommitted(index_t idx) {
     auto it = _log.begin() + (idx - _first_idx);
     const auto released_memory = range_memory_usage(it, _log.end());
     _log.erase(it, _log.end());
+    _log.shrink_to_fit();
     _memory_usage -= released_memory;
     stable_to(std::min(_stable_idx, last_idx()));
     if (_last_conf_idx > last_idx()) {
@@ -238,6 +239,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
         // entries and the next entry index.
         released_memory = std::exchange(_memory_usage, 0);
         _log.clear();
+        _log.shrink_to_fit();
         _first_idx = idx + index_t{1};
     } else {
         auto entries_to_remove = _log.size() - (last_idx() - idx);
@@ -251,6 +253,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
         }
         released_memory = range_memory_usage(_log.begin(), _log.begin() + entries_to_remove);
         _log.erase(_log.begin(), _log.begin() + entries_to_remove);
+        _log.shrink_to_fit();
         _memory_usage -= released_memory;
         _first_idx = _first_idx + index_t{entries_to_remove};
     }

--- a/raft/log.cc
+++ b/raft/log.cc
@@ -17,6 +17,14 @@ const log_entry_ptr& log::get_entry(index_t i) const {
     return _log[i - _first_idx];
 }
 
+size_t log::range_memory_usage(log_entries::iterator first, log_entries::iterator last) const {
+    size_t result = 0;
+    for (auto it = first; it != last; ++it) {
+        result += memory_usage_of(**it);
+    }
+    return result;
+}
+
 log_entry_ptr& log::operator[](size_t i) {
     assert(!_log.empty() && index_t(i) >= _first_idx);
     return get_entry(index_t(i));
@@ -24,6 +32,7 @@ log_entry_ptr& log::operator[](size_t i) {
 
 void log::emplace_back(log_entry_ptr&& e) {
     _log.emplace_back(std::move(e));
+    _memory_usage += memory_usage_of(*_log.back());
     if (std::holds_alternative<configuration>(_log.back()->data)) {
         _prev_conf_idx = _last_conf_idx;
         _last_conf_idx = last_idx();
@@ -55,7 +64,9 @@ index_t log::next_idx() const {
 void log::truncate_uncommitted(index_t idx) {
     assert(idx >= _first_idx);
     auto it = _log.begin() + (idx - _first_idx);
+    const auto released_memory = range_memory_usage(it, _log.end());
     _log.erase(it, _log.end());
+    _memory_usage -= released_memory;
     stable_to(std::min(_stable_idx, last_idx()));
     if (_last_conf_idx > last_idx()) {
         // If _prev_conf_idx is 0, this log does not contain any
@@ -215,24 +226,33 @@ const configuration* log::get_prev_configuration() const {
     return nullptr;
 }
 
-size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t trailing) {
+size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries, size_t max_trailing_bytes) {
     assert (snp.idx > _snapshot.idx);
 
-    size_t removed;
+    size_t released_memory;
     auto idx = snp.idx;
 
     if (idx > last_idx()) {
-        // Remove all entries ignoring the 'trailing' argument,
+        // Remove all entries ignoring 'trailing' arguments,
         // since otherwise there would be a gap between old
         // entries and the next entry index.
-        removed = _log.size();
+        released_memory = std::exchange(_memory_usage, 0);
         _log.clear();
         _first_idx = idx + index_t{1};
     } else {
-        removed = _log.size() - (last_idx() - idx);
-        removed -= std::min(trailing, removed);
-        _log.erase(_log.begin(), _log.begin() + removed);
-        _first_idx = _first_idx + index_t{removed};
+        auto entries_to_remove = _log.size() - (last_idx() - idx);
+        size_t trailing_bytes = 0;
+        for (int i = 0; i < max_trailing_entries && entries_to_remove > 0; ++i) {
+            trailing_bytes += memory_usage_of(*_log[entries_to_remove - 1]);
+            if (trailing_bytes > max_trailing_bytes) {
+                break;
+            }
+            --entries_to_remove;
+        }
+        released_memory = range_memory_usage(_log.begin(), _log.begin() + entries_to_remove);
+        _log.erase(_log.begin(), _log.begin() + entries_to_remove);
+        _memory_usage -= released_memory;
+        _first_idx = _first_idx + index_t{entries_to_remove};
     }
 
     _stable_idx = std::max(idx, _stable_idx);
@@ -250,7 +270,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t trailing) {
 
     _snapshot = std::move(snp);
 
-    return removed;
+    return released_memory;
 }
 
 std::ostream& operator<<(std::ostream& os, const log& l) {

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -22,8 +22,7 @@ namespace raft {
 class log {
     // Snapshot of the prefix of the log.
     snapshot_descriptor _snapshot;
-    // We need something that can be truncated from both sides.
-    // std::deque move constructor is not nothrow hence cannot be used
+    // In-memory log data.
     log_entries _log;
     // Raft log index of the first entry in the log.
     // Usually it's simply _snapshot.idx + 1,
@@ -57,6 +56,7 @@ class log {
     // The previous value of _last_conf_idx, to avoid scanning
     // the log backwards after truncate().
     index_t _prev_conf_idx = index_t{0};
+    size_t _memory_usage;
 private:
     // Drop uncommitted log entries not present on the leader.
     void truncate_uncommitted(index_t i);
@@ -65,6 +65,7 @@ private:
     void init_last_conf_idx();
     log_entry_ptr& get_entry(index_t);
     const log_entry_ptr& get_entry(index_t) const;
+    size_t range_memory_usage(log_entries::iterator first, log_entries::iterator last) const;
 public:
     explicit log(snapshot_descriptor snp, log_entries log = {})
             : _snapshot(std::move(snp)), _log(std::move(log)) {
@@ -77,6 +78,7 @@ public:
             // perform an initial state transfer.
             assert(_first_idx <= _snapshot.idx + 1);
         }
+        _memory_usage = range_memory_usage(_log.begin(), _log.end());
         // The snapshot index is at least 0, so _first_idx
         // is at least 1
         assert(_first_idx > 0);
@@ -116,16 +118,21 @@ public:
     size_t in_memory_size() const {
         return _log.size();
     }
+    // Returns memory usage of the log entries in bytes
+    size_t memory_usage() const {
+        return _memory_usage;
+    }
 
     // The function returns current snapshot state of the log
     const snapshot_descriptor& get_snapshot() const {
         return _snapshot;
     }
 
-    // This call will update the log to point to the new snaphot
-    // and will truncate the log prefix up to (snp.idx - trailing)
-    // entry. Return value specifies how many log entries were dropped
-    size_t apply_snapshot(snapshot_descriptor&& snp, size_t trailing);
+    // This call will update the log to point to the new snapshot
+    // and will truncate the log prefix so that the number of
+    // remaining applied entries is <= max_trailing_entries and their total size is <= max_trailing_bytes.
+    // Return value specifies the size in bytes of the dropped log entries.
+    size_t apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries, size_t max_trailing_bytes);
 
     // 3.5
     // Raft maintains the following properties, which
@@ -177,6 +184,28 @@ public:
     index_t maybe_append(std::vector<log_entry_ptr>&& entries);
 
     friend std::ostream& operator<<(std::ostream& os, const log& l);
+
+    // The log keeps track of the memory it uses. This function returns the number
+    // of bytes that will be marked as used when a log_entry is added to the log.
+    // This logic should match the handling of log_limiter_semaphore,
+    // which is currently incremented only for command, but not for configuration and log_entry::dummy.
+    // This is why zero is returned for other log_entry elements
+    // and why this function has been kept separate from entry_size,
+    // which returns non-zero for configuration.
+    template <typename T>
+    requires std::is_same_v<T, log_entry> ||
+             std::is_same_v<T, command> || std::is_same_v<T, configuration> || std::is_same_v<T, log_entry::dummy>
+    static inline size_t memory_usage_of(const T& v) {
+        if constexpr(std::is_same_v<T, command>) {
+            return v.size() + sizeof(log_entry);
+        }
+        if constexpr(std::is_same_v<T, log_entry>) {
+            if (const auto* c = get_if<command>(&v.data); c != nullptr) {
+                return memory_usage_of(*c);
+            }
+        }
+        return 0;
+    }
 };
 
 }

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -468,8 +468,10 @@ using rpc_message = std::variant<append_request,
       read_quorum,
       read_quorum_reply>;
 
-// we need something that can be truncated form both sides.
+// we need something that can be truncated from both sides.
 // std::deque move constructor is not nothrow hence cannot be used
+// also, boost::deque deallocates blocks when items are removed,
+// we don't want to hold on to memory we don't use.
 using log_entries = boost::container::deque<log_entry_ptr>;
 
 // 3.4 Leader election

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -173,14 +173,17 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto storage = std::make_unique<raft_sys_table_storage>(_qp, gid, my_addr.id);
     auto& persistence_ref = *storage;
     auto* cl = _qp.proxy().get_db().local().commitlog();
+    auto config = raft::server::configuration {
+        // Dividing by two is to protect against paddings that the
+        // commit log can add for each mutation, as well as
+        // against different commit log limits on different nodes.
+        .max_command_size = cl ? cl->max_record_size() / 2 : 0
+    };
+    config.max_log_size = std::max(3 * config.max_command_memory_usage() + config.max_snapshot_trailing_bytes,
+        config.max_log_size);
     auto server = raft::create_server(my_addr.id, std::move(rpc), std::move(state_machine),
-            std::move(storage), _raft_gr.failure_detector(),
-            raft::server::configuration {
-                // Dividing by two is to protect against paddings that the
-                // commit log can add for each mutation, as well as
-                // against different commit log limits on different nodes.
-                .max_command_size = cl ? cl->max_record_size() / 2 : 0
-            });
+        std::move(storage), _raft_gr.failure_detector(),
+        config);
 
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -179,7 +179,7 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
         // against different commit log limits on different nodes.
         .max_command_size = cl ? cl->max_record_size() / 2 : 0
     };
-    config.max_log_size = std::max(3 * config.max_command_memory_usage() + config.max_snapshot_trailing_bytes,
+    config.max_log_size = std::max(config.max_command_memory_usage() + config.max_snapshot_trailing_bytes,
         config.max_log_size);
     auto server = raft::create_server(my_addr.id, std::move(rpc), std::move(state_machine),
         std::move(storage), _raft_gr.failure_detector(),

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -1,0 +1,43 @@
+#include "replication.hh"
+#include "utils/error_injection.hh"
+#include <seastar/util/defer.hh>
+
+#ifdef SEASTAR_DEBUG
+// Increase tick time to allow debug to process messages
+ const auto tick_delay = 200ms;
+#else
+const auto tick_delay = 100ms;
+#endif
+
+SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+#else
+    raft_cluster<std::chrono::steady_clock> cluster(
+            test_case {
+                .nodes = 1,
+                .config = std::vector<raft::server::configuration>({
+                    raft::server::configuration {
+                        .max_snapshot_trailing_bytes = 1,
+                        .max_log_size = 16 + sizeof(raft::log_entry),
+                        .max_command_size = 10
+                    }
+                })
+            },
+            ::apply_changes,
+            0,
+            0,
+            0, false, tick_delay, rpc_config{});
+    cluster.start_all().get0();
+    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+
+    utils::get_local_injector().enable("fsm::add_entry/test-failure", true);
+    auto check_error = [](const std::runtime_error& e) {
+        return e.what() == sstring("fsm::add_entry/test-failure");
+    };
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), std::runtime_error, check_error);
+
+    cluster.add_entries(1, 0).get0();
+    cluster.read(read_value{0, 1}).get();
+#endif
+}

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -3165,12 +3165,15 @@ SEASTAR_TEST_CASE(basic_generator_test) {
         bool nemesis_crashes = true;
 
         // TODO: randomize the snapshot thresholds between different servers for more chaos.
+        const auto max_command_size = 30;
         auto srv_cfg = frequent_snapshotting
             ? raft::server::configuration {
                 .snapshot_threshold{10},
                 .snapshot_trailing{5},
-                .max_log_size{20},
+                .max_snapshot_trailing_bytes{2 * (max_command_size + sizeof(raft::log_entry))},
+                .max_log_size{5 * (max_command_size + sizeof(raft::log_entry))},
                 .enable_forwarding{forwarding},
+                .max_command_size{max_command_size}
             }
             : raft::server::configuration {
                 .enable_forwarding{forwarding},

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -158,7 +158,19 @@ RAFT_TEST_CASE(take_snapshot, (test_case{
 // 2 nodes doing simple replication/snapshoting while leader's log size is limited
 RAFT_TEST_CASE(backpressure, (test_case{
          .nodes = 2,
-         .config = {{.snapshot_threshold = 10, .snapshot_trailing = 5, .max_log_size = 20}, {.snapshot_threshold = 20, .snapshot_trailing = 10}},
+         .config = {
+             {
+                 .snapshot_threshold = 10,
+                 .snapshot_trailing = 5,
+                 .max_snapshot_trailing_bytes = 150,
+                 .max_log_size = 450,
+                 .max_command_size = 150
+             },
+             {
+                 .snapshot_threshold = 20,
+                 .snapshot_trailing = 10
+            }
+         },
          .updates = {entries{100}}}));
 
 // 3 nodes, add entries, drop leader 0, add entries [implicit re-join all]


### PR DESCRIPTION
This PR is follow-up for #11397

Previously, applier_fiber would trigger snapshots
if memory usage exceeded max_log_size -max_command_memory_usage.
On one hand this guaranteed that in add_entry_on_leader
we would never wait for the semaphore forever,
on the other hand it could cause more frequent snapshots than needed.
For example, if max_command_memory_usage() == max_log_size
the snapshot could be taken on every iteration of applier_fiber.

In this patch, we explicitly track the moments when progress
becomes impossible and a deadlock occurs, take a snapshot and
give a warning that an excessive snapshot has been created.