### PR TITLE
Revert "topology: Do not add bootstrapping nodes to topology" and some associated commits

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1289,7 +1289,6 @@ future<> system_keyspace::save_local_supported_features(const std::set<std::stri
 // updates are propagated correctly.
 struct local_cache {
     std::unordered_map<gms::inet_address, locator::endpoint_dc_rack> _cached_dc_rack_info;
-    locator::endpoint_dc_rack _local_dc_rack_info;
     system_keyspace::bootstrap_state _state;
 };
 
@@ -2806,10 +2805,6 @@ system_keyspace::load_dc_rack_info() {
     return _cache->_cached_dc_rack_info;
 }
 
-locator::endpoint_dc_rack system_keyspace::local_dc_rack() const {
-    return _cache->_local_dc_rack_info;
-}
-
 future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
 system_keyspace::query_mutations(distributed<service::storage_proxy>& proxy, const sstring& ks_name, const sstring& cf_name) {
     replica::database& db = proxy.local().get_db().local();
@@ -3359,14 +3354,6 @@ future<> system_keyspace::start() {
     if (this_shard_id() == 0) {
         qctx = std::make_unique<query_context>(_qp);
     }
-
-    // FIXME
-    // This should be coupled with setup_version()'s part committing these values into
-    // the system.local table. However, cql_test_env needs cached local_dc_rack strings,
-    // but it doesn't call system_keyspace::setup() and thus ::setup_version() either
-    auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
-    _cache->_local_dc_rack_info.dc = snitch->get_datacenter(utils::fb_utilities::get_broadcast_address());
-    _cache->_local_dc_rack_info.rack = snitch->get_rack(utils::fb_utilities::get_broadcast_address());
 
     co_return;
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -285,7 +285,6 @@ public:
      * Return a map of IP addresses containing a map of dc and rack info
      */
     std::unordered_map<gms::inet_address, locator::endpoint_dc_rack> load_dc_rack_info();
-    locator::endpoint_dc_rack local_dc_rack() const;
 
     enum class bootstrap_state {
         NEEDS_BOOTSTRAP,

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -39,7 +39,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         throw std::runtime_error("Wrong stream_reason provided: it can only be replace or bootstrap");
     }
     try {
-        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason);
+        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, description, reason);
         auto nodes_to_filter = gossiper.get_unreachable_members();
         if (reason == streaming::stream_reason::replace) {
             nodes_to_filter.insert(std::move(replace_address));
@@ -51,7 +51,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
             auto& strategy = erm->get_replication_strategy();
             // We took a strategy ptr to keep it alive during the `co_await`.
             // The keyspace may be dropped in the meantime.
-            dht::token_range_vector ranges = co_await strategy.get_pending_address_ranges(_token_metadata_ptr, _tokens, _address, _dr);
+            dht::token_range_vector ranges = co_await strategy.get_pending_address_ranges(_token_metadata_ptr, _tokens, _address);
             blogger.debug("Will stream keyspace={}, ranges={}", keyspace_name, ranges);
             co_await streamer->add_ranges(keyspace_name, erm, ranges, gossiper, reason == streaming::stream_reason::replace);
         }

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -35,19 +35,15 @@ class boot_strapper {
     abort_source& _abort_source;
     /* endpoint that needs to be bootstrapped */
     inet_address _address;
-    /* its DC/RACK info */
-    locator::endpoint_dc_rack _dr;
     /* token of the node being bootstrapped. */
     std::unordered_set<token> _tokens;
     const token_metadata_ptr _token_metadata_ptr;
 public:
-    boot_strapper(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source,
-            inet_address addr, locator::endpoint_dc_rack dr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr)
+    boot_strapper(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source, inet_address addr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr)
         : _db(db)
         , _stream_manager(sm)
         , _abort_source(abort_source)
         , _address(addr)
-        , _dr(std::move(dr))
         , _tokens(tokens)
         , _token_metadata_ptr(std::move(tmptr)) {
     }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -126,7 +126,6 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
     auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
 
     //Pending ranges
-    metadata_clone.update_topology(_address, _dr);
     metadata_clone.update_normal_tokens(_tokens, _address).get();
     auto pending_range_addresses  = strat.get_range_addresses(metadata_clone).get0();
     metadata_clone.clear_gently().get();

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -76,24 +76,21 @@ public:
         }
     };
 
-    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
-            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason)
+    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens, inet_address address, sstring description, streaming::stream_reason reason)
         : _db(db)
         , _stream_manager(sm)
         , _token_metadata_ptr(std::move(tmptr))
         , _abort_source(abort_source)
         , _tokens(std::move(tokens))
         , _address(address)
