### PR TITLE
readers/mutation_reader: stream validator: fix log level detection logic

### DIFF
--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -183,7 +183,7 @@ mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_
     , _name(format("{} ({}.{} {})", name, s.ks_name(), s.cf_name(), s.id()))
     , _validation_level(level)
 {
-    if (mrlog.level() <= log_level::debug) {
+    if (mrlog.is_enabled(log_level::debug)) {
         std::string_view what;
         switch (_validation_level) {
             case mutation_fragment_stream_validation_level::partition_region:


### PR DESCRIPTION
The mutation fragment stream validator filter has a detailed debug log in its constructor. To avoid putting together this message when the log level is above debug, it is enclosed in an if, activated when log level is debug or trace... at least that was intended. Actually the if is activated when the log level is debug or above (info, warn or error) but is only actually logged if the log level is exactly debug. Fix the logic to work as intended.