### PR TITLE
doc: upgrade guides from 4.5 to 4.6 for Ubuntu and Debian 

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-v4-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-v4-ubuntu-and-debian.rst
@@ -96,30 +96,6 @@ Answer ‘y’ to the first two questions.
 
    Alternator users upgrading from Scylla 4.0 to 4.1, need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`
 
-Update 3rd party and OS packages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: Scylla 5.0
-.. versionadded:: Scylla Enterprise 2021.1.10
-
-This step is optional. It is recommended if you run a Scylla official image (EC2 AMI, GCP, and Azure images) based on Ubuntu 20.04.
-
-Run the following command:
-
-.. code:: sh 
-
-   cat scylla-packages-xxx-x86_64.txt | sudo xargs -n1 apt-get -y
-
-
-Where xxx is the relevant Scylla version ( |NEW_VERSION| ). The file is included in the Scylla packages downloaded in the previous step.
-
-For example
-
-.. code:: sh 
-   
-   cat scylla-packages-5.1.2-x86_64.txt | sudo xargs -n1 apt-get -y
-
-
 Start the node
 --------------
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/11456 

This PR fixes the upgrade guides from 4.5 to 4.6 for Ubuntu and Debian. They include the "Update 3rd party and OS packages" section, which is a bug because this feature:
- was introduced in version 5.0.
- only for ScyllaDB image.