### PR TITLE
docs: update docs/alternator/getting-started.md

### DIFF
--- a/docs/alternator/getting-started.md
+++ b/docs/alternator/getting-started.md
@@ -1,21 +1,21 @@
 # Getting Started With ScyllaDB Alternator
 
-## Installing Scylla
+## Installing ScyllaDB
 Before you can start using ScyllaDB Alternator, you will have to have an up
-and running scylla cluster configured to expose the alternator port.
+and running a ScyllaDB cluster configured to expose the Alternator port.
 This section will guide you through the steps for setting up the cluster:
-### Get Scylla with alternator support from a docker:
-1. Because Alternator is still improving quickly, it is recommended to run
-   the latest nightly build. Make sure you have the latest nightly image by
-   running: `docker pull scylladb/scylla-nightly:latest`
-2. Follow the steps in the [Scylla official download web page](https://www.scylladb.com/download/open-source/#docker)
-   add to every "docker run" command: `-p 8000:8000` before the image name
-   and `--alternator-port=8000 --alternator-write-isolation=always` at the end.
+### Get ScyllaDB with Alternator support from a docker:
+1. Download the latest stable ScyllaDB image for Docker, by running
+   `docker pull scylladb/scylla:latest`
+2. To run this Docker image, follow the instructions in
+   <https://hub.docker.com/r/scylladb/scylla/>, but add to every `docker run`
+   command a `-p 8000:8000` before the image name and
+   `--alternator-port=8000 --alternator-write-isolation=always` at the end.
    The "alternator-port" option specifies on which port Scylla will listen for
    the (unencrypted) DynamoDB API, and the "alternator-write-isolation" chooses
    whether or not Alternator will use LWT for every write.
    For example,
-   `docker run --name scylla -d -p 8000:8000 scylladb/scylla-nightly:latest --alternator-port=8000 --alternator-write-isolation=always`.
+   `docker run --name scylla -d -p 8000:8000 scylladb/scylla:latest --alternator-port=8000 --alternator-write-isolation=always`.
    The `--alternator-https-port=...` option can also be used to enable
    Alternator on an encrypted (HTTPS) port. Note that in this case, the files
    `/etc/scylla/scylla.crt` and `/etc/scylla/scylla.key` must be inserted into


### PR DESCRIPTION
Update several aspects of the alternator/getting-started.md which were not up-to-date:

* When the documented was written, Alternator was moving quickly so we recommended running a nightly version. This is no longer the case, so we should recommend running the latest stable build.

* The link to the download link is no longer helpful for getting Docker instructions (it shows some generic download options). Instead point to our dockerhub page.

* Replace mentions of "Scylla" by the new official name, "ScyllaDB".

* Miscelleneous copy-edits.

Fixes #11218

Signed-off-by: Nadav Har'El <nyh@scylladb.com>