### PR TITLE
tools/scylla-sstable: add lua scripting support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1175,7 +1175,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
 
-scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc']
+scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
 
 deps = {
     'scylla': idls + ['main.cc'] + scylla_core + api + alternator + redis + scylla_tools,

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -532,6 +532,7 @@ public:
 
     const dht::token& token() const noexcept { return _token; }
     const std::optional<partition_key>& key() const { return _key; }
+    int8_t weight() const { return _weight; }
 
     // Only when key() == std::nullopt
     token_bound get_token_bound() const { return token_bound(_weight); }

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -617,6 +617,555 @@ Note that levels are cumulative - each contains all the checks of the previous l
 By default, the strictest level is used.
 This can be relaxed, for example, if you want to produce intentionally corrupt SStables for tests.
 
+script
+^^^^^^
+
+.. versionadded:: 5.2
+
+Reads the SStable(s) and passes the resulting `fragment stream <scylla-sstable-sstable-content_>`_ to the script specified by `--script-file`.
+Currently, only scripts written in `Lua <http://www.lua.org/>`_ are supported.
+It is possible to pass command line arguments to the script, via the ``--script-arg`` command line flag.
+The format of this argument is the following:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    --script-arg $key1=$value1:$key2=$value2
+
+Alternatively, you can provide each key-value pair via a separate ``--script-arg``:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    --script-arg $key1=$value1 --script-arg $key2=$value2
+
+Command line arguments will be received by the `consume_stream_start() <scylla-consume-stream-start-method_>`_ API method.
+
+.. _scylla-consume-api:
+
+ScyllaDB Consume API
+~~~~~~~~~~~~~~~~~~~~~~
+
+These methods represent the glue code between scylla-sstable's C++ code and the Lua script.
+Conceptually a script is an implementation of a consumer interface. The script has to implement only the methods it is interested in. Each method has a default implementation in the interface, which simply drops the respective `mutation fragment <scylla-sstable-sstable-content_>`_.
+For example, a script only interested in partitions can define only `consume_partition_start() <scylla-consume-partition-start-method_>`_ and nothing else.
+Therefore a completely empty script is also valid, although not very useful.
+Below you will find the listing of the API methods.
+These methods (if provided by the script) will be called by the scylla-sstable runtime for the appropriate events and fragment types.
+
+.. _scylla-consume-stream-start-method:
+
+consume_stream_start(args)
+""""""""""""""""""""""""""
+
+* Part of the Consume API. Called on the very start of the stream.
+* Parameter is a Lua table containing command line arguments for the script, passed via ``--script-arg``.
+* Can be used to initialize global state.
+
+.. _scylla-consume-sstable-start-method:
+
+consume_sstable_start(sst)
+""""""""""""""""""""""""""
+
+* Part of the Consume API.
+* Called on the start of each stable. 
+* The parameter is of type `Scylla.sstable <scylla-sstable-type_>`_. 
+* When SStables are merged (``--merge``), the parameter is ``nil``.
+
+Returns whether to stop. If ``true``, `consume_sstable_end() <scylla-consume-sstable-end-method_>`_ is called, skipping the content of the sstable (or that of the entire stream if ``--merge`` is used). If ``false``, consumption follows with the content of the sstable.
+
+.. _scylla-consume-partition-start-method:
+
+consume_partition_start(ps)
+"""""""""""""""""""""""""""
+
+* Part of the Consume API. Called on the start of each partition. 
+* The parameter is of type `Scylla.partition_start <scylla-partition-start-type_>`_.
+* Returns whether to stop. If ``true``, `consume_partition_end() <scylla-consume-partition-end-method_>`_ is called, skipping the content of the partition. If ``false``, consumption follows with the content of the partition.
+
+consume_static_row(sr)
+""""""""""""""""""""""
+
+* Part of the Consume API. 
+* Called if the partition has a static row. 
+* The parameter is of type `Scylla.static_row <scylla-static-row-type_>`_.
+* Returns whether to stop. If ``true``, `consume_partition_end() <scylla-consume-partition-end-method_>`_ is called, and the remaining content of the partition is skipped. If ``false``, consumption follows with the remaining content of the partition.
+
+consume_clustering_row(cr)
+""""""""""""""""""""""""""
+
+* Part of the Consume API. 
+* Called for each clustering row. 
+* The parameter is of type `Scylla.clustering_row <scylla-clustering-row-type_>`_.
+* Returns whether to stop. If ``true``, `consume_partition_end() <scylla-consume-partition-end-method_>`_ is called, the remaining content of the partition is skipped. If ``false``, consumption follows with the remaining content of the partition.
+
+consume_range_tombstone_change(crt)
+"""""""""""""""""""""""""""""""""""
+
+* Part of the Consume API.
+* Called for each range tombstone change. 
+* The parameter is of type `Scylla.range_tombstone_change <scylla-range-tombstone-change-type_>`_.
+* Returns whether to stop. If ``true``, `consume_partition_end() <scylla-consume-partition-end-method_>`_ is called, the remaining content of the partition is skipped. If ``false``, consumption follows with the remaining content of the partition.
+
+.. _scylla-consume-partition-end-method:
+
+consume_partition_end()
+"""""""""""""""""""""""
+
+* Part of the Consume API.
+* Called at the end of the partition.
+* Returns whether to stop. If ``true``, `consume_sstable_end() <scylla-consume-sstable-end-method_>`_ is called,  the remaining content of the SStable is skipped. If ``false``, consumption follows with the remaining content of the SStable.
+
+.. _scylla-consume-sstable-end-method:
+
+consume_sstable_end()
+"""""""""""""""""""""
+
+* Part of the Consume API.
+* Called at the end of the SStable.
+* Returns whether to stop. If true, `consume_stream_end() <scylla-consume-stream-end-method_>`_ is called, the remaining content of the stream is skipped. If false, consumption follows with the remaining content of the stream.
+
+.. _scylla-consume-stream-end-method:
+
+consume_stream_end()
+""""""""""""""""""""
+
+* Part of the Consume API. 
+* Called at the very end of the stream.
+
+Scylla LUA API
+~~~~~~~~~~~~~~
+
+In addition to the `ScyllaDB Consume API <scylla-consume-api_>`_, the Lua bindings expose various types and methods that allow you to work with ScyllaDB types and values.
+The listing uses the following terminology:
+
+* Attribute - a simple attribute accessible via ``obj.attribute_name``;
+* Method - a method operating on an instance of said type, invokable as ``obj:method()``;
+* Magic method - magic methods defined in the metatable which define behaviour of these objects w.r.t. `Lua operators and more <http://www.lua.org/manual/5.4/manual.html#2.4>`_;
+
+The format of an attribute description is the following:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    attribute_name (type) - description
+
+and that of a method:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    method_name(arg1_type, arg2_type...) (return_type) - description
+
+Magic methods have their signature defined by Lua and so that is not described here (these methods are not used directly anyway).
+
+.. _scylla-atomic-cell-type:
+
+Scylla.atomic_cell
+""""""""""""""""""
+
+Attributes:
+
+* timestamp (integer)
+* is_live (boolean) - is the cell live?
+* type (string) - one of: ``regular``, ``counter-update``, ``counter-shards``, ``frozen-collection`` or ``collection``.
+* has_ttl (boolean) - is the cell expiring?
+* ttl (integer) - time to live in seconds, ``nil`` if cell is not expiring.
+* expiry (`Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_) - time at which cell expires, ``nil`` if cell is not expiring.
+* deletion_time (`Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_) - time at which cell was deleted, ``nil`` unless cell is dead or expiring.
+* value:
+
+    - ``nil`` if cell is dead.
+    - appropriate Lua native type if type == ``regular``.
+    - integer if type == ``counter-update``.
+    - `Scylla.counter_shards_value <scylla-counter-shards-value-type_>`_ if type == ``counter-shards``.
+
+A counter-shard table has the following keys:
+
+* id (string)
+* value (integer)
+* clock (integer)
+
+.. _scylla-clustering-key-type:
+
+Scylla.clustering_key
+"""""""""""""""""""""
+
+Attributes:
+
+* components (table) - the column values (`Scylla.data_value <scylla-data-value-type_>`_) making up the composite clustering key.
+
+Methods:
+
+* to_hex - convert the key to its serialized format, encoded in hex.
+
+Magic methods:
+
+* __tostring - can be converted to string with tostring(), uses the built-in operator<< in Scylla.
+
+.. _scylla-clustering-row-type:
+
+Scylla.clustering_row
+"""""""""""""""""""""
+
+Attributes:
+
+* key ($TYPE) - the clustering key's value as the appropriate Lua native type.
+* tombstone (`Scylla.tombstone <scylla-tombstone-type_>`_) - row tombstone, ``nil`` if no tombstone.
+* shadowable_tombstone (`Scylla.tombstone <scylla-tombstone-type_>`_) - shadowable tombstone of the row tombstone, ``nil`` if no tombstone.
+* marker (`Scylla.row_marker <scylla-row-marker-type_>`_) - the row marker, ``nil`` if row doesn't have one.
+* cells (table) - table of cells, where keys are the column names and the values are either of type `Scylla.atomic_cell <scylla-atomic-cell-type_>`_ or `Scylla.collection <scylla-collection-type_>`_.
+
+See also:
+
+* `Scylla.unserialize_clustering_key() <scylla-unserialize-clustering-key-method_>`_.
+
+.. _scylla-collection-type:
+
+Scylla.collection
+"""""""""""""""""
+
+Attributes:
+
+* type (string) - always ``collection`` for collection.
+* tombstone (`Scylla.tombstone <scylla-tombstone-type_>`_) - ``nil`` if no tombstone.
+* cells (table) - the collection cells, each collection cell is a table, with a ``key`` and ``value`` attribute. The key entry is the key of the collection cell for actual collections (list, set and map) and is of type `Scylla.data-value <scylla-data-value-type_>`_. For tuples and UDT this is just an empty string. The value entry is the value of the collection cell and is of type `Scylla.atomic-cell <scylla-atomic-cell-type_>`_. 
+
+.. _scylla-collection-cell-value-type:
+
+Scylla.collection_cell_value
+""""""""""""""""""""""""""""
+
+Attributes:
+
+* key (sstring) - collection cell key in human readable form.
+* value (`Scylla.atomic_cell <scylla-atomic-cell-type_>`_) - collection cell value.
+
+.. _scylla-column-definition-type:
+
+Scylla.column_definition
+""""""""""""""""""""""""
+
+Attributes:
+
+* id (integer) - the id of the column.
+* name (string) - the name of the column.
+* kind (string) - the kind of the column, one of ``partition_key``, ``clustering_key``, ``static_column`` or ``regular_column``.
+
+.. _scylla-counter-shards-value-type:
+
+Scylla.counter_shards_value
+"""""""""""""""""""""""""""
+
+Attributes:
+
+* value (integer) - the total value of the counter (the sum of all the shards).
+* shards (table) - the shards making up this counter, a lua list containing tables, representing shards, with the following key/values:
+
+    - id (string) - the shard's id (UUID).
+    - value (integer) - the shard's value.
+    - clock (integer) - the shard's logical clock.
+
+Magic methods:
+
+* __tostring - can be converted to string with tostring().
+
+.. _scylla-data-value-type:
+
+Scylla.data_value
+"""""""""""""""""
+
+Attributes:
+
+* value - the value represented as the appropriate Lua type
+
+Magic methods:
+
+* __tostring - can be converted to string with tostring().
+
+.. _scylla-gc-clock-time-point-type:
+
+Scylla.gc_clock_time_point
+""""""""""""""""""""""""""
+
+A time point belonging to the gc_clock, in UTC.
+
+Attributes:
+
+* year (integer) - [1900, +inf).
+* month (integer) - [1, 12].
+* day (integer) - [1, 31].
+* hour (integer) - [0, 23].
+* min (integer) - [0, 59].
+* sec (integer) - [0, 59].
+
+Magic methods:
+
+* __eq - can be equal compared.
+* __lt - can be less compared.
+* __le - can be less-or-equal compared.
+* __tostring - can be converted to string with tostring().
+
+See also:
+
+* `Scylla.now() <scylla-now-method_>`_.
+* `Scylla.time_point_from_string() <scylla-time-point-from-string-method_>`_.
+
+.. _scylla-json-writer-type:
+
+Scylla.json_writer
+""""""""""""""""""
+
+A JSON writer object, with both low-level and high-level APIs.
+The low-level API allows you to write custom JSON and it loosely follows the API of `rapidjson::Writer <https://rapidjson.org/classrapidjson_1_1_writer.html_>`_ (upon which it is implemented).
+The high-level API is for writing `mutation fragments <scylla-sstable-sstable-content_>`_ as JSON directly, using the built-in JSON conversion logic that is used by `dump-data <dump-data_>`_ operation.
+
+Low level API Methods:
+
+* null() - write a null json value.
+* bool(boolean) - write a bool json value.
+* int(integer) - write an integer json value.
+* double(number) - write a double json value.
+* string(string) - write a string json value.
+* start_object() - start a json object.
+* key(string) - write the key of a json object.
+* end_object() - write the end of a json object.
+* start_array() - write the start of a json array.
+* end_array() - write the end of a json array.
+
+High level API Methods:
+
+* start_stream() - start the stream, call at the very beginning.
+* start_sstable() - start an sstable.
+* start_partition() - start a partition.
+* static_row() - write a static row to the stream.
+* clustering_row() - write a clustering row to the stream.
+* range_tombstone_change() - write a range tombstone change to the stream.
+* end_partition() - end the current partition.
+* end_sstable() - end the current sstable.
+* end_stream() - end the stream, call at the very end.
+
+.. _scylla-new-json-writer-method:
+
+Scylla.new_json_writer()
+""""""""""""""""""""""""
+
+Create a `Scylla.json_writer <scylla-json-writer-type_>`_ instance.
+
+.. _scylla-new-position-in-partition-method:
+
+Scylla.new_position_in_partition()
+""""""""""""""""""""""""""""""""""
+
+Creates a `Scylla.position_in_partition <scylla-position-in-partition-type_>`_ instance.
+
+Arguments:
+
+* weight (integer) - the weight of the key.
+* key (`Scylla.clustering_key <scylla-clustering-key-type_>`_) - the clustering key, optional.
+
+.. _scylla-new-ring-position-method:
+
+Scylla.new_ring_position()
+""""""""""""""""""""""""""
+
+Creates a `Scylla.ring_position <scylla-ring-position-type_>`_ instance.
+
+Has severeal overloads:
+
+* ``Scylla.new_ring_position(weight, key)``.
+* ``Scylla.new_ring_position(weight, token)``.
+* ``Scylla.new_ring_position(weight, key, token)``.
+
+Where:
+
+* weight (integer) - the weight of the key.
+* key (`Scylla.partition_key <scylla-partition-key-type_>`_) - the partition key.
+* token (integer) - the token (of the key if a key is provided).
+
+.. _scylla-now-method:
+
+Scylla.now()
+""""""""""""
+
+Create a `Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_ instance, representing the current time.
+
+.. _scylla-partition-key-type:
+
+Scylla.partition_key
+""""""""""""""""""""
+
+Attributes:
+
+* components (table) - the column values (`Scylla.data_value <scylla-data-value-type_>`_) making up the composite partition key.
+
+Methods:
+
+* to_hex - convert the key to its serialized format, encoded in hex.
+
+Magic methods:
+
+* __tostring - can be converted to string with tostring(), uses the built-in operator<< in Scylla.
+
+See also:
+
+* `Scylla.unserialize_partition_key() <scylla-unserialize-partition-key-method_>`_.
+* `Scylla.token_of() <scylla-token-of-method>`_.
+
+.. _scylla-partition-start-type:
+
+Scylla.partition_start
+""""""""""""""""""""""
+
+Attributes:
+
+* key - the partition key's value as the appropriate Lua native type.
+* token (integer) - the partition key's token.
+* tombstone (`Scylla.tombstone <scylla-tombstone-type_>`_) - the partition tombstone, ``nil`` if no tombstone.
+
+.. _scylla-position-in-partition-type:
+
+Scylla.position_in_partition
+""""""""""""""""""""""""""""
+
+Currently used only for clustering positions.
+
+Attributes:
+
+* key (`Scylla.clustering_key <scylla-clustering-key-type_>`_) - the clustering key, ``nil`` if the position in partition represents the min or max clustering positions.
+* weight (integer) - weight of the position, either -1 (before key), 0 (at key) or 1 (after key). If key atribute is ``nil``, the weight is never 0.
+
+Methods:
+
+* tri_cmp - compare this position in partition to another position in partition, returns -1 (``<``), 0 (``==``) or 1 (``>``).
+
+See also:
+
+* `Scylla.new_position_in_partition() <scylla-new-position-in-partition-method_>`_.
+
+.. _scylla-range-tombstone-change-type:
+
+Scylla.range_tombstone_change
+"""""""""""""""""""""""""""""
+
+Attributes:
+
+* key ($TYPE) - the clustering key's value as the appropriate Lua native type.
+* key_weight (integer) - weight of the position, either -1 (before key), 0 (at key) or 1 (after key).
+* tombstone (`Scylla.tombstone <scylla-tombstone-type_>`_) - tombstone, ``nil`` if no tombstone.
+
+.. _scylla-ring-position-type:
+
+Scylla.ring_position
+""""""""""""""""""""
+
+Attributes:
+
+* token (integer) - the token, ``nil`` if the ring position represents the min or max ring positions.
+* key (`Scylla.partition_key <scylla-partition-key-type_>`_) - the partition key, ``nil`` if the ring position represents a position before/after a token.
+* weight (integer) - weight of the position, either -1 (before key/token), 0 (at key) or 1 (after key/token). If key atribute is ``nil``, the weight is never 0.
+
+Methods:
+
+* tri_cmp - compare this ring position to another ring position, returns -1 (``<``), 0 (``==``) or 1 (``>``).
+
+See also:
+
+* `Scylla.new_ring_position() <scylla-new-ring-position-method_>`_.
+
+.. _scylla-row-marker-type:
+
+Scylla.row_marker
+"""""""""""""""""
+
+Attributes:
+
+* timestamp (integer).
+* is_live (boolean) - is the marker live?
+* has_ttl (boolean) - is the marker expiring?
+* ttl (integer) - time to live in seconds, ``nil`` if marker is not expiring.
+* expiry (`Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_) - time at which marker expires, ``nil`` if marker is not expiring.
+* deletion_time (`Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_) - time at which marker was deleted, ``nil`` unless marker is dead or expiring.
+
+.. _scylla-schema-type:
+
+Scylla.schema
+"""""""""""""
+
+Attributes:
+
+* partition_key_columns (table) - list of `Scylla.column_definition <scylla-column-definition-type_>`_ of the key columns making up the partition key.
+* clustering_key_columns (table) - list of `Scylla.column_definition <scylla-column-definition-type_>`_ of the key columns making up the clustering key.
+* static_columns (table) - list of `Scylla.column_definition <scylla-column-definition-type_>`_ of the static columns.
+* regular_columns (table) - list of `Scylla.column_definition <scylla-column-definition-type_>`_ of the regular columns.
+* all_columns (table) - list of `Scylla.column_definition <scylla-column-definition-type_>`_ of all columns.
+
+.. _scylla-sstable-type:
+
+Scylla.sstable
+""""""""""""""
+
+Attributes:
+
+* filename (string) - the full path of the sstable Data component file;
+
+.. _scylla-static-row-type:
+
+Scylla.static_row
+"""""""""""""""""
+
+Attributes:
+
+* cells (table) - table of cells, where keys are the column names and the values are either of type `Scylla.atomic_cell <scylla-atomic-cell-type_>`_ or `Scylla.collection <scylla-collection-type_>`_.
+
+.. _scylla-time-point-from-string-method:
+
+Scylla.time_point_from_string()
+"""""""""""""""""""""""""""""""
+
+Create a `Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_ instance from the passed in string.
+Argument is string, using the same format as the CQL timestamp type, see https://en.wikipedia.org/wiki/ISO_8601.
+
+.. _scylla-token-of-method:
+
+Scylla.token_of()
+"""""""""""""""""
+
+Compute and return the token (integer) for a `Scylla.partition_key <scylla-partition-key-type_>`_.
+
+.. _scylla-tombstone-type:
+
+Scylla.tombstone
+""""""""""""""""
+
+Attributes:
+
+* timestamp (integer)
+* deletion_time (`Scylla.gc_clock_time_point <scylla-gc-clock-time-point-type_>`_) - the point in time at which the tombstone was deleted.
+
+.. _scylla-unserialize-clustering-key-method:
+
+Scylla.unserialize_clustering_key()
+"""""""""""""""""""""""""""""""""""
+
+Create a `Scylla.clustering_key <scylla-clustering-key-type_>`_ instance.
+
+Argument is a string representing serialized clustering key in hex format.
+
+.. _scylla-unserialize-partition-key-method:
+
+Scylla.unserialize_partition_key()
+""""""""""""""""""""""""""""""""""
+
+Create a `Scylla.partition_key <scylla-partition-key-type_>`_ instance.
+
+Argument is a string representing serialized partition key in hex format.
+
+Examples
+~~~~~~~~
+
+You can find example scripts at https://github.com/scylladb/scylladb/tree/master/tools/scylla-sstable-scripts.
+
 Examples
 --------
 Dumping the content of the SStable:

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -100,7 +100,7 @@ static void* lua_alloc(void* ud, void* ptr, size_t osize, size_t nsize) {
 
 static const luaL_Reg loadedlibs[] = {
     {"_G", luaopen_base},
-    {LUA_COLIBNAME, luaopen_string},
+    {LUA_STRLIBNAME, luaopen_string},
     {LUA_COLIBNAME, luaopen_coroutine},
     {LUA_TABLIBNAME, luaopen_table},
     {NULL, NULL},

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -192,7 +192,7 @@ static big_decimal* get_decimal(lua_State* l, int arg) {
 }
 
 template <typename T>
-static T* aligned_used_data(lua_State* l) {
+static T* aligned_user_data(lua_State* l) {
     constexpr size_t alignment = alignof(T);
     // We know lua_newuserdata aligns allocations to 8, so we need a
     // padding of at most alignment - 8 to find a sufficiently aligned
@@ -204,7 +204,7 @@ static T* aligned_used_data(lua_State* l) {
 }
 
 static void push_big_decimal(lua_State* l, const big_decimal& v) {
-    auto* p = aligned_used_data<big_decimal>(l);
+    auto* p = aligned_user_data<big_decimal>(l);
     new (p) big_decimal(v);
     luaL_setmetatable(l, scylla_decimal_metatable_name);
 }

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -473,7 +473,7 @@ static sstring get_string(lua_State *l, int index) {
         }));
 }
 
-static data_value convert_from_lua(lua_slice_state &l, const data_type& type);
+static data_value convert_from_lua(lua_State* l, const data_type& type);
 
 namespace {
 struct lua_date_table {
@@ -541,7 +541,7 @@ static lua_date_table get_lua_date_table(lua_State* l, int index) {
 }
 
 struct simple_date_return_visitor {
-    lua_slice_state& l;
+    lua_State* l;
     template <typename T>
     uint32_t operator()(const T&) {
         throw exceptions::invalid_request_exception("date must be a string, integer or date table");
@@ -559,7 +559,7 @@ struct simple_date_return_visitor {
 };
 
 struct timestamp_return_visitor {
-    lua_slice_state& l;
+    lua_State* l;
     template <typename T>
     db_clock::time_point operator()(const T&) {
         throw exceptions::invalid_request_exception("timestamp must be a string, integer or date table");
@@ -578,7 +578,7 @@ struct timestamp_return_visitor {
 };
 
 struct from_lua_visitor {
-    lua_slice_state& l;
+    lua_State* l;
 
     data_value operator()(const reversed_type_impl& t) {
         // This is unreachable since reversed_type_impl is used only
@@ -890,7 +890,7 @@ db_clock::time_point timestamp_return_visitor::operator()(const lua_table&) {
 }
 }
 
-static data_value convert_from_lua(lua_slice_state &l, const data_type& type) {
+static data_value convert_from_lua(lua_State* l, const data_type& type) {
     if (lua_isnil(l, -1)) {
         return data_value::make_null(type);
     }
@@ -910,15 +910,15 @@ static bytes_opt convert_return(lua_slice_state &l, const data_type& return_type
     return convert_from_lua(l, return_type).serialize();
 }
 
-static void push_sstring(lua_slice_state& l, const sstring& v) {
+static void push_sstring(lua_State* l, const sstring& v) {
     lua_pushlstring(l, v.c_str(), v.size());
 }
 
-static void push_argument(lua_slice_state& l, const data_value& arg);
+static void push_argument(lua_State* l, const data_value& arg);
 
 namespace {
 struct to_lua_visitor {
-    lua_slice_state& l;
+    lua_State* l;
 
     void operator()(const varint_type_impl& t, const emptyable<utils::multiprecision_int>* v) {
         push_cpp_int(l, *v);
@@ -1054,7 +1054,7 @@ struct to_lua_visitor {
 };
 }
 
-static void push_argument(lua_slice_state& l, const data_value& arg) {
+static void push_argument(lua_State* l, const data_value& arg) {
     if (arg.is_null()) {
         lua_pushnil(l);
         return;

--- a/lang/lua_scylla_types.hh
+++ b/lang/lua_scylla_types.hh
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <lua.hpp>
+#include "types.hh"
+
+namespace lua {
+
+template <typename T>
+static T* aligned_user_data(lua_State* l) {
+    constexpr size_t alignment = alignof(T);
+    // We know lua_newuserdata aligns allocations to 8, so we need a
+    // padding of at most alignment - 8 to find a sufficiently aligned
+    // address.
+    static_assert(alignment>= 8);
+    constexpr size_t pad = alignment - 8;
+    char* p = reinterpret_cast<char*>(lua_newuserdata(l, sizeof(T) + pad));
+    return reinterpret_cast<T*>(align_up(p, alignment));
+}
+
+void register_metatables(lua_State* l);
+
+void push_sstring(lua_State* l, const sstring& v);
+
+void push_data_value(lua_State* l, const data_value& value);
+data_value pop_data_value(lua_State* l, const data_type& type);
+
+} // namespace lua

--- a/tools/json_writer.hh
+++ b/tools/json_writer.hh
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "dht/i_partitioner.hh"
+#include "schema_fwd.hh"
+#include "sstables/sstables.hh"
+#include "utils/rjson.hh"
+
+// has to be below the utils/rjson.hh include
+#include <rapidjson/ostreamwrapper.h>
+
+namespace tools {
+
+class json_writer {
+    using stream = rapidjson::BasicOStreamWrapper<std::ostream>;
+    using writer = rapidjson::Writer<stream, rjson::encoding, rjson::encoding, rjson::allocator>;
+
+    stream _stream;
+    writer _writer;
+
+public:
+    json_writer() : _stream(std::cout), _writer(_stream)
+    { }
+
+    // following the rapidjson method names here
+    bool Null() { return _writer.Null(); }
+    bool Bool(bool b) { return _writer.Bool(b); }
+    bool Int(int i) { return _writer.Int(i); }
+    bool Uint(unsigned i) { return _writer.Uint(i); }
+    bool Int64(int64_t i) { return _writer.Int64(i); }
+    bool Uint64(uint64_t i) { return _writer.Uint64(i); }
+    bool Double(double d) { return _writer.Double(d); }
+    bool RawNumber(std::string_view str) { return _writer.RawNumber(str.data(), str.size(), false); }
+    bool String(std::string_view str) { return _writer.String(str.data(), str.size(), false); }
+    bool StartObject() { return _writer.StartObject(); }
+    bool Key(std::string_view str) { return _writer.Key(str.data(), str.size(), false); }
+    bool EndObject(rapidjson::SizeType memberCount = 0) { return _writer.EndObject(memberCount); }
+    bool StartArray() { return _writer.StartArray(); }
+    bool EndArray(rapidjson::SizeType elementCount = 0) { return _writer.EndArray(elementCount); }
+
+    // scylla-specific extensions (still following rapidjson naming scheme for consistency)
+    template <typename T>
+    void AsString(const T& obj) {
+        String(fmt::format("{}", obj));
+    }
+    // partition or clustering key
+    template <typename KeyType>
+    void DataKey(const schema& schema, const KeyType& key, std::optional<dht::token> token = {}) {
+        StartObject();
+        if (token) {
+            Key("token");
+            AsString(*token);
+        }
+        Key("raw");
+        String(to_hex(key.representation()));
+        Key("value");
+        AsString(key.with_schema(schema));
+        EndObject();
+    }
+    void StartStream() {
+        StartObject();
+        Key("sstables");
+        StartObject();
+    }
+    void EndStream() {
+        EndObject();
+        EndObject();
+    }
+    void SstableKey(const sstables::sstable& sst) {
+        Key(sst.get_filename());
+    }
+    void SstableKey(const sstables::sstable* const sst) {
+        if (sst) {
+            SstableKey(*sst);
+        } else {
+            Key("anonymous");
+        }
+    }
+};
+
+} // namespace tools

--- a/tools/json_writer.hh
+++ b/tools/json_writer.hh
@@ -83,4 +83,33 @@ public:
     }
 };
 
+class mutation_fragment_json_writer {
+    const schema& _schema;
+    json_writer _writer;
+    bool _clustering_array_created;
+private:
+    sstring to_string(gc_clock::time_point tp);
+    void write(gc_clock::duration ttl, gc_clock::time_point expiry);
+    void write(const tombstone& t);
+    void write(const row_marker& m);
+    void write(counter_cell_view cv);
+    void write(const atomic_cell_view& cell, data_type type);
+    void write(const collection_mutation_view_description& mv, data_type type);
+    void write(const atomic_cell_or_collection& cell, const column_definition& cdef);
+    void write(const row& r, column_kind kind);
+    void write(const clustering_row& cr);
+    void write(const range_tombstone_change& rtc);
+public:
+    explicit mutation_fragment_json_writer(const schema& s) : _schema(s) {}
+    void start_stream();
+    void start_sstable(const sstables::sstable* const sst);
+    void start_partition(const partition_start& ps);
+    void partition_element(const static_row& sr);
+    void partition_element(const clustering_row& cr);
+    void partition_element(const range_tombstone_change& rtc);
+    void end_partition();
+    void end_sstable();
+    void end_stream();
+};
+
 } // namespace tools

--- a/tools/json_writer.hh
+++ b/tools/json_writer.hh
@@ -27,6 +27,8 @@ public:
     json_writer() : _stream(std::cout), _writer(_stream)
     { }
 
+    writer& rjson_writer() { return _writer; }
+
     // following the rapidjson method names here
     bool Null() { return _writer.Null(); }
     bool Bool(bool b) { return _writer.Bool(b); }
@@ -101,6 +103,7 @@ private:
     void write(const range_tombstone_change& rtc);
 public:
     explicit mutation_fragment_json_writer(const schema& s) : _schema(s) {}
+    json_writer& writer() { return _writer; }
     void start_stream();
     void start_sstable(const sstables::sstable* const sst);
     void start_partition(const partition_start& ps);

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -1,0 +1,1464 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <boost/algorithm/string/join.hpp>
+#include <fmt/chrono.h>
+#include <lua.hpp>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/short_streams.hh>
+
+#include "lang/lua_scylla_types.hh"
+#include "reader_permit.hh"
+#include "schema.hh"
+#include "sstables/sstables.hh"
+#include "tools/json_writer.hh"
+#include "tools/lua_sstable_consumer.hh"
+#include "types/collection.hh"
+#include "types/tuple.hh"
+
+namespace {
+
+class gc_clock_time_point;
+class counter_shards_value;
+class atomic_cell_with_type;
+class collection_with_type;
+class json_writer;
+
+template <typename T> struct type_to_metatable { static constexpr const char* metatable_name = nullptr; };
+template <> struct type_to_metatable<column_definition> { static constexpr const char* metatable_name = "Scylla.column_definition"; };
+template <> struct type_to_metatable<schema> { static constexpr const char* metatable_name = "Scylla.schema"; };
+template <> struct type_to_metatable<partition_key> { static constexpr const char* metatable_name = "Scylla.partition_key"; };
+template <> struct type_to_metatable<clustering_key> { static constexpr const char* metatable_name = "Scylla.clustering_key"; };
+template <> struct type_to_metatable<dht::ring_position_ext> { static constexpr const char* metatable_name = "Scylla.ring_position"; };
+template <> struct type_to_metatable<position_in_partition> { static constexpr const char* metatable_name = "Scylla.position_in_partition"; };
+template <> struct type_to_metatable<sstables::sstable> { static constexpr const char* metatable_name = "Scylla.sstable"; };
+template <> struct type_to_metatable<partition_start> { static constexpr const char* metatable_name = "Scylla.partition_start"; };
+template <> struct type_to_metatable<gc_clock_time_point> { static constexpr const char* metatable_name = "Scylla.gc_clock_time_point"; };
+template <> struct type_to_metatable<tombstone> { static constexpr const char* metatable_name = "Scylla.tombstone"; };
+template <> struct type_to_metatable<data_value> { static constexpr const char* metatable_name = "Scylla.data_value"; };
+template <> struct type_to_metatable<counter_shards_value> { static constexpr const char* metatable_name = "Scylla.counter_shards_value"; };
+template <> struct type_to_metatable<atomic_cell_with_type> { static constexpr const char* metatable_name = "Scylla.atomic_cell"; };
+template <> struct type_to_metatable<collection_with_type> { static constexpr const char* metatable_name = "Scylla.collection"; };
+template <> struct type_to_metatable<static_row> { static constexpr const char* metatable_name = "Scylla.static_row"; };
+template <> struct type_to_metatable<row_marker> { static constexpr const char* metatable_name = "Scylla.row_marker"; };
+template <> struct type_to_metatable<clustering_row> { static constexpr const char* metatable_name = "Scylla.clustering_row"; };
+template <> struct type_to_metatable<range_tombstone_change> { static constexpr const char* metatable_name = "Scylla.range_tombstone_change"; };
+template <> struct type_to_metatable<json_writer> { static constexpr const char* metatable_name = "Scylla.json_writer"; };
+
+template <typename T>
+const char* get_metatable_name() {
+    const auto metatable_name = type_to_metatable<std::remove_cv_t<T>>::metatable_name;
+    assert(metatable_name);
+    return metatable_name;
+}
+
+struct lua_closer {
+    void operator()(lua_State* l) {
+        lua_close(l);
+    }
+};
+
+void* lua_alloc(void* ud, void* ptr, size_t osize, size_t nsize) {
+    if (!nsize) {
+        free(ptr);
+        return nullptr;
+    } else {
+        return realloc(ptr, nsize);
+    }
+}
+
+static const luaL_Reg loadedlibs[] = {
+    {"base", luaopen_base},
+    {LUA_STRLIBNAME, luaopen_string},
+    {LUA_TABLIBNAME, luaopen_table},
+    {NULL, NULL},
+};
+
+template <typename T>
+void push_userdata_ref(lua_State* l, T& v) {
+    *reinterpret_cast<T**>(lua_newuserdata(l, sizeof(T*))) = &v;
+    luaL_setmetatable(l, get_metatable_name<T>());
+}
+
+template <typename T>
+T& pop_userdata_ref(lua_State* l, int i) {
+    return **reinterpret_cast<T**>(luaL_checkudata(l, i, get_metatable_name<T>()));
+}
+
+template <typename T>
+void* alloc_userdata(lua_State* l) {
+    if constexpr (alignof(T) > 8) {
+        return lua::aligned_user_data<T>(l);
+    } else {
+        return lua_newuserdata(l, sizeof(T));
+    }
+}
+
+template <typename T, typename... Arg>
+void push_userdata(lua_State* l, Arg&&... arg) {
+    new (alloc_userdata<T>(l)) T(std::forward<Arg>(arg)...);
+    luaL_setmetatable(l, get_metatable_name<T>());
+}
+
+// Push userdata with default constructed T in it.
+template <typename T>
+void push_userdata(lua_State* l) {
+    new (alloc_userdata<T>(l)) T;
+    luaL_setmetatable(l, get_metatable_name<T>());
+}
+
+template <typename T>
+T* get_userdata_ptr(lua_State* l, int i) {
+    auto p = luaL_checkudata(l, i, get_metatable_name<T>());
+    if constexpr (alignof(T) <= 8) {
+        return reinterpret_cast<T*>(p);
+    } else {
+        return align_up(reinterpret_cast<char*>(p), alignof(T));
+    }
+}
+
+template <typename T>
+T pop_userdata(lua_State* l, int i) {
+    return std::move(*get_userdata_ptr<T>(l, i));
+}
+
+// Get reference to userdata stored by-value.
+// Valid only until Lua GC:s the value, so don't keep it around for long.
+template <typename T>
+T& pop_userdata_as_ref(lua_State* l, int i) {
+    return *get_userdata_ptr<T>(l, i);
+}
+
+template <typename T>
+int cxx_gc_l(lua_State* l) {
+    auto& v = pop_userdata_as_ref<T>(l, 1);
+    v.~T();
+    lua_pop(l, 1);
+    return 0;
+}
+
+template <typename T>
+int tostring_l(lua_State* l) {
+    const auto& v = pop_userdata_as_ref<T>(l, 1);
+    lua_pop(l, 1);
+    lua::push_sstring(l, format("{}", v));
+    return 1;
+}
+
+const schema& get_schema_l(lua_State* l) {
+    lua_getglobal(l, "schema");
+    auto& s = pop_userdata_ref<const schema>(l, -1);
+    lua_pop(l, 1);
+    return s;
+}
+
+template <typename T, typename Wrapper>
+int tostring_with_wrapper(lua_State* l) {
+    const auto& v = pop_userdata_as_ref<T>(l, 1);
+    const auto& s = get_schema_l(l);
+    lua_pop(l, 1);
+    lua::push_sstring(l, format("{}", Wrapper(s, v)));
+    return 1;
+}
+
+int column_definition_index_l(lua_State* l) {
+    const auto& cdef = pop_userdata_ref<const column_definition>(l, 1);
+    auto field = lua_tostring(l, 2);
+    lua_pop(l, 2);
+    if (strcmp(field, "id") == 0) {
+        lua_pushinteger(l, cdef.id);
+        return 1;
+    } else if (strcmp(field, "name") == 0) {
+        lua::push_sstring(l, cdef.name_as_text());
+        return 1;
+    } else if (strcmp(field, "kind") == 0) {
+        lua::push_sstring(l, to_sstring(cdef.kind));
+        return 1;
+    }
+    return 0;
+}
+
+int push_column_definitions(lua_State* l, schema::const_iterator_range_type cols) {
+    lua_createtable(l, std::distance(cols.begin(), cols.end()), 0);
+    size_t i = 1; // lua arrays start from 1
+    for (const auto& col : cols) {
+        push_userdata_ref<const column_definition>(l, col);
+        lua_seti(l, -2, i++);
+    }
+    return 1;
+}
+
+int schema_index_l(lua_State* l) {
+    const auto& s = pop_userdata_ref<const schema>(l, 1);
+    auto field = lua_tostring(l, 2);
+    lua_pop(l, 2);
+    if (strcmp(field, "partition_key_columns") == 0) {
+        return push_column_definitions(l, s.partition_key_columns());
+    } else if (strcmp(field, "clustering_key_columns") == 0) {
+        return push_column_definitions(l, s.clustering_key_columns());
+    } else if (strcmp(field, "static_columns") == 0) {
+        return push_column_definitions(l, s.static_columns());
+    } else if (strcmp(field, "regular_columns") == 0) {
+        return push_column_definitions(l, s.regular_columns());
+    } else if (strcmp(field, "all_columns") == 0) {
+        return push_column_definitions(l, s.all_columns());
+    }
+    return 0;
+}
+
+template <typename Key>
+int key_to_hex_l(lua_State* l) {
+    auto& k = pop_userdata_as_ref<Key>(l, 1);
+    auto hex = to_hex(to_bytes(k.representation()));
+    lua_pop(l, 1);
+    lua::push_sstring(l, hex);
+    return 1;
+}
+
+template <typename Key>
+int key_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    const auto& k = pop_userdata_as_ref<Key>(l, 1);
+    const auto& s = get_schema_l(l);
+    lua_pop(l, 2);
+    if (strcmp(field, "components") == 0) {
+        const std::vector<data_type>* types;
+        if constexpr (std::is_same_v<Key, partition_key>) {
+            types = &s.partition_key_type()->types();
+        } else {
+            types = &s.clustering_key_type()->types();
+        }
+        const auto values = k.explode(s);
+        lua_createtable(l, types->size(), 0);
+        for (size_t i = 0; i < types->size(); ++i) {
+            if (i == values.size()) {
+                // prefix key
+                break;
+            }
+            lua::push_data_value(l, types->at(i)->deserialize(values.at(i)));
+            lua_seti(l, -2, i + 1); // lua arrays start from 1
+        }
+        return 1;
+    } else if (strcmp(field, "to_hex") == 0) {
+        lua_pushcfunction(l, key_to_hex_l<Key>);
+        return 1;
+    }
+    return 0;
+}
+
+int8_t normalize_weight(int w) {
+    if (!w) {
+        return w;
+    } else if (w < 0) {
+        return -1;
+    } else {
+        return 1;
+    }
+}
+
+int new_ring_position_l(lua_State* l) {
+    const auto weight = normalize_weight(lua_tointeger(l, 1));
+    const auto n = lua_gettop(l);
+
+    const auto& s = get_schema_l(l);
+
+    std::optional<partition_key> pk;
+    std::optional<dht::token> token;
+
+    if (lua_gettop(l) == 2) {
+        if (lua_type(l, 2) == LUA_TUSERDATA) {
+            pk = pop_userdata<partition_key>(l, 2);
+            token = dht::get_token(s, *pk);
+        } else if (lua_type(l, 2) == LUA_TNUMBER) {
+            token = dht::token(dht::token_kind::key, lua_tointeger(l, 2));
+        }
+    }
+
+    if (lua_gettop(l) == 3) {
+        pk = pop_userdata<partition_key>(l, 2);
+        if (lua_type(l, 3) == LUA_TNUMBER) {
+            token = dht::token(dht::token_kind::key, lua_tointeger(l, 3));
+        } else {
+            luaL_checktype(l, 3, LUA_TNIL);
+        }
+    }
+    if (!token) {
+        if (!weight) {
+            luaL_error(l, "weight of 0 is invalid for min/max ring_position");
+        }
+        token = dht::token(weight < 0 ? dht::token_kind::after_all_keys : dht::token_kind::before_all_keys, 0);
+    }
+
+    push_userdata<dht::ring_position_ext>(l, *token, std::move(pk), weight);
+    return 1;
+}
+
+int tri_cmp_to_int(std::strong_ordering r) {
+    if (r < 0) {
+        return -1;
+    } else if (r == 0) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+int ring_position_tri_cmp_l(lua_State* l) {
+    const auto& a = pop_userdata_as_ref<const dht::ring_position_ext>(l, 1);
+    const auto& b = pop_userdata_as_ref<const dht::ring_position_ext>(l, 2);
+    lua_pop(l, 2);
+    const auto& s = get_schema_l(l);
+    lua_pushinteger(l, tri_cmp_to_int(dht::ring_position_tri_compare(s, a, b)));
+    return 1;
+}
+
+int ring_position_index_l(lua_State* l) {
+    const auto& rp = pop_userdata_as_ref<const dht::ring_position_ext>(l, 1);
+    auto field = lua_tostring(l, 2);
+    lua_pop(l, 2);
+    if (strcmp(field, "tri_cmp") == 0) {
+        lua_pushcfunction(l, ring_position_tri_cmp_l);
+        return 1;
+    } else if (strcmp(field, "token") == 0) {
+        if (rp.token()._kind == dht::token_kind::key) {
+            lua_pushinteger(l, rp.token()._data);
+            return 1;
+        }
+    } else if (strcmp(field, "key") == 0) {
+        if (rp.key()) {
+            push_userdata<partition_key>(l, *rp.key());
+            return 1;
+        }
+    } else if (strcmp(field, "weight") == 0) {
+        lua_pushinteger(l, rp.weight());
+        return 1;
+    }
+    return 0;
+}
+
+int position_in_partition_tri_cmp_l(lua_State* l) {
+    const auto& a = pop_userdata_as_ref<const position_in_partition>(l, 1);
+    const auto& b = pop_userdata_as_ref<const position_in_partition>(l, 2);
+    lua_pop(l, 2);
+    const auto& s = get_schema_l(l);
+    position_in_partition::tri_compare cmp(s);
+    lua_pushinteger(l, tri_cmp_to_int(cmp(a, b)));
+    return 1;
+}
+
+int position_in_partition_index_l(lua_State* l) {
+    const auto& pos = pop_userdata_as_ref<const position_in_partition>(l, 1);
+    auto field = lua_tostring(l, 2);
+    lua_pop(l, 2);
+    if (strcmp(field, "tri_cmp") == 0) {
+        lua_pushcfunction(l, position_in_partition_tri_cmp_l);
+        return 1;
+    } else if (strcmp(field, "key") == 0) {
+        if (pos.has_key()) {
+            push_userdata<clustering_key>(l, pos.key());
+            return 1;
+        }
+    } else if (strcmp(field, "weight") == 0) {
+        lua_pushinteger(l, int(pos.get_bound_weight()));
+        return 1;
+    }
+    return 0;
+}
+
+int new_position_in_partition_l(lua_State* l) {
+    const auto weight = normalize_weight(lua_tointeger(l, 1));
+    const auto n = lua_gettop(l);
+
+    std::optional<clustering_key> ck;
+
+    if (lua_gettop(l) == 2) {
+        if (lua_type(l, 2) == LUA_TUSERDATA) {
+            ck = pop_userdata<clustering_key>(l, 2);
+        } else {
+            luaL_checktype(l, 2, LUA_TNIL);
+        }
+    }
+    if (!ck) {
+        if (!weight) {
+            luaL_error(l, "weight of 0 is invalid for nil min/max position_in_partition");
+        }
+    }
+
+    push_userdata<position_in_partition>(l, partition_region::clustered, bound_weight(weight), std::move(ck));
+    return 1;
+}
+
+template <allow_prefixes AllowPrefix>
+int unserialize_key_l(lua_State* l) {
+    const auto& s = get_schema_l(l);
+    auto key_str = lua_tostring(l, 1);
+    lua_pop(l, 2);
+    lw_shared_ptr<compound_type<AllowPrefix>> type;
+    managed_bytes value;
+    try {
+        value = managed_bytes(from_hex(key_str));
+        if constexpr (AllowPrefix == allow_prefixes::no) {
+            type = s.partition_key_type();
+        } else {
+            type = s.clustering_key_type();
+        }
+        type->validate(value);
+        if constexpr (AllowPrefix == allow_prefixes::no) {
+            push_userdata<partition_key>(l, partition_key::from_bytes(value));
+        } else {
+            push_userdata<clustering_key>(l, clustering_key::from_bytes(value));
+        }
+        return 1;
+    } catch (const std::exception& e) {
+        return luaL_error(l, "unserialize partition key: %s", e.what());
+    }
+}
+
+int token_of_l(lua_State* l) {
+    const auto& s = pop_userdata_ref<const schema>(l, 1);
+    const auto& k = pop_userdata_as_ref<partition_key>(l, 1);
+    lua_pop(l, 2);
+    auto t = dht::get_token(s, k);
+    lua_pushinteger(l, t._data);
+    return 1;
+}
+
+int sstable_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& sst = pop_userdata_ref<const sstables::sstable>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "filename") == 0) {
+        lua::push_sstring(l, sst.get_filename());
+        return 1;
+    }
+    return 0;
+}
+
+int partition_start_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& ps = pop_userdata_as_ref<partition_start>(l, 1);
+    lua_pop(l, 2);
+    auto& s = get_schema_l(l);
+    if (strcmp(field, "key") == 0) {
+        push_userdata<partition_key>(l, ps.key().key());
+        return 1;
+    } else if (strcmp(field, "token") == 0) {
+        lua_pushinteger(l, ps.key().token()._data);
+        return 1;
+    } else if (strcmp(field, "tombstone") == 0) {
+        if (!ps.partition_tombstone()) {
+            return 0;
+        }
+        push_userdata<tombstone>(l, ps.partition_tombstone());
+        return 1;
+    }
+    return 0;
+}
+
+void push_gc_clock_time_point(lua_State* l, gc_clock::time_point tp) {
+    auto t = gc_clock::to_time_t(tp);
+    std::tm tm{};
+    // This time is actually UTC, but C API assumes local-times and there is no
+    // way to specify the TZ used. So we lie about it being local-time to avoid
+    // libC doing TZ adjustments.
+    localtime_r(&t, &tm);
+
+    lua_createtable(l, 0, 6);
+    luaL_setmetatable(l, get_metatable_name<gc_clock_time_point>());
+
+    lua_pushinteger(l, 1900 + tm.tm_year);
+    lua_setfield(l, -2, "year");
+
+    lua_pushinteger(l, 1 + tm.tm_mon);
+    lua_setfield(l, -2, "month");
+
+    lua_pushinteger(l, tm.tm_mday);
+    lua_setfield(l, -2, "day");
+
+    lua_pushinteger(l, tm.tm_hour);
+    lua_setfield(l, -2, "hour");
+
+    lua_pushinteger(l, tm.tm_min);
+    lua_setfield(l, -2, "min");
+
+    lua_pushinteger(l, tm.tm_sec);
+    lua_setfield(l, -2, "sec");
+}
+
+gc_clock::time_point get_gc_clock_time_point_l(lua_State* l) {
+    std::tm tm{};
+    tm.tm_isdst = -1;
+
+    lua_getfield(l, 1, "year");
+    tm.tm_year = lua_tointeger(l, -1) - 1900;
+    lua_pop(l, 1);
+
+    lua_getfield(l, 1, "month");
+    tm.tm_mon = lua_tointeger(l, -1) - 1;
+    lua_pop(l, 1);
+
+    lua_getfield(l, 1, "day");
+    tm.tm_mday = lua_tointeger(l, -1);
+    lua_pop(l, 1);
+
+    lua_getfield(l, 1, "hour");
+    tm.tm_hour = lua_tointeger(l, -1);
+    lua_pop(l, 1);
+
+    lua_getfield(l, 1, "min");
+    tm.tm_min = lua_tointeger(l, -1);
+    lua_pop(l, 1);
+
+    lua_getfield(l, 1, "sec");
+    tm.tm_sec = lua_tointeger(l, -1);
+    lua_pop(l, 1);
+
+    lua_pop(l, 1);
+
+    return gc_clock::from_time_t(std::mktime(&tm));
+}
+
+template <typename Op>
+int gc_clock_time_point_binary_op_l(lua_State* l) {
+    auto b = get_gc_clock_time_point_l(l);
+    lua_pop(l, 1);
+    auto a = get_gc_clock_time_point_l(l);
+    lua_pop(l, 1);
+
+    Op op;
+
+    lua_pushboolean(l, op(a, b));
+    return 1;
+}
+
+int gc_clock_time_point_tostring_l(lua_State* l) {
+    auto tp = get_gc_clock_time_point_l(l);
+    lua::push_sstring(l, format("{:%F %T}z", fmt::gmtime(gc_clock::to_time_t(tp))));
+    return 1;
+}
+
+int gc_clock_time_point_now_l(lua_State* l) {
+    push_gc_clock_time_point(l, gc_clock::now());
+    return 1;
+}
+
+int gc_clock_time_point_from_string_l(lua_State* l) {
+    try {
+        auto tp = gc_clock::time_point(gc_clock::duration(timestamp_from_string(lua_tostring(l, 1)) / 1000));
+        lua_pop(l, 1);
+        push_gc_clock_time_point(l, tp);
+    } catch (const std::exception& e) {
+        return luaL_error(l, "failed to parse gc_clock_deletion_time from string: %s", e.what());
+    }
+    return 1;
+}
+
+int tombstone_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto tomb = pop_userdata<tombstone>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "timestamp") == 0) {
+        lua_pushinteger(l, tomb.timestamp);
+        return 1;
+    } else if (strcmp(field, "deletion_time") == 0) {
+        push_gc_clock_time_point(l, tomb.deletion_time);
+        return 1;
+    }
+    return 0;
+}
+
+int data_value_tostring_l(lua_State* l) {
+    auto& dv = pop_userdata_as_ref<data_value>(l, 1);
+    lua_pop(l, 1);
+    auto type = dv.type();
+    if (auto bvopt = dv.serialize()) {
+        lua::push_sstring(l, type->to_string(*bvopt));
+    } else {
+        lua_pushliteral(l, "");
+    }
+    return 1;
+}
+
+int data_value_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& dv = pop_userdata_as_ref<data_value>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "value") == 0) {
+        lua::push_data_value(l, dv);
+        return 1;
+    }
+    return 0;
+}
+
+struct counter_shards_value {
+    data_type type;
+    managed_bytes data;
+};
+
+int counter_shards_value_tostring_l(lua_State* l) {
+    auto& csv = pop_userdata_as_ref<counter_shards_value>(l, 1);
+    lua_pop(l, 1);
+    auto cv = counter_cell_view(atomic_cell_view::from_bytes(*csv.type, csv.data));
+    lua::push_sstring(l, format("{}", cv.total_value()));
+    return 1;
+}
+
+int counter_shards_value_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& csv = pop_userdata_as_ref<counter_shards_value>(l, 1);
+    lua_pop(l, 2);
+    auto cv = counter_cell_view(atomic_cell_view::from_bytes(*csv.type, csv.data));
+    if (strcmp(field, "value") == 0) {
+        lua::push_data_value(l, data_value(cv.total_value()));
+    } else if (strcmp(field, "shards") == 0) {
+        lua_createtable(l, 0, 0);
+        int i = 1; // Lua arrays start from 1
+        for (const auto& shard : cv.shards()) {
+            lua_createtable(l, 0, 3);
+
+            lua::push_sstring(l, shard.id().to_sstring());
+            lua_setfield(l, -2, "id");
+
+            lua_pushinteger(l, shard.value());
+            lua_setfield(l, -2, "value");
+
+            lua_pushinteger(l, shard.logical_clock());
+            lua_setfield(l, -2, "clock");
+
+            lua_seti(l, -2, i++);
+        }
+        return 1;
+    }
+    return 0;
+}
+
+struct atomic_cell_with_type {
+    atomic_cell data;
+    data_type type;
+
+    atomic_cell_with_type(atomic_cell_view data_view, data_type type) : data(*type, data_view), type(std::move(type)) { }
+};
+
+int atomic_cell_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& ct = pop_userdata_as_ref<atomic_cell_with_type>(l, 1);
+    auto& cell = ct.data;
+    auto& type = ct.type;
+    lua_pop(l, 2);
+    if (strcmp(field, "timestamp") == 0) {
+        lua_pushinteger(l, cell.timestamp());
+        return 1;
+    } else if (strcmp(field, "type") == 0) {
+        if (type->is_counter()) {
+            if (cell.is_counter_update()) {
+                lua_pushliteral(l, "counter-update");
+            } else {
+                lua_pushliteral(l, "counter-shards");
+            }
+        } else if (type->is_collection()) {
+            if (type->is_atomic()) {
+                lua_pushliteral(l, "frozen-collection");
+            } else {
+                lua_pushliteral(l, "collection");
+            }
+        } else {
+            lua_pushliteral(l, "regular");
+        }
+        return 1;
+    } else if (strcmp(field, "is_live") == 0) {
+        lua_pushboolean(l, cell.is_live());
+        return 1;
+    } else if (strcmp(field, "has_ttl") == 0) {
+        lua_pushboolean(l, cell.is_live_and_has_ttl());
+        return 1;
+    } else if (strcmp(field, "ttl") == 0) {
+        if (!cell.is_live_and_has_ttl()) {
+            return 0;
+        }
+        lua_pushinteger(l, std::chrono::duration_cast<std::chrono::seconds>(cell.ttl()).count());
+        return 1;
+    } else if (strcmp(field, "expiry") == 0) {
+        if (!cell.is_live_and_has_ttl()) {
+            return 0;
+        }
+        push_gc_clock_time_point(l, cell.expiry());
+        return 1;
+    } else if (strcmp(field, "deletion_time") == 0) {
+        if (!cell.is_dead(gc_clock::now())) {
+            return 0;
+        }
+        push_gc_clock_time_point(l, cell.deletion_time());
+        return 1;
+    } else if (strcmp(field, "value") == 0) {
+        if (!cell.is_live()) {
+            return 0;
+        }
+        if (type->is_counter()) {
+            if (cell.is_counter_update()) {
+                push_userdata<data_value>(l, cell.counter_update_value());
+            } else {
+                push_userdata<counter_shards_value>(l, counter_shards_value{type, managed_bytes(cell.serialize())});
+            }
+        } else {
+            push_userdata<data_value>(l, type->deserialize(managed_bytes_view(cell.value())));
+        }
+        return 1;
+    }
+    return 0;
+}
+
+struct collection_with_type {
+    collection_mutation data;
+    data_type type;
+
+    collection_with_type(collection_mutation_view data_view, data_type type) : data(*type, data_view), type(std::move(type)) { }
+};
+
+int collection_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& ct = pop_userdata_as_ref<collection_with_type>(l, 1);
+    auto type = ct.type;
+    lua_pop(l, 2);
+    return collection_mutation_view(ct.data).with_deserialized(*type, [l, field, type] (const collection_mutation_view_description& mv) {
+        if (strcmp(field, "tombstone") == 0) {
+            if (!mv.tomb) {
+                return 0;
+            }
+            push_userdata<tombstone>(l, mv.tomb);
+            return 1;
+        } else if (strcmp(field, "type") == 0) {
+            lua_pushliteral(l, "collection");
+            return 1;
+        } else if (strcmp(field, "values") == 0) {
+            const auto size = mv.cells.size();
+            std::function<void(size_t, bytes_view)> push_key;
+            std::function<void(size_t, atomic_cell_view)> push_value;
+            if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
+                push_key = [l, t = t->name_comparator()] (size_t, bytes_view k) {
+                    push_userdata<data_value>(l, t->deserialize(k));
+                };
+                push_value = [l, t = t->value_comparator()] (size_t, atomic_cell_view v) {
+                    push_userdata<atomic_cell_with_type>(l, v, t);
+                };
+            } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
+                push_key = [l] (size_t, bytes_view) { lua_pushliteral(l, ""); };
+                push_value = [l, t] (size_t i, atomic_cell_view v) {
+                    push_userdata<atomic_cell_with_type>(l, v, t->type(i));
+                };
+            } else {
+                return 0;
+            }
+
+            lua_createtable(l, size, 0);
+
+            for (size_t i = 0; i < size; ++i) {
+                const auto& e = mv.cells[i];
+
+                lua_createtable(l, 0, 3);
+
+                push_key(i, e.first);
+                lua_setfield(l, -2, "key");
+
+                push_value(i, e.second);
+                lua_setfield(l, -2, "value");
+
+                lua_seti(l, -2, i + 1); // Lua arrays start from 1
+            }
+            return 1;
+        }
+        return 0;
+    });
+}
+
+int push_cells(lua_State* l, const row& cells, column_kind kind) {
+    auto& schema = get_schema_l(l);
+    lua_createtable(l, 0, 0);
+    cells.for_each_cell([l, &schema, kind] (column_id id, const atomic_cell_or_collection& cell) {
+        auto cdef = schema.column_at(kind, id);
+        if (cdef.is_atomic()) {
+            push_userdata<atomic_cell_with_type>(l, cell.as_atomic_cell(cdef), cdef.type);
+        } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
+            push_userdata<collection_with_type>(l, cell.as_collection_mutation(), cdef.type);
+        } else {
+            lua_pushnil(l);
+        }
+        lua_setfield(l, -2, cdef.name_as_text().data());
+    });
+    return 1;
+}
+
+int static_row_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& sr = pop_userdata_as_ref<static_row>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "cells") == 0) {
+        return push_cells(l, sr.cells(), column_kind::static_column);
+    }
+    return 0;
+}
+
+int row_marker_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& m = pop_userdata_as_ref<row_marker>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "timestamp") == 0) {
+        lua_pushinteger(l, m.timestamp());
+        return 1;
+    } else if (strcmp(field, "is_live") == 0) {
+        lua_pushboolean(l, m.is_live());
+        return 1;
+    } else if (strcmp(field, "has_ttl") == 0) {
+        lua_pushboolean(l, m.is_expiring());
+        return 1;
+    } else if (strcmp(field, "ttl") == 0) {
+        if (!m.is_live() || !m.is_expiring()) {
+            return 0;
+        }
+        lua_pushinteger(l, std::chrono::duration_cast<std::chrono::seconds>(m.ttl()).count());
+        return 1;
+    } else if (strcmp(field, "expiry") == 0) {
+        if (!m.is_live() || !m.is_expiring()) {
+            return 0;
+        }
+        push_gc_clock_time_point(l, m.expiry());
+        return 1;
+    } else if (strcmp(field, "deletion_time") == 0) {
+        if (!m.is_expiring() && !m.is_dead(gc_clock::now())) {
+            return 0;
+        }
+        push_gc_clock_time_point(l, m.deletion_time());
+        return 1;
+    }
+    return 0;
+}
+
+int clustering_row_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& cr = pop_userdata_as_ref<clustering_row>(l, 1);
+    lua_pop(l, 2);
+    if (strcmp(field, "key") == 0) {
+        push_userdata<clustering_key>(l, cr.key());
+        return 1;
+    } else if (strcmp(field, "tombstone") == 0) {
+        if (!cr.tomb()) {
+            return 0;
+        }
+        push_userdata<tombstone>(l, cr.tomb().regular());
+        return 1;
+    } else if (strcmp(field, "shadowable_tombstone") == 0) {
+        if (!cr.tomb()) {
+            return 0;
+        }
+        push_userdata<tombstone>(l, cr.tomb().shadowable().tomb());
+        return 1;
+    } else if (strcmp(field, "marker") == 0) {
+        if (cr.marker().is_missing()) {
+            return 0;
+        }
+        push_userdata<row_marker>(l, cr.marker());
+        return 1;
+    } else if (strcmp(field, "cells") == 0) {
+        return push_cells(l, cr.cells(), column_kind::regular_column);
+    }
+    return 0;
+}
+
+int range_tombstone_change_tostring_l(lua_State* l) {
+    auto& rtc = pop_userdata_as_ref<range_tombstone_change>(l, 1);
+    lua_pop(l, 1);
+    lua::push_sstring(l, format("{}", rtc));
+    return 1;
+}
+
+int range_tombstone_change_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    auto& rtc = pop_userdata_as_ref<range_tombstone_change>(l, 1);
+    lua_pop(l, 2);
+    const auto& pos = rtc.position();
+    if (strcmp(field, "key") == 0) {
+        if (!pos.has_key()) {
+            return 0;
+        }
+        push_userdata<clustering_key>(l, pos.key());
+        return 1;
+    } else if (strcmp(field, "key_weight") == 0) {
+        lua_pushinteger(l, static_cast<int>(pos.get_bound_weight()));
+        return 1;
+    } else if (strcmp(field, "tombstone") == 0) {
+        if (!rtc.tombstone()) {
+            return 0;
+        }
+        push_userdata<tombstone>(l, rtc.tombstone());
+        return 1;
+    } else if (strcmp(field, "__tostring") == 0) {
+        lua_pushcfunction(l, range_tombstone_change_tostring_l);
+        return 1;
+    }
+    return 0;
+}
+
+class json_writer {
+    tools::mutation_fragment_json_writer _writer;
+
+private:
+    static json_writer& get_this(lua_State* l) {
+        return pop_userdata_as_ref<json_writer>(l, 1);
+    }
+
+    template <typename Function>
+    static int do_invoke(lua_State* l, const char* name, Function&& fun) {
+        try {
+            fun(get_this(l));
+        } catch (const std::exception& e) {
+            return luaL_error(l, "json_writer::%s(): %s", name, e.what());
+        }
+        return 0;
+    }
+
+    template <typename Function>
+    static int invoke(lua_State* l, const char* name, int expected_type, Function&& fun) {
+        auto nargs = int(expected_type != LUA_TNIL) + 1;
+        if (const auto n = lua_gettop(l); n != nargs) {
+            return luaL_error(l, "json_writer::%s(): expected %I arguments, got %I", name, nargs, n);
+        }
+        const auto type = lua_type(l, 2);
+        if (expected_type != LUA_TNIL && type != expected_type) {
+            return luaL_error(l, "json_writer::%s(): expected argument of type %s, got %s", name, lua_typename(l, expected_type), lua_typename(l, type));
+        }
+        return do_invoke(l, name, fun);
+    }
+
+    template <typename Function>
+    static int invoke_optional_arg(lua_State* l, const char* name, int expected_type, Function&& fun) {
+        auto nargs = 2;
+        const auto n = lua_gettop(l);
+        if (n > nargs) {
+            return luaL_error(l, "json_writer::%s(): expected at most %I arguments, got %I", name, nargs, n);
+        }
+        if (n == 2) {
+            if (const auto type = lua_type(l, 2); type != LUA_TNIL && type != expected_type) {
+                return luaL_error(l, "json_writer::%s(): expected argument of type %s, got %s", name, lua_typename(l, expected_type), lua_typename(l, type));
+            }
+        }
+        return do_invoke(l, name, fun);
+    }
+
+public:
+    json_writer(const schema& s) : _writer(s)
+    { }
+    static int null_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.writer().Null();
+        });
+    }
+    static int bool_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TBOOLEAN, [l] (json_writer& w) {
+            w._writer.writer().Bool(lua_toboolean(l, 2));
+        });
+    }
+    static int int_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNUMBER, [l] (json_writer& w) {
+            w._writer.writer().Int64(lua_tointeger(l, 2));
+        });
+    }
+    static int double_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNUMBER, [l] (json_writer& w) {
+            w._writer.writer().Double(lua_tonumber(l, 2));
+        });
+    }
+    static int string_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TSTRING, [l] (json_writer& w) {
+            size_t len = 0;
+            auto str = lua_tolstring(l, 2, &len);
+            w._writer.writer().rjson_writer().String(str, len, false);
+        });
+    }
+    static int start_object_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.writer().StartObject();
+        });
+    }
+    static int key_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TSTRING, [l] (json_writer& w) {
+            size_t len = 0;
+            auto str = lua_tolstring(l, 2, &len);
+            w._writer.writer().rjson_writer().Key(str, len, false);
+        });
+    }
+    static int end_object_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.writer().EndObject();
+        });
+    }
+    static int start_array_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.writer().StartArray();
+        });
+    }
+    static int end_array_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.writer().EndArray();
+        });
+    }
+    static int start_stream_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+            w._writer.start_stream();
+        });
+    }
+    static int start_sstable_l(lua_State* l) {
+        return invoke_optional_arg(l, __FUNCTION__, LUA_TUSERDATA, [l] (json_writer& w) {
+            const sstables::sstable* sst = nullptr;
+            if (lua_gettop(l) > 1 && lua_type(l, 2) != LUA_TNIL) {
+                sst = &pop_userdata_ref<const sstables::sstable>(l, 2);
+            }
+            w._writer.start_sstable(sst);
+        });
+    }
+    static int start_partition_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TUSERDATA, [l] (json_writer& w) {
+            w._writer.start_partition(pop_userdata_as_ref<const partition_start>(l, 2));
+        });
+    }
+    static int static_row_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TUSERDATA, [l] (json_writer& w) {
+            w._writer.partition_element(pop_userdata_as_ref<const static_row>(l, 2));
+        });
+    }
+    static int clustering_row_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TUSERDATA, [l] (json_writer& w) {
+            w._writer.partition_element(pop_userdata_as_ref<const clustering_row>(l, 2));
+        });
+    }
+    static int range_tombstone_change_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TUSERDATA, [l] (json_writer& w) {
+            w._writer.partition_element(pop_userdata_as_ref<const range_tombstone_change>(l, 2));
+        });
+    }
+    static int end_partition_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
+            w._writer.end_partition();
+        });
+    }
+    static int end_sstable_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
+            w._writer.end_sstable();
+        });
+    }
+    static int end_stream_l(lua_State* l) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
+            w._writer.end_stream();
+        });
+    }
+};
+
+int json_writer_new_l(lua_State* l) {
+    push_userdata<json_writer>(l, get_schema_l(l));
+    return 1;
+}
+
+int json_writer_index_l(lua_State* l) {
+    auto field = lua_tostring(l, 2);
+    lua_pop(l, 2);
+    std::pair<const char*, lua_CFunction> methods[] = {
+            {"null", &json_writer::null_l},
+            {"bool", &json_writer::bool_l},
+            {"int", &json_writer::int_l},
+            {"double", &json_writer::double_l},
+            {"string", &json_writer::string_l},
+            {"start_object", &json_writer::start_object_l},
+            {"key", &json_writer::key_l},
+            {"end_object", &json_writer::end_object_l},
+            {"start_array", &json_writer::start_array_l},
+            {"end_array", &json_writer::end_array_l},
+            {"start_stream", &json_writer::start_stream_l},
+            {"start_sstable", &json_writer::start_sstable_l},
+            {"start_partition", &json_writer::start_partition_l},
+            {"static_row", &json_writer::static_row_l},
+            {"clustering_row", &json_writer::clustering_row_l},
+            {"range_tombstone_change", &json_writer::range_tombstone_change_l},
+            {"end_partition", &json_writer::end_partition_l},
+            {"end_sstable", &json_writer::end_sstable_l},
+            {"end_stream", &json_writer::end_stream_l},
+    };
+    for (const auto& [name, method] : methods) {
+        if (strcmp(field, name) == 0) {
+            lua_pushcfunction(l, method);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+class lua_sstable_consumer : public sstable_consumer {
+    schema_ptr _schema;
+    reader_permit _permit;
+    program_options::string_map _script_params;
+    std::unique_ptr<lua_State, lua_closer> _l;
+private:
+    void register_metatables() {
+        auto* l = _l.get();
+
+        lua::register_metatables(l);
+
+        luaL_newmetatable(l, get_metatable_name<column_definition>());
+        lua_pushcfunction(l, column_definition_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<schema>());
+        lua_pushcfunction(l, schema_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<partition_key>());
+        lua_pushcfunction(l, key_index_l<partition_key>);
+        lua_setfield(l, -2, "__index");
+        lua_pushcclosure(l, tostring_with_wrapper<partition_key, partition_key::with_schema_wrapper>, 0);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<partition_key>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<clustering_key>());
+        lua_pushcfunction(l, key_index_l<clustering_key>);
+        lua_setfield(l, -2, "__index");
+        lua_pushcclosure(l, tostring_with_wrapper<clustering_key, clustering_key::with_schema_wrapper>, 0);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<clustering_key>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<dht::ring_position_ext>());
+        lua_pushcfunction(l, ring_position_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, tostring_l<dht::ring_position_ext>);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<dht::ring_position_ext>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<position_in_partition>());
+        lua_pushcfunction(l, position_in_partition_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, tostring_l<position_in_partition>);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<position_in_partition>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<sstables::sstable>());
+        lua_pushcfunction(l, sstable_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<partition_start>());
+        lua_pushcfunction(l, partition_start_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, tostring_l<partition_start>);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<partition_start>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        // type is used just to tag metatable, underlying type is a lua table
+        luaL_newmetatable(l, get_metatable_name<gc_clock_time_point>());
+        lua_pushcfunction(l, gc_clock_time_point_binary_op_l<std::equal_to<gc_clock::time_point>>);
+        lua_setfield(l, -2, "__eq");
+        lua_pushcfunction(l, gc_clock_time_point_binary_op_l<std::less<gc_clock::time_point>>);
+        lua_setfield(l, -2, "__lt");
+        lua_pushcfunction(l, gc_clock_time_point_binary_op_l<std::less_equal<gc_clock::time_point>>);
+        lua_setfield(l, -2, "__le");
+        lua_pushcfunction(l, gc_clock_time_point_tostring_l);
+        lua_setfield(l, -2, "__tostring");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<tombstone>());
+        lua_pushcfunction(l, tombstone_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, tostring_l<tombstone>);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<tombstone>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<data_value>());
+        lua_pushcfunction(l, data_value_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, data_value_tostring_l);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<data_value>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<counter_shards_value>());
+        lua_pushcfunction(l, counter_shards_value_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, counter_shards_value_tostring_l);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<counter_shards_value>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<atomic_cell_with_type>());
+        lua_pushcfunction(l, atomic_cell_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, cxx_gc_l<atomic_cell_with_type>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<collection_with_type>());
+        lua_pushcfunction(l, collection_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, cxx_gc_l<collection_with_type>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<static_row>());
+        lua_pushcfunction(l, static_row_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcclosure(l, tostring_with_wrapper<static_row, static_row::printer>, 0);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<static_row>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<clustering_row>());
+        lua_pushcfunction(l, clustering_row_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcclosure(l, tostring_with_wrapper<clustering_row, clustering_row::printer>, 0);
+        lua_setfield(l, -2, "__tostring");
+        lua_pushcfunction(l, cxx_gc_l<clustering_row>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<row_marker>());
+        lua_pushcfunction(l, row_marker_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, cxx_gc_l<row_marker>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<range_tombstone_change>());
+        lua_pushcfunction(l, range_tombstone_change_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, cxx_gc_l<range_tombstone_change>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+
+        luaL_newmetatable(l, get_metatable_name<json_writer>());
+        lua_pushcfunction(l, json_writer_index_l);
+        lua_setfield(l, -2, "__index");
+        lua_pushcfunction(l, cxx_gc_l<json_writer>);
+        lua_setfield(l, -2, "__gc");
+        lua_pop(l, 1);
+    }
+
+    void register_types() {
+        auto* l = _l.get();
+        const luaL_Reg scylla_lib[] = {
+            {"now", gc_clock_time_point_now_l},
+            {"time_point_from_string", gc_clock_time_point_from_string_l},
+            {"new_json_writer", json_writer_new_l},
+            {"new_ring_position", new_ring_position_l},
+            {"new_position_in_partition", new_position_in_partition_l},
+            {"unserialize_partition_key", unserialize_key_l<allow_prefixes::no>},
+            {"unserialize_clustering_key", unserialize_key_l<allow_prefixes::yes>},
+            {"token_of", token_of_l},
+            {NULL, NULL},
+        };
+        luaL_newlib(l, scylla_lib);
+        lua_setglobal(l, "Scylla");
+    }
+
+    void register_globals() {
+        auto* l = _l.get();
+
+        push_userdata_ref<const schema>(l, *_schema.get());
+        lua_setglobal(l, "schema");
+    }
+
+    future<int> call(std::string_view func_name, int nargs) {
+        auto* l = _l.get();
+        int ret = LUA_YIELD;
+        int nresults = 0;
+        while (ret == LUA_YIELD) {
+            ret = lua_resume(l, nullptr, nargs, &nresults);
+            if (ret == LUA_YIELD) {
+                if (nresults == 0) {
+                    co_await coroutine::maybe_yield();
+                } else if (nresults != 1) {
+                    throw std::runtime_error(fmt::format("{} failed: unexpected number of results yielded, expected 1, got {}", func_name, nresults));
+                } else {
+                    if (!lua_isuserdata(l, -1)) {
+                        throw std::runtime_error(fmt::format("{} failed: only future<> is allowed to be yielded from a coroutine", func_name));
+                    }
+                    co_await pop_userdata<future<>>(l, -1);
+                    lua_pop(l, 1);
+                }
+            }
+        }
+        if (ret != LUA_OK) {
+            throw std::runtime_error(fmt::format("{} failed: {}", func_name, lua_tostring(l, -1)));
+        }
+        co_return nresults;
+    }
+
+    struct invoke_meta {
+        int nargs;
+        bool returns_stop_iteration;
+    };
+    template <typename Func>
+    future<stop_iteration> invoke_script_method(const char* name, Func&& prepare_stack) {
+        auto* l = _l.get();
+        // basic stack sanity check
+        if (auto n = lua_gettop(l); n) {
+            throw std::runtime_error(fmt::format("{}() failed: stack expected to be empty (clean), but got {} items", name, n));
+        }
+        const auto type = lua_getglobal(l, name);
+        // check whether script has this method, short-circuit if not
+        if (type == LUA_TNIL) {
+            lua_pop(l, 1);
+            co_return stop_iteration::no;
+        }
+        // is symbol callable?
+        if (type != LUA_TFUNCTION) {
+            throw std::runtime_error(fmt::format("{}() failed: symbol is not callable", name));
+        }
+        const auto desc = prepare_stack();
+        // sanity check for argument count
+        // function to be called is also on the stack, account for that
+        if (auto n = lua_gettop(l); n != desc.nargs + 1) {
+            throw std::runtime_error(fmt::format("{}() failed: unexpected number of arguments for function, expected: {}, got: {}", name, desc.nargs, n - 1));
+        }
+        // call + sanity check for return value count
+        const auto nret = co_await call(name, desc.nargs);
+        if (nret > int(desc.returns_stop_iteration)) {
+            throw std::runtime_error(fmt::format("{}() failed: unexpected number of return values from function, expected: {}, got: {}", name, int(desc.returns_stop_iteration), nret));
+        }
+        // extract and convert return value if method has it (it can only be stop_iteration)
+        // we allow method to return nothing, int this case we assume stop_iteration::no
+        auto stop = stop_iteration::no;
+        if (desc.returns_stop_iteration && nret) {
+            // lua method return false when they don't want to continue
+            // stop_iteration expressed in boolean is too counter-intuitive
+            stop = stop_iteration(!lua_toboolean(l, 1));
+            lua_pop(l, 1);
+        }
+        co_return stop;
+    }
+
+public:
+    explicit lua_sstable_consumer(schema_ptr s, reader_permit p, program_options::string_map script_params)
+        : _schema(std::move(s))
+        , _permit(std::move(p))
+        , _script_params(std::move(script_params))
+        , _l(lua_newstate(lua_alloc, nullptr))
+    {
+    }
+    future<> load_script(std::string_view script_name, std::string_view script) {
+        auto* l = _l.get();
+        // load lua standard libraries
+        for (const luaL_Reg* lib = loadedlibs; lib->func; lib++) {
+            luaL_requiref(l, lib->name, lib->func, 1);
+            lua_pop(l, 1);
+        }
+        register_metatables();
+        register_types();
+        register_globals();
+        // parse and load script
+        if (luaL_loadbuffer(l, script.data(), script.size(), script_name.data())) {
+            throw std::runtime_error(fmt::format("Failed to load {}: {}", script_name, lua_tostring(l, -1)));
+        }
+        // execute script (runs global code)
+        if (auto n = co_await call(script_name, 0); n) {
+            throw std::runtime_error(fmt::format("Failed to execute {}: unexpected return value, expected 0, got {}", script_name, n));
+        }
+        co_return;
+    }
+    virtual future<> consume_stream_start() override {
+        return invoke_script_method(__FUNCTION__, [this] {
+            auto* l = _l.get();
+            lua_newtable(l);
+            for (const auto& [k, v] : _script_params) {
+                lua::push_sstring(l, v);
+                lua_setfield(l, -2, k.data());
+            }
+            return invoke_meta{1, false};
+        }).discard_result();
+    }
+    virtual future<stop_iteration> consume_sstable_start(const sstables::sstable* const sst) override {
+        return invoke_script_method(__FUNCTION__, [this, sst] {
+            auto* l = _l.get();
+            if (sst) {
+                push_userdata_ref<const sstables::sstable>(l, *sst);
+            } else {
+                lua_pushnil(l);
+            }
+            return invoke_meta{1, true};
+        });
+    }
+    virtual future<stop_iteration> consume(partition_start&& ps) override {
+        return invoke_script_method("consume_partition_start", [this, ps = std::move(ps)] () mutable {
+            auto* l = _l.get();
+            push_userdata<partition_start>(l, std::move(ps));
+            return invoke_meta{1, true};
+        });
+    }
+    virtual future<stop_iteration> consume(static_row&& sr) override {
+        return invoke_script_method("consume_static_row", [this, sr = std::move(sr)] () mutable {
+            auto* l = _l.get();
+            push_userdata<static_row>(l, std::move(sr));
+            return invoke_meta{1, true};
+        });
+    }
+    virtual future<stop_iteration> consume(clustering_row&& cr) override {
+        return invoke_script_method("consume_clustering_row", [this, cr = std::move(cr)] () mutable {
+            auto* l = _l.get();
+            push_userdata<clustering_row>(l, std::move(cr));
+            return invoke_meta{1, true};
+        });
+    }
+    virtual future<stop_iteration> consume(range_tombstone_change&& rtc) override {
+        return invoke_script_method("consume_range_tombstone_change", [this, rtc = std::move(rtc)] () mutable {
+            auto* l = _l.get();
+            push_userdata<range_tombstone_change>(l, std::move(rtc));
+            return invoke_meta{1, true};
+        });
+    }
+    virtual future<stop_iteration> consume(partition_end&& pe) override {
+        return invoke_script_method("consume_partition_end", [] {
+            return invoke_meta{0, true};
+        });
+    }
+    virtual future<stop_iteration> consume_sstable_end() override {
+        return invoke_script_method(__FUNCTION__, [] {
+            return invoke_meta{0, true};
+        });
+    }
+    virtual future<> consume_stream_end() override {
+        return invoke_script_method(__FUNCTION__, [] {
+            return invoke_meta{0, false};
+        }).discard_result();
+    }
+};
+
+}
+
+future<std::unique_ptr<sstable_consumer>> make_lua_sstable_consumer(schema_ptr s, reader_permit p, std::string_view script_path,
+        program_options::string_map script_args) {
+    auto consumer = std::make_unique<lua_sstable_consumer>(std::move(s), std::move(p), std::move(script_args));
+
+    auto file = co_await open_file_dma(script_path, open_flags::ro);
+    auto fstream = make_file_input_stream(file);
+    auto script = co_await util::read_entire_stream_contiguous(fstream);
+    co_await consumer->load_script(script_path, script);
+
+    co_return consumer;
+}

