### PR TITLE
raft: remove large election test

### DIFF
--- a/test/raft/many_test.cc
+++ b/test/raft/many_test.cc
@@ -41,18 +41,4 @@ SEASTAR_THREAD_TEST_CASE(test_many_400) {
     , true, tick_delay,
     rpc_config{ .network_delay = 20ms, .local_delay = 1ms });
 }
-
-// Expected to work for release and dev builds
-SEASTAR_THREAD_TEST_CASE(test_many_1000) {
-    replication_test<steady_clock_type>(
-        {.nodes = 1000, .total_values = 10,
-         .updates = {entries{1},
-                     isolate{0},              // drop leader, free election
-                     entries{1},
-                     new_leader{1},
-                     set_config{1,2,3,4,5},   // Set configuration to smaller size
-                     }}
-    , true, tick_delay,
-    rpc_config{ .network_delay = 20ms, .local_delay = 1ms });
-}
 #endif


### PR DESCRIPTION
Since randomized nemesis test does cover election with large number of participants, remove the large many test for now.
