### PR TITLE
raft: broadcast_tables: add support for bind variables

### DIFF
--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -10,7 +10,7 @@
 
 #include "cql3/constants.hh"
 #include "cql3/cql3_type.hh"
-#include "service/broadcast_tables/experimental/lang.hh"
+#include "cql3/statements/strongly_consistent_modification_statement.hh"
 
 namespace cql3 {
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
@@ -24,8 +24,8 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
     }
 }
 
-void constants::setter::prepare_for_broadcast_tables(service::broadcast_tables::update_query& query) const {
-    // FIXME: this works only for constants and bind markers are unimplemented at this point.
-    query.new_value = expr::evaluate(*_e, query_options::DEFAULT).to_bytes();
+void
+constants::setter::prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update& query) const {
+    query.new_value = *_e;
 }
 }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -50,7 +50,7 @@ public:
             }
         }
 
-        virtual void prepare_for_broadcast_tables(service::broadcast_tables::update_query& query) const override;
+        virtual void prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update& query) const override;
     };
 
     struct adder final : operation {

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -359,7 +359,7 @@ operation::element_deletion::prepare(data_dictionary::database db, const sstring
 }
 
 void
-operation::prepare_for_broadcast_tables(service::broadcast_tables::update_query&) const {
+operation::prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update&) const {
     // FIXME: implement for every type of `operation`.
     throw service::broadcast_tables::unsupported_operation_error{};
 }

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <seastar/core/shared_ptr.hh>
+#include "cql3/cql3_type.hh"
 #include "exceptions/exceptions.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "update_parameters.hh"
@@ -19,11 +20,11 @@
 
 #include <optional>
 
-namespace service::broadcast_tables {
-    class update_query;
-}
-
 namespace cql3 {
+
+namespace statements::broadcast_tables {
+    struct prepared_update;
+}
 
 class update_parameters;
 
@@ -90,7 +91,7 @@ public:
      */
     virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) = 0;
     
-    virtual void prepare_for_broadcast_tables(service::broadcast_tables::update_query&) const;
+    virtual void prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update&) const;
 
     /**
      * A parsed raw UPDATE operation.

--- a/cql3/statements/strongly_consistent_modification_statement.hh
+++ b/cql3/statements/strongly_consistent_modification_statement.hh
@@ -18,13 +18,23 @@ namespace cql3 {
 
 namespace statements {
 
+namespace broadcast_tables {
+
+struct prepared_update {
+    expr::expression key;
+    expr::expression new_value;
+    std::optional<expr::expression> value_condition;
+};
+
+}
+
 class strongly_consistent_modification_statement : public cql_statement_opt_metadata {
     const uint32_t _bound_terms;
     const schema_ptr _schema;
-    const service::broadcast_tables::update_query _query;
+    const broadcast_tables::prepared_update _query;
 
 public:
-    strongly_consistent_modification_statement(uint32_t bound_terms, schema_ptr schema, service::broadcast_tables::update_query query);
+    strongly_consistent_modification_statement(uint32_t bound_terms, schema_ptr schema, broadcast_tables::prepared_update query);
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;

--- a/cql3/statements/strongly_consistent_select_statement.hh
+++ b/cql3/statements/strongly_consistent_select_statement.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cql3/expr/expression.hh"
 #include "cql3/statements/select_statement.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 
@@ -17,10 +18,18 @@ namespace cql3 {
 
 namespace statements {
 
-class strongly_consistent_select_statement : public select_statement {
-    const service::broadcast_tables::select_query _query;
+namespace broadcast_tables {
 
-    service::broadcast_tables::select_query prepare_query() const;
+struct prepared_select {
+    expr::expression key;
+};
+
+}
+
+class strongly_consistent_select_statement : public select_statement {
+    const broadcast_tables::prepared_select _query;
+
+    broadcast_tables::prepared_select prepare_query() const;
 public:
     strongly_consistent_select_statement(schema_ptr schema,
                      uint32_t bound_terms,


### PR DESCRIPTION
Extended the queries language to support bind variables which are bound in the execution stage, before creating a raft command.

Adjusted `test_broadcast_tables.py` to prepare statements at the beginning of the test.

Fixed a small bug in `strongly_consistent_modification_statement::check_access`.