### PR TITLE
Raft test topology fix request paths and API response handling

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -562,6 +562,7 @@ raft_tests = set([
     'test/raft/replication_test',
     'test/raft/randomized_nemesis_test',
     'test/raft/many_test',
+    'test/raft/raft_server_test',
     'test/raft/fsm_test',
     'test/raft/etcd_test',
     'test/raft/raft_sys_table_storage_test',
@@ -1187,7 +1188,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
     'test/lib/random_schema.cc',
 ]
 
-scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc']
+scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
 
 scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc']
 
@@ -1321,6 +1322,7 @@ deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']
 deps['test/boost/rust_test'] += rusts
 
 deps['test/raft/replication_test'] = ['test/raft/replication_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
+deps['test/raft/raft_server_test'] = ['test/raft/raft_server_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/failure_detector_test'] = ['test/raft/failure_detector_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies

--- a/db/config.cc
+++ b/db/config.cc
@@ -898,7 +898,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , flush_schema_tables_after_modification(this, "flush_schema_tables_after_modification", liveness::LiveUpdate, value_status::Used, true,
         "Flush tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them")
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
-    , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
+    , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::TRUE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
     , restrict_twcs_without_default_ttl(this, "restrict_twcs_without_default_ttl", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent creating TimeWindowCompactionStrategy tables without a default TTL. Can be true, false, or warn.")
     , ignore_truncation_record(this, "unsafe_ignore_truncation_record", value_status::Used, false,
         "Ignore truncation record stored in system tables as if tables were never truncated.")

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -520,8 +520,4 @@ public:
     unsigned get_rpc_client_idx(messaging_verb verb) const;
 };
 
-void init_messaging_service(sharded<messaging_service>& ms,
-        messaging_service::config cfg, messaging_service::scheduling_config scheduling_config, const db::config& db_config);
-future<> uninit_messaging_service(sharded<messaging_service>& ms);
-
 } // namespace netw

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -269,7 +269,10 @@ struct commit_status_unknown : public error {
 };
 
 struct stopped_error : public error {
-    stopped_error() : error("Raft instance is stopped") {}
+    explicit stopped_error(const sstring& reason = "")
+            : error(!reason.empty()
+                    ? fmt::format("Raft instance is stopped, reason: \"{}\"", reason)
+                    : std::string("Raft instance is stopped")) {}
 };
 
 struct conf_change_in_progress : public error {

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -7,6 +7,7 @@
  */
 #include "server.hh"
 
+#include "utils/error_injection.hh"
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
@@ -80,7 +81,7 @@ public:
     future<> set_configuration(config_member_set c_new, seastar::abort_source* as = nullptr) override;
     raft::configuration get_configuration() const override;
     future<> start() override;
-    future<> abort() override;
+    future<> abort(sstring reason) override;
     term_t get_current_term() const override;
     future<> read_barrier(seastar::abort_source* as = nullptr) override;
     void wait_until_candidate() override;
@@ -113,8 +114,8 @@ private:
     std::list<active_read> _reads;
     std::multimap<index_t, awaited_index> _awaited_indexes;
 
-    // Set to true when abort() is called
-    bool _aborted = false;
+    // Set to abort reason when abort() is called
+    std::optional<sstring> _aborted;
 
     // Signaled when apply index is changed
     condition_variable _applied_index_changed;
@@ -273,6 +274,9 @@ private:
     // term.
     future<> wait_for_apply(index_t idx, abort_source*);
 
+    void check_not_aborted();
+    void handle_background_error(const char* fiber_name);
+
     friend std::ostream& operator<<(std::ostream& os, const server_impl& s);
 };
 
@@ -389,9 +393,7 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
         }
     }
 
