### PR TITLE
cql: validate bloom_filter_fp_chance up-front

### DIFF
--- a/test/cql-pytest/test_bloom_filter.py
+++ b/test/cql-pytest/test_bloom_filter.py
@@ -6,6 +6,7 @@ import pytest
 import rest_api
 import nodetool
 from util import new_test_table
+from cassandra.protocol import ConfigurationException
 
 # Test inserts `N` rows into table, flushes it 
 # and tries to read `M` non-existing keys.
@@ -29,3 +30,27 @@ def test_bloom_filter(scylla_only, cql, test_keyspace, N, M, fp_chance):
         ratio = fp / M
         assert ratio >= fp_chance * 0.7 and ratio <= fp_chance * 1.15
             
+# Test very small bloom_filter_fp_chance settings.
+# The Cassandra documentation suggests that bloom_filter_fp_chance can be set
+# to anything between 0 and 1, and the Datastax documentation even goes further
+# and explains that 0 means "the largest possible Bloom filter".
+# But in practice, there is a minimal false-positive chance that the Bloom
+# filter can possibly achieve and Cassandra refuses lower settings (see
+# CASSANDRA-11920) and Scylla should do the same instead of crashing much
+# later during a memtable flush as it did in issue #11524.
+@pytest.mark.parametrize("fp_chance", [1e-5, 0])
+def test_small_bloom_filter_fp_chance(cql, test_keyspace, fp_chance):
+    with pytest.raises(ConfigurationException):
+        with new_test_table(cql, test_keyspace, 'a int PRIMARY KEY', f'WITH bloom_filter_fp_chance = {fp_chance}') as table:
+            cql.execute(f'INSERT INTO {table} (a) VALUES (1)')
+            # In issue #11524, Scylla used to crash during this flush after the
+            # table creation succeeded above.
+            nodetool.flush(cql, table)
+
+# Check that bloom_filter_fp_chance outside [0, 1] (i.e., > 1 or < 0)
+# is, unsurprisingly, forbidden.
+@pytest.mark.parametrize("fp_chance", [-0.1, 1.1])
+def test_invalid_bloom_filter_fp_chance(cql, test_keyspace, fp_chance):
+    with pytest.raises(ConfigurationException):
+        with new_test_table(cql, test_keyspace, 'a int PRIMARY KEY', f'WITH bloom_filter_fp_chance = {fp_chance}') as table:
+            pass

--- a/utils/bloom_calculations.hh
+++ b/utils/bloom_calculations.hh
@@ -123,6 +123,18 @@ namespace bloom_calculations {
         }
         return std::min(probs.size() - 1, size_t(v));
     }
+
+    /**
+     * Retrieves the minimum supported bloom_filter_fp_chance value
+     * if compute_bloom_spec() above is attempted with bloom_filter_fp_chance
+     * lower than this, it will throw an unsupported_operation_exception.
+     */
+    inline double min_supported_bloom_filter_fp_chance() {
+        int max_buckets = probs.size() - 1;
+        int max_K = probs[max_buckets].size() - 1;
+        return probs[max_buckets][max_K];
+    }
+
 }
 
 }


### PR DESCRIPTION
Scylla's Bloom filter implementation has a minimal false-positive rate that it can support (6.71e-5). When setting bloom_filter_fp_chance any lower than that, the compute_bloom_spec() function, which writes the bloom filter, throws an exception. However, this is too late - it only happens while flushing the memtable to disk, and a failure at that point causes Scylla to crash.

Instead, we should refuse the table creation with the unsupported bloom_filter_fp_chance. This is also what Cassandra did six years ago - see CASSANDRA-11920.

This patch also includes a regression test, which crashes Scylla before this patch but passes after the patch (and also passes on Cassandra).

Fixes #11524.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>