### PR TITLE
doc: add a troubleshooting article about the missing configuration files

### DIFF
--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -1,6 +1,6 @@
-======================
-Troubleshooting Scylla
-======================
+=========================
+Troubleshooting ScyllaDB
+=========================
 
 .. toctree::
    :hidden:
@@ -25,13 +25,14 @@ Keep your versions up-to-date. The two latest versions are supported. Also, alwa
   :id: "getting-started"
   :class: my-panel
 
-  * :doc:`Errors and Scylla Customer Support <support/index>`
-  * :doc:`Scylla Startup <startup/index>`
-  * :doc:`Scylla Cluster and Node <cluster/index>`
+  * :doc:`Errors and ScyllaDB Customer Support <support/index>`
+  * :doc:`ScyllaDB Startup <startup/index>`
+  * :doc:`ScyllaDB Cluster and Node <cluster/index>`
+  * :doc:`ScyllaDB Upgrade <upgrade/index>`
   * :doc:`Data Modeling <modeling/index>`
   * :doc:`Data Storage and SSTables <storage/index>`
   * :doc:`CQL errors <CQL/index>`
-  * :doc:`Scylla Monitoring and Scylla Manager <monitor/index>`
+  * :doc:`ScyllaDB Monitoring and Scylla Manager <monitor/index>`
 
 Also check out the `Monitoring lesson <https://university.scylladb.com/courses/scylla-operations/lessons/scylla-monitoring/>`_ on Scylla University, which covers how to troubleshoot different issues when running a Scylla cluster.
 

--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -8,6 +8,7 @@ Troubleshooting Scylla
    
    support/index   
    startup/index
+   upgrade/index
    cluster/index
    modeling/index
    storage/index

--- a/docs/troubleshooting/missing-dotmount-files.rst
+++ b/docs/troubleshooting/missing-dotmount-files.rst
@@ -11,21 +11,21 @@ The problem may occur when you upgrade ScylaDB Open Source 4.6 or later to a ver
 the ``/etc/systemd/system/var-lib-scylla.mount`` and ``/etc/systemd/system/var-lib-systemd-coredump.mount`` are 
 deleted by RPM.
 
-To avoid losing the files, the :doc:`upgrade procedure </upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm/>` 
-includes a step to backup the .mount files:
-
+To avoid losing the files, the upgrade procedure includes a step to backup the .mount files. The following 
+example shows the command to backup the files before the :doc:`upgrade from version 5.0 </upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm/>`:
 
 .. code-block:: console
 
-    for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) /etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; do sudo cp -v $conf $conf.backup-4.3; done
+    for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) /etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; do sudo cp -v $conf $conf.backup-5.0; done
  
-However, if you don't backup the .mount before the upgrade, the files may be lost.
+If you don't backup the .mount files before the upgrade, the files may be lost.
 
 
 Solution
 ^^^^^^^^
 
-To fix this problem, you need to manually restore .mount files.
+If you didn't backup the .mount files before the upgrade and the files were deleted during the upgrade, 
+you need to restore them manually.
 
 To restore ``/etc/systemd/system/var-lib-systemd-coredump.mount``, run the following:
 

--- a/docs/troubleshooting/missing-dotmount-files.rst
+++ b/docs/troubleshooting/missing-dotmount-files.rst
@@ -1,0 +1,79 @@
+Inaccessible "/var/lib/scylla" and "/var/lib/systemd/coredump" after ScyllaDB upgrade 
+======================================================================================
+
+Problem
+^^^^^^^
+When you reboot the machine after a ScyllaDB upgrade, you cannot access data directories under ``/var/lib/scylla``, and 
+coredump saves to ``rootfs``.
+
+
+The problem may occur when you upgrade ScylaDB Open Source 4.6 or later to a version of ScyllaDB Enterprise if
+the ``/etc/systemd/system/var-lib-scylla.mount`` and ``/etc/systemd/system/var-lib-systemd-coredump.mount`` are 
+deleted by RPM.
+
+To avoid losing the files, the :doc:`upgrade procedure </upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm/>` 
+includes a step to backup the .mount files:
+
+
+.. code-block:: console
+
+    for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) /etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; do sudo cp -v $conf $conf.backup-4.3; done
+ 
+However, if you don't backup the .mount before the upgrade, the files may be lost.
+
+
+Solution
+^^^^^^^^
+
+To fix this problem, you need to manually restore .mount files.
+
+To restore ``/etc/systemd/system/var-lib-systemd-coredump.mount``, run the following:
+
+.. code-block:: console
+
+   $ cat << EOS | sudo tee /etc/systemd/system/var-lib-systemd-coredump.mount
+   [Unit]
+   Description=Save coredump to scylla data directory
+   Conflicts=umount.target
+   Before=scylla-server.service
+   After=local-fs.target
+   DefaultDependencies=no
+   [Mount]
+   What=/var/lib/scylla/coredump
+   Where=/var/lib/systemd/coredump
+   Type=none
+   Options=bind
+   [Install]
+   WantedBy=multi-user.target
+   EOS
+
+To restore ``/etc/systemd/system/var-lib-scylla.mount``, run the following (specifying your data disk):
+
+.. code-block:: console
+
+   $ UUID=`blkid -s UUID -o value <specify your data disk, eg: /dev/md0>`
+   $ cat << EOS | sudo tee /etc/systemd/system/var-lib-scylla.mount
+   [Unit]
+   Description=Scylla data directory
+   Before=scylla-server.service
+   After=local-fs.target
+   DefaultDependencies=no
+   [Mount]
+   What=/dev/disk/by-uuid/$UUID
+   Where=/var/lib/scylla
+   Type=xfs
+   Options=noatime
+   [Install]
+   WantedBy=multi-user.target
+   EOS
+
+After restoring .mount files, you need to enable them:
+
+.. code-block:: console
+
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl enable --now var-lib-scylla.mount 
+   $ sudo systemctl enable --now var-lib-systemd-coredump.mount
+
+
+.. include:: /troubleshooting/_common/ts-return.rst

--- a/docs/troubleshooting/upgrade/index.rst
+++ b/docs/troubleshooting/upgrade/index.rst
@@ -1,0 +1,16 @@
+Upgrade
+=================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2 
+
+   Inaccessible configuration files after ScyllaDB upgrade </troubleshooting/missing-dotmount-files>
+
+.. panel-box::
+  :title: Upgrade Issues
+  :id: "getting-started"
+  :class: my-panel
+
+  * :doc:`Inaccessible "/var/lib/scylla" and "/var/lib/systemd/coredump" after ScyllaDB upgrade </troubleshooting//missing-dotmount-files>`
+  


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/11598

This PR adds the troubleshooting article submitted by @syuu1228 in the deprecated _scylla-docs_ repo, with https://github.com/scylladb/scylla-docs/pull/4152.
I copied and reorganized the content and rewritten it a little according to the RST guidelines so that the page renders correctly.

@syuu1228 Could you review this PR to make sure that my changes didn't distort the original meaning?