### PR TITLE
Add validator to the mutation compactor

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3642,7 +3642,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
 
     if (exclusive_start_key) {
         partition_key pk = pk_from_json(*exclusive_start_key, schema);
-        auto pos = position_in_partition(position_in_partition::partition_start_tag_t());
+        auto pos = position_in_partition::for_partition_start();
         if (schema->clustering_key_size() > 0) {
             pos = pos_from_json(*exclusive_start_key, schema);
         }

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -279,7 +279,7 @@ position_in_partition pos_from_json(const rjson::value& item, schema_ptr schema)
         return position_in_partition(region, weight, region == partition_region::clustered ? std::optional(std::move(ck)) : std::nullopt);
     }
     if (ck.is_empty()) {
-        return position_in_partition(position_in_partition::partition_start_tag_t());
+        return position_in_partition::for_partition_start();
     }
     return position_in_partition::for_key(std::move(ck));
 }

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -949,7 +949,7 @@ void compacted_fragments_writer::consume_new_partition(const dht::decorated_key&
         .dk = dk,
         .tombstone = tombstone(),
         .current_emitted_tombstone = tombstone(),
-        .last_pos = position_in_partition(position_in_partition::partition_start_tag_t()),
+        .last_pos = position_in_partition::for_partition_start(),
         .is_splitting_partition = false
     };
     do_consume_new_partition(dk);

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -312,7 +312,7 @@ public:
         _max_purgeable = api::missing_timestamp;
         _gc_before = std::nullopt;
         _last_static_row.reset();
-        _last_pos = position_in_partition(position_in_partition::partition_start_tag_t());
+        _last_pos = position_in_partition::for_partition_start();
         _effective_tombstone = {};
         _current_emitted_tombstone = {};
         _current_emitted_gc_tombstone = {};

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -275,7 +275,7 @@ public:
         , _partition_row_limit(_slice.options.contains(query::partition_slice::option::distinct) ? 1 : slice.partition_row_limit())
         , _tombstone_gc_state(nullptr)
         , _last_dk({dht::token(), partition_key::make_empty()})
-        , _last_pos(position_in_partition::end_of_partition_tag_t())
+        , _last_pos(position_in_partition::for_partition_end())
     {
         static_assert(!sstable_compaction(), "This constructor cannot be used for sstable compaction.");
     }
@@ -290,7 +290,7 @@ public:
         , _slice(s.full_slice())
         , _tombstone_gc_state(gc_state)
         , _last_dk({dht::token(), partition_key::make_empty()})