-        , _dr(std::move(dr))
         , _description(std::move(description))
         , _reason(reason)
     {
         _abort_source.check();
     }
 
-    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
-            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason)
-        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason) {
+    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, inet_address address, sstring description, streaming::stream_reason reason)
+        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, description, reason) {
     }
 
     void add_source_filter(std::unique_ptr<i_source_filter> filter) {
@@ -152,7 +149,6 @@ private:
     abort_source& _abort_source;
     std::unordered_set<token> _tokens;
     inet_address _address;
-    locator::endpoint_dc_rack _dr;
     sstring _description;
     streaming::stream_reason _reason;
     std::unordered_multimap<sstring, std::unordered_map<inet_address, dht::token_range_vector>> _to_stream;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -284,11 +284,10 @@ abstract_replication_strategy::get_range_addresses(const token_metadata& tm) con
 }
 
 future<dht::token_range_vector>
-abstract_replication_strategy::get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address, locator::endpoint_dc_rack dr) const {
+abstract_replication_strategy::get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address) const {
     dht::token_range_vector ret;
     token_metadata temp;
     temp = co_await tmptr->clone_only_token_map();
-    temp.update_topology(pending_address, std::move(dr));
     co_await temp.update_normal_tokens(pending_tokens, pending_address);
     for (const auto& t : temp.sorted_tokens()) {
         auto eps = co_await calculate_natural_endpoints(t, temp);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -123,7 +123,7 @@ public:
     // Caller must ensure that token_metadata will not change throughout the call.
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_addresses(const token_metadata& tm) const;
 
-    future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address, locator::endpoint_dc_rack dr) const;
+    future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address) const;
 };
 
 // Holds the full replication_map resulting from applying the

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -53,12 +53,18 @@ public:
     /**
      * Stores current DC/rack assignment for ep
      */
-    void update_endpoint(const inet_address& ep, endpoint_dc_rack dr);
+    void add_endpoint(const inet_address& ep);
 
     /**
      * Removes current DC/rack assignment for ep
      */
     void remove_endpoint(inet_address ep);