--- a/tools/lua_sstable_consumer.hh
+++ b/tools/lua_sstable_consumer.hh
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <seastar/util/program-options.hh>
+
+#include "schema_fwd.hh"
+#include "tools/sstable_consumer.hh"
+
+class reader_permit;
+
+/// Sstable consumer consuming the content via a lua script
+///
+/// Loads the script from /p script_path and feeds the consumed content to the
+/// script.
+/// See the help section for the script operation in ./scylla-sstable.cc for more
+/// details on the Lua API.
+future<std::unique_ptr<sstable_consumer>> make_lua_sstable_consumer(schema_ptr s, reader_permit p, std::string_view script_path,
+        program_options::string_map script_args);

--- a/tools/scylla-sstable-scripts/README.md
+++ b/tools/scylla-sstable-scripts/README.md
@@ -1,0 +1,9 @@
+Scripts for scylla-sstable
+==========================
+
+This directory contains various example scripts for `scylla-sstable script`.
+It serves the dual purpose of being a repository of examples scripts so people can see the Lua API in action and also as a collection of the most commonly used and useful scripts.
+
+For more details on the Lua API, see https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#script.
+
+For more details on Lua, see the [Lua manual](http://www.lua.org/manual/).

--- a/tools/scylla-sstable-scripts/dump.lua
+++ b/tools/scylla-sstable-scripts/dump.lua
@@ -1,0 +1,254 @@
+--
+-- Copyright (C) 2022-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Dumps the content of the sstable(s).
+--
+-- Mirrors the dump-data operation. Useful for testing the lua bindings and
+-- showcasing how to use the lua API to traverse all corners of the data, as well
+-- as how to generate custom JSON.
+-- For dumping the content of sstables, prefer the dump-data operation, it is
+-- much more performant.
+
+writer = Scylla.new_json_writer()
+
+clustering_array_created = false
+
+function write_key(obj)
+    writer:start_object()
+
+    if obj.token then
+        writer:key("token")
+        writer:string(tostring(obj.token))
+    end
+
+    writer:key("raw")
+    writer:string(obj.key:to_hex())
+
+    writer:key("value")
+    writer:string(tostring(obj.key))
+
+    writer:end_object()
+end
+
+function write_tombstone(tombstone)
+    writer:start_object()
+
+    if tombstone then
+        writer:key("timestamp")
+        writer:int(tombstone.timestamp)
+
+        writer:key("deletion_time")
+        writer:string(tostring(tombstone.deletion_time))
+    end
+
+    writer:end_object()
+end
+
+function write_ttl(obj)
+    writer:key("ttl")
+    writer:string(string.format("%is", obj.ttl))
+    writer:key("expiry")
+    writer:string(tostring(obj.expiry))
+end
+
+function maybe_start_clustering_array()
+    if clustering_array_created then
+        return
+    end
+    writer:key("clustering_elements")
+    writer:start_array()
+    clustering_array_created = true
+end
+
+function write_atomic_cell(cell)
+    writer:key("is_live")
+    writer:bool(cell.is_live)
+
+    writer:key("type")
+    writer:string(cell.type)
+
+    writer:key("timestamp")
+    writer:int(cell.timestamp)
+
+    if cell.type == "counter-shards" then
+        writer:key("value")
+        writer:start_array()
+        for _, shard in ipairs(cell.value.shards) do
+            writer:start_object()
+            writer:key("id")
+            writer:string(shard.id)
+            writer:key("value")
+            writer:int(shard.value)
+            writer:key("clock")
+            writer:int(shard.clock)
+            writer:end_object()
+        end
+        writer:end_array()
+    elseif cell.is_live then -- type == "regular" | "frozen-collection" | "counter-update"
+        writer:key("value")
+        writer:string(tostring(cell.value))
+    end
+
+    if cell.is_live and cell.has_ttl then
+        write_ttl(cell)
+    end
+    if not cell.is_live then
+        writer:key("deletion_time")
+        writer:string(tostring(cell.deletion_time))
+    end
+end
+
+function write_collection(cell)
+    if cell.tombstone then
+        writer:key("tombstone")
+        write_tombstone(cell.tombstone)
+    end
+    writer:key("cells")
+    writer:start_array()
+    for _, v in ipairs(cell.values) do
+        writer:start_object()
+
+        writer:key("key")
+        writer:string(tostring(v.key))
+
+        writer:key("value")
+        writer:start_object()
+        write_atomic_cell(v.value)
+        writer:end_object()
+
+        writer:end_object()
+    end
+    writer:end_array()
+end
+
+function write_cells(cells)
+    writer:start_object()
+
+    for name, cell in pairs(cells) do
+        writer:key(name)
+        writer:start_object()
+
+        if cell.type == "collection" then
+            write_collection(cell)
+        else
+            write_atomic_cell(cell)
+        end
+
+        writer:end_object()
+    end
+
+    writer:end_object()
+end
+
+function consume_stream_start()
+    writer:start_object()
+    writer:key("sstables")
+    writer:start_object()
+end
+
+function consume_sstable_start(sst)
+    if sst == nil then
+        writer:key("anonymous")
+    else
+        writer:key(sst.filename)
+    end
+    writer:start_array()
+end
+
+function consume_partition_start(ps)
+    writer:start_object()
+
+    clustering_array_created = false
+
+    writer:key("key")
+    write_key(ps)
+
+    if ps.tombstone then
+        writer:key("tombstone")
+        write_tombstone(ps.tombstone)
+    end
+end
+
+function consume_static_row(sr)
+    writer:key("static_row")
+    write_cells(sr.cells)
+end
+
+function consume_clustering_row(cr)
+    maybe_start_clustering_array()
+
+    writer:start_object()
+
+    writer:key("type")
+    writer:string("clustering-row")
+
+    writer:key("key")
+    write_key(cr)
+
+    if cr.tombstone then
+        writer:key("tombstone")
+        write_tombstone(cr.tombstone)
+        writer:key("shadowable_tombstone")
+        write_tombstone(cr.shadowable_tombstone)
+    end
+
+    if cr.marker then
+        writer:key("marker")
+        writer:start_object()
+
+        writer:key("timestamp")
+        writer:int(cr.marker.timestamp)
+
+        if cr.marker.is_live and cr.marker.has_ttl then
+            write_ttl(cr.marker)
+        end
+
+        writer:end_object()
+    end
+
+    writer:key("columns")
+    write_cells(cr.cells)
+
+    writer:end_object()
+end
+
+function consume_range_tombstone_change(crt)
+    maybe_start_clustering_array()
+
+    writer:start_object()
+
+    writer:key("type")
+    writer:string("range-tombstone-change")
+
+    if crt.key then
+        writer:key("key")
+        write_key(crt)
+    end
+
+    writer:key("weight")
+    writer:int(crt.key_weight)
+
+    writer:key("tombstone")
+    write_tombstone(crt.tombstone)
+
+    writer:end_object()
+end
+
+function consume_partition_end()
+    if clustering_array_created then
+        writer:end_array()
+    end
+    writer:end_object()
+end
+
+function consume_sstable_end()
+    writer:end_array()
+end
+
+function consume_stream_end()
+    writer:end_object()
+    writer:end_object()
+end

--- a/tools/scylla-sstable-scripts/find-incomplete-clustering-row-keys.lua
+++ b/tools/scylla-sstable-scripts/find-incomplete-clustering-row-keys.lua
@@ -1,0 +1,34 @@
+--
+-- Copyright (C) 2022-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Finds clustering rows which have incomplete (prefix) keys.
+--
+-- Such keys can be created in tables created with the `WITH COMPACT STORAGE`
+-- legacy CQL option.
+-- Found keys are printed to the standard output.
+
+partition_key = nil
+
+function format_key(key)
+    key_str = ""
+    for i, component in ipairs(key.components) do
+        key_str = key_str..tostring(component)
+        if i < #key.components then
+            key_str = key_str..":"
+        end
+    end
+    return key_str
+end
+
+function consume_partition_start(ps)
+    partition_key = format_key(ps.key)
+end
+
+function consume_clustering_row(cr)
+    if #cr.key.components < #schema.clustering_key_columns then
+        print(string.format("Incomplete key in partition %s: %s (%s)", partition_key, format_key(cr.key), cr.key:to_hex()))
+    end
+end

--- a/tools/scylla-sstable-scripts/fragment-stats.lua
+++ b/tools/scylla-sstable-scripts/fragment-stats.lua
@@ -1,0 +1,82 @@
+--
+-- Copyright (C) 2022-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Creates simple statistics of the fragments in the sstable
+--
+-- Prints the number of each fragment type as well as the total fragment count
+-- and stats for the partition with the most fragments.
+
+function new_stats(key)
+    return {
+        partition_key = key,
+        total = 0,
+        partition = 0,
+        static_row = 0,
+        clustering_row = 0,
+        range_tombstone_change = 0,
+    }
+end
+
+total_stats = new_stats(nil)
+
+function inc_stat(stats, field)
+    stats[field] = stats[field] + 1
+    stats.total = stats.total + 1
+    total_stats[field] = total_stats[field] + 1
+    total_stats.total = total_stats.total + 1
+end
+
+function consume_sstable_start(sst)
+    max_partition_stats = new_stats(nil)
+    if sst then
+        current_sst_filename = sst.filename
+    else
+        current_sst_filename = nil
+    end
+end
+
+function consume_partition_start(ps)
+    current_partition_stats = new_stats(ps.key)
+    inc_stat(current_partition_stats, "partition")
+end
+
+function consume_static_row(sr)
+    inc_stat(current_partition_stats, "static_row")
+end
+
+function consume_clustering_row(cr)
+    inc_stat(current_partition_stats, "clustering_row")
+end
+
+function consume_range_tombstone_change(crt)
+    inc_stat(current_partition_stats, "range_tombstone_change")
+end
+
+function consume_partition_end()
+    if current_partition_stats.total > max_partition_stats.total then
+        max_partition_stats = current_partition_stats
+    end
+end
+
+function consume_sstable_end()
+    if current_sst_filename then
+        print(string.format("Stats for sstable %s:", current_sst_filename))
+    else
+        print("Stats for stream:")
+    end
+    print(string.format("\t%d fragments in %d partitions - %d static rows, %d clustering rows and %d range tombstone changes",
+        total_stats.total,
+        total_stats.partition,
+        total_stats.static_row,
+        total_stats.clustering_row,
+        total_stats.range_tombstone_change))
+    print(string.format("\tPartition with max number of fragments (%d): %s - %d static rows, %d clustering rows and %d range tombstone changes",
+        max_partition_stats.total,
+        max_partition_stats.partition_key,
+        max_partition_stats.static_row,
+        max_partition_stats.clustering_row,
+        max_partition_stats.range_tombstone_change))
+end

--- a/tools/scylla-sstable-scripts/slice.lua
+++ b/tools/scylla-sstable-scripts/slice.lua
@@ -1,0 +1,183 @@
+--
+-- Copyright (C) 2022-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Filters and dumps the content of the sstable(s).
+--
+-- With no arguments, this script is identical to the dump-data operation.
+-- It demonstrates how to use the high-level JSON write API, as well as how to
+-- work with partition and clustering keys and how to accepts arguments from the
+-- command-line
+-- The script accepts two kind of arguments from the command-line: partition
+-- ranges and clustering ranges.
+-- Partition ranges are expected to have keys with the format of `prN`, where N
+-- is an integer. N can have any value but it should be unique across all other
+-- partition-ranges passed to the script. A simple scheme is to use a running
+-- counter to number them.
+-- Clustering ranges are expected to have keys with the format of `crN`. The same
+-- restrictions apply to `N`.
+-- The ranges themselves have the format:
+-- * [X,Y] - inclusive range from X to Y
+-- * [X,Y) - from X (inclusive) to Y (exclusive)
+-- * (X,Y] - from X (exclusive) to Y (inclusive)
+-- * (X,Y) - exclusive range from X to Y
+--
+-- The key values should be hex encoded serialized keys. For partition ranges, it
+-- is possible to pass tokens, as `tTOKEN`. The special values of `-inf` and
+-- `+inf` can be used to denote infinity, but note that infinity should always be
+-- an exclusive bound.
+--
+-- Examples:
+--
+-- # a single partition range, from key 000400000005 to inf
+-- $ scylla sstable script --script-file slice.lua --script-args "pk0=[000400000005,+inf)"
+--
+-- # two partition ranges
+-- $ scylla sstable script --script-file slice.lua --script-args "pk0=(-inf,000400000002):pk1=[000400000005,+inf)"
+--
+-- # token-range
+-- $ scylla sstable script --script-file slice.lua --script-args "pk0=(t-1000,t1000)"
+--
+-- # a single clustering range, from key 000400000005 to inf
+-- $ scylla sstable script --script-file slice.lua --script-args "ck0=[000400000005,+inf)"
+--
+-- # partition (mixed key and token) and clustering range
+-- $ scylla sstable script --script-file slice.lua --script-args "pk0=(000400000001,t1000):ck0=[000400000005,+inf)"
+
+wr = Scylla.new_json_writer()
+
+partition_ranges = {}
+clustering_ranges = {}
+
+arg_key_pattern = "^([pc]r)(%d*)$"
+arg_value_pattern = "^([%(%[])(.+),(.+)([%]%)])$"
+key_pattern = "^([0-9a-f]+)$"
+token_pattern = "^t(-?%d+)$"
+
+paren_to_key_weight = {
+    ["["] = 0,
+    ["]"] = 0,
+    ["("] = 1,
+    [")"] = -1,
+}
+
+paren_to_token_weight = {
+    ["["] = -1,
+    ["]"] = 1,
+    ["("] = 1,
+    [")"] = -1,
+}
+
+function make_ring_position(paren, bound)
+    if bound == '-inf' or bound == 'inf' or bound == '+inf' then
+        return Scylla.new_ring_position(paren_to_token_weight[paren], nil)
+    end
+
+    local serialized_key = string.match(bound, key_pattern)
+    if serialized_key ~= nil then
+        return Scylla.new_ring_position(paren_to_key_weight[paren], Scylla.unserialize_partition_key(serialized_key))
+    end
+
+    local token = string.match(bound, token_pattern)
+    if token ~= nil then
+        return Scylla.new_ring_position(paren_to_token_weight[paren], tonumber(token))
+    end
+
+    error(string.format("failed to parse %s as a partition-range bound, expected t$TOKEN, +-inf or a serialized key value", bound))
+end
+
+function make_position_in_partition(paren, bound)
+    local weight = paren_to_key_weight[paren]
+
+    if bound == '-inf' or bound == 'inf' or bound == '+inf' then
+        return Scylla.new_position_in_partition(weight, nil)
+    end
+
+    local serialized_key = string.match(bound, key_pattern)
+    if serialized_key ~= nil then
+        return Scylla.new_position_in_partition(weight, Scylla.unserialize_clustering_key(serialized_key))
+    end
+
+    error(string.format("failed to parse %s as a clustering-range bound, expected +-inf or a serialized key value", bound))
+end
+
+function parse_ranges(args)
+    for k, v in pairs(args) do
+        local kind, index = string.match(k, arg_key_pattern)
+        if kind == nil then
+            error(string.format("failed to parse command line argument key: %s", k))
+        end
+        local start_paren, start_bound, end_bound, end_paren = string.match(v, arg_value_pattern)
+        if start_paren == nil then
+            error(string.format("failed to parse command line argument value for key %s: %s", k, v))
+        end
+        if kind == 'pr' then
+            partition_ranges[#partition_ranges + 1] = {make_ring_position(start_paren, start_bound), make_ring_position(end_paren, end_bound)}
+        else
+            clustering_ranges[#clustering_ranges + 1] = {make_position_in_partition(start_paren, start_bound), make_position_in_partition(end_paren, end_bound)}
+        end
+    end
+end
+
+function filter(point, ranges)
+    if #ranges == 0 then
+        return true
+    end
+    for _, range in ipairs(ranges) do
+        if range[1]:tri_cmp(point) <= 0 and range[2]:tri_cmp(point) >= 0 then
+            return true
+        end
+    end
+    return false
+end
+
+function consume_stream_start(args)
+    parse_ranges(args)
+    wr:start_stream()
+end
+
+function consume_sstable_start(sst)
+    wr:start_sstable(sst)
+end
+
+skip_partition = false
+
+function consume_partition_start(ps)
+    skip_partition = not filter(Scylla.new_ring_position(0, ps.key, ps.token), partition_ranges)
+    if skip_partition then
+        return false
+    end
+    wr:start_partition(ps)
+end
+
+function consume_static_row(sr)
+    wr:static_row(sr)
+end
+
+function consume_clustering_row(cr)
+    if filter(Scylla.new_position_in_partition(0, cr.key), clustering_ranges) then
+        wr:clustering_row(cr)
+    end
+end
+
+function consume_range_tombstone_change(rtc)
+    wr:range_tombstone_change(rtc)
+end
+
+function consume_partition_end()
+    if skip_partition then
+        return
+    end
+    wr:end_partition()
+end
+
+function consume_sstable_end()
+    wr:end_sstable()
+end
+
+function consume_stream_end()
+    wr:end_stream()
+end
+

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -220,6 +220,251 @@ output_format get_output_format_from_options(const bpo::variables_map& opts, out
     return default_format;
 }
 
+class mutation_fragment_json_writer : public sstable_consumer {
+    const schema& _schema;
+    json_writer _writer;
+    bool _clustering_array_created;
+private:
+    sstring to_string(gc_clock::time_point tp) {
+        return fmt::format("{:%F %T}z", fmt::gmtime(gc_clock::to_time_t(tp)));
+    }
+    void write(gc_clock::duration ttl, gc_clock::time_point expiry) {
+        _writer.Key("ttl");
+        _writer.AsString(ttl);
+        _writer.Key("expiry");
+        _writer.String(to_string(expiry));
+    }
+    void write(const tombstone& t) {
+        _writer.StartObject();
+        if (t) {
+            _writer.Key("timestamp");
+            _writer.Int64(t.timestamp);
+            _writer.Key("deletion_time");
+            _writer.String(to_string(t.deletion_time));
+        }
+        _writer.EndObject();
+    }
+    void write(const row_marker& m) {
+        _writer.StartObject();
+        _writer.Key("timestamp");
+        _writer.Int64(m.timestamp());
+        if (m.is_live() && m.is_expiring()) {
+            write(m.ttl(), m.expiry());
+        }
+        _writer.EndObject();
+    }
+    void write(counter_cell_view cv) {
+        _writer.StartArray();
+        for (const auto& shard : cv.shards()) {
+            _writer.StartObject();
+            _writer.Key("id");
+            _writer.AsString(shard.id());
+            _writer.Key("value");
+            _writer.Int64(shard.value());
+            _writer.Key("clock");
+            _writer.Int64(shard.logical_clock());
+            _writer.EndObject();
+        }
+        _writer.EndArray();
+    }
+    void write(const atomic_cell_view& cell, data_type type) {
+        _writer.StartObject();
+        _writer.Key("is_live");
+        _writer.Bool(cell.is_live());
+        _writer.Key("type");
+        if (type->is_counter()) {
+            if (cell.is_counter_update()) {
+                _writer.String("counter-update");
+            } else {
+                _writer.String("counter-shards");
+            }
+        } else if (type->is_collection()) {
+            _writer.String("frozen-collection");
+        } else {
+            _writer.String("regular");
+        }
+        _writer.Key("timestamp");
+        _writer.Int64(cell.timestamp());
+        if (type->is_counter()) {
+            _writer.Key("value");
+            if (cell.is_counter_update()) {
+                _writer.Int64(cell.counter_update_value());
+            } else {
+                write(counter_cell_view(cell));
+            }
+        } else {
+            if (cell.is_live_and_has_ttl()) {
+                write(cell.ttl(), cell.expiry());
+            }
+            if (cell.is_live()) {
+                _writer.Key("value");
+                _writer.String(type->to_string(cell.value().linearize()));
+            } else {
+                _writer.Key("deletion_time");
+                _writer.String(to_string(cell.deletion_time()));
+            }
+        }
+        _writer.EndObject();
+    }
+    void write(const collection_mutation_view_description& mv, data_type type) {
+        _writer.StartObject();
+
+        if (mv.tomb) {
+            _writer.Key("tombstone");
+            write(mv.tomb);
+        }
+
+        _writer.Key("cells");
+
+        std::function<void(size_t, bytes_view)> write_key;
+        std::function<void(size_t, atomic_cell_view)> write_value;
+        if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
+            write_key = [this, t = t->name_comparator()] (size_t, bytes_view k) { _writer.String(t->to_string(k)); };
+            write_value = [this, t = t->value_comparator()] (size_t, atomic_cell_view v) { write(v, t); };
+        } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
+            write_key = [this] (size_t i, bytes_view) { _writer.String(""); };
+            write_value = [this, t] (size_t i, atomic_cell_view v) { write(v, t->type(i)); };
+        }
+
+        if (write_key && write_value) {
+            _writer.StartArray();
+            for (size_t i = 0; i < mv.cells.size(); ++i) {
+                _writer.StartObject();
+                _writer.Key("key");
+                write_key(i, mv.cells[i].first);
+                _writer.Key("value");
+                write_value(i, mv.cells[i].second);
+                _writer.EndObject();
+            }
+            _writer.EndArray();
+        } else {
+            _writer.Null();
+        }
+
+        _writer.EndObject();
+    }
+    void write(const atomic_cell_or_collection& cell, const column_definition& cdef) {
+        if (cdef.is_atomic()) {
+            write(cell.as_atomic_cell(cdef), cdef.type);
+        } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
+            cell.as_collection_mutation().with_deserialized(*cdef.type, [&, this] (collection_mutation_view_description mv) {
+                write(mv, cdef.type);
+            });
+        } else {
+            _writer.Null();
+        }
+    }
+    void write(const row& r, column_kind kind) {
+        _writer.StartObject();
+        r.for_each_cell([this, kind] (column_id id, const atomic_cell_or_collection& cell) {
+            auto cdef = _schema.column_at(kind, id);
+            _writer.Key(cdef.name_as_text());
+            write(cell, cdef);
+        });
+        _writer.EndObject();
+    }
+    void write(const clustering_row& cr) {
+        _writer.StartObject();
+        _writer.Key("type");
+        _writer.String("clustering-row");
+        _writer.Key("key");
+        _writer.DataKey(_schema, cr.key());
+        if (cr.tomb()) {
+            _writer.Key("tombstone");
+            write(cr.tomb().regular());
+            _writer.Key("shadowable_tombstone");
+            write(cr.tomb().shadowable().tomb());
+        }
+        if (!cr.marker().is_missing()) {
+            _writer.Key("marker");
+            write(cr.marker());
+        }
+        _writer.Key("columns");
+        write(cr.cells(), column_kind::regular_column);
+        _writer.EndObject();
+    }
+    void write(const range_tombstone_change& rtc) {
+        _writer.StartObject();
+        _writer.Key("type");
+        _writer.String("range-tombstone-change");
+        const auto pos = rtc.position();
+        if (pos.has_key()) {
+            _writer.Key("key");
+            _writer.DataKey(_schema, pos.key());
+        }
+        _writer.Key("weight");
+        _writer.Int(static_cast<int>(pos.get_bound_weight()));
+        _writer.Key("tombstone");
+        write(rtc.tombstone());
+        _writer.EndObject();
+    }
+public:
+    explicit mutation_fragment_json_writer(const schema& s) : _schema(s) {}
+    virtual future<> on_start_of_stream() override {
+        _writer.StartStream();
+        return make_ready_future<>();
+    }
+    virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const sst) override {
+        _writer.SstableKey(sst);
+        _writer.StartArray();
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> consume(partition_start&& ps) override {
+        const auto& dk = ps.key();
+        _clustering_array_created = false;
+
+        _writer.StartObject();
+
+        _writer.Key("key");
+        _writer.DataKey(_schema, dk.key(), dk.token());
+
+        if (ps.partition_tombstone()) {
+            _writer.Key("tombstone");
+            write(ps.partition_tombstone());
+        }
+
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> consume(static_row&& sr) override {
+        _writer.Key("static_row");
+        write(sr.cells(), column_kind::static_column);
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> consume(clustering_row&& cr) override {
+        if (!_clustering_array_created) {
+            _writer.Key("clustering_elements");
+            _writer.StartArray();
+            _clustering_array_created = true;
+        }
+        write(cr);
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> consume(range_tombstone_change&& rtc) override {
+        if (!_clustering_array_created) {
+            _writer.Key("clustering_elements");
+            _writer.StartArray();
+            _clustering_array_created = true;
+        }
+        write(rtc);
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> consume(partition_end&& pe) override {
+        if (_clustering_array_created) {
+            _writer.EndArray();
+        }
+        _writer.EndObject();
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<stop_iteration> on_end_of_sstable() override {
+        _writer.EndArray();
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    }
+    virtual future<> on_end_of_stream() override {
+        _writer.EndStream();
+        return make_ready_future<>();
+    }
+};
+
 class dumping_consumer : public sstable_consumer {
     class text_dumper : public sstable_consumer {
         const schema& _schema;
@@ -263,247 +508,35 @@ class dumping_consumer : public sstable_consumer {
         }
     };
     class json_dumper : public sstable_consumer {
-        const schema& _schema;
-        json_writer _writer;
-        bool _clustering_array_created;
-    private:
-        sstring to_string(gc_clock::time_point tp) {
-            return fmt::format("{:%F %T}z", fmt::gmtime(gc_clock::to_time_t(tp)));
-        }
-        void write(gc_clock::duration ttl, gc_clock::time_point expiry) {
-            _writer.Key("ttl");
-            _writer.AsString(ttl);
-            _writer.Key("expiry");
-            _writer.String(to_string(expiry));
-        }
-        void write(const tombstone& t) {
-            _writer.StartObject();
-            if (t) {
-                _writer.Key("timestamp");
-                _writer.Int64(t.timestamp);
-                _writer.Key("deletion_time");
-                _writer.String(to_string(t.deletion_time));
-            }
-            _writer.EndObject();
-        }
-        void write(const row_marker& m) {
-            _writer.StartObject();
-            _writer.Key("timestamp");
-            _writer.Int64(m.timestamp());
-            if (m.is_live() && m.is_expiring()) {
-                write(m.ttl(), m.expiry());
-            }
-            _writer.EndObject();
-        }
-        void write(counter_cell_view cv) {
-            _writer.StartArray();
-            for (const auto& shard : cv.shards()) {
-                _writer.StartObject();
-                _writer.Key("id");
-                _writer.AsString(shard.id());
-                _writer.Key("value");
-                _writer.Int64(shard.value());
-                _writer.Key("clock");
-                _writer.Int64(shard.logical_clock());
-                _writer.EndObject();
-            }
-            _writer.EndArray();
-        }
-        void write(const atomic_cell_view& cell, data_type type) {
-            _writer.StartObject();
-            _writer.Key("is_live");
-            _writer.Bool(cell.is_live());
-            _writer.Key("type");
-            if (type->is_counter()) {
-                if (cell.is_counter_update()) {
-                    _writer.String("counter-update");
-                } else {
-                    _writer.String("counter-shards");
-                }
-            } else if (type->is_collection()) {
-                _writer.String("frozen-collection");
-            } else {
-                _writer.String("regular");
-            }
-            _writer.Key("timestamp");
-            _writer.Int64(cell.timestamp());
-            if (type->is_counter()) {
-                _writer.Key("value");
-                if (cell.is_counter_update()) {
-                    _writer.Int64(cell.counter_update_value());
-                } else {
-                    write(counter_cell_view(cell));
-                }
-            } else {
-                if (cell.is_live_and_has_ttl()) {
-                    write(cell.ttl(), cell.expiry());
-                }
-                if (cell.is_live()) {
-                    _writer.Key("value");
-                    _writer.String(type->to_string(cell.value().linearize()));
-                } else {
-                    _writer.Key("deletion_time");
-                    _writer.String(to_string(cell.deletion_time()));
-                }
-            }
-            _writer.EndObject();
-        }
-        void write(const collection_mutation_view_description& mv, data_type type) {
-            _writer.StartObject();
-
-            if (mv.tomb) {
-                _writer.Key("tombstone");
-                write(mv.tomb);
-            }
-
-            _writer.Key("cells");
-
-            std::function<void(size_t, bytes_view)> write_key;
-            std::function<void(size_t, atomic_cell_view)> write_value;
-            if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
-                write_key = [this, t = t->name_comparator()] (size_t, bytes_view k) { _writer.String(t->to_string(k)); };
-                write_value = [this, t = t->value_comparator()] (size_t, atomic_cell_view v) { write(v, t); };
-            } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
-                write_key = [this] (size_t i, bytes_view) { _writer.String(""); };
-                write_value = [this, t] (size_t i, atomic_cell_view v) { write(v, t->type(i)); };
-            }
-
-            if (write_key && write_value) {
-                _writer.StartArray();
-                for (size_t i = 0; i < mv.cells.size(); ++i) {
-                    _writer.StartObject();
-                    _writer.Key("key");
-                    write_key(i, mv.cells[i].first);
-                    _writer.Key("value");
-                    write_value(i, mv.cells[i].second);
-                    _writer.EndObject();
-                }
-                _writer.EndArray();
-            } else {
-                _writer.Null();
-            }
-
-            _writer.EndObject();
-        }
-        void write(const atomic_cell_or_collection& cell, const column_definition& cdef) {
-            if (cdef.is_atomic()) {
-                write(cell.as_atomic_cell(cdef), cdef.type);
-            } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-                cell.as_collection_mutation().with_deserialized(*cdef.type, [&, this] (collection_mutation_view_description mv) {
-                    write(mv, cdef.type);
-                });
-            } else {
-                _writer.Null();
-            }
-        }
-        void write(const row& r, column_kind kind) {
-            _writer.StartObject();
-            r.for_each_cell([this, kind] (column_id id, const atomic_cell_or_collection& cell) {
-                auto cdef = _schema.column_at(kind, id);
-                _writer.Key(cdef.name_as_text());
-                write(cell, cdef);
-            });
-            _writer.EndObject();
-        }
-        void write(const clustering_row& cr) {
-            _writer.StartObject();
-            _writer.Key("type");
-            _writer.String("clustering-row");
-            _writer.Key("key");
-            _writer.DataKey(_schema, cr.key());
-            if (cr.tomb()) {
-                _writer.Key("tombstone");
-                write(cr.tomb().regular());
-                _writer.Key("shadowable_tombstone");
-                write(cr.tomb().shadowable().tomb());
-            }
-            if (!cr.marker().is_missing()) {
-                _writer.Key("marker");
-                write(cr.marker());
-            }
-            _writer.Key("columns");
-            write(cr.cells(), column_kind::regular_column);
-            _writer.EndObject();
-        }
-        void write(const range_tombstone_change& rtc) {
-            _writer.StartObject();
-            _writer.Key("type");
-            _writer.String("range-tombstone-change");
-            const auto pos = rtc.position();
-            if (pos.has_key()) {
-                _writer.Key("key");
-                _writer.DataKey(_schema, pos.key());
-            }
-            _writer.Key("weight");
-            _writer.Int(static_cast<int>(pos.get_bound_weight()));
-            _writer.Key("tombstone");
-            write(rtc.tombstone());
-            _writer.EndObject();
-        }
+        mutation_fragment_json_writer _writer;
     public:
-        explicit json_dumper(const schema& s) : _schema(s) {}
+        explicit json_dumper(const schema& s) : _writer(s) {}
         virtual future<> on_start_of_stream() override {
-            _writer.StartStream();
-            return make_ready_future<>();
+            return _writer.on_start_of_stream();
         }
         virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const sst) override {
-            _writer.SstableKey(sst);
-            _writer.StartArray();
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.on_new_sstable(sst);
         }
         virtual future<stop_iteration> consume(partition_start&& ps) override {
-            const auto& dk = ps.key();
-            _clustering_array_created = false;
-
-            _writer.StartObject();
-
-            _writer.Key("key");
-            _writer.DataKey(_schema, dk.key(), dk.token());
-
-            if (ps.partition_tombstone()) {
-                _writer.Key("tombstone");
-                write(ps.partition_tombstone());
-            }
-
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.consume(std::move(ps));
         }
         virtual future<stop_iteration> consume(static_row&& sr) override {
-            _writer.Key("static_row");
-            write(sr.cells(), column_kind::static_column);
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.consume(std::move(sr));
         }
         virtual future<stop_iteration> consume(clustering_row&& cr) override {
-            if (!_clustering_array_created) {
-                _writer.Key("clustering_elements");
-                _writer.StartArray();
-                _clustering_array_created = true;
-            }
-            write(cr);
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.consume(std::move(cr));
         }
         virtual future<stop_iteration> consume(range_tombstone_change&& rtc) override {
-            if (!_clustering_array_created) {
-                _writer.Key("clustering_elements");
-                _writer.StartArray();
-                _clustering_array_created = true;
-            }
-            write(rtc);
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.consume(std::move(rtc));
         }
         virtual future<stop_iteration> consume(partition_end&& pe) override {
-            if (_clustering_array_created) {
-                _writer.EndArray();
-            }
-            _writer.EndObject();
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.consume(std::move(pe));
         }
         virtual future<stop_iteration> on_end_of_sstable() override {
-            _writer.EndArray();
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            return _writer.on_end_of_sstable();
         }
         virtual future<> on_end_of_stream() override {
-            _writer.EndStream();
-            return make_ready_future<>();
+            return _writer.on_end_of_stream();
         }
     };
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -738,43 +738,6 @@ public:
     }
 };
 
