### PR TITLE
dirty_memory_manager: simplify, clarify, and document

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -394,7 +394,7 @@ void set_column_family(http_context& ctx, routes& r) {
     cf::get_all_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
         warn(unimplemented::cause::INDEXES);
         return ctx.db.map_reduce0([](const replica::database& db){
-            return db.dirty_memory_region_group().memory_used();
+            return db.dirty_memory_region_group().virtual_memory_used();
         }, int64_t(0), std::plus<int64_t>()).then([](int res) {
             return make_ready_future<json::json_return_type>(res);
         });

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -394,7 +394,7 @@ void set_column_family(http_context& ctx, routes& r) {
     cf::get_all_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
         warn(unimplemented::cause::INDEXES);
         return ctx.db.map_reduce0([](const replica::database& db){
-            return db.dirty_memory_region_group().virtual_memory_used();
+            return db.dirty_memory_region_group().real_memory_used();
         }, int64_t(0), std::plus<int64_t>()).then([](int res) {
             return make_ready_future<json::json_return_type>(res);
         });

--- a/db/config.cc
+++ b/db/config.cc
@@ -808,7 +808,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , prometheus_prefix(this, "prometheus_prefix", value_status::Used, "scylla", "Set the prefix of the exported Prometheus metrics. Changing this will break Scylla's dashboard compatibility, do not change unless you know what you are doing.")
     , abort_on_lsa_bad_alloc(this, "abort_on_lsa_bad_alloc", value_status::Used, false, "Abort when allocation in LSA region fails")
     , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, 12, "Number of most siginificant token bits to ignore in murmur3 partitioner; increase for very large clusters")
-    , virtual_dirty_soft_limit(this, "virtual_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of virtual dirty memory expressed as a portion of the hard limit")
+    , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit")
     , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default) "
         "bytes written to data file. Value must be between 0 and 1.")
     , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, size_t(1) << 20, "Warn about memory allocations above this size; set to zero to disable")

--- a/db/config.hh
+++ b/db/config.hh
@@ -316,7 +316,7 @@ public:
     named_value<sstring> prometheus_prefix;
     named_value<bool> abort_on_lsa_bad_alloc;
     named_value<unsigned> murmur3_partitioner_ignore_msb_bits;
-    named_value<double> virtual_dirty_soft_limit;
+    named_value<double> unspooled_dirty_soft_limit;
     named_value<double> sstable_summary_ratio;
     named_value<size_t> large_memory_allocation_warning_threshold;
     named_value<bool> enable_deprecated_partitioners;

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -39,14 +39,36 @@ public:
     std::optional<region_heap::handle_type> _heap_handle;
 };
 
-// Users of a region_group configure reclaim with a soft limit (where reclaim starts, but allocation
-// can still continue), a hard limit (where allocation cannot proceed until reclaim makes progress),
-// and callbacks that are called when reclaiming is required and no longer necessary.
+// The region_group class keeps track of two memory use counts:
 //
-// These callbacks will be called when the LSA
+//  - real memory: this is LSA memory used by memtables, whether active or being
+//            flushed. 
+//  - spooled memory: this is LSA memory used by memtables undergoing a flush
+//            that has been copied to an sstable. It a subset of
+//            real memory. Once a flushing memtable is sealed, its spooled memory
+//            drops to zero and real memory drops by the size of the memtable.
+//
+// Since the control loop is interested in (real memory) - (spooled memory), we keep
+// track of the difference as unspooled memory.
+//
+// real memory and unspooled memory react to events in this way:
+//   - data added to memtable: both real memory and unspooled memory increase by the same amount
+//            (spooled memory does not change). Note the increase can actually be a decrease if
+//            data was deleted or overwritten.
+//   - part of the memtable was flushed to disk: unspooled memory decreases (spooled memory
+//            increases)
+//
+// Users of a region_group configure reclaim with an unspooled memory soft limit (where
+// sstable flush starts, but allocation can still continue), an unspooled memory hard limit (where
+// allocation cannot proceed until sstable flush makes progress),
+// and callbacks that are called when reclaiming is required and no longer necessary.
+// There is also a real memory hard limit.
+
+//
+// These callbacks will be called when the dirty memory manager
 // see relevant changes in the memory pressure conditions for this region_group. By specializing
-// those methods - which are a nop by default - the callers can take action to aid the LSA in
-// alleviating pressure.
+// those methods - which are a nop by default - the callers initiate memtable flusing to
+// free real and unspooled memory.
 
 // The following restrictions apply to implementations of start_reclaiming() and stop_reclaiming():
 //
