### PR TITLE
messaging_service: Remove init/uninit helpers

### DIFF
--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -520,8 +520,4 @@ public:
     unsigned get_rpc_client_idx(messaging_verb verb) const;
 };
 
-void init_messaging_service(sharded<messaging_service>& ms,
-        messaging_service::config cfg, messaging_service::scheduling_config scheduling_config, const db::config& db_config);
-future<> uninit_messaging_service(sharded<messaging_service>& ms);
-
 } // namespace netw


### PR DESCRIPTION
These two are just getting in the way when touching inter-components dependencies around messaging service. Without it m.-s. start/stop just looks like any other service out there

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>