### PR TITLE
test.py: reconnect driver, use whitelist, and enforce shutdown for topology changes

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -50,6 +50,7 @@ class ManagerClient():
     async def driver_connect(self) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:
+            self.driver_close()
             servers = await self.servers()
             logger.debug("driver connecting to %s", servers)
             self.ccluster = self.con_gen(servers, self.port, self.ssl)

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -19,7 +19,7 @@ import pytest
 from cassandra.cluster import Session, ResponseFuture                    # type: ignore
 from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore
-from cassandra.policies import RoundRobinPolicy                          # type: ignore
+from cassandra.policies import WhiteListRoundRobinPolicy, RetryPolicy    # type: ignore
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
@@ -97,7 +97,7 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
        It does not .connect() yet."""
     assert len(hosts) > 0, "python driver connection needs at least one host to connect to"
     profile = ExecutionProfile(
-        load_balancing_policy=RoundRobinPolicy(),
+        load_balancing_policy=WhiteListRoundRobinPolicy(hosts=hosts),
         consistency_level=ConsistencyLevel.LOCAL_QUORUM,
         serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
         # The default timeouts should have been more than enough, but in some


### PR DESCRIPTION
As a workaround for https://github.com/scylladb/python-driver/issues/170, when doing topology changes close and open a new driver with known running hosts.