### PR TITLE
doc: add the upgrade guide from 5.0 to 5.1

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-v4-rpm.rst
+++ b/docs/upgrade/_common/upgrade-guide-v4-rpm.rst
@@ -2,89 +2,84 @@
 Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION| for |OS|
 =============================================================================================================
 
-This document is a step by step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|, and rollback to |SRC_VERSION| if required.
+This document is a step by step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|, and rollback to version |SRC_VERSION| if required.
 
 
-Applicable versions
+Applicable Versions
 ===================
-This guide covers upgrading Scylla from the following versions: |SRC_VERSION|.x or later to |SCYLLA_NAME| version |NEW_VERSION|.y, on the following platforms:
-
-* |OS|
+This guide covers upgrading |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION| on |OS|. 
+See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
 
 Upgrade Procedure
 =================
 
-Upgrading your Scylla version is a rolling procedure that does not require a full cluster shutdown. For each of the nodes in the cluster, serially (i.e. one at a time), you will:
+Upgrading your ScyllaDB version is a rolling procedure that does not require a full cluster shutdown. For each of the nodes in the cluster, serially (i.e. one at a time), you will:
 
 * Check the cluster's schema
 * Drain the node and backup the data
 * Backup the configuration file
-* Stop the Scylla service
-* Download and install new Scylla packages
-* Start the Scylla service
+* Stop ScyllaDB
+* Download and install new ScyllaDB packages
+* Start ScyllaDB
 * Validate that the upgrade was successful
 
-Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running with the new version.
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running the new version.
 
 **During** the rolling upgrade, it is highly recommended:
 
-* Not to use new |NEW_VERSION| features
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/index.html>`_ for suspending Scylla Manager (only available Scylla Enterprise) scheduled or running repairs.
+* Not to use the new |NEW_VERSION| features
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/index.html>`_ for suspending ScyllaDB Manager (only available for ScyllaDB Enterprise) scheduled or running repairs.
 * Not to apply schema changes
 
-.. note:: Before upgrading, make sure to use the latest `Scylla Montioring <https://monitoring.docs.scylladb.com/>`_ stack.
+.. note:: Before upgrading, make sure to use the latest `ScyllaDB Montioring <https://monitoring.docs.scylladb.com/>`_ stack.
 
-Upgrade steps
+Upgrade Steps
 =============
 Check the cluster schema
 ------------------------
-Make sure that all nodes have the schema synched prior to upgrade as any schema disagreement between the nodes causes the upgrade to fail.
+Make sure that all nodes have the schema synced before the upgrade. The upgrade will fail if there is a schema disagreement between nodes.
 
 .. code:: sh
 
        nodetool describecluster
 
-Drain node and backup the data
-------------------------------
-Before any major procedure, like an upgrade, it is **highly recommended** to backup all the data to an external device. In Scylla, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+Drain the nodes and backup the data
+--------------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In ScyllaDB, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
 
 .. code:: sh
 
    nodetool drain
    nodetool snapshot
 
-Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to an external backup device.
+Take note of the directory name that nodetool gives you, and copy all the directories having that name under ``/var/lib/scylla`` to an external backup device.
 
-When the upgrade is complete (for all nodes), remove the snapshot by running ``nodetool clearsnapshot -t <snapshot>``, or you risk running out of disk space.
+When the upgrade is completed on all nodes, remove the snapshot with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
 
-Backup configuration file
--------------------------
+Backup the configuration file
+------------------------------
 .. code:: sh
 
    sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-src
 
-Stop Scylla
------------
+Stop ScyllaDB
+---------------
 .. include:: /rst_include/scylla-commands-stop-index.rst
 
 
 Download and install the new release
 ------------------------------------
-Before upgrading, check what Scylla version you are currently running with ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
 To upgrade:
 
-1. Update the |SCYLLA_REPO|_  to |NEW_VERSION|
-2. Install the new Scylla version
+#. Update the |SCYLLA_REPO|_  to |NEW_VERSION|.
+#. Install the new ScyllaDB version:
 
-.. code:: sh
+    .. code:: sh
 
