### PR TITLE
test: add a topology suite with Raft disabled

### DIFF
--- a/test.py
+++ b/test.py
@@ -339,11 +339,14 @@ class PythonTestSuite(TestSuite):
 
         def create_server(cluster_name: str, seeds: List[str]):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])
-            config_options = self.cfg.get("extra_scylla_config_options",
-                                          {"authenticator": "PasswordAuthenticator",
-                                           "authorizer": "CassandraAuthorizer"})
             if type(cmdline_options) == str:
                 cmdline_options = [cmdline_options]
+
+            default_config_options = \
+                    {"authenticator": "PasswordAuthenticator",
+                     "authorizer": "CassandraAuthorizer"}
+            config_options = default_config_options | self.cfg.get("extra_scylla_config_options", {})
+
             server = ScyllaServer(
                 exe=self.scylla_exe,
                 vardir=os.path.join(self.options.tmpdir, self.mode),

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -141,8 +141,7 @@ class ScyllaServer:
         self.log_savepoint = 0
         self.control_cluster: Optional[Cluster] = None
         self.control_connection: Optional[Session] = None
-        self.authenticator: str = config_options["authenticator"]
-        self.authorizer: str = config_options["authorizer"]
+        self.config_options = config_options
 
         async def stop_server() -> None:
             if self.is_running:
@@ -219,9 +218,7 @@ class ScyllaServer:
               "host": self.hostname,
               "seeds": ",".join(self.seeds),
               "workdir": self.workdir,
-              "authenticator": self.authenticator,
-              "authorizer": self.authorizer
-        }
+        } | self.config_options
         with self.config_filename.open('w') as config_file:
             config_file.write(SCYLLA_CONF_TEMPLATE.format(**fmt))
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -22,6 +22,8 @@ from io import BufferedWriter
 from test.pylib.pool import Pool
 import aiohttp
 import aiohttp.web
+import yaml
+
 from cassandra import InvalidRequest                    # type: ignore
 from cassandra import OperationTimedOut                 # type: ignore
 from cassandra.auth import PlainTextAuthProvider        # type: ignore
@@ -32,70 +34,56 @@ from cassandra.cluster import ExecutionProfile  # pylint: disable=no-name-in-mod
 from cassandra.cluster import EXEC_PROFILE_DEFAULT  # pylint: disable=no-name-in-module
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 
-#
-# Put all Scylla options in a template file. Sic: if you make a typo in the
-# configuration file, Scylla will boot fine and ignore the setting.
-# Always check the error log after modifying the template.
-#
-SCYLLA_CONF_TEMPLATE = """cluster_name: {cluster_name}
-developer_mode: true
 
-# Allow testing experimental features. Following issue #9467, we need
-# to add here specific experimental features as they are introduced.
+def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str], cluster_name: str) -> dict[str, object]:
+    return {
+        'cluster_name': cluster_name,
+        'workdir': str(workdir.resolve()),
+        'listen_address': host_addr,
+        'rpc_address': host_addr,
+        'api_address': host_addr,
+        'prometheus_address': host_addr,
+        'alternator_address': host_addr,
+        'seed_provider': [{
+            'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
+            'parameters': [{
+                'seeds': '{}'.format(','.join(seed_addrs))
+                }]
+            }],
 
-enable_user_defined_functions: true
-experimental: true
-experimental_features:
-    - raft
-    - udf
+        'developer_mode': True,
 
-data_file_directories:
-    - {workdir}/data
-commitlog_directory: {workdir}/commitlog
-hints_directory: {workdir}/hints
-view_hints_directory: {workdir}/view_hints
+        # Allow testing experimental features. Following issue #9467, we need
+        # to add here specific experimental features as they are introduced.
+        'enable_user_defined_functions': True,
+        'experimental': True,
+        'experimental_features': ['raft', 'udf'],
 
-listen_address: {host}
-rpc_address: {host}
-api_address: {host}
-prometheus_address: {host}
-alternator_address: {host}
+        'skip_wait_for_gossip_to_settle': 0,
+        'ring_delay_ms': 0,
+        'num_tokens': 16,
+        'flush_schema_tables_after_modification': False,
+        'auto_snapshot': False,
 
-seed_provider:
-    - class_name: org.apache.cassandra.locator.simple_seed_provider
-      parameters:
-          - seeds: {seeds}
+        # Significantly increase default timeouts to allow running tests
+        # on a very slow setup (but without network losses). Note that these
+        # are server-side timeouts: The client should also avoid timing out
+        # its own requests - for this reason we increase the CQL driver's
+        # client-side timeout in conftest.py.
 
-skip_wait_for_gossip_to_settle: 0
-ring_delay_ms: 0
-num_tokens: 16
-flush_schema_tables_after_modification: false
-auto_snapshot: false
+        'range_request_timeout_in_ms': 300000,
+        'read_request_timeout_in_ms': 300000,
+        'counter_write_request_timeout_in_ms': 300000,
+        'cas_contention_timeout_in_ms': 300000,
+        'truncate_request_timeout_in_ms': 300000,
+        'write_request_timeout_in_ms': 300000,
+        'request_timeout_in_ms': 300000,
 
-# Significantly increase default timeouts to allow running tests
-# on a very slow setup (but without network losses). Note that these
-# are server-side timeouts: The client should also avoid timing out
-# its own requests - for this reason we increase the CQL driver's
-# client-side timeout in conftest.py.
+        'strict_allow_filtering': True,
 
-range_request_timeout_in_ms: 300000
-read_request_timeout_in_ms: 300000
-counter_write_request_timeout_in_ms: 300000
-cas_contention_timeout_in_ms: 300000
-truncate_request_timeout_in_ms: 300000
-write_request_timeout_in_ms: 300000
-request_timeout_in_ms: 300000
-
-# Set up authentication in order to allow testing this module
-# and other modules dependent on it: e.g. service levels
-
-authenticator: {authenticator}
-authorizer: {authorizer}
-strict_allow_filtering: true
-
-permissions_update_interval_in_ms: 100
-permissions_validity_in_ms: 100
-"""
+        'permissions_update_interval_in_ms': 100,
+        'permissions_validity_in_ms': 100,
+    }
 
 # Seastar options can not be passed through scylla.yaml, use command line
 # for them. Keep everything else in the configuration file to make