-// scribble here, then call with --operation=custom
-class custom_consumer : public sstable_consumer {
-    schema_ptr _schema;
-    reader_permit _permit;
-public:
-    explicit custom_consumer(schema_ptr s, reader_permit p, const bpo::variables_map&)
-        : _schema(std::move(s)), _permit(std::move(p))
-    { }
-    virtual future<> consume_stream_start() override {
-        return make_ready_future<>();
-    }
-    virtual future<stop_iteration> consume_sstable_start(const sstables::sstable* const sst) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume(partition_start&& ps) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume(static_row&& sr) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume(clustering_row&& cr) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume(range_tombstone_change&& rtc) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume(partition_end&& pe) override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<stop_iteration> consume_sstable_end() override {
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    }
-    virtual future<> consume_stream_end() override {
-        return make_ready_future<>();
-    }
-};
-
 stop_iteration consume_reader(flat_mutation_reader_v2 rd, sstable_consumer& consumer, sstables::sstable* sst, const partition_set& partitions, bool no_skips) {
     auto close_rd = deferred_close(rd);
     if (consumer.consume_sstable_start(sst).get() == stop_iteration::yes) {
@@ -2634,15 +2597,6 @@ following example python script:
 )",
             {"bucket"},
             sstable_consumer_operation<writetime_histogram_collecting_consumer>},