+
+    /**
+     * Re-reads the DC/rack info for the given endpoint
+     * @param ep endpoint in question
+     */
+    void update_endpoint(inet_address ep);
 
     /**
      * Returns true iff contains given endpoint
@@ -176,7 +182,7 @@ public:
     const std::unordered_map<token, inet_address>& get_token_to_endpoint() const;
     const std::unordered_set<inet_address>& get_leaving_endpoints() const;
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
-    void update_topology(inet_address ep, endpoint_dc_rack dr);
+    void update_topology(inet_address ep);
     /**
      * Creates an iterable range of the sorted tokens starting at the token next
      * after the given one.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1351,7 +1351,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                 continue;
             }
             auto& strat = erm->get_replication_strategy();
-            dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip, _sys_ks.local().local_dc_rack()).get0();
+            dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip).get0();
             seastar::thread::maybe_yield();
             auto nr_tables = get_nr_tables(db.local(), keyspace_name);
             nr_ranges_total += desired_ranges.size() * nr_tables;
@@ -1367,7 +1367,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                 continue;
             }
             auto& strat = erm->get_replication_strategy();
-            dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip, _sys_ks.local().local_dc_rack()).get0();
+            dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip).get0();
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
             bool everywhere_topology = strat.get_type() == locator::replication_strategy_type::everywhere_topology;
             auto replication_factor = erm->get_replication_factor();
@@ -1377,7 +1377,6 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
 
             //Pending ranges
-            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack());
             metadata_clone.update_normal_tokens(tokens, myip).get();
             auto pending_range_addresses = strat.get_range_addresses(metadata_clone).get0();
             metadata_clone.clear_gently().get();
@@ -1832,7 +1831,6 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     // update a cloned version of tmptr
     // no need to set the original version
     auto cloned_tmptr = make_token_metadata_ptr(std::move(cloned_tm));
-    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack());
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, utils::fb_utilities::get_broadcast_address());
     co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -288,10 +288,7 @@ private:
     future<> shutdown_protocol_servers();
 
     // Tokens and the CDC streams timestamp of the replaced node.
-    struct replacement_info {
-        std::unordered_set<token> tokens;
-        locator::endpoint_dc_rack dc_rack;
-    };
+    using replacement_info = std::unordered_set<token>;
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
@@ -489,7 +486,6 @@ private:
     future<> do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);
-    locator::endpoint_dc_rack get_dc_rack_for(inet_address endpoint);
 private:
     // Should be serialized under token_metadata_lock.
     future<> replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept;

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -91,8 +91,7 @@ void strategy_sanity_check(
 void endpoints_check(
     abstract_replication_strategy::ptr_type ars_ptr,
     const token_metadata& tm,
-    inet_address_vector_replica_set& endpoints,
-    const locator::topology& topo) {
+    inet_address_vector_replica_set& endpoints) {
 
     // Check the total RF
     BOOST_CHECK(endpoints.size() == ars_ptr->get_replication_factor(tm));
@@ -102,9 +101,10 @@ void endpoints_check(
     BOOST_CHECK(endpoints.size() == ep_set.size());
 
     // Check the per-DC RF
+    auto& snitch = i_endpoint_snitch::get_local_snitch_ptr();
     std::unordered_map<sstring, size_t> dc_rf;
     for (auto ep : endpoints) {
-        sstring dc = topo.get_location(ep).dc;
+        sstring dc = snitch->get_datacenter(ep);
 
         auto rf = dc_rf.find(dc);
         if (rf == dc_rf.end()) {
@@ -140,8 +140,7 @@ auto d2t = [](double d) -> int64_t {
 void full_ring_check(const std::vector<ring_point>& ring_points,
                      const std::map<sstring, sstring>& options,
                      abstract_replication_strategy::ptr_type ars_ptr,
-                     locator::token_metadata_ptr tmptr,
-                     const locator::topology& topo) {
+                     locator::token_metadata_ptr tmptr) {
     auto& tm = *tmptr;
     strategy_sanity_check(ars_ptr, tm, options);
 
@@ -152,7 +151,7 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
         token t1(dht::token::kind::key, d2t(cur_point1 / ring_points.size()));
         auto endpoints1 = erm->get_natural_endpoints(t1);
 
-        endpoints_check(ars_ptr, tm, endpoints1, topo);
+        endpoints_check(ars_ptr, tm, endpoints1);
 
         print_natural_endpoints(cur_point1, endpoints1);
 
@@ -165,24 +164,10 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
         token t2(dht::token::kind::key, d2t(cur_point2 / ring_points.size()));
         auto endpoints2 = erm->get_natural_endpoints(t2);
 
-        endpoints_check(ars_ptr, tm, endpoints2, topo);
+        endpoints_check(ars_ptr, tm, endpoints2);
         check_ranges_are_sorted(erm, rp.host);
         BOOST_CHECK(endpoints1 == endpoints2);
     }
-}
-
-std::unique_ptr<locator::topology> generate_topology(const std::vector<ring_point>& pts) {
-    auto topo = std::make_unique<locator::topology>();
-
-    // This resembles rack_inferring_snitch dc/rack generation which is
-    // still in use by this test via token_metadata internals
-    for (const auto& p : pts) {
-        auto rack = std::to_string(uint8_t(p.host.bytes()[2]));
-        auto dc = std::to_string(uint8_t(p.host.bytes()[1]));
-        topo->update_endpoint(p.host, { dc, rack });
-    }
-
-    return topo;
 }
 
 // Run in a seastar thread.
@@ -215,17 +200,14 @@ void simple_test() {
         { 11.0, inet_address("192.102.40.2") }
     };
 
-    auto topo = generate_topology(ring_points);
-
     std::unordered_map<inet_address, std::unordered_set<token>> endpoint_tokens;
     for (const auto& [ring_point, endpoint] : ring_points) {
         endpoint_tokens[endpoint].insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
     }
 
     // Initialize the token_metadata
-    stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
+    stm.mutate_token_metadata([&endpoint_tokens] (token_metadata& tm) -> future<> {
         for (auto&& i : endpoint_tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
             co_await tm.update_normal_tokens(std::move(i.second), i.first);
         }
     }).get();
@@ -242,7 +224,7 @@ void simple_test() {
         "NetworkTopologyStrategy", options323);
 
 
-    full_ring_check(ring_points, options323, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
     ///////////////
     // Create the replication strategy
@@ -255,7 +237,7 @@ void simple_test() {
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", options320);
 
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
     //
     // Check cache invalidation: invalidate the cache and run a full ring
@@ -267,7 +249,7 @@ void simple_test() {
         tm.invalidate_cached_rings();
         return make_ready_future<>();
     }).get();
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 }
 
 // Run in a seastar thread.
@@ -328,11 +310,8 @@ void heavy_origin_test() {
         }
     }
 
-    auto topo = generate_topology(ring_points);
-
-    stm.mutate_token_metadata([&tokens, &topo] (token_metadata& tm) -> future<> {
+    stm.mutate_token_metadata([&tokens] (token_metadata& tm) -> future<> {
         for (auto&& i : tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
             co_await tm.update_normal_tokens(std::move(i.second), i.first);
         }
     }).get();
@@ -340,7 +319,7 @@ void heavy_origin_test() {
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", config_options);
 
-    full_ring_check(ring_points, config_options, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
 
 
@@ -396,7 +375,7 @@ static bool has_sufficient_replicas(
 
 static locator::endpoint_set calculate_natural_endpoints(
                 const token& search_token, const token_metadata& tm,
-                locator::topology& topo,
+                snitch_ptr& snitch,
                 const std::unordered_map<sstring, size_t>& datacenters) {
     //
     // We want to preserve insertion order so that the first added endpoint
@@ -455,7 +434,7 @@ static locator::endpoint_set calculate_natural_endpoints(
         }
 
         inet_address ep = *tm.get_endpoint(next);
-        sstring dc = topo.get_location(ep).dc;
+        sstring dc = snitch->get_datacenter(ep);
 
         auto& seen_racks_dc_set = seen_racks[dc];
         auto& racks_dc_map = racks.at(dc);
@@ -476,7 +455,7 @@ static locator::endpoint_set calculate_natural_endpoints(
             dc_replicas_dc_set.insert(ep);
             replicas.push_back(ep);
         } else {
-            sstring rack = topo.get_location(ep).rack;
+            sstring rack = snitch->get_rack(ep);
             // is this a new rack? - we prefer to replicate on different racks
             if (seen_racks_dc_set.contains(rack)) {
                 skipped_dc_endpoints_set.push_back(ep);
@@ -506,7 +485,7 @@ static locator::endpoint_set calculate_natural_endpoints(
 }
 
 // Called in a seastar thread.
-static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<locator::topology> topo, const std::unordered_map<sstring, size_t>& datacenters) {
+static void test_equivalence(const shared_token_metadata& stm, snitch_ptr& snitch, const std::unordered_map<sstring, size_t>& datacenters) {
     class my_network_topology_strategy : public network_topology_strategy {
     public:
         using network_topology_strategy::network_topology_strategy;
@@ -524,7 +503,7 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {
         auto token = dht::token::get_random_token();
-        auto expected = calculate_natural_endpoints(token, tm, *topo, datacenters);
+        auto expected = calculate_natural_endpoints(token, tm, snitch, datacenters);
         auto actual = nts.calculate_natural_endpoints(token, tm).get0();
 
         // Because the old algorithm does not put the nodes in the correct order in the case where more replicas
@@ -539,9 +518,12 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
 }
 
 
-std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
+std::unique_ptr<i_endpoint_snitch> generate_snitch(const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
     auto& e1 = seastar::testing::local_random_engine;
 
+    using addr_to_string_type = std::unordered_map<inet_address, sstring>;
+
+    addr_to_string_type node_to_rack, node_to_dc;
     std::unordered_map<sstring, size_t> racks_per_dc;
     std::vector<std::reference_wrapper<const sstring>> dcs;
 
@@ -559,21 +541,48 @@ std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<ss
         out = std::fill_n(out, rf, std::cref(dc));
     }
 
-    auto topo = std::make_unique<locator::topology>();
-
     for (auto& node : nodes) {
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo->update_endpoint(node, { dc, to_sstring(r) });
+        node_to_rack.emplace(node, to_sstring(r));
+        node_to_dc.emplace(node, dc);
     }
 
-    return topo;
+    class my_snitch : public snitch_base {
+    public:
+        my_snitch(addr_to_string_type node_to_rack,
+                        addr_to_string_type node_to_dc)
+            : _node_to_rack(std::move(node_to_rack))
+            , _node_to_dc(std::move(node_to_dc))
+        {}
+        sstring get_rack(inet_address endpoint) override {
+            return _node_to_rack.at(endpoint);
+        }
+        sstring get_datacenter(inet_address endpoint) override {
+            return _node_to_dc.at(endpoint);
+        }
+        sstring get_name() const override {
+            return "muminpappa";
+        }
+    private:
+        addr_to_string_type _node_to_rack, _node_to_dc;
+    };
+
+    return std::make_unique<my_snitch>(std::move(node_to_rack), std::move(node_to_dc));
 }
 
 SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+
+    snitch_config cfg;
+    cfg.name = "RackInferringSnitch";
+    sharded<gms::gossiper> g;
+    sharded<snitch_ptr>& g_snitch = i_endpoint_snitch::snitch_instance();
+    g_snitch.start(cfg, std::ref(g)).get();
+    auto stop_snitch = defer([&g_snitch] { g_snitch.stop().get(); });
+    g_snitch.invoke_on_all(&snitch_ptr::start).get();
 
     constexpr size_t NODES = 100;
     constexpr size_t VNODES = 64;
@@ -592,10 +601,14 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
         return inet_address((127u << 24) | ++i);
     });
 
+    auto& snitch = i_endpoint_snitch::get_local_snitch_ptr();
+
     for (size_t run = 0; run < RUNS; ++run) {
         semaphore sem(1);
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); });
-        auto topo = generate_topology(datacenters, nodes);
+        // not doing anything sharded. We can just play fast and loose with the snitch.
+        (void)snitch.stop();
+        snitch = generate_snitch(datacenters, nodes);
 
         std::unordered_set<dht::token> random_tokens;
         while (random_tokens.size() < nodes.size() * VNODES) {
@@ -610,13 +623,12 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
             }
         }
         
-        stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
+        stm.mutate_token_metadata([&endpoint_tokens] (token_metadata& tm) -> future<> {
             for (auto&& i : endpoint_tokens) {
-                tm.update_topology(i.first, topo->get_location(i.first));
                 co_await tm.update_normal_tokens(std::move(i.second), i.first);
             }
         }).get();
-        test_equivalence(stm, std::move(topo), datacenters);
+        test_equivalence(stm, snitch, datacenters);
     }
 }
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -55,7 +55,6 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
             {
                 // Ring with minimum token
                 auto tmptr = locator::make_token_metadata_ptr();
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({dht::minimum_token()}), gms::inet_address("10.0.0.1")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {
@@ -69,9 +68,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
 
             {
                 auto tmptr = locator::make_token_metadata_ptr();
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[2].token()}), gms::inet_address("10.0.0.1")).get();
-                tmptr->update_topology(gms::inet_address("10.0.0.2"), {});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[5].token()}), gms::inet_address("10.0.0.2")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {


### PR DESCRIPTION

This reverts the following commits:

   6dedc69608810d455d3233b71e8d67af6a41b004 "topology: Do not add
       bootstrapping nodes to topology" - it was found to cause a regression
       in cdc_test.TestCdc.test_cluster_expansion_with_cdc[Multi_DC_cluster].
   9db940ff1b16812830c4e94e3eb14460936e54b0 "Merge "Make
       network_topology_strategy_test use topology" from Pavel Emelyanov"
       - just an innocent bystander, it stands in the way of reverting the
       next commit.
   421557b40aa8d1adf5016722418936a99595cb20 "Merge "Provide DC/RACK when
       populating topology" from Pavel E" - one of its commits was fixed by
       the first reverted commit, so reverting the first commit requires
       reverting this one too.

It's not clear exactly why it's the root cause, but was reliably bisected.

Fixes #11531.