### PR TITLE
test.py: remove spurious after test check

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -708,7 +708,6 @@ class ScyllaClusterManager:
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
         await self.site.stop()
-        self.cluster.after_test(self.test_name)
         if not self.cluster.is_dirty:
             logging.info("Returning Scylla cluster %s", self.cluster)
             await self.clusters.put(self.cluster)


### PR DESCRIPTION
Before/after test checks are done per test case, there's no longer need to check after pytest finishes.
