### PR TITLE
exception: fix the error code used for rate_limit_exception

### DIFF
--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -83,7 +83,7 @@ overloaded_exception::overloaded_exception(size_t c) noexcept
     {}
 
 rate_limit_exception::rate_limit_exception(const sstring& ks, const sstring& cf, db::operation_type op_type_, bool rejected_by_coordinator_) noexcept
-    : cassandra_exception(exception_code::CONFIG_ERROR, prepare_message("Per-partition rate limit reached for {} in table {}.{}, rejected by {}", op_type_, ks, cf, rejected_by_coordinator_ ? "coordinator" : "replicas"))
+    : cassandra_exception(exception_code::RATE_LIMIT_ERROR, prepare_message("Per-partition rate limit reached for {} in table {}.{}, rejected by {}", op_type_, ks, cf, rejected_by_coordinator_ ? "coordinator" : "replicas"))
     , op_type(op_type_)
     , rejected_by_coordinator(rejected_by_coordinator_)
     { }


### PR DESCRIPTION
Per-partition rate limiting added a new error type which should be returned when Scylla decides to reject an operation due to per-partition rate limit being exceeded. The new error code requires drivers to negotiate support for it, otherwise Scylla will report the error as `Config_error`. The existing error code override logic works properly, however due to a mistake Scylla will report the `Config_error` code even if the driver correctly negotiated support for it.

This commit fixes the problem by specifying the correct error code in `rate_limit_exception`'s constructor.

Tested manually with a modified version of the Rust driver which negotiates support for the new error. Additionally, tested what happens when the driver doesn't negotiate support (Scylla properly falls back to `Config_error`).

Branches: 5.1
Fixes: #11517