### PR TITLE
Detect and record large collections

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -410,6 +410,9 @@ commitlog_total_space_in_mb: -1
 # Log a warning when row number is larger than this value
 # compaction_rows_count_warning_threshold: 100000
 
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
 # How long the coordinator should wait for seq or index scans to complete
 # range_request_timeout_in_ms: 10000
 # How long the coordinator should wait for writes to complete

--- a/db/config.cc
+++ b/db/config.cc
@@ -382,6 +382,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Log a warning when writing cells larger than this value")
     , compaction_rows_count_warning_threshold(this, "compaction_rows_count_warning_threshold", value_status::Used, 100000,
         "Log a warning when writing a number of rows larger than this value")
+    , compaction_collection_elements_count_warning_threshold(this, "compaction_collection_elements_count_warning_threshold", value_status::Used, 10000,
+        "Log a warning when writing a collection containing more elements than this value")
     /* Common memtable settings */
     , memtable_total_space_in_mb(this, "memtable_total_space_in_mb", value_status::Invalid, 0,
         "Specifies the total memory used for all memtables on a node. This replaces the per-table storage settings memtable_operations_in_millions and memtable_throughput_in_mb.")

--- a/db/config.cc
+++ b/db/config.cc
@@ -374,15 +374,15 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , compaction_throughput_mb_per_sec(this, "compaction_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
         "Throttles compaction to the specified total throughput across the entire system. The faster you insert data, the faster you need to compact in order to keep the SSTable count down. The recommended Value is 16 to 32 times the rate of write throughput (in MBs/second). Setting the value to 0 disables compaction throttling.\n"
         "Related information: Configuring compaction")
