### PR TITLE
Improve test.py logging

### DIFF
--- a/test.py
+++ b/test.py
@@ -837,7 +837,7 @@ class TopologyTest(PythonTest):
     async def run(self, options: argparse.Namespace) -> Test:
 
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
-        async with get_cluster_manager(self.shortname, self.suite.clusters, test_path) as manager:
+        async with get_cluster_manager(self.uname, self.suite.clusters, test_path) as manager:
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -74,13 +74,13 @@ class ManagerClient():
             logger.debug("refresh driver node list")
             self.ccluster.control_connection.refresh_node_list_and_token_map()
 
-    async def before_test(self, test_name: str) -> None:
+    async def before_test(self, test_case_name: str) -> None:
         """Before a test starts check if cluster needs cycling and update driver connection"""
-        logger.debug("before_test for %s", test_name)
+        logger.debug("before_test for %s", test_case_name)
         dirty = await self.is_dirty()
         if dirty:
             self.driver_close()  # Close driver connection to old cluster
-        resp = await self._get(f"/cluster/before-test/{test_name}")
+        resp = await self._get(f"/cluster/before-test/{test_case_name}")
         if resp.status != 200:
             raise RuntimeError(f"Failed before test check {await resp.text()}")
         if self.cql is None:
@@ -88,10 +88,10 @@ class ManagerClient():
             # await self._wait_for_cluster()
             await self.driver_connect()  # Connect driver to new cluster
 
-    async def after_test(self, test_name: str) -> None:
+    async def after_test(self, test_case_name: str) -> None:
         """Tell harness this test finished"""
-        logger.debug("after_test for %s", test_name)
-        await self._get(f"/cluster/after-test/{test_name}")
+        logger.debug("after_test for %s", test_case_name)
+        await self._get(f"/cluster/after-test/{test_case_name}")
 
     async def _get(self, resource: str) -> aiohttp.ClientResponse:
         # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -91,7 +91,7 @@ class ManagerClient():
     async def after_test(self, test_case_name: str) -> None:
         """Tell harness this test finished"""
         logger.debug("after_test for %s", test_case_name)
-        await self._get(f"/cluster/after-test/{test_case_name}")
+        await self._get(f"/cluster/after-test")
 
     async def _get(self, resource: str) -> aiohttp.ClientResponse:
         # Can raise exception. See https://docs.aiohttp.org/en/latest/web_exceptions.html

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -530,13 +530,14 @@ class ScyllaCluster:
         server = self.create_server(self.name, self._seeds())
         self.is_dirty = True
         try:
-            logging.info("Cluster %s adding server", server)
+            logging.info("Cluster %s adding server...", self)
             await server.install_and_start()
         except Exception as exc:
             logging.error("Failed to start Scylla server at host %s in %s: %s",
                           server.hostname, server.workdir.name, str(exc))
             raise
         self.running[server.host] = server
+        logging.info("Cluster %s added server %s", self, server)
         return server.host
 
     def endpoint(self) -> str:
@@ -565,7 +566,9 @@ class ScyllaCluster:
             return None
 
     def __str__(self):
