### PR TITLE
test.py: handle the --markers pytest arguments

### DIFF
--- a/test/topology/pytest.ini
+++ b/test/topology/pytest.ini
@@ -4,3 +4,6 @@ asyncio_mode = auto
 log_cli = true
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+
+markers =
+    slow: tests that take more than 30 seconds to run


### PR DESCRIPTION
Some tests may take longer than a few seconds to run. We want to mark such tests in some way, so that we can run them selectively. This patch proposes to use `pytest` markers for this. The markers from the test.py command line are passed to `pytest`. A special marker with the reserved name 'default' is supported. Its value is replaced by the fixed expression '(not slow)'. This marker is also used as the default value for `--markers`, which means that slow test won't be run by default.

The `--markers` parameter is currently only supported by Python tests, other tests ignore it. We intend to support this parameter for other types of tests in the future.

Another possible improvement is not to run suites for which all tests have been filtered out by markers. The markers are currently handled by `pytest`, which means that the logic in `test.py` (e.g., running a scylla test cluster) will be run for such suites.