### PR TITLE
Projection field added to return from DescribeTable which describes GSIs and LSIs

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -465,6 +465,11 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
             rjson::add(view_entry, "IndexArn", generate_arn_for_index(*schema, index_name));
             // Add indexes's KeySchema and collect types for AttributeDefinitions:
             describe_key_schema(view_entry, *vptr, key_attribute_types);
+            // Add projection type
+            rjson::value projection = rjson::empty_object();
+            rjson::add(projection, "ProjectionType", "ALL");
+            // FIXME: we have to get ProjectionType from the schema when it is added
+            rjson::add(view_entry, "Projection", std::move(projection));
             // Local secondary indexes are marked by an extra '!' sign occurring before the ':' delimiter
             rjson::value& index_array = (delim_it > 1 && cf_name[delim_it-1] == '!') ? lsi_array : gsi_array;
             rjson::push_back(index_array, std::move(view_entry));

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -168,7 +168,6 @@ def test_gsi_empty_value(test_table_gsi_2):
         test_table_gsi_2.put_item(Item={'p': random_string(), 'x': ''})
 
 # Verify that a GSI is correctly listed in describe_table
-@pytest.mark.xfail(reason="issues #7550, #11466, #11470, #11471")
 def test_gsi_describe(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
     assert 'Table' in desc
@@ -177,15 +176,25 @@ def test_gsi_describe(test_table_gsi_1):
     assert len(gsis) == 1
     gsi = gsis[0]
     assert gsi['IndexName'] == 'hello'
-    assert 'IndexSizeBytes' in gsi     # actual size depends on content
-    assert 'ItemCount' in gsi
     assert gsi['Projection'] == {'ProjectionType': 'ALL'}
-    assert gsi['IndexStatus'] == 'ACTIVE'
     assert gsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'c'},
                                 {'KeyType': 'RANGE', 'AttributeName': 'p'}]
     # The index's ARN should look like the table's ARN followed by /index/<indexname>.
     assert gsi['IndexArn'] == desc['Table']['TableArn'] + '/index/hello'
     # TODO: check also ProvisionedThroughput
+
+# In addition to the basic listing of an GSI in DescribeTable tested above,
+# in this test we check additional fields that should appear in each GSI's
+# description.
+@pytest.mark.xfail(reason="issues #7550, #11466, #11471")
+def test_gsi_describe_fields(test_table_gsi_1):
+    desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
+    gsis = desc['Table']['GlobalSecondaryIndexes']
+    assert len(gsis) == 1
+    gsi = gsis[0]
+    assert 'IndexSizeBytes' in gsi    # actual size depends on content
+    assert 'ItemCount' in gsi
+    assert gsi['IndexStatus'] == 'ACTIVE'
 
 # When a GSI's key includes an attribute not in the base table's key, we
 # need to remember to add its type to AttributeDefinitions.

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -242,6 +242,7 @@ def test_lsi_describe(test_table_lsi_4):
     assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_x1', 'hello_x2', 'hello_x3', 'hello_x4'])
     for lsi in lsis:
         assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/' + lsi['IndexName']
+    assert lsi['Projection'] == {'ProjectionType': 'ALL'}
 
 # In addition to the basic listing of an LSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each LSI's
@@ -250,7 +251,7 @@ def test_lsi_describe(test_table_lsi_4):
 # fields, LSIs do not. IndexStatus is not needed because LSIs cannot be
 # added after the base table is created, and ProvisionedThroughput isn't
 # needed because an LSI shares its provisioning with the base table.
-@pytest.mark.xfail(reason="issues #7550, #11466, #11470")
+@pytest.mark.xfail(reason="issues #7550, #11466")
 def test_lsi_describe_fields(test_table_lsi_1):
     desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
     assert 'Table' in desc
@@ -263,7 +264,6 @@ def test_lsi_describe_fields(test_table_lsi_1):
     assert 'ItemCount' in lsi
     assert not 'IndexStatus' in lsi
     assert not 'ProvisionedThroughput' in lsi
-    assert lsi['Projection'] == {'ProjectionType': 'ALL'}
     assert lsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'p'},
                                 {'KeyType': 'RANGE', 'AttributeName': 'b'}]
     # The index's ARN should look like the table's ARN followed by /index/<indexname>.


### PR DESCRIPTION
Projection field added to return from DescribeTable which describes GSIs and LSIs.
We do not yet support all the settings Projection (see #5036), but the default which we support is ALL, and DescribeTable returns that in its description.

Fixes #11470