### PR TITLE
test.py: limit cluster pool size to cpu cores available

### DIFF
--- a/test.py
+++ b/test.py
@@ -331,11 +331,11 @@ class PythonTestSuite(TestSuite):
 
         topology = self.cfg.get("topology", {"class": "simple", "replication_factor": 1})
 
-        self.create_cluster = self.topology_for_class(topology["class"], topology)
+        self.create_cluster = self.get_cluster_factory(topology["class"], topology)
 
         self.clusters = Pool(cfg.get("pool_size", 2), self.create_cluster)
 
-    def topology_for_class(self, class_name: str, cfg: dict) -> Callable[[], Awaitable]:
+    def get_cluster_factory(self, class_name: str, cfg: dict) -> Callable[[], Awaitable]:
 
         def create_server(cluster_name: str, seeds: List[str]):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])

--- a/test.py
+++ b/test.py
@@ -366,7 +366,7 @@ class PythonTestSuite(TestSuite):
             return server
 
         if class_name.lower() == "simple":
-            async def create_cluster():
+            async def create_cluster() -> ScyllaCluster:
                 cluster = ScyllaCluster(int(cfg["replication_factor"]),
                                         create_server)
                 await cluster.install_and_start()

--- a/test.py
+++ b/test.py
@@ -329,14 +329,13 @@ class PythonTestSuite(TestSuite):
             self.scylla_env = dict()
         self.scylla_env['SCYLLA'] = self.scylla_exe
 
-        topology = self.cfg.get("topology", {"class": "simple", "replication_factor": 1})
+        cluster_size = self.cfg.get("cluster_size", 1)
+        pool_size = cfg.get("pool_size", 2)
 
-        self.create_cluster = self.get_cluster_factory(topology["class"], topology)
+        self.create_cluster = self.get_cluster_factory(cluster_size)
+        self.clusters = Pool(pool_size, self.create_cluster)
 
-        self.clusters = Pool(cfg.get("pool_size", 2), self.create_cluster)
-
-    def get_cluster_factory(self, class_name: str, cfg: dict) -> Callable[[], Awaitable]:
-
+    def get_cluster_factory(self, cluster_size: int) -> Callable[[], Awaitable]:
         def create_server(cluster_name: str, seeds: List[str]):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])
             if type(cmdline_options) == str:
@@ -365,16 +364,12 @@ class PythonTestSuite(TestSuite):
             self.artifacts.add_exit_artifact(self, server.stop_artifact)
             return server
 
-        if class_name.lower() == "simple":
-            async def create_cluster() -> ScyllaCluster:
-                cluster = ScyllaCluster(int(cfg["replication_factor"]),
-                                        create_server)
-                await cluster.install_and_start()
-                return cluster
+        async def create_cluster() -> ScyllaCluster:
+            cluster = ScyllaCluster(cluster_size, create_server)
+            await cluster.install_and_start()
+            return cluster
 
-            return create_cluster
-        else:
-            raise RuntimeError("Unsupported topology name")
+        return create_cluster
 
     def build_test_list(self) -> List[str]:
         """For pytest, search for directories recursively"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -465,7 +465,7 @@ class ScyllaCluster:
         data: dict = {}
 
     def __init__(self, replicas: int,
-                 create_server: Callable[[str, Optional[List[str]]], ScyllaServer]) -> None:
+                 create_server: Callable[[str, List[str]], ScyllaServer]) -> None:
         self.name = str(uuid.uuid1())
         self.replicas = replicas
         self.create_server = create_server

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -1,10 +1,6 @@
 type: Topology
 pool_size: 4
-topology:
-    class: Simple
-    replication_factor: 3
+cluster_size: 3
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
-disable:
-    - test_null

--- a/test/topology_raft_disabled/suite.yaml
+++ b/test/topology_raft_disabled/suite.yaml
@@ -1,8 +1,6 @@
 type: Topology
 pool_size: 4
-topology:
-    class: Simple
-    replication_factor: 3
+cluster_size: 3
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer


### PR DESCRIPTION
Use at most one core per Scylla process for `PythonTestSuite` and `TopologyTestSuite` tests.
