### PR TITLE
storage_proxy: update rate limited reads metric when coordinator rejects

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5000,6 +5000,8 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     if (cmd->allow_limit && _db.local().can_apply_per_partition_rate_limit(*schema, db::operation_type::read)) {
         auto r_rate_limit_info = choose_rate_limit_info(_db.local(), !is_read_non_local, db::operation_type::read, schema, token, trace_state);
         if (!r_rate_limit_info) {
+            slogger.debug("Read was rate limited");
+            get_stats().read_rate_limited_by_coordinator.mark();
             return std::move(r_rate_limit_info).as_failure();
         }
         rate_limit_info = r_rate_limit_info.value();


### PR DESCRIPTION
The decision to reject a read operation can either be made by replicas, or by the coordinator. In the second case, the

  `scylla_storage_proxy_coordinator_read_rate_limited`

metric was not incremented, but it should. This commit fixes the issue.

Fixes: #11651