### PR TITLE
idl: streaming: include stream_fwd.hh

### DIFF
--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -10,6 +10,8 @@
 #include "idl/token.idl.hh"
 #include "idl/uuid.idl.hh"
 
+#include "streaming/stream_fwd.hh"
+
 namespace streaming {
 
 class plan_id final {


### PR DESCRIPTION
To keep the idl definition of plan_id from
getting out of sync with the one in stream_fwd.hh.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>