@@ -65,8 +87,8 @@ using reclaim_start_callback = noncopyable_function<void () noexcept>;
 using reclaim_stop_callback = noncopyable_function<void () noexcept>;
 
 struct reclaim_config {
-    size_t virtual_hard_limit = std::numeric_limits<size_t>::max();
-    size_t virtual_soft_limit = virtual_hard_limit;
+    size_t unspooled_hard_limit = std::numeric_limits<size_t>::max();
+    size_t unspooled_soft_limit = unspooled_hard_limit;
     size_t real_hard_limit = std::numeric_limits<size_t>::max();
     reclaim_start_callback start_reclaiming = [] () noexcept {};
     reclaim_stop_callback stop_reclaiming = [] () noexcept {};
@@ -150,8 +172,8 @@ public:
 class region_group : public region_listener {
     reclaim_config _cfg;
 
-    bool _under_virtual_pressure = false;
-    bool _under_virtual_soft_pressure = false;
+    bool _under_unspooled_pressure = false;
+    bool _under_unspooled_soft_pressure = false;
 
     region_group* _subgroup = nullptr;
 
@@ -173,48 +195,48 @@ private:
     bool do_update_real_and_check_relief(ssize_t delta);
 
 public:
-    bool under_virtual_pressure() const noexcept {
-        return _under_virtual_pressure;
+    bool under_unspooled_pressure() const noexcept {
+        return _under_unspooled_pressure;
     }
 
-    bool over_virtual_soft_limit() const noexcept {
-        return _under_virtual_soft_pressure;
+    bool over_unspooled_soft_limit() const noexcept {
+        return _under_unspooled_soft_pressure;
     }
 
-    void notify_virtual_soft_pressure() noexcept {
-        if (!_under_virtual_soft_pressure) {
-            _under_virtual_soft_pressure = true;
+    void notify_unspooled_soft_pressure() noexcept {
+        if (!_under_unspooled_soft_pressure) {
+            _under_unspooled_soft_pressure = true;
             _cfg.start_reclaiming();
         }
     }
 
 private:
-    void notify_virtual_soft_relief() noexcept {
-        if (_under_virtual_soft_pressure) {
-            _under_virtual_soft_pressure = false;
+    void notify_unspooled_soft_relief() noexcept {
+        if (_under_unspooled_soft_pressure) {
+            _under_unspooled_soft_pressure = false;
             _cfg.stop_reclaiming();
         }
     }
 
-    void notify_virtual_pressure() noexcept {
-        _under_virtual_pressure = true;
+    void notify_unspooled_pressure() noexcept {
+        _under_unspooled_pressure = true;
     }
 
-    void notify_virtual_relief() noexcept {
-        _under_virtual_pressure = false;
+    void notify_unspooled_relief() noexcept {
+        _under_unspooled_pressure = false;
     }
 
 public:
-    size_t virtual_throttle_threshold() const noexcept {
-        return _cfg.virtual_hard_limit;
+    size_t unspooled_throttle_threshold() const noexcept {
+        return _cfg.unspooled_hard_limit;
     }
 private:
-    size_t virtual_soft_limit_threshold() const noexcept {
-        return _cfg.virtual_soft_limit;
+    size_t unspooled_soft_limit_threshold() const noexcept {
+        return _cfg.unspooled_soft_limit;
     }
     using region_heap = dirty_memory_manager_logalloc::region_heap;
 
-    size_t _virtual_total_memory = 0;
+    size_t _unspooled_total_memory = 0;
 
     region_heap _regions;
 
@@ -233,7 +255,7 @@ private:
 
     bool reclaimer_can_block() const;
     future<> start_releaser(scheduling_group deferered_work_sg);
-    void notify_virtual_pressure_relieved();
+    void notify_unspooled_pressure_relieved();
     friend void region_group_binomial_group_sanity_check(const region_group::region_heap& bh);
 private: // from region_listener
     virtual void moved(region* old_address, region* new_address) override;
@@ -260,10 +282,10 @@ public:
     }
     region_group& operator=(const region_group&) = delete;
     region_group& operator=(region_group&&) = delete;
-    size_t virtual_memory_used() const noexcept {
-        return _virtual_total_memory;
+    size_t unspooled_memory_used() const noexcept {
+        return _unspooled_total_memory;
     }
-    void update_virtual(ssize_t delta);
+    void update_unspooled(ssize_t delta);
 
     // It would be easier to call update, but it is unfortunately broken in boost versions up to at
     // least 1.59.
@@ -277,7 +299,7 @@ public:
     //    the full update cycle even then.
     virtual void increase_usage(region* r, ssize_t delta) override { // From region_listener
         _regions.increase(*static_cast<size_tracked_region*>(r)->_heap_handle);
-        update_virtual(delta);
+        update_unspooled(delta);
     }
 
     virtual void decrease_evictable_usage(region* r) override { // From region_listener
@@ -286,7 +308,7 @@ public:
 
     virtual void decrease_usage(region* r, ssize_t delta) override { // From region_listener
         decrease_evictable_usage(r);
-        update_virtual(delta);
+        update_unspooled(delta);
     }
 
     //
@@ -391,14 +413,14 @@ class dirty_memory_manager {
     bool _db_shutdown_requested = false;
 
     replica::database* _db;
-    // The _region_group accounts for virtual memory usage. It is defined as the real dirty
+    // The _region_group accounts for unspooled memory usage. It is defined as the real dirty
     // memory usage minus bytes that were already written to disk.
     dirty_memory_manager_logalloc::region_group _region_group;
 
     // We would like to serialize the flushing of memtables. While flushing many memtables
     // simultaneously can sustain high levels of throughput, the memory is not freed until the
     // memtable is totally gone. That means that if we have throttled requests, they will stay
-    // throttled for a long time. Even when we have virtual dirty, that only provides a rough
+    // throttled for a long time. Even when we have unspooled dirty, that only provides a rough
     // estimate, and we can't release requests that early.
     semaphore _flush_serializer;
     // We will accept a new flush before another one ends, once it is done with the data write.
@@ -418,7 +440,7 @@ class dirty_memory_manager {
     void start_reclaiming() noexcept;
 
     bool has_pressure() const noexcept {
-        return _region_group.over_virtual_soft_limit();
+        return _region_group.over_unspooled_soft_limit();
     }
 
     unsigned _extraneous_flushes = 0;
@@ -432,7 +454,7 @@ public:
     // Limits and pressure conditions:
     // ===============================
     //
-    // Virtual Dirty
+    // Unspooled Dirty
     // -------------
     // We can't free memory until the whole memtable is flushed because we need to keep it in memory
     // until the end, but we can fake freeing memory. When we are done with an element of the
@@ -441,13 +463,13 @@ public:
     // Because the amount of memory that we pretend to free should be close enough to the actual
     // memory used by the memtables, that effectively creates two sub-regions inside the dirty
     // region group, of equal size. In the worst case, we will have <memtable_total_space> dirty
-    // bytes used, and half of that already virtually freed.
+    // bytes used, and half of that already spooled.
     //
     // Hard Limit
     // ----------
     // The total space that can be used by memtables in each group is defined by the threshold, but
-    // we will only allow the region_group to grow to half of that. This is because of virtual_dirty
-    // as explained above. Because virtual dirty is implemented by reducing the usage in the
+    // we will only allow the region_group to grow to half of that. This is because of unspooled_dirty
+    // as explained above. Because unspooled dirty is implemented by reducing the usage in the
     // region_group directly on partition written, we want to throttle every time half of the memory
     // as seen by the region_group. To achieve that we need to set the hard limit (first parameter
     // of the region_group_reclaimer) to 1/2 of the user-supplied threshold
@@ -459,12 +481,12 @@ public:
     // flushing only when the hard limit is hit, workloads in which the disk is fast enough to cope
     // would see latency added to some requests unnecessarily.
     //
-    // We then set the soft limit to 80 % of the virtual dirty hard limit, which is equal to 40 % of
+    // We then set the soft limit to 80 % of the unspooled dirty hard limit, which is equal to 40 % of
     // the user-supplied threshold.
     dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg);
     dirty_memory_manager()
         : _db(nullptr)
-        , _region_group("memtable (virtual)",
+        , _region_group("memtable (unspooled)",
                 dirty_memory_manager_logalloc::reclaim_config{
                     .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this),
                 })
@@ -485,13 +507,13 @@ public:
 
     void revert_potentially_cleaned_up_memory(logalloc::region* from, int64_t delta) {
         _region_group.update_real(-delta);
-        _region_group.update_virtual(delta);
+        _region_group.update_unspooled(delta);
         _dirty_bytes_released_pre_accounted -= delta;
     }
 
     void account_potentially_cleaned_up_memory(logalloc::region* from, int64_t delta) {
         _region_group.update_real(delta);
-        _region_group.update_virtual(-delta);
+        _region_group.update_unspooled(-delta);
         _dirty_bytes_released_pre_accounted += delta;
     }
 
@@ -507,16 +529,16 @@ public:
         return _region_group.real_memory_used();
     }
 
-    size_t virtual_dirty_memory() const noexcept {
-        return _region_group.virtual_memory_used();
+    size_t unspooled_dirty_memory() const noexcept {
+        return _region_group.unspooled_memory_used();
     }
 
     void notify_soft_pressure() {
-        _region_group.notify_virtual_soft_pressure();
+        _region_group.notify_unspooled_soft_pressure();
     }
 
     size_t throttle_threshold() const {
-        return _region_group.virtual_throttle_threshold();
+        return _region_group.unspooled_throttle_threshold();
     }
 
     future<> flush_one(replica::memtable_list& cf, flush_permit&& permit) noexcept;
@@ -564,7 +586,7 @@ futurize_t<std::result_of_t<Func()>>
 region_group::run_when_memory_available(Func&& func, db::timeout_clock::time_point timeout) {
     auto rg = this;
     bool blocked = 
-        !(rg->_blocked_requests.empty() && !rg->under_virtual_pressure());
+        !(rg->_blocked_requests.empty() && !rg->under_unspooled_pressure());
     if (!blocked) {
         blocked = _under_real_pressure;
     }

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -699,13 +699,13 @@ determining where the memory is. Lets look at a concrete example:
      total:          1067319296
      Regular:
       real dirty:    1064566784
-      virt dirty:     811568656
+      unspooled:      811568656
      System:
       real dirty:        393216
-      virt dirty:        393216
+      unspooled:         393216
      Streaming:
       real dirty:             0
-      virt dirty:             0
+      unspooled:              0
 
     Coordinator:
       bg write bytes:         42133 B

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -450,9 +450,9 @@ void backlog_controller::update_controller(float shares) {
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
     : _db(&db)
     , _virtual_region_group("memtable (virtual)", dirty_memory_manager_logalloc::reclaim_config{
-            .hard_limit = threshold / 2,
-            .soft_limit = threshold * soft_limit / 2,
-            .absolute_hard_limit = threshold,
+            .virtual_hard_limit = threshold / 2,
+            .virtual_soft_limit = threshold * soft_limit / 2,
+            .real_hard_limit = threshold,
             .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
       }, deferred_work_sg)
     , _flush_serializer(1)

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -86,7 +86,7 @@ namespace replica {
 inline
 flush_controller
 make_flush_controller(const db::config& cfg, backlog_controller::scheduling_group& sg, std::function<double()> fn) {
-    return flush_controller(sg, cfg.memtable_flush_static_shares(), 50ms, cfg.virtual_dirty_soft_limit(), std::move(fn));
+    return flush_controller(sg, cfg.memtable_flush_static_shares(), 50ms, cfg.unspooled_dirty_soft_limit(), std::move(fn));
 }
 
 keyspace::keyspace(lw_shared_ptr<keyspace_metadata> metadata, config cfg, locator::effective_replication_map_factory& erm_factory)
@@ -208,10 +208,10 @@ void database::setup_scylla_memory_diagnostics_producer() {
 
         writeln(" Regular:\n");
         writeln("  real dirty: {}\n", utils::to_hr_size(_dirty_memory_manager.real_dirty_memory()));
-        writeln("  virt dirty: {}\n", utils::to_hr_size(_dirty_memory_manager.virtual_dirty_memory()));
+        writeln("  virt dirty: {}\n", utils::to_hr_size(_dirty_memory_manager.unspooled_dirty_memory()));
         writeln(" System:\n");
         writeln("  real dirty: {}\n", utils::to_hr_size(_system_dirty_memory_manager.real_dirty_memory()));
-        writeln("  virt dirty: {}\n\n", utils::to_hr_size(_system_dirty_memory_manager.virtual_dirty_memory()));
+        writeln("  virt dirty: {}\n\n", utils::to_hr_size(_system_dirty_memory_manager.unspooled_dirty_memory()));
 
         writeln("Replica:\n");
 
@@ -313,12 +313,12 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _cl_stats(std::make_unique<cell_locker_stats>())
     , _cfg(cfg)
     // Allow system tables a pool of 10 MB memory to write, but never block on other regions.
-    , _system_dirty_memory_manager(*this, 10 << 20, cfg.virtual_dirty_soft_limit(), default_scheduling_group())
-    , _dirty_memory_manager(*this, dbcfg.available_memory * 0.50, cfg.virtual_dirty_soft_limit(), dbcfg.statement_scheduling_group)
+    , _system_dirty_memory_manager(*this, 10 << 20, cfg.unspooled_dirty_soft_limit(), default_scheduling_group())
+    , _dirty_memory_manager(*this, dbcfg.available_memory * 0.50, cfg.unspooled_dirty_soft_limit(), dbcfg.statement_scheduling_group)
     , _dbcfg(dbcfg)
     , _flush_sg(backlog_controller::scheduling_group{dbcfg.memtable_scheduling_group, service::get_local_memtable_flush_priority()})
     , _memtable_controller(make_flush_controller(_cfg, _flush_sg, [this, limit = float(_dirty_memory_manager.throttle_threshold())] {
-        auto backlog = (_dirty_memory_manager.virtual_dirty_memory()) / limit;
+        auto backlog = (_dirty_memory_manager.unspooled_dirty_memory()) / limit;
         if (_dirty_memory_manager.has_extraneous_flushes_requested()) {
             backlog = std::max(backlog, _memtable_controller.backlog_of_shares(200));
         }
@@ -449,9 +449,9 @@ void backlog_controller::update_controller(float shares) {
 
 dirty_memory_manager::dirty_memory_manager(replica::database& db, size_t threshold, double soft_limit, scheduling_group deferred_work_sg)
     : _db(&db)
-    , _region_group("memtable (virtual)", dirty_memory_manager_logalloc::reclaim_config{
-            .virtual_hard_limit = threshold / 2,
-            .virtual_soft_limit = threshold * soft_limit / 2,
+    , _region_group("memtable (unspooled)", dirty_memory_manager_logalloc::reclaim_config{
+            .unspooled_hard_limit = threshold / 2,
+            .unspooled_soft_limit = threshold * soft_limit / 2,
             .real_hard_limit = threshold,
             .start_reclaiming = std::bind_front(&dirty_memory_manager::start_reclaiming, this)
       }, deferred_work_sg)
@@ -466,9 +466,9 @@ dirty_memory_manager::setup_collectd(sstring namestr) {
         sm::make_gauge(namestr + "_dirty_bytes", [this] { return real_dirty_memory(); },
                        sm::description("Holds the current size of a all non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. "
                                        "Total memory size minus this value represents the amount of available memory. "
-                                       "If this value minus virtual_dirty_bytes is too high then this means that the dirty memory eviction lags behind.")),
+                                       "If this value minus unspooled_dirty_bytes is too high then this means that the dirty memory eviction lags behind.")),
 
-        sm::make_gauge(namestr +"_virtual_dirty_bytes", [this] { return virtual_dirty_memory(); },
+        sm::make_gauge(namestr +"_unspooled_dirty_bytes", [this] { return unspooled_dirty_memory(); },
                        sm::description("Holds the size of used memory in bytes. Compare it to \"dirty_bytes\" to see how many memory is wasted (neither used nor available).")),
     });
 }
@@ -492,9 +492,9 @@ database::setup_metrics() {
         sm::make_gauge("dirty_bytes", [this] { return _dirty_memory_manager.real_dirty_memory() + _system_dirty_memory_manager.real_dirty_memory(); },
                        sm::description("Holds the current size of all (\"regular\", \"system\" and \"streaming\") non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. "
                                        "Total memory size minus this value represents the amount of available memory. "
-                                       "If this value minus virtual_dirty_bytes is too high then this means that the dirty memory eviction lags behind.")),
+                                       "If this value minus unspooled_dirty_bytes is too high then this means that the dirty memory eviction lags behind.")),
 
-        sm::make_gauge("virtual_dirty_bytes", [this] { return _dirty_memory_manager.virtual_dirty_memory() + _system_dirty_memory_manager.virtual_dirty_memory(); },
+        sm::make_gauge("unspooled_dirty_bytes", [this] { return _dirty_memory_manager.unspooled_dirty_memory() + _system_dirty_memory_manager.unspooled_dirty_memory(); },
                        sm::description("Holds the size of all (\"regular\", \"system\" and \"streaming\") used memory in bytes. Compare it to \"dirty_bytes\" to see how many memory is wasted (neither used nor available).")),
     });
 

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1733,8 +1733,8 @@ class dirty_mem_mgr():
     def real_dirty(self):
         return int(self.ref['_region_group']['_real_total_memory'])
 
-    def virt_dirty(self):
-        return int(self.ref['_region_group']['_virtual_total_memory'])
+    def unspooled(self):
+        return int(self.ref['_region_group']['_unspooled_total_memory'])
 
 
 def find_instances(type_name):
@@ -2064,15 +2064,15 @@ class scylla_memory(gdb.Command):
                   ' total:       {total:>13}\n'
                   ' Regular:\n'
                   '  real dirty: {reg_real_dirty:>13}\n'
-                  '  virt dirty: {reg_virt_dirty:>13}\n'
+                  '  unspooled:  {reg_unspooled:>13}\n'
                   ' System:\n'
                   '  real dirty: {sys_real_dirty:>13}\n'
-                  '  virt dirty: {sys_virt_dirty:>13}\n\n'
+                  '  unspooled:  {sys_unspooled:>13}\n\n'
                   .format(total=(lsa_allocated-cache_region.total()),
                           reg_real_dirty=dirty_mem_mgr(db['_dirty_memory_manager']).real_dirty(),
-                          reg_virt_dirty=dirty_mem_mgr(db['_dirty_memory_manager']).virt_dirty(),
+                          reg_unspooled=dirty_mem_mgr(db['_dirty_memory_manager']).unspooled(),
                           sys_real_dirty=dirty_mem_mgr(db['_system_dirty_memory_manager']).real_dirty(),
-                          sys_virt_dirty=dirty_mem_mgr(db['_system_dirty_memory_manager']).virt_dirty()))
+                          sys_unspooled=dirty_mem_mgr(db['_system_dirty_memory_manager']).unspooled()))
 
         scylla_memory.print_coordinator_stats()
         scylla_memory.print_replica_stats()

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1731,10 +1731,10 @@ class dirty_mem_mgr():
         self.ref = ref
 
     def real_dirty(self):
-        return int(self.ref['_virtual_region_group']['_real_total_memory'])
+        return int(self.ref['_region_group']['_real_total_memory'])
 
     def virt_dirty(self):
-        return int(self.ref['_virtual_region_group']['_virtual_total_memory'])
+        return int(self.ref['_region_group']['_virtual_total_memory'])
 
 
 def find_instances(type_name):

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1731,10 +1731,10 @@ class dirty_mem_mgr():
         self.ref = ref
 
     def real_dirty(self):
-        return int(self.ref['_virtual_region_group']['_hard_total_memory'])
+        return int(self.ref['_virtual_region_group']['_real_total_memory'])
 
     def virt_dirty(self):
-        return int(self.ref['_virtual_region_group']['_total_memory'])
+        return int(self.ref['_virtual_region_group']['_virtual_total_memory'])
 
 
 def find_instances(type_name):

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -72,8 +72,8 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().used_space()), ssize_t(one_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().total_space()), ssize_t(one->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one->occupancy().total_space());
 
         constexpr size_t two_count = 8 * base_count;
         std::vector<managed_ref<int>> two_objs;
@@ -84,8 +84,8 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().used_space()), ssize_t(two_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().total_space()), ssize_t(two->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space() + two->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space() + two->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
 
         constexpr size_t three_count = 32 * base_count;
         std::vector<managed_ref<int>> three_objs;
@@ -96,7 +96,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t(three_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
 
         constexpr size_t four_count = 4 * base_count;
         std::vector<managed_ref<int>> four_objs;
@@ -107,7 +107,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(four->occupancy().used_space()), ssize_t(four_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(four->occupancy().total_space()), ssize_t(four->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(just_four.memory_used(), four->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(just_four.virtual_memory_used(), four->occupancy().total_space());
 
         with_allocator(five->allocator(), [] {
             constexpr size_t five_count = base_count;
@@ -120,27 +120,27 @@ SEASTAR_TEST_CASE(test_region_groups) {
         three->merge(*four);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one_and_two.memory_used());
-        BOOST_REQUIRE_EQUAL(just_four.memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
+        BOOST_REQUIRE_EQUAL(just_four.virtual_memory_used(), 0);
 
         three->merge(*five);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
 
         with_allocator(two->allocator(), [&] {
             two_objs.clear();
         });
         two.reset();
-        BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), one->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), one_and_two.memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
 
         with_allocator(one->allocator(), [&] {
             one_objs.clear();
         });
         one.reset();
-        BOOST_REQUIRE_EQUAL(one_and_two.memory_used(), 0);
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), 0);
 
         with_allocator(three->allocator(), [&] {
             three_objs.clear();
@@ -149,7 +149,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         three.reset();
         four.reset();
         five.reset();
-        BOOST_REQUIRE_EQUAL(one_and_two.hard_memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), 0);
     });
 }
 
@@ -209,7 +209,7 @@ private:
 SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
     return seastar::async([] {
         // singleton hierarchy, only one segment allowed
-        test_region_group simple({ .hard_limit = logalloc::segment_size });
+        test_region_group simple({ .virtual_hard_limit = logalloc::segment_size });
         auto simple_region = std::make_unique<test_region>();
         simple_region->listen(&simple);
 
@@ -221,11 +221,11 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         // the group and we'll be okay to do that a second time.
         auto fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), true);
-        BOOST_REQUIRE_EQUAL(simple.memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_EQUAL(simple.virtual_memory_used(), logalloc::segment_size);
 
         fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), true);
-        BOOST_REQUIRE_EQUAL(simple.memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_EQUAL(simple.virtual_memory_used(), logalloc::segment_size);
 
         auto big_region = std::make_unique<test_region>();
         big_region->listen(&simple);
@@ -236,10 +236,10 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
         fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), false);
-        BOOST_REQUIRE_GT(simple.memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_GT(simple.virtual_memory_used(), logalloc::segment_size);
 
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
-        testlog.info("used = {}", simple.memory_used());
+        testlog.info("used = {}", simple.virtual_memory_used());
 
         testlog.info("Resetting");
 
@@ -248,14 +248,14 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         // that's up to the internal policies. So to make sure we need to remove the whole region.
         big_region.reset();
 
-        testlog.info("used = {}", simple.memory_used());
+        testlog.info("used = {}", simple.virtual_memory_used());
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
         try {
             quiesce(std::move(fut));
         } catch (...) {
             testlog.info("Aborting: {}", std::current_exception());
             testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
-            testlog.info("used = {}", simple.memory_used());
+            testlog.info("used = {}", simple.virtual_memory_used());
             abort();
         }
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
@@ -265,14 +265,14 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
 SEASTAR_TEST_CASE(test_region_groups_fifo_order) {
     // tests that requests that are queued for later execution execute in FIFO order
     return seastar::async([] {
-        test_region_group rg({.hard_limit = logalloc::segment_size});
+        test_region_group rg({.virtual_hard_limit = logalloc::segment_size});
 
         auto region = std::make_unique<test_region>();
         region->listen(&rg);
 
         // fill the parent. Try allocating at child level. Should not be allowed.
         region->alloc();
-        BOOST_REQUIRE_GE(rg.memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_GE(rg.virtual_memory_used(), logalloc::segment_size);
 
         auto exec_cnt = make_lw_shared<int>(0);
         std::vector<future<>> executions;
@@ -346,7 +346,7 @@ public:
         (void)with_gate(_reclaimers_done, [this] {
             return _unleash_reclaimer.get_shared_future().then([this] {
                 _unleashed.set_value();
-                while (_rg.under_pressure()) {
+                while (_rg.under_virtual_pressure()) {
                     size_t reclaimed = test_async_reclaim_region::from_region(_rg.get_largest_region()).evict();
                     _result_accumulator->_reclaim_sizes.push_back(reclaimed);
                 }
@@ -370,7 +370,7 @@ public:
     test_reclaimer(size_t threshold)
         : _result_accumulator(this)
         , _rg("test_reclaimer RG", {
-            .hard_limit = threshold,
+            .virtual_hard_limit = threshold,
             .start_reclaiming = std::bind_front(&test_reclaimer::start_reclaiming, this),
         }) {}
 
@@ -439,7 +439,7 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
 
         auto free_space = memory::stats().free_memory();
         size_t threshold = size_t(0.75 * free_space);
-        region_group gr(test_name, {.hard_limit = threshold, .soft_limit = threshold});
+        region_group gr(test_name, {.virtual_hard_limit = threshold, .virtual_soft_limit = threshold});
         auto close_gr = defer([&gr] () noexcept { gr.shutdown().get(); });
         size_tracked_region r;
         r.listen(&gr);
@@ -458,7 +458,7 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
             });
 
             auto fill_to_pressure = [&] {
-                while (!gr.under_pressure()) {
+                while (!gr.under_virtual_pressure()) {
                     objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), 1024));
                 }
             };
@@ -470,14 +470,14 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
                 fill_to_pressure();
                 future<> f = gr.run_when_memory_available([&, op = request_barrier.start()] {
                     // Trigger group size change (Refs issue #2021)
-                    gr.update(-10);
-                    gr.update(+10);
+                    gr.update_virtual(-10);
+                    gr.update_virtual(+10);
                 }, db::no_timeout);
                 BOOST_REQUIRE(!f.available());
             }
 
             // Release
-            while (gr.under_pressure()) {
+            while (gr.under_virtual_pressure()) {
                 objs.pop_back();
             }
         });
@@ -492,8 +492,8 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
 
         bool reclaiming = false;
         region_group gr(test_name, {
-                .hard_limit = hard_threshold,
-                .soft_limit = soft_threshold,
+                .virtual_hard_limit = hard_threshold,
+                .virtual_soft_limit = soft_threshold,
                 .start_reclaiming = [&] () noexcept { reclaiming = true; },
                 .stop_reclaiming = [&] () noexcept { reclaiming = false; },
         });
@@ -506,26 +506,26 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
 
             BOOST_REQUIRE(!reclaiming);
 
-            while (!gr.over_soft_limit()) {
+            while (!gr.over_virtual_soft_limit()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
             BOOST_REQUIRE(reclaiming);
 
-            while (!gr.under_pressure()) {
+            while (!gr.under_virtual_pressure()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
             BOOST_REQUIRE(reclaiming);
 
-            while (gr.under_pressure()) {
+            while (gr.under_virtual_pressure()) {
                 objs.pop_back();
             }
 
-            BOOST_REQUIRE(gr.over_soft_limit());
+            BOOST_REQUIRE(gr.over_virtual_soft_limit());
             BOOST_REQUIRE(reclaiming);
 
-            while (gr.over_soft_limit()) {
+            while (gr.over_virtual_soft_limit()) {
                 objs.pop_back();
             }
 

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -72,7 +72,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().used_space()), ssize_t(one_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(one->occupancy().total_space()), ssize_t(one->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.unspooled_memory_used(), one->occupancy().total_space());
         BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one->occupancy().total_space());
 
         constexpr size_t two_count = 8 * base_count;
@@ -84,8 +84,8 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().used_space()), ssize_t(two_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(two->occupancy().total_space()), ssize_t(two->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space() + two->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.unspooled_memory_used(), one->occupancy().total_space() + two->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.unspooled_memory_used());
 
         constexpr size_t three_count = 32 * base_count;
         std::vector<managed_ref<int>> three_objs;
@@ -96,7 +96,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t(three_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.unspooled_memory_used());
 
         constexpr size_t four_count = 4 * base_count;
         std::vector<managed_ref<int>> four_objs;
@@ -107,7 +107,7 @@ SEASTAR_TEST_CASE(test_region_groups) {
         });
         BOOST_REQUIRE_GE(ssize_t(four->occupancy().used_space()), ssize_t(four_count * sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(four->occupancy().total_space()), ssize_t(four->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(just_four.virtual_memory_used(), four->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(just_four.unspooled_memory_used(), four->occupancy().total_space());
 
         with_allocator(five->allocator(), [] {
             constexpr size_t five_count = base_count;
@@ -120,26 +120,26 @@ SEASTAR_TEST_CASE(test_region_groups) {
         three->merge(*four);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
-        BOOST_REQUIRE_EQUAL(just_four.virtual_memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.unspooled_memory_used());
+        BOOST_REQUIRE_EQUAL(just_four.unspooled_memory_used(), 0);
 
         three->merge(*five);
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().used_space()), ssize_t((three_count  + four_count)* sizeof(int)));
         BOOST_REQUIRE_GE(ssize_t(three->occupancy().total_space()), ssize_t(three->occupancy().used_space()));
-        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.unspooled_memory_used());
 
         with_allocator(two->allocator(), [&] {
             two_objs.clear();
         });
         two.reset();
-        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), one->occupancy().total_space());
-        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.virtual_memory_used());
+        BOOST_REQUIRE_EQUAL(one_and_two.unspooled_memory_used(), one->occupancy().total_space());
+        BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), one_and_two.unspooled_memory_used());
 
         with_allocator(one->allocator(), [&] {
             one_objs.clear();
         });
         one.reset();
-        BOOST_REQUIRE_EQUAL(one_and_two.virtual_memory_used(), 0);
+        BOOST_REQUIRE_EQUAL(one_and_two.unspooled_memory_used(), 0);
         BOOST_REQUIRE_EQUAL(one_and_two.real_memory_used(), 0);
 
         with_allocator(three->allocator(), [&] {
@@ -209,7 +209,7 @@ private:
 SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
     return seastar::async([] {
         // singleton hierarchy, only one segment allowed
-        test_region_group simple({ .virtual_hard_limit = logalloc::segment_size });
+        test_region_group simple({ .unspooled_hard_limit = logalloc::segment_size });
         auto simple_region = std::make_unique<test_region>();
         simple_region->listen(&simple);
 
@@ -221,11 +221,11 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         // the group and we'll be okay to do that a second time.
         auto fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), true);
-        BOOST_REQUIRE_EQUAL(simple.virtual_memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_EQUAL(simple.unspooled_memory_used(), logalloc::segment_size);
 
         fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), true);
-        BOOST_REQUIRE_EQUAL(simple.virtual_memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_EQUAL(simple.unspooled_memory_used(), logalloc::segment_size);
 
         auto big_region = std::make_unique<test_region>();
         big_region->listen(&simple);
@@ -236,10 +236,10 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
         fut = simple.run_when_memory_available([&simple_region] { simple_region->alloc_small(); }, db::no_timeout);
         BOOST_REQUIRE_EQUAL(fut.available(), false);
-        BOOST_REQUIRE_GT(simple.virtual_memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_GT(simple.unspooled_memory_used(), logalloc::segment_size);
 
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
-        testlog.info("used = {}", simple.virtual_memory_used());
+        testlog.info("used = {}", simple.unspooled_memory_used());
 
         testlog.info("Resetting");
 
@@ -248,14 +248,14 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
         // that's up to the internal policies. So to make sure we need to remove the whole region.
         big_region.reset();
 
-        testlog.info("used = {}", simple.virtual_memory_used());
+        testlog.info("used = {}", simple.unspooled_memory_used());
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
         try {
             quiesce(std::move(fut));
         } catch (...) {
             testlog.info("Aborting: {}", std::current_exception());
             testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
-            testlog.info("used = {}", simple.virtual_memory_used());
+            testlog.info("used = {}", simple.unspooled_memory_used());
             abort();
         }
         testlog.info("now = {}", lowres_clock::now().time_since_epoch().count());
@@ -265,14 +265,14 @@ SEASTAR_TEST_CASE(test_region_groups_basic_throttling) {
 SEASTAR_TEST_CASE(test_region_groups_fifo_order) {
     // tests that requests that are queued for later execution execute in FIFO order
     return seastar::async([] {
-        test_region_group rg({.virtual_hard_limit = logalloc::segment_size});
+        test_region_group rg({.unspooled_hard_limit = logalloc::segment_size});
 
         auto region = std::make_unique<test_region>();
         region->listen(&rg);
 
         // fill the parent. Try allocating at child level. Should not be allowed.
         region->alloc();
-        BOOST_REQUIRE_GE(rg.virtual_memory_used(), logalloc::segment_size);
+        BOOST_REQUIRE_GE(rg.unspooled_memory_used(), logalloc::segment_size);
 
         auto exec_cnt = make_lw_shared<int>(0);
         std::vector<future<>> executions;
@@ -346,7 +346,7 @@ public:
         (void)with_gate(_reclaimers_done, [this] {
             return _unleash_reclaimer.get_shared_future().then([this] {
                 _unleashed.set_value();
-                while (_rg.under_virtual_pressure()) {
+                while (_rg.under_unspooled_pressure()) {
                     size_t reclaimed = test_async_reclaim_region::from_region(_rg.get_largest_region()).evict();
                     _result_accumulator->_reclaim_sizes.push_back(reclaimed);
                 }
@@ -370,7 +370,7 @@ public:
     test_reclaimer(size_t threshold)
         : _result_accumulator(this)
         , _rg("test_reclaimer RG", {
-            .virtual_hard_limit = threshold,
+            .unspooled_hard_limit = threshold,
             .start_reclaiming = std::bind_front(&test_reclaimer::start_reclaiming, this),
         }) {}
 
@@ -439,7 +439,7 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
 
         auto free_space = memory::stats().free_memory();
         size_t threshold = size_t(0.75 * free_space);
-        region_group gr(test_name, {.virtual_hard_limit = threshold, .virtual_soft_limit = threshold});
+        region_group gr(test_name, {.unspooled_hard_limit = threshold, .unspooled_soft_limit = threshold});
         auto close_gr = defer([&gr] () noexcept { gr.shutdown().get(); });
         size_tracked_region r;
         r.listen(&gr);
@@ -458,7 +458,7 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
             });
 
             auto fill_to_pressure = [&] {
-                while (!gr.under_virtual_pressure()) {
+                while (!gr.under_unspooled_pressure()) {
                     objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), 1024));
                 }
             };
@@ -470,14 +470,14 @@ SEASTAR_TEST_CASE(test_no_crash_when_a_lot_of_requests_released_which_change_reg
                 fill_to_pressure();
                 future<> f = gr.run_when_memory_available([&, op = request_barrier.start()] {
                     // Trigger group size change (Refs issue #2021)
-                    gr.update_virtual(-10);
-                    gr.update_virtual(+10);
+                    gr.update_unspooled(-10);
+                    gr.update_unspooled(+10);
                 }, db::no_timeout);
                 BOOST_REQUIRE(!f.available());
             }
 
             // Release
-            while (gr.under_virtual_pressure()) {
+            while (gr.under_unspooled_pressure()) {
                 objs.pop_back();
             }
         });
@@ -492,8 +492,8 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
 
         bool reclaiming = false;
         region_group gr(test_name, {
-                .virtual_hard_limit = hard_threshold,
-                .virtual_soft_limit = soft_threshold,
+                .unspooled_hard_limit = hard_threshold,
+                .unspooled_soft_limit = soft_threshold,
                 .start_reclaiming = [&] () noexcept { reclaiming = true; },
                 .stop_reclaiming = [&] () noexcept { reclaiming = false; },
         });
@@ -506,26 +506,26 @@ SEASTAR_TEST_CASE(test_reclaiming_runs_as_long_as_there_is_soft_pressure) {
 
             BOOST_REQUIRE(!reclaiming);
 
-            while (!gr.over_virtual_soft_limit()) {
+            while (!gr.over_unspooled_soft_limit()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
             BOOST_REQUIRE(reclaiming);
 
-            while (!gr.under_virtual_pressure()) {
+            while (!gr.under_unspooled_pressure()) {
                 objs.emplace_back(managed_bytes(managed_bytes::initialized_later(), logalloc::segment_size));
             }
 
             BOOST_REQUIRE(reclaiming);
 
-            while (gr.under_virtual_pressure()) {
+            while (gr.under_unspooled_pressure()) {
                 objs.pop_back();
             }
 
-            BOOST_REQUIRE(gr.over_virtual_soft_limit());
+            BOOST_REQUIRE(gr.over_unspooled_soft_limit());
             BOOST_REQUIRE(reclaiming);
 
-            while (gr.over_virtual_soft_limit()) {
+            while (gr.over_unspooled_soft_limit()) {
                 objs.pop_back();
             }
 

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -312,7 +312,7 @@ int main(int argc, char** argv) {
 
         db_cfg.enable_cache(app.configuration().contains("enable-cache"));
         db_cfg.enable_commitlog(false);
-        db_cfg.virtual_dirty_soft_limit(1.0);
+        db_cfg.unspooled_dirty_soft_limit(1.0);
 
         db_cfg.sstable_format(app.configuration()["sstable-format"].as<std::string>());
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1949,7 +1949,7 @@ int main(int argc, char** argv) {
         db_cfg.enable_cache(app.configuration().contains("enable-cache"));
         db_cfg.enable_commitlog(false);
         db_cfg.data_file_directories({datadir}, db::config::config_source::CommandLine);
-        db_cfg.virtual_dirty_soft_limit(1.0); // prevent background memtable flushes.
+        db_cfg.unspooled_dirty_soft_limit(1.0); // prevent background memtable flushes.
 
         db_cfg.sstable_format(app.configuration()["sstable-format"].as<std::string>());
 


### PR DESCRIPTION
This series undoes some recent damage to clarity, then
goes further by renaming terms around dirty_memory_manager
to be clearer. Documentation is added.