### PR TITLE
Preliminary changes for multiple Compaction Groups

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -36,6 +36,10 @@ class compaction_group {
     lw_shared_ptr<sstables::sstable_set> _main_sstables;
     // Holds SSTables created by maintenance operations, which need reshaping before integration into the main set
     lw_shared_ptr<sstables::sstable_set> _maintenance_sstables;
+    // sstables that have been compacted (so don't look up in query) but
+    // have not been deleted yet, so must not GC any tombstones in other sstables
+    // that may delete data in these sstables:
+    std::vector<sstables::shared_sstable> _sstables_compacted_but_not_deleted;
 public:
     compaction_group(table& t);
 
@@ -77,6 +81,8 @@ public:
 
     // Makes a compound set, which includes main and maintenance sets
     lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
+
+    const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept;
 
     compaction::table_state& as_table_state() const noexcept;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -411,10 +411,6 @@ private:
     std::unique_ptr<compaction_group> _compaction_group;
     // Compound SSTable set for all the compaction groups, which is useful for operations spanning all of them.
     lw_shared_ptr<sstables::sstable_set> _sstables;
-    // sstables that have been compacted (so don't look up in query) but
-    // have not been deleted yet, so must not GC any tombstones in other sstables
-    // that may delete data in these sstables:
-    std::vector<sstables::shared_sstable> _sstables_compacted_but_not_deleted;
     // Control background fibers waiting for sstables to be deleted
     seastar::gate _sstable_deletion_gate;
     // This semaphore ensures that an operation like snapshot won't have its selected
@@ -889,7 +885,6 @@ public:
     const sstables::sstable_set& get_sstable_set() const;
     lw_shared_ptr<const sstable_list> get_sstables() const;
     lw_shared_ptr<const sstable_list> get_sstables_including_compacted_undeleted() const;
-    const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const;
     std::vector<sstables::shared_sstable> select_sstables(const dht::partition_range& range) const;
     size_t sstables_count() const;
     std::vector<uint64_t> sstable_count_per_level() const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -785,7 +785,7 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
         auto estimated_partitions = _compaction_strategy.adjust_partition_estimate(metadata, old->partition_count());
 
         if (!_async_gate.is_closed()) {
-            co_await _compaction_manager.maybe_wait_for_sstable_count_reduction(as_table_state());
+            co_await _compaction_manager.maybe_wait_for_sstable_count_reduction(cg.as_table_state());
         }
 
         auto consumer = _compaction_strategy.make_interposer_consumer(metadata, [this, old, permit, &newtabs, metadata, estimated_partitions] (flat_mutation_reader_v2 reader) mutable -> future<> {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -148,7 +148,7 @@ public:
         return _t->as_table_state().maintenance_sstable_set();
     }
     std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
-        return sstables::get_fully_expired_sstables(_t->as_table_state(), sstables, query_time);
+        return sstables::get_fully_expired_sstables(*this, sstables, query_time);
     }
     const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override {
         return _compacted_undeleted;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -190,6 +190,26 @@ static std::unique_ptr<table_state> make_table_state_for_test(column_family_for_
     return std::make_unique<table_state_for_test>(t, env);
 }
 
+static future<compaction_result>
+compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, column_family_for_tests t,
+                 std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
+                 can_purge_tombstones can_purge = can_purge_tombstones::yes) {
+    auto table_s = make_table_state_for_test(t, env);
+    std::exception_ptr err;
+    compaction_result result;
+    try {
+        t.get_compaction_manager().add(*table_s);
+        result = co_await compact_sstables(t.get_compaction_manager(), std::move(descriptor), *table_s, std::move(creator), std::move(replacer), can_purge);
+    } catch (...) {
+        err = std::current_exception();
+    }
+    co_await t.get_compaction_manager().remove(*table_s);
+    if (err) {
+        co_await coroutine::return_exception_ptr(std::move(err));
+    }
+    co_return result;
+}
+
 class strategy_control_for_test : public strategy_control {
     bool _has_ongoing_compaction;
 public:
@@ -284,7 +304,7 @@ SEASTAR_TEST_CASE(compact) {
                 return env.make_sstable(s, tmpdir_path,
                         (*gen)++, sstables::get_highest_sstable_version(), sstables::sstable::format_types::big);
             };
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, new_sstable).then([&env, s, generation, cf, tmpdir_path] (auto) {
+            return compact_sstables(env, sstables::compaction_descriptor(std::move(sstables), default_priority_class()), cf, new_sstable).then([&env, s, generation, cf, tmpdir_path] (auto) {
                 // Verify that the compacted sstable has the right content. We expect to see:
                 //  name  | age | height
                 // -------+-----+--------
@@ -433,8 +453,8 @@ static future<std::vector<unsigned long>> compact_sstables(test_env& env, sstrin
             auto sstables_to_compact = sstables::size_tiered_compaction_strategy::most_interesting_bucket(*sstables, min_threshold, max_threshold);
             // We do expect that all candidates were selected for compaction (in this case).
             BOOST_REQUIRE(sstables_to_compact.size() == sstables->size());
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(sstables_to_compact),
-                default_priority_class()), *cf, new_sstable).then([generation] (auto) {});
+            return compact_sstables(env, sstables::compaction_descriptor(std::move(sstables_to_compact),
+                default_priority_class()), cf, new_sstable).then([generation] (auto) {});
         } else if (strategy == compaction_strategy_type::leveled) {
             std::vector<sstables::shared_sstable> candidates;
             candidates.reserve(sstables->size());
@@ -453,8 +473,8 @@ static future<std::vector<unsigned long>> compact_sstables(test_env& env, sstrin
             BOOST_REQUIRE(candidate.level == 1);
             BOOST_REQUIRE(candidate.max_sstable_bytes == 1024*1024);
 
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(candidate.sstables),
-                default_priority_class(), candidate.level, 1024*1024), *cf, new_sstable).then([generation] (auto) {});
+            return compact_sstables(env, sstables::compaction_descriptor(std::move(candidate.sstables),
+                default_priority_class(), candidate.level, 1024*1024), cf, new_sstable).then([generation] (auto) {});
         } else {
             throw std::runtime_error("unexpected strategy");
         }
@@ -1075,7 +1095,7 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
             for (auto&& sst : all) {
                 column_family_test(cf).add_sstable(sst).get();
             }
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(to_compact, default_priority_class()), *cf, sst_gen).get0().new_sstables;
+            return compact_sstables(env, sstables::compaction_descriptor(to_compact, default_priority_class()), cf, sst_gen).get0().new_sstables;
         };
 
         auto next_timestamp = [] {
@@ -1286,7 +1306,7 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
             std::vector<shared_sstable> sstables;
             sstables.push_back(std::move(sstp));
 
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, creator).then([&env, s, key, new_tables] (auto) {
+            return compact_sstables(env, sstables::compaction_descriptor(std::move(sstables), default_priority_class()), cf, creator).then([&env, s, key, new_tables] (auto) {
                 BOOST_REQUIRE(new_tables->size() == 1);
                 auto newsst = (*new_tables)[0];
                 BOOST_REQUIRE(generation_value(newsst->generation()) == 52);
@@ -1358,7 +1378,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time_2) {
                 BOOST_REQUIRE(now.time_since_epoch().count() == sst2->get_stats_metadata().max_local_deletion_time);
 
                 auto creator = [&env, s, tmpdir_path, version, gen = make_lw_shared<unsigned>(56)] { return env.make_sstable(s, tmpdir_path, (*gen)++, version, big); };
-                auto info = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor({sst1, sst2}, default_priority_class()), *cf, creator).get0();
+                auto info = compact_sstables(env, sstables::compaction_descriptor({sst1, sst2}, default_priority_class()), cf, creator).get0();
                 BOOST_REQUIRE(info.new_sstables.size() == 1);
                 BOOST_REQUIRE(((now + gc_clock::duration(100)).time_since_epoch().count()) ==
                               info.new_sstables.front()->get_stats_metadata().max_local_deletion_time);
@@ -1451,7 +1471,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
         auto expired_sst = *expired.begin();
         BOOST_REQUIRE(generation_value(expired_sst->generation()) == 1);
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(ssts, default_priority_class()), *cf, sst_gen).get0();
+        auto ret = compact_sstables(env, sstables::compaction_descriptor(ssts, default_priority_class()), cf, sst_gen).get0();
         BOOST_REQUIRE(ret.new_sstables.empty());
         BOOST_REQUIRE(ret.stats.end_size == 0);
     });
