### PR TITLE
test.py: don't refresh node list on topology change

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -151,18 +151,15 @@ class ManagerClient():
         """Start specified server"""
         logger.debug("ManagerClient starting %s", server_id)
         await self._get_text(f"/cluster/server/{server_id}/start")
-        self._driver_update()
 
     async def server_restart(self, server_id: str) -> None:
         """Restart specified server"""
         logger.debug("ManagerClient restarting %s", server_id)
         await self._get_text(f"/cluster/server/{server_id}/restart")
-        self._driver_update()
 
     async def server_add(self) -> str:
         """Add a new server"""
         server_id = await self._get_text("/cluster/addserver")
-        self._driver_update()
         logger.debug("ManagerClient added %s", server_id)
         return server_id
 
@@ -170,7 +167,6 @@ class ManagerClient():
         """Remove a specified server"""
         logger.debug("ManagerClient removing %s", server_id)
         await self._get_text(f"/cluster/removeserver/{server_id}")
-        self._driver_update()
 
     async def server_get_config(self, server_id: str) -> dict[str, object]:
         resp = await self._get(f"/cluster/server/{server_id}/get_config")


### PR DESCRIPTION
Due to timeouts seen when a host was down, we started doing a node refresh after each topology change.

But this is no longer necessary after the recent timeout fixes and node refresh is causing an issue in CI when the driver is doing other things and it's closed.

So we can safely remove these calls to `control_connection`'s `refresh_node_list_and_token_map()`.
