### PR TITLE
raft, fix snapshots leak

### DIFF
--- a/raft/server.hh
+++ b/raft/server.hh
@@ -172,6 +172,7 @@ public:
     virtual void tick() = 0;
     // Server id of this server
     virtual raft::server_id id() const = 0;
+    virtual void set_applier_queue_max_size(size_t queue_max_size) = 0;
 };
 
 std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,


### PR DESCRIPTION
applier_fiber could create multiple snapshots between
io_fiber run. The fsm_output.snp variable was
overwritten by applier_fiber and io_fiber didn't drop
the previous snapshot.

In this patch we introduce the variable
fsm_output.snps_to_drop, store in it
the current snapshot id before applying
a new one, and then sequentially drop them in
io_fiber after storing the last snapshot_descriptor.

_sm_events.signal() is added to fsm::apply_snapshot,
since this method mutates the _output and thus gives a
reason to run io_fiber.

The new test test_frequent_snapshotting demonstrates
the problem by causing frequent snapshots and
setting the applier queue size to one.