-/* custom */
-    {"custom",
-            "Hackable custom operation for expert users, until scripting support is implemented",
-R"(
-Poor man's scripting support. Aimed at developers as it requires editing C++
-source code and re-building the binary. Will be replaced by proper scripting
-support soon (don't quote me on that).
-)",
-            sstable_consumer_operation<custom_consumer>},
 /* validate */
     {"validate",
             "Validate the sstable(s), same as scrub in validate mode",

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -30,15 +30,14 @@
 #include "types/user.hh"
 #include "types/set.hh"
 #include "types/map.hh"
+#include "tools/json_writer.hh"
 #include "tools/schema_loader.hh"
 #include "tools/utils.hh"
-#include "utils/rjson.hh"
 #include "locator/host_id.hh"
 
-// has to be below the utils/rjson.hh include
-#include <rapidjson/ostreamwrapper.h>
-
 using namespace seastar;
+
+using json_writer = tools::json_writer;
 
 namespace bpo = boost::program_options;
 
@@ -200,73 +199,6 @@ public:
             return make_ready_future<stop_iteration>(stop_iteration::yes);
         }
         return std::move(mf).consume(_consumer);
-    }
-};
-
-class json_writer {
-    using stream = rapidjson::BasicOStreamWrapper<std::ostream>;
-    using writer = rapidjson::Writer<stream, rjson::encoding, rjson::encoding, rjson::allocator>;
-
-    stream _stream;
-    writer _writer;
-
-public:
-    json_writer() : _stream(std::cout), _writer(_stream)
-    { }
-
-    // following the rapidjson method names here
-    bool Null() { return _writer.Null(); }
-    bool Bool(bool b) { return _writer.Bool(b); }
-    bool Int(int i) { return _writer.Int(i); }
-    bool Uint(unsigned i) { return _writer.Uint(i); }
-    bool Int64(int64_t i) { return _writer.Int64(i); }
-    bool Uint64(uint64_t i) { return _writer.Uint64(i); }
-    bool Double(double d) { return _writer.Double(d); }
-    bool RawNumber(std::string_view str) { return _writer.RawNumber(str.data(), str.size(), false); }
-    bool String(std::string_view str) { return _writer.String(str.data(), str.size(), false); }
-    bool StartObject() { return _writer.StartObject(); }
-    bool Key(std::string_view str) { return _writer.Key(str.data(), str.size(), false); }
-    bool EndObject(rapidjson::SizeType memberCount = 0) { return _writer.EndObject(memberCount); }
-    bool StartArray() { return _writer.StartArray(); }
-    bool EndArray(rapidjson::SizeType elementCount = 0) { return _writer.EndArray(elementCount); }
-
-    // scylla-specific extensions (still following rapidjson naming scheme for consistency)
-    template <typename T>
-    void AsString(const T& obj) {
-        String(fmt::format("{}", obj));
-    }
-    // partition or clustering key
-    template <typename KeyType>
-    void DataKey(const schema& schema, const KeyType& key, std::optional<dht::token> token = {}) {
-        StartObject();
-        if (token) {
-            Key("token");
-            AsString(*token);
-        }
-        Key("raw");
-        String(to_hex(key.representation()));
-        Key("value");
-        AsString(key.with_schema(schema));
-        EndObject();
-    }
-    void StartStream() {
-        StartObject();
-        Key("sstables");
-        StartObject();
-    }
-    void EndStream() {
-        EndObject();
-        EndObject();
-    }
-    void SstableKey(const sstables::sstable& sst) {
-        Key(sst.get_filename());
-    }
-    void SstableKey(const sstables::sstable* const sst) {
-        if (sst) {
-            SstableKey(*sst);
-        } else {
-            Key("anonymous");
-        }
     }
 };
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -32,6 +32,7 @@
 #include "types/map.hh"
 #include "tools/json_writer.hh"
 #include "tools/schema_loader.hh"
