### PR TITLE
alternator: better error message when adding a GSI to an existing table

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1087,7 +1087,6 @@ future<executor::request_return_type> executor::update_table(client_state& clien
     elogger.trace("Updating table {}", request);
 
     static const std::vector<sstring> unsupported = {
-        "AttributeDefinitions", 
         "GlobalSecondaryIndexUpdates", 
         "ProvisionedThroughput",
         "ReplicaUpdates",


### PR DESCRIPTION
Due to issue #11567, Alternator do not yet support adding a GSI to an existing table via UpdateTable with the GlobalSecondaryIndexUpdates parameter.

However, currently, we print a misleading error message in this case, complaining about the AttributeDefinitions parameter. This parameter is also required with GlobalSecondaryIndexUpdates, but it's not the main problem, and the user is likely to be confused why the error message points to that specific paramter and what it means that this parameter is claimed to be "not supported" (while it is supported, in CreateTable). With this patch, we report that GlobalSecondaryIndexUpdates is not supported.

This patch does not fix the unsupported feature - it just improves the error message saying that it's not supported.

Refs #11567

Signed-off-by: Nadav Har'El <nyh@scylladb.com>