-    , compaction_large_partition_warning_threshold_mb(this, "compaction_large_partition_warning_threshold_mb", value_status::Used, 1000,
+    , compaction_large_partition_warning_threshold_mb(this, "compaction_large_partition_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 1000,
         "Log a warning when writing partitions larger than this value")
-    , compaction_large_row_warning_threshold_mb(this, "compaction_large_row_warning_threshold_mb", value_status::Used, 10,
+    , compaction_large_row_warning_threshold_mb(this, "compaction_large_row_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 10,
         "Log a warning when writing rows larger than this value")
-    , compaction_large_cell_warning_threshold_mb(this, "compaction_large_cell_warning_threshold_mb", value_status::Used, 1,
+    , compaction_large_cell_warning_threshold_mb(this, "compaction_large_cell_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 1,
         "Log a warning when writing cells larger than this value")
-    , compaction_rows_count_warning_threshold(this, "compaction_rows_count_warning_threshold", value_status::Used, 100000,
+    , compaction_rows_count_warning_threshold(this, "compaction_rows_count_warning_threshold", liveness::LiveUpdate, value_status::Used, 100000,
         "Log a warning when writing a number of rows larger than this value")
-    , compaction_collection_elements_count_warning_threshold(this, "compaction_collection_elements_count_warning_threshold", value_status::Used, 10000,
+    , compaction_collection_elements_count_warning_threshold(this, "compaction_collection_elements_count_warning_threshold", liveness::LiveUpdate, value_status::Used, 10000,
         "Log a warning when writing a collection containing more elements than this value")
     /* Common memtable settings */
     , memtable_total_space_in_mb(this, "memtable_total_space_in_mb", value_status::Invalid, 0,

--- a/db/config.hh
+++ b/db/config.hh
@@ -163,6 +163,7 @@ public:
     named_value<uint32_t> compaction_large_row_warning_threshold_mb;
     named_value<uint32_t> compaction_large_cell_warning_threshold_mb;
     named_value<uint32_t> compaction_rows_count_warning_threshold;
+    named_value<uint32_t> compaction_collection_elements_count_warning_threshold;
     named_value<uint32_t> memtable_total_space_in_mb;
     named_value<uint32_t> concurrent_reads;
     named_value<uint32_t> concurrent_writes;

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -170,6 +170,8 @@ future<> cql_table_large_data_handler::delete_large_data_entries(const schema& s
     const sstring req =
             format("DELETE FROM system.{} WHERE keyspace_name = ? AND table_name = ? AND sstable_name = ?",
                     large_table_name);
+    large_data_logger.debug("Dropping entries from {}: ks = {}, table = {}, sst = {}",
+            large_table_name, s.ks_name(), s.cf_name(), sstable_name);
     return db::qctx->execute_cql(req, s.ks_name(), s.cf_name(), sstable_name)
             .discard_result()
             .handle_exception([&s, sstable_name, large_table_name] (std::exception_ptr ep) {

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -140,7 +140,7 @@ future<> cql_table_large_data_handler::record_large_partitions(const sstables::s
 }
 
 future<> cql_table_large_data_handler::record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
-        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size) const {
+        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const {
     auto column_name = cdef.name_as_text();
     std::string_view cell_type = cdef.is_atomic() ? "cell" : "collection";
     static const std::vector<sstring> extra_fields{"clustering_key", "column_name"};

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -103,6 +103,10 @@ future<> large_data_handler::maybe_delete_large_data_entries(sstables::shared_ss
     return when_all(std::move(large_partitions), std::move(large_rows), std::move(large_cells)).discard_result();
 }
 
+cql_table_large_data_handler::cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold)
+    : large_data_handler(partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, collection_elements_count_threshold)
+    {}
+
 template <typename... Args>
 static future<> try_record(std::string_view large_table, const sstables::sstable& sst,  const sstables::key& partition_key, int64_t size,
         std::string_view desc, std::string_view extra_path, const std::vector<sstring> &extra_fields, Args&&... args) {

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -18,19 +18,20 @@ namespace db {
 
 nop_large_data_handler::nop_large_data_handler()
     : large_data_handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(),
-          std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()) {
+          std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()) {
     // Don't require start() to be called on nop large_data_handler.
     start();
 }
 
-large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold)
+large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold)
         : _partition_threshold_bytes(partition_threshold_bytes)
         , _row_threshold_bytes(row_threshold_bytes)
         , _cell_threshold_bytes(cell_threshold_bytes)
         , _rows_count_threshold(rows_count_threshold)
+        , _collection_elements_count_threshold(collection_elements_count_threshold)
 {
-    large_data_logger.debug("partition_threshold_bytes={} row_threshold_bytes={} cell_threshold_bytes={} rows_count_threshold={}",
-        partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold);
+    large_data_logger.debug("partition_threshold_bytes={} row_threshold_bytes={} cell_threshold_bytes={} rows_count_threshold={} collection_elements_count_threshold={}",
+        partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, _collection_elements_count_threshold);
 }
 
 future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows) {

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -130,8 +130,7 @@ protected:
 
 class cql_table_large_data_handler : public large_data_handler {
 public:
-    explicit cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold)
-        : large_data_handler(partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, collection_elements_count_threshold) {}
+    explicit cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
 
 protected:
     virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const override;

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -54,10 +54,11 @@ private:
     uint64_t _row_threshold_bytes;
     uint64_t _cell_threshold_bytes;
     uint64_t _rows_count_threshold;
+    uint64_t _collection_elements_count_threshold;
     mutable large_data_handler::stats _stats;
 
 public:
-    explicit large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold);
+    explicit large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
     virtual ~large_data_handler() {}
 
     // Once large_data_handler is stopped no further updates will be accepted.
@@ -113,6 +114,9 @@ public:
     uint64_t get_rows_count_threshold() const noexcept {
         return _rows_count_threshold;
     }
+    uint64_t get_collection_elements_count_threshold() const noexcept {
+        return _collection_elements_count_threshold;
+    }
 
     static sstring sst_filename(const sstables::sstable& sst);
 
@@ -126,8 +130,8 @@ protected:
 
 class cql_table_large_data_handler : public large_data_handler {
 public:
-    explicit cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold)
-        : large_data_handler(partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold) {}
+    explicit cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold)
+        : large_data_handler(partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, collection_elements_count_threshold) {}
 
 protected:
     virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const override;

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -129,8 +129,10 @@ protected:
 };
 
 class cql_table_large_data_handler : public large_data_handler {
+    gms::feature_service& _feat;
 public:
-    explicit cql_table_large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
+    explicit cql_table_large_data_handler(gms::feature_service& feat,
+            uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
 
 protected:
     virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const override;

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -130,6 +130,9 @@ protected:
 
 class cql_table_large_data_handler : public large_data_handler {
     gms::feature_service& _feat;
+    std::function<future<> (const sstables::sstable& sst, const sstables::key& partition_key,
+            const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_items)> _record_large_cells;
+    std::optional<std::any> _feat_listener;
 public:
     explicit cql_table_large_data_handler(gms::feature_service& feat,
             uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
@@ -140,6 +143,12 @@ protected:
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override;
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key, const clustering_key_prefix* clustering_key, uint64_t row_size) const override;
+
+private:
+    future<> internal_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
+            const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_items) const;
+    future<> internal_record_large_cells_and_collections(const sstables::sstable& sst, const sstables::key& partition_key,
+            const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_items) const;
 };
 
 class nop_large_data_handler : public large_data_handler {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -602,6 +602,7 @@ schema_ptr system_keyspace::large_rows() {
 }
 
 schema_ptr system_keyspace::large_cells() {
+    constexpr uint16_t schema_version_offset = 1; // collection_elements
     static thread_local auto large_cells = [] {
         auto id = generate_legacy_id(NAME, LARGE_CELLS);
         return schema_builder(NAME, LARGE_CELLS, id)
@@ -613,9 +614,11 @@ schema_ptr system_keyspace::large_cells() {
                 .with_column("partition_key", utf8_type, column_kind::clustering_key)
                 .with_column("clustering_key", utf8_type, column_kind::clustering_key)
                 .with_column("column_name", utf8_type, column_kind::clustering_key)
+                // regular rows
+                .with_column("collection_elements", long_type)
                 .with_column("compaction_time", timestamp_type)
                 .set_comment("cells larger than specified threshold")
-                .with_version(generate_schema_version(id))
+                .with_version(generate_schema_version(id, schema_version_offset))
                 .set_gc_grace_seconds(0)
                 .set_caching_options(caching_options::get_disabled_caching_options())
                 .build();

--- a/docs/dev/sstable-scylla-format.md
+++ b/docs/dev/sstable-scylla-format.md
@@ -124,11 +124,12 @@ guaranteed to be disjoint (non-overlapping) in their partition keys.
     large_data_stats = large_data_count large_data_pair*
     large_data_count = be32
     large_data_pair = large_data_type large_data_stats_entry
-    large_data_type = partition_size | row_size | cell_size | rows_in_partition
+    large_data_type = partition_size | row_size | cell_size | rows_in_partition | elements_in_collection
         partition_size = be32(1)    // partition size, in bytes
         row_size = be32(2)          // row size, in bytes
         cell_size = be32(3)         // cell size, in bytes
         rows_in_partition = be32(4) // number of rows in a partition
+        elements_in_collection = be32(5) // number of elements in a collection
     large_data_stats_entry = max_value threshold above_threshold
         max_value = be64
         threshold = be64

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -99,6 +99,7 @@ CREATE TABLE system.large_cells (
     clustering_key text,
     column_name text,
     compaction_time timestamp,
+    collection_elements bigint,
     PRIMARY KEY ((keyspace_name, table_name), sstable_name, cell_size, partition_key, clustering_key, column_name)
 ) WITH CLUSTERING ORDER BY (sstable_name ASC, cell_size DESC, partition_key ASC, clustering_key ASC, column_name ASC)
 ~~~

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -65,9 +65,9 @@ For example:
     > SELECT * FROM system.large_cells;
 
 
-    keyspace_name | table_name | sstable_name     | cell_size | partition_key | clustering_key | column_name | compaction_time
-    --------------+------------+------------------+-----------+---------------+----------------+-------------+---------------------------------
-    mykeyspace    |         gr | md-1-big-Data.db |   1206115 |             1 |              1 |        link | 2019-06-14 13:03:24.034000+0000
+    keyspace_name | table_name | sstable_name     | cell_size | partition_key | clustering_key | column_name | collection_elements | compaction_time                
+    --------------+------------+------------------+-----------+---------------+----------------+-------------+---------------------+---------------------------------
+    mykeyspace    |         gr | md-1-big-Data.db |   1206115 |             1 |              1 |        link |               17042 | 2019-06-14 13:03:24.034000+0000
    
   
 ================================================  =================================================================================
@@ -84,6 +84,8 @@ cell_size                                         The size of the row, in bytes
 clustering_key                                     The clustering key that holds the large row
 ------------------------------------------------  ---------------------------------------------------------------------------------
 column_name                                       The column of the large cell 
+------------------------------------------------  ---------------------------------------------------------------------------------
+collection_elements                               The number of elements in the large collection cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
 compaction_time                                   Time when compaction occur
 ================================================  =================================================================================
@@ -149,6 +151,7 @@ Large rows and large cells are stored in system tables with the following schema
       partition_key text,
       clustering_key text,
       column_name text,
+      collection_elements bigint,
       compaction_time timestamp,
       PRIMARY KEY ((keyspace_name, table_name), sstable_name, cell_size, partition_key, clustering_key, column_name)
   ) WITH CLUSTERING ORDER BY (sstable_name ASC, cell_size DESC, partition_key ASC, clustering_key ASC, column_name ASC)

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -31,17 +31,17 @@ For example:
 ================================================  =================================================================================
 Parameter                                         Description
 ================================================  =================================================================================
-keyspace_name                                     The keyspace name that holds the large partition
+keyspace_name                                     The keyspace name that holds the large row
 ------------------------------------------------  ---------------------------------------------------------------------------------
-table_name                                        The table name that holds the large partition
+table_name                                        The table name that holds the large row
 ------------------------------------------------  ---------------------------------------------------------------------------------
-sstable_name                                      The SSTable name that holds the large partition
+sstable_name                                      The SSTable name that holds the large row
 ------------------------------------------------  ---------------------------------------------------------------------------------
 row_size                                          The size of the row in bytes
 ------------------------------------------------  ---------------------------------------------------------------------------------
-clustering_key                                     The clustering key that holds the large row
+clustering_key                                    The clustering key that holds the large row
 ------------------------------------------------  ---------------------------------------------------------------------------------
-compaction_time                                   Time when compaction occur
+compaction_time                                   Time when compaction occurred
 ================================================  =================================================================================
 
 * Search within all the large rows for a specific keyspace and or table.
@@ -73,21 +73,21 @@ For example:
 ================================================  =================================================================================
 Parameter                                         Description
 ================================================  =================================================================================
-keyspace_name                                     The keyspace name that holds the large partition
+keyspace_name                                     The keyspace name that holds the large cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
-table_name                                        The table name that holds the large partition
+table_name                                        The table name that holds the large cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
-sstable_name                                      The SSTable name that holds the large partition
+sstable_name                                      The SSTable name that holds the large cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
-cell_size                                         The size of the row, in bytes
+cell_size                                         The size of the cell, in bytes
 ------------------------------------------------  ---------------------------------------------------------------------------------
-clustering_key                                     The clustering key that holds the large row
+clustering_key                                    The clustering key of the row that holds the large cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
 column_name                                       The column of the large cell 
 ------------------------------------------------  ---------------------------------------------------------------------------------
 collection_elements                               The number of elements in the large collection cell
 ------------------------------------------------  ---------------------------------------------------------------------------------
-compaction_time                                   Time when compaction occur
+compaction_time                                   Time when compaction occurred
 ================================================  =================================================================================
 
 * Search within all the large cells for a specific keyspace and or table.

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -104,6 +104,7 @@ Configure the detection threshold of large rows and large cells with the corresp
 
 * ``compaction_large_row_warning_threshold_mb`` parameter (default: 10MB).
 * ``compaction_large_cell_warning_threshold_mb`` parameter (default: 1MB).
+* ``compaction_collection_elements_count_warning_threshold`` parameter (default: 10000).
 
 Once the threshold is reached, the relevant information is captured in the ``system.large_rows`` / ``system.large_cells`` tables.
 In addition,  a warning message is logged in the Scylla log (refer to :doc:`logging </getting-started/logging>`).

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -123,6 +123,7 @@ std::set<std::string_view> feature_service::supported_feature_set() {
         "CORRECT_STATIC_COMPACT_IN_MC"sv,
         "UNBOUNDED_RANGE_TOMBSTONES"sv,
         "MC_SSTABLE_FORMAT"sv,
+        "LARGE_COLLECTION_DETECTION"sv,
     };
 
     for (auto& [name, f_ref] : _registered_features) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -111,6 +111,7 @@ public:
     gms::feature uda_native_parallelized_aggregation { *this, "UDA_NATIVE_PARALLELIZED_AGGREGATION"sv };
     gms::feature aggregate_storage_options { *this, "AGGREGATE_STORAGE_OPTIONS"sv };
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
+    gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
 
 public:
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -349,11 +349,11 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _compaction_manager(cm)
     , _enable_incremental_backups(cfg.incremental_backups())
     , _large_data_handler(std::make_unique<db::cql_table_large_data_handler>(feat,
-              _cfg.compaction_large_partition_warning_threshold_mb()*1024*1024,
-              _cfg.compaction_large_row_warning_threshold_mb()*1024*1024,
-              _cfg.compaction_large_cell_warning_threshold_mb()*1024*1024,
-              _cfg.compaction_rows_count_warning_threshold(),
-              _cfg.compaction_collection_elements_count_warning_threshold()))
+              _cfg.compaction_large_partition_warning_threshold_mb,
+              _cfg.compaction_large_row_warning_threshold_mb,
+              _cfg.compaction_large_cell_warning_threshold_mb,
+              _cfg.compaction_rows_count_warning_threshold,
+              _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
     , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
     , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -351,7 +351,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _large_data_handler(std::make_unique<db::cql_table_large_data_handler>(_cfg.compaction_large_partition_warning_threshold_mb()*1024*1024,
               _cfg.compaction_large_row_warning_threshold_mb()*1024*1024,
               _cfg.compaction_large_cell_warning_threshold_mb()*1024*1024,
-              _cfg.compaction_rows_count_warning_threshold()))
+              _cfg.compaction_rows_count_warning_threshold(),
+              _cfg.compaction_collection_elements_count_warning_threshold()))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
     , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
     , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -348,7 +348,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _version(empty_version)
     , _compaction_manager(cm)
     , _enable_incremental_backups(cfg.incremental_backups())
-    , _large_data_handler(std::make_unique<db::cql_table_large_data_handler>(_cfg.compaction_large_partition_warning_threshold_mb()*1024*1024,
+    , _large_data_handler(std::make_unique<db::cql_table_large_data_handler>(feat,
+              _cfg.compaction_large_partition_warning_threshold_mb()*1024*1024,
               _cfg.compaction_large_row_warning_threshold_mb()*1024*1024,
               _cfg.compaction_large_cell_warning_threshold_mb()*1024*1024,
               _cfg.compaction_rows_count_warning_threshold(),

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -594,9 +594,9 @@ private:
     run_id _run_identifier;
     bool _write_regular_as_static; // See #4139
     large_data_stats_entry _partition_size_entry;
+    large_data_stats_entry _rows_in_partition_entry;
     large_data_stats_entry _row_size_entry;
     large_data_stats_entry _cell_size_entry;
-    large_data_stats_entry _rows_in_partition_entry;
     large_data_stats_entry _elements_in_collection_entry;
 
     void init_file_writers();
@@ -761,6 +761,11 @@ public:
                         .threshold = _sst.get_large_data_handler().get_partition_threshold_bytes(),
                     }
                 )
+        , _rows_in_partition_entry(
+                    large_data_stats_entry{
+                        .threshold = _sst.get_large_data_handler().get_rows_count_threshold(),
+                    }
+                )
         , _row_size_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_row_threshold_bytes(),
@@ -769,11 +774,6 @@ public:
         , _cell_size_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_cell_threshold_bytes(),
-                    }
-                )
-        , _rows_in_partition_entry(
-                    large_data_stats_entry{
-                        .threshold = _sst.get_large_data_handler().get_rows_count_threshold(),
                     }
                 )
         , _elements_in_collection_entry(
@@ -1470,9 +1470,9 @@ void writer::consume_end_of_stream() {
     std::optional<scylla_metadata::large_data_stats> ld_stats(scylla_metadata::large_data_stats{
         .map = {
             { large_data_type::partition_size, std::move(_partition_size_entry) },
+            { large_data_type::rows_in_partition, std::move(_rows_in_partition_entry) },
             { large_data_type::row_size, std::move(_row_size_entry) },
             { large_data_type::cell_size, std::move(_cell_size_entry) },
-            { large_data_type::rows_in_partition, std::move(_rows_in_partition_entry) },
             { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
         }
     });

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1000,8 +1000,7 @@ void writer::maybe_record_large_cells(const sstables::sstable& sst, const sstabl
     if (collection_elements_entry.max_value < collection_elements) {
         collection_elements_entry.max_value = collection_elements;
     }
-    // FIXME: pass collection_elements to large_data_handler
-    if (_sst.get_large_data_handler().maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, cell_size).get0()) {
+    if (_sst.get_large_data_handler().maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, cell_size, collection_elements).get0()) {
         if (cell_size > cell_size_entry.threshold) {
             cell_size_entry.above_threshold++;
         }

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -593,7 +593,11 @@ private:
     } _pi_write_m;
     run_id _run_identifier;
     bool _write_regular_as_static; // See #4139
-    scylla_metadata::large_data_stats _large_data_stats;
+    large_data_stats_entry _partition_size_entry;
+    large_data_stats_entry _row_size_entry;
+    large_data_stats_entry _cell_size_entry;
+    large_data_stats_entry _rows_in_partition_entry;
+    large_data_stats_entry _elements_in_collection_entry;
 
     void init_file_writers();
 
@@ -752,38 +756,31 @@ public:
         , _sst_schema(make_sstable_schema(s, _enc_stats, _cfg))
         , _run_identifier(cfg.run_identifier)
         , _write_regular_as_static(s.is_static_compact_table())
-        , _large_data_stats({{
-                {
-                    large_data_type::partition_size,
+        , _partition_size_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_partition_threshold_bytes(),
                     }
-                },
-                {
-                    large_data_type::row_size,
+                )
+        , _row_size_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_row_threshold_bytes(),
                     }
-                },
-                {
-                    large_data_type::cell_size,
+                )
+        , _cell_size_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_cell_threshold_bytes(),
                     }
-                },
-                {
-                    large_data_type::rows_in_partition,
+                )
+        , _rows_in_partition_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_rows_count_threshold(),
                     }
-                },
-                {
-                    large_data_type::elements_in_collection,
+                )
+        , _elements_in_collection_entry(
                     large_data_stats_entry{
                         .threshold = _sst.get_large_data_handler().get_collection_elements_count_threshold(),
                     }
-                },
-            }})
+                )
     {
         // This can be 0 in some cases, which is albeit benign, can wreak havoc
         // in lower-level writer code, so clamp it to [1, +inf) here, which is
@@ -970,8 +967,8 @@ void writer::consume(tombstone t) {
 
 void writer::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
                                            uint64_t partition_size, uint64_t rows) {
-    auto& size_entry = _large_data_stats.map.at(large_data_type::partition_size);
-    auto& row_count_entry = _large_data_stats.map.at(large_data_type::rows_in_partition);
+    auto& size_entry = _partition_size_entry;
+    auto& row_count_entry = _rows_in_partition_entry;
     size_entry.max_value = std::max(size_entry.max_value, partition_size);
     row_count_entry.max_value = std::max(row_count_entry.max_value, rows);
     auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows).get0();
@@ -981,7 +978,7 @@ void writer::maybe_record_large_partitions(const sstables::sstable& sst, const s
 
 void writer::maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
         const clustering_key_prefix* clustering_key, uint64_t row_size) {
-    auto& entry = _large_data_stats.map.at(large_data_type::row_size);
+    auto& entry = _row_size_entry;
     if (entry.max_value < row_size) {
         entry.max_value = row_size;
     }
@@ -992,11 +989,11 @@ void writer::maybe_record_large_rows(const sstables::sstable& sst, const sstable
 
 void writer::maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
         const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
-    auto& cell_size_entry = _large_data_stats.map.at(large_data_type::cell_size);
+    auto& cell_size_entry = _cell_size_entry;
     if (cell_size_entry.max_value < cell_size) {
         cell_size_entry.max_value = cell_size;
     }
-    auto& collection_elements_entry = _large_data_stats.map.at(large_data_type::elements_in_collection);
+    auto& collection_elements_entry = _elements_in_collection_entry;
     if (collection_elements_entry.max_value < collection_elements) {
         collection_elements_entry.max_value = collection_elements;
     }
@@ -1470,7 +1467,15 @@ void writer::consume_end_of_stream() {
     _sst.write_compression(_pc);
     auto features = sstable_enabled_features::all();
     run_identifier identifier{_run_identifier};
-    std::optional<scylla_metadata::large_data_stats> ld_stats(std::move(_large_data_stats));
+    std::optional<scylla_metadata::large_data_stats> ld_stats(scylla_metadata::large_data_stats{
+        .map = {
+            { large_data_type::partition_size, std::move(_partition_size_entry) },
+            { large_data_type::row_size, std::move(_row_size_entry) },
+            { large_data_type::cell_size, std::move(_cell_size_entry) },
+            { large_data_type::rows_in_partition, std::move(_rows_in_partition_entry) },
+            { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
+        }
+    });
     _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
     if (!_cfg.leave_unsealed) {
         _sst.seal_sstable(_cfg.backup).get();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -777,6 +777,12 @@ public:
                         .threshold = _sst.get_large_data_handler().get_rows_count_threshold(),
                     }
                 },
+                {
+                    large_data_type::elements_in_collection,
+                    large_data_stats_entry{
+                        .threshold = _sst.get_large_data_handler().get_collection_elements_count_threshold(),
+                    }
+                },
             }})
     {
         // This can be 0 in some cases, which is albeit benign, can wreak havoc

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -686,7 +686,7 @@ private:
     void maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const uint64_t row_size);
     void maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
-            const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size);
+            const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements);
 
     // Writes single atomic cell
     void write_cell(bytes_ostream& writer, const clustering_key_prefix* clustering_key, atomic_cell_view cell, const column_definition& cdef,
@@ -991,13 +991,23 @@ void writer::maybe_record_large_rows(const sstables::sstable& sst, const sstable
 }
 
 void writer::maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
-        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size) {
-    auto& entry = _large_data_stats.map.at(large_data_type::cell_size);
-    if (entry.max_value < cell_size) {
-        entry.max_value = cell_size;
+        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
+    auto& cell_size_entry = _large_data_stats.map.at(large_data_type::cell_size);
+    if (cell_size_entry.max_value < cell_size) {
+        cell_size_entry.max_value = cell_size;
     }
+    auto& collection_elements_entry = _large_data_stats.map.at(large_data_type::elements_in_collection);
+    if (collection_elements_entry.max_value < collection_elements) {
+        collection_elements_entry.max_value = collection_elements;
+    }
+    // FIXME: pass collection_elements to large_data_handler
     if (_sst.get_large_data_handler().maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, cell_size).get0()) {
-        entry.above_threshold++;
+        if (cell_size > cell_size_entry.threshold) {
+            cell_size_entry.above_threshold++;
+        }
+        if (collection_elements > collection_elements_entry.threshold) {
+            collection_elements_entry.above_threshold++;
+        }
     };
 }
 
@@ -1067,7 +1077,7 @@ void writer::write_cell(bytes_ostream& writer, const clustering_key_prefix* clus
     // We record collections in write_collection, so ignore them here
     if (cdef.is_atomic()) {
         uint64_t size = writer.size() - current_pos;
-        maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size);
+        maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size, 0);
     }
 
     _c_stats.update_timestamp(cell.timestamp());
