### PR TITLE
Reduce dependencies on large data handler header

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -14,7 +14,7 @@
 #include "sstables/metadata_collector.hh"
 #include "utils/estimated_histogram.hh"
 #include <algorithm>
-#include "db/system_keyspace_view_types.hh"
+#include "db/system_keyspace.hh"
 #include "db/data_listeners.hh"
 #include "storage_service.hh"
 #include "unimplemented.hh"

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -17,6 +17,7 @@
 #include "db/config.hh"
 #include "atomic_cell.hh"
 #include "utils/exceptions.hh"
+#include "db/large_data_handler.hh"
 
 #include <functional>
 #include <boost/iterator/iterator_facade.hpp>

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -39,7 +39,6 @@
 #include "db/commitlog/replay_position.hh"
 #include "component_type.hh"
 #include "sstable_version.hh"
-#include "db/large_data_handler.hh"
 #include "column_translation.hh"
 #include "stats.hh"
 #include "utils/observable.hh"
@@ -56,6 +55,10 @@
 
 class sstable_assertions;
 class cached_file;
+
+namespace db {
+class large_data_handler;
+}
 
 namespace sstables {
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -41,6 +41,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/exception_utils.hh"
 #include "db/config.hh"
+#include "db/large_data_handler.hh"
 #include "readers/combined.hh"
 
 #include <boost/range/algorithm/sort.hpp>

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -43,10 +43,7 @@ class test_env {
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
 
-        impl()
-            : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
-            , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
-        { }
+        impl();
         impl(impl&&) = delete;
         impl(const impl&) = delete;
     };

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -9,6 +9,7 @@
 #include "test/lib/test_services.hh"
 #include "test/lib/sstable_test_env.hh"
 #include "db/config.hh"
+#include "db/large_data_handler.hh"
 #include "dht/i_partitioner.hh"
 #include "gms/feature_service.hh"
 #include "repair/row_level.hh"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -7,6 +7,7 @@
  */
 
 #include "test/lib/test_services.hh"
+#include "test/lib/sstable_test_env.hh"
 #include "db/config.hh"
 #include "dht/i_partitioner.hh"
 #include "gms/feature_service.hh"
@@ -60,4 +61,13 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     _data->cm.enable();
     _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, replica::column_family::no_commitlog(), _data->cm, sstables_manager, _data->cl_stats, _data->tracker);
     _data->cf->mark_ready_for_writes();
+}
+
+namespace sstables {
+
+test_env::impl::impl()
+    : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
+    , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
+{ }
+
 }

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -31,10 +31,8 @@
 #include "replica/database.hh"
 #include "cell_locking.hh"
 #include "compaction/compaction_manager.hh"
-#include "db/large_data_handler.hh"
 #include "sstables/sstables_manager.hh"
 
-extern db::nop_large_data_handler nop_lp_handler;
 extern db::config test_db_config;
 extern gms::feature_service test_feature_service;
 


### PR DESCRIPTION
Reduce the false dependencies on db/large_data_handler.hh by
not including it from commonly used header files, and rather including
it only in the source files that actually need it.

The is in preparation for https://github.com/scylladb/scylladb/issues/11449