-    if (_aborted) {
-        throw stopped_error();
-    }
+    check_not_aborted();
 
     if (as && as->abort_requested()) {
         throw request_aborted();
@@ -501,6 +503,7 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         if (as && as->abort_requested()) {
             throw request_aborted();
         }
+        check_not_aborted();
         if (leader == server_id{}) {
             co_await wait_for_leader(as);
             leader = _fsm->current_leader();
@@ -600,6 +603,7 @@ future<> server_impl::modify_config(std::vector<config_member> add, std::vector<
         if (as && as->abort_requested()) {
             throw request_aborted();
         }
+        check_not_aborted();
         if (leader == server_id{}) {
             co_await wait_for_leader(as);
             leader = _fsm->current_leader();
@@ -852,6 +856,9 @@ future<> server_impl::io_fiber(index_t last_stable) {
                     _stats.truncate_persisted_log++;
                 }
 
+                utils::get_local_injector().inject("store_log_entries/test-failure",
+                    [] { throw std::runtime_error("store_log_entries/test-failure"); });
+
                 // Combine saving and truncating into one call?
                 // will require persistence to keep track of last idx
                 co_await _persistence->store_log_entries(entries);
@@ -950,7 +957,7 @@ future<> server_impl::io_fiber(index_t last_stable) {
     } catch (stop_apply_fiber&) {
         // Log fiber is stopped explicitly
     } catch (...) {
-        logger.error("[{}] io fiber stopped because of the error: {}", _id, std::current_exception());
+        handle_background_error("io");
     }
     co_return;
 }
@@ -1096,7 +1103,7 @@ future<> server_impl::applier_fiber() {
     } catch(stop_apply_fiber& ex) {
         // the fiber is aborted
     } catch (...) {
-        logger.error("[{}] applier fiber stopped because of the error: {}", _id, std::current_exception());
+        handle_background_error("applier");
     }
     co_return;
 }
@@ -1125,9 +1132,7 @@ future<> server_impl::wait_for_apply(index_t idx, abort_source* as) {
 }
 
 future<read_barrier_reply> server_impl::execute_read_barrier(server_id from, seastar::abort_source* as) {
-    if (_aborted) {
-        throw stopped_error();
-    }
+    check_not_aborted();
 
     logger.trace("[{}] execute_read_barrier start", _id);
 
@@ -1176,6 +1181,7 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
         if (as && as->abort_requested()) {
             throw request_aborted();
         }
+        check_not_aborted();
         logger.trace("[{}] read_barrier forward to  {}", _id, leader);
         if (leader == server_id{}) {
             co_await wait_for_leader(as);
@@ -1233,8 +1239,22 @@ void server_impl::abort_snapshot_transfers() {
     _snapshot_transfers.clear();
 }
 
-future<> server_impl::abort() {
-    _aborted = true;
+void server_impl::check_not_aborted() {
+    if (_aborted) {
+        throw stopped_error(*_aborted);
+    }
+}
+
+void server_impl::handle_background_error(const char* fiber_name) {
+    const auto e = std::current_exception();
+    logger.error("[{}] {} fiber stopped because of the error: {}", _id, fiber_name, e);
+    if (_config.on_background_error) {
+        _config.on_background_error(e);
+    }
+}
+
+future<> server_impl::abort(sstring reason) {
+    _aborted = std::move(reason);
     logger.trace("[{}]: abort() called", _id);
     _fsm->stop();
 
@@ -1260,15 +1280,15 @@ future<> server_impl::abort() {
     // since the RPC implementation may wait for forwarded `modify_config` calls to finish
     // (and `modify_config` does not finish until the configuration entry is committed or an error occurs).
     for (auto& ac: _awaited_commits) {
-        ac.second.done.set_exception(stopped_error());
+        ac.second.done.set_exception(stopped_error(*_aborted));
     }
     for (auto& aa: _awaited_applies) {
-        aa.second.done.set_exception(stopped_error());
+        aa.second.done.set_exception(stopped_error(*_aborted));
     }
     _awaited_commits.clear();
     _awaited_applies.clear();
     if (_non_joint_conf_commit_promise) {
-        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(stopped_error());
+        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(stopped_error(*_aborted));
     }
 
     // Complete all read attempts with not_a_leader
@@ -1279,14 +1299,14 @@ future<> server_impl::abort() {
 
     // Abort all read_barriers with an exception
     for (auto& i : _awaited_indexes) {
-        i.second.promise.set_exception(stopped_error());
+        i.second.promise.set_exception(stopped_error(*_aborted));
     }
     _awaited_indexes.clear();
 
     co_await seastar::when_all_succeed(std::move(abort_rpc), std::move(abort_sm), std::move(abort_persistence)).discard_result();
 
     if (_leader_promise) {
-        _leader_promise->set_exception(stopped_error());
+        _leader_promise->set_exception(stopped_error(*_aborted));
     }
 
     abort_snapshot_transfers();
@@ -1301,6 +1321,7 @@ future<> server_impl::abort() {
 }
 
 future<> server_impl::set_configuration(config_member_set c_new, seastar::abort_source* as) {
+    check_not_aborted();
     const auto& cfg = _fsm->get_configuration();
     // 4.1 Cluster membership changes. Safety.
     // When the leader receives a request to add or remove a server

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -45,6 +45,9 @@ public:
         // Max size of a single command, add_entry with a bigger command will throw command_is_too_big_error.
         // The value of zero means no limit.
         size_t max_command_size = 0;
+        // A callback to invoke if one of internal server
+        // background activities has stopped because of an error.
+        std::function<void(std::exception_ptr e)> on_background_error;
     };
 
     virtual ~server() {}
@@ -136,7 +139,7 @@ public:
     // to know if they succeeded or not. If this server was
     // a leader it will relinquish its leadership and cease
     // replication.
-    virtual future<> abort() = 0;
+    virtual future<> abort(sstring reason = "") = 0;
 
     // Return Raft protocol current term.
     virtual term_t get_current_term() const = 0;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -92,8 +92,10 @@ raft_group0::raft_group0(seastar::abort_source& abort_source,
         gms::feature_service& feat,
         raft_group0_client& client)
     : _abort_source(abort_source), _raft_gr(raft_gr), _ms(ms), _gossiper(gs), _qp(qp), _mm(mm), _feat(feat), _client(client)
+    , _status_for_monitoring(_raft_gr.is_enabled() ? status_for_monitoring::normal : status_for_monitoring::disabled)
 {
     init_rpc_verbs();
+    register_metrics();
 }
 
 void raft_group0::init_rpc_verbs() {
@@ -179,7 +181,11 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
                 // Dividing by two is to protect against paddings that the
                 // commit log can add for each mutation, as well as
                 // against different commit log limits on different nodes.
-                .max_command_size = cl ? cl->max_record_size() / 2 : 0
+                .max_command_size = cl ? cl->max_record_size() / 2 : 0,
+                .on_background_error = [gid, this](std::exception_ptr e) {
+                    _raft_gr.abort_server(gid, fmt::format("background error, {}", e));
+                    _status_for_monitoring = status_for_monitoring::aborted;
+                }
             });
 
     // initialize the corresponding timer to tick the raft server instance
@@ -1430,6 +1436,14 @@ future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state) {
     }
 
     upgrade_log.info("Schema synchronized.");
+}
+
+void raft_group0::register_metrics() {
+    namespace sm = seastar::metrics;
+    _metrics.add_group("raft_group0", {
+        sm::make_gauge("status", [this] { return static_cast<uint8_t>(_status_for_monitoring); },
+            sm::description("status of the raft group, 0 - disabled, 1 - normal, 2 - aborted"))
+    });
 }
 
 std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -82,6 +82,17 @@ class raft_group0 {
 
     gms::feature::listener_registration _raft_support_listener;
 
+    seastar::metrics::metric_groups _metrics;
+    void register_metrics();
+
+    // Status of the raft group0 for monitoring.
+    enum class status_for_monitoring : uint8_t {
+        // Raft is disabled.
+        disabled = 0,
+        normal = 1,
+        aborted = 2
+    } _status_for_monitoring;
+
 public:
     // Assumes that the provided services are fully started.
     raft_group0(seastar::abort_source& abort_source,

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -39,6 +39,7 @@ struct raft_server_for_group {
     std::unique_ptr<raft_ticker_type> ticker;
     raft_rpc& rpc;
     raft_sys_table_storage& persistence;
+    std::optional<seastar::future<>> aborted;
 };
 
 // This class is responsible for creating, storing and accessing raft servers.
@@ -102,6 +103,7 @@ public:
     // Start raft server instance, store in the map of raft servers and
     // arm the associated timer to tick the server.
     future<> start_server_for_group(raft_server_for_group grp);
+    void abort_server(raft::group_id gid, sstring reason = "");
     unsigned shard_for_group(const raft::group_id& gid) const;
     shared_ptr<raft::failure_detector> failure_detector();
     raft_address_map<>& address_map() { return _srv_address_mappings; }

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -13,8 +13,10 @@
 #include "test/lib/log.hh"
 
 #include "utils/UUID_gen.hh"
+#include "utils/error_injection.hh"
 #include "transport/messages/result_message.hh"
 #include "service/migration_manager.hh"
+#include "seastar/core/metrics_api.hh"
 
 static future<utils::chunked_vector<std::vector<bytes_opt>>> fetch_rows(cql_test_env& e, std::string_view cql) {
     auto msg = co_await e.execute_cql(cql);
@@ -25,6 +27,48 @@ static future<utils::chunked_vector<std::vector<bytes_opt>>> fetch_rows(cql_test
 
 static future<size_t> get_history_size(cql_test_env& e) {
     co_return (co_await fetch_rows(e, "select * from system.group0_history")).size();
+}
+
+SEASTAR_TEST_CASE(test_abort_server_on_background_error) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+    return make_ready_future<>();
+#else
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        utils::get_local_injector().enable("store_log_entries/test-failure", true);
+
+        auto get_metric_ui64 = [&](sstring name) {
+            const auto& value_map = seastar::metrics::impl::get_value_map();
+            const auto& metric_family = value_map.at("raft_group0_" + name);
+            const auto& registered_metric = metric_family.at({{"shard", "0"}});
+            return (*registered_metric)().ui();
+        };
+
+        auto get_status = [&] {
+            return get_metric_ui64("status");
+        };
+
+        auto perform_schema_change = [&, has_ks = false] () mutable -> future<> {
+            if (has_ks) {
+                co_await e.execute_cql("drop keyspace new_ks");
+            } else {
+                co_await e.execute_cql("create keyspace new_ks with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            }
+            has_ks = !has_ks;
+        };
+
+        auto check_error = [](const raft::stopped_error& e) {
+            return e.what() == sstring("Raft instance is stopped, reason: \"background error, std::runtime_error (store_log_entries/test-failure)\"");
+        };
+        BOOST_REQUIRE_EQUAL(get_status(), 1);
+        BOOST_CHECK_EXCEPTION(co_await perform_schema_change(), raft::stopped_error, check_error);
+        BOOST_REQUIRE_EQUAL(get_status(), 2);
+        BOOST_CHECK_EXCEPTION(co_await perform_schema_change(), raft::stopped_error, check_error);
+        BOOST_REQUIRE_EQUAL(get_status(), 2);
+        BOOST_CHECK_EXCEPTION(co_await perform_schema_change(), raft::stopped_error, check_error);
+        BOOST_REQUIRE_EQUAL(get_status(), 2);
+    }, raft_cql_test_config());
+#endif
 }
 
 SEASTAR_TEST_CASE(test_group0_history_clearing_old_entries) {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -51,6 +51,7 @@ namespace service {
 class client_state;
 class migration_manager;
 class raft_group0_client;
+class raft_group_registry;
 
 }
 
@@ -165,6 +166,8 @@ public:
     virtual future<> refresh_client_state() = 0;
 
     virtual service::raft_group0_client& get_raft_group0_client() = 0;
+
+    virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
     data_dictionary::database data_dictionary();
 };

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -123,29 +123,25 @@ class ManagerClient():
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
-        await self._get("/cluster/mark-dirty")
+        await self._get_text("/cluster/mark-dirty")
 
-    async def server_stop(self, server_id: str) -> bool:
+    async def server_stop(self, server_id: str) -> None:
         """Stop specified server"""
-        ret = await self._get_text(f"/cluster/server/{server_id}/stop")
-        return ret == "OK"
+        await self._get_text(f"/cluster/server/{server_id}/stop")
 
-    async def server_stop_gracefully(self, server_id: str) -> bool:
+    async def server_stop_gracefully(self, server_id: str) -> None:
         """Stop specified server gracefully"""
-        ret = await self._get_text(f"/cluster/server/{server_id}/stop_gracefully")
-        return ret == "OK"
+        await self._get_text(f"/cluster/server/{server_id}/stop_gracefully")
 
-    async def server_start(self, server_id: str) -> bool:
+    async def server_start(self, server_id: str) -> None:
         """Start specified server"""
-        ret = await self._get_text(f"/cluster/server/{server_id}/start")
+        await self._get_text(f"/cluster/server/{server_id}/start")
         self._driver_update()
-        return ret == "OK"
 
-    async def server_restart(self, server_id: str) -> bool:
+    async def server_restart(self, server_id: str) -> None:
         """Restart specified server"""
-        ret = await self._get_text(f"/cluster/server/{server_id}/restart")
+        await self._get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
-        return ret == "OK"
 
     async def server_add(self) -> str:
         """Add a new server"""
@@ -155,12 +151,12 @@ class ManagerClient():
 
     async def server_remove(self, server_id: str) -> None:
         """Remove a specified server"""
-        await self._get(f"/cluster/removeserver/{server_id}")
+        await self._get_text(f"/cluster/removeserver/{server_id}")
         self._driver_update()
 
     async def start_stopped(self) -> None:
         """Start all previously stopped servers"""
-        await self._get(f"/cluster/start_stopped")
+        await self._get_text(f"/cluster/start_stopped")
         self._driver_update()
 
     async def server_get_config(self, server_id: str) -> dict[str, object]:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -79,7 +79,11 @@ class ManagerClient():
     async def _get(self, resource: str) -> aiohttp.ClientResponse:
         # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html
         # NOTE: using Python requests style URI for Unix domain sockets to avoid using "localhost"
-        return await self.session.get(self._resource_uri(resource))
+        resp = await self.session.get(self._resource_uri(resource))
+        if resp.status != 200:
+            text = await resp.text()
+            raise Exception(f'status code: {resp.status}, body text: {text}')
+        return resp
 
     async def _get_text(self, resource: str) -> str:
         resp = await self._get(resource)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -122,36 +122,36 @@ class ManagerClient():
         await self._get("/cluster/mark-dirty")
 
     async def server_stop(self, server_id: str) -> bool:
-        """Stop specified node"""
-        ret = await self._get_text(f"/cluster/node/{server_id}/stop")
+        """Stop specified server"""
+        ret = await self._get_text(f"/cluster/server/{server_id}/stop")
         return ret == "OK"
 
     async def server_stop_gracefully(self, server_id: str) -> bool:
-        """Stop specified node gracefully"""
-        ret = await self._get_text(f"/cluster/node/{server_id}/stop_gracefully")
+        """Stop specified server gracefully"""
+        ret = await self._get_text(f"/cluster/server/{server_id}/stop_gracefully")
         return ret == "OK"
 
     async def server_start(self, server_id: str) -> bool:
-        """Start specified node"""
-        ret = await self._get_text(f"/cluster/node/{server_id}/start")
+        """Start specified server"""
+        ret = await self._get_text(f"/cluster/server/{server_id}/start")
         self._driver_update()
         return ret == "OK"
 
     async def server_restart(self, server_id: str) -> bool:
-        """Restart specified node"""
-        ret = await self._get_text(f"/cluster/node/{server_id}/restart")
+        """Restart specified server"""
+        ret = await self._get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
         return ret == "OK"
 
     async def server_add(self) -> str:
-        """Add a new node"""
-        server_id = await self._get_text("/cluster/addnode")
+        """Add a new server"""
+        server_id = await self._get_text("/cluster/addserver")
         self._driver_update()
         return server_id
 
     async def server_remove(self, server_id: str) -> None:
-        """Remove a specified node"""
-        await self._get(f"/cluster/removenode/{server_id}")
+        """Remove a specified server"""
+        await self._get(f"/cluster/removeserver/{server_id}")
         self._driver_update()
 
     async def start_stopped(self) -> None:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -154,11 +154,6 @@ class ManagerClient():
         await self._get_text(f"/cluster/removeserver/{server_id}")
         self._driver_update()
 
-    async def start_stopped(self) -> None:
-        """Start all previously stopped servers"""
-        await self._get_text(f"/cluster/start_stopped")
-        self._driver_update()
-
     async def server_get_config(self, server_id: str) -> dict[str, object]:
         resp = await self._get(f"/cluster/server/{server_id}/get_config")
         if resp.status != 200:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -728,6 +728,7 @@ class ScyllaClusterManager:
     async def _before_test(self, test_name: str) -> None:
         if self.cluster.is_dirty:
             await self.cluster.stop()
+            await self.clusters.add_one(took_one=True)   # Replace with fresh one
             await self._get_cluster()
         logging.info("Leasing Scylla cluster %s for test %s", self.cluster, test_name)
         self.cluster.before_test(self.test_name)
@@ -736,12 +737,18 @@ class ScyllaClusterManager:
 
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
+        logging.info("ScyllaManager stopping for test %s", self.test_name)
         await self.site.stop()
         if not self.cluster.is_dirty:
-            logging.info("Returning Scylla cluster %s", self.cluster)
+            logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_name)
             await self.clusters.put(self.cluster)
         else:
+            logging.info("ScyllaManager stopping Scylla cluster %s for test %s", self.cluster,
+                         self.test_name)
             await self.cluster.stop()
+            logging.info("ScyllaManager adding fresh ScylaCluster to the pool for test %s",
+                         self.test_name)
+            await self.clusters.add_one(took_one=True)   # Replace with fresh one
         del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -638,8 +638,10 @@ class ScyllaCluster:
 
     async def server_restart(self, server_id: str) -> ActionReturn:
         """Restart a running server"""
+        logging.info("Cluster %s restarting server %s", self, server_id)
         ret = await self.server_stop(server_id, gracefully=True)
         if not ret.success:
+            logging.error("Cluster %s failed to stop server %s", self, server_id)
             return ret
         return await self.server_start(server_id)
 

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -1,0 +1,30 @@
+#include "replication.hh"
+
+#ifdef SEASTAR_DEBUG
+// Increase tick time to allow debug to process messages
+const auto tick_delay = 200ms;
+#else
+const auto tick_delay = 100ms;
+#endif
+
+SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
+    raft_cluster<std::chrono::steady_clock> cluster(
+        test_case { .nodes = 1 },
+        [](raft::server_id id, const std::vector<raft::command_cref>& commands, lw_shared_ptr<hasher_int> hasher) {
+            return 0;
+        },
+        0,
+        0,
+        0, false, tick_delay, rpc_config{});
+    cluster.start_all().get0();
+
+    cluster.stop_server(0, "test crash").get0();
+
+    auto check_error = [](const raft::stopped_error& e) {
+        return e.what() == sstring("Raft instance is stopped, reason: \"test crash\"");
+    };
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).modify_config({}, {to_raft_id(0)}).get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).read_barrier().get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).set_configuration({}).get0(), raft::stopped_error, check_error);
+}

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -62,10 +62,16 @@ def _wrap_future(f: ResponseFuture) -> asyncio.Future:
     aio_future = loop.create_future()
 
     def on_result(result):
-        loop.call_soon_threadsafe(aio_future.set_result, result)
+        if not aio_future.done():
+            loop.call_soon_threadsafe(aio_future.set_result, result)
+        else:
+            logger.debug("_wrap_future: on_result() on already done future: %s", result)
 
     def on_error(exception, *_):
-        loop.call_soon_threadsafe(aio_future.set_exception, exception)
+        if not aio_future.done():
+            loop.call_soon_threadsafe(aio_future.set_exception, exception)
+        else:
+            logger.debug("_wrap_future: on_error() on already done future: %s"), result
 
     f.add_callback(on_result)
     f.add_errback(on_error)

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -188,9 +188,7 @@ def fails_without_raft(request, check_pre_raft):
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
 # used in tests to make schema changes. Tables are dropped after finished.
 @pytest.fixture(scope="function")
-async def random_tables(request, cql, manager):
+def random_tables(request, cql):
     tables = RandomTables(request.node.name, cql, unique_name())
     yield tables
-    # NOTE: to avoid occasional timeouts on keyspace teardown, start stopped servers
-    await manager.start_stopped()
     tables.drop_all()

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -126,7 +126,9 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
                    # See issue #11289.
                    connect_timeout = 200,
                    control_connection_timeout = 200,
-                   max_schema_agreement_wait=200,
+                   # NOTE: max_schema_agreement_wait must be 2x or 3x smaller than request_timeout
+                   # else the driver can't handle a server being down
+                   max_schema_agreement_wait=20,
                    idle_heartbeat_timeout=200,
                    )
 


### PR DESCRIPTION
- Raise on response not HTTP 200 for `.get_text()` helper
- Fix API paths
- Close and start a fresh driver when restarting a server and it's the only server in the cluster
- Fix stop/restart response as text instead of inspecting (errors are status 500 and raise exceptions)