### PR TITLE
docs/alternator: refer to the right issue

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -201,9 +201,10 @@ not implemented yet. Unimplemented features return an error when used, so
 they should be easy to detect. Here is a list of these unimplemented features:
 
 * Currently in Alternator, a GSI (Global Secondary Index) can only be added
-  to a table at table creation time. Unlike DynamoDB which also allows adding
-  a GSI (but not an LSI) to an existing table using an UpdateTable operation.
-  <https://github.com/scylladb/scylla/issues/5022>
+  to a table at table creation time. DynamoDB allows adding a GSI (but not an
+  LSI) to an existing table using an UpdateTable operation, and similarly it
+  allows removing a GSI from a table.
+  <https://github.com/scylladb/scylla/issues/11567>
 
 * GSI (Global Secondary Index) and LSI (Local Secondary Index) may be
   configured to project only a subset of the base-table attributes to the


### PR DESCRIPTION
In compatibility.md where we refer to the missing ability to add a GSI to an existing table - let's refer to a new issue specifically about this feature, instead of the old bigger issue about UpdateItem.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>