### PR TITLE
Don't use qctx in CDC tables quering

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -613,7 +613,7 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
     if (times_and_ttls.empty()) {
         // There's no point in rewriting old generations' streams (they don't contain any data).
         cdc_log.info("No CDC log tables present, not rewriting stream tables.");
-        co_return co_await db::system_keyspace::cdc_set_rewritten(std::nullopt);
+        co_return co_await _sys_ks.local().cdc_set_rewritten(std::nullopt);
     }
 
     auto get_num_token_owners = [tm = _token_metadata.get()] { return tm->count_normal_token_owners(); };
@@ -631,7 +631,7 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
             std::move(get_num_token_owners),
             _abort_src);
 
-    co_await db::system_keyspace::cdc_set_rewritten(last_rewritten);
+    co_await _sys_ks.local().cdc_set_rewritten(last_rewritten);
 }
 
 static void assert_shard_zero(const sstring& where) {

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -583,7 +583,7 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
         co_return;
     }
 
-    if (co_await db::system_keyspace::cdc_is_rewritten()) {
+    if (co_await _sys_ks.local().cdc_is_rewritten()) {
         co_return;
     }
 

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -875,7 +875,7 @@ future<> generation_service::check_and_repair_cdc_streams() {
             { gms::application_state::CDC_GENERATION_ID, gms::versioned_value::cdc_generation_id(new_gen_id) },
             { gms::application_state::STATUS, *status }
     });
