### PR TITLE
test.py: close aiohttp session for topology tests

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -47,6 +47,11 @@ class ManagerClient():
         self.conn = aiohttp.UnixConnector(path=self.sock_path)
         self.session = aiohttp.ClientSession(connector=self.conn)
 
+    async def stop(self):
+        """Close client session and close driver"""
+        await self.session.close()
+        self.driver_close()
+
     async def driver_connect(self) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -152,7 +152,7 @@ async def manager_internal(event_loop, request):
     manager_int = ManagerClient(request.config.getoption('manager_api'), port, ssl, cluster_con)
     await manager_int.start()
     yield manager_int
-    manager_int.driver_close()   # Close after last test case
+    await manager_int.stop()  # Stop client session and close driver after last test
 
 @pytest.fixture(scope="function")
 async def manager(request, manager_internal):


### PR DESCRIPTION
Close the aiohttp ClientSession after pytest session finishes.