@@ -1754,7 +1774,7 @@ SEASTAR_TEST_CASE(time_window_strategy_size_tiered_behavior_correctness) {
         auto close_cf = deferred_stop(cf);
         auto major_compact_bucket = [&] (api::timestamp_type window_ts) {
             auto bound = time_window_compaction_strategy::get_window_lower_bound(window_size, window_ts);
-            auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(buckets[bound]), default_priority_class()), *cf, sst_gen).get0();
+            auto ret = compact_sstables(env, sstables::compaction_descriptor(std::move(buckets[bound]), default_priority_class()), cf, sst_gen).get0();
             BOOST_REQUIRE(ret.new_sstables.size() == 1);
             buckets[bound] = std::move(ret.new_sstables);
         };
@@ -1855,7 +1875,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test_2) {
             check_min_max_column_names(sst2, {"9ck101"}, {"9ck298"});
 
             auto creator = [&env, s, &tmp, version] { return env.make_sstable(s, tmp.path().string(), 3, version, big); };
-            auto info = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor({sst, sst2}, default_priority_class()), *cf, creator).get0();
+            auto info = compact_sstables(env, sstables::compaction_descriptor({sst, sst2}, default_priority_class()), cf, creator).get0();
             BOOST_REQUIRE(info.new_sstables.size() == 1);
             check_min_max_column_names(info.new_sstables.front(), {"0ck100"}, {"9ck298"});
         }
