### PR TITLE
logalloc: don't crash while reporting reclaim stalls if --abort-on-seastar-bad-alloc is specified

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1295,6 +1295,12 @@ void reclaim_timer::sample_stats(stats& data) {
 }
 
 void reclaim_timer::report() const noexcept {
+    // The logger can allocate (and will recover from allocation failure), and
+    // we're in a memory-sensitive situation here and allocation can easily fail.
+    // Prevent --abort-on-seastar-bad-alloc from crashing us in a situation that
+    // we're likely to recover from, by reclaiming more.
+    auto guard = memory::disable_abort_on_alloc_failure_temporarily();
+
     auto time_level = _stall_detected ? log_level::warn : log_level::debug;
     auto info_level = _stall_detected ? log_level::info : log_level::debug;
     auto MiB = 1024*1024;


### PR DESCRIPTION
The logger is proof against allocation failures, except if --abort-on-seastar-bad-alloc is specified. If it is, it will crash.

The reclaim stall report is likely to be called in low memory conditions (reclaim's job is to alleviate these conditions after all), so we're likely to crash here if we're reclaiming a very low memory condition and have a large stall simultaneously (AND we're running in a debug environment).

Prevent all this by disabling --abort-on-seastar-bad-alloc temporarily.

Fixes #11549