### PR TITLE
test.py topology Scylla REST API client

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -9,11 +9,9 @@
    Manages driver refresh when cluster is cycled.
 """
 
-import os.path
 from typing import List, Optional, Callable
 import logging
-import aiohttp                                                             # type: ignore
-import aiohttp.web                                                         # type: ignore
+from test.pylib.rest_client import UnixRESTClient
 from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 
@@ -27,9 +25,6 @@ class ManagerClient():
         sock_path (str): path to an AF_UNIX socket where Manager server is listening
         con_gen (Callable): generator function for CQL driver connection to a cluster
     """
-    # pylint: disable=too-many-instance-attributes
-    conn: aiohttp.UnixConnector
-    session: aiohttp.ClientSession
 
     def __init__(self, sock_path: str, port: int, use_ssl: bool,
                  con_gen: Optional[Callable[[List[str], int, bool], CassandraSession]]) -> None:
@@ -38,18 +33,12 @@ class ManagerClient():
         self.con_gen = con_gen
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
-        # API
-        self.sock_path = sock_path
-        self.sock_name = os.path.basename(sock_path)
-
-    async def start(self):
-        """Setup connection to Manager server"""
-        self.conn = aiohttp.UnixConnector(path=self.sock_path)
-        self.session = aiohttp.ClientSession(connector=self.conn)
+        # A client for communicating with ScyllaClusterManager (server)
+        self.client = UnixRESTClient(sock_path)
 
     async def stop(self):
-        """Close client session and close driver"""
-        await self.session.close()
+        """Close client session and driver"""
+        await self.client.close()
         self.driver_close()
 
     async def driver_connect(self) -> None:
@@ -80,7 +69,7 @@ class ManagerClient():
         dirty = await self.is_dirty()
         if dirty:
             self.driver_close()  # Close driver connection to old cluster
-        resp = await self._get(f"/cluster/before-test/{test_case_name}")
+        resp = await self.client.get(f"/cluster/before-test/{test_case_name}")
         if resp.status != 200:
             raise RuntimeError(f"Failed before test check {await resp.text()}")
         if self.cql is None:
@@ -91,93 +80,75 @@ class ManagerClient():
     async def after_test(self, test_case_name: str) -> None:
         """Tell harness this test finished"""
         logger.debug("after_test for %s", test_case_name)
-        await self._get(f"/cluster/after-test")
-
-    async def _get(self, resource: str) -> aiohttp.ClientResponse:
-        # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html
-        # NOTE: using Python requests style URI for Unix domain sockets to avoid using "localhost"
-        resp = await self.session.get(self._resource_uri(resource))
-        if resp.status != 200:
-            text = await resp.text()
-            raise Exception(f'status code: {resp.status}, body text: {text}')
-        return resp
-
-    async def _get_text(self, resource: str) -> str:
-        resp = await self._get(resource)
-        return await resp.text()
-
-    async def _put_json(self, resource: str, json: dict) -> aiohttp.ClientResponse:
-        return await self.session.request(method='PUT', url=self._resource_uri(resource), json=json)
-
-    def _resource_uri(self, resource: str) -> str:
-        return f"http+unix://{self.sock_name}{resource}"
+        await self.client.get(f"/cluster/after-test")
 
     async def is_manager_up(self) -> bool:
         """Check if Manager server is up"""
-        ret = await self._get_text("/up")
+        ret = await self.client.get_text("/up")
         return ret == "True"
 
     async def is_cluster_up(self) -> bool:
         """Check if cluster is up"""
-        ret = await self._get_text("/cluster/up")
+        ret = await self.client.get_text("/cluster/up")
         return ret == "True"
 
     async def is_dirty(self) -> bool:
         """Check if current cluster dirty."""
-        dirty = await self._get_text("/cluster/is-dirty")
+        dirty = await self.client.get_text("/cluster/is-dirty")
         return dirty == "True"
 
     async def replicas(self) -> int:
         """Get number of configured replicas for the cluster (replication factor)"""
-        resp = await self._get_text("/cluster/replicas")
+        resp = await self.client.get_text("/cluster/replicas")
         return int(resp)
 
     async def servers(self) -> List[str]:
         """Get list of running servers"""
-        host_list = await self._get_text("/cluster/servers")
-        return host_list.split(',')
+        host_list = await self.client.get_text("/cluster/servers")
+        return host_list.split(",")
 
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
-        await self._get_text("/cluster/mark-dirty")
+        await self.client.get_text("/cluster/mark-dirty")
 
     async def server_stop(self, server_id: str) -> None:
         """Stop specified server"""
         logger.debug("ManagerClient stopping %s", server_id)
