### PR TITLE
cql3: expr: allow to prepare and evaluate binary_operators and conjunctions

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -361,10 +361,11 @@ bool contains(const data_value& collection, const raw_value_view& value) {
 }
 
 /// True iff a column is a collection containing value.
-bool contains(const column_value& col, const raw_value_view& value, const evaluation_inputs& inputs) {
-    const auto collection = get_value(col, inputs);
-    if (collection) {
-        return contains(col.col->type->deserialize(managed_bytes_view(*collection)), value);
+bool contains(const expression& collection_val, const raw_value_view& value, const evaluation_inputs& inputs) {
+    const data_type collection_type = type_of(collection_val);
+    const managed_bytes_opt collection_bytes = evaluate(collection_val, inputs).to_managed_bytes_opt();
+    if (collection_bytes) {
+        return contains(collection_type->deserialize(managed_bytes_view(*collection_bytes)), value);
     } else {
         return false;
     }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -511,171 +511,20 @@ struct intersection_visitor {
 value_set intersection(value_set a, value_set b, const abstract_type* type) {
     return std::visit(intersection_visitor{type}, std::move(a), std::move(b));
 }
-
-bool is_satisfied_by(const binary_operator& opr, const evaluation_inputs& inputs) {
-    return expr::visit(overloaded_functor{
-            [&] (const column_value& col) {
-                if (opr.op == oper_t::EQ) {
-                    return equal(col, opr.rhs, inputs);
-                } else if (opr.op == oper_t::NEQ) {
-                    return !equal(col, opr.rhs, inputs);
-                } else if (is_slice(opr.op)) {
-                    return limits(col, opr.op, opr.rhs, inputs);
-                } else if (opr.op == oper_t::CONTAINS) {
-                    cql3::raw_value val = evaluate(opr.rhs, inputs);
-                    return contains(col, val.view(), inputs);
-                } else if (opr.op == oper_t::CONTAINS_KEY) {
-                    cql3::raw_value val = evaluate(opr.rhs, inputs);
-                    return contains_key(col, val.view(), inputs);
-                } else if (opr.op == oper_t::LIKE) {
-                    cql3::raw_value val = evaluate(opr.rhs, inputs);
-                    return like(col, val.view(), inputs);
-                } else if (opr.op == oper_t::IN) {
-                    return is_one_of(col, opr.rhs, inputs);
-                } else {
-                    throw exceptions::unsupported_operation_exception(format("Unhandled binary_operator: {}", opr));
-                }
-            },
-            [&] (const subscript& sub) {
-                if (opr.op == oper_t::EQ) {
-                    return equal(sub, opr.rhs, inputs);
-                } else if (opr.op == oper_t::NEQ) {
-                    return !equal(sub, opr.rhs, inputs);
-                } else if (is_slice(opr.op)) {
-                    return limits(sub, opr.op, opr.rhs, inputs);
-                } else if (opr.op == oper_t::CONTAINS) {
-                    throw exceptions::unsupported_operation_exception("CONTAINS lhs is subscripted");
-                } else if (opr.op == oper_t::CONTAINS_KEY) {
-                    throw exceptions::unsupported_operation_exception("CONTAINS KEY lhs is subscripted");
-                } else if (opr.op == oper_t::LIKE) {
-                    throw exceptions::unsupported_operation_exception("LIKE lhs is subscripted");
-                } else if (opr.op == oper_t::IN) {
-                    return is_one_of(sub, opr.rhs, inputs);
-                } else {
-                    throw exceptions::unsupported_operation_exception(format("Unhandled binary_operator: {}", opr));
-                }
-            },
-            [&] (const tuple_constructor& cvs) {
-                if (opr.op == oper_t::EQ) {
-                    return equal(cvs, opr.rhs, inputs);
-                } else if (is_slice(opr.op)) {
-                    return limits(cvs, opr.op, opr.rhs, inputs);
-                } else if (opr.op == oper_t::IN) {
-                    return is_one_of(cvs, opr.rhs, inputs);
-                } else {
-                    throw exceptions::unsupported_operation_exception(
-                            format("Unhandled multi-column binary_operator: {}", opr));
-                }
-            },
-            [] (const token& tok) -> bool {
-                // The RHS value was already used to ensure we fetch only rows in the specified
-                // token range.  It is impossible for any fetched row not to match now.
-                return true;
-            },
-            [] (const constant&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: A constant cannot serve as the LHS of a binary expression");
-            },
-            [] (const conjunction&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a conjunction cannot serve as the LHS of a binary expression");
-            },
-            [] (const binary_operator&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: binary operators cannot be nested");
-            },
-            [] (const unresolved_identifier&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: an unresolved identifier cannot serve as the LHS of a binary expression");
-            },
-            [] (const column_mutation_attribute&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: column_mutation_attribute cannot serve as the LHS of a binary expression");
-            },
-            [] (const function_call&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: function_call cannot serve as the LHS of a binary expression");
-            },
-            [] (const cast&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: cast cannot serve as the LHS of a binary expression");
-            },
-            [] (const field_selection&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: field_selection cannot serve as the LHS of a binary expression");
-            },
-            [] (const null&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: null cannot serve as the LHS of a binary expression");
-            },
-            [] (const bind_variable&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: bind_variable cannot serve as the LHS of a binary expression");
-            },
-            [] (const untyped_constant&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: untyped_constant cannot serve as the LHS of a binary expression");
-            },
-            [] (const collection_constructor&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: collection_constructor cannot serve as the LHS of a binary expression");
-            },
-            [] (const usertype_constructor&) -> bool {
-                on_internal_error(expr_logger, "is_satisified_by: usertype_constructor cannot serve as the LHS of a binary expression");
-            },
-        }, opr.lhs);
-}
-
 } // anonymous namespace
 
 bool is_satisfied_by(const expression& restr, const evaluation_inputs& inputs) {
-    return expr::visit(overloaded_functor{
-            [] (const constant& constant_val) {
-                std::optional<bool> bool_val = get_bool_value(constant_val);
-                if (bool_val.has_value()) {
-                    return *bool_val;
-                }
-
-                on_internal_error(expr_logger,
-                    "is_satisfied_by: a constant that is not a bool value cannot serve as a restriction by itself");
-            },
-            [&] (const conjunction& conj) {
-                return boost::algorithm::all_of(conj.children, [&] (const expression& c) {
-                    return is_satisfied_by(c, inputs);
-                });
-            },
-            [&] (const binary_operator& opr) { return is_satisfied_by(opr, inputs); },
-            [] (const column_value&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a column cannot serve as a restriction by itself");
-            },
-            [] (const subscript&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a subscript cannot serve as a restriction by itself");
-            },
-            [] (const token&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: the token function cannot serve as a restriction by itself");
-            },
-            [] (const unresolved_identifier&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: an unresolved identifier cannot serve as a restriction");
-            },
-            [] (const column_mutation_attribute&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: the writetime/ttl cannot serve as a restriction by itself");
-            },
-            [] (const function_call&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a function call cannot serve as a restriction by itself");
-            },
-            [] (const cast&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a a type cast cannot serve as a restriction by itself");
-            },
-            [] (const field_selection&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a field selection cannot serve as a restriction by itself");
-            },
-            [] (const null&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: NULL cannot serve as a restriction by itself");
-            },
-            [] (const bind_variable&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a bind variable cannot serve as a restriction by itself");
-            },
-            [] (const untyped_constant&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: an untyped constant cannot serve as a restriction by itself");
-            },
-            [] (const tuple_constructor&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a tuple constructor cannot serve as a restriction by itself");
-            },
-            [] (const collection_constructor&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a collection constructor cannot serve as a restriction by itself");
-            },
-            [] (const usertype_constructor&) -> bool {
-                on_internal_error(expr_logger, "is_satisfied_by: a user type constructor cannot serve as a restriction by itself");
-            },
-        }, restr);
+    cql3::raw_value restr_value = evaluate(restr, inputs);
+    if (restr_value.is_null()) {
+        throw exceptions::invalid_request_exception("restriction expression evaluated to NULL");
+    }
+    if (restr_value.is_unset_value()) {
+        throw exceptions::invalid_request_exception("restriction expression evaluated to UNSET VALUE");
+    }
+    if (restr_value.is_empty_value()) {
+        throw exceptions::invalid_request_exception("restriction expression evaluated to EMPTY_VALUE");
+    }
+    return restr_value.view().deserialize<bool>(*boolean_type);
 }
 
 namespace {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -438,12 +438,16 @@ std::vector<managed_bytes_opt> get_non_pk_values(const selection& selection, con
 namespace {
 
 /// True iff cv matches the CQL LIKE pattern.
-bool like(const column_value& cv, const raw_value_view& pattern, const evaluation_inputs& inputs) {
-    if (!cv.col->type->is_string()) {
+bool like(const expression& string_val, const raw_value_view& pattern, const evaluation_inputs& inputs) {
+    if (!type_of(string_val)->is_string()) {
+        expression::printer val_printer {
+            .expr_to_print = string_val,
+            .debug_mode = false
+        };
         throw exceptions::invalid_request_exception(
-                format("LIKE is allowed only on string types, which {} is not", cv.col->name_as_text()));
+                format("LIKE is allowed only on string types, which {} is not", val_printer));
     }
-    auto value = get_value(cv, inputs);
+    const managed_bytes_opt value = evaluate(string_val, inputs).to_managed_bytes_opt();
     // TODO: reuse matchers.
     if (pattern && value) {
         return value->with_linearized([&pattern] (bytes_view linearized_value) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1765,8 +1765,14 @@ cql3::raw_value evaluate(const binary_operator& binop, const evaluation_inputs& 
             binop_result = is_one_of(binop.lhs, binop.rhs, inputs);
             break;
         }
-        default: {
-            throw exceptions::unsupported_operation_exception(format("Unhandled binary_operator: {}", binop));
+        case oper_t::IS_NOT: {
+            cql3::raw_value lhs_val = evaluate(binop.lhs, inputs);
+            cql3::raw_value rhs_val = evaluate(binop.rhs, inputs);
+            if (!rhs_val.is_null()) {
+                throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
+            }
+            binop_result = !lhs_val.is_null();
+            break;
         }
     };
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -372,17 +372,17 @@ bool contains(const expression& collection_val, const raw_value_view& value, con
 }
 
 /// True iff a column is a map containing \p key.
-bool contains_key(const column_value& col, cql3::raw_value_view key, const evaluation_inputs& inputs) {
+bool contains_key(const expression& collection_val, cql3::raw_value_view key, const evaluation_inputs& inputs) {
     if (!key) {
         return true; // Compatible with old code, which skips null terms in key comparisons.
     }
-    auto type = col.col->type;
-    const auto collection = get_value(col, inputs);
-    if (!collection) {
+    const data_type collection_type = type_of(collection_val);
+    const managed_bytes_opt collection_bytes = evaluate(collection_val, inputs).to_managed_bytes_opt();
+    if (!collection_bytes) {
         return false;
     }
-    const auto data_map = value_cast<map_type_impl::native_type>(type->deserialize(managed_bytes_view(*collection)));
-    auto key_type = static_pointer_cast<const collection_type_impl>(type)->name_comparator();
+    const auto data_map = value_cast<map_type_impl::native_type>(collection_type->deserialize(managed_bytes_view(*collection_bytes)));
+    auto key_type = static_pointer_cast<const collection_type_impl>(collection_type)->name_comparator();
     auto found = key.with_linearized([&] (bytes_view k_bv) {
         using entry = std::pair<data_value, data_value>;
         return std::find_if(data_map.begin(), data_map.end(), [&] (const entry& element) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -704,7 +704,7 @@ std::optional<expression> try_prepare_expression(const expression& expr, data_di
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.
-extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, schema_ptr schema);
+extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema);
 
 
 /**

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1176,16 +1176,16 @@ static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column
     }
 }
 
-binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, schema_ptr schema) {
-    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, "", schema.get(), {});
+binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema) {
+    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, "", &table_schema, {});
     if (!prepared_lhs_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", binop.lhs));
     }
     auto& prepared_lhs = *prepared_lhs_opt;
-    lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, *schema);
+    lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, table_schema);
 
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
-    expression prepared_rhs = prepare_expression(binop.rhs, db, schema->ks_name(), schema.get(), rhs_receiver);
+    expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
     return binary_operator(std::move(prepared_lhs), binop.op, std::move(prepared_rhs), binop.order);
 }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -870,8 +870,22 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
         [] (const constant&) -> std::optional<expression> {
             on_internal_error(expr_logger, "Can't prepare constant_value, it should not appear in parser output");
         },
-        [&] (const binary_operator&) -> std::optional<expression> {
-            on_internal_error(expr_logger, "binary_operators are not yet reachable via prepare_expression()");
+        [&] (const binary_operator& binop) -> std::optional<expression> {
+            if (receiver.get() != nullptr && &receiver->type->without_reversed() != boolean_type.get()) {
+                throw exceptions::invalid_request_exception(
+                    format("binary operator produces a boolean value, which doesn't match the type: {} of {}",
+                           receiver->type->name(), receiver->name->text()));
+            }
+
+            binary_operator result = prepare_binary_operator(binop, db, *schema_opt);
+
+            // A binary operator where both sides of the equation are known can be evaluated to a boolean value.
+            // This only applies to operators in the CQL order, operations in the clustering order should only be
+            // of form (clustering_column1, colustering_column2) < SCYLLA_CLUSTERING_BOUND(1, 2).
+            if (is<constant>(result.lhs) && is<constant>(result.rhs) && result.order == comparison_order::cql) {
+                return constant(evaluate(result, query_options::DEFAULT), boolean_type);
+            }
+            return result;
         },
         [&] (const conjunction&) -> std::optional<expression> {
             on_internal_error(expr_logger, "conjunctions are not yet reachable via prepare_expression()");

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -201,7 +201,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
     preliminary_binop_vaidation_checks(restriction);
 
     // Prepare the restriction
-    binary_operator prepared_binop = prepare_binary_operator(restriction, db, schema);
+    binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema);
 
     // Fill prepare context
     const column_value* lhs_pk_col_search_res = find_in_expression<column_value>(prepared_binop.lhs,

--- a/cql3/values.cc
+++ b/cql3/values.cc
@@ -78,4 +78,8 @@ bool operator==(const raw_value& v1, const raw_value& v2) {
     return false;
 }
 
+std::ostream& operator<<(std::ostream& os, const raw_value& value) {
+    return os << value.view();
+}
+
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -307,6 +307,7 @@ public:
     friend class raw_value_view;
 
     friend bool operator==(const raw_value& v1, const raw_value& v2);
+    friend std::ostream& operator<<(std::ostream& os, const raw_value& value);
 };
 
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -85,6 +85,14 @@ public:
     bool is_unset_value() const {
         return std::holds_alternative<unset_value>(_data);
     }
+    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty int value can be created in CQL using blobasint(0x).
+    bool is_empty_value() const {
+        if (is_null() || is_unset_value()) {
+            return false;
+        }
+        return size_bytes() == 0;
+    }
     bool is_value() const {
         return _data.index() <= 1;
     }
@@ -232,6 +240,14 @@ public:
     }
     bool is_null_or_unset() const {
         return !is_value();
+    }
+    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty int value can be created in CQL using blobasint(0x).
+    bool is_empty_value() const {
+        if (is_null_or_unset()) {
+            return false;
+        }
+        return view().size_bytes() == 0;
     }
     bool is_value() const {
         return _data.index() <= 1;

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -15,6 +15,7 @@
 #include "cql3/query_options.hh"
 #include "types/set.hh"
 #include "types/user.hh"
+#include "cql3/selection/selection.hh"
 
 using namespace cql3;
 using namespace cql3::expr;
@@ -375,4 +376,671 @@ BOOST_AUTO_TEST_CASE(boolean_factors_test) {
             {bv1, bv2, bv3, bv4}
         )
     );
+}
+
+// Creates a schema_ptr that can be used for testing
+// The schema corresponds to a table created by:
+// CREATE TABLE test_ks.test_cf (pk int, ck int, r int, s int static, primary key (pk, ck));
+static schema_ptr make_simple_test_schema() {
+    return schema_builder("test_ks", "test_cf")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("ck", int32_type, column_kind::clustering_key)
+        .with_column("r", int32_type, column_kind::regular_column)
+        .with_column("s", int32_type, column_kind::static_column)
+        .build();
+}
+
+using column_values = std::map<sstring, raw_value>;
+
+static raw_value make_bool_val(bool val) {
+    return raw_value::make_value(boolean_type->decompose(val));
+}
+
+static raw_value make_int_val(int32_t val) {
+    return raw_value::make_value(int32_type->decompose(val));
+}
+
+static raw_value make_text_val(const sstring_view& text) {
+    return raw_value::make_value(utf8_type->decompose(text));
+}
+
+static raw_value make_int_list_val(const std::vector<int32_t>& list_elems) {
+    list_type_impl::native_type list;
+    for (const int32_t& elem : list_elems) {
+        list.push_back(data_value(elem));
+    }
+    data_type list_type = list_type_impl::get_instance(int32_type, true);
+    bytes list_bytes = list_type->decompose(make_list_value(list_type, list));
+    return raw_value::make_value(std::move(list_bytes));
+}
+
+static raw_value make_int_set_val(std::vector<int32_t> set_elems) {
+    std::sort(set_elems.begin(), set_elems.end());
+
+    // Set and list have the same binary representation
+    return make_int_list_val(set_elems);
+}
+
+static raw_value make_int_int_map_val(const std::vector<std::pair<int32_t, int32_t>>& map_elems) {
+    map_type_impl::native_type map;
+    for (const std::pair<int32_t, int32_t>& key_value_elem : map_elems) {
+        map.push_back(key_value_elem);
+    }
+    data_type map_type = map_type_impl::get_instance(int32_type, int32_type, true);
+    bytes map_bytes = map_type->decompose(make_map_value(map_type, map));
+    return raw_value::make_value(std::move(map_bytes));
+}
+
+static raw_value make_tuple_val(const std::vector<constant>& tuple_vals) {
+    tuple_type_impl::native_type tuple;
+    for (const constant& val : tuple_vals) {
+        if (val.value.is_null()) {
+            tuple.push_back(data_value::make_null(val.type));
+            continue;
+        }
+        if (val.value.is_unset_value()) {
+            throw std::runtime_error("make_tuple_val - unset value is not allowed");
+        }
+        if (val.value.is_empty_value()) {
+            throw std::runtime_error("make_tuple_val - empty value is not supported");
+        }
+        data_value cur_val = val.value.view().with_value(
+            [&](const FragmentedView auto& val_bytes) { return val.type->deserialize(val_bytes); });
+        tuple.push_back(cur_val);
+    }
+    data_type tuple_type = tuple_type_impl::get_instance({int32_type, boolean_type});
+    bytes tuple_bytes = tuple_type->decompose(make_tuple_value(tuple_type, tuple));
+    return raw_value::make_value(std::move(tuple_bytes));
+}
+
+static raw_value make_int_bool_usertype_val(int32_t int_val, bool bool_val) {
+    data_type usertype_type = user_type_impl::get_instance("test_ks", "test_type", {"int_field", "bool_field"},
+                                                           {int32_type, boolean_type}, true);
+    bytes usertype_bytes =
+        usertype_type->decompose(make_user_value(usertype_type, {data_value(int_val), data_value(bool_val)}));
+    return raw_value::make_value(std::move(usertype_bytes));
+}
+
+struct evaluation_inputs_data {
+    std::vector<bytes> partition_key;
+    std::vector<bytes> clustering_key;
+    std::vector<managed_bytes_opt> static_and_regular_columns;
+    ::shared_ptr<selection::selection> selection;
+    query_options options;
+};
+
+static std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
+    const schema_ptr& table_schema,
+    const column_values& column_vals,
+    const std::vector<raw_value>& bind_marker_values = {}) {
+    auto throw_error = [&](const auto&... fmt_args) -> sstring {
+        sstring error_msg = format(fmt_args...);
+        sstring final_msg = format("make_evaluation_inputs error: {}. (table_schema: {}, column_vals: {})", error_msg,
+                                   *table_schema, column_vals);
+        throw std::runtime_error(final_msg);
+    };
+
+    auto get_col_val = [&](const column_definition& col) -> const raw_value& {
+        auto col_value_iter = column_vals.find(col.name_as_text());
+        if (col_value_iter == column_vals.end()) {
+            throw_error("no value for column {}", col.name_as_text());
+        }
+        return col_value_iter->second;
+    };
+
+    std::vector<bytes> partition_key;
+    for (const column_definition& pk_col : table_schema->partition_key_columns()) {
+        const raw_value& col_value = get_col_val(pk_col);
+
+        if (col_value.is_null()) {
+            throw_error("Passed NULL as value for {}. This is not allowed for partition key columns.",
+                        pk_col.name_as_text());
+        }
+        if (col_value.is_unset_value()) {
+            throw_error("Passed UNSET_VALUE as value for {}. This is not allowed for partition key columns.",
+                        pk_col.name_as_text());
+        }
+        partition_key.push_back(raw_value(col_value).to_bytes());
+    }
+
+    std::vector<bytes> clustering_key;
+    for (const column_definition& ck_col : table_schema->clustering_key_columns()) {
+        const raw_value& col_value = get_col_val(ck_col);
+
+        if (col_value.is_null()) {
+            throw_error("Passed NULL as value for {}. This is not allowed for clustering key columns.",
+                        ck_col.name_as_text());
+        }
+        if (col_value.is_unset_value()) {
+            throw_error("Passed UNSET_VALUE as value for {}. This is not allowed for clustering key columns.",
+                        ck_col.name_as_text());
+        }
+        clustering_key.push_back(raw_value(col_value).to_bytes());
+    }
+
+    std::vector<const column_definition*> selection_columns;
+    for (const column_definition& cdef : table_schema->regular_columns()) {
+        selection_columns.push_back(&cdef);
+    }
+    for (const column_definition& cdef : table_schema->static_columns()) {
+        selection_columns.push_back(&cdef);
+    }
+
+    ::shared_ptr<selection::selection> selection =
+        cql3::selection::selection::for_columns(table_schema, std::move(selection_columns));
+    std::vector<managed_bytes_opt> static_and_regular_columns(table_schema->regular_columns_count() +
+                                                              table_schema->static_columns_count());
+
+    for (const column_definition& col : table_schema->regular_columns()) {
+        const raw_value& col_value = get_col_val(col);
+        if (col_value.is_unset_value()) {
+            throw_error("Passed UNSET_VALUE as value for {}. This is not allowed.", col.name_as_text());
+        }
+        int32_t index = selection->index_of(col);
+        static_and_regular_columns[index] = raw_value(col_value).to_managed_bytes_opt();
+    }
+
+    for (const column_definition& col : table_schema->static_columns()) {
+        const raw_value& col_value = get_col_val(col);
+        if (col_value.is_unset_value()) {
+            throw_error("Passed UNSET_VALUE as value for {}. This is not allowed.", col.name_as_text());
+        }
+        int32_t index = selection->index_of(col);
+        static_and_regular_columns[index] = raw_value(col_value).to_managed_bytes_opt();
+    }
+
+    query_options options(default_cql_config, db::consistency_level::ONE, std::nullopt, bind_marker_values, true,
+                          query_options::specific_options::DEFAULT, cql_serialization_format::internal());
+
+    std::unique_ptr<evaluation_inputs_data> data = std::make_unique<evaluation_inputs_data>(
+        evaluation_inputs_data{.partition_key = std::move(partition_key),
+                               .clustering_key = std::move(clustering_key),
+                               .static_and_regular_columns = std::move(static_and_regular_columns),
+                               .selection = std::move(selection),
+                               .options = std::move(options)});
+
+    evaluation_inputs inputs{.partition_key = &data->partition_key,
+                             .clustering_key = &data->clustering_key,
+                             .static_and_regular_columns = &data->static_and_regular_columns,
+                             .selection = data->selection.get(),
+                             .options = &data->options};
+
+    return std::pair(std::move(inputs), std::move(data));
+}
+
+// Empty expression defaults to an empty conjunction, which evaluates to true.
+BOOST_AUTO_TEST_CASE(evaluate_empty_expression) {
+    expression empty;
+    raw_value val = evaluate(empty, evaluation_inputs{});
+    BOOST_REQUIRE_EQUAL(val, make_bool_val(true));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_bool) {
+    expression bool_true = constant::make_bool(true);
+    BOOST_REQUIRE_EQUAL(evaluate(bool_true, evaluation_inputs{}), make_bool_val(true));
+
+    expression bool_false = constant::make_bool(false);
+    BOOST_REQUIRE_EQUAL(evaluate(bool_false, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_null) {
+    expression constant_null = constant::make_null();
+    BOOST_REQUIRE_EQUAL(evaluate(constant_null, evaluation_inputs{}), raw_value::make_null());
+
+    expression constant_null_with_type = constant::make_null(int32_type);
+    BOOST_REQUIRE_EQUAL(evaluate(constant_null_with_type, evaluation_inputs{}), raw_value::make_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_unset) {
+    expression constant_unset = constant::make_unset_value();
+    BOOST_REQUIRE_EQUAL(evaluate(constant_unset, evaluation_inputs{}), raw_value::make_unset_value());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_empty) {
+    expression constant_empty_bool = constant(raw_value::make_value(bytes()), boolean_type);
+    BOOST_REQUIRE(evaluate(constant_empty_bool, evaluation_inputs{}).is_empty_value());
+
+    expression constant_empty_int = constant(raw_value::make_value(bytes()), int32_type);
+    BOOST_REQUIRE(evaluate(constant_empty_int, evaluation_inputs{}).is_empty_value());
+
+    expression constant_empty_text = constant(raw_value::make_value(bytes()), utf8_type);
+    BOOST_REQUIRE_EQUAL(evaluate(constant_empty_text, evaluation_inputs{}), make_text_val(""));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_partition_key_column) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+                                                                         {"pk", make_int_val(1)},
+                                                                         {"ck", make_int_val(2)},
+                                                                         {"r", make_int_val(3)},
+                                                                         {"s", make_int_val(4)},
+                                                                     });
+    expression pk_val = column_value(test_schema->get_column_definition("pk"));
+    raw_value val = evaluate(pk_val, inputs);
+    BOOST_REQUIRE_EQUAL(val, make_int_val(1));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_clustering_key_column) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+                                                                         {"pk", make_int_val(1)},
+                                                                         {"ck", make_int_val(2)},
+                                                                         {"r", make_int_val(3)},
+                                                                         {"s", make_int_val(4)},
+                                                                     });
+    expression ck_val = column_value(test_schema->get_column_definition("ck"));
+    raw_value val = evaluate(ck_val, inputs);
+    BOOST_REQUIRE_EQUAL(val, make_int_val(2));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_regular_column) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+                                                                         {"pk", make_int_val(1)},
+                                                                         {"ck", make_int_val(2)},
+                                                                         {"r", make_int_val(3)},
+                                                                         {"s", make_int_val(4)},
+                                                                     });
+    expression r_val = column_value(test_schema->get_column_definition("r"));
+    raw_value val = evaluate(r_val, inputs);
+    BOOST_REQUIRE_EQUAL(val, make_int_val(3));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_static_column) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+                                                                         {"pk", make_int_val(1)},
+                                                                         {"ck", make_int_val(2)},
+                                                                         {"r", make_int_val(3)},
+                                                                         {"s", make_int_val(4)},
+                                                                     });
+    BOOST_REQUIRE(test_schema->get_column_definition("s") != nullptr);
+    expression s_val = column_value(test_schema->get_column_definition("s"));
+    raw_value val = evaluate(s_val, inputs);
+    BOOST_REQUIRE_EQUAL(val, make_int_val(4));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_bind_variable) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema,
+                                                        {
+                                                            {"pk", make_int_val(1)},
+                                                            {"ck", make_int_val(2)},
+                                                            {"r", make_int_val(3)},
+                                                            {"s", make_int_val(4)},
+                                                        },
+                                                        {make_int_val(123)});
+
+    expression bind_variable = cql3::expr::bind_variable{
+        .bind_index = 0,
+        .receiver = ::make_lw_shared<column_specification>(
+            "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var_0", true), int32_type)};
+
+    raw_value val = evaluate(bind_variable, inputs);
+    BOOST_REQUIRE_EQUAL(val, make_int_val(123));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_two_bind_variables) {
+    schema_ptr test_schema = make_simple_test_schema();
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema,
+                                                        {
+                                                            {"pk", make_int_val(1)},
+                                                            {"ck", make_int_val(2)},
+                                                            {"r", make_int_val(3)},
+                                                            {"s", make_int_val(4)},
+                                                        },
+                                                        {make_int_val(123), make_int_val(456)});
+
+    expression bind_variable0 = cql3::expr::bind_variable{
+        .bind_index = 0,
+        .receiver = ::make_lw_shared<column_specification>(
+            "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var_0", true), int32_type)};
+
+    expression bind_variable1 = cql3::expr::bind_variable{
+        .bind_index = 1,
+        .receiver = ::make_lw_shared<column_specification>(
+            "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var_1", true), int32_type)};
+
+    raw_value val0 = evaluate(bind_variable0, inputs);
+    BOOST_REQUIRE_EQUAL(val0, make_int_val(123));
+
+    raw_value val1 = evaluate(bind_variable1, inputs);
+    BOOST_REQUIRE_EQUAL(val1, make_int_val(456));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_subscripted_list) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("l", list_type_impl::get_instance(int32_type, true), column_kind::regular_column)
+            .build();
+
+    const column_definition* list_col = table_schema->get_column_definition("l");
+
+    raw_value list_val = make_int_list_val({357, 468, 579});
+    expression sub = subscript{
+        .val = column_value(list_col), .sub = make_int(1), .type = list_type_impl::get_instance(int32_type, true)};
+
+    auto inputs_pair = make_evaluation_inputs(table_schema, {{"pk", make_int_val(0)}, {"l", list_val}});
+
+    auto evaluate_subscripted = [&](const raw_value& sub_val) -> raw_value {
+        expression sub = subscript{.val = column_value(list_col),
+                                   .sub = constant(sub_val, int32_type),
+                                   .type = set_type_impl::get_instance(int32_type, true)};
+        return evaluate(sub, inputs_pair.first);
+    };
+
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(0)), make_int_val(357));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(1)), make_int_val(468));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(2)), make_int_val(579));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(-10000000)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(4)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(10000000)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(raw_value::make_null()), raw_value::make_null());
+    BOOST_REQUIRE_THROW(evaluate_subscripted(raw_value::make_unset_value()), exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(evaluate_subscripted(raw_value::make_value(bytes())), empty_value_exception);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_subscripted_map) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("m", map_type_impl::get_instance(int32_type, int32_type, true), column_kind::regular_column)
+            .build();
+
+    const column_definition* map_col = table_schema->get_column_definition("m");
+
+    raw_value map_val = make_int_int_map_val({{1, 2}, {3, 4}, {5, 6}});
+
+    auto inputs_pair = make_evaluation_inputs(table_schema, {{"pk", make_int_val(0)}, {"m", map_val}});
+
+    auto evaluate_subscripted = [&](const raw_value& sub_val) -> raw_value {
+        expression sub = subscript{.val = column_value(map_col),
+                                   .sub = constant(sub_val, int32_type),
+                                   .type = set_type_impl::get_instance(int32_type, true)};
+        return evaluate(sub, inputs_pair.first);
+    };
+
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(1)), make_int_val(2));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(3)), make_int_val(4));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(5)), make_int_val(6));
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(-10000000)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(4)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(make_int_val(10000000)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(raw_value::make_null()), raw_value::make_null());
+    BOOST_REQUIRE_THROW(evaluate_subscripted(raw_value::make_unset_value()), exceptions::invalid_request_exception);
+    BOOST_REQUIRE_EQUAL(evaluate_subscripted(raw_value::make_value(bytes())), raw_value::make_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_conjunction) {
+    BOOST_REQUIRE_EQUAL(evaluate(expression(conjunction{.children = {}}), evaluation_inputs{}), make_bool_val(true));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(false)}}), evaluation_inputs{}),
+        make_bool_val(false));
+
+    BOOST_REQUIRE_EQUAL(evaluate(expression(conjunction{.children = {constant::make_bool(true)}}), evaluation_inputs{}),
+                        make_bool_val(true));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(false), constant::make_bool(false)}}),
+                 evaluation_inputs{}),
+        make_bool_val(false));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(false), constant::make_bool(true)}}),
+                 evaluation_inputs{}),
+        make_bool_val(false));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(true), constant::make_bool(false)}}),
+                 evaluation_inputs{}),
+        make_bool_val(false));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(true), constant::make_bool(true)}}),
+                 evaluation_inputs{}),
+        make_bool_val(true));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{
+                     .children = {constant::make_bool(true), constant::make_bool(true), constant::make_bool(false)},
+                 }),
+                 evaluation_inputs{}),
+        make_bool_val(false));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{.children = {constant::make_bool(true), constant::make_bool(true),
+                                                     constant::make_bool(true), constant::make_bool(true)}}),
+                 evaluation_inputs{}),
+        make_bool_val(true));
+
+    BOOST_REQUIRE_EQUAL(
+        evaluate(expression(conjunction{
+                     .children = {constant::make_bool(false), constant::make_bool(true), constant::make_bool(true)}}),
+                 evaluation_inputs{}),
+        make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_list_collection_constructor) {
+    data_type list_type = list_type_impl::get_instance(int32_type, true);
+
+    expression empty_list =
+        collection_constructor{.style = collection_constructor::style_type::list, .elements = {}, .type = list_type};
+    BOOST_REQUIRE_EQUAL(evaluate(empty_list, evaluation_inputs{}), make_int_list_val({}));
+
+    expression list = collection_constructor{.style = collection_constructor::style_type::list,
+                                             .elements = {make_int(1), make_int(2), make_int(3)},
+                                             .type = list_type};
+    BOOST_REQUIRE_EQUAL(evaluate(list, evaluation_inputs{}), make_int_list_val({1, 2, 3}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_set_collection_constructor) {
+    data_type set_type = set_type_impl::get_instance(int32_type, true);
+
+    expression empty_set =
+        collection_constructor{.style = collection_constructor::style_type::set, .elements = {}, .type = set_type};
+    BOOST_REQUIRE_EQUAL(evaluate(empty_set, evaluation_inputs{}), make_int_set_val({}));
+
+    expression set = collection_constructor{.style = collection_constructor::style_type::set,
+                                            .elements = {make_int(1), make_int(2), make_int(3)},
+                                            .type = set_type};
+    BOOST_REQUIRE_EQUAL(evaluate(set, evaluation_inputs{}), make_int_set_val({1, 2, 3}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_map_collection_constructor) {
+    data_type map_type = map_type_impl::get_instance(int32_type, int32_type, true);
+
+    expression empty_map =
+        collection_constructor{.style = collection_constructor::style_type::map, .elements = {}, .type = map_type};
+    BOOST_REQUIRE_EQUAL(evaluate(empty_map, evaluation_inputs{}), make_int_int_map_val({}));
+
+    expression map = collection_constructor{.style = collection_constructor::style_type::map,
+                                            .elements = {tuple_constructor{.elements = {make_int(1), make_int(2)}},
+                                                         tuple_constructor{.elements = {make_int(3), make_int(4)}},
+                                                         tuple_constructor{.elements = {make_int(5), make_int(6)}}},
+                                            .type = map_type};
+    BOOST_REQUIRE_EQUAL(evaluate(map, evaluation_inputs{}), make_int_int_map_val({{1, 2}, {3, 4}, {5, 6}}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_tuple_constructor) {
+    data_type tuple_type = tuple_type_impl::get_instance({int32_type, boolean_type});
+
+    expression empty_tuple = tuple_constructor{
+        .elements = {},
+        .type = tuple_type,
+    };
+    BOOST_REQUIRE_EQUAL(evaluate(empty_tuple, evaluation_inputs{}), raw_value::make_value(bytes()));
+
+    // It's possible to have tuples with only some values present
+    expression single_elem_tuple = tuple_constructor{.elements = {make_int(123)}, .type = tuple_type};
+    BOOST_REQUIRE_EQUAL(evaluate(single_elem_tuple, evaluation_inputs{}), make_tuple_val({make_int(123)}));
+
+    // Tuples can contain nulls
+    expression null_tuple =
+        tuple_constructor{.elements = {constant::make_null(int32_type), constant::make_bool(12)}, .type = tuple_type};
+    BOOST_REQUIRE_EQUAL(evaluate(null_tuple, evaluation_inputs{}),
+                        make_tuple_val({constant::make_null(int32_type), constant::make_bool(true)}));
+
+    expression tuple = tuple_constructor{.elements = {make_int(123), constant::make_bool(true)}, .type = tuple_type};
+    BOOST_REQUIRE_EQUAL(evaluate(tuple, evaluation_inputs{}),
+                        make_tuple_val({make_int(123), constant::make_bool(true)}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor) {
+    data_type usertype_type = user_type_impl::get_instance("test_ks", "test_type", {"int_field", "bool_field"},
+                                                           {int32_type, boolean_type}, true);
+
+    expression type =
+        usertype_constructor{.elements = {{column_identifier("int_field", true), make_int(321)},
+                                          {column_identifier("bool_field", true), constant::make_bool(false)}},
+                             .type = usertype_type};
+    BOOST_REQUIRE_EQUAL(evaluate(type, evaluation_inputs{}),
+                        make_tuple_val({make_int(321), constant::make_bool(false)}));
+
+    // user types can contain nulls
+    expression null_type =
+        usertype_constructor{.elements = {{column_identifier("int_field", true), constant::make_null(int32_type)},
+                                          {column_identifier("bool_field", true), constant::make_bool(false)}},
+                             .type = usertype_type};
+    BOOST_REQUIRE_EQUAL(evaluate(null_type, evaluation_inputs{}),
+                        make_tuple_val({constant::make_null(int32_type), constant::make_bool(false)}));
+
+    // evaluate() doesn't support evaluating user type values without some fields present.
+    // Missing fields are filled with nulls during prepare(), and then evaluate doesn't need to think about them.
+    // Trying to pass a usertype_constructor without some fields present results in on_internal_error.
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_eq) {
+    expression true_eq_binop = binary_operator(make_int(1), oper_t::EQ, make_int(1));
+    BOOST_REQUIRE_EQUAL(evaluate(true_eq_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_eq_binop = binary_operator(make_int(1), oper_t::EQ, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_eq_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_neq) {
+    expression true_neq_binop = binary_operator(make_int(1), oper_t::NEQ, make_int(1000));
+    BOOST_REQUIRE_EQUAL(evaluate(true_neq_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_neq_binop = binary_operator(make_int(2), oper_t::NEQ, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_neq_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lt) {
+    expression true_lt_binop = binary_operator(make_int(1), oper_t::LT, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lt_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_lt_binop = binary_operator(make_int(10), oper_t::LT, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lt_binop, evaluation_inputs{}), make_bool_val(false));
+
+    expression false_lt_binop2 = binary_operator(make_int(2), oper_t::LT, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lt_binop2, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lte) {
+    expression true_lte_binop = binary_operator(make_int(1), oper_t::LTE, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lte_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression true_lte_binop2 = binary_operator(make_int(12), oper_t::LTE, make_int(12));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lte_binop2, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_lte_binop = binary_operator(make_int(123), oper_t::LTE, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lte_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gt) {
+    expression true_gt_binop = binary_operator(make_int(2), oper_t::GT, make_int(1));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gt_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_gt_binop = binary_operator(make_int(1), oper_t::GT, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gt_binop, evaluation_inputs{}), make_bool_val(false));
+
+    expression false_gt_binop2 = binary_operator(make_int(2), oper_t::GT, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gt_binop2, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gte) {
+    expression true_gte_binop = binary_operator(make_int(20), oper_t::GTE, make_int(10));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gte_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression true_gte_binop2 = binary_operator(make_int(10), oper_t::GTE, make_int(10));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gte_binop2, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_gte_binop = binary_operator(make_int(-10), oper_t::GTE, make_int(10));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gte_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in) {
+    expression in_list = constant(make_int_list_val({1, 3, 5}), list_type_impl::get_instance(int32_type, true));
+
+    expression true_in_binop = binary_operator(make_int(3), oper_t::IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(true_in_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_in_binop = binary_operator(make_int(2), oper_t::IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(false_in_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_list_contains) {
+    expression list_val = constant(make_int_list_val({1, 3, 5}), list_type_impl::get_instance(int32_type, true));
+
+    expression list_contains_true = binary_operator(list_val, oper_t::CONTAINS, make_int(3));
+    BOOST_REQUIRE_EQUAL(evaluate(list_contains_true, evaluation_inputs{}), make_bool_val(true));
+
+    expression list_contains_false = binary_operator(list_val, oper_t::CONTAINS, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(list_contains_false, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_set_contains) {
+    expression set_val = constant(make_int_set_val({1, 3, 5}), set_type_impl::get_instance(int32_type, true));
+
+    expression set_contains_true = binary_operator(set_val, oper_t::CONTAINS, make_int(3));
+    BOOST_REQUIRE_EQUAL(evaluate(set_contains_true, evaluation_inputs{}), make_bool_val(true));
+
+    expression set_contains_false = binary_operator(set_val, oper_t::CONTAINS, make_int(2));
+    BOOST_REQUIRE_EQUAL(evaluate(set_contains_false, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains) {
+    expression map_val = constant(make_int_int_map_val({{1, 2}, {3, 4}, {5, 6}}),
+                                  map_type_impl::get_instance(int32_type, int32_type, true));
+
+    expression map_contains_true = binary_operator(map_val, oper_t::CONTAINS, make_int(4));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_true, evaluation_inputs{}), make_bool_val(true));
+
+    expression map_contains_false = binary_operator(map_val, oper_t::CONTAINS, make_int(3));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_false, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains_key) {
+    expression map_val = constant(make_int_int_map_val({{1, 2}, {3, 4}, {5, 6}}),
+                                  map_type_impl::get_instance(int32_type, int32_type, true));
+
+    expression true_contains_key_binop = binary_operator(map_val, oper_t::CONTAINS_KEY, make_int(5));
+    BOOST_REQUIRE_EQUAL(evaluate(true_contains_key_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_contains_key_binop = binary_operator(map_val, oper_t::CONTAINS_KEY, make_int(6));
+    BOOST_REQUIRE_EQUAL(evaluate(false_contains_key_binop, evaluation_inputs{}), make_bool_val(false));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
+    expression true_is_not_binop = binary_operator(make_int(1), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_is_not_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_is_not_binop =
+        binary_operator(constant::make_null(int32_type), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_is_not_binop, evaluation_inputs{}), make_bool_val(false));
+
+    expression forbidden_is_not_binop = binary_operator(make_int(1), oper_t::IS_NOT, make_int(2));
+    BOOST_REQUIRE_THROW(evaluate(forbidden_is_not_binop, evaluation_inputs{}), exceptions::invalid_request_exception);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_like) {
+    expression true_like_binop = binary_operator(constant(make_text_val("some_text"), utf8_type), oper_t::LIKE,
+                                                 constant(make_text_val("some_%"), utf8_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_like_binop, evaluation_inputs{}), make_bool_val(true));
+
+    expression false_like_binop = binary_operator(constant(make_text_val("some_text"), utf8_type), oper_t::LIKE,
+                                                  constant(make_text_val("some_other_%"), utf8_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_like_binop, evaluation_inputs{}), make_bool_val(false));
 }


### PR DESCRIPTION
Currently trying to prepare or evaluate a `binary_operator` or a `conjunction` results with `on_internal_error`.
It would be useful to be able to do that, in particular it's needed for #11519.

prepare depends on evaluate because preparation evaluates all values that can be evaluated without additional data.

`is_satisfied_by` is a function which takes an expression and checks whether it evaluates to `true`.
It can now be implemented by using a single `evaluate()`,

I added unit tests for `evaluate()`, but there are none for `is_satisfied_by` or `prepare_expression` yet.