@@ -1118,23 +1128,25 @@ void writer::write_collection(bytes_ostream& writer, const clustering_key_prefix
         const column_definition& cdef, collection_mutation_view collection, const row_time_properties& properties,
         bool has_complex_deletion) {
     uint64_t current_pos = writer.size();
+    uint64_t collection_elements = 0;
     collection.with_deserialized(*cdef.type, [&] (collection_mutation_view_description mview) {
         if (has_complex_deletion) {
             write_delta_deletion_time(writer, mview.tomb);
             _c_stats.update(mview.tomb);
         }
 
-        write_vint(writer, mview.cells.size());
+        collection_elements = mview.cells.size();
+        write_vint(writer, collection_elements);
         if (!mview.cells.empty()) {
             ++_c_stats.column_count;
         }
         for (const auto& [cell_path, cell]: mview.cells) {
-            ++_c_stats.cells_count;
             write_cell(writer, clustering_key, cell, cdef, properties, cell_path);
         }
+        _c_stats.cells_count += collection_elements;
     });
     uint64_t size = writer.size() - current_pos;
-    maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size);
+    maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size, collection_elements);
 }
 
 void writer::write_cells(bytes_ostream& writer, const clustering_key_prefix* clustering_key, column_kind kind, const row& row_body,

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -551,6 +551,7 @@ enum class large_data_type : uint32_t {
     row_size = 2,           // row size, in bytes
     cell_size = 3,          // cell size, in bytes
     rows_in_partition = 4,  // number of rows in a partition
+    elements_in_collection = 5,// number of elements in a collection
 };
 
 struct large_data_stats_entry {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -29,6 +29,7 @@
 #include "test/lib/tmpdir.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/index_reader_assertions.hh"
+#include "test/lib/random_utils.hh"
 #include "sstables/types.hh"
 #include "keys.hh"
 #include "types.hh"
@@ -5262,7 +5263,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_log_too_many_rows) {
     // Generates a pseudo-random number from 1 to 100
-    uint64_t random = (rand() % 100 + 1);
+    uint64_t random = tests::random::get_int(1, 100);
 
     // This test creates a sstable with a given number of rows and test it against a
     // compaction_rows_count_warning_threshold. A warning is triggered when the number of rows

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5142,7 +5142,7 @@ struct large_row_handler : public db::large_data_handler {
 
     large_row_handler(uint64_t large_rows_threshold, uint64_t rows_count_threshold, uint64_t cell_threshold_bytes, callback_t callback)
         : large_data_handler(std::numeric_limits<uint64_t>::max(), large_rows_threshold, cell_threshold_bytes,
-            rows_count_threshold)
+            rows_count_threshold, std::numeric_limits<uint64_t>::max())
         , callback(std::move(callback)) {
         start();
     }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5155,7 +5155,7 @@ struct large_row_handler : public db::large_data_handler {
     }
 
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
-        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size) const override {
+        const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override {
         const schema_ptr s = sst.get_schema();
         callback(*s, partition_key, clustering_key, 0, &cdef, cell_size);
         return make_ready_future<>();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5140,8 +5140,8 @@ struct large_row_handler : public db::large_data_handler {
             const clustering_key_prefix* clustering_key, uint64_t row_size, const column_definition* cdef, uint64_t cell_size)>;
     callback_t callback;
 
-    large_row_handler(uint64_t large_rows_threshold, uint64_t rows_count_threshold, callback_t callback)
-        : large_data_handler(std::numeric_limits<uint64_t>::max(), large_rows_threshold, std::numeric_limits<uint64_t>::max(),
+    large_row_handler(uint64_t large_rows_threshold, uint64_t rows_count_threshold, uint64_t cell_threshold_bytes, callback_t callback)
+        : large_data_handler(std::numeric_limits<uint64_t>::max(), large_rows_threshold, cell_threshold_bytes,
             rows_count_threshold)
         , callback(std::move(callback)) {
         start();
@@ -5192,7 +5192,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
         ++i;
     };
 
-    large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), f);
+    large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
@@ -5253,7 +5253,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
         logged = true;
     };
 
-    large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, f);
+    large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5137,12 +5137,12 @@ SEASTAR_TEST_CASE(test_sstable_reader_on_unknown_column) {
 namespace {
 struct large_row_handler : public db::large_data_handler {
     using callback_t = std::function<void(const schema& s, const sstables::key& partition_key,
-            const clustering_key_prefix* clustering_key, uint64_t row_size, const column_definition* cdef, uint64_t cell_size)>;
+            const clustering_key_prefix* clustering_key, uint64_t row_size, const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements)>;
     callback_t callback;
 
-    large_row_handler(uint64_t large_rows_threshold, uint64_t rows_count_threshold, uint64_t cell_threshold_bytes, callback_t callback)
+    large_row_handler(uint64_t large_rows_threshold, uint64_t rows_count_threshold, uint64_t cell_threshold_bytes, uint64_t collection_elements_threshold, callback_t callback)
         : large_data_handler(std::numeric_limits<uint64_t>::max(), large_rows_threshold, cell_threshold_bytes,
-            rows_count_threshold, std::numeric_limits<uint64_t>::max())
+            rows_count_threshold, collection_elements_threshold)
         , callback(std::move(callback)) {
         start();
     }
@@ -5150,21 +5150,21 @@ struct large_row_handler : public db::large_data_handler {
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, uint64_t row_size) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, clustering_key, row_size, nullptr, 0);
+        callback(*s, partition_key, clustering_key, row_size, nullptr, 0, 0);
         return make_ready_future<>();
     }
 
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
         const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, clustering_key, 0, &cdef, cell_size);
