### PR TITLE
dirty_memory_manager: simplify region_group

### DIFF
--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -187,7 +187,7 @@ void region_group::update(ssize_t delta) {
     }
 }
 
-void region_group::on_request_expiry::operator()(std::unique_ptr<allocating_function>& func) noexcept {
+void allocation_queue::on_request_expiry::operator()(std::unique_ptr<allocating_function>& func) noexcept {
     func->fail(std::make_exception_ptr(blocked_requests_timed_out_error{_name}));
 }
 

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -167,12 +167,6 @@ void memory_hard_limit::notify_pressure_relieved() {
 void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta) {
     rg->_total_memory += delta;
 
-    if (rg->_total_memory > rg->soft_limit_threshold()) {
-        rg->notify_soft_pressure();
-    } else {
-        rg->notify_soft_relief();
-    }
-
     if (rg->_total_memory > rg->throttle_threshold()) {
         rg->notify_pressure();
     } else if (rg->under_pressure()) {

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -156,13 +156,13 @@ bool region_group::reclaimer_can_block() const {
     return _reclaimer.throttle_threshold() != std::numeric_limits<size_t>::max();
 }
 
-void region_group::notify_relief() {
+void region_group::notify_pressure_relieved() {
     _relief.signal();
 }
 
-void memory_hard_limit::notify_relief() {
+void memory_hard_limit::notify_pressure_relieved() {
     if (_subgroup) {
-        _subgroup->notify_relief();
+        _subgroup->notify_pressure_relieved();
     }
 }
 
@@ -191,7 +191,7 @@ void memory_hard_limit::update(ssize_t delta) {
     do_update(this, top_relief, delta);
 
     if (top_relief) {
-        top_relief->notify_relief();
+        top_relief->notify_pressure_relieved();
     }
 }
 
@@ -206,9 +206,9 @@ void region_group::update(ssize_t delta) {
     }
 
     if (top_relief_memory_hard_limit) {
-        top_relief_memory_hard_limit->notify_relief();
+        top_relief_memory_hard_limit->notify_pressure_relieved();
     } else if (top_relief_region_group) {
-        top_relief_region_group->notify_relief();
+        top_relief_region_group->notify_pressure_relieved();
     }
 }
 

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -141,10 +141,6 @@ void region_group::notify_pressure_relieved() {
     _relief.signal();
 }
 
-void region_group::notify_hard_pressure_relieved() {
-    notify_pressure_relieved();
-}
-
 bool region_group::do_update_hard_and_check_relief(ssize_t delta) {
     _hard_total_memory += delta;
 
@@ -159,7 +155,7 @@ bool region_group::do_update_hard_and_check_relief(ssize_t delta) {
 
 void region_group::update_hard(ssize_t delta) {
     if (do_update_hard_and_check_relief(delta)) {
-        notify_hard_pressure_relieved();
+        notify_pressure_relieved();
     }
 }
 
@@ -186,7 +182,7 @@ void region_group::update(ssize_t delta) {
     top_relief_memory_hard_limit = do_update_hard_and_check_relief(delta);
 
     if (top_relief_memory_hard_limit) {
-        notify_hard_pressure_relieved();
+        notify_pressure_relieved();
     } else if (top_relief_region_group) {
         top_relief_region_group->notify_pressure_relieved();
     }

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -126,8 +126,8 @@ region_group::start_releaser(scheduling_group deferred_work_sg) {
 }
 
 region_group::region_group(sstring name,
-        reclaim_config cfg, size_t memory_hard_limit, scheduling_group deferred_work_sg)
-    : _cfg(std::move(cfg)), _hard_limit(memory_hard_limit)
+        reclaim_config cfg, scheduling_group deferred_work_sg)
+    : _cfg(std::move(cfg))
     , _blocked_requests(on_request_expiry{std::move(name)})
     , _releaser(reclaimer_can_block() ? start_releaser(deferred_work_sg) : make_ready_future<>())
 {

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -161,8 +161,7 @@ void region_group::update_hard(ssize_t delta) {
 
 void region_group::update(ssize_t delta) {
     // Most-enclosing group which was relieved.
-    region_group* top_relief_region_group = nullptr;
-    bool top_relief_memory_hard_limit = false;
+    bool relief = false;
 
     _total_memory += delta;
 
@@ -176,15 +175,13 @@ void region_group::update(ssize_t delta) {
         notify_pressure();
     } else if (under_pressure()) {
         notify_relief();
-        top_relief_region_group = this;
+        relief = true;
     }
 
-    top_relief_memory_hard_limit = do_update_hard_and_check_relief(delta);
+    relief |= do_update_hard_and_check_relief(delta);
 
-    if (top_relief_memory_hard_limit) {
+    if (relief) {
         notify_pressure_relieved();
-    } else if (top_relief_region_group) {
-        top_relief_region_group->notify_pressure_relieved();
     }
 }
 

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -168,7 +168,7 @@ template <region_group_or_memory_hard_limit RG>
 void do_update(RG* rg, RG*& top_relief, ssize_t delta) {
     rg->_total_memory += delta;
 
-    if (rg->_total_memory >= rg->soft_limit_threshold()) {
+    if (rg->_total_memory > rg->soft_limit_threshold()) {
         rg->notify_soft_pressure();
     } else {
         rg->notify_soft_relief();

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -145,7 +145,8 @@ void region_group::notify_hard_pressure_relieved() {
     notify_pressure_relieved();
 }
 
-bool do_update_hard_and_check_relief(region_group* rg, ssize_t delta) {
+bool region_group::do_update_hard_and_check_relief(ssize_t delta) {
+    auto rg = this;
     rg->_hard_total_memory += delta;
 
     if (rg->_hard_total_memory > rg->hard_throttle_threshold()) {
@@ -158,7 +159,7 @@ bool do_update_hard_and_check_relief(region_group* rg, ssize_t delta) {
 }
 
 void region_group::update_hard(ssize_t delta) {
-    if (do_update_hard_and_check_relief(this, delta)) {
+    if (do_update_hard_and_check_relief(delta)) {
         notify_hard_pressure_relieved();
     }
 }
@@ -183,7 +184,7 @@ void region_group::update(ssize_t delta) {
         top_relief_region_group = this;
     }
 
-    top_relief_memory_hard_limit = do_update_hard_and_check_relief(this, delta);
+    top_relief_memory_hard_limit = do_update_hard_and_check_relief(delta);
 
     if (top_relief_memory_hard_limit) {
         notify_hard_pressure_relieved();

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -164,8 +164,24 @@ void memory_hard_limit::notify_pressure_relieved() {
     }
 }
 
-template <region_group_or_memory_hard_limit RG>
-void do_update(RG* rg, RG*& top_relief, ssize_t delta) {
+void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta) {
+    rg->_total_memory += delta;
+
+    if (rg->_total_memory > rg->soft_limit_threshold()) {
+        rg->notify_soft_pressure();
+    } else {
+        rg->notify_soft_relief();
+    }
+
+    if (rg->_total_memory > rg->throttle_threshold()) {
+        rg->notify_pressure();
+    } else if (rg->under_pressure()) {
+        rg->notify_relief();
+        top_relief = rg;
+    }
+}
+
+void do_update(region_group* rg, region_group*& top_relief, ssize_t delta) {
     rg->_total_memory += delta;
 
     if (rg->_total_memory > rg->soft_limit_threshold()) {

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -56,13 +56,14 @@ dirty_memory_manager_logalloc::size_tracked_region* region_group::get_largest_re
 
 void
 region_group::add(region_group* child) {
-    _subgroups.push_back(child);
+    assert(!_subgroup);
+    _subgroup = child;
     update(child->_total_memory);
 }
 
 void
 region_group::del(region_group* child) {
-    _subgroups.erase(std::find(_subgroups.begin(), _subgroups.end(), child));
+    _subgroup = nullptr;
     update(-child->_total_memory);
 }
 
@@ -153,8 +154,8 @@ bool region_group::reclaimer_can_block() const {
 
 void region_group::notify_relief() {
     _relief.signal();
-    for (region_group* child : _subgroups) {
-        child->notify_relief();
+    if (_subgroup) {
+        _subgroup->notify_relief();
     }
 }
 

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -187,6 +187,13 @@ void region_group::update(ssize_t delta) {
     }
 }
 
+future<>
+region_group::shutdown() noexcept {
+    _shutdown_requested = true;
+    _relief.signal();
+    return std::move(_releaser);
+}
+
 void allocation_queue::on_request_expiry::operator()(std::unique_ptr<allocating_function>& func) noexcept {
     func->fail(std::make_exception_ptr(blocked_requests_timed_out_error{_name}));
 }

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -90,7 +90,7 @@ region_group::moved(region* old_address, region* new_address) {
 bool
 region_group::execution_permitted() noexcept {
     return !(this->under_pressure()
-                || (under_hard_pressure()));
+                || (_under_hard_pressure));
 }
 
 void
@@ -149,9 +149,9 @@ bool do_update_hard_and_check_relief(region_group* rg, ssize_t delta) {
     rg->_hard_total_memory += delta;
 
     if (rg->_hard_total_memory > rg->hard_throttle_threshold()) {
-        rg->notify_hard_pressure();
-    } else if (rg->under_hard_pressure()) {
-        rg->notify_hard_relief();
+        rg->_under_hard_pressure = true;
+    } else if (rg->_under_hard_pressure) {
+        rg->_under_hard_pressure = false;
         return true;
     }
     return false;

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -146,13 +146,12 @@ void region_group::notify_hard_pressure_relieved() {
 }
 
 bool region_group::do_update_hard_and_check_relief(ssize_t delta) {
-    auto rg = this;
-    rg->_hard_total_memory += delta;
+    _hard_total_memory += delta;
 
-    if (rg->_hard_total_memory > rg->hard_throttle_threshold()) {
-        rg->_under_hard_pressure = true;
-    } else if (rg->_under_hard_pressure) {
-        rg->_under_hard_pressure = false;
+    if (_hard_total_memory > hard_throttle_threshold()) {
+        _under_hard_pressure = true;
+    } else if (_under_hard_pressure) {
+        _under_hard_pressure = false;
         return true;
     }
     return false;

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -211,7 +211,7 @@ public:
             , _reclaimer(reclaimer) {
     }
 
-    void notify_relief();
+    void notify_pressure_relieved();
 
     void update(ssize_t delta);
 
@@ -257,7 +257,7 @@ class region_group : public region_listener {
 
     bool reclaimer_can_block() const;
     future<> start_releaser(scheduling_group deferered_work_sg);
-    void notify_relief();
+    void notify_pressure_relieved();
     friend void region_group_binomial_group_sanity_check(const region_group::region_heap& bh);
 private: // from region_listener
     virtual void moved(region* old_address, region* new_address) override;

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -155,26 +155,12 @@ class memory_hard_limit {
     size_t _limit;
 
     bool _under_pressure = false;
-    bool _under_soft_pressure = false;
-
 public:
     bool under_pressure() const noexcept {
         return _under_pressure;
     }
 
 private:
-    bool over_soft_limit() const noexcept {
-        return _under_soft_pressure;
-    }
-
-    void notify_soft_pressure() noexcept {
-        _under_soft_pressure = true;
-    }
-
-    void notify_soft_relief() noexcept {
-        _under_soft_pressure = false;
-    }
-
     void notify_pressure() noexcept {
         _under_pressure = true;
     }
@@ -186,11 +172,6 @@ private:
     size_t throttle_threshold() const noexcept {
         return _limit;
     }
-    size_t soft_limit_threshold() const noexcept {
-        return _limit;
-    }
-
-
 public:
     memory_hard_limit(
             size_t limit = std::numeric_limits<size_t>::max())

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -147,9 +147,6 @@ public:
 class region_group;
 class memory_hard_limit;
 
-template <typename T>
-concept region_group_or_memory_hard_limit = std::same_as<T, region_group> || std::same_as<T, memory_hard_limit>;
-
 class memory_hard_limit {
     region_group* _subgroup = nullptr;
 
@@ -211,8 +208,7 @@ public:
     void add(region_group* child);
     void del(region_group* child);
 
-    template <region_group_or_memory_hard_limit RG>
-    friend void do_update(RG* rg, RG*& top_relief, ssize_t delta);
+    friend void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta);
 
     friend class region_group;
 };
@@ -394,8 +390,8 @@ private:
     virtual void add(region* child) override; // from region_listener
     virtual void del(region* child) override; // from region_listener
 
-    template <region_group_or_memory_hard_limit RG>
-    friend void do_update(RG* rg, RG*& top_relief, ssize_t delta);
+    friend void do_update(region_group* rg, region_group*& top_relief, ssize_t delta);
+    friend void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta);
     friend class test_region_group;
     friend class memory_hard_limit;
 };

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -151,8 +151,6 @@ template <typename T>
 concept region_group_or_memory_hard_limit = std::same_as<T, region_group> || std::same_as<T, memory_hard_limit>;
 
 class memory_hard_limit {
-    sstring _name;
-
     region_group* _subgroup = nullptr;
 
     size_t _total_memory = 0;
@@ -197,10 +195,9 @@ private:
 
 
 public:
-    memory_hard_limit(sstring name = "(unnamed region_group)",
+    memory_hard_limit(
             size_t limit = std::numeric_limits<size_t>::max())
-            : _name(std::move(name))
-            , _limit(limit) {
+            : _limit(limit) {
     }
 
     void notify_pressure_relieved();
@@ -533,7 +530,7 @@ public:
     dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg);
     dirty_memory_manager()
         : _db(nullptr)
-        , _real_region_group("memtable", std::numeric_limits<size_t>::max())
+        , _real_region_group(std::numeric_limits<size_t>::max())
         , _virtual_region_group("memtable (virtual)", &_real_region_group,
                 dirty_memory_manager_logalloc::reclaim_config{
                     .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this),

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -225,10 +225,6 @@ public:
     void add(region_group* child);
     void del(region_group* child);
 
-    future<> shutdown() {
-        return make_ready_future<>();
-    }
-
     template <region_group_or_memory_hard_limit RG>
     friend void do_update(RG* rg, RG*& top_relief, ssize_t delta);
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -189,7 +189,7 @@ public:
     void add(region_group* child);
     void del(region_group* child);
 
-    friend void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta);
+    friend bool do_update_and_check_relief(memory_hard_limit* rg, ssize_t delta);
 
     friend class region_group;
 };
@@ -372,7 +372,6 @@ private:
     virtual void del(region* child) override; // from region_listener
 
     friend void do_update(region_group* rg, region_group*& top_relief, ssize_t delta);
-    friend void do_update(memory_hard_limit* rg, memory_hard_limit*& top_relief, ssize_t delta);
     friend class test_region_group;
     friend class memory_hard_limit;
 };

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -160,18 +160,6 @@ class region_group : public region_listener {
 
     bool _under_hard_pressure = false;
 
-    bool under_hard_pressure() const noexcept {
-        return _under_hard_pressure;
-    }
-
-    void notify_hard_pressure() noexcept {
-        _under_hard_pressure = true;
-    }
-
-    void notify_hard_relief() noexcept {
-        _under_hard_pressure = false;
-    }
-
     size_t hard_throttle_threshold() const noexcept {
         return _hard_limit;
     }
@@ -581,7 +569,7 @@ region_group::run_when_memory_available(Func&& func, db::timeout_clock::time_poi
     bool blocked = 
         !(rg->_blocked_requests.empty() && !rg->under_pressure());
     if (!blocked) {
-        blocked = under_hard_pressure();
+        blocked = _under_hard_pressure;
     }
 
     if (!blocked) {

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -97,9 +97,9 @@ public:
     }
 
     region_group_reclaimer() noexcept
-        : _threshold(std::numeric_limits<size_t>::max()), _soft_limit(std::numeric_limits<size_t>::max()) {}
+        : region_group_reclaimer(std::numeric_limits<size_t>::max()) {}
     region_group_reclaimer(size_t threshold) noexcept
-        : _threshold(threshold), _soft_limit(threshold) {}
+        : region_group_reclaimer(threshold, threshold) {}
     region_group_reclaimer(size_t threshold, size_t soft) noexcept
         : _threshold(threshold), _soft_limit(soft) {
         assert(_soft_limit <= _threshold);

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -347,6 +347,7 @@ private:
     virtual void add(region* child) override; // from region_listener
     virtual void del(region* child) override; // from region_listener
 
+    friend void do_update(region_group* rg, region_group*& top_relief, ssize_t delta);
     friend class test_region_group;
 };
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -163,9 +163,6 @@ class region_group : public region_listener {
     size_t hard_throttle_threshold() const noexcept {
         return _hard_limit;
     }
-
-    void notify_hard_pressure_relieved();
-
 public:
     void update_hard(ssize_t delta);
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -206,8 +206,7 @@ class memory_hard_limit {
 
 public:
     memory_hard_limit(sstring name = "(unnamed region_group)",
-            region_group_reclaimer& reclaimer = no_reclaimer,
-            scheduling_group deferred_work_sg = default_scheduling_group() /* unused */)
+            region_group_reclaimer& reclaimer = no_reclaimer)
             : _name(std::move(name))
             , _reclaimer(reclaimer) {
     }

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -126,7 +126,7 @@ class region_group : public region_listener {
     size_t _total_memory = 0;
     region_group_reclaimer& _reclaimer;
 
-    std::vector<region_group*> _subgroups;
+    region_group* _subgroup = nullptr;
     region_heap _regions;
 
     struct allocating_function {

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -173,7 +173,8 @@ public:
         return _hard_total_memory;
     }
 
-    friend bool do_update_hard_and_check_relief(region_group* rg, ssize_t delta);
+private:
+    bool do_update_hard_and_check_relief(ssize_t delta);
 
 public:
     bool under_pressure() const noexcept {

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -371,7 +371,6 @@ private:
     virtual void add(region* child) override; // from region_listener
     virtual void del(region* child) override; // from region_listener
 
-    friend void do_update(region_group* rg, region_group*& top_relief, ssize_t delta);
     friend class test_region_group;
     friend class memory_hard_limit;
 };

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -452,8 +452,9 @@ dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t thresho
     , _virtual_region_group("memtable (virtual)", dirty_memory_manager_logalloc::reclaim_config{
             .hard_limit = threshold / 2,
             .soft_limit = threshold * soft_limit / 2,
+            .absolute_hard_limit = threshold,
             .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
-      }, threshold, deferred_work_sg)
+      }, deferred_work_sg)
     , _flush_serializer(1)
     , _waiting_flush(flush_when_needed()) {}
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1729,9 +1729,7 @@ future<> dirty_memory_manager::shutdown() {
     _db_shutdown_requested = true;
     _should_flush.signal();
     return std::move(_waiting_flush).then([this] {
-        return _virtual_region_group.shutdown().then([this] {
-            return _real_region_group.shutdown();
-        });
+        return _virtual_region_group.shutdown();
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -451,7 +451,7 @@ dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t thresho
     : dirty_memory_manager_logalloc::region_group_reclaimer(threshold / 2, threshold * soft_limit / 2)
     , _real_dirty_reclaimer(threshold)
     , _db(&db)
-    , _real_region_group("memtable", _real_dirty_reclaimer, deferred_work_sg)
+    , _real_region_group("memtable", _real_dirty_reclaimer)
     , _virtual_region_group("memtable (virtual)", &_real_region_group, *this, deferred_work_sg)
     , _flush_serializer(1)
     , _waiting_flush(flush_when_needed()) {}

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -448,8 +448,12 @@ void backlog_controller::update_controller(float shares) {
 
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
-    : dirty_memory_manager_logalloc::region_group_reclaimer(threshold / 2, threshold * soft_limit / 2, std::bind_front(&dirty_memory_manager::start_reclaiming, this))
-    , _real_dirty_reclaimer(threshold)
+    : dirty_memory_manager_logalloc::region_group_reclaimer({
+            .hard_limit = threshold / 2,
+            .soft_limit = threshold * soft_limit / 2,
+            .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
+      })
+    , _real_dirty_reclaimer({.hard_limit = threshold})
     , _db(&db)
     , _real_region_group("memtable", _real_dirty_reclaimer)
     , _virtual_region_group("memtable (virtual)", &_real_region_group, *this, deferred_work_sg)

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -449,12 +449,11 @@ void backlog_controller::update_controller(float shares) {
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
     : _db(&db)
-    , _real_region_group(threshold)
-    , _virtual_region_group("memtable (virtual)", &_real_region_group, dirty_memory_manager_logalloc::reclaim_config{
+    , _virtual_region_group("memtable (virtual)", dirty_memory_manager_logalloc::reclaim_config{
             .hard_limit = threshold / 2,
             .soft_limit = threshold * soft_limit / 2,
             .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
-      }, deferred_work_sg)
+      }, threshold, deferred_work_sg)
     , _flush_serializer(1)
     , _waiting_flush(flush_when_needed()) {}
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -448,7 +448,7 @@ void backlog_controller::update_controller(float shares) {
 
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
-    : dirty_memory_manager_logalloc::region_group_reclaimer(threshold / 2, threshold * soft_limit / 2)
+    : dirty_memory_manager_logalloc::region_group_reclaimer(threshold / 2, threshold * soft_limit / 2, std::bind_front(&dirty_memory_manager::start_reclaiming, this))
     , _real_dirty_reclaimer(threshold)
     , _db(&db)
     , _real_region_group("memtable", _real_dirty_reclaimer)

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -449,7 +449,7 @@ void backlog_controller::update_controller(float shares) {
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
     : _db(&db)
-    , _real_region_group("memtable", dirty_memory_manager_logalloc::reclaim_config{.hard_limit = threshold})
+    , _real_region_group("memtable", threshold)
     , _virtual_region_group("memtable (virtual)", &_real_region_group, dirty_memory_manager_logalloc::reclaim_config{
             .hard_limit = threshold / 2,
             .soft_limit = threshold * soft_limit / 2,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -448,7 +448,7 @@ void backlog_controller::update_controller(float shares) {
 
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
-    : dirty_memory_manager_logalloc::region_group_reclaimer({
+    : _virtual_dirty_reclaimer({
             .hard_limit = threshold / 2,
             .soft_limit = threshold * soft_limit / 2,
             .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
@@ -456,7 +456,7 @@ dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t thresho
     , _real_dirty_reclaimer({.hard_limit = threshold})
     , _db(&db)
     , _real_region_group("memtable", _real_dirty_reclaimer)
-    , _virtual_region_group("memtable (virtual)", &_real_region_group, *this, deferred_work_sg)
+    , _virtual_region_group("memtable (virtual)", &_real_region_group, _virtual_dirty_reclaimer, deferred_work_sg)
     , _flush_serializer(1)
     , _waiting_flush(flush_when_needed()) {}
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -449,7 +449,7 @@ void backlog_controller::update_controller(float shares) {
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
     : _db(&db)
-    , _real_region_group("memtable", threshold)
+    , _real_region_group(threshold)
     , _virtual_region_group("memtable (virtual)", &_real_region_group, dirty_memory_manager_logalloc::reclaim_config{
             .hard_limit = threshold / 2,
             .soft_limit = threshold * soft_limit / 2,

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1731,7 +1731,7 @@ class dirty_mem_mgr():
         self.ref = ref
 
     def real_dirty(self):
-        return int(self.ref['_real_region_group']['_total_memory'])
+        return int(self.ref['_real_region_group']['_hard_total_memory'])
 
     def virt_dirty(self):
         return int(self.ref['_virtual_region_group']['_total_memory'])

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1731,7 +1731,7 @@ class dirty_mem_mgr():
         self.ref = ref
 
     def real_dirty(self):
-        return int(self.ref['_real_region_group']['_hard_total_memory'])
+        return int(self.ref['_virtual_region_group']['_hard_total_memory'])
 
     def virt_dirty(self):
         return int(self.ref['_virtual_region_group']['_total_memory'])

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -496,29 +496,13 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
         size_t hard_threshold = logalloc::segment_size * 8;
         size_t soft_threshold = hard_threshold / 2;
 
-        class reclaimer : public region_group_reclaimer {
-            bool _reclaim = false;
-        protected:
-            void start_reclaiming() noexcept {
-                _reclaim = true;
-            }
-
-            void stop_reclaiming() noexcept {
-                _reclaim = false;
-            }
-        public:
-            reclaimer(size_t hard_threshold, size_t soft_threshold)
-                : region_group_reclaimer({
-                        .hard_limit = hard_threshold,
-                        .soft_limit = soft_threshold,
-                        .start_reclaiming = std::bind_front(&reclaimer::start_reclaiming, this),
-                        .stop_reclaiming =std::bind_front(&reclaimer::stop_reclaiming, this)
-                  })
-            { }
-            bool reclaiming() const { return _reclaim; };
-        };
-
-        reclaimer recl(hard_threshold, soft_threshold);
+        bool reclaiming = false;
+        region_group_reclaimer recl({
+                .hard_limit = hard_threshold,
+                .soft_limit = soft_threshold,
+                .start_reclaiming = [&] () noexcept { reclaiming = true; },
+                .stop_reclaiming = [&] () noexcept { reclaiming = false; },
+        });
         region_group gr(test_name, recl);
         auto close_gr = defer([&gr] () noexcept { gr.shutdown().get(); });
         size_tracked_region r;
@@ -527,32 +511,32 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
         with_allocator(r.allocator(), [&] {
             std::vector<managed_bytes> objs;
 
-            BOOST_REQUIRE(!recl.reclaiming());
+            BOOST_REQUIRE(!reclaiming);
 
             while (!recl.over_soft_limit()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
-            BOOST_REQUIRE(recl.reclaiming());
+            BOOST_REQUIRE(reclaiming);
 
             while (!recl.under_pressure()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
-            BOOST_REQUIRE(recl.reclaiming());
+            BOOST_REQUIRE(reclaiming);
 
             while (recl.under_pressure()) {
                 objs.pop_back();
             }
 
             BOOST_REQUIRE(recl.over_soft_limit());
-            BOOST_REQUIRE(recl.reclaiming());
+            BOOST_REQUIRE(reclaiming);
 
             while (recl.over_soft_limit()) {
                 objs.pop_back();
             }
 
-            BOOST_REQUIRE(!recl.reclaiming());
+            BOOST_REQUIRE(!reclaiming);
         });
     });
 }

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -74,7 +74,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().used_space()), ssize_t(one_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().total_space()), ssize_t(one->occupancy().used_space()));
         BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one->occupancy().total_space());
 
         constexpr size_t two_count = 8 * base_count;
         std::vector<managed_ref<int>> two_objs;
@@ -86,7 +86,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().used_space()), ssize_t(two_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().total_space()), ssize_t(two->occupancy().used_space()));
         BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space() + two->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one_and_two.memory_used());
 
         constexpr size_t three_count = 32 * base_count;
         std::vector<managed_ref<int>> three_objs;
@@ -97,7 +97,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t(three_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one_and_two.memory_used());
 
         constexpr size_t four_count = 4 * base_count;
         std::vector<managed_ref<int>> four_objs;
@@ -121,27 +121,27 @@ SEASTAR_TEST_CASE(test_region_groups) {
         three->merge(*four);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one_and_two.memory_used());
         BOOST_REQUIRE_EQUAL(just_four.memory_used(), 0);
 
         three->merge(*five);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one_and_two.memory_used());
 
         with_allocator(two->allocator(), [&] {
             two_objs.clear();
         });
         two.reset();
         BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(all.memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), one_and_two.memory_used());
 
         with_allocator(one->allocator(), [&] {
             one_objs.clear();
         });
         one.reset();
         BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), 0);
-        BOOST_REQUIRE_EQUAL(all.memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), 0);
 
         with_allocator(three->allocator(), [&] {
             three_objs.clear();
@@ -150,7 +150,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         three.reset();
         four.reset();
         five.reset();
-        BOOST_REQUIRE_EQUAL(all.memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(all.hard_memory_used(), 0);
     });
 }
 


### PR DESCRIPTION
region_group evolved as a tree, each node of which contains some
regions (memtables). Each node has some constraints on memory, and
can start flushing and/or stop allocation into its memtables and those
below it when those constraints are violated.

Today, the tree has exactly two nodes, only one of which can hold memtables.
However, all the complexity of the tree remains.


This series applies some mechanical code transformations that remove
the tree structure and all the excess functionality, leaving a much simpler
structure behind.

Before:
 - a tree of region_group objects
 - each with two parameters: soft limit and hard limit
 - but only two instances ever instantiated
After:
 - a single region_group object
 - with three parameters - two from the bottom instance, one from the top instance
