### PR TITLE
treewide: remove mentions of seastar::thread::should_yield()

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -968,9 +968,6 @@ future<> row_cache::do_update(external_updater eu, replica::memtable& m, Updater
                     size_t partition_count = 0;
                     {
                         STAP_PROBE(scylla, row_cache_update_one_batch_start);
-                        // FIXME: we should really be checking should_yield() here instead of
-                        // need_preempt(). However, should_yield() is currently quite
-                        // expensive and we need to amortize it somehow.
                         do {
                           STAP_PROBE(scylla, row_cache_update_partition_start);
                           {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6116,7 +6116,7 @@ void storage_proxy::retire_view_response_handlers(noncopyable_function<bool(cons
             it->timeout_cb();
         }
         ++it;
-        if (seastar::thread::should_yield()) {
+        if (need_preempt()) {
             view_update_handlers_list::iterator_guard ig{*_view_update_handlers_list, it};
             seastar::thread::yield();
         }


### PR DESCRIPTION
thread_scheduling_group has been retired many years ago. Remove the leftovers, they are confusing.