### PR TITLE
Raft transport error

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -293,8 +293,10 @@ struct state_machine_error: public error {
         : error(fmt::format("State machine error at {}:{}", l.file_name(), l.line())) {}
 };
 
-struct intermittent_connection_error: public error {
-    intermittent_connection_error() : error("Intermittent connection error") {}
+// Should be thrown by the rpc implementation to signal that the connection to the peer has been lost.
+// It's unspecified if any actions caused by rpc were actually performed on the target node.
+struct transport_error: public error {
+    using error::error;
 };
 
 struct command_is_too_big_error: public error {
@@ -578,7 +580,7 @@ public:
     virtual void send_read_quorum_reply(server_id id, const read_quorum_reply& read_quorum_reply) = 0;
 
     // Forward a read barrier request to the leader.
-    // Should throw a raft::intermittent_connection_error if the target host is unreachable.
+    // Should throw a raft::transport_error if the target host is unreachable.
     // In this case, the call will be retried after some time,
     // possibly with a different server_id if the leader has changed by then.
     virtual future<read_barrier_reply> execute_read_barrier_on_leader(server_id id) = 0;
@@ -592,6 +594,7 @@ public:
 
     // Send a configuration change request to the leader. Block until the
     // leader replies.
+    // Should throw a raft::transport_error if the target host is unreachable.
     virtual future<add_entry_reply> send_modify_config(server_id id,
         const std::vector<config_member>& add,
         const std::vector<server_id>& del) = 0;

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -70,9 +70,6 @@ public:
     // Returned future is resolved depending on wait_type parameter:
     //  'committed' - when the entry is committed
     //  'applied'   - when the entry is applied (happens after it is committed)
-    // May fail because of an internal error or because leader changed and an entry was either
-    // replaced by the new leader or the server lost track of it. The former will result in
-    // dropped_entry exception the later in commit_status_unknown.
     //
     // If forwarding is enabled and this is a follower, and the returned future resolves without exception,
     // this means that the entry is committed/applied locally (depending on the wait type).
@@ -80,14 +77,27 @@ public:
     // committed locally means simply that the commit index is beyond this entry's index.
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
-    // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
     //
-    // Successfull `add_entry` with `wait_type::committed` does not guarantee that `state_machine::apply` will be called
+    // Successful `add_entry` with `wait_type::committed` does not guarantee that `state_machine::apply` will be called
     // locally for this entry. Between the commit and the application we may receive a snapshot containing this entry,
     // so the state machine's state 'jumps' forward in time, skipping the entry application.
     // However, for `wait_type::applied`, we guarantee that the entry will be applied locally with `state_machine::apply`.
     // If a snapshot causes the state machine to jump over the entry, `add_entry` will return `commit_status_unknown`
     // (even if the snapshot included that entry).
+    //
+    // Exceptions:
+    // raft::commit_status_unknown
+    //     Thrown if the leader has changed and the log entry has either
+    //     been replaced by the new leader or the server has lost track of it.
+    //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.L
+    // raft::dropped_entry
+    //     Thrown if the entry was replaced because of a leader change.
+    // raft::request_aborted
+    //     Thrown if abort is requested before the operation finishes.
+    // raft::stopped_error
+    //     Thrown if abort() was called on the server instance.
+    // raft::not_a_leader
+    //     Thrown if the node is not a leader and forwarding is not enabled through enable_forwarding config option.
     virtual future<> add_entry(command command, wait_type type, seastar::abort_source* as = nullptr) = 0;
 
     // Set a new cluster configuration. If the configuration is
@@ -114,7 +124,17 @@ public:
     // returned even in case of a successful config change.
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
-    // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
+    //
+    // Exceptions:
+    // raft::conf_change_in_progress
+    //     Thrown if the previous set_configuration/modify_config is not completed.
+    // raft::commit_status_unknown
+    //     Thrown if the leader has changed and the config mutation has either
+    //     been replaced by the new leader or the server has lost track of it.
+    //     It may also be thrown in case of a transport error while
+    //     forwarding the corresponding add_entry to the leader.
+    // raft::request_aborted
+    //     Thrown if abort is requested before the operation finishes.
     virtual future<> set_configuration(config_member_set c_new, seastar::abort_source* as = nullptr) = 0;
 
     // A simplified wrapper around set_configuration() which adds
@@ -138,6 +158,20 @@ public:
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
     // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
+    //
+    // Exceptions:
+    // raft::commit_status_unknown
+    //     Thrown if the leader has changed and the config mutation has either
+    //     been replaced by the new leader or the server has lost track of it.
+    //     It may also be thrown in case of a transport error while forwarding modify_config to the leader.
+    // raft::request_aborted
+    //     Thrown if abort is requested before the operation finishes.
+    // raft::stopped_error
+    //     Thrown if abort() was called on the server instance.
+    // raft::not_a_leader
+    //     Thrown if the node is not a leader and forwarding is not enabled through enable_forwarding config option.
+    // raft::conf_change_in_progress
+    //     Thrown if the previous set_configuration/modify_config is not completed.
     virtual future<> modify_config(std::vector<config_member> add,
         std::vector<server_id> del, seastar::abort_source* as = nullptr) = 0;
 
@@ -164,12 +198,25 @@ public:
     // future has resolved successfully.
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
-    // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
+    //
+    // Exceptions:
+    // raft::request_aborted
+    //     Thrown if abort is requested before the operation finishes.
+    // raft::stopped_error
+    //     Thrown if abort() was called on the server instance.
     virtual future<> read_barrier(seastar::abort_source* as = nullptr) = 0;
 
     // Initiate leader stepdown process.
-    // If the node is not a leader returns not_a_leader exception.
-    // In case of a timeout returns timeout_error.
+    //
+    // Exceptions:
+    // raft::timeout_error
+    //     Thrown in case of timeout.
+    // raft::not_a_leader
+    //     Thrown if the node is not a leader and forwarding is not enabled through enable_forwarding config option.
+    // raft::no_other_voting_member
+    //     Thrown if there is no other voting member.
+    // std::logic_error
+    //     Thrown if the stepdown process is already in progress.
     virtual future<> stepdown(logical_clock::duration timeout) = 0;
 
     // Register metrics for this server. Metric are global but their names

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -599,7 +599,7 @@ future<> raft_group0::leave_group0() {
 
     // Note: if this gets stuck due to a failure, the DB admin can abort.
     // FIXME: this gets stuck without failures if we're the leader (#10833)
-    co_return co_await _raft_gr.group0().modify_config({}, {my_id}, &_abort_source);
+    co_return co_await remove_from_raft_config(my_id);
 }
 
 future<> raft_group0::remove_from_group0(gms::inet_address node) {
@@ -685,8 +685,27 @@ future<> raft_group0::remove_from_group0(gms::inet_address node) {
         "remove_from_group0({}): found the node in group 0 configuration, Raft ID: {}. Proceeding with the remove...",
         node, *their_id);
 
-    // TODO: add a timeout+retry mechanism? This could get stuck (and _abort_source is only called on shutdown).
-    co_return co_await _raft_gr.group0().modify_config({}, {*their_id}, &_abort_source);
+    co_await remove_from_raft_config(*their_id);
+}
+
+future<> raft_group0::remove_from_raft_config(raft::server_id id) {
+    static constexpr auto max_retry_period = std::chrono::seconds{1};
+    auto retry_period = std::chrono::milliseconds{10};
+
+    // TODO: add a timeout mechanism? This could get stuck (and _abort_source is only called on shutdown).
+    while (true) {
+        try {
+            co_await _raft_gr.group0().modify_config({}, {id}, &_abort_source);
+            break;
+        } catch (const raft::commit_status_unknown& e) {
+            group0_log.info("remove_from_raft_config({}): modify_config returned \"{}\", retrying", id, e);
+        }
+        retry_period *= 2;
+        if (retry_period > max_retry_period) {
+            retry_period = max_retry_period;
+        }
+        co_await sleep_abortable(retry_period, _abort_source);
+    }
 }
 
 bool raft_group0::joined_group0() const {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -235,6 +235,9 @@ private:
     // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
     // (we could then try restarting the server internally).
     future<> start_server_for_group0(raft::group_id group0_id);
+
+    // Remove the node from raft config, retries raft::commit_status_unknown.
+    future<> remove_from_raft_config(raft::server_id id);
 };
 
 } // end of namespace service


### PR DESCRIPTION
The `add_entry` and `modify_config` methods sometimes do an rpc to
execute the request on the current leader. If the tcp connection
was broken, a `seastar::rpc::closed_error` would be thrown to the client.
This exception was not documented in the method comments and the
client could have missed handling it. For example, this exception
was not handled when calling `modify_config` in `raft_group0`,
which sometimes broke the `removenode` command.

An `intermittent_connection_error` exception was added earlier to
solve a similar problem with the `read_barrier` method. In this patch it
is renamed to `transport_error`, as it seems to better describe the
situation, and an explicit specification for this exception
was added - the rpc implementation can throw it if it is not known
whether the call reached the destination and whether any mutations were made.

In case of `read_barrier` it does not matter and we just retry, in case
of `add_entry` and `modify_config` we cannot retry because of possible mutations,
so we convert this exception to `commit_status_unknown`, which
the client has to handle.

Explicit comments have also been added to `raft::server` methods
describing all possible exceptions.