-   sudo yum clean all
-   sudo yum update scylla\* -y
-
-.. note::
-
-   Alternator users upgrading from Scylla 4.0 to 4.1, need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`
+       sudo yum clean all
+       sudo yum update scylla\* -y
 
 
 Start the node
@@ -94,62 +89,63 @@ Start the node
 
 Validate
 --------
-1. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
-2. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the Scylla version. Validate that the version matches the one you upgraded to. 
-3. Use ``journalctl _COMM=scylla`` to check there are no new errors in the log.
-4. Check again after two minutes, to validate no new issues are introduced.
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version. Validate that the version matches the one you upgraded to. 
+#. Use ``journalctl _COMM=scylla`` to check there are no new errors in the log.
+#. Check again after two minutes, to validate no new issues are introduced.
 
 Once you are sure the node upgrade was successful, move to the next node in the cluster.
 
-* More on |Scylla_METRICS|_
+See |Scylla_METRICS|_ for more information..
 
 Rollback Procedure
 ==================
 
 .. include:: /upgrade/_common/warning_rollback.rst
 
-The following procedure describes a rollback from |SCYLLA_NAME| release |NEW_VERSION|.x to |SRC_VERSION|.y. Apply this procedure if an upgrade from |SRC_VERSION| to |NEW_VERSION| failed before completing on all nodes. Use this procedure only for the nodes that you upgraded to |NEW_VERSION|
+The following procedure describes a rollback from |SCYLLA_NAME| release |NEW_VERSION|.x to |SRC_VERSION|.y. Apply this procedure if an upgrade from |SRC_VERSION| to |NEW_VERSION| failed before completing on all nodes. Use this procedure only for the nodes that you upgraded to |NEW_VERSION|.
 
 
-Scylla rollback is a rolling procedure that does **not** require a full cluster shutdown.
-For each of the nodes rollback to |SRC_VERSION|, you will:
+ScyllaDB rollback is a rolling procedure that does **not** require a full cluster shutdown.
+For each of the nodes you rollback to |SRC_VERSION|, you will:
 
-* Drain the node and stop Scylla
-* Retrieve the old Scylla packages
+* Drain the node and stop ScyllaDB
+* Retrieve the old ScyllaDB packages
 * Restore the configuration file
 * Reload the systemd configuration
-* Restart the Scylla service
+* Restart ScyllaDB
 * Validate the rollback success
 
-Apply the following procedure **serially** on each node. Do not move to the next node before validating the rollback was successful and that the node is up and running with the old version.
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the rollback was successful and that the node is up and running the old version.
 
-Rollback steps
+Rollback Steps
 ==============
-Gracefully shutdown Scylla
---------------------------
+Gracefully shutdown ScyllaDB
+-----------------------------
 .. code:: sh
 
    nodetool drain
  .. include:: /rst_include/scylla-commands-stop-index.rst
 
-Download and install the new release
+Download and install the old release
 ------------------------------------
-1. Remove the old repo file.
+#. Remove the old repo file.
 
-.. code:: sh
+    .. code:: sh
 
-   sudo rm -rf /etc/yum.repos.d/scylla.repo
+       sudo rm -rf /etc/yum.repos.d/scylla.repo
 
-2. Update the |SCYLLA_REPO|_  to |SRC_VERSION|
-3. Install
+#. Update the |SCYLLA_REPO|_  to |SRC_VERSION|.
+#. Install:
 
-.. parsed-literal::
-   \    sudo yum clean all
-   \    sudo rm -rf /var/cache/yum
-   \    sudo yum remove scylla\\*tools-core
-   \    sudo yum downgrade scylla\\* -y
-   \    sudo yum install |PKG_NAME|
-   \    
+    .. code:: console
+
+       sudo yum clean all
+       sudo rm -rf /var/cache/yum
+       sudo yum remove scylla\\*tools-core
+       sudo yum downgrade scylla\\* -y
+       sudo yum install scylla
+     
 
 Restore the configuration file
 ------------------------------
@@ -162,7 +158,7 @@ Restore the configuration file
 Restore system tables
 ---------------------
 
-Restore all tables of **system** and **system_schema** from previous snapshot, |NEW_VERSION| uses a different set of system tables. Reference doc: :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`
+Restore all tables of **system** and **system_schema** from previous snapshot because |NEW_VERSION| uses a different set of system tables. See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` for details.
 
 .. code:: sh
 
@@ -173,7 +169,7 @@ Restore all tables of **system** and **system_schema** from previous snapshot, |
 Reload systemd configuration
 ---------------------------------
 
-Require to reload the unit file if the systemd unit file is changed.
+You must reload the unit file if the systemd unit file is changed.
 
 .. code:: sh
 
@@ -182,9 +178,8 @@ Require to reload the unit file if the systemd unit file is changed.
 Start the node
 --------------
 
-
    .. include:: /rst_include/scylla-commands-start-index.rst
 
 Validate
 --------
-Check the upgrade instruction above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster. Keep in mind that the version you want to see on your node is the old version, which you noted at the beginning of the procedure.
+Check the upgrade instructions above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
@@ -2,49 +2,43 @@
 Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION| for |OS|
 =============================================================================
 
-This document is a step by step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|, and rollback to |SRC_VERSION| if required.
+This document is a step by step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|, and rollback to version |SRC_VERSION| if required.
 
-..
-  Relevant and tested for Ubuntu 20.04. Remove from other OSes and versions.
-
-There are two upgrade alternatives: you can upgrade ScyllaDB simultaneously updating 3rd party and OS packages (recommended for Ubuntu 20.04), or upgrade ScyllaDB without updating any external packages.
-
-Applicable versions
+Applicable Versions
 ===================
-This guide covers upgrading Scylla from version |SRC_VERSION|.x or later to |SCYLLA_NAME| version |NEW_VERSION|.y on the following platform:
-
-* |OS|
+This guide covers upgrading |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION| on |OS|.
+See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
 
 Upgrade Procedure
 =================
 
-A Scylla upgrade is a rolling procedure which does **not** require full cluster shutdown.
+A ScyllaDB upgrade is a rolling procedure which does **not** require full cluster shutdown.
 For each of the nodes in the cluster, you will:
 
-* Check cluster schema
-* Drain node and backup the data
-* Backup configuration file
-* Stop Scylla
-* Download and install new Scylla packages
-* Start Scylla
+* Check the cluster's schema
+* Drain the node and backup the data
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install new ScyllaDB packages
+* Start ScyllaDB
 * Validate that the upgrade was successful
 
-Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node you upgraded is up and running with the new version.
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node you upgraded is up and running the new version.
 
 
 **During** the rolling upgrade, it is highly recommended:
 
-* Not to use new |NEW_VERSION| features
-* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `here <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending Scylla Manager (only available Scylla Enterprise) scheduled or running repairs.
+* Not to use the new |NEW_VERSION| features
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending ScyllaDB Manager (only available for ScyllaDB Enterprise) scheduled or running repairs.
 * Not to apply schema changes
 
