### PR TITLE
test/topology_raft_disabled: reenable `test_raft_upgrade`

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -243,6 +243,9 @@ class RandomTables():
         cql.execute(f"CREATE KEYSPACE {keyspace} WITH REPLICATION = "
                      "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
 
+    def set_cql(self, cql: CassandraSession) -> None:
+        self.cql = cql
+
     async def add_tables(self, ntables: int = 1, ncolumns: int = 5) -> None:
         """Add random tables to the list.
         ntables specifies how many tables.


### PR DESCRIPTION
The test was disabled due to a bug in the Python driver which caused the driver not to reconnect after a node was restarted (see scylladb/python-driver#170).

Introduce a workaround for that bug: we simply create a new driver session after restarting the nodes. Reenable the test.