@@ -1935,7 +1955,7 @@ SEASTAR_TEST_CASE(sstable_expired_data_ratio) {
             auto sst = env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
             return sst;
         };
-        auto info = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor({ sst }, default_priority_class()), *cf, creator).get0();
+        auto info = compact_sstables(env, sstables::compaction_descriptor({ sst }, default_priority_class()), cf, creator).get0();
         BOOST_REQUIRE(info.new_sstables.size() == 1);
         BOOST_REQUIRE(info.new_sstables.front()->estimate_droppable_tombstone_ratio(gc_before) == 0.0f);
         BOOST_REQUIRE_CLOSE(info.new_sstables.front()->data_size(), uncompacted_size*(1-expired), 5);
@@ -2011,8 +2031,8 @@ SEASTAR_TEST_CASE(compaction_correctness_with_partitioned_sstable_set) {
             std::for_each(all.begin(), all.end(), [] (auto& sst) { sst->set_sstable_level(1); });
             column_family_for_tests cf(env.manager(), s);
             auto close_cf = deferred_stop(cf);
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(all), default_priority_class(), 0, 0 /*std::numeric_limits<uint64_t>::max()*/),
-                *cf, sst_gen).get0().new_sstables;
+            return compact_sstables(env, sstables::compaction_descriptor(std::move(all), default_priority_class(), 0, 0 /*std::numeric_limits<uint64_t>::max()*/),
+                cf, sst_gen).get0().new_sstables;
         };
 
         auto make_insert = [&] (auto p) {
@@ -2137,7 +2157,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(ks_name));
             auto descriptor = sstables::compaction_descriptor({std::move(sst)}, default_priority_class(), compaction_descriptor::default_level,
                 compaction_descriptor::default_max_sstable_bytes, run_identifier, compaction_type_options::make_cleanup(std::move(local_ranges)));
-            auto ret = compact_sstables(cf.get_compaction_manager(), std::move(descriptor), *cf, sst_gen).get0();
+            auto ret = compact_sstables(env, std::move(descriptor), cf, sst_gen).get0();
 
             BOOST_REQUIRE(ret.new_sstables.size() == 1);
             BOOST_REQUIRE(ret.new_sstables.front()->get_estimated_key_count() >= total_partitions);