+#include "tools/sstable_consumer.hh"
 #include "tools/utils.hh"
 #include "locator/host_id.hh"
 
@@ -157,31 +158,6 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
 
     return sstables;
 }
-
-// stop_iteration::no -> continue consuming sstable content
-class sstable_consumer {
-public:
-    virtual ~sstable_consumer() = default;
-    // called at the very start
-    virtual future<> on_start_of_stream() = 0;
-    // stop_iteration::yes -> on_end_of_sstable() - skip sstable content
-    // sstable parameter is nullptr when merging multiple sstables
-    virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const) = 0;
-    // stop_iteration::yes -> consume(partition_end) - skip partition content
-    virtual future<stop_iteration> consume(partition_start&&) = 0;
-    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
-    virtual future<stop_iteration> consume(static_row&&) = 0;
-    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
-    virtual future<stop_iteration> consume(clustering_row&&) = 0;
-    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
-    virtual future<stop_iteration> consume(range_tombstone_change&&) = 0;
-    // stop_iteration::yes -> on_end_of_sstable() - skip remaining partitions in sstable
-    virtual future<stop_iteration> consume(partition_end&&) = 0;
-    // stop_iteration::yes -> full stop - skip remaining sstables
-    virtual future<stop_iteration> on_end_of_sstable() = 0;
-    // called at the very end
-    virtual future<> on_end_of_stream() = 0;
-};
 
 class consumer_wrapper {
 public:

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -423,9 +423,8 @@ $ scylla types {{action}} --help
         {"value", bpo::value<std::vector<sstring>>(), "value(s) to process, can also be provided as positional arguments", -1}
     });
 
