### PR TITLE
Handle storage_io_error's ENOSPC when flushing

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -663,6 +663,8 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
                     allowed_retries--;
                 } else if (auto ep = try_catch<std::system_error>(ex)) {
                     allowed_retries = ep->code().value() == ENOSPC ? default_retries : 0;
+                } else if (auto ep = try_catch<storage_io_error>(ex)) {
+                    allowed_retries = ep->code().value() == ENOSPC ? default_retries : 0;
                 } else {
                     allowed_retries = 0;
                 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -657,7 +657,17 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
             } catch (...) {
                 ex = std::current_exception();
                 _config.cf_stats->failed_memtables_flushes_count++;
-                auto abort_on_error = [ex] () {
+
+                if (try_catch<std::bad_alloc>(ex)) {
+                    // There is a chance something else will free the memory, so we can try again
+                    allowed_retries--;
+                } else if (auto ep = try_catch<std::system_error>(ex)) {
+                    allowed_retries = ep->code().value() == ENOSPC ? default_retries : 0;
+                } else {
+                    allowed_retries = 0;
+                }
+
+                if (allowed_retries <= 0) {
                     // At this point we don't know what has happened and it's better to potentially
                     // take the node down and rely on commitlog to replay.
                     //
@@ -666,21 +676,6 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
                     // may end up in an infinite crash loop.
                     tlogger.error("Memtable flush failed due to: {}. Aborting, at {}", ex, current_backtrace());
                     std::abort();
-                };
-                if (try_catch<std::bad_alloc>(ex)) {
-                    // There is a chance something else will free the memory, so we can try again
-                    if (allowed_retries-- <= 0) {
-                        abort_on_error();
-                    }
-                } else if (auto ep = try_catch<std::system_error>(ex)) {
-                    if (ep->code().value() == ENOSPC) {
-                        // Keep on trying
-                        allowed_retries = default_retries;
-                    } else {
-                        abort_on_error();
-                    }
-                } else {
-                    abort_on_error();
                 }
             }
             if (_async_gate.is_closed()) {


### PR DESCRIPTION
This is the continuation of the a980510654e5a504da1b58bf8398c05676e01572 that tries to catch ENOSPCs reported via storage_io_error similarly to how defer_verbose_shutdown() does on stop