### PR TITLE
compaction_manager: Don't let ENOSPC throw out of ::stop() method

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -848,6 +848,20 @@ future<> compaction_manager::really_do_stop() {
     cmlog.info("Stopped");
 }
 
+template <typename Ex>
+requires std::is_base_of_v<std::exception, Ex> &&
+requires (const Ex& ex) {
+    { ex.code() } noexcept -> std::same_as<const std::error_code&>;
+}
+auto swallow_enospc(const Ex& ex) noexcept {
+    if (ex.code().value() != ENOSPC) {
+        return make_exception_future<>(std::make_exception_ptr(ex));
+    }
+
+    cmlog.warn("Got ENOSPC on stop, ignoring...");
+    return make_ready_future<>();
+}
+
 void compaction_manager::do_stop() noexcept {
     if (_state == state::none || _state == state::stopped) {
         return;
@@ -855,7 +869,10 @@ void compaction_manager::do_stop() noexcept {
 
     try {
         _state = state::stopped;
-        _stop_future = really_do_stop();
+        _stop_future = really_do_stop()
+            .handle_exception_type([] (const std::system_error& ex) { return swallow_enospc(ex); })
+            .handle_exception_type([] (const storage_io_error& ex) { return swallow_enospc(ex); })
+        ;
     } catch (...) {
         cmlog.error("Failed to stop the manager: {}", std::current_exception());
     }

--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -52,7 +52,7 @@ public:
         return _what.c_str();
     }
 
-    const std::error_code& code() const { return _code; }
+    const std::error_code& code() const noexcept { return _code; }
 };
 
 // Rethrow exception if not null


### PR DESCRIPTION
The seastar defer_stop() helper is cool, but it forwards any exception from the .stop() towards the caller. In case the caller is main() the exception causes Scylla to abort(). This fires, for example, in compaction_manager::stop() when it steps on ENOSPC

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>