### PR TITLE
pylib: Cast port number config to int explicitly

### DIFF
--- a/test/pylib/cql_repl/conftest.py
+++ b/test/pylib/cql_repl/conftest.py
@@ -69,7 +69,7 @@ def cql(request):
         ssl_context = None
     cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
                       contact_points=[request.config.getoption('host')],
-                      port=request.config.getoption('port'),
+                      port=int(request.config.getoption('port')),
                       # TODO: make the protocol version an option, to allow testing with
                       # different versions. If we drop this setting completely, it will
                       # mean pick the latest version supported by the client and the server.


### PR DESCRIPTION
Otherwise it crashes some python versions.

The cast was there before a2dd64f68ff3b452d9bd6ea676e19afed64838d8 explicitly dropped one while moving the code between files.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>