### PR TITLE
token_metadata: Provide dc/rack for bootstrapping nodes

### DIFF
--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -129,6 +129,7 @@ private:
     bool _sort_by_proximity = true;
 };
 
+using dc_rack_fn = seastar::noncopyable_function<endpoint_dc_rack(inet_address)>;
 class token_metadata_impl;
 
 class token_metadata final {
@@ -305,7 +306,7 @@ public:
      * NOTE: This is heavy and ineffective operation. This will be done only once when a node
      * changes state in the cluster, so it should be manageable.
      */
-    future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name);
+    future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name, dc_rack_fn& get_dc_rack);
 
     token get_predecessor(token t) const;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3231,7 +3231,8 @@ future<> storage_service::update_pending_ranges(mutable_token_metadata_ptr tmptr
         for (const auto& [keyspace_name, erm] : ks_erms) {
             auto& strategy = erm->get_replication_strategy();
             slogger.debug("Updating pending ranges for keyspace={} starts", keyspace_name);
-            co_await tmptr->update_pending_ranges(strategy, keyspace_name);
+            locator::dc_rack_fn get_dc_rack_from_gossiper([this] (inet_address ep) { return get_dc_rack_for(ep); });
+            co_await tmptr->update_pending_ranges(strategy, keyspace_name, get_dc_rack_from_gossiper);
             slogger.debug("Updating pending ranges for keyspace={} ends", keyspace_name);
         }
     } catch (...) {


### PR DESCRIPTION
The token_metadata::calculate_pending_ranges_for_bootstrap() makes a clone of itself and adds bootstrapping nodes to the clone to calculate ranges. Currently added nodes lack the dc/rack which affects the calculations the bad way.

Unfortunately, the dc/rack for those nodes is not available on topology (yet) and needs pretty heavy patching to have. Fortunately, the only caller of this method has gossiper at hand to provide the dc/rack from.

fixes: #11531

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>