@@ -2983,7 +3003,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
         cf->start();
         cf->set_compaction_strategy(sstables::compaction_strategy_type::size_tiered);
         auto compact = [&, s] (std::vector<shared_sstable> all, auto replacer) -> std::vector<shared_sstable> {
-            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(all), default_priority_class(), 1, 0), *cf, sst_gen, replacer).get0().new_sstables;
+            return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(all), default_priority_class(), 1, 0), cf->as_table_state(), sst_gen, replacer).get0().new_sstables;
         };
         auto make_insert = [&] (auto p) {
             auto key = partition_key::from_exploded(*s, {to_bytes(p.first)});
@@ -3008,7 +3028,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
                 sstables.insert(new_sst);
             }
             column_family_test(cf).rebuild_sstable_list(new_sstables, old_sstables).get();
-            compaction_manager_test(cf.get_compaction_manager()).propagate_replacement(&*cf, old_sstables, new_sstables);
+            compaction_manager_test(cf.get_compaction_manager()).propagate_replacement(cf->as_table_state(), old_sstables, new_sstables);
         };
 
         auto do_incremental_replace = [&] (auto old_sstables, auto new_sstables, auto& expected_sst, auto& closed_sstables_tracker) {
@@ -3038,9 +3058,8 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
 
         auto do_compaction = [&] (size_t expected_input, size_t expected_output) -> std::vector<shared_sstable> {
             auto input_ssts = std::vector<shared_sstable>(sstables.begin(), sstables.end());
-            auto table_s = make_table_state_for_test(cf, env);
             auto strategy_c = make_strategy_control_for_test(false);
-            auto desc = cs.get_sstables_for_compaction(*table_s, *strategy_c, std::move(input_ssts));
+            auto desc = cs.get_sstables_for_compaction(cf->as_table_state(), *strategy_c, std::move(input_ssts));
 
             // nothing to compact, move on.
             if (desc.sstables.empty()) {
@@ -3188,7 +3207,7 @@ SEASTAR_TEST_CASE(backlog_tracker_correctness_after_changing_compaction_strategy
             // Start compaction, then stop tracking compaction, switch to TWCS, wait for compaction to finish and check for backlog.
             // That's done to assert backlog will work for compaction that is finished and was stopped tracking.
 
-            auto fut = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(ssts, default_priority_class()), *cf, sst_gen);
+            auto fut = compact_sstables(env, sstables::compaction_descriptor(ssts, default_priority_class()), cf, sst_gen);
 
             // set_compaction_strategy() itself is responsible for transferring charges from old to new backlog tracker.
             cf->set_compaction_strategy(sstables::compaction_strategy_type::time_window);
@@ -3239,7 +3258,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         // register partial sstable run
         auto cm_test = compaction_manager_test(cf.get_compaction_manager());
-        cm_test.run(partial_sstable_run_identifier, &*cf, [&cf] (sstables::compaction_data&) {
+        cm_test.run(partial_sstable_run_identifier, cf->as_table_state(), [&cf] (sstables::compaction_data&) {
             return cf->compact_all_sstables();
         }).get();
 
@@ -3513,7 +3532,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         try {
             // The goal is to have one sstable generated for each mutation to trigger the issue.
             auto max_sstable_size = 0;
-            auto result = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(sstables, default_priority_class(), 0, max_sstable_size), *cf, sst_gen, replacer).get0().new_sstables;
+            auto result = compact_sstables(env, sstables::compaction_descriptor(sstables, default_priority_class(), 0, max_sstable_size), cf, sst_gen, replacer).get0().new_sstables;
             BOOST_REQUIRE_EQUAL(2, result.size());
         } catch (...) {
             // swallow exception
@@ -3578,11 +3597,11 @@ SEASTAR_TEST_CASE(twcs_major_compaction_test) {
 
         auto original_together = make_sstable_containing(sst_gen, {mut3, mut4});
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor({original_together}, default_priority_class()), *cf, sst_gen, replacer_fn_no_op()).get0();
+        auto ret = compact_sstables(env, sstables::compaction_descriptor({original_together}, default_priority_class()), cf, sst_gen, replacer_fn_no_op()).get0();
         BOOST_REQUIRE(ret.new_sstables.size() == 1);
 
         auto original_apart = make_sstable_containing(sst_gen, {mut1, mut2});
-        ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor({original_apart}, default_priority_class()), *cf, sst_gen, replacer_fn_no_op()).get0();
+        ret = compact_sstables(env, sstables::compaction_descriptor({original_apart}, default_priority_class()), cf, sst_gen, replacer_fn_no_op()).get0();
         BOOST_REQUIRE(ret.new_sstables.size() == 2);
     });
 }
@@ -3718,8 +3737,8 @@ SEASTAR_TEST_CASE(test_bug_6472) {
         // Make sure everything we wanted expired is expired by now.
         forward_jump_clocks(std::chrono::hours(101));
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(sstables_spanning_many_windows,
-            default_priority_class()), *cf, sst_gen, replacer_fn_no_op()).get0();
+        auto ret = compact_sstables(env, sstables::compaction_descriptor(sstables_spanning_many_windows,
+            default_priority_class()), cf, sst_gen, replacer_fn_no_op()).get0();
         BOOST_REQUIRE(ret.new_sstables.size() == 1);
         return make_ready_future<>();
     });
