### PR TITLE
gms: feature_service: don't distinguish between 'known' and 'supported' features

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3164,7 +3164,7 @@ future<> system_keyspace::enable_features_on_startup(sharded<gms::feature_servic
         co_return;
     }
     gms::feature_service& local_feat_srv = feat.local();
-    const auto known_features = local_feat_srv.known_feature_set();
+    const auto known_features = local_feat_srv.supported_feature_set();
     const auto& registered_features = local_feat_srv.registered_features();
     const auto persisted_features = gms::feature_service::to_feature_set(*pre_enabled_features);
     for (auto&& f : persisted_features) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -98,16 +98,7 @@ void feature_service::enable(const sstring& name) {
     }
 }
 
-future<> feature_service::support(const std::string_view& name) {
-    _config._masked_features.erase(sstring(name));
-
-    if (db::qctx) {
-        // Update `system.local#supported_features` accordingly
-        co_await db::system_keyspace::save_local_supported_features(supported_feature_set());
-    }
-}
-
-std::set<std::string_view> feature_service::known_feature_set() {
+std::set<std::string_view> feature_service::supported_feature_set() {
     // Add features known by this local node. When a new feature is
     // introduced in scylla, update it here, e.g.,
     // return sstring("FEATURE1,FEATURE2")
@@ -146,15 +137,6 @@ std::set<std::string_view> feature_service::known_feature_set() {
 
 const std::unordered_map<sstring, std::reference_wrapper<feature>>& feature_service::registered_features() const {
     return _registered_features;
-}
-
-std::set<std::string_view> feature_service::supported_feature_set() {
-    auto features = known_feature_set();
-
-    for (const sstring& s : _config._masked_features) {
-        features.erase(s);
-    }
-    return features;
 }
 
 feature::feature(feature_service& service, std::string_view name, bool enabled)

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -29,7 +29,6 @@ class feature_service;
 struct feature_config {
 private:
     std::set<sstring> _disabled_features;
-    std::set<sstring> _masked_features;
     feature_config();
 
     friend class feature_service;
@@ -60,10 +59,8 @@ public:
     future<> stop();
     // Has to run inside seastar::async context
     void enable(const sstring& name);
-    future<> support(const std::string_view& name);
     void enable(const std::set<std::string_view>& list);
     db::schema_features cluster_schema_features() const;
-    std::set<std::string_view> known_feature_set();
     std::set<std::string_view> supported_feature_set();
 
     // Key in the 'system.scylla_local' table, that is used to

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -331,7 +331,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     } else if (should_bootstrap()) {
         co_await check_for_endpoint_collision(initial_contact_nodes, loaded_peer_features);
     } else {
-        auto local_features = _feature_service.known_feature_set();
+        auto local_features = _feature_service.supported_feature_set();
         slogger.info("Checking remote features with gossip, initial_contact_nodes={}", initial_contact_nodes);
         co_await _gossiper.do_shadow_round(initial_contact_nodes);
         _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
@@ -1552,7 +1552,7 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
     return seastar::async([this, initial_contact_nodes, loaded_peer_features] {
         auto t = gms::gossiper::clk::now();
         bool found_bootstrapping_node = false;
-        auto local_features = _feature_service.known_feature_set();
+        auto local_features = _feature_service.supported_feature_set();
         do {
             slogger.info("Checking remote features with gossip");
             _gossiper.do_shadow_round(initial_contact_nodes).get();
@@ -1623,7 +1623,7 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
     // make magic happen
     slogger.info("Checking remote features with gossip");
     co_await _gossiper.do_shadow_round(initial_contact_nodes);
-    auto local_features = _feature_service.known_feature_set();
+    auto local_features = _feature_service.supported_feature_set();
     _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
 
     // now that we've gossiped at least once, we should be able to find the node we're replacing

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -672,7 +672,7 @@ public:
 
             feature_service.invoke_on_all([] (auto& fs) {
                 return seastar::async([&fs] {
-                    fs.enable(fs.known_feature_set());
+                    fs.enable(fs.supported_feature_set());
                 });
             }).get();
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -195,7 +195,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     cfg.volatile_system_keyspace_for_testing(true);
 
     gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
-    feature_service.enable(feature_service.known_feature_set());
+    feature_service.enable(feature_service.supported_feature_set());
     sharded<locator::shared_token_metadata> token_metadata;
 
     token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }).get();


### PR DESCRIPTION
`feature_service` provided two sets of features: `known_feature_set` and
`supported_feature_set`. The purpose of both and the distinction between
them was unclear and undocumented.

The 'supported' features were gossiped by every node. Once a feature is
supported by every node in the cluster, it becomes 'enabled'. This means
that whatever piece of functionality is covered by the feature, it can
by used by the cluster from now on.

The 'known' set was used to perform feature checks on node start; if the
node saw that a feature is enabled in the cluster, but the node does not
'know' the feature, it would refuse to start. However, if the feature
was 'known', but wasn't 'supported', the node would not complain. This
means that we could in theory allow the following scenario:
1. all nodes support feature X.
2. X becomes enabled in the cluster.
3. the user changes the configuration of some node so feature X will
   become unsupported but still known.
4. The node restarts without error.

So now we have a feature X which is enabled in the cluster, but not
every node supports it. That does not make sense.

It is not clear whether it was accidental or purposeful that we used the
'known' set instead of the 'supported' set to perform the feature check.

What I think is clear, is that having two sets makes the entire thing
unnecessarily complicated and hard to think about.

Fortunately, at the base to which this patch is applied, the sets are
always the same. So we can easily get rid of one of them.

I decided that the name which should stay is 'supported', I think it's
more specific than 'known' and it matches the name of the corresponding
gossiper application state.