-.. note:: Before upgrading, make sure to use the latest `Scylla Montioring <https://monitoring.docs.scylladb.com/>`_ stack.
+.. note:: Before upgrading, make sure to use the latest `ScyllaDB Montioring <https://monitoring.docs.scylladb.com/>`_ stack.
 
-Upgrade steps
+Upgrade Steps
 =============
 Check the cluster schema
 -------------------------
-Make sure that all nodes have the schema synched before the upgrade. The upgrade will fail if there is any disagreement between the nodes.
+Make sure that all nodes have the schema synced before the upgrade. The upgrade will fail if there is a schema disagreement between nodes.
 
 .. code:: sh
 
@@ -59,12 +53,12 @@ Before any major procedure, like an upgrade, it is recommended to backup all the
    nodetool drain
    nodetool snapshot
 
-Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+Take note of the directory name that nodetool gives you, and copy all the directories having that name under ``/var/lib/scylla`` to a backup device.
 
-When the upgrade is complete on all nodes, the snapshot should be removed by ``nodetool clearsnapshot -t <snapshot>`` to prevent running out of space.
+When the upgrade is completed on all nodes, remove the snapshot with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
 
-Backup configuration file
--------------------------
+Backup the configuration file
+------------------------------
 
 .. code:: sh
 

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p2.rst
@@ -1,22 +1,17 @@
 **To upgrade ScyllaDB:**
 
-1. Update the |SCYLLA_REPO|_ to |NEW_VERSION|
+#. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.
 
-2. Install
+#. Install:
 
-.. code-block::
+    .. code-block:: console
    
-   sudo apt-get clean all
-   sudo apt-get update
-   sudo apt-get dist-upgrade |PKG_NAME|
+       sudo apt-get clean all
+       sudo apt-get update
+       sudo apt-get dist-upgrade scylla
 
 
 Answer ‘y’ to the first two questions.