@@ -3825,8 +3844,8 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
             make_sstable(3),
         };
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(sstables_spanning_many_windows,
-                    default_priority_class()), *cf, sst_gen, replacer_fn_no_op()).get0();
+        auto ret = compact_sstables(env, sstables::compaction_descriptor(sstables_spanning_many_windows,
+                    default_priority_class()), cf, sst_gen, replacer_fn_no_op()).get0();
         // The real test here is that we don't assert() in
         // sstables::prepare_summary() with the compact_sstables() call above,
         // this is only here as a sanity check.
@@ -4011,8 +4030,8 @@ SEASTAR_TEST_CASE(test_twcs_compaction_across_buckets) {
         }();
         sstables_spanning_many_windows.push_back(make_sstable_containing(sst_gen, {deletion_mut}));
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(sstables_spanning_many_windows),
-            default_priority_class()), *cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get0();
+        auto ret = compact_sstables(env, sstables::compaction_descriptor(std::move(sstables_spanning_many_windows),
+            default_priority_class()), cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get0();
 
         BOOST_REQUIRE(ret.new_sstables.size() == 1);
         assert_that(sstable_reader(ret.new_sstables[0], s, env.make_reader_permit()))
@@ -4996,7 +5015,7 @@ SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
         // Set block size to 1, so promoted index is generated for every row written, allowing the split to happen as soon as possible.
         env.manager().set_promoted_index_block_size(1);
 
-        auto ret = compact_sstables(cf.get_compaction_manager(), std::move(desc), *cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get0();
+        auto ret = compact_sstables(env, std::move(desc), cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get0();
 
         testlog.info("Large partition splitting on compaction created {} sstables", ret.new_sstables.size());
         BOOST_REQUIRE(ret.new_sstables.size() > 1);

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -19,6 +19,7 @@
 #include "cell_locking.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/sstable_utils.hh"
+#include "test/lib/test_services.hh"
 #include "service/storage_proxy.hh"
 #include "db/config.hh"
 
@@ -41,14 +42,11 @@ static schema_ptr get_schema(unsigned shard_count, unsigned sharding_ignore_msb_
 void run_sstable_resharding_test() {
     test_env env;
     auto close_env = defer([&] { env.stop().get(); });
-    cache_tracker tracker;
   for (const auto version : writable_sstable_versions) {
     auto tmp = tmpdir();
     auto s = get_schema();
-    auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
-    auto cl_stats = make_lw_shared<cell_locker_stats>();
-    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, tracker);
-    cf->mark_ready_for_writes();
+    table_for_tests cf(env.manager(), s);
+    auto close_cf = deferred_stop(cf);
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;
 
@@ -99,7 +97,7 @@ void run_sstable_resharding_test() {
             version, sstables::sstable::format_types::big);
     };
     auto cdata = compaction_manager::create_compaction_data();
-    auto res = sstables::compact_sstables(std::move(descriptor), cdata, cf->as_table_state()).get0();
+    auto res = sstables::compact_sstables(std::move(descriptor), cdata, cf.as_table_state()).get0();
     auto new_sstables = std::move(res.new_sstables);
     BOOST_REQUIRE(new_sstables.size() == smp::count);
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -37,9 +37,9 @@ public:
         return _cf->as_table_state().on_compaction_completion(sstables::compaction_completion_desc{ .new_sstables = new_sstables }, sstables::offstrategy::no);
     }
 
-    future<> rebuild_sstable_list(const std::vector<sstables::shared_sstable>& new_sstables,
+    future<> rebuild_sstable_list(compaction::table_state& table_s, const std::vector<sstables::shared_sstable>& new_sstables,
             const std::vector<sstables::shared_sstable>& sstables_to_remove) {
-        return _cf->as_table_state().on_compaction_completion(sstables::compaction_completion_desc{ .old_sstables = sstables_to_remove, .new_sstables = new_sstables }, sstables::offstrategy::no);
+        return table_s.on_compaction_completion(sstables::compaction_completion_desc{ .old_sstables = sstables_to_remove, .new_sstables = new_sstables }, sstables::offstrategy::no);
     }
 
     static void update_sstables_known_generation(replica::column_family& cf, unsigned generation) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -374,10 +374,10 @@ class compaction_manager_test {
 public:
     explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
 
-    future<> run(sstables::run_id output_run_id, replica::column_family* cf, noncopyable_function<future<> (sstables::compaction_data&)> job);
+    future<> run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
 
-    void propagate_replacement(replica::table* t, const std::vector<sstables::shared_sstable>& removed, const std::vector<sstables::shared_sstable>& added) {
-        _cm.propagate_replacement(t->as_table_state(), removed, added);
+    void propagate_replacement(table_state& table_s, const std::vector<sstables::shared_sstable>& removed, const std::vector<sstables::shared_sstable>& added) {
+        _cm.propagate_replacement(table_s, removed, added);
     }
 private:
     sstables::compaction_data& register_compaction(shared_ptr<compaction_manager::task> task);
@@ -386,7 +386,7 @@ private:
 };
 
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;
-future<compaction_result> compact_sstables(compaction_manager& cm, sstables::compaction_descriptor descriptor, replica::column_family& cf,
+future<compaction_result> compact_sstables(compaction_manager& cm, sstables::compaction_descriptor descriptor, table_state& table_s,
         std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
         can_purge_tombstones can_purge = can_purge_tombstones::yes);
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -41,6 +41,8 @@ column_family_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
 { }
 
+column_family_for_tests::data::~data() {}
+
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager)
     : column_family_for_tests(
         sstables_manager,
@@ -49,6 +51,76 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
             .build()
     )
 { }
+
+class column_family_for_tests::table_state : public compaction::table_state {
+    column_family_for_tests::data& _data;
+    sstables::sstables_manager& _sstables_manager;
+    std::vector<sstables::shared_sstable> _compacted_undeleted;
+    tombstone_gc_state _tombstone_gc_state;
+private:
+    replica::table& table() const noexcept {
+        return *_data.cf;
+    }
+public:
+    explicit table_state(column_family_for_tests::data& data, sstables::sstables_manager& sstables_manager)
+            : _data(data)
+            , _sstables_manager(sstables_manager)
+            , _tombstone_gc_state(nullptr)
+    {
+    }
+    const schema_ptr& schema() const noexcept override {
+        return table().schema();
+    }
+    unsigned min_compaction_threshold() const noexcept override {
+        return schema()->min_compaction_threshold();
+    }
+    bool compaction_enforce_min_threshold() const noexcept override {
+        return true;
+    }
+    const sstables::sstable_set& main_sstable_set() const override {
+        return table().get_sstable_set();
+    }
+    const sstables::sstable_set& maintenance_sstable_set() const override {
+        return table().as_table_state().maintenance_sstable_set();
+    }
+    std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
+        return sstables::get_fully_expired_sstables(*this, sstables, query_time);
+    }
+    const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override {
+        return _compacted_undeleted;
+    }
+    sstables::compaction_strategy& get_compaction_strategy() const noexcept override {
+        return table().get_compaction_strategy();
+    }
+    reader_permit make_compaction_reader_permit() const override {
+        return _data.semaphore.make_tracking_only_permit(&*schema(), "column_family_for_tests::table_state", db::no_timeout);
+    }
+    sstables::sstables_manager& get_sstables_manager() noexcept override {
+        return _sstables_manager;
+    }
+    sstables::shared_sstable make_sstable() const override {
+        return table().make_sstable();
+    }
+    sstables::sstable_writer_config configure_writer(sstring origin) const override {
+        return _sstables_manager.configure_writer(std::move(origin));
+    }
+
+    api::timestamp_type min_memtable_timestamp() const override {
+        return table().min_memtable_timestamp();
+    }
+    future<> update_compaction_history(utils::UUID compaction_id, sstring ks_name, sstring cf_name, std::chrono::milliseconds ended_at, int64_t bytes_in, int64_t bytes_out) override {
+        return make_ready_future<>();
+    }
+    future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override {
+        return table().as_table_state().on_compaction_completion(std::move(desc), offstrategy);
+    }
+    bool is_auto_compaction_disabled_by_user() const noexcept override {
+        return false;
+    }
+    const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
+        return _tombstone_gc_state;
+    }
+};
 
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)
     : _data(make_lw_shared<data>())
@@ -62,6 +134,18 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     _data->cm.enable();
     _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, replica::column_family::no_commitlog(), _data->cm, sstables_manager, _data->cl_stats, _data->tracker);
     _data->cf->mark_ready_for_writes();
+    _data->table_s = std::make_unique<table_state>(*_data, sstables_manager);
+    _data->cm.add(*_data->table_s);
+}
+
+compaction::table_state& column_family_for_tests::as_table_state() noexcept {
+    return *_data->table_s;
+}
+
+future<> column_family_for_tests::stop() {
+    auto data = _data;
+    co_await data->cm.remove(*data->table_s);
+    co_await when_all_succeed(data->cm.stop(), data->semaphore.stop()).discard_result();
 }
 
 namespace sstables {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -78,7 +78,7 @@ public:
         return true;
     }
     const sstables::sstable_set& main_sstable_set() const override {
-        return table().get_sstable_set();
+        return table().as_table_state().main_sstable_set();
     }
     const sstables::sstable_set& maintenance_sstable_set() const override {
         return table().as_table_state().maintenance_sstable_set();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -115,7 +115,7 @@ public:
         return table().as_table_state().on_compaction_completion(std::move(desc), offstrategy);
     }
     bool is_auto_compaction_disabled_by_user() const noexcept override {
-        return false;
+        return table().is_auto_compaction_disabled_by_user();
     }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _tombstone_gc_state;

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -37,7 +37,7 @@
 extern db::config test_db_config;
 extern gms::feature_service test_feature_service;
 
