### PR TITLE
repair: change utils::UUID to node_ops_id

### DIFF
--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -13,6 +13,7 @@
 #include "idl/uuid.idl.hh"
 #include "idl/frozen_mutation.idl.hh"
 #include "idl/token.idl.hh"
+#include "repair/id.hh"
 
 class repair_hash {
     uint64_t hash;
@@ -95,11 +96,15 @@ enum class node_ops_cmd : uint32_t {
      repair_updater,
 };
 
+class node_ops_id final {
+    utils::UUID uuid();
+};
+
 struct node_ops_cmd_request {
     // Mandatory field, set by all cmds
     node_ops_cmd cmd;
     // Mandatory field, set by all cmds
-    utils::UUID ops_uuid;
+    node_ops_id ops_uuid;
     // Optional field, list nodes to ignore, set by all cmds
     std::list<gms::inet_address> ignore_nodes;
     // Optional field, list leaving nodes, set by decommission and removenode cmd
@@ -116,7 +121,7 @@ struct node_ops_cmd_response {
     // Mandatory field, set by all cmds
     bool ok;
     // Optional field, set by query_pending_ops cmd
-    std::list<utils::UUID> pending_ops;
+    std::list<node_ops_id> pending_ops;
 };
 
 struct repair_update_system_table_request {

--- a/repair/id.hh
+++ b/repair/id.hh
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "utils/UUID.hh"
+
+using node_ops_id = utils::tagged_uuid<struct node_ops_id_tag>;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -28,6 +28,7 @@
 #include "streaming/stream_reason.hh"
 #include "locator/token_metadata.hh"
 #include "repair/hash.hh"
+#include "repair/id.hh"
 #include "repair/sync_boundary.hh"
 #include "tasks/types.hh"
 
@@ -84,7 +85,7 @@ std::ostream& operator<<(std::ostream& os, const repair_uniq_id& x);
 
 class node_ops_info {
 public:
-    utils::UUID ops_uuid;
+    node_ops_id ops_uuid;
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
 
@@ -94,7 +95,7 @@ private:
     future<> _abort_done = make_ready_future<>();
 
 public:
-    node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
+    node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
 
@@ -288,7 +289,7 @@ struct node_ops_cmd_request {
     // Mandatory field, set by all cmds
     node_ops_cmd cmd;
     // Mandatory field, set by all cmds
-    utils::UUID ops_uuid;
+    node_ops_id ops_uuid;
     // Optional field, list nodes to ignore, set by all cmds
     std::list<gms::inet_address> ignore_nodes;
     // Optional field, list leaving nodes, set by decommission and removenode cmd
@@ -300,7 +301,7 @@ struct node_ops_cmd_request {
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<table_id> repair_tables;
     node_ops_cmd_request(node_ops_cmd command,
-            utils::UUID uuid,
+            node_ops_id uuid,
             std::list<gms::inet_address> ignore = {},
             std::list<gms::inet_address> leaving = {},
             std::unordered_map<gms::inet_address, gms::inet_address> replace = {},
@@ -320,8 +321,8 @@ struct node_ops_cmd_response {
     // Mandatory field, set by all cmds
     bool ok;
     // Optional field, set by query_pending_ops cmd
-    std::list<utils::UUID> pending_ops;
-    node_ops_cmd_response(bool o, std::list<utils::UUID> pending = {})
+    std::list<node_ops_id> pending_ops;
+    node_ops_cmd_response(bool o, std::list<node_ops_id> pending = {})
         : ok(o)
         , pending_ops(std::move(pending)) {
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1912,7 +1912,7 @@ future<> storage_service::do_stop_ms() {
     });
 }
 
-future<> storage_service::node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, utils::UUID uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done) {
+future<> storage_service::node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done) {
     std::string ops;
     if (cmd == node_ops_cmd::decommission_heartbeat) {
         ops = "decommission";
@@ -1950,7 +1950,7 @@ future<> storage_service::node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, utils
 future<> storage_service::decommission() {
     return run_with_api_lock(sstring("decommission"), [] (storage_service& ss) {
         return seastar::async([&ss] {
-            auto uuid = utils::make_random_uuid();
+            auto uuid = node_ops_id::create_random_id();
             auto tmptr = ss.get_token_metadata_ptr();
             auto& db = ss._db.local();
             auto endpoint = ss.get_broadcast_address();
@@ -2098,7 +2098,7 @@ future<> storage_service::decommission() {
 
 // Runs inside seastar::async context
 void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tokens) {
-    auto uuid = utils::make_random_uuid();
+    auto uuid = node_ops_id::create_random_id();
     // TODO: Specify ignore_nodes
     std::list<gms::inet_address> ignore_nodes;
     std::list<gms::inet_address> sync_nodes;
@@ -2120,7 +2120,7 @@ void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tok
         sync_nodes.push_front(get_broadcast_address());
 
         // Step 2: Wait until no pending node operations
-        std::unordered_map<gms::inet_address, std::list<utils::UUID>> pending_ops;
+        std::unordered_map<gms::inet_address, std::list<node_ops_id>> pending_ops;
         auto req = node_ops_cmd_request(node_ops_cmd::query_pending_ops, uuid);
         parallel_for_each(sync_nodes, [this, req, uuid, &pending_ops] (const gms::inet_address& node) {
             return _messaging.local().send_node_ops_cmd(netw::msg_addr(node), req).then([uuid, node, &pending_ops] (node_ops_cmd_response resp) {
@@ -2220,7 +2220,7 @@ void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tok
 // Runs inside seastar::async context
 void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_tokens) {
     auto replace_address = get_replace_address().value();
-    auto uuid = utils::make_random_uuid();
+    auto uuid = node_ops_id::create_random_id();
     auto tmptr = get_token_metadata_ptr();
     std::list<gms::inet_address> ignore_nodes = get_ignore_dead_nodes_for_replace(*tmptr);
     // Step 1: Decide who needs to sync data for replace operation
@@ -2349,7 +2349,7 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
 future<> storage_service::removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params) {
     return run_with_api_lock(sstring("removenode"), [host_id, ignore_nodes_params = std::move(ignore_nodes_params)] (storage_service& ss) mutable {
         return seastar::async([&ss, host_id, ignore_nodes_params = std::move(ignore_nodes_params)] () mutable {
-            auto uuid = utils::make_random_uuid();
+            auto uuid = node_ops_id::create_random_id();
             auto tmptr = ss.get_token_metadata_ptr();
             auto endpoint_opt = tmptr->get_endpoint_for_host_id(host_id);
             if (!endpoint_opt) {
@@ -2478,7 +2478,7 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
 }
 
 void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req) {
-    auto ops_uuids = boost::copy_range<std::vector<utils::UUID>>(_node_ops| boost::adaptors::map_keys);
+    auto ops_uuids = boost::copy_range<std::vector<node_ops_id>>(_node_ops| boost::adaptors::map_keys);
     std::string msg;
     if (req.cmd == node_ops_cmd::removenode_prepare || req.cmd == node_ops_cmd::replace_prepare ||
             req.cmd == node_ops_cmd::decommission_prepare || req.cmd == node_ops_cmd::bootstrap_prepare) {
@@ -2513,7 +2513,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
 
         if (req.cmd == node_ops_cmd::query_pending_ops) {
             bool ok = true;
-            auto ops_uuids = boost::copy_range<std::list<utils::UUID>>(_node_ops| boost::adaptors::map_keys);
+            auto ops_uuids = boost::copy_range<std::list<node_ops_id>>(_node_ops| boost::adaptors::map_keys);
             node_ops_cmd_response resp(ok, ops_uuids);
             slogger.debug("node_ops_cmd_handler: Got query_pending_ops request from {}, pending_ops={}", coordinator, ops_uuids);
             return resp;
@@ -2952,7 +2952,7 @@ future<> storage_service::removenode_with_stream(gms::inet_address leaving_node,
 
 future<> storage_service::restore_replica_count(inet_address endpoint, inet_address notify_endpoint) {
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::removenode)) {
-        auto ops_uuid = utils::make_random_uuid();
+        auto ops_uuid = node_ops_id::create_random_id();
         auto ops = seastar::make_shared<node_ops_info>(ops_uuid, nullptr, std::list<gms::inet_address>());
         return _repair.local().removenode_with_repair(get_token_metadata_ptr(), endpoint, ops).finally([this, notify_endpoint] () {
             return send_replication_notification(notify_endpoint);
@@ -3630,7 +3630,7 @@ bool storage_service::is_repair_based_node_ops_enabled(streaming::stream_reason 
 }
 
 node_ops_meta_data::node_ops_meta_data(
-        utils::UUID ops_uuid,
+        node_ops_id ops_uuid,
         gms::inet_address coordinator,
         std::list<gms::inet_address> ignore_nodes,
         std::function<future<> ()> abort_func,
@@ -3681,7 +3681,7 @@ shared_ptr<abort_source> node_ops_meta_data::get_abort_source() {
     return _abort_source;
 }
 
-future<> storage_service::node_ops_update_heartbeat(utils::UUID ops_uuid) {
+future<> storage_service::node_ops_update_heartbeat(node_ops_id ops_uuid) {
     slogger.debug("node_ops_update_heartbeat: ops_uuid={}", ops_uuid);
     auto permit = co_await seastar::get_units(_node_ops_abort_sem, 1);
     auto it = _node_ops.find(ops_uuid);
@@ -3691,7 +3691,7 @@ future<> storage_service::node_ops_update_heartbeat(utils::UUID ops_uuid) {
     }
 }
 
-future<> storage_service::node_ops_done(utils::UUID ops_uuid) {
+future<> storage_service::node_ops_done(node_ops_id ops_uuid) {
     slogger.debug("node_ops_done: ops_uuid={}", ops_uuid);
     auto permit = co_await seastar::get_units(_node_ops_abort_sem, 1);
     auto it = _node_ops.find(ops_uuid);
@@ -3703,7 +3703,7 @@ future<> storage_service::node_ops_done(utils::UUID ops_uuid) {
     }
 }
 
-future<> storage_service::node_ops_abort(utils::UUID ops_uuid) {
+future<> storage_service::node_ops_abort(node_ops_id ops_uuid) {
     slogger.debug("node_ops_abort: ops_uuid={}", ops_uuid);
     auto permit = co_await seastar::get_units(_node_ops_abort_sem, 1);
 
@@ -3737,7 +3737,7 @@ future<> storage_service::node_ops_abort(utils::UUID ops_uuid) {
     }
 }
 
-void storage_service::node_ops_singal_abort(std::optional<utils::UUID> ops_uuid) {
+void storage_service::node_ops_singal_abort(std::optional<node_ops_id> ops_uuid) {
     slogger.debug("node_ops_singal_abort: ops_uuid={}", ops_uuid);
     _node_ops_abort_queue.push_back(ops_uuid);
     _node_ops_abort_cond.signal();
@@ -3752,7 +3752,7 @@ future<> storage_service::node_ops_abort_thread() {
             auto uuid_opt = _node_ops_abort_queue.front();
             _node_ops_abort_queue.pop_front();
             try {
-                co_await node_ops_abort(uuid_opt.value_or(utils::null_uuid()));
+                co_await node_ops_abort(uuid_opt.value_or(node_ops_id::create_null_id()));
             } catch (...) {
                 slogger.warn("Failed to abort node operation ops_uuid={}: {}", *uuid_opt, std::current_exception());
             }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -42,6 +42,7 @@
 #include "locator/snitch_base.hh"
 #include "cdc/generation_id.hh"
 #include "raft/raft.hh"
+#include "repair/id.hh"
 
 class node_ops_cmd_request;
 class node_ops_cmd_response;
@@ -91,7 +92,7 @@ class raft_group0;
 enum class disk_error { regular, commit };
 
 class node_ops_meta_data {
-    utils::UUID _ops_uuid;
+    node_ops_id _ops_uuid;
     gms::inet_address _coordinator;
     std::function<future<> ()> _abort;
     shared_ptr<abort_source> _abort_source;
@@ -101,7 +102,7 @@ class node_ops_meta_data {
     std::chrono::seconds _watchdog_interval{120};
 public:
     explicit node_ops_meta_data(
-            utils::UUID ops_uuid,
+            node_ops_id ops_uuid,
             gms::inet_address coordinator,
             std::list<gms::inet_address> ignore_nodes,
             std::function<future<> ()> abort_func,
@@ -157,15 +158,15 @@ private:
     std::vector<std::any> _listeners;
     gate _async_gate;
 
-    std::unordered_map<utils::UUID, node_ops_meta_data> _node_ops;
-    std::list<std::optional<utils::UUID>> _node_ops_abort_queue;
+    std::unordered_map<node_ops_id, node_ops_meta_data> _node_ops;
+    std::list<std::optional<node_ops_id>> _node_ops_abort_queue;
     seastar::condition_variable _node_ops_abort_cond;
     named_semaphore _node_ops_abort_sem{1, named_semaphore_exception_factory{"node_ops_abort_sem"}};
     future<> _node_ops_abort_thread;
-    future<> node_ops_update_heartbeat(utils::UUID ops_uuid);
-    future<> node_ops_done(utils::UUID ops_uuid);
-    future<> node_ops_abort(utils::UUID ops_uuid);
-    void node_ops_singal_abort(std::optional<utils::UUID> ops_uuid);
+    future<> node_ops_update_heartbeat(node_ops_id ops_uuid);
+    future<> node_ops_done(node_ops_id ops_uuid);
+    future<> node_ops_abort(node_ops_id ops_uuid);
+    void node_ops_singal_abort(std::optional<node_ops_id> ops_uuid);
     future<> node_ops_abort_thread();
 public:
     storage_service(abort_source& as, distributed<replica::database>& db,
@@ -705,7 +706,7 @@ public:
     future<> removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes);
     future<node_ops_cmd_response> node_ops_cmd_handler(gms::inet_address coordinator, node_ops_cmd_request req);
     void node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req);
-    future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, utils::UUID uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
+    future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
 
     future<mode> get_operation_mode();
 


### PR DESCRIPTION
Type of the id of node operations is changed from `utils::UUID` to `node_ops_id`. This way the id of node operations would be easily distinguished from the ids of other entities.