### PR TITLE
Cut one of snitch->gossiper links

### DIFF
--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -171,22 +171,8 @@ future<> gossiping_property_file_snitch::reload_configuration() {
             local_s->set_my_dc_and_rack(_my_dc, _my_rack);
             local_s->set_prefer_local(_prefer_local);
         }).then([this] {
-            // FIXME -- tests don't start gossiper
-            if (!local().get_gossiper().local_is_initialized()) {
-                return make_ready_future<>();
-            }
-
             return seastar::async([this] {
                 _reconfigured();
-
-                // spread the word...
-                container().invoke_on(0, [] (snitch_ptr& local_snitch_ptr) {
-                    auto& gossiper = local_snitch_ptr.get_local_gossiper();
-                    if (gossiper.is_enabled()) {
-                        return gossiper.add_local_application_state(local_snitch_ptr->get_app_states());
-                    }
-                    return make_ready_future<>();
-                }).get();
             });
         });
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3260,17 +3260,17 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
 
 future<> storage_service::snitch_reconfigured() {
     assert(this_shard_id() == 0);
-        return mutate_token_metadata([] (mutable_token_metadata_ptr tmptr) {
-            // re-read local rack and DC info
-            auto endpoint = utils::fb_utilities::get_broadcast_address();
-            auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
-            auto dr = locator::endpoint_dc_rack {
-                .dc = snitch->get_datacenter(endpoint),
-                .rack = snitch->get_rack(endpoint),
-            };
-            tmptr->update_topology(endpoint, std::move(dr));
-            return make_ready_future<>();
-        });
+    return mutate_token_metadata([] (mutable_token_metadata_ptr tmptr) {
+        // re-read local rack and DC info
+        auto endpoint = utils::fb_utilities::get_broadcast_address();
+        auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
+        auto dr = locator::endpoint_dc_rack {
+            .dc = snitch->get_datacenter(endpoint),
+            .rack = snitch->get_rack(endpoint),
+        };
+        tmptr->update_topology(endpoint, std::move(dr));
+        return make_ready_future<>();
+    });
 }
 
 void storage_service::init_messaging_service() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3271,6 +3271,11 @@ future<> storage_service::snitch_reconfigured() {
         tmptr->update_topology(endpoint, std::move(dr));
         return make_ready_future<>();
     });
+
+    if (_gossiper.is_enabled()) {
+        auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
+        co_await _gossiper.add_local_application_state(snitch->get_app_states());
+    }
 }
 
 void storage_service::init_messaging_service() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3260,7 +3260,7 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
 
 future<> storage_service::snitch_reconfigured() {
     assert(this_shard_id() == 0);
-    return mutate_token_metadata([] (mutable_token_metadata_ptr tmptr) {
+    co_await mutate_token_metadata([] (mutable_token_metadata_ptr tmptr) -> future<> {
         // re-read local rack and DC info
         auto endpoint = utils::fb_utilities::get_broadcast_address();
         auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -212,7 +212,6 @@ private:
     future<> keyspace_changed(const sstring& ks_name);
     void register_metrics();
     future<> snitch_reconfigured();
-    future<> update_topology(inet_address endpoint);
 
     future<mutable_token_metadata_ptr> get_mutable_token_metadata_ptr() noexcept {
         return get_token_metadata_ptr()->clone_async().then([] (token_metadata tm) {


### PR DESCRIPTION
Snitch uses gossiper for several reasons, one of is to re-gossip the topology-related app states when property-file snitch config changes. This set cuts this link by moving re-gossiping into the existing storage_service::snitch_reconfigured() subscription. Since initial snitch state gossiping happens in storage service as well, this change is not unreasonable.