-        await self._get_text(f"/cluster/server/{server_id}/stop")
+        await self.client.get_text(f"/cluster/server/{server_id}/stop")
 
     async def server_stop_gracefully(self, server_id: str) -> None:
         """Stop specified server gracefully"""
         logger.debug("ManagerClient stopping gracefully %s", server_id)
-        await self._get_text(f"/cluster/server/{server_id}/stop_gracefully")
+        await self.client.get_text(f"/cluster/server/{server_id}/stop_gracefully")
 
     async def server_start(self, server_id: str) -> None:
         """Start specified server"""
         logger.debug("ManagerClient starting %s", server_id)
-        await self._get_text(f"/cluster/server/{server_id}/start")
+        await self.client.get_text(f"/cluster/server/{server_id}/start")
         self._driver_update()
 
     async def server_restart(self, server_id: str) -> None:
         """Restart specified server"""
         logger.debug("ManagerClient restarting %s", server_id)
-        await self._get_text(f"/cluster/server/{server_id}/restart")
+        await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
     async def server_add(self) -> str:
         """Add a new server"""
-        server_id = await self._get_text("/cluster/addserver")
+        server_id = await self.client.get_text("/cluster/addserver")
         self._driver_update()
         logger.debug("ManagerClient added %s", server_id)
         return server_id
 
     async def server_get_config(self, server_id: str) -> dict[str, object]:
-        resp = await self._get(f"/cluster/server/{server_id}/get_config")
+        resp = await self.client.get(f"/cluster/server/{server_id}/get_config")
         if resp.status != 200:
             raise Exception(await resp.text())
         return await resp.json()
 
     async def server_update_config(self, server_id: str, key: str, value: object) -> None:
-        resp = await self._put_json(f"/cluster/server/{server_id}/update_config", {'key': key, 'value': value})
+        resp = await self.client.put_json(f"/cluster/server/{server_id}/update_config",
+                                       {"key": key, "value": value})
         if resp.status != 200:
             raise Exception(await resp.text())

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -31,10 +31,10 @@ class ManagerClient():
     conn: aiohttp.UnixConnector
     session: aiohttp.ClientSession
 
-    def __init__(self, sock_path: str, port: int, ssl: bool,
+    def __init__(self, sock_path: str, port: int, use_ssl: bool,
                  con_gen: Optional[Callable[[List[str], int, bool], CassandraSession]]) -> None:
         self.port = port
-        self.ssl = ssl
+        self.use_ssl = use_ssl
         self.con_gen = con_gen
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
@@ -57,7 +57,7 @@ class ManagerClient():
         if self.con_gen is not None:
             servers = await self.servers()
             logger.debug("driver connecting to %s", servers)
-            self.ccluster = self.con_gen(servers, self.port, self.ssl)
+            self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
             self.cql = self.ccluster.connect()
 
     def driver_close(self) -> None:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -171,12 +171,6 @@ class ManagerClient():
         logger.debug("ManagerClient added %s", server_id)
         return server_id
 
-    async def server_remove(self, server_id: str) -> None:
-        """Remove a specified server"""
-        logger.debug("ManagerClient removing %s", server_id)
-        await self._get_text(f"/cluster/removeserver/{server_id}")
-        self._driver_update()
-
     async def server_get_config(self, server_id: str) -> dict[str, object]:
         resp = await self._get(f"/cluster/server/{server_id}/get_config")
         if resp.status != 200:

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -38,6 +38,7 @@ import uuid
 from typing import Optional, Type, List, Set, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from cassandra.cluster import Session as CassandraSession            # type: ignore
+    from test.pylib.manager_client import ManagerClient
 
 
 logger = logging.getLogger('random_tables')
@@ -115,13 +116,13 @@ class RandomTable():
     # Sequential unique id
     newid = itertools.count(start=1).__next__
 
-    def __init__(self, cql: CassandraSession, keyspace: str, ncolumns: Optional[int]=None,
+    def __init__(self, manager: ManagerClient, keyspace: str, ncolumns: Optional[int]=None,
                  columns: Optional[List[Column]]=None, pks: int=2, name: str=None):
         """Set up a new table definition from column definitions.
            If column definitions not specified pick a random number of columns with random types.
            By default there will be 4 columns with first column as Primary Key"""
         self.id: int = RandomTable.newid()
-        self.cql: CassandraSession = cql
+        self.manager: ManagerClient = manager
         self.keyspace: str = keyspace
         self.name: str = name if name is not None else f"t_{self.id:02}"
         self.full_name: str = keyspace + "." + self.name
@@ -160,13 +161,15 @@ class RandomTable():
         pk_names = ", ".join(c.name for c in self.columns[:self.pks])
         cql_stmt = f"CREATE TABLE {self.full_name} ({col_defs}, , primary key({pk_names}))"
         logger.debug(cql_stmt)
-        return await self.cql.run_async(cql_stmt)
+        assert self.manager.cql is not None
+        return await self.manager.cql.run_async(cql_stmt)
 
     async def drop(self) -> asyncio.Future:
         """Drop this table"""
         cql_stmt = f"DROP TABLE {self.full_name}"
         logger.debug(cql_stmt)
-        return await self.cql.run_async(cql_stmt)
+        assert self.manager.cql is not None
+        return await self.manager.cql.run_async(cql_stmt)
 
     async def add_column(self, name: str = None, ctype: Type[ValueType] = None, column: Column = None):
         if column is not None:
@@ -176,7 +179,9 @@ class RandomTable():
             ctype = ctype if ctype is not None else TextType
             column = Column(name, ctype=ctype)
         self.columns.append(column)
-        await self.cql.run_async(f"ALTER TABLE {self.full_name} ADD {column.name} {column.ctype.name}")
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"ALTER TABLE {self.full_name} "
+                                         f"ADD {column.name} {column.ctype.name}")
 
     async def drop_column(self, column: Union[Column, str] = None):
         if column is None:
@@ -196,14 +201,16 @@ class RandomTable():
         assert len(self.columns) - 1 > self.pks, f"Cannot remove last value column {col.name} from {self.name}"
         self.columns.remove(col)
         self.removed_columns.append(col)
-        await self.cql.run_async(f"ALTER TABLE {self.full_name} DROP {col.name}")
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"ALTER TABLE {self.full_name} DROP {col.name}")
 
     async def insert_seq(self) -> asyncio.Future:
         """Insert a row of next sequential values"""
         seed = self.next_seq()