-struct column_family_for_tests {
+struct table_for_tests {
     class table_state;
     struct data {
         schema_ptr s;
@@ -54,9 +54,9 @@ struct column_family_for_tests {
     };
     lw_shared_ptr<data> _data;
 
-    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager);
+    explicit table_for_tests(sstables::sstables_manager& sstables_manager);
 
-    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir = {});
+    explicit table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir = {});
 
     schema_ptr schema() { return _data->s; }
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -56,6 +56,8 @@ struct column_family_for_tests {
 
     schema_ptr schema() { return _data->s; }
 
+    const replica::cf_stats& cf_stats() const noexcept { return _data->cf_stats; }
+
     operator lw_shared_ptr<replica::column_family>() { return _data->cf; }
 
     replica::column_family& operator*() { return *_data->cf; }


### PR DESCRIPTION
What's contained in this series:
- Refactored compaction tests (and utilities) for integration with multiple groups
    - The idea is to write a new class of tests that will stress multiple groups, whereas the existing ones will still stress a single group.
- Fixed a problem when cloning compound sstable set (cannot be triggered today so I didn't open a GH issue)
- Many changes in replica::table for allowing integration with multiple groups

Next:
- Introduce for_each_compaction_group() for iterating over groups wherever needed.
- Use for_each_compaction_group() in replica::table operations spanning all groups (API, readers, etc).
- Decouple backlog tracker from compaction strategy, to allow for backlog isolation across groups
- Introduce static option for defining number of compaction groups and implement function to map a token to its respective group.
- Testing infrastructure for multiple compaction groups (helpful when testing the dynamic behavior: i.e. merging / splitting).