-    co_await db::system_keyspace::update_cdc_generation_id(new_gen_id);
+    co_await _sys_ks.local().update_cdc_generation_id(new_gen_id);
 }
 
 future<> generation_service::handle_cdc_generation(std::optional<cdc::generation_id> gen_id) {
@@ -1018,7 +1018,7 @@ future<bool> generation_service::do_handle_cdc_generation(cdc::generation_id gen
     // The assumption follows from the requirement of bootstrapping nodes sequentially.
     if (!_gen_id || get_ts(*_gen_id) < get_ts(gen_id)) {
         _gen_id = gen_id;
-        co_await db::system_keyspace::update_cdc_generation_id(gen_id);
+        co_await _sys_ks.local().update_cdc_generation_id(gen_id);
         co_await _gossiper.add_local_application_state(
                 gms::application_state::CDC_GENERATION_ID, gms::versioned_value::cdc_generation_id(gen_id));
     }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1750,13 +1750,13 @@ future<std::unordered_set<dht::token>> system_keyspace::get_local_tokens() {
 
 future<> system_keyspace::update_cdc_generation_id(cdc::generation_id gen_id) {
     co_await std::visit(make_visitor(
-    [] (cdc::generation_id_v1 id) -> future<> {
-        co_await qctx->execute_cql(
+    [this] (cdc::generation_id_v1 id) -> future<> {
+        co_await execute_cql(
                 format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)", v3::CDC_LOCAL),
                 sstring(v3::CDC_LOCAL), id.ts);
     },
-    [] (cdc::generation_id_v2 id) -> future<> {
-        co_await qctx->execute_cql(
+    [this] (cdc::generation_id_v2 id) -> future<> {
+        co_await execute_cql(
                 format("INSERT INTO system.{} (key, streams_timestamp, uuid) VALUES (?, ?, ?)", v3::CDC_LOCAL),
                 sstring(v3::CDC_LOCAL), id.ts, id.id);
     }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1806,7 +1806,7 @@ future<> system_keyspace::cdc_set_rewritten(std::optional<cdc::generation_id_v1>
 
 future<bool> system_keyspace::cdc_is_rewritten() {
     // We don't care about the actual timestamp; it's additional information for debugging purposes.
-    return qctx->execute_cql(format("SELECT key FROM system.{} WHERE key = ?", v3::CDC_LOCAL), CDC_REWRITTEN_KEY)
+    return execute_cql(format("SELECT key FROM system.{} WHERE key = ?", v3::CDC_LOCAL), CDC_REWRITTEN_KEY)
             .then([] (::shared_ptr<cql3::untyped_result_set> msg) {
         return !msg->empty();
     });

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1766,7 +1766,7 @@ future<> system_keyspace::update_cdc_generation_id(cdc::generation_id gen_id) {
 }
 
 future<std::optional<cdc::generation_id>> system_keyspace::get_cdc_generation_id() {
-    auto msg = co_await qctx->execute_cql(
+    auto msg = co_await execute_cql(
             format("SELECT streams_timestamp, uuid FROM system.{} WHERE key = ?", v3::CDC_LOCAL),
             sstring(v3::CDC_LOCAL));
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1793,12 +1793,12 @@ static const sstring CDC_REWRITTEN_KEY = "rewritten";
 
 future<> system_keyspace::cdc_set_rewritten(std::optional<cdc::generation_id_v1> gen_id) {
     if (gen_id) {
-        return qctx->execute_cql(
+        return execute_cql(
                 format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)", v3::CDC_LOCAL),
                 CDC_REWRITTEN_KEY, gen_id->ts).discard_result();
     } else {
         // Insert just the row marker.
-        return qctx->execute_cql(
+        return execute_cql(
                 format("INSERT INTO system.{} (key) VALUES (?)", v3::CDC_LOCAL),
                 CDC_REWRITTEN_KEY).discard_result();
     }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -410,7 +410,7 @@ public:
     /*
     * Save the CDC generation ID announced by this node in persistent storage.
     */
-    static future<> update_cdc_generation_id(cdc::generation_id);
+    future<> update_cdc_generation_id(cdc::generation_id);
 
     /*
     * Read the CDC generation ID announced by this node from persistent storage.

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -416,7 +416,7 @@ public:
     * Read the CDC generation ID announced by this node from persistent storage.
     * Used to initialize a restarting node.
     */
-    static future<std::optional<cdc::generation_id>> get_cdc_generation_id();
+    future<std::optional<cdc::generation_id>> get_cdc_generation_id();
 
     future<bool> cdc_is_rewritten();
     future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -419,7 +419,7 @@ public:
     static future<std::optional<cdc::generation_id>> get_cdc_generation_id();
 
     static future<bool> cdc_is_rewritten();
-    static future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);
+    future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);
 
     static future<> enable_features_on_startup(sharded<gms::feature_service>& feat);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -418,7 +418,7 @@ public:
     */
     static future<std::optional<cdc::generation_id>> get_cdc_generation_id();
 
-    static future<bool> cdc_is_rewritten();
+    future<bool> cdc_is_rewritten();
     future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);
 
     static future<> enable_features_on_startup(sharded<gms::feature_service>& feat);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -550,7 +550,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
 
         // Don't try rewriting CDC stream description tables.
         // See cdc.md design notes, `Streams description table V1 and rewriting` section, for explanation.
-        co_await db::system_keyspace::cdc_set_rewritten(std::nullopt);
+        co_await _sys_ks.local().cdc_set_rewritten(std::nullopt);
     }
 
     if (!cdc_gen_id) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -582,7 +582,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
 
     // Persist the CDC streams timestamp before we persist bootstrap_state = COMPLETED.
     if (cdc_gen_id) {
-        co_await db::system_keyspace::update_cdc_generation_id(*cdc_gen_id);
+        co_await _sys_ks.local().update_cdc_generation_id(*cdc_gen_id);
     }
     // If we crash now, we will choose a new CDC streams timestamp anyway (because we will also choose a new set of tokens).
     // But if we crash after setting bootstrap_state = COMPLETED, we will keep using the persisted CDC streams timestamp after restarting.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -366,7 +366,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack());
         co_await tmptr->update_normal_tokens(my_tokens, get_broadcast_address());
 
-        cdc_gen_id = co_await db::system_keyspace::get_cdc_generation_id();
+        cdc_gen_id = co_await _sys_ks.local().get_cdc_generation_id();
         if (!cdc_gen_id) {
             // We could not have completed joining if we didn't generate and persist a CDC streams timestamp,
             // unless we are restarting after upgrading from non-CDC supported version.
@@ -1842,7 +1842,7 @@ future<> storage_service::start_gossiping() {
             co_await ss._gossiper.container().invoke_on_all(&gms::gossiper::start);
             bool should_stop_gossiper = false; // undo action
             try {
-                auto cdc_gen_ts = co_await db::system_keyspace::get_cdc_generation_id();
+                auto cdc_gen_ts = co_await ss._sys_ks.local().get_cdc_generation_id();
                 if (!cdc_gen_ts) {
                     cdc_log.warn("CDC generation timestamp missing when starting gossip");
                 }


### PR DESCRIPTION
There's a bunch of helpers for CDC gen service in db/system_keyspace.cc. All are static and use global qctx to make queries. Fortunately, both callers -- storage_service and cdc_generation_service -- already have local system_keyspace references and can call the methods via it, thus reducing the global qctx usage.