### PR TITLE
test.py: fix  topology init error handling

### DIFF
--- a/test.py
+++ b/test.py
@@ -846,6 +846,8 @@ class TopologyTest(PythonTest):
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
+                # Note: start manager here so cluster (and its logs) is availale in case of failure
+                await manager.start()
                 self.success = await run_test(self, options)
             except Exception as e:
                 self.server_log = manager.cluster.read_server_log()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -875,7 +875,6 @@ async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], tes
     """Create a temporary manager for the active cluster used in a test
        and provide the cluster to the caller."""
     manager = ScyllaClusterManager(test_name, clusters, test_path)
-    await manager.start()
     try:
         yield manager
     finally:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -710,6 +710,9 @@ class ScyllaClusterManager:
 
     async def start(self) -> None:
         """Get first cluster, setup API"""
+        if self.is_running:
+            logging.warning("ScyllaClusterManager already running")
+            return
         await self._get_cluster()
         await self.runner.setup()
         self.site = aiohttp.web.UnixSite(self.runner, path=self.sock_path)
@@ -741,6 +744,7 @@ class ScyllaClusterManager:
         del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)
+        self.is_running = False
 
     async def _get_cluster(self) -> None:
         self.cluster = await self.clusters.get()


### PR DESCRIPTION
When there are errors starting the first cluster(s) the logs of the server logs are needed. So move `.start()` to the `try` block in `test.py` (out of `asynccontextmanager`).

While there, make `ScyllaClusterManager.start()` idempotent.