### PR TITLE
Fix large data warning and docs

### DIFF
--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -146,9 +146,9 @@ future<> cql_table_large_data_handler::record_large_cells(const sstables::sstabl
     if (clustering_key) {
         const schema &s = *sst.get_schema();
         auto ck_str = key_to_str(*clustering_key, s);
-        return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, format("{} {}", ck_str, column_name), extra_fields, ck_str, column_name);
+        return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, format("/{}/{}", ck_str, column_name), extra_fields, ck_str, column_name);
     } else {
-        return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, column_name, extra_fields, data_value::make_null(utf8_type), column_name);
+        return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, format("//{}", column_name), extra_fields, data_value::make_null(utf8_type), column_name);
     }
 }
 
@@ -158,7 +158,7 @@ future<> cql_table_large_data_handler::record_large_rows(const sstables::sstable
     if (clustering_key) {
         const schema &s = *sst.get_schema();
         std::string ck_str = key_to_str(*clustering_key, s);
-        return try_record("row", sst, partition_key, int64_t(row_size), "row", ck_str, extra_fields,  ck_str);
+        return try_record("row", sst, partition_key, int64_t(row_size), "row", format("/{}", ck_str), extra_fields,  ck_str);
     } else {
         return try_record("row", sst, partition_key, int64_t(row_size), "static row", "", extra_fields, data_value::make_null(utf8_type));
     }

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -148,7 +148,8 @@ future<> cql_table_large_data_handler::record_large_cells(const sstables::sstabl
         auto ck_str = key_to_str(*clustering_key, s);
         return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, format("/{}/{}", ck_str, column_name), extra_fields, ck_str, column_name);
     } else {
-        return try_record("cell", sst, partition_key, int64_t(cell_size), cell_type, format("//{}", column_name), extra_fields, data_value::make_null(utf8_type), column_name);
+        auto desc = format("static {}", cell_type);
+        return try_record("cell", sst, partition_key, int64_t(cell_size), desc, format("//{}", column_name), extra_fields, data_value::make_null(utf8_type), column_name);
     }
 }
 

--- a/docs/troubleshooting/debugging-large-partition.rst
+++ b/docs/troubleshooting/debugging-large-partition.rst
@@ -17,12 +17,11 @@ Any of the following:
 
      seastar_memory - oversized allocation: 2842624 bytes, please report
 
-* A warning of "too many rows" is issued when writing to a table (usually happens during a compaction):
+* A warning of "Writing large (partition|row|cell)" is issued when writing to a table (usually happens during a compaction):
 
   .. code-block:: none
 
-     Nov 26 07:36:29 hostname scylla[24314]:  [shard 9] large_partition - Writing a partition with too many rows [Some_KS/Some_table:PK_VAL1] (211663 rows)
-     Nov 26 08:36:19 hostname scylla[24314]:  [shard 34] large_partition - Writing a partition with too many rows [Some_KS/Some_table:PK_VAL2] (171994 rows)
+     WARN  2022-09-22 17:33:11,075 [shard 1]large_data - Writing large partition Some_KS/Some_table: PK[/CK[/COL]] (SIZE bytes) to SSTABLE_NAME
 
   In this case, refer to :ref:`Troubleshooting Large Partition Tables <large-partition-table-configure>` for more information.
 

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -35,10 +35,10 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | rows   | compaction_time
-   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+--------+--------------------------
-          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |    100 | 2018-07-23 08:10:34
-          testdb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cbs45c008e4f11e3418a000871000002/la-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} | 100101 | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | rows   | compaction_time
+   --------------+------------+------------------+----------------+-----------------------------------------------------+--------+--------------------------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |    100 | 2018-07-23 08:10:34
+          testdb |       tmcr | md-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} | 100101 | 2018-07-23 08:10:34
   
 ================================================  =================================================================================
 Parameter                                         Description
@@ -75,9 +75,9 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | rows | compaction_time
-   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+------+--------------------------
-          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 1942 | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | rows | compaction_time
+   --------------+------------+------------------+----------------+-----------------------------------------------------+------+--------------------------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 1942 | 2018-07-23 08:10:34
 
 
 .. _large-partition-table-configure:

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -35,10 +35,10 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | compaction_time
-   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+--------------------------
-          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 2018-07-23 08:10:34
-          testdb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cbs45c008e4f11e3418a000871000002/la-7-big-Data.db |     1188816032 | {key: pk{000400000001}, token:-3169959284402457813} | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | rows   | compaction_time
+   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+--------+--------------------------
+          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |    100 | 2018-07-23 08:10:34
+          testdb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cbs45c008e4f11e3418a000871000002/la-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} | 100101 | 2018-07-23 08:10:34
   
 ================================================  =================================================================================
 Parameter                                         Description