-
-.. note::
-
-   Alternator users upgrading from Scylla 4.0 to 4.1 need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`.
-
 
 Start the node
 --------------
@@ -27,10 +22,10 @@ Start the node
 
 Validate
 --------
-1. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
-2. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the Scylla version.
-3. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
-4. Check again after two minutes to validate no new issues are introduced.
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the Scylla version.
+#. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+#. Check again after two minutes to validate no new issues are introduced.
 
 Once you are sure the node upgrade is successful, move to the next node in the cluster.
 
@@ -41,25 +36,25 @@ Rollback Procedure
 
 .. include:: /upgrade/_common/warning_rollback.rst
 
-The following procedure describes a rollback from |SCYLLA_NAME| release |NEW_VERSION|.x to |SRC_VERSION|.y. Apply this procedure if an upgrade from |SRC_VERSION| to |NEW_VERSION| failed before completing on all nodes. Use this procedure only for nodes you upgraded to |NEW_VERSION|.
+The following procedure describes a rollback from |SCYLLA_NAME| |NEW_VERSION|.x to |SRC_VERSION|.y. Apply this procedure if an upgrade from |SRC_VERSION| to |NEW_VERSION| failed before completing on all nodes. Use this procedure only for nodes you upgraded to |NEW_VERSION|.
 
-Scylla rollback is a rolling procedure which does **not** require full cluster shutdown.
-For each of the nodes rollback to |SRC_VERSION|, you will:
+ScyllaDB rollback is a rolling procedure which does **not** require full cluster shutdown.
+For each of the nodes you rollback to |SRC_VERSION|, you will:
 
 * Drain the node and stop Scylla
-* Retrieve the old Scylla packages
+* Retrieve the old ScyllaDB packages
 * Restore the configuration file
 * Restore system tables
 * Reload systemd configuration
-* Restart Scylla
+* Restart ScyllaDB
 * Validate the rollback success
 
-Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running with the new version.
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running the old version.
 
-Rollback steps
+Rollback Steps
 ==============
-Gracefully shutdown Scylla
---------------------------
+Gracefully shutdown ScyllaDB
+----------------------------
 
 .. code:: sh
 
@@ -68,20 +63,20 @@ Gracefully shutdown Scylla
 
 Download and install the old release
 ------------------------------------
-1. Remove the old repo file.
+#. Remove the old repo file.
 
-.. code:: sh
+    .. code:: sh
 
-   sudo rm -rf /etc/apt/sources.list.d/scylla.list
+       sudo rm -rf /etc/apt/sources.list.d/scylla.list
 
-2. Update the |SCYLLA_REPO|_ to |SRC_VERSION|
-3. Install
+#. Update the |SCYLLA_REPO|_ to |SRC_VERSION|.
+#. Install:
 
-.. code-block::
+    .. code-block::
    
-   sudo apt-get update
-   sudo apt-get remove scylla\* -y
-   sudo apt-get install |PKG_NAME|
+       sudo apt-get update
+       sudo apt-get remove scylla\* -y
+       sudo apt-get install scylla
 
 Answer ‘y’ to the first two questions.
 
@@ -95,7 +90,7 @@ Restore the configuration file
 Restore system tables
 ---------------------
 
-Restore all tables of **system** and **system_schema** from the previous snapshot - |NEW_VERSION| uses a different set of system tables. See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` for reference.
+Restore all tables of **system** and **system_schema** from the previous snapshot because |NEW_VERSION| uses a different set of system tables. See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` for reference.
 
 .. code:: sh
 

--- a/docs/upgrade/_common/upgrade-image-opensource.rst
+++ b/docs/upgrade/_common/upgrade-image-opensource.rst
@@ -20,24 +20,30 @@ Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and 
     
        sudo apt-get update
 
-#. Run the following command to update the manifest file:
 
+#. Run the following command to update the manifest file:
+    
     .. code:: sh 
     
-       cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get -y
+       cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get install -y
     
     Where:
 
       * ``<version>`` - The ScyllaDB version to which you are upgrading ( |NEW_VERSION| ).
       * ``<arch>`` - Architecture type: ``x86_64`` or ``aarch64``.
-
+    
     The file is included in the ScyllaDB packages downloaded in the previous step. The file location is ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
 
     Example:
-
+    
         .. code:: sh 
            
-           cat scylla-packages-5.1.2-x86_64.txt | sudo xargs -n1 apt-get -y
+           cat scylla-packages-5.1.2-x86_64.txt | sudo xargs -n1 apt-get install -y
 
+        .. note:: 
+
+           Alternatively, you can update the manifest file with the following command:
+
+           ``sudo apt-get install $(awk '{print $1'} scylla-packages-<version>-<arch>.txt) -y``
 
 .. _upgrade-image-upgrade-guide-regular-procedure:

--- a/docs/upgrade/_common/upgrade-image-opensource.rst
+++ b/docs/upgrade/_common/upgrade-image-opensource.rst
@@ -1,0 +1,43 @@
+There are two alternative upgrade procedures:
+
+* :ref:`Upgrading ScyllaDB and simultaneously updating 3rd party and OS packages <upgrade-image-recommended-procedure>`. It is recommended if you are running a ScyllaDB official image (EC2 AMI, GCP, and Azure images), which is based on Ubuntu 20.04.
+
+* :ref:`Upgrading ScyllaDB without updating any external packages <upgrade-image-upgrade-guide-regular-procedure>`.
+
+.. _upgrade-image-recommended-procedure:
+
+**To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
+
+.. versionadded:: 5.0
+
+Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command. 
+
+#. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.
+
+#. Load the new repo:
+
+    .. code:: sh 
+    
+       sudo apt-get update
+
+#. Run the following command to update the manifest file:
+
+    .. code:: sh 
+    
+       cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get -y
+    
+    Where:
+
+      * ``<version>`` - The ScyllaDB version to which you are upgrading ( |NEW_VERSION| ).
+      * ``<arch>`` - Architecture type: ``x86_64`` or ``aarch64``.
+
+    The file is included in the ScyllaDB packages downloaded in the previous step. The file location is ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
+
+    Example:
+
+        .. code:: sh 
+           
+           cat scylla-packages-5.1.2-x86_64.txt | sudo xargs -n1 apt-get -y
+
+
+.. _upgrade-image-upgrade-guide-regular-procedure:

--- a/docs/upgrade/upgrade-opensource/index.rst
+++ b/docs/upgrade/upgrade-opensource/index.rst
@@ -5,6 +5,7 @@ Upgrade ScyllaDB Open Source
 .. toctree::
    :hidden:
 
+   ScyllaDB 5.1 to 5.1 <upgrade-guide-from-5.0-to-5.1/index>
    ScyllaDB 5.x maintenance release <upgrade-guide-from-5.x.y-to-5.x.z/index>
    ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/index>
    ScyllaDb 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/index>
@@ -35,6 +36,7 @@ Upgrade ScyllaDB Open Source
 
   Procedures for upgrading to a newer version of ScyllaDB Open Source.
 
+  * :doc:`Upgrade Guide - ScyllaDB 5.0 to 5.1 <upgrade-guide-from-5.0-to-5.1/index>`
   * :doc:`Upgrade Guide - ScyllaDB 5.x maintenance releases <upgrade-guide-from-5.x.y-to-5.x.z/index>`
   * :doc:`Upgrade Guide - ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/index>`
   * :doc:`Upgrade Guide - ScyllaDB 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/index>`

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/index.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/index.rst
@@ -1,0 +1,27 @@
+====================================
+Upgrade Guide - ScyllaDB 4.6 to 5.0
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   ScyllaDB Image <upgrade-guide-from-5.0-to-5.1-image>
+   Red Hat Enterprise Linux and CentOS <upgrade-guide-from-5.0-to-5.1-rpm>
+   Ubuntu <upgrade-guide-from-5.0-to-5.1-ubuntu>
+   Debian <upgrade-guide-from-5.0-to-5.1-debian>
+   Metrics <metric-update-5.0-to-5.1>
+
+.. panel-box::
+  :title: Upgrade Scylla
+  :id: "getting-started"
+  :class: my-panel
+
+
+  Upgrade guides are available for:
+
+  * :doc:`Upgrade ScyllaDB Image from 5.0.x to 5.1.y <upgrade-guide-from-5.0-to-5.1-image>`
+  * :doc:`Upgrade ScyllaDB from 5.0.x to 5.1.y on Red Hat Enterprise Linux and CentOS <upgrade-guide-from-5.0-to-5.1-rpm>`
+  * :doc:`Upgrade ScyllaDB from 5.0.x to 5.1.y on Ubuntu <upgrade-guide-from-5.0-to-5.1-ubuntu>`
+  * :doc:`Upgrade ScyllaDB from 5.0.x to 5.1.y on Debian <upgrade-guide-from-5.0-to-5.1-debian>`
+  * :doc:`ScyllaDB Metrics Update - Scylla 5.0 to 5.1 <metric-update-5.0-to-5.1>`

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/metric-update-5.0-to-5.1.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/metric-update-5.0-to-5.1.rst
@@ -1,0 +1,9 @@
+Scylla Metric Update - Scylla 5.0 to 5.1
+========================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+Scylla 5.1 Dashboards are available as part of the latest |mon_root|.
+

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-debian.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-debian.rst
@@ -1,0 +1,13 @@
+.. |OS| replace:: Debian
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: ./#rollback-procedure
+.. |SRC_VERSION| replace:: 5.0
+.. |NEW_VERSION| replace:: 5.1
+.. |SCYLLA_NAME| replace:: ScyllaDB
+.. |PKG_NAME| replace:: scylla
+.. |SCYLLA_REPO| replace:: ScyllaDB deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/download/?platform=debian-10&version=scylla-5.1
+.. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - Scylla 5.0 to 5.1
+.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+.. |UPGRADE_NOTES| replace:: _
+.. include:: /upgrade/_common/upgrade-guide-v5-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-image.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-image.rst
@@ -1,0 +1,16 @@
+.. |OS| replace:: EC2, GCP, and Azure
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: ./#rollback-procedure
+.. |SRC_VERSION| replace:: 5.0
+.. |NEW_VERSION| replace:: 5.1
+.. |SCYLLA_NAME| replace:: ScyllaDB Image
+.. |PKG_NAME| replace:: scylla
+.. |APT| replace:: ScyllaDB deb repo
+.. _APT: https://www.scylladb.com/download/?platform=ubuntu-20.04&version=scylla-5.1
+.. |SCYLLA_REPO| replace:: ScyllaDB deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/download/?platform=ubuntu-20.04&version=scylla-5.1
+.. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - Scylla 5.0 to 5.1
+.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+.. include:: /upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
+.. include:: /upgrade/_common/upgrade-image-opensource.rst
+.. include:: /upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p2.rst

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-rpm.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-rpm.rst
@@ -1,0 +1,10 @@
+.. |OS| replace:: Red Hat Enterprise Linux and CentOS
+.. |SRC_VERSION| replace:: 5.0
+.. |NEW_VERSION| replace:: 5.1
+.. |SCYLLA_NAME| replace:: ScyllaDB
+.. |PKG_NAME| replace:: scylla
+.. |SCYLLA_REPO| replace:: ScyllaDB rpm repo
+.. _SCYLLA_REPO: https://www.scylladb.com/download/?platform=centos&version=scylla-5.1
+.. |SCYLLA_METRICS| replace:: Scylla Metrics Update - Scylla 5.0 to 5.1
+.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+.. include:: /upgrade/_common/upgrade-guide-v4-rpm.rst

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-ubuntu.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-ubuntu.rst
@@ -1,0 +1,13 @@
+.. |OS| replace:: Ubuntu
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: ./#rollback-procedure
+.. |SRC_VERSION| replace:: 5.0
+.. |NEW_VERSION| replace:: 5.1
+.. |SCYLLA_NAME| replace:: ScyllaDB
+.. |PKG_NAME| replace:: scylla
+.. |SCYLLA_REPO| replace:: ScyllaDB deb repo
+.. _SCYLLA_REPO: https://www.scylladb.com/download/?platform=ubuntu-20.04&version=scylla-5.1
+.. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - Scylla 5.0 to 5.1
+.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+.. |UPGRADE_NOTES| replace:: _
+.. include:: /upgrade/_common/upgrade-guide-v5-ubuntu-and-debian.rst


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11376

This PR adds the upgrade guide from version 5.0 to 5.1. It involves adding new files (5.0-to-5.1) and language/formatting improvements to the existing content (shared by several upgrade guides).