### PR TITLE
test.py: topology raft not experimental

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -182,7 +182,10 @@ def check_pre_raft(cql):
         return False
     # In Scylla, we check Raft mode by inspecting the configuration via CQL.
     experimental_features = list(cql.execute("SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
-    return 'raft' in experimental_features
+    # Check if command line option was set (if not present set to false)
+    ccm = list(cql.execute("SELECT value FROM system.config WHERE name = 'consistent_cluster_management'"))
+    ccm = 'false' if not ccm else ccm[0].value
+    return 'raft' in experimental_features or ccm == 'true'
 
 @pytest.fixture(scope="function")
 def fails_without_raft(request, check_pre_raft):

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -182,12 +182,11 @@ def check_pre_raft(cql):
         return False
     # In Scylla, we check Raft mode by inspecting the configuration via CQL.
     experimental_features = list(cql.execute("SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
-    return not '"raft"' in experimental_features
-
+    return 'raft' in experimental_features
 
 @pytest.fixture(scope="function")
 def fails_without_raft(request, check_pre_raft):
-    if check_pre_raft:
+    if not check_pre_raft:
         request.node.add_marker(pytest.mark.xfail(reason='Test expected to fail without Raft experimental feature on'))
 
 


### PR DESCRIPTION
Preparing for the switch of raft from experimental feature to dedicated option, adjust checks for topology tests.

While there, fix previous check.