### PR TITLE
test/pylib: scylla_cluster: mark `server_remove` as not implemented

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -471,7 +471,6 @@ class ScyllaCluster:
         self.create_server = create_server
         self.running: Dict[str, ScyllaServer] = {}  # started servers
         self.stopped: Dict[str, ScyllaServer] = {}  # servers no longer running but present
-        self.removed: Set[str] = set()              # servers stopped and uninstalled (can't return)
         # cluster is started (but it might not have running servers)
         self.is_running: bool = False
         # cluster was modified in a way it should not be used in subsequent tests
@@ -606,8 +605,6 @@ class ScyllaCluster:
         if server_id in self.stopped:
             return ScyllaCluster.ActionReturn(success=True,
                                               msg=f"Server {server_id} already stopped")
-        if server_id in self.removed:
-            return ScyllaCluster.ActionReturn(success=False, msg=f"Server {server_id} removed")
         if server_id not in self.running:
             return ScyllaCluster.ActionReturn(success=False, msg=f"Server {server_id} unknown")
         self.is_dirty = True
@@ -625,8 +622,6 @@ class ScyllaCluster:
         if server_id in self.running:
             return ScyllaCluster.ActionReturn(success=True,
                                               msg=f"Server {server_id} already started")
-        if server_id in self.removed:
-            return ScyllaCluster.ActionReturn(success=False, msg=f"Server {server_id} removed")
         if server_id not in self.stopped:
             return ScyllaCluster.ActionReturn(success=False, msg=f"Server {server_id} unknown")
         self.is_dirty = True
@@ -647,18 +642,7 @@ class ScyllaCluster:
 
     async def server_remove(self, server_id: str) -> ActionReturn:
         """Remove a specified server"""
-        self.is_dirty = True
-        logging.info("Cluster %s removing server %s", self, server_id)
-        if server_id in self.running:
-            server = self.running.pop(server_id)
-            await server.stop_gracefully()
-        elif server_id in self.stopped:
-            server = self.stopped.pop(server_id)
-        else:
-            return ScyllaCluster.ActionReturn(success=False, msg=f"Server {server_id} unknown")
-        await server.uninstall()
-        self.removed.add(server_id)
-        return ScyllaCluster.ActionReturn(success=True, msg=f"Server {server_id} removed")
+        raise NotImplementedError
 
     def get_config(self, server_id: str) -> ActionReturn:
         """Get conf/scylla.yaml of the given server as a dictionary.

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -37,14 +37,3 @@ async def test_restart_server_add_column(manager, random_tables):
     ret = await manager.server_restart(servers[1])
     await table.add_column()
     await random_tables.verify_schema()
-
-
-@pytest.mark.asyncio
-async def test_remove_server_add_column(manager, random_tables):
-    """Add a node, remove an original node, add a column"""
-    servers = await manager.servers()
-    table = await random_tables.add_table(ncolumns=5)
-    await manager.server_add()
-    await manager.server_remove(servers[1])
-    await table.add_column()
-    await random_tables.verify_schema()


### PR DESCRIPTION
The `server_remove` function did a very weird thing: it shut down a server and made the framework 'forget' about it. From the point of view of the Scylla cluster and the driver the server was still there.

Replace the function's body with `raise NotImplementedError`. In the future it can be replaced with an implementation that calls `removenode` on the Scylla cluster.

Remove `test_remove_server_add_column` from `test_topology`. It effectively does the same thing as `test_stop_server_add_column`, except that the framework also 'forgets' about the stopped server. This could lead to weird situations because the forgotten server's IP could be reused in another test that was running concurrently with this test.