### PR TITLE
test/pylib: pool: make it possible to free up space

### DIFF
--- a/test/pylib/host_registry.py
+++ b/test/pylib/host_registry.py
@@ -72,7 +72,7 @@ class HostRegistry:
             self.next_host_id += 1
             return Host(self.subnet.format(self.next_host_id))
 
-        self.pool = Pool(254, create_host)
+        self.pool = Pool[Host](254, create_host)
 
         async def cleanup() -> None:
             if self.lock_filename:

--- a/test/pylib/pool.py
+++ b/test/pylib/pool.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Generic, Callable, Awaitable, TypeVar, AsyncContextManager
+from typing import Generic, Callable, Awaitable, TypeVar, AsyncContextManager, Final
 
 T = TypeVar('T')
 
@@ -13,46 +13,72 @@ class Pool(Generic[T]):
     builder async function to build a new object.
 
     Usage example:
-    async def start_server():
-        return Server()
-    pool = Pool(4, start_server)
-    ...
-    async with pool.instance() as server:
-        await run_test(test, server)
-    """
+        async def start_server():
+            return Server()
+        pool = Pool(4, start_server)
 
-    def __init__(self, size: int, build: Callable[[], Awaitable[T]]):
-        assert(size >= 0)
-        self.pool: asyncio.Queue[T] = asyncio.Queue(size)
-        self.build = build
-        self.total = 0
+        server = await pool.get()
+        try:
+            await run_test(test, server)
+        finally:
+            await pool.put(server)
+
+    Alternatively:
+        async with pool.instance() as server:
+            await run_test(test, server)
+
+    If the object is considered no longer usable by other users of the pool
+    you can 'steal' it, which frees up space in the pool.
+        server = await.pool.get()
+        dirty = True
+        try:
+            dirty = await run_test(test, server)
+        finally:
+            if dirty:
+                await pool.steal()
+            else:
+                await pool.put(server)
+    """
+    def __init__(self, max_size: int, build: Callable[[], Awaitable[T]]):
+        assert(max_size >= 0)
+        self.max_size: Final[int] = max_size
+        self.build: Final[Callable[[], Awaitable[T]]] = build
+        self.cond: Final[asyncio.Condition] = asyncio.Condition()
+        self.pool: list[T] = []
+        self.total: int = 0 # len(self.pool) + leased objects
 
     async def get(self) -> T:
-        """Get an entry from the pool.
-           If pool is empty, if total less than limit, add a new one,
-           else block until an entry is returned.
-        """
-        if self.pool.empty() and self.total < self.pool.maxsize:
-            await self.add_one(took_one=False)
-        return await self.pool.get()
+        """Borrow an object from the pool."""
+        async with self.cond:
+            await self.cond.wait_for(lambda: self.pool or self.total < self.max_size)
+            if self.pool:
+                return self.pool.pop()
 
-    async def add_one(self, took_one:bool) -> None:
-        """Build and add a new entry to the pool"""
-        if took_one:
-            self.total -= 1
-        if self.total < self.pool.maxsize:
-            # Increment the total first to avoid a race
-            # during self.build()
+            # No object in pool, but total < max_size so we can construct one
             self.total += 1
-            try:
-                await self.pool.put(await self.build())
-            except:     # noqa: E722
+
+        try:
+            obj = await self.build()
+        except:
+            async with self.cond:
                 self.total -= 1
-                raise
+                self.cond.notify()
+            raise
+        return obj
+
+    async def steal(self) -> None:
+        """Take ownership of a previously borrowed object.
+           Frees up space in the pool.
+        """
+        async with self.cond:
+            self.total -= 1
+            self.cond.notify()
 
     async def put(self, obj: T):
-        """Add an entry to the pool"""
-        await self.pool.put(obj)
+        """Return a previously borrowed object to the pool."""
+        async with self.cond:
+            self.pool.append(obj)
+            self.cond.notify()
 
     def instance(self) -> AsyncContextManager[T]:
         class Instance:


### PR DESCRIPTION
Some tests mark clusters as 'dirty', which makes them non-reusable by
later tests; we don't want to return them to the pool of clusters.

This use-case was covered by the `add_one` function in the `Pool` class.
However, it had the unintended side effect of creating extra clusters
even if there were no more tests that were waiting for new clusters.

Rewrite the implementation of `Pool` so it provides 3 interface
functions:
- `get` borrows an object, building it first if necessary
- `put` returns a borrowed object
- `steal` is called by a borrower to free up space in the pool;
  the borrower is then responsible for cleaning up the object.

Both `put` and `steal` wake up any outstanding `get` calls. Objects are
built only in `get`, so no objects are built if none are needed.