### PR TITLE
docs: automatic previews configuration

### DIFF
--- a/.github/workflows/docs-amplify-enhanced.yaml
+++ b/.github/workflows/docs-amplify-enhanced.yaml
@@ -1,0 +1,17 @@
+name: "Docs / Amplify enhanced"
+
+on: issue_comment
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Amplify enhanced
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: scylladb/sphinx-scylladb-theme/.github/actions/amplify-enhanced@master

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,15 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        build:
+          commands:
+            - make setupenv
+            - make dirhtml
+      artifacts:
+        baseDirectory: _build/dirhtml
+        files:
+          - '**/*'
+      cache:
+        paths: []
+    appRoot: docs


### PR DESCRIPTION
This pull request adds the necessary configuration files to support [automatic docs previews on pull requests](https://sphinx-theme.scylladb.com/stable/deployment/previews.html).

![image](https://user-images.githubusercontent.com/9107969/191319744-7b137e68-cc38-47b6-935a-387f897868e9.png)

Once we merge this pull request, @tzach will follow the guide [Enable previews](Enable previews[¶](https://sphinx-theme.scylladb.com/stable/deployment/previews.html#enable-previews) to enable the integration.