### PR TITLE
docs/using-scylla/migrate-scylla.rst: remove link to unirestore

### DIFF
--- a/docs/using-scylla/migrate-scylla.rst
+++ b/docs/using-scylla/migrate-scylla.rst
@@ -24,6 +24,5 @@ Migrate to Scylla
   :class: my-panel
 
   * :doc:`Migration tools overview <mig-tool-review>` - Overview of all tools available.
-  * `unirestore <https://github.com/scylladb/field-engineering/tree/master/unirestore>`_ for migrating from SSTable to SSTable. Based on Scylla refresh.
   * `Spark Migrator <https://github.com/scylladb/scylla-migrator>`_ - for  migrating from CQL to CQL
   * :doc:`SSTable Loader </operating-scylla/admin-tools/sstableloader/>` - for migrating SSTables to CQL


### PR DESCRIPTION
It points to a private scylladb repo, which has no place in user-facing documentation. For now there is no public replacement, but a similar functionality is in the works for Scylla Manager.

Fixes: #11573