### PR TITLE
Return all sstables in table::get_sstable_set()

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1222,8 +1222,7 @@ future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const s
 }
 
 const sstables::sstable_set& table::get_sstable_set() const {
-    // main sstables is enough for the outside world. sstables in other set like maintenance is not needed even for expiration purposes in compaction
-    return *_compaction_group->main_sstables();
+    return *_sstables;
 }
 
 lw_shared_ptr<const sstable_list> table::get_sstables() const {

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -946,9 +946,10 @@ compound_sstable_set::compound_sstable_set(schema_ptr schema, std::vector<lw_sha
 std::unique_ptr<sstable_set_impl> compound_sstable_set::clone() const {
     std::vector<lw_shared_ptr<sstable_set>> cloned_sets;
     cloned_sets.reserve(_sets.size());
-    for (auto& set : _sets) {
+    for (const auto& set : _sets) {
         // implicit clone by using sstable_set's copy ctor.
-        cloned_sets.push_back(make_lw_shared(std::move(*set)));
+        auto cloned_set = make_lw_shared(*set);
+        cloned_sets.push_back(std::move(cloned_set));
     }
     return std::make_unique<compound_sstable_set>(_schema, std::move(cloned_sets));
 }

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3050,6 +3050,11 @@ SEASTAR_TEST_CASE(compound_sstable_set_basic_test) {
             BOOST_REQUIRE(compound_size == found);
         }
 
+        {
+            auto cloned_compound = *compound;
+            BOOST_REQUIRE(cloned_compound.all()->size() == 3);
+        }
+
         set2 = make_lw_shared(cs.make_sstable_set(s));
         compound = make_lw_shared(sstables::make_compound_sstable_set(s, {set1, set2}));
         {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -165,7 +165,7 @@ future<compaction_result> compact_sstables(compaction_manager& cm, sstables::com
     };
     descriptor.replacer = std::move(replacer);
     if (can_purge) {
-        descriptor.enable_garbage_collection(cf.get_sstable_set());
+        descriptor.enable_garbage_collection(cf.as_table_state().main_sstable_set());
     }
     auto cmt = compaction_manager_test(cm);
     sstables::compaction_result ret;


### PR DESCRIPTION
This fixes a regression introduced by 1e7a444, where table::get_sstable_set() isn't exposing all sstables, but rather only the ones in the main set. That causes user of the interface, such as get_sstables_by_partition_key() (used by API to return sstable name list which contains a particular key), to miss files in the maintenance set.

Fixes https://github.com/scylladb/scylladb/issues/11681.