-        return await self.cql.run_async(f"INSERT INTO {self.full_name} ({self.all_col_names}) " +
-                                        f"VALUES ({', '.join(['%s'] * len(self.columns)) })",
-                                        parameters=[c.val(seed) for c in self.columns])
+        assert self.manager.cql is not None
+        return await self.manager.cql.run_async(f"INSERT INTO {self.full_name} ({self.all_col_names})"
+                                                f"VALUES ({', '.join(['%s'] * len(self.columns)) })",
+                                                parameters=[c.val(seed) for c in self.columns])
 
     async def add_index(self, column: Union[Column, str], name: str = None) -> str:
         if isinstance(column, int):
@@ -219,13 +226,15 @@ class RandomTable():
             raise TypeError(f"Wrong column type {type(column)} given to add_column")
 
         name = name if name is not None else f"{self.name}_{col_name}_{self.next_idx_id():02}"
-        await self.cql.run_async(f"CREATE INDEX {name} on {self.full_name} ({col_name})")
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"CREATE INDEX {name} on {self.full_name} ({col_name})")
         self.indexes.add(name)
         return name
 
     async def drop_index(self, name: str) -> None:
         self.indexes.remove(name)
-        await self.cql.run_async(f"DROP INDEX {self.keyspace}.{name}")
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"DROP INDEX {self.keyspace}.{name}")
         self.removed_indexes.add(name)
 
     def __str__(self):
@@ -234,30 +243,28 @@ class RandomTable():
 
 class RandomTables():
     """A list of managed random tables"""
-    def __init__(self, test_name: str, cql: CassandraSession, keyspace: str):
+    def __init__(self, test_name: str, manager: ManagerClient, keyspace: str):
         self.test_name = test_name
-        self.cql = cql
+        self.manager = manager
         self.keyspace = keyspace
         self.tables: List[RandomTable] = []
         self.removed_tables: List[RandomTable] = []
