### PR TITLE
Alternator: test and fix crashes and errors when using ":attrs" attribute

### DIFF
--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -280,14 +280,12 @@ def test_create_table_special_column_name(dynamodb):
 # using various operations like PutItem, GetItem, UpdateItem and various
 # expressions involving attribute names. Before issue #5009 was fixed, some of
 # these tests used to crash Scylla or otherwise fail.
-@pytest.mark.skip(reason="#5009: name ':attrs' for non-key attribute crashes Scylla")
 def test_special_attribute_name_putitem(test_table_s):
     p = random_string()
     expected = {'p': p, ':attrs': random_string()}
     test_table_s.put_item(Item=expected)
     assert expected == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
-@pytest.mark.skip(reason="#5009: name ':attrs' for non-key attribute crashes Scylla")
 def test_special_attribute_name_updateitem_put(test_table_s):
     p = random_string()
     s = random_string()
@@ -295,7 +293,6 @@ def test_special_attribute_name_updateitem_put(test_table_s):
         AttributeUpdates={':attrs': {'Value': s, 'Action': 'PUT'}})
     assert {'p': p, ':attrs': s} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
-@pytest.mark.xfail(reason="#5009: name ':attrs' for non-key attribute")
 def test_special_attribute_name_updateitem_delete(test_table_s):
     p = random_string()
     s = random_string()
@@ -305,7 +302,6 @@ def test_special_attribute_name_updateitem_delete(test_table_s):
         AttributeUpdates={':attrs': {'Action': 'DELETE'}})
     assert {'p': p, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
-@pytest.mark.xfail(reason="#5009: name ':attrs' for non-key attribute")
 def test_special_attribute_name_updateitem_rmw(test_table_s):
     p = random_string()
     test_table_s.put_item(Item={'p': p, ':attrs': 7})


### PR DESCRIPTION
This PR improves the testing for issue #5009 and fixes most of it (but not all - see below). Issue #5009 is about what happens when a user tries to use the name `:attrs` for an attribute - while Alternator uses a map column with that name to hold all the schema-less attributes of an item.  The tests we had for this issue were partial, and missed the worst cases which could result in Scylla crashing on specially-crafted PutItem or UpdateItem requests.

What the tests missed were the cases that `:attrs` is used as a **non-key**. So in this PR we add additional tests for this case, several of them fail or even crash Scylla, and then we fix all these cases.

Issue #5009 remains open because using `:attrs` as the name of a **key** is still not allowed. But because it results in a clean error message when attempting to create a table with such a key, I consider this remaining problem very minor.

Refs #5009.