-        , _last_pos(position_in_partition::end_of_partition_tag_t())
+        , _last_pos(position_in_partition::for_partition_end())
         , _collector(std::make_unique<mutation_compactor_garbage_collector>(_schema))
     {
         static_assert(sstable_compaction(), "This constructor can only be used for sstable compaction.");

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -10,6 +10,7 @@
 
 #include "compaction/compaction_garbage_collector.hh"
 #include "mutation_fragment.hh"
+#include "mutation_fragment_stream_validator.hh"
 #include "range_tombstone_assembler.hh"
 #include "tombstone_gc.hh"
 #include "full_position.hh"
@@ -168,12 +169,15 @@ class compact_mutation_state {
 
     compaction_stats _stats;
 
+    mutation_fragment_stream_validating_filter _validator;
+
     // Remember if we requested to stop mid-partition.
     stop_iteration _stop = stop_iteration::no;
 private:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration do_consume(range_tombstone_change&& rtc, Consumer& consumer, GCConsumer& gc_consumer) {
+        _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
         stop_iteration gc_consumer_stop = stop_iteration::no;
         stop_iteration consumer_stop = stop_iteration::no;
         if (rtc.tombstone() <= _partition_tombstone) {
@@ -276,6 +280,7 @@ public:
         , _tombstone_gc_state(nullptr)
         , _last_dk({dht::token(), partition_key::make_empty()})
         , _last_pos(position_in_partition::for_partition_end())
+        , _validator("mutation_compactor for read", _schema, mutation_fragment_stream_validation_level::token)
     {
         static_assert(!sstable_compaction(), "This constructor cannot be used for sstable compaction.");
     }
@@ -292,11 +297,15 @@ public:
         , _last_dk({dht::token(), partition_key::make_empty()})
         , _last_pos(position_in_partition::for_partition_end())
         , _collector(std::make_unique<mutation_compactor_garbage_collector>(_schema))
+        // We already have a validator for compaction in the sstable writer, no need to validate twice
+        , _validator("mutation_compactor for compaction", _schema, mutation_fragment_stream_validation_level::none)
     {
         static_assert(sstable_compaction(), "This constructor can only be used for sstable compaction.");
     }
 
     void consume_new_partition(const dht::decorated_key& dk) {
+        _validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view::for_partition_start(), {});
+        _validator(dk);
         _stop = stop_iteration::no;
         auto& pk = dk.key();
         _dk = &dk;
@@ -338,6 +347,7 @@ public:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration consume(static_row&& sr, Consumer& consumer, GCConsumer& gc_consumer) {
+        _validator(mutation_fragment_v2::kind::static_row, sr.position(), {});
         _last_static_row = static_row(_schema, sr);
         _last_pos = position_in_partition(position_in_partition::static_row_tag_t());
         auto current_tombstone = _partition_tombstone;
@@ -370,6 +380,7 @@ public:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration consume(clustering_row&& cr, Consumer& consumer, GCConsumer& gc_consumer) {
+        _validator(mutation_fragment_v2::kind::clustering_row, cr.position(), {});
         if (!sstable_compaction()) {
             _last_pos = cr.position();
         }
@@ -441,6 +452,7 @@ public:
             do_consume(std::move(rtc), consumer, gc_consumer);
             _effective_tombstone = prev_tombstone;
         }
+        _validator.on_end_of_partition();
         if (!_empty_partition_in_gc_consumer) {
             gc_consumer.consume_end_of_partition();
         }
@@ -466,6 +478,7 @@ public:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     auto consume_end_of_stream(Consumer& consumer, GCConsumer& gc_consumer) {
+        _validator.on_end_of_stream();
         if (_dk) {
             _last_dk = *_dk;
             _dk = &_last_dk;
@@ -518,6 +531,9 @@ public:
 
         noop_compacted_fragments_consumer nc;
 
+        if (next_fragment_region != partition_region::partition_start) {
+            _validator.reset(mutation_fragment_v2::kind::partition_start, position_in_partition_view::for_partition_start(), {});
+        }
         if (next_fragment_region == partition_region::clustered && _last_static_row) {
             // Stopping here would cause an infinite loop so ignore return value.
             consume(*std::exchange(_last_static_row, {}), consumer, nc);

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -517,7 +517,7 @@ inline position_in_partition_view clustering_row::position() const
 
 inline position_in_partition_view partition_start::position() const
 {
-    return position_in_partition_view(position_in_partition_view::partition_start_tag_t{});
+    return position_in_partition_view::for_partition_start();
 }
 
 inline position_in_partition_view partition_end::position() const

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -522,7 +522,7 @@ inline position_in_partition_view partition_start::position() const
 
 inline position_in_partition_view partition_end::position() const
 {
-    return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t());
+    return position_in_partition_view::for_partition_end();
 }
 
 std::ostream& operator<<(std::ostream&, mutation_fragment::kind);

--- a/mutation_fragment_stream_validator.hh
+++ b/mutation_fragment_stream_validator.hh
@@ -11,6 +11,7 @@
 #include "mutation_fragment_v2.hh"
 
 enum class mutation_fragment_stream_validation_level {
+    none, // disable validation altogether
     partition_region, // fragment kind
     token,
     partition_key,

--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -152,6 +152,14 @@ public:
         return {position_in_partition_view::range_tag_t(), bound_view::top()};
     }
 
+    static position_in_partition_view for_partition_start() {
+        return position_in_partition_view(partition_start_tag_t());
+    }
+
+    static position_in_partition_view for_partition_end() {
+        return position_in_partition_view(end_of_partition_tag_t());
+    }
+
     static position_in_partition_view for_static_row() {
         return position_in_partition_view(static_row_tag_t());
     }
@@ -321,6 +329,10 @@ public:
 
     static position_in_partition for_partition_start() {
         return position_in_partition{partition_start_tag_t()};
+    }
+
+    static position_in_partition for_partition_end() {
+        return position_in_partition(end_of_partition_tag_t());
     }
 
     static position_in_partition for_static_row() {

--- a/querier.hh
+++ b/querier.hh
@@ -41,7 +41,7 @@ auto consume_page(flat_mutation_reader_v2& reader,
         gc_clock::time_point query_time) {
     return reader.peek().then([=, &reader, consumer = std::move(consumer), &slice] (
                 mutation_fragment_v2* next_fragment) mutable {
-        const auto next_fragment_region = next_fragment ? next_fragment->position().region() : partition_region::partition_end;
+        const auto next_fragment_region = next_fragment ? next_fragment->position().region() : partition_region::partition_start;
         compaction_state->start_new_page(row_limit, partition_limit, query_time, next_fragment_region, consumer);
 
         auto reader_consumer = compact_for_query_v2<Consumer>(compaction_state, std::move(consumer));

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -195,7 +195,7 @@ public:
         }
         auto p = *pit;
         auto rs = p.rows();
-        auto pos = position_in_partition(position_in_partition::partition_start_tag_t());
+        auto pos = position_in_partition::for_partition_start();
         if (!rs.empty()) {
             auto rit = rs.begin();
             auto rnext = rit;

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -118,7 +118,7 @@ bool mutation_fragment_stream_validator::validate(mutation_fragment_v2::kind kin
     } else {
         switch (kind) {
             case mutation_fragment_v2::kind::partition_start:
-                _prev_pos = position_in_partition(position_in_partition::partition_start_tag_t{});
+                _prev_pos = position_in_partition::for_partition_start();
                 break;
             case mutation_fragment_v2::kind::static_row:
                 _prev_pos = position_in_partition(position_in_partition::static_row_tag_t{});

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -229,6 +229,9 @@ mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_
     if (mrlog.is_enabled(log_level::debug)) {
         std::string_view what;
         switch (_validation_level) {
+            case mutation_fragment_stream_validation_level::none:
+                what = "no";
+                break;
             case mutation_fragment_stream_validation_level::partition_region:
                 what = "partition region";
                 break;
@@ -248,6 +251,10 @@ mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_
 
 bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos,
         std::optional<tombstone> new_current_tombstone) {
+    if (_validation_level < mutation_fragment_stream_validation_level::partition_region) {
+        return true;
+    }
+
     bool valid = false;
 
     mrlog.debug("[validator {}] {}:{} new_current_tombstone: {}", static_cast<void*>(this), kind, pos, new_current_tombstone);
@@ -314,6 +321,9 @@ bool mutation_fragment_stream_validating_filter::on_end_of_partition() {
 }
 
 void mutation_fragment_stream_validating_filter::on_end_of_stream() {
+    if (_validation_level < mutation_fragment_stream_validation_level::partition_region) {
+        return;
+    }
     mrlog.debug("[validator {}] EOS", static_cast<const void*>(this));
     if (!_validator.on_end_of_stream()) {
         on_validation_error(mrlog, format("[validator {} for {}] Stream ended with unclosed partition: {}", static_cast<const void*>(this), _name,

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -131,7 +131,7 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
         }
     public:
         reader(flat_mutation_reader_v2 r) : impl(r.schema(), r.permit()), _underlying(std::move(r)), _current({
-            position_in_partition(position_in_partition::partition_start_tag_t()),
+            position_in_partition::for_partition_start(),
             position_in_partition(position_in_partition::after_static_row_tag_t())
         }) { }
         virtual future<> fill_buffer() override {
@@ -178,7 +178,7 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
             }
             clear_buffer_to_next_partition();
             _current = {
-                position_in_partition(position_in_partition::partition_start_tag_t()),
+                position_in_partition::for_partition_start(),
                 position_in_partition(position_in_partition::after_static_row_tag_t())
             };
             _active_tombstone = {};
@@ -189,7 +189,7 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
             clear_buffer();
             _next = {};
             _current = {
-                position_in_partition(position_in_partition::partition_start_tag_t()),
+                position_in_partition::for_partition_start(),
                 position_in_partition(position_in_partition::after_static_row_tag_t())
             };
             _active_tombstone = {};

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -49,7 +49,7 @@ query_pager::query_pager(service::storage_proxy& p, schema_ptr s,
                 : _has_clustering_keys(has_clustering_keys(*s, *cmd))
                 , _max(cmd->get_row_limit())
                 , _per_partition_limit(cmd->slice.partition_row_limit())
-                , _last_pos(position_in_partition::partition_start_tag_t())
+                , _last_pos(position_in_partition::for_partition_start())
                 , _proxy(p.shared_from_this())
                 , _schema(std::move(s))
                 , _selection(selection)
@@ -371,7 +371,7 @@ void query_pager::handle_result(
 
     auto view = query::result_view(*results);
 
-    _last_pos = position_in_partition(position_in_partition::partition_start_tag_t());
+    _last_pos = position_in_partition::for_partition_start();
     uint64_t row_count;
     if constexpr(!std::is_same_v<std::decay_t<Visitor>, noop_visitor>) {
         query_result_visitor<Visitor> v(std::forward<Visitor>(visitor));

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -830,7 +830,7 @@ public:
         if (_is_mutation_end) {
             return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{});
         }
-        return position_in_partition_view(position_in_partition_view::partition_start_tag_t{});
+        return position_in_partition_view::for_partition_start();
     }
 
     // Changes current fragment range.

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -828,7 +828,7 @@ public:
             return _ready->position();
         }
         if (_is_mutation_end) {
-            return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{});
+            return position_in_partition_view::for_partition_end();
         }
         return position_in_partition_view::for_partition_start();
     }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -641,7 +641,7 @@ public:
             return _in_progress_row->position();
         }
         if (_is_mutation_end) {
-            return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{});
+            return position_in_partition_view::for_partition_end();
         }
         return position_in_partition_view::for_partition_start();
     }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -643,7 +643,7 @@ public:
         if (_is_mutation_end) {
             return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{});
         }
-        return position_in_partition_view(position_in_partition_view::partition_start_tag_t{});
+        return position_in_partition_view::for_partition_start();
     }
 
     // Under which priority class to place I/O coming from this consumer

--- a/sstables/writer.cc
+++ b/sstables/writer.cc
@@ -30,7 +30,7 @@ sstable_writer::sstable_writer(sstable& sst, const schema& s, uint64_t estimated
 
 void sstable_writer::consume_new_partition(const dht::decorated_key& dk) {
     _impl->_validator(dk);
-    _impl->_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{}), {});
+    _impl->_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view::for_partition_start(), {});
     _impl->_sst.get_stats().on_partition_write();
     return _impl->consume_new_partition(dk);
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2694,8 +2694,8 @@ SEASTAR_THREAD_TEST_CASE(test_position_in_partition_reversal) {
     BOOST_REQUIRE(rev_cmp(p_i_p::for_partition_start().reversed(),
                           p_i_p::for_partition_start()) == 0);
 
-    BOOST_REQUIRE(rev_cmp(p_i_p(p_i_p::end_of_partition_tag_t()).reversed(),
-                          p_i_p(p_i_p::end_of_partition_tag_t())) == 0);
+    BOOST_REQUIRE(rev_cmp(p_i_p(p_i_p::for_partition_end()).reversed(),
+                          p_i_p(p_i_p::for_partition_end())) == 0);
 
     BOOST_REQUIRE(rev_cmp(p_i_p::for_static_row().reversed(),
                           p_i_p::for_static_row()) == 0);

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -547,7 +547,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
             // which is a valid paging state as well, and should return
             // no rows.
             paging_state = make_lw_shared<service::pager::paging_state>(partition_key::make_empty(),
-                    position_in_partition_view(position_in_partition_view::partition_start_tag_t()),
+                    position_in_partition_view::for_partition_start(),
                     paging_state->get_remaining(), paging_state->get_query_uuid(),
                     paging_state->get_last_replicas(), paging_state->get_query_read_repair_decision(),
                     paging_state->get_rows_fetched_for_last_partition());
@@ -563,7 +563,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
             // An artificial paging state with an empty key pair is also valid and is expected
             // not to return rows (since no row matches an empty partition key)
             auto paging_state = make_lw_shared<service::pager::paging_state>(partition_key::make_empty(),
-                    position_in_partition_view(position_in_partition_view::partition_start_tag_t()),
+                    position_in_partition_view::for_partition_start(),
                     1, query_id::create_random_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 1);
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -225,7 +225,7 @@ public:
     }
     stop_iteration consume_end_of_partition() {
         testlog.debug("consume end of partition");
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{}), {}));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view::for_partition_end(), {}));
         return stop_iteration::no;
     }
     void consume_end_of_stream() {

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -205,7 +205,7 @@ public:
 
     void consume_new_partition(const dht::decorated_key& dk) {
         testlog.debug("consume new partition: {}", dk);
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{}), {}));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view::for_partition_start(), {}));
     }
     void consume(tombstone) { }
     stop_iteration consume(static_row&& sr) {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -188,7 +188,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                                 start_position = std::move(end_position);
                             }
                         }
-                        actual.may_produce_tombstones(position_range(start_position, position_in_partition(position_in_partition::end_of_partition_tag_t())));
+                        actual.may_produce_tombstones(position_range(start_position, position_in_partition::for_partition_end()));
                         actual.produces_partition_end();
                     }
                     actual.produces_end_of_stream();


### PR DESCRIPTION
Fragment reordering and fragment dropping bugs have been plaguing us since forever. To fight them we added a validator to the sstable write path to prevent really messed up sstables from being written.
This series adds validation to the mutation compactor. This will cover reads and compaction among others, hopefully ridding us of such bugs on the read path too.
This series fixes some benign looking issues found by unit tests after the validator was added -- although how benign a producer emitting two partition-ends depends entirely on how the consumer reacts to it, so no such bug is actually benign.

Fixes: https://github.com/scylladb/scylladb/issues/11174