### PR TITLE
utils: config_file: fix handling of workdir,W in the YAML file

### DIFF
--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -199,7 +199,13 @@ utils::config_type::to_json(const void* value) const {
 
 bool
 utils::config_file::config_src::matches(std::string_view name) const {
-    if (_name == name) {
+    // The below line provides support for option names in the "long_name,short_name" format,
+    // such as "workdir,W". We only want the long name ("workdir") to be used in the YAML.
+    // But since at some point (due to a bug) the YAML config parser expected the silly
+    // double form ("workdir,W") instead, we support both for backward compatibility.
+    std::string_view long_name = _name.substr(0, _name.find_first_of(','));
+
+    if (_name == name || long_name == name) {
         return true;
     }
     if (!_alias.empty() && _alias == name) {


### PR DESCRIPTION
Option names given in db/config.cc are handled for the command line by passing them to boost::program_options, and by YAML by comparing them with YAML keys.
boost::program_options has logic for understanding the long_name,short_name syntax, so for a "workdir,W" option both --workdir and -W worked, as intended. But our YAML config parsing doesn't have this logic and expected "workdir,W" verbatim, which is obviously not intended. Fix that.

Fixes #7478
Fixes #9500
Fixes #11503