### PR TITLE
gms: feature_service: remove the USES_RAFT feature

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -65,13 +65,6 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
     }
     if (!cfg.check_experimental(db::experimental_features_t::feature::RAFT)) {
         fcfg._disabled_features.insert("SUPPORTS_RAFT_CLUSTER_MANAGEMENT"s);
-        fcfg._disabled_features.insert("USES_RAFT_CLUSTER_MANAGEMENT"s);
-    } else {
-        // Disable support for using raft cluster management so that it cannot
-        // be enabled by accident.
-        // This prevents the `USES_RAFT_CLUSTER_MANAGEMENT` feature from being
-        // advertised via gossip ahead of time.
-        fcfg._masked_features.insert("USES_RAFT_CLUSTER_MANAGEMENT"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -106,7 +106,6 @@ public:
     // Replica is allowed to send back empty pages to coordinator on queries.
     gms::feature empty_replica_pages { *this, "EMPTY_REPLICA_PAGES"sv };
     gms::feature supports_raft_cluster_mgmt { *this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv };
-    gms::feature uses_raft_cluster_mgmt { *this, "USES_RAFT_CLUSTER_MANAGEMENT"sv };
     gms::feature tombstone_gc_options { *this, "TOMBSTONE_GC_OPTIONS"sv };
     gms::feature parallelized_aggregation { *this, "PARALLELIZED_AGGREGATION"sv };
     gms::feature keyspace_storage_options { *this, "KEYSPACE_STORAGE_OPTIONS"sv };


### PR DESCRIPTION
It was not and won't be used for anything.
Note that the feature was always disabled or masked so no node ever announced it, thus it's safe to get rid of.