### PR TITLE
[RFC] framework for supporting new cluster features dynamically

### DIFF
--- a/db/sstables-format-selector.hh
+++ b/db/sstables-format-selector.hh
@@ -23,7 +23,6 @@ class database;
 }
 
 namespace gms {
-class gossiper;
 class feature_service;
 }
 
@@ -44,7 +43,6 @@ public:
 };
 
 class sstables_format_selector {
-    gms::gossiper& _gossiper;
     sharded<gms::feature_service>& _features;
     sharded<replica::database>& _db;
     seastar::named_semaphore _sem = {1, named_semaphore_exception_factory{"feature listeners"}};
@@ -58,7 +56,7 @@ class sstables_format_selector {
     future<> read_sstables_format();
 
 public:
-    sstables_format_selector(gms::gossiper& g, sharded<gms::feature_service>& f, sharded<replica::database>& db);
+    sstables_format_selector(sharded<gms::feature_service>& f, sharded<replica::database>& db);
 
     future<> start();
     future<> stop();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -216,4 +216,26 @@ void feature_service::enable(const std::set<std::string_view>& list) {
     }
 }
 
+struct feature_service::supported_features_change_subscription::impl {
+    feature_service& _service;
+    std::list<features_changed_callback_t>::iterator _it;
+
+    impl(feature_service& service, features_changed_callback_t cb)
+        : _service(service)
+        , _it(_service._supported_features_change_callbacks.insert(_service._supported_features_change_callbacks.begin(), std::move(cb)))
+    {}
+
+    ~impl() {
+        _service._supported_features_change_callbacks.erase(_it);
+    }
+};
+
+feature_service::supported_features_change_subscription::supported_features_change_subscription(std::unique_ptr<impl> impl) : _impl(std::move(impl)) {}
+feature_service::supported_features_change_subscription::~supported_features_change_subscription() = default;
+
+feature_service::supported_features_change_subscription
+feature_service::on_supported_features_change(features_changed_callback_t cb) {
+    return { std::make_unique<feature_service::supported_features_change_subscription::impl>(*this, std::move(cb)) };
+}
+
 } // namespace gms

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -26,16 +26,11 @@ namespace gms {
 
 class feature_service;
 
-struct feature_config {
-private:
-    std::set<sstring> _disabled_features;
-    feature_config();
-
-    friend class feature_service;
-    friend feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled);
+// Disable some features additionally to the ones disabled by `db::config`.
+// Use for tests only!
+struct custom_feature_config_for_tests {
+    std::set<sstring> extra_disabled_features;
 };
-
-feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled = {});
 
 using namespace std::literals;
 
@@ -56,11 +51,11 @@ private:
     friend class feature;
     std::unordered_map<sstring, std::reference_wrapper<feature>> _registered_features;
 
-    feature_config _config;
+    std::set<sstring> _disabled_features;
 
     std::list<features_changed_callback_t> _supported_features_change_callbacks;
 public:
-    explicit feature_service(feature_config cfg);
+    explicit feature_service(db::config& cfg, custom_feature_config_for_tests custom_cfg = {});
     ~feature_service() = default;
     future<> stop();
     // Has to run inside seastar::async context

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -127,6 +127,8 @@ private:
     // Map ip address and generation number
     std::unordered_map<gms::inet_address, int32_t> _advertise_to_nodes;
     future<> _failure_detector_loop_done{make_ready_future<>()} ;
+    future<> _update_supported_features_loop_done{make_ready_future<>()};
+    condition_variable _gossiper_stopped;
 
     rpc::no_wait_type background_msg(sstring type, noncopyable_function<future<>(gossiper&)> fn);
 
@@ -607,6 +609,7 @@ public:
 private:
     future<> failure_detector_loop();
     future<> failure_detector_loop_for_node(gms::inet_address node, int64_t gossip_generation, uint64_t live_endpoints_version);