+        callback(*s, partition_key, clustering_key, 0, &cdef, cell_size, collection_elements);
         return make_ready_future<>();
     }
 
     virtual future<> record_large_partitions(const sstables::sstable& sst,
         const sstables::key& partition_key, uint64_t partition_size, uint64_t rows_count) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, nullptr, rows_count, nullptr, 0);
+        callback(*s, partition_key, nullptr, rows_count, nullptr, 0, 0);
         return make_ready_future<>();
     }
 
@@ -5179,7 +5179,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     unsigned i = 0;
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t row_size,
-                     const column_definition* cdef, uint64_t cell_size) {
+                     const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
         BOOST_REQUIRE_LT(i, expected.size());
         BOOST_REQUIRE_GT(row_size, threshold);
@@ -5192,7 +5192,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
         ++i;
     };
 
-    large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
+    large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
@@ -5235,7 +5235,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
     unsigned i = 0;
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t row_size,
-                     const column_definition* cdef, uint64_t cell_size) {
+                     const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_TEST_MESSAGE(format("i={} ck={} cell_size={} threshold={}", i, clustering_key ? format("{}", *clustering_key) : "null", cell_size, threshold));
         BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
         BOOST_REQUIRE_LT(i, expected.size());
@@ -5249,7 +5249,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
         ++i;
     };
 