-        cql.execute(f"CREATE KEYSPACE {keyspace} WITH REPLICATION = "
-                     "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
-
-    def set_cql(self, cql: CassandraSession) -> None:
-        self.cql = cql
+        assert self.manager.cql is not None
+        self.manager.cql.execute(f"CREATE KEYSPACE {keyspace} WITH REPLICATION = "
+                                 "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
 
     async def add_tables(self, ntables: int = 1, ncolumns: int = 5) -> None:
         """Add random tables to the list.
         ntables specifies how many tables.
         ncolumns specifies how many random columns per table."""
-        tables = [RandomTable(self.cql, self.keyspace, ncolumns) for _ in range(ntables)]
+        tables = [RandomTable(self.manager, self.keyspace, ncolumns) for _ in range(ntables)]
         await asyncio.gather(*(t.create() for t in tables))
         self.tables.extend(tables)
 
     async def add_table(self, ncolumns: int = None, columns: List[Column] = None,
                         pks: int = 2, name: str = None) -> RandomTable:
         """Add a random table. See random_tables.RandomTable()"""
-        table = RandomTable(self.cql, self.keyspace, ncolumns=ncolumns, columns=columns,
+        table = RandomTable(self.manager, self.keyspace, ncolumns=ncolumns, columns=columns,
                             pks=pks, name=name)
         await table.create()
         self.tables.append(table)
@@ -285,7 +292,8 @@ class RandomTables():
 
     def drop_all(self) -> None:
         """Drop keyspace (and tables)"""
-        self.cql.execute(f"DROP KEYSPACE {self.keyspace}")
+        assert self.manager.cql is not None
+        self.manager.cql.execute(f"DROP KEYSPACE {self.keyspace}")
 
     async def verify_schema(self, table: Union[RandomTable, str] = None) -> None:
         """Verify schema of all active managed random tables"""
@@ -305,7 +313,8 @@ class RandomTables():
                         f"WHERE keyspace_name = '{self.keyspace}'"
 
         logger.debug(cql_stmt1)
-        res1 = {row.table_name for row in await self.cql.run_async(cql_stmt1)}
+        assert self.manager.cql is not None
+        res1 = {row.table_name for row in await self.manager.cql.run_async(cql_stmt1)}
         assert not tables - res1, f"Tables {tables - res1} not present"
 
         for table_name in tables:
@@ -315,7 +324,8 @@ class RandomTables():
             cql_stmt2 = f"SELECT column_name, position, kind, type FROM system_schema.columns " \
                         f"WHERE keyspace_name = '{self.keyspace}' AND table_name = '{table_name}'"
             logger.debug(cql_stmt2)
-            res2 = {row.column_name: row for row in await self.cql.run_async(cql_stmt2)}
+            assert self.manager.cql is not None
+            res2 = {row.column_name: row for row in await self.manager.cql.run_async(cql_stmt2)}
             assert res2.keys() == cols.keys(), f"Column names for {table_name} do not match " \
                                                f"expected ({', '.join(cols.keys())}) " \
                                                f"got ({', '.join(res2.keys())})"

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""Asynchronous helper for Scylla REST API operations.
+"""
+import os.path
+from typing import Optional
+import aiohttp
+
+
+class RESTSession:
+    def __init__(self, connector: aiohttp.BaseConnector = None):
+        self.session: aiohttp.ClientSession = aiohttp.ClientSession(connector = connector)
+
+    async def close(self) -> None:
+        """End session"""
+        await self.session.close()
+
+    async def get(self, resource_uri: str) -> aiohttp.ClientResponse:
+        """Fetch remote resource or raise"""
+        # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html
+        resp = await self.session.get(resource_uri)
+        if resp.status != 200:
+            text = await resp.text()
+            raise RuntimeError(f"status code: {resp.status}, body text: {text}")
+        return resp
+
+    async def get_text(self, resource_uri: str) -> str:
+        """Fetch remote resource text response or raise"""
+        resp = await self.get(resource_uri)
+        return await resp.text()
+
+    async def post(self, resource_uri: str, params: Optional[dict[str, str]]) \
+            -> aiohttp.ClientResponse:
+        """Post to remote resource or raise"""
+        resp = await self.session.post(resource_uri, params=params)
+        if resp.status != 200:
+            text = await resp.text()
+            raise RuntimeError(f"status code: {resp.status}, body text: {text}, "
+                               f"resource {resource_uri} params {params}")
+        return resp
+
+    async def put_json(self, resource_uri: str, json: dict) \
+            -> aiohttp.ClientResponse:
+        """Put JSON"""
+        return await self.session.request(method="PUT", url=resource_uri, json=json)
+
+
+class UnixRESTClient:
+    """An async helper for REST API operations using AF_UNIX socket"""
+
+    def __init__(self, sock_path: str):
+        self.sock_name: str = os.path.basename(sock_path)
+        self.session = RESTSession(aiohttp.UnixConnector(path=sock_path))
+
+    async def close(self) -> None:
+        """End session"""
+        await self.session.close()
+
+    async def get(self, resource: str) -> aiohttp.ClientResponse:
+        return await self.session.get(self._resource_uri(resource))
+
+    async def put_json(self, resource: str, json: dict) -> aiohttp.ClientResponse:
+        """Put JSON"""
+        return await self.session.put_json(self._resource_uri(resource), json=json)
+
+    async def get_text(self, resource: str) -> str:
+        """Fetch remote resource text response or raise"""
+        return await self.session.get_text(self._resource_uri(resource))
+
+    async def post(self, resource: str, params: Optional[dict[str, str]] = None) \
+            -> aiohttp.ClientResponse:
+        """Post to remote resource or raise"""
+        return await self.session.post(self._resource_uri(resource), params)
+
+    def _resource_uri(self, resource: str) -> str:
+        # NOTE: using Python requests style URI for Unix domain sockets to avoid using "localhost"
+        #       host parameter is ignored
+        return f"http+unix://{self.sock_name}{resource}"
+
+
+class TCPRESTClient:
+    """An async helper for REST API operations"""
+
+    def __init__(self, port: int):
+        self.port: int = port
+        self.session = RESTSession()
+
+    async def close(self) -> None:
+        """End session"""
+        await self.session.close()
+
+    async def get(self, resource: str, host: str) -> aiohttp.ClientResponse:
+        return await self.session.get(self._resource_uri(resource, host))
+
+    async def put_json(self, resource: str, host: str, json: dict) -> aiohttp.ClientResponse:
+        """Put JSON"""
+        return await self.session.put_json(self._resource_uri(resource, host), json=json)
+
+    async def get_text(self, resource: str, host: str) -> str:
+        """Fetch remote resource text response or raise"""
+        return await self.session.get_text(self._resource_uri(resource, host))
+
+    async def post(self, resource: str, host: str, params: Optional[dict[str, str]] = None) \
+            -> aiohttp.ClientResponse:
+        """Post to remote resource or raise"""
+        return await self.session.post(self._resource_uri(resource, host), params)
+
+    def _resource_uri(self, resource: str, host: str) -> str:
+        return f"http://{host}:{self.port}{resource}"

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -643,10 +643,6 @@ class ScyllaCluster:
             return ret
         return await self.server_start(server_id)
 
-    async def server_remove(self, server_id: str) -> ActionReturn:
-        """Remove a specified server"""
-        raise NotImplementedError
-
     def get_config(self, server_id: str) -> ActionReturn:
         """Get conf/scylla.yaml of the given server as a dictionary.
            Fails if the server cannot be found."""
@@ -757,7 +753,6 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/server/{id}/start', self._cluster_server_start)
         self.app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
         self.app.router.add_get('/cluster/addserver', self._cluster_server_add)
-        self.app.router.add_get('/cluster/removeserver/{id}', self._cluster_server_remove)
         self.app.router.add_get('/cluster/server/{id}/get_config', self._server_get_config)
         self.app.router.add_put('/cluster/server/{id}/update_config', self._server_update_config)
 
@@ -839,14 +834,6 @@ class ScyllaClusterManager:
         assert self.cluster
         server_id = await self.cluster.add_server()
         return aiohttp.web.Response(text=server_id)
-
-    async def _cluster_server_remove(self, _request) -> aiohttp.web.Response:
-        """Remove a specified server"""
-        assert self.cluster
-        server_id = _request.match_info['id']
-        if not await self.cluster.server_remove(server_id):
-            return aiohttp.web.Response(status=500, text=f"Host {server_id} not found")
-        return aiohttp.web.Response(text="OK")
 
     async def _server_get_config(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
         """Get conf/scylla.yaml of the given server as a dictionary."""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -21,6 +21,7 @@ from typing import Optional, Dict, List, Set, Callable, AsyncIterator, NamedTupl
 import uuid
 from io import BufferedWriter
 from test.pylib.pool import Pool
+from test.pylib.rest_client import ScyllaRESTAPIClient
 import aiohttp
 import aiohttp.web
 import yaml
@@ -469,8 +470,13 @@ class ScyllaCluster:
         self.name = str(uuid.uuid1())
         self.replicas = replicas
         self.create_server = create_server
-        self.running: Dict[str, ScyllaServer] = {}  # started servers
-        self.stopped: Dict[str, ScyllaServer] = {}  # servers no longer running but present
+        # Every ScyllaServer is in one of self.running, self.stopped, self.decommissioned.
+        # These dicts are disjoint.
+        # A server ID present in self.removed may be either in self.running or in self.stopped.
+        self.running: Dict[str, ScyllaServer] = {}        # started servers
+        self.stopped: Dict[str, ScyllaServer] = {}        # servers no longer running but present
+        self.decommissioned: Dict[str, ScyllaServer] = {} # decommissioned servers
+        self.removed: Set[str] = set()                    # removed servers (might be running)
         # cluster is started (but it might not have running servers)
         self.is_running: bool = False
         # cluster was modified in a way it should not be used in subsequent tests
@@ -570,10 +576,15 @@ class ScyllaCluster:
         stopped = f"{{{', '.join(str(c) for c in self.stopped)}}}"
         return f"ScyllaCluster(name: {self.name}, running: {running}, stopped: {stopped})"
 
+    def running_servers(self) -> List[str]:
+        return list(set(self.running.keys()) - self.removed)
+
     def _get_keyspace_count(self) -> int:
         """Get the current keyspace count"""
         assert self.start_exception is None
+        assert self.running, "No active nodes left"
         server = next(iter(self.running.values()))
+        logging.debug("_get_keyspace_count() using server %s", server)
         assert server.control_connection is not None
         rows = server.control_connection.execute(
                "select count(*) as c from system_schema.keyspaces")
@@ -618,6 +629,17 @@ class ScyllaCluster:
             await server.stop()
         self.stopped[server_ip] = server
         return ScyllaCluster.ActionReturn(success=True, msg=f"Server {server_ip} stopped")
+
+    def server_mark_decommissioned(self, server_ip: str) -> None:
+        """Mark a stopped server as decommissioned"""
+        assert server_ip in self.stopped, "Server must be stopped when marking as decommissioned"""
+        logging.debug("Cluster %s marking server %s as decommissioned", self, server_ip)
+        self.decommissioned[server_ip] = self.stopped.pop(server_ip)
+
+    def server_mark_removed(self, server_ip: str) -> None:
+        """Mark server as removed."""
+        logging.debug("Cluster %s marking server %s as removed", self, server_ip)
+        self.removed.add(server_ip)
 
     async def server_start(self, server_ip: str) -> ActionReturn:
         """Start a stopped server"""
@@ -693,6 +715,7 @@ class ScyllaClusterManager:
         self.app = aiohttp.web.Application()
         self._setup_routes()
         self.runner = aiohttp.web.AppRunner(self.app)
+        self.api = ScyllaRESTAPIClient()
 
     async def start(self) -> None:
         """Get first cluster, setup API"""
@@ -720,6 +743,7 @@ class ScyllaClusterManager:
         """Stop, cycle last cluster if not dirty and present"""
         logging.info("ScyllaManager stopping for test %s", self.test_uname)
         await self.site.stop()
+        await self.api.close()
         if not self.cluster.is_dirty:
             logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
             await self.clusters.put(self.cluster)
@@ -743,7 +767,7 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/up', self._cluster_up)
         self.app.router.add_get('/cluster/is-dirty', self._is_dirty)
         self.app.router.add_get('/cluster/replicas', self._cluster_replicas)
-        self.app.router.add_get('/cluster/servers', self._cluster_servers)
+        self.app.router.add_get('/cluster/running-servers', self._cluster_running_servers)
         self.app.router.add_get('/cluster/before-test/{test_case_name}', self._before_test_req)
         self.app.router.add_get('/cluster/after-test', self._after_test)
         self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
@@ -753,6 +777,10 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/server/{id}/start', self._cluster_server_start)
         self.app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
         self.app.router.add_get('/cluster/addserver', self._cluster_server_add)
+        # TODO: only pass UUID
+        self.app.router.add_get('/cluster/remove-node/{initiator}/{ip}/{uuid}',
+                                self._cluster_remove_node)
+        self.app.router.add_get('/cluster/decommission-node/{ip}', self._cluster_decommission_node)
         self.app.router.add_get('/cluster/server/{id}/get_config', self._server_get_config)
         self.app.router.add_put('/cluster/server/{id}/update_config', self._server_update_config)
 
@@ -775,9 +803,9 @@ class ScyllaClusterManager:
             return aiohttp.web.Response(status=500, text="No cluster active")
         return aiohttp.web.Response(text=f"{self.cluster.replicas}")
 
-    async def _cluster_servers(self, _request) -> aiohttp.web.Response:
-        """Return a list of active server ids (IPs)"""
-        return aiohttp.web.Response(text=f"{','.join(sorted(self.cluster.running))}")
+    async def _cluster_running_servers(self, _request) -> aiohttp.web.Response:
+        """Return a list of running server ids (IPs)"""
+        return aiohttp.web.Response(text=f"{','.join(sorted(self.cluster.running_servers()))}")
 
     async def _before_test_req(self, _request) -> aiohttp.web.Response:
         await self._before_test(_request.match_info['test_case_name'])
@@ -834,6 +862,52 @@ class ScyllaClusterManager:
         assert self.cluster
         server_ip = await self.cluster.add_server()
         return aiohttp.web.Response(text=server_ip)
+
+    async def _cluster_remove_node(self, _request) -> aiohttp.web.Response:
+        """Run remove node on Scylla REST API for a specified server"""
+        assert self.cluster
+        # TODO: only pass UUID
+        initiator_ip = _request.match_info["initiator"]
+        to_remove_ip = _request.match_info["ip"]
+        host_id = _request.match_info["uuid"]
+        if to_remove_ip in self.cluster.running:
+            logging.warning("_cluster_remove_node %s is a running node", to_remove_ip)
+        logging.info("_cluster_remove_node initiator %s server %s %s", initiator_ip,
+                     to_remove_ip, host_id)
+
+        # initate remove
+        try:
+            await self.api.remove_node(initiator_ip, host_id)
+        except RuntimeError as exc:
+            logging.error("_cluster_remove_node initiator %s server %s %s, check log at %s",
+                          initiator_ip, to_remove_ip, host_id,
+                          self.cluster.running[initiator_ip].log_filename)
+            return aiohttp.web.Response(status=500,
+                                        text=f"Error removing {to_remove_ip} {host_id} {exc}")
+        self.cluster.server_mark_removed(to_remove_ip)
+        return aiohttp.web.Response(text="OK")
+
+    async def _cluster_decommission_node(self, _request) -> aiohttp.web.Response:
+        """Run remove node on Scylla REST API for a specified server"""
+        assert self.cluster
+        to_decommission_ip = _request.match_info["ip"]
+        logging.info("_cluster_decommission_node %s", to_decommission_ip)
+        assert to_decommission_ip in self.cluster.running, "Can't decommission not running node"
+        if len(self.cluster.running) == 1:
+            logging.warning("_cluster_decommission_node %s is only running node left",
+                            to_decommission_ip)
+
+        # initate decommission
+        try:
+            await self.api.decommission_node(to_decommission_ip)
+        except RuntimeError as exc:
+            logging.error("_cluster_decommission_node %s, check log at %s", to_decommission_ip,
+                          self.cluster.running[to_decommission_ip].log_filename)
+            return aiohttp.web.Response(status=500,
+                                        text=f"Error decommissioning {to_decommission_ip}: {exc}")
+        await self.cluster.server_stop(to_decommission_ip, gracefully=True)
+        self.cluster.server_mark_decommissioned(to_decommission_ip)
+        return aiohttp.web.Response(text="OK")
 
     async def _server_get_config(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
         """Get conf/scylla.yaml of the given server as a dictionary."""

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -150,7 +150,6 @@ async def manager_internal(event_loop, request):
     port = int(request.config.getoption('port'))
     ssl = bool(request.config.getoption('ssl'))
     manager_int = ManagerClient(request.config.getoption('manager_api'), port, ssl, cluster_con)
-    await manager_int.start()
     yield manager_int
     await manager_int.stop()  # Stop client session and close driver after last test
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -176,13 +176,15 @@ def cql(manager):
 # These tests should use the "fails_without_raft" fixture. When Raft mode
 # becomes the default, this fixture can be removed.
 @pytest.fixture(scope="function")
-def check_pre_raft(cql):
+def check_pre_raft(manager):
     # If not running on Scylla, return false.
-    names = [row.table_name for row in cql.execute("SELECT * FROM system_schema.tables WHERE keyspace_name = 'system'")]
+    names = [row.table_name for row in manager.cql.execute(
+            "SELECT * FROM system_schema.tables WHERE keyspace_name = 'system'")]
     if not any('scylla' in name for name in names):
         return False
     # In Scylla, we check Raft mode by inspecting the configuration via CQL.
-    experimental_features = list(cql.execute("SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
+    experimental_features = list(manager.cql.execute(
+            "SELECT value FROM system.config WHERE name = 'experimental_features'"))[0].value
     return not '"raft"' in experimental_features
 
 
@@ -195,7 +197,7 @@ def fails_without_raft(request, check_pre_raft):
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
 # used in tests to make schema changes. Tables are dropped after finished.
 @pytest.fixture(scope="function")
-def random_tables(request, cql):
-    tables = RandomTables(request.node.name, cql, unique_name())
+def random_tables(request, manager):
+    tables = RandomTables(request.node.name, manager, unique_name())
     yield tables
     tables.drop_all()

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -9,7 +9,9 @@ from cassandra.protocol import InvalidRequest                            # type:
 
 # Simple test of schema helper
 @pytest.mark.asyncio
-async def test_new_table(cql, random_tables):
+async def test_new_table(manager, random_tables):
+    cql = manager.cql
+    assert cql is not None
     table = await random_tables.add_table(ncolumns=5)
     await cql.run_async(f"INSERT INTO {table} ({','.join(c.name for c in table.columns)})" \
                         f"VALUES ({', '.join(['%s'] * len(table.columns))})",
@@ -29,8 +31,10 @@ async def test_new_table(cql, random_tables):
 
 # Simple test of schema helper with alter
 @pytest.mark.asyncio
-async def test_alter_verify_schema(cql, random_tables):
+async def test_alter_verify_schema(manager, random_tables):
     """Verify table schema"""
+    cql = manager.cql
+    assert cql is not None
     await random_tables.add_tables(ntables=4, ncolumns=5)
     await random_tables.verify_schema()
     # Manually remove a column
@@ -41,7 +45,9 @@ async def test_alter_verify_schema(cql, random_tables):
 
 
 @pytest.mark.asyncio
-async def test_new_table_insert_one(cql, random_tables):
+async def test_new_table_insert_one(manager, random_tables):
+    cql = manager.cql
+    assert cql is not None
     table = await random_tables.add_table(ncolumns=5)
     await table.insert_seq()
     pk_col = table.columns[0]
@@ -54,8 +60,10 @@ async def test_new_table_insert_one(cql, random_tables):
 
 
 @pytest.mark.asyncio
-async def test_drop_column(cql, random_tables):
+async def test_drop_column(manager, random_tables):
     """Drop a random column from a table"""
+    cql = manager.cql
+    assert cql is not None
     table = await random_tables.add_table(ncolumns=5)
     await table.insert_seq()
     await table.drop_column()
@@ -70,7 +78,7 @@ async def test_drop_column(cql, random_tables):
 
 
 @pytest.mark.asyncio
-async def test_add_index(cql, random_tables):
+async def test_add_index(random_tables):
     """Add and drop an index"""
     table = await random_tables.add_table(ncolumns=5)
     with pytest.raises(AssertionError, match='partition key'):

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -21,7 +21,7 @@ async def test_add_server_add_column(manager, random_tables):
 @pytest.mark.asyncio
 async def test_stop_server_add_column(manager, random_tables):
     """Add a node, stop an original node, add a column"""
-    servers = await manager.servers()
+    servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
     await manager.server_add()
     await manager.server_stop(servers[1])
@@ -32,8 +32,32 @@ async def test_stop_server_add_column(manager, random_tables):
 @pytest.mark.asyncio
 async def test_restart_server_add_column(manager, random_tables):
     """Add a node, stop an original node, add a column"""
-    servers = await manager.servers()
+    servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
     ret = await manager.server_restart(servers[1])
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_remove_node_add_column(manager, random_tables):
+    """Add a node, remove an original node, add a column"""
+    servers = await manager.running_servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    server_uuid = await manager.get_host_id(servers[1])              # get uuid [1]
+    await manager.server_stop_gracefully(servers[1])                 # stop     [1]
+    await manager.remove_node(servers[0], servers[1], server_uuid)   # Remove   [1]
+    await table.add_column()
+    await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+async def test_decommission_node_add_column(manager, random_tables):
+    """Add a node, remove an original node, add a column"""
+    servers = await manager.running_servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_add()
+    await manager.decommission_node(servers[1])             # Decommission [1]
     await table.add_column()
     await random_tables.verify_schema()

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -17,7 +17,7 @@ from test.pylib.random_tables import RandomTables
 @pytest.mark.asyncio
 async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):
     start = time.time()
-    servers = await manager.servers()
+    servers = await manager.running_servers()
 
     cql = manager.cql
     assert(cql)

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -50,8 +50,6 @@ async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomT
     manager.driver_close()
     await manager.driver_connect()
     cql = manager.cql
-    assert(cql)
-    random_tables.set_cql(cql)
 
     deadline = time.time() + 300
     # Using `servers` doesn't work for the `host` parameter in `cql.run_async` (we need objects of type `Host`).


### PR DESCRIPTION

- Separate `aiohttp` client code
- Helper to access Scylla server REST API
- Use helper both in `ScyllaClusterManager` (test.py process) and `ManagerClient` (pytest process)

As `ScyllaCluster` manages through IPs some APIs require to specify both.