### PR TITLE
logalloc: prevent false positives in reclaim_timer

### DIFF
--- a/utils/coarse_steady_clock.hh
+++ b/utils/coarse_steady_clock.hh
@@ -32,6 +32,12 @@ struct coarse_steady_clock {
         clock_gettime(CLOCK_MONOTONIC_COARSE, &tp);
         return time_point(std::chrono::seconds(tp.tv_sec) + std::chrono::nanoseconds(tp.tv_nsec));
     };
+
+    static duration get_resolution() noexcept {
+        timespec tp;
+        clock_getres(CLOCK_MONOTONIC_COARSE, &tp);
+        return std::chrono::seconds(tp.tv_sec) + std::chrono::nanoseconds(tp.tv_nsec);
+    }
 };
 
 };


### PR DESCRIPTION
reclaim_timer uses a coarse clock, but does not account for the measurement error introduced by that -- it can falsely report reclaims as stalls, even if they are shorter by a full coarse clock tick from the requested threshold
(blocked-reactor-notify-ms).

Notably, if the stall threshold happens to be smaller or equal to coarse clock resolution, Scylla's log gets spammed with false stall reports. The resolution of coarse clocks in Linux is 1/CONFIG_HZ. This is typically equal to 1 ms or 4 ms, and stall thresholds of this order can occur in practice.

Eliminate false positives by requiring the measured reclaim duration to be at least 1 clock tick longer than the configured threshold for it to be considered a stall.

Fixes #10981