### PR TITLE
mutation_fragment_stream_validator: various API improvements

### DIFF
--- a/mutation_fragment_stream_validator.hh
+++ b/mutation_fragment_stream_validator.hh
@@ -108,6 +108,7 @@ public:
     /// normally invalid and hence wouldn't advance the internal state. This
     /// can be used by users that can correct such invalid streams and wish to
     /// continue validating it.
+    void reset(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);
     void reset(const mutation_fragment&);
     void reset(const mutation_fragment_v2&);
 
@@ -177,6 +178,8 @@ public:
     /// Equivalent to `operator()(mf.kind(), mf.position())`
     bool operator()(const mutation_fragment_v2& mv);
     bool operator()(const mutation_fragment& mv);
+    void reset(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);
+    void reset(const mutation_fragment_v2& mf);
     /// Equivalent to `operator()(partition_end{})`
     bool on_end_of_partition();
     void on_end_of_stream();

--- a/mutation_fragment_stream_validator.hh
+++ b/mutation_fragment_stream_validator.hh
@@ -41,9 +41,11 @@ public:
     /// `operator()(const mutation_fragment&)` is not desired.
     /// Using both overloads for the same stream is not supported.
     /// Advances the previous fragment kind, but only if the validation passes.
+    /// `new_current_tombstone` should be engaged only when the fragment changes
+    /// the current tombstone (range tombstone change fragments).
     ///
     /// \returns true if the fragment kind is valid.
-    bool operator()(mutation_fragment_v2::kind kind);
+    bool operator()(mutation_fragment_v2::kind kind, std::optional<tombstone> new_current_tombstone);
     bool operator()(mutation_fragment::kind kind);
 
     /// Validates the monotonicity of the mutation fragment kind and position.
@@ -54,9 +56,11 @@ public:
     /// Using both overloads for the same stream is not supported.
     /// Advances the previous fragment kind and position-in-partition, but only
     /// if the validation passes.
+    /// `new_current_tombstone` should be engaged only when the fragment changes
+    /// the current tombstone (range tombstone change fragments).
     ///
     /// \returns true if the mutation fragment kind is valid.
-    bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos);
+    bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);
     bool operator()(mutation_fragment::kind kind, position_in_partition_view pos);
 
     /// Validates the monotonicity of the mutation fragment.
@@ -158,7 +162,6 @@ class mutation_fragment_stream_validating_filter {
     mutation_fragment_stream_validator _validator;
     sstring _name;
     mutation_fragment_stream_validation_level _validation_level;
-    tombstone _current_tombstone;
 
 public:
     /// Constructor.
@@ -169,7 +172,7 @@ public:
     mutation_fragment_stream_validating_filter(sstring_view name, const schema& s, mutation_fragment_stream_validation_level level);
 
     bool operator()(const dht::decorated_key& dk);
-    bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos);
+    bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);
     bool operator()(mutation_fragment::kind kind, position_in_partition_view pos);
     /// Equivalent to `operator()(mf.kind(), mf.position())`
     bool operator()(const mutation_fragment_v2& mv);

--- a/sstables/writer.cc
+++ b/sstables/writer.cc
@@ -30,7 +30,7 @@ sstable_writer::sstable_writer(sstable& sst, const schema& s, uint64_t estimated
 
 void sstable_writer::consume_new_partition(const dht::decorated_key& dk) {
     _impl->_validator(dk);
-    _impl->_validator(mutation_fragment::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{}));
+    _impl->_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{}), {});
     _impl->_sst.get_stats().on_partition_write();
     return _impl->consume_new_partition(dk);
 }
@@ -41,7 +41,7 @@ void sstable_writer::consume(tombstone t) {
 }
 
 stop_iteration sstable_writer::consume(static_row&& sr) {
-    _impl->_validator(mutation_fragment::kind::static_row, sr.position());
+    _impl->_validator(mutation_fragment_v2::kind::static_row, sr.position(), {});
     if (!sr.empty()) {
         _impl->_sst.get_stats().on_static_row_write();
     }
@@ -49,13 +49,13 @@ stop_iteration sstable_writer::consume(static_row&& sr) {
 }
 
 stop_iteration sstable_writer::consume(clustering_row&& cr) {
-    _impl->_validator(mutation_fragment::kind::clustering_row, cr.position());
+    _impl->_validator(mutation_fragment_v2::kind::clustering_row, cr.position(), {});
     _impl->_sst.get_stats().on_row_write();
     return _impl->consume(std::move(cr));
 }
 
 stop_iteration sstable_writer::consume(range_tombstone_change&& rtc) {
-    _impl->_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position());
+    _impl->_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
     _impl->_sst.get_stats().on_range_tombstone_write();
     return _impl->consume(std::move(rtc));
 }

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -205,27 +205,27 @@ public:
 
     void consume_new_partition(const dht::decorated_key& dk) {
         testlog.debug("consume new partition: {}", dk);
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{})));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{}), {}));
     }
     void consume(tombstone) { }
     stop_iteration consume(static_row&& sr) {
         testlog.debug("consume static_row");
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::static_row, sr.position()));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::static_row, sr.position(), {}));
         return stop_iteration::no;
     }
     stop_iteration consume(clustering_row&& cr) {
         testlog.debug("consume clustering_row: {}", cr.key());
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::clustering_row, cr.position()));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::clustering_row, cr.position(), {}));
         return stop_iteration::no;
     }
     stop_iteration consume(range_tombstone_change&& rtc) {
         testlog.debug("consume range_tombstone_change: {} {}", rtc.position(), rtc.tombstone());
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position()));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone()));
         return stop_iteration::no;
     }
     stop_iteration consume_end_of_partition() {
         testlog.debug("consume end of partition");
-        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{})));
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{}), {}));
         return stop_iteration::no;
     }
     void consume_end_of_stream() {


### PR DESCRIPTION
The low-level `mutation_fragment_stream_validator` gets `reset()` methods that until now only the high-level `mutation_fragment_stream_validating_filter` had.
Active tombstone validation is pushed down to the low level validator.
The low level validator, which was a pain to use until now due to being very fussy on which subset of its API one used, is made much more robust, not requiring the user to stick to a subset of its API anymore.