-        return f"{{{', '.join(str(c) for c in self.running)}}}"
+        running = f"{{{', '.join(str(c) for c in self.running)}}}"
+        stopped = f"{{{', '.join(str(c) for c in self.stopped)}}}"
+        return f"ScyllaCluster(name: {self.name}, running: {running}, stopped: {stopped})"
 
     def _get_keyspace_count(self) -> int:
         """Get the current keyspace count"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -709,7 +709,7 @@ class ScyllaClusterManager:
             await self.cluster.stop()
             await self._get_cluster()
         logging.info("Leasing Scylla cluster %s for test %s", self.cluster, test_case_name)
-        self.cluster.before_test(self.test_name)
+        self.cluster.before_test(test_case_name)
         self.is_before_test_ok = True
         self.cluster.take_log_savepoint()
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -678,8 +678,8 @@ class ScyllaClusterManager:
     site: aiohttp.web.UnixSite
     is_after_test_ok: bool
 
-    def __init__(self, test_name: str, clusters: Pool[ScyllaCluster], base_dir: str) -> None:
-        self.test_name: str = test_name
+    def __init__(self, test_uname: str, clusters: Pool[ScyllaCluster], base_dir: str) -> None:
+        self.test_uname: str = test_uname
         self.clusters: Pool[ScyllaCluster] = clusters
         self.is_running: bool = False
         self.is_before_test_ok: bool = False
@@ -715,14 +715,14 @@ class ScyllaClusterManager:
 
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
-        logging.info("ScyllaManager stopping for test %s", self.test_name)
+        logging.info("ScyllaManager stopping for test %s", self.test_uname)
         await self.site.stop()
         if not self.cluster.is_dirty:
-            logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_name)
+            logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
             await self.clusters.put(self.cluster)
         else:
             logging.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
-                            self.cluster, self.test_name)
+                            self.cluster, self.test_uname)
             await self.clusters.steal()
             await self.cluster.stop()
         del self.cluster
@@ -858,11 +858,11 @@ class ScyllaClusterManager:
 
 
 @asynccontextmanager
-async def get_cluster_manager(test_name: str, clusters: Pool[ScyllaCluster], test_path: str) \
+async def get_cluster_manager(test_uname: str, clusters: Pool[ScyllaCluster], test_path: str) \
         -> AsyncIterator[ScyllaClusterManager]:
     """Create a temporary manager for the active cluster used in a test
        and provide the cluster to the caller."""
-    manager = ScyllaClusterManager(test_name, clusters, test_path)
+    manager = ScyllaClusterManager(test_uname, clusters, test_path)
     try:
         yield manager
     finally:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -746,7 +746,7 @@ class ScyllaClusterManager:
         self.app.router.add_get('/cluster/replicas', self._cluster_replicas)
         self.app.router.add_get('/cluster/servers', self._cluster_servers)
         self.app.router.add_get('/cluster/before-test/{test_case_name}', self._before_test_req)
-        self.app.router.add_get('/cluster/after-test/{test_case_name}', self._after_test)
+        self.app.router.add_get('/cluster/after-test', self._after_test)
         self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
         self.app.router.add_get('/cluster/server/{id}/stop', self._cluster_server_stop)
         self.app.router.add_get('/cluster/server/{id}/stop_gracefully',
@@ -786,7 +786,6 @@ class ScyllaClusterManager:
         return aiohttp.web.Response(text="OK")
 
     async def _after_test(self, _request) -> aiohttp.web.Response:
-        test_case_name = _request.match_info['test_case_name']
         assert self.cluster is not None
         assert self.current_test_case_full_name
         logging.info("Finished test %s, cluster: %s", self.current_test_case_full_name, self.cluster)

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -159,9 +159,10 @@ async def manager(request, manager_internal):
     """Per test fixture to notify Manager client object when tests begin so it can
     perform checks for cluster state.
     """
-    await manager_internal.before_test(request.node.name)
+    test_case_name = request.node.name
+    await manager_internal.before_test(test_case_name)
     yield manager_internal
-    await manager_internal.after_test(request.node.name)
+    await manager_internal.after_test(test_case_name)
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object


### PR DESCRIPTION
Include the unique test name (the unique name distinguishes between different test repeats) and the test case name where possible. Improve printing of clusters: include the cluster name and stopped servers. Fix some logging calls and add new ones.

Examples:
```
------ Starting test test_topology ------
```
became this:
```
------ Starting test test_topology.1::test_add_server_add_column ------
```

This:
```
INFO> Leasing Scylla cluster {127.191.142.1, 127.191.142.2, 127.191.142.3} for test test_add_server_add_column
```
became this:
```
INFO> Leasing Scylla cluster ScyllaCluster(name: 02cdd180-40d1-11ed-8803-3c2c30d32d96, running: {127.144.164.1, 127.144.164.2, 127.144.164.3}, stopped: {}) for test test_topology.1::test_add_server_add_column
```