### PR TITLE
cql-pytest: more neutral command in cql_test_connection fixture

### DIFF
--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -51,9 +51,9 @@ def cql(request):
 def cql_test_connection(cql, request):
     yield
     try:
-        # We want to run a do-nothing CQL command. "use system" is the
-        # closest to do-nothing I could find...
-        cql.execute("use system")
+        # We want to run a do-nothing CQL command. 
+        # "BEGIN BATCH APPLY BATCH" is the closest to do-nothing I could find...
+        cql.execute("BEGIN BATCH APPLY BATCH")
     except:
         pytest.exit(f"Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}")
 


### PR DESCRIPTION
I'm currently testing server-side describe statement and executing `USE system` isn't neutral for those tests.