### PR TITLE
token_metadata: make local_dc_filter a lambda, not a std::function

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1313,12 +1313,6 @@ sstring topology::get_datacenter(inet_address ep) const {
     return i_endpoint_snitch::get_local_snitch_ptr()->get_datacenter(ep);
 }
 
-std::function<bool(inet_address)> topology::get_local_dc_filter() const noexcept {
-    return [ this, local_dc = get_datacenter() ] (inet_address ep) {
-        return get_datacenter(ep) == local_dc;
-    };
-}
-
 void topology::sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const {
     if (_sort_by_proximity) {
         std::sort(addresses.begin(), addresses.end(), [this, &address](inet_address& a1, inet_address& a2) {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -84,12 +84,15 @@ public:
     sstring get_datacenter() const;
     sstring get_datacenter(inet_address ep) const;
 
-    std::function<bool(inet_address)> get_local_dc_filter() const noexcept;
+    auto get_local_dc_filter() const noexcept {
+        return [ this, local_dc = get_datacenter() ] (inet_address ep) {
+            return get_datacenter(ep) == local_dc;
+        };
+    };
 
     template <std::ranges::range Range>
     inline size_t count_local_endpoints(const Range& endpoints) const {
-        auto filter = get_local_dc_filter();
-        return std::count_if(endpoints.begin(), endpoints.end(), filter);
+        return std::count_if(endpoints.begin(), endpoints.end(), get_local_dc_filter());
     }
 
     /**

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -778,7 +778,7 @@ storage_service::get_range_to_address_map_in_local_dc(
     for (auto entry : orig_map) {
         auto& addresses = filtered_map[entry.first];
         addresses.reserve(entry.second.size());
-        std::copy_if(entry.second.begin(), entry.second.end(), std::back_inserter(addresses), local_dc_filter);
+        std::copy_if(entry.second.begin(), entry.second.end(), std::back_inserter(addresses), std::cref(local_dc_filter));
         co_await coroutine::maybe_yield();
     }
 


### PR DESCRIPTION
This std::function causes allocations, both on construction and in other operations. This costs ~2200 instructions for a DC-local query. Fix that.