@@ -49,9 +49,11 @@ table_name                                        The name of a table containing
 ------------------------------------------------  ---------------------------------------------------------------------------------
 sstable_name                                      The name of SSTable containing the large partition
 ------------------------------------------------  ---------------------------------------------------------------------------------
-partition_size                                    The size of the partition
+partition_size                                    The size of the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
 partition_key                                     The value of a partition key that identifies the large partition
+------------------------------------------------  ---------------------------------------------------------------------------------
+rows                                              The number of rows in the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
 compaction_time                                   Time when compaction last occurred
 ================================================  =================================================================================
@@ -73,9 +75,9 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | compaction_time
-   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+--------------------------
-          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name                                                                       | partition_size | partition_key                                       | rows | compaction_time
+   --------------+------------+------------------------------------------------------------------------------------+----------------+-----------------------------------------------------+------+--------------------------
+          demodb |       tmcr | /var/lib/scylla/data/demodb/tmcr-cba79c008e4f11e8908a000000000001/la-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 1942 | 2018-07-23 08:10:34
 
 
 .. _large-partition-table-configure:
@@ -83,14 +85,17 @@ Example output:
 Configure
 ^^^^^^^^^
 
-Configure the detection threshold of large partitions with the ``compaction_large_partition_warning_threshold_mb`` parameter (default: 1000MB) in the scylla.yaml configuration file.
-Partitions bigger than this threshold are reported in the ``system.large_partitions`` table and generate a warning in the Scylla log (refer to :doc:`log </getting-started/logging/>`).
+Configure the detection thresholds of large partitions with the ``compaction_large_partition_warning_threshold_mb`` parameter (default: 1000MB)
+and the ``compaction_rows_count_warning_threshold`` paramater (default 100000)
+in the scylla.yaml configuration file.
+Partitions that are bigger than the size threshold and/or hold more than the rows count threshold are reported in the ``system.large_partitions`` table and generate a warning in the Scylla log (refer to :doc:`log </getting-started/logging/>`).
 
-For example (set to 500MB):
+For example (set to 500MB / 50000, respectively):
 
 .. code-block:: console
 
    compaction_large_partition_warning_threshold_mb: 500
+   compaction_rows_count_warning_threshold: 50000
 
 
 Storing
@@ -108,6 +113,7 @@ Large partitions are stored in a system table with the following schema:
        sstable_name text,
        partition_size bigint,
        partition_key text,
+       rows bigint,
        compaction_time timestamp,
        PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)
    ) WITH CLUSTERING ORDER BY (sstable_name ASC, partition_size DESC, partition_key ASC)

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -23,9 +23,9 @@ For example:
 
    > SELECT * FROM system.large_rows;
 
-      keyspace_name | table_name | sstable_name                                                                         | row_size | partition_key | clustering_key | compaction_time
-      --------------+------------+--------------------------------------------------------------------------------------+----------+---------------+----------------+---------------------------------
-      mykeyspace    |         gr | /var/lib/scylla/data/mykeyspace/gr-67d502908ea211e98d05000000000000/mc-1-big-Data.db |  1206130 |             1 |              1 | 2019-06-14 13:03:24.039000+0000
+      keyspace_name | table_name | sstable_name     | row_size | partition_key | clustering_key | compaction_time
+      --------------+------------+------------------+----------+---------------+----------------+---------------------------------
+      mykeyspace    |         gr | md-1-big-Data.db |  1206130 |             1 |              1 | 2019-06-14 13:03:24.039000+0000
 
   
 ================================================  =================================================================================
@@ -65,9 +65,9 @@ For example:
     > SELECT * FROM system.large_cells;
 
 
-    keyspace_name | table_name | sstable_name                                                                         | cell_size | partition_key | clustering_key | column_name | compaction_time
-    --------------+------------+--------------------------------------------------------------------------------------+-----------+---------------+----------------+-------------+---------------------------------
-    mykeyspace    |         gr | /var/lib/scylla/data/mykeyspace/gr-67d502908ea211e98d05000000000000/mc-1-big-Data.db |   1206115 |             1 |              1 |        link | 2019-06-14 13:03:24.034000+0000
+    keyspace_name | table_name | sstable_name     | cell_size | partition_key | clustering_key | column_name | compaction_time
+    --------------+------------+------------------+-----------+---------------+----------------+-------------+---------------------------------
+    mykeyspace    |         gr | md-1-big-Data.db |   1206115 |             1 |              1 |        link | 2019-06-14 13:03:24.034000+0000
    
   
 ================================================  =================================================================================


### PR DESCRIPTION
The series contains fixes for system.large_* log warning and respective documentation.
This prepares the way for adding a new system.large_collections table (See #11449):

Fixes #11620
Fixes #11621
Fixes #11622

the respective fixes should be backported to different release branches, based on the respective patches they depend on (mentioned in each issue).