+    future<> update_supported_features_loop();
     future<> update_live_endpoints_version();
 
 public:

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -591,7 +591,7 @@ private:
     // Get features supported by a particular node
     std::set<sstring> get_supported_features(inet_address endpoint) const;
     // Get features supported by all the nodes this node knows about
-    std::set<sstring> get_supported_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
+    std::set<sstring> calculate_enabled_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
 public:
     void check_knows_remote_features(std::set<std::string_view>& local_features, const std::unordered_map<inet_address, sstring>& loaded_peer_features) const;

--- a/main.cc
+++ b/main.cc
@@ -1118,7 +1118,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             group0_client.init().get();
 
-            db::sstables_format_selector sst_format_selector(gossiper.local(), feature_service, db);
+            db::sstables_format_selector sst_format_selector(feature_service, db);
 
             sst_format_selector.start().get();
             auto stop_format_selector = defer_verbose_shutdown("sstables format selector", [&sst_format_selector] {

--- a/main.cc
+++ b/main.cc
@@ -603,10 +603,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     throw bad_configuration_error();
                 }
             }
-            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg);
-
             debug::the_feature_service = &feature_service;
-            feature_service.start(fcfg).get();
+            feature_service.start(std::ref(*cfg)).get();
             // FIXME storage_proxy holds a reference on it and is not yet stopped.
             // also the proxy leaves range_slice_read_executor-s hanging around
             // and willing to find out if the cluster_supports_digest_multipartition_reads

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -556,9 +556,8 @@ public:
 
             auto stop_sys_dist_ks = defer([&sys_dist_ks] { sys_dist_ks.stop().get(); });
 
-            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg, cfg_in.disabled_features);
             sharded<gms::feature_service> feature_service;
-            feature_service.start(fcfg).get();
+            feature_service.start(std::ref(*cfg), gms::custom_feature_config_for_tests{cfg_in.disabled_features}).get();
             auto stop_feature_service = defer([&] { feature_service.stop().get(); });
 
             sharded<gms::gossiper> gossiper;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -33,7 +33,7 @@ static const sstring some_column_family("cf");
 
 db::nop_large_data_handler nop_lp_handler;
 db::config test_db_config;
-gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
+gms::feature_service test_feature_service(test_db_config);
 
 column_family_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -62,7 +62,7 @@ int main(int ac, char ** av) {
             auto cfg = std::make_unique<db::config>();
 
             sharded<gms::feature_service> feature_service;
-            feature_service.start(gms::feature_config_from_db_config(*cfg)).get();
+            feature_service.start(std::ref(*cfg)).get();
             auto stop_feature_service = deferred_stop(feature_service);
 
             sharded<abort_source> abort_sources;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -194,7 +194,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     cfg.enable_cache(false);
     cfg.volatile_system_keyspace_for_testing(true);
 
-    gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
+    gms::feature_service feature_service(cfg);
     feature_service.enable(feature_service.supported_feature_set());
     sharded<locator::shared_token_metadata> token_metadata;
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3197,7 +3197,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             }
 
             db::config dbcfg;
-            gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
+            gms::feature_service feature_service(dbcfg);
             cache_tracker tracker;
             dbcfg.host_id = locator::host_id::create_random_id();
             sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker);


### PR DESCRIPTION
Currently the Scylla codebase assumes that the set of supported features is
calculated once on startup. This set is calculated from the configuration
(conf/scylla.yaml + cmdline parameters). The configuration can be reloaded in
runtime, but this doesn't affect the supported features; to change them, one
has to restart the Scylla node.

We can change this by recalculating the set of supported features once the
configuration is reloaded.

We need to perform some side effects when the features are recalculated, such
as updating the gossiper application state. Each feature may also require some
additional steps to actually start being usable other than simply supporting
it. To handle these use cases, we implement a simple notification API in
feature_service so other services can register callbacks. The gossiper use case
is included in this PR.

The PR contains the scaffolding for dynamically supporting features, but a
developer must explicitly mark a feature as safe for such dynamic change by
including it in a `can_be_supported_dynamically` set which is empty for now.

The PR also contains some minor refactors/cleanups.