### PR TITLE
dbuild: prepare for sharing cargo cache

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -133,6 +133,11 @@ MAVEN_LOCAL_REPO="$HOME/.m2"
 
 mkdir -p "$MAVEN_LOCAL_REPO"
 
+if [[ -z "$CARGO_HOME" ]]; then
+    export CARGO_HOME="$HOME/.cargo"
+    mkdir -p "$CARGO_HOME"
+fi
+
 is_podman="$($tool --help | grep -o podman)"
 
 docker_common_args=()
@@ -187,6 +192,8 @@ docker_common_args+=(
        -v "$tmpdir:/tmp" \
        -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO" \
        -v /etc/localtime:/etc/localtime:ro \
+       --env CARGO_HOME \
+       -v "${CARGO_HOME}:${CARGO_HOME}" \
        -w "$PWD" \
        -e HOME="$HOME" \
        "${docker_args[@]}" \


### PR DESCRIPTION
Rust's cargo caches downloaded sources in ~/.cargo. However dbuild won't provide access to this directory since it's outside the source directory.

Prepare for sharing the cargo cache between the host and the dbuild environment by:
 - Creating the cache if it doesn't already exist. This is likely if the user only builds in a dbuild environment.
 - Propagating the cache directory as a mounted volume.
 - Respecting the CARGO_HOME override.