### PR TITLE
test.py: include modes in log file name

### DIFF
--- a/test.py
+++ b/test.py
@@ -1277,10 +1277,10 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
     et.write(f'{tmpdir}/{mode}/xml/boost.xunit.xml', encoding='unicode')
 
 
-def open_log(tmpdir: str, log_level: str) -> None:
+def open_log(tmpdir: str, log_file_name: str, log_level: str) -> None:
     pathlib.Path(tmpdir).mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
-        filename=os.path.join(tmpdir, "test.py.log"),
+        filename=os.path.join(tmpdir, log_file_name),
         filemode="w",
         level=log_level,
         format="%(asctime)s.%(msecs)03d %(levelname)s> %(message)s",
@@ -1293,7 +1293,7 @@ async def main() -> int:
 
     options = parse_cmd_line()
 
-    open_log(options.tmpdir, options.log_level)
+    open_log(options.tmpdir, f"test.py.{'-'.join(options.modes)}.log", options.log_level)
 
     await find_tests(options)
     if options.list_tests:


### PR DESCRIPTION
Instead of `test.py.log`, use:
`test.py.dev.log`
when running with `--mode dev`,
`test.py.dev,release.log`
when running with `--mode dev --mode release`,
and so on.

This is useful in Jenkins which is running test.py multiple times in different modes; a later run would overwrite a previous run's test.py file. With this change we can preserve the test.py files of all of these runs.