### PR TITLE
wasm: directly handle recycling of invalidated instance

### DIFF
--- a/lang/wasm_instance_cache.cc
+++ b/lang/wasm_instance_cache.cc
@@ -147,6 +147,9 @@ void instance_cache::recycle(instance_cache::value_type val) noexcept {
     val->mutex.unlock();
     size_t size;
     try {
+        if (!val->instance) {
+            return;
+        }
         size = get_instance_size(val->instance.value());
         if (size > 1 * MB) {
             val->instance = std::nullopt;


### PR DESCRIPTION
An instance may be invalidated before we try to recycle it. We perform this by setting its value to a nullopt. This patch adds a check for it when calculating its size. This behavior didn't cause issues before because the catch clause below caught errors caused by calling value() on a nullopt, even though it was intended for errors from get_instance_size.

Signed-off-by: Wojciech Mitros <wojciech.mitros@scylladb.com>