-    return app.run(argc, argv, [&app, found_ah] () -> future<> {
-        co_await logalloc::use_standard_allocator_segment_pool_backend(1 * 1024 * 1024);
-
+    return app.run(argc, argv, [&app, found_ah] {
+      return logalloc::use_standard_allocator_segment_pool_backend(1 * 1024 * 1024).then([&app, found_ah] {
         const action_handler& handler = *found_ah;
 
         if (!app.configuration().contains("type")) {
@@ -463,8 +462,7 @@ $ scylla types {{action}} --help
                 handler(std::move(type), app.configuration()["value"].as<std::vector<sstring>>(), app.configuration());
                 break;
         }
-
-        co_return;
+      });
     });
 }
 

--- a/tools/sstable_consumer.hh
+++ b/tools/sstable_consumer.hh
@@ -27,10 +27,10 @@ class sstable_consumer {
 public:
     virtual ~sstable_consumer() = default;
     // called at the very start
-    virtual future<> on_start_of_stream() = 0;
-    // stop_iteration::yes -> on_end_of_sstable() - skip sstable content
+    virtual future<> consume_stream_start() = 0;
+    // stop_iteration::yes -> consume_end_of_sstable() - skip sstable content
     // sstable parameter is nullptr when merging multiple sstables
-    virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const) = 0;
+    virtual future<stop_iteration> consume_sstable_start(const sstables::sstable* const) = 0;
     // stop_iteration::yes -> consume(partition_end) - skip partition content
     virtual future<stop_iteration> consume(partition_start&&) = 0;
     // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
@@ -39,10 +39,10 @@ public:
     virtual future<stop_iteration> consume(clustering_row&&) = 0;
     // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
     virtual future<stop_iteration> consume(range_tombstone_change&&) = 0;
-    // stop_iteration::yes -> on_end_of_sstable() - skip remaining partitions in sstable
+    // stop_iteration::yes -> consume_end_of_sstable() - skip remaining partitions in sstable
     virtual future<stop_iteration> consume(partition_end&&) = 0;
     // stop_iteration::yes -> full stop - skip remaining sstables
-    virtual future<stop_iteration> on_end_of_sstable() = 0;
+    virtual future<stop_iteration> consume_sstable_end() = 0;
     // called at the very end
-    virtual future<> on_end_of_stream() = 0;
+    virtual future<> consume_stream_end() = 0;
 };

