### PR TITLE
sstables: index_reader: remove a stray vsprintf call from the hot path

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -765,7 +765,9 @@ public:
         , _use_caching(caching)
         , _single_page_read(single_partition_read) // all entries for a given partition are within a single page
     {
-        sstlog.trace("index {}: index_reader for {}", fmt::ptr(this), _sstable->get_filename());
+        if (sstlog.is_enabled(logging::log_level::trace)) {
+            sstlog.trace("index {}: index_reader for {}", fmt::ptr(this), _sstable->get_filename());
+        }
     }
 
     // Ensures that partition_data_ready() returns true.


### PR DESCRIPTION
sstable::get_filename() constructs the filename from components, which takes some work. It happens to be called on every
index_reader::index_reader() call even though it's only used for TRACE logs. That's 1700 instructions (~1% of a full query) wasted on every SSTable read. Fix that.