### PR TITLE
Fix invalid mutation fragment stream issues

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2261,7 +2261,9 @@ void view_builder::execute(build_step& step, exponential_backoff_retry r) {
             batch_size,
             query::max_partitions,
             view_builder::consumer{*this, step, now});
-    consumer.consume_new_partition(step.current_key); // Initialize the state in case we're resuming a partition
+    if (auto mfp = step.reader.peek().get(); mfp && !mfp->is_partition_start()) {
+        consumer.consume_new_partition(step.current_key); // Initialize the state in case we're resuming a partition
+    }
     auto built = step.reader.consume_in_thread(std::move(consumer));
 
     _as.check();

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -847,12 +847,12 @@ future<> shard_reader_v2::do_fill_buffer() {
     }
 
     auto res = co_await(std::move(fill_buf_fut));
-    _end_of_stream = res.end_of_stream;
     reserve_additional(res.buffer->size());
     for (const auto& mf : *res.buffer) {
         push_mutation_fragment(mutation_fragment_v2(*_schema, _permit, mf));
         co_await coroutine::maybe_yield();
     }
+    _end_of_stream = res.end_of_stream;
 }
 
 future<> shard_reader_v2::fill_buffer() {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1409,6 +1409,7 @@ private:
         if (_last_uncompacted_kind != mutation_fragment_v2::kind::partition_end) {
             _ignore_partition_end = true;
             _compactor.consume_end_of_partition(*this, _gc_consumer);
+            _last_uncompacted_kind = mutation_fragment_v2::kind::partition_end;
             _ignore_partition_end = false;
         }
     }


### PR DESCRIPTION
Found by a fragment stream validator added to the mutation-compactor (https://github.com/scylladb/scylladb/pull/11532). As that PR moves very slowly, the fixes for the issues found are split out into a PR of their own.
The first two of these issues seems benign, but it is important to remember that how benign an invalid fragment stream is depends entirely on the consumer of said stream. The present consumer of said streams may swallow the invalid stream without problem now but any future change may cause it to enter into a corrupt state.
The last one is a non-benign problem (again because the consumer reacts badly already) causing problems when building query results for range scans.