### PR TITLE
raft: test_topology.py: remove_node test

### DIFF
--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -129,21 +129,29 @@ void raft_rpc::send_read_quorum_reply(raft::server_id id, const raft::read_quoru
 
 future<raft::add_entry_reply> raft_rpc::send_add_entry(raft::server_id id, const raft::command& cmd) {
     return ser::raft_rpc_verbs::send_raft_add_entry(&_messaging,
-        netw::msg_addr(_address_map.get_inet_address(id)), db::no_timeout, _group_id, _server_id, id, cmd);
+        netw::msg_addr(_address_map.get_inet_address(id)), db::no_timeout, _group_id, _server_id, id, cmd)
+        .handle_exception_type([id] (const seastar::rpc::closed_error& e) {
+            rlogger.trace("Failed to execute add entry on leader {}: {}", id, e);
+            return make_exception_future<raft::add_entry_reply>(raft::transport_error());
+        });
 }
 
 future<raft::add_entry_reply> raft_rpc::send_modify_config(raft::server_id id,
     const std::vector<raft::config_member>& add,
     const std::vector<raft::server_id>& del) {
-   return ser::raft_rpc_verbs::send_raft_modify_config(&_messaging, netw::msg_addr(_address_map.get_inet_address(id)),
-       db::no_timeout, _group_id, _server_id, id, add, del);
+    return ser::raft_rpc_verbs::send_raft_modify_config(&_messaging, netw::msg_addr(_address_map.get_inet_address(id)),
+        db::no_timeout, _group_id, _server_id, id, add, del)
+        .handle_exception_type([id] (const seastar::rpc::closed_error& e) {
+            rlogger.trace("Failed to execute modify config on leader {}: {}", id, e);
+            return make_exception_future<raft::add_entry_reply>(raft::transport_error());
+        });
 }
 
 future<raft::read_barrier_reply> raft_rpc::execute_read_barrier_on_leader(raft::server_id id) {
     return ser::raft_rpc_verbs::send_raft_execute_read_barrier_on_leader(&_messaging, netw::msg_addr(_address_map.get_inet_address(id)), db::no_timeout, _group_id, _server_id, id)
         .handle_exception_type([id] (const seastar::rpc::closed_error& e) {
             rlogger.trace("Failed to execute read barrier on leader {}: {}", id, e);
-            return make_exception_future<raft::read_barrier_reply>(raft::intermittent_connection_error());
+            return make_exception_future<raft::read_barrier_reply>(raft::transport_error());
         });
 }
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -99,6 +99,10 @@ SCYLLA_CMDLINE_OPTIONS = [
     '--max-networking-io-control-blocks', '100',
     '--unsafe-bypass-fsync', '1',
     '--kernel-page-cache', '1',
+    '--abort-on-lsa-bad-alloc', '1',
+    '--abort-on-seastar-bad-alloc',
+    '--abort-on-internal-error', '1',
+    '--abort-on-ebadf', '1'
 ]
 
 

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -7,6 +7,13 @@
 Test consistency of schema changes with topology changes.
 """
 import pytest
+import logging
+import asyncio
+import random
+import aiohttp
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
@@ -48,3 +55,87 @@ async def test_remove_server_add_column(manager, random_tables):
     await manager.server_remove(servers[1])
     await table.add_column()
     await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_remove_node_add_table(manager, random_tables):
+    http_session = aiohttp.ClientSession()
+
+    stopped = False
+
+    async def get_server_api_url(server_id):
+        config = await manager.server_get_config(server_id)
+        return f'http://{config["api_address"]}:10000/storage_service'
+
+    async def get_host_id(url):
+        async with http_session.get(url + '/hostid/local') as resp:
+            assert resp.status == 200
+            host_id = await resp.text()
+        if len(host_id) >= 2 and host_id[0] == '"' and host_id[-1] == '"':
+            host_id = host_id[1:-1]
+        return host_id
+
+    async def do_ddl():
+        iteration = 0
+        while not stopped:
+            logger.info(f'ddl, iteration {iteration} started')
+            await random_tables.add_tables(5, 5)
+            await random_tables.verify_schema()
+            while len(random_tables.tables) > 0:
+                await random_tables.drop_table(random_tables.tables[-1])
+            logger.info(f'ddl, iteration {iteration} finished')
+            iteration += 1
+
+    async def wait_for_host_id(url, host_id):
+        logger.info(f'wait_for_host_id enter, url [{url}], host_id [{host_id}]')
+        while True:
+            logger.info(f'wait_for_host_id, running query')
+            async with await http_session.get(url + '/host_id') as resp:
+                resp_body = await resp.text()
+                logger.info(f'wait_for_host_id request finished, status {resp.status}, body [{resp_body}]')
+                if host_id in resp_body:
+                    logger.info(f'wait_for_host_id host_id [{host_id}] found, SUCCESS')
+                    break
+            await asyncio.sleep(0.05)
+
+    async def remove_node(url, host_id):
+        logger.info(f'remove_node request started, url [{url}], host_id [{host_id}]')
+        async with await http_session.post(url + '/remove_node', params={'host_id': host_id}) as resp:
+            logger.info(f'remove_node request finished, status {resp.status}, text [{await resp.text()}]')
+            assert resp.status == 200
+
+    async def main():
+        for i in range(10):
+            logger.info(f'main [{i}], iteration started')
+            server_ids = await manager.servers()
+            server_api_urls = []
+            host_ids = []
+            for server_id in server_ids:
+                api_url = await get_server_api_url(server_id)
+                server_api_urls.append(api_url)
+                host_id = await get_host_id(api_url)
+                host_ids.append(host_id)
+                logger.info(f'main [{i}], server [{server_id}], api_url [{api_url}], host_id [{host_id}]')
+            initiator_index = random.randint(0, len(server_ids) - 1)
+            while True:
+                removenode_index = random.randint(0, len(server_ids) - 1)
+                if removenode_index != initiator_index:
+                    break
+            logger.info(f'main [{i}], running remove_node, initiator server [{server_api_urls[initiator_index]}], '
+                        f'remove_node server [{server_api_urls[removenode_index]}]')
+            await wait_for_host_id(server_api_urls[initiator_index], host_ids[removenode_index])
+            logger.info(f'stopping target server [{server_ids[removenode_index]}], host_id [{host_ids[removenode_index]}]')
+            await manager.server_stop_gracefully(server_ids[removenode_index])
+            logger.info(f'target server [{server_ids[removenode_index]}] stopped')
+            await remove_node(server_api_urls[initiator_index], host_ids[removenode_index])
+
+            new_server_id = await manager.server_add()
+            logger.info(f'main [{i}], server_add [{new_server_id}] done')
+            logger.info(f'main [{i}], iteration finished')
+
+    ddl_task = asyncio.create_task(do_ddl())
+    await main()
+    logger.info("main, finished, waiting for ddl fiber")
+    stopped = True
+    await ddl_task
+    logger.info("main, ddl fiber done, finished")


### PR DESCRIPTION
The test is making several iterations of `remove_node/add_server`
while keeping a `ddl` workload.