--- a/tools/sstable_consumer.hh
+++ b/tools/sstable_consumer.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "seastarx.hh"
+
+#include <seastar/core/loop.hh>
+
+namespace sstables {
+class sstable;
+}
+
+class partition_start;
+class static_row;
+class clustering_row;
+class range_tombstone_change;
+class partition_end;
+
+// stop_iteration::no -> continue consuming sstable content
+class sstable_consumer {
+public:
+    virtual ~sstable_consumer() = default;
+    // called at the very start
+    virtual future<> on_start_of_stream() = 0;
+    // stop_iteration::yes -> on_end_of_sstable() - skip sstable content
+    // sstable parameter is nullptr when merging multiple sstables
+    virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const) = 0;
+    // stop_iteration::yes -> consume(partition_end) - skip partition content
+    virtual future<stop_iteration> consume(partition_start&&) = 0;
+    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
+    virtual future<stop_iteration> consume(static_row&&) = 0;
+    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
+    virtual future<stop_iteration> consume(clustering_row&&) = 0;
+    // stop_iteration::yes -> consume(partition_end) - skip remaining partition content
+    virtual future<stop_iteration> consume(range_tombstone_change&&) = 0;
+    // stop_iteration::yes -> on_end_of_sstable() - skip remaining partitions in sstable
+    virtual future<stop_iteration> consume(partition_end&&) = 0;
+    // stop_iteration::yes -> full stop - skip remaining sstables
+    virtual future<stop_iteration> on_end_of_sstable() = 0;
+    // called at the very end
+    virtual future<> on_end_of_stream() = 0;
+};


