### PR TITLE
Avoid default initialization of token_metadata and topology when not needed

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -286,8 +286,7 @@ abstract_replication_strategy::get_range_addresses(const token_metadata& tm) con
 future<dht::token_range_vector>
 abstract_replication_strategy::get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, inet_address pending_address, locator::endpoint_dc_rack dr) const {
     dht::token_range_vector ret;
-    token_metadata temp;
-    temp = co_await tmptr->clone_only_token_map();
+    token_metadata temp = co_await tmptr->clone_only_token_map();
     temp.update_topology(pending_address, std::move(dr));
     co_await temp.update_normal_tokens(pending_tokens, pending_address);
     for (const auto& t : temp.sorted_tokens()) {

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1241,10 +1241,11 @@ inline future<> topology::clear_gently() noexcept {
     co_return;
 }
 
-topology::topology(const topology& other) {
-    _dc_endpoints = other._dc_endpoints;
-    _dc_racks = other._dc_racks;
-    _current_locations = other._current_locations;
+topology::topology(const topology& other)
+        : _dc_endpoints(other._dc_endpoints)
+        , _dc_racks(other._dc_racks)
+        , _current_locations(other._current_locations)
+{
 }
 
 void topology::update_endpoint(const inet_address& ep, endpoint_dc_rack dr)


### PR DESCRIPTION
The goal is not to default initialize an object when its fields are about to be immediately overwritten by the consecutive code.
