### PR TITLE
service/raft: raft_group_registry: pass `direct_fd_pinger` by reference

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -632,7 +632,10 @@ public:
         future<> update_generation_number(int64_t n);
 
         direct_fd_pinger(gossiper& g) : _gossiper(g) {}
+
     public:
+        direct_fd_pinger(const direct_fd_pinger&) = delete;
+
         // Allocate a new endpoint_id for `addr`, or if one already exists, return it.
         // Call only on shard 0.
         direct_failure_detector::pinger::endpoint_id allocate_id(gms::inet_address addr);

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -21,13 +21,13 @@ namespace service {
 logging::logger rslog("raft_group_registry");
 
 class raft_group_registry::direct_fd_proxy : public raft::failure_detector, public direct_failure_detector::listener {
-    gms::gossiper::direct_fd_pinger _fd_pinger;
+    gms::gossiper::direct_fd_pinger& _fd_pinger;
     raft_address_map<>& _address_map;
 
     std::unordered_set<gms::inet_address> _alive_set;
 
 public:
-    direct_fd_proxy(gms::gossiper::direct_fd_pinger fd_pinger, raft_address_map<>& address_map)
+    direct_fd_proxy(gms::gossiper::direct_fd_pinger& fd_pinger, raft_address_map<>& address_map)
             : _fd_pinger(fd_pinger), _address_map(address_map) {
     }
 


### PR DESCRIPTION
It was passed to `raft_group_registry::direct_fd_proxy` by value. That is a bug, we want to pass a reference to the instance that is living inside `gossiper`.

Fortunately this bug didn't cause problems, because the pinger is only used for one function, `get_address`, which looks up an address in a map and if it doesn't find it, accesses the map that lives inside `gossiper` on shard 0 (and then caches it in the local copy).

Explicitly delete the copy constructor of `direct_fd_pinger` so this doesn't happen again.