### PR TITLE
test/alternator: fix timeout in flaky test test_ttl_stats

### DIFF
--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -279,7 +279,7 @@ def test_ttl_stats(dynamodb, metrics, alternator_ttl_period_in_seconds):
             # to have increased. Add some time to that, to account for
             # extremely overloaded test machines.
             start_time = time.time()
-            while time.time() < start_time + alternator_ttl_period_in_seconds + 60:
+            while time.time() < start_time + alternator_ttl_period_in_seconds + 120:
                 if not 'Item' in table.get_item(Key={'p': p0}):
                     break
                 time.sleep(0.1)


### PR DESCRIPTION
The test `test_metrics.py::test_ttl_stats` tests the metrics associated with Alternator TTL expiration events. It normally finishes in less than a second (the TTL scanning is configured to run every 0.5 seconds), so we arbitrarily set a 60 second timeout for this test to allow for extremely slow test machines. But in some extreme cases even this was not enough - in one case we measured the TTL scan to take 63 seconds.

So in this patch we increase the timeout in this test from 60 seconds to 120 seconds. We already did the same change in other Alternator TTL tests in the past - in commit 746c4bd.

Fixes #11695

Signed-off-by: Nadav Har'El <nyh@scylladb.com>