@@ -213,14 +201,14 @@ class ScyllaServer:
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.config_filename.parent.mkdir(parents=True, exist_ok=True)
         # Create a configuration file.
-        fmt = {
-              "cluster_name": self.cluster_name,
-              "host": self.hostname,
-              "seeds": ",".join(self.seeds),
-              "workdir": self.workdir,
-        } | self.config_options
+        config = make_scylla_conf(
+                workdir = self.workdir,
+                host_addr = self.hostname,
+                seed_addrs = self.seeds,
+                cluster_name = self.cluster_name) \
+            | self.config_options
         with self.config_filename.open('w') as config_file:
-            config_file.write(SCYLLA_CONF_TEMPLATE.format(**fmt))
+            yaml.dump(config, config_file)
 
         self.log_file = self.log_filename.open("wb")
 

--- a/test/topology_raft_disabled/README.md
+++ b/test/topology_raft_disabled/README.md
@@ -1,0 +1,3 @@
+This suite is similar to the `topology` suite except Raft is disabled
+initially. It can still be enabled during a test.
+ The original purpose of this suite is to test the Raft upgrade procedure.

--- a/test/topology_raft_disabled/conftest.py
+++ b/test/topology_raft_disabled/conftest.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file configures pytest for all tests in this directory, and also
+# defines common test fixtures for all of them to use
+
+from test.topology.conftest import *

--- a/test/topology_raft_disabled/pytest.ini
+++ b/test/topology_raft_disabled/pytest.ini
@@ -1,0 +1,7 @@
+# Pytest configuration file. If we don't have one in this directory,
+# pytest will look for one in our ancestor directories, and may find
+# something irrelevant. So we should have one here, even if empty.
+[pytest]
+# Use shared fixtures from the parent dir
+addopts = --confcutdir ..
+asyncio_mode = auto

--- a/test/topology_raft_disabled/suite.yaml
+++ b/test/topology_raft_disabled/suite.yaml
@@ -1,0 +1,9 @@
+type: Topology
+pool_size: 1
+topology:
+    class: Simple
+    replication_factor: 3
+extra_scylla_config_options:
+    authenticator: AllowAllAuthenticator
+    authorizer: AllowAllAuthorizer
+    experimental_features: []

--- a/test/topology_raft_disabled/test_basic.py
+++ b/test/topology_raft_disabled/test_basic.py
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_basic(manager, random_tables):
+    table = await random_tables.add_table(ncolumns=3)
+    await table.add_column()
+    await random_tables.verify_schema()


### PR DESCRIPTION
Add a suite which is basically equivalent to `topology` except that it
doesn't start servers with Raft enabled.

The suite will be used to test the Raft upgrade procedure.

The suite contains a basic test just to check the suite itself can run;
the test will be removed when 'real' tests are added.