-    large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, f);
+    large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
@@ -5304,13 +5304,13 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     bool logged = false;
     auto f = [&logged, &expected, &pk, &threshold](const schema& sc, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t rows_count,
-                     const column_definition* cdef, uint64_t cell_size) {
+                     const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_GT(rows_count, threshold);
         BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
         logged = true;
     };
 
-    large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
+    large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
     cache_tracker tracker;
     test_db_config.host_id = locator::host_id::create_random_id();
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
@@ -5336,6 +5336,59 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_log_too_many_rows) {
     test_sstable_log_too_many_rows_f(random, (random + 1), false, version);
     test_sstable_log_too_many_rows_f((random + 1), random, true, version);
   }
+}
+
+
+static void test_sstable_too_many_collection_elements_f(int elements, uint64_t threshold, bool expected, sstable_version_types version) {
+    simple_schema s(simple_schema::with_static::no, simple_schema::with_collection::yes);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    mutation p = s.new_mutation("pv");
+    const partition_key& pk = p.key();
+    std::map<bytes, bytes> kv_map;
+    for (auto i = 0; i < elements; i++) {
+        kv_map[to_bytes(format("key{}", i))] = to_bytes(format("val{}", i));
+    }
+    s.add_row_with_collection(p, s.make_ckey("ck1"), kv_map);
+    schema_ptr sc = s.schema();
+    auto mt = make_lw_shared<replica::memtable>(sc);
+    mt->apply(p);
+
+    bool logged = false;
+    auto f = [&logged, &expected, &pk, &threshold](const schema& sc, const sstables::key& partition_key,
+                     const clustering_key_prefix* clustering_key, uint64_t rows_count,
+                     const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
+        BOOST_REQUIRE_GT(collection_elements, threshold);
+        BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        logged = true;
+    };
+
+    BOOST_TEST_MESSAGE(format("elements={} threshold={} expected={}", elements, threshold, expected));
+    large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, f);
+    cache_tracker tracker;
+    test_db_config.host_id = locator::host_id::create_random_id();
+    sstables_manager manager(handler, test_db_config, test_feature_service, tracker, memory::stats().total_memory());
+    auto close_manager = defer([&] { manager.close().get(); });
+    tmpdir dir;
+    auto sst = manager.make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+    sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, manager.configure_writer("test"), encoding_stats{}).get();
+
+    BOOST_REQUIRE_EQUAL(logged, expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sstable_too_many_collection_elements) {
+    // Generates a pseudo-random number from 1 to 100
+    uint64_t random = tests::random::get_int(1, 100);
+
+    // This test creates a sstable with a row containing a collection with given number of elements and test it against a
+    // compaction_collection_elements_count_warning_threshold. A warning is triggered when the number of collection elements
+    // exceeds the threshold.
+    for (auto version : test_sstable_versions) {
+        test_sstable_too_many_collection_elements_f(random, 0, true, version);
+        test_sstable_too_many_collection_elements_f(random, (random - 1), true, version);
+        test_sstable_too_many_collection_elements_f(random, random, false, version);
+        test_sstable_too_many_collection_elements_f(random, (random + 1), false, version);
+        test_sstable_too_many_collection_elements_f((random + 1), random, true, version);
+    }
 }
 
 // The following test runs on test/resource/sstables/3.x/uncompressed/legacy_udt_in_collection

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5178,8 +5178,8 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t row_size) {
         BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
-        BOOST_REQUIRE(i < expected.size());
-        BOOST_REQUIRE(row_size > threshold);
+        BOOST_REQUIRE_LT(i, expected.size());
+        BOOST_REQUIRE_GT(row_size, threshold);
 
         if (clustering_key) {
             BOOST_REQUIRE(expected[i]->equal(s, *clustering_key));
@@ -5244,7 +5244,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     bool logged = false;
     auto f = [&logged, &expected, &pk, &threshold](const schema& sc, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t rows_count) {
-        BOOST_REQUIRE(rows_count > threshold);
+        BOOST_REQUIRE_GT(rows_count, threshold);
         BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
         logged = true;
     };

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -24,12 +24,16 @@
 //   CREATE TABLE ks.cf (pk text, ck text, v text, s1 text static, PRIMARY KEY (pk, ck));
 //
 class simple_schema {
+public:
+    using with_static = bool_class<class static_tag>;
+private:
     friend class global_simple_schema;
 
     schema_ptr _s;
     api::timestamp_type _timestamp = api::min_timestamp;
     const column_definition* _v_def = nullptr;
     table_schema_version _v_def_version;
+    with_static _ws;
 
     simple_schema(schema_ptr s, api::timestamp_type timestamp)
         : _s(s)
@@ -55,7 +59,6 @@ public:
         return {new_timestamp(), gc_clock::now()};
     }
 public:
-    using with_static = bool_class<class static_tag>;
     simple_schema(with_static ws = with_static::yes)
         : _s(schema_builder("ks", "cf")
             .with_column("pk", utf8_type, column_kind::partition_key)
@@ -63,10 +66,11 @@ public:
             .with_column("s1", utf8_type, ws ? column_kind::static_column : column_kind::regular_column)
             .with_column("v", utf8_type)
             .build())
+        , _ws(ws)
     { }
 
     sstring cql() const {
-        return "CREATE TABLE ks.cf (pk text, ck text, v text, s1 text static, PRIMARY KEY (pk, ck))";
+        return format("CREATE TABLE ks.cf (pk text, ck text, v text, s1 text{}, PRIMARY KEY (pk, ck))", _ws ? " static" : "");
     }
 
     clustering_key make_ckey(sstring ck) {

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "schema.hh"
 #include "schema_registry.hh"
 #include "keys.hh"
@@ -18,6 +20,8 @@
 #include "schema_builder.hh"
 #include "sstable_utils.hh"
 #include "reader_permit.hh"
+#include "types/map.hh"
+#include "atomic_cell_or_collection.hh"
 
 // Helper for working with the following table:
 //
@@ -26,6 +30,7 @@
 class simple_schema {
 public:
     using with_static = bool_class<class static_tag>;
+    using with_collection = bool_class<class collection_tag>;
 private:
     friend class global_simple_schema;
 
@@ -34,6 +39,7 @@ private:
     const column_definition* _v_def = nullptr;
     table_schema_version _v_def_version;
     with_static _ws;
+    with_collection _wc;
 
     simple_schema(schema_ptr s, api::timestamp_type timestamp)
         : _s(s)
@@ -48,6 +54,9 @@ private:
         _v_def_version = s.version();
         return *_v_def;
     }
+    static auto get_collection_type() {
+        return map_type_impl::get_instance(utf8_type, utf8_type, true);
+    }
 public:
     api::timestamp_type current_timestamp() {
         return _timestamp;
@@ -59,19 +68,24 @@ public:
         return {new_timestamp(), gc_clock::now()};
     }
 public:
-    simple_schema(with_static ws = with_static::yes)
+    simple_schema(with_static ws = with_static::yes, with_collection wc = with_collection::no)
         : _ws(ws)
+        , _wc(wc)
     {
         auto sb = schema_builder("ks", "cf")
             .with_column("pk", utf8_type, column_kind::partition_key)
             .with_column("ck", utf8_type, column_kind::clustering_key)
             .with_column("s1", utf8_type, ws ? column_kind::static_column : column_kind::regular_column)
             .with_column("v", utf8_type);
+        if (wc) {
+            sb.with_column("c1", get_collection_type());
+        }
         _s = sb.build();
     }
 
     sstring cql() const {
-        return format("CREATE TABLE ks.cf (pk text, ck text, v text, s1 text{}, PRIMARY KEY (pk, ck))", _ws ? " static" : "");
+        return format("CREATE TABLE ks.cf (pk text, ck text, v text, s1 text{}{}, PRIMARY KEY (pk, ck))", _ws ? " static" : "",
+                _wc ? ", c1 map<text, text>" : "");
     }
 
     clustering_key make_ckey(sstring ck) {
@@ -104,6 +118,23 @@ public:
         }
         const column_definition& v_def = get_v_def(*_s);
         m.set_clustered_cell(key, v_def, atomic_cell::make_live(*v_def.type, t, serialized(v)));
+        return t;
+    }
+
+    api::timestamp_type add_row_with_collection(mutation& m, const clustering_key& ck, const std::map<bytes, bytes>& kv_map, api::timestamp_type t = api::missing_timestamp) {
+        if (t == api::missing_timestamp) {
+            t = new_timestamp();
+        }
+
+        collection_mutation_description cmd;
+        for (const auto& [k, v] : kv_map) {
+            cmd.cells.emplace_back(k, atomic_cell::make_live(*bytes_type, t, v, atomic_cell::collection_member::yes));
+        }
+
+        const auto map_type = get_collection_type();
+        auto serialized_map = cmd.serialize(*map_type);
+        const column_definition& c1_def = *_s->get_column_definition(to_bytes("c1"));
+        m.set_clustered_cell(ck, c1_def, atomic_cell_or_collection(std::move(serialized_map)));
         return t;
     }
 

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -29,7 +29,7 @@ public:
 private:
     friend class global_simple_schema;
 
-    schema_ptr _s;
+    schema_ptr _s = nullptr;
     api::timestamp_type _timestamp = api::min_timestamp;
     const column_definition* _v_def = nullptr;
     table_schema_version _v_def_version;
@@ -60,14 +60,15 @@ public:
     }
 public:
     simple_schema(with_static ws = with_static::yes)
-        : _s(schema_builder("ks", "cf")
+        : _ws(ws)
+    {
+        auto sb = schema_builder("ks", "cf")
             .with_column("pk", utf8_type, column_kind::partition_key)
             .with_column("ck", utf8_type, column_kind::clustering_key)
             .with_column("s1", utf8_type, ws ? column_kind::static_column : column_kind::regular_column)
-            .with_column("v", utf8_type)
-            .build())
-        , _ws(ws)
-    { }
+            .with_column("v", utf8_type);
+        _s = sb.build();
+    }
 
     sstring cql() const {
         return format("CREATE TABLE ks.cf (pk text, ck text, v text, s1 text{}, PRIMARY KEY (pk, ck))", _ws ? " static" : "");

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1344,6 +1344,7 @@ const char* to_string(sstables::large_data_type t) {
         case sstables::large_data_type::row_size: return "row_size";
         case sstables::large_data_type::cell_size: return "cell_size";
         case sstables::large_data_type::rows_in_partition: return "rows_in_partition";
+        case sstables::large_data_type::elements_in_collection: return "elements_in_collection";
     }
     std::abort();
 }

--- a/utils/updateable_value.hh
+++ b/utils/updateable_value.hh
@@ -14,6 +14,7 @@
 #include <vector>
 #include <functional>
 #include "observable.hh"
+#include "serialized_action.hh"
 #include "seastarx.hh"
 
 namespace utils {
@@ -209,5 +210,30 @@ updateable_value<T>::observe(std::function<void (const T&)> callback) const {
     auto* src = source();
     return src ? src->observe(std::move(callback)) : dummy_observer<T>();
 }
+
+// Automatically updates a value from a utils::updateable_value
+// Where they can be of different types.
+// An optional transfom function can provide an additional transformation
+// when updating the value, like multiplying it by a factor for unit conversion,
+// for example.
+template <typename ValueType, typename UpdateableValueType>
+class transforming_value_updater {
+    ValueType& _value;
+    utils::updateable_value<UpdateableValueType> _updateable_value;
+    serialized_action _updater;
+    utils::observer<UpdateableValueType> _observer;
+
+public:
+    transforming_value_updater(ValueType& value, utils::updateable_value<UpdateableValueType> updateable_value,
+            std::function<ValueType (UpdateableValueType)> transform = [] (UpdateableValueType uv) { return static_cast<ValueType>(uv); })
+        : _value(value)
+        , _updateable_value(std::move(updateable_value))
+        , _updater([this, transform = std::move(transform)] {
+                _value = transform(_updateable_value());
+                return make_ready_future<>();
+          })
+        , _observer(_updateable_value.observe(_updater.make_observer()))
+    {}
+};
 
 }


### PR DESCRIPTION
This series adds support for detecting collections that have too many items
and recording them in `system.large_cells`.

A configuration variable was added to db/config: `compaction_collection_items_count_warning_threshold` set by default to 10000.
Collections that have more items than this threshold will be warned about and will be recorded as a large cell in the `system.large_cells` table.  Documentation has been updated respectively.

A new column was added to system.large_cells: `collection_items`.
Similar to the `rows` column in system.large_partition, `collection_items` holds the number of items in a collection when the large cell is a collection, or 0 if it isn't.  Note that the collection may be recorded in system.large_cells either due to its size, like any other cell, and/or due to the number of items in it, if it cross the said threshold.

Note that #11449 called for a new system.large_collections table, but extending system.large_cells follows the logic of system.large_partitions is a smaller change overall, hence it was preferred.

Since the system keyspace schema is hard coded, the schema version of system.large_cells was bumped, and since the change is not backward compatible, we added a cluster feature - `LARGE_COLLECTION_DETECTION` - to enable using it.
The large_data_handler large cell detection record function will populate the new column only when the new cluster feature is enabled.

In addition, unit tests were added in sstable_3_x_test for testing large cells detection by cell size, and large_collection detection by the number of items.

Closes #11449