### PR DESCRIPTION
Introduce a new "script" operation, which loads a script from the specified path, then feeds the mutation fragment stream to it. The script can then extract, process and present information from the sstable as it wishes.
For now only Lua scripts are supported for the simple reason that Lua is easy to write bindings for, it is simple and lightweight and more importantly we already have Lua included in the Scylla binary as it is used as the implementation language for UDF/UDA. We might consider WASM support in the future, but for now we don't have any language support in WASM available.

Example:
```lua
function new_stats(key)
    return {
        partition_key = key,
        total = 0,
        partition = 0,
        static_row = 0,
        clustering_row = 0,
        range_tombstone_change = 0,
    };
end

total_stats = new_stats(nil);

function inc_stat(stats, field)
    stats[field] = stats[field] + 1;
    stats.total = stats.total + 1;
    total_stats[field] = total_stats[field] + 1;
    total_stats.total = total_stats.total + 1;
end

function on_new_sstable(sst)
    max_partition_stats = new_stats(nil);
    if sst then
        current_sst_filename = sst.filename;
    else
        current_sst_filename = nil;
    end
end

function consume_partition_start(ps)
    current_partition_stats = new_stats(ps.key);
    inc_stat(current_partition_stats, "partition");
end

function consume_static_row(sr)
    inc_stat(current_partition_stats, "static_row");
end

function consume_clustering_row(cr)
    inc_stat(current_partition_stats, "clustering_row");
end

function consume_range_tombstone_change(crt)
    inc_stat(current_partition_stats, "range_tombstone_change");
end

function consume_partition_end()
    if current_partition_stats.total > max_partition_stats.total then
        max_partition_stats = current_partition_stats;
    end
end

function on_end_of_sstable()
    if current_sst_filename then
        print(string.format("Stats for sstable %s:", current_sst_filename));
    else
        print("Stats for stream:");
    end
    print(string.format("\t%d fragments in %d partitions - %d static rows, %d clustering rows and %d range tombstone changes",
        total_stats.total,
        total_stats.partition,
        total_stats.static_row,
        total_stats.clustering_row,
        total_stats.range_tombstone_change));
    print(string.format("\tPartition with max number of fragments (%d): %s - %d static rows, %d clustering rows and %d range tombstone changes",
        max_partition_stats.total,
        max_partition_stats.partition_key,
        max_partition_stats.static_row,
        max_partition_stats.clustering_row,
        max_partition_stats.range_tombstone_change));
end
```
Running this script wilt yield the following:
```
$ scylla sstable script --script-file fragment-stats.lua --system-schema system_schema.columns /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-1-big-Data.db 
Stats for sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f//me-1-big-Data.db:
        397 fragments in 7 partitions - 0 static rows, 362 clustering rows and 28 range tombstone changes
        Partition with max number of fragments (180): system - 0 static rows, 179 clustering rows and 0 range tombstone changes
```

Fixes: https://github.com/scylladb/scylladb/issues/9679