### PR TITLE
test.py: Pool add fresh when item not returned

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -699,6 +699,7 @@ class ScyllaClusterManager:
     async def _before_test(self, test_name: str) -> None:
         if self.cluster.is_dirty:
             await self.cluster.stop()
+            await self.clusters.add_one(took_one=True)   # Replace with fresh one
             await self._get_cluster()
         logging.info("Leasing Scylla cluster %s for test %s", self.cluster, test_name)
         self.cluster.before_test(self.test_name)
@@ -707,12 +708,18 @@ class ScyllaClusterManager:
 
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
+        logging.info("ScyllaManager stopping for test %s", self.test_name)
         await self.site.stop()
         if not self.cluster.is_dirty:
-            logging.info("Returning Scylla cluster %s", self.cluster)
+            logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_name)
             await self.clusters.put(self.cluster)
         else:
+            logging.info("ScyllaManager stopping Scylla cluster %s for test %s", self.cluster,
+                         self.test_name)
             await self.cluster.stop()
+            logging.info("ScyllaManager adding fresh ScylaCluster to the pool for test %s",
+                         self.test_name)
+            await self.clusters.add_one(took_one=True)   # Replace with fresh one
         del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)


### PR DESCRIPTION
Pool.get() might have waiting callers, so if an item is not returned to the pool after use, tell the pool to add a new one.

Use it when a ScyllaCluster is dirty and not returned.

Issue reported by @kbr-.
