### PR TITLE
More Raft upgrade tests

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -21,6 +21,7 @@
 #include "gms/feature_service.hh"
 #include "db/system_keyspace.hh"
 #include "replica/database.hh"
+#include "utils/error_injection.hh"
 
 #include <seastar/core/smp.hh>
 #include <seastar/core/sleep.hh>
@@ -1438,6 +1439,9 @@ future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state) {
                     auto current_config = get_raft_members_inet_addrs(group0_server.get_configuration().current);
                     return make_ready_future<std::vector<gms::inet_address>>(std::move(current_config));
                 }, _ms, _abort_source);
+
+        utils::get_local_injector().inject("group0_upgrade_before_synchronize",
+            [] { throw std::runtime_error("error injection before group 0 upgrade enters synchronize"); });
 
         upgrade_log.info("Entering synchronize state.");
         upgrade_log.warn("Schema changes are disabled in synchronize state."

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -145,12 +145,13 @@ class ManagerClient():
         return server_id
 
     # TODO: only pass UUID
-    async def remove_node(self, initiator_ip: str, to_remove_ip: str, to_remove_uuid: str) -> None:
+    async def remove_node(self, initiator_ip: str,
+                          to_remove_ip: str, to_remove_host_id: str, ignore_dead: list[str] = []) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
         logger.debug("ManagerClient remove node %s %s on initiator %s", to_remove_ip,
-                     to_remove_uuid, initiator_ip)
-        await self.client.get_text(
-                f"/cluster/remove-node/{initiator_ip}/{to_remove_ip}/{to_remove_uuid}")
+                     to_remove_host_id, initiator_ip)
+        data = {"to_remove_ip": to_remove_ip, "to_remove_host_id": to_remove_host_id, "ignore_dead": ignore_dead}
+        await self.client.put_json(f"/cluster/remove-node/{initiator_ip}", data)
         self._driver_update()
 
     async def decommission_node(self, to_remove_ip: str) -> None:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -171,6 +171,6 @@ class ManagerClient():
         if resp.status != 200:
             raise Exception(await resp.text())
 
-    async def get_host_id(self, server_id: str) -> None:
+    async def get_host_id(self, server_id: str) -> str:
         """Get host id through Scylla REST API"""
         return await self.api.get_host_id(server_id)

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -137,10 +137,11 @@ class ScyllaRESTAPIClient():
         host_uuid = host_uuid.lstrip('"').rstrip('"')
         return host_uuid
 
-    async def remove_node(self, initiator_ip: str, server_uuid: str) -> None:
+    async def remove_node(self, initiator_ip: str, server_uuid: str, ignore_dead: list[str]) -> None:
         """Initiate remove node of server_uuid in initiator initiator_ip"""
-        resp = await self.client.post("/storage_service/remove_node", params={"host_id": server_uuid},
-                                   host=initiator_ip)
+        resp = await self.client.post("/storage_service/remove_node",
+                               params={"host_id": server_uuid, "ignore_nodes": ",".join(ignore_dead)},
+                               host=initiator_ip)
         logger.info("remove_node status %s for %s", resp.status, server_uuid)
 
     async def decommission_node(self, node_ip: str) -> None:

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -49,7 +49,12 @@ class RESTSession:
     async def put_json(self, resource_uri: str, json: dict) \
             -> aiohttp.ClientResponse:
         """Put JSON"""
-        return await self.session.request(method="PUT", url=resource_uri, json=json)
+        resp = await self.session.request(method="PUT", url=resource_uri, json=json)
+        if resp.status != 200:
+            text = await resp.text()
+            raise RuntimeError(f"status code: {resp.status}, body text: {text}, "
+                               f"resource {resource_uri} json {json}")
+        return resp
 
 
 class UnixRESTClient:

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -6,9 +6,11 @@
 """Asynchronous helper for Scylla REST API operations.
 """
 import logging
+import pytest
 import os.path
-from typing import Optional
 import aiohttp
+from typing import Optional
+from contextlib import asynccontextmanager
 
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,13 @@ class RESTSession:
             text = await resp.text()
             raise RuntimeError(f"status code: {resp.status}, body text: {text}, "
                                f"resource {resource_uri} json {json}")
+        return resp
+
+    async def delete(self, resource_uri: str) -> aiohttp.ClientResponse:
+        resp = await self.session.delete(url=resource_uri)
+        if resp.status != 200:
+            text = await resp.text()
+            raise RuntimeError(f"status code: {resp.status}, body text: {text}")
         return resp
 
 
@@ -117,6 +126,9 @@ class TCPRESTClient:
         """Post to remote resource or raise"""
         return await self.session.post(self._resource_uri(resource, host), params)
 
+    async def delete(self, resource: str, host: str) -> aiohttp.ClientResponse:
+        return await self.session.delete(self._resource_uri(resource, host))
+
     def _resource_uri(self, resource: str, host: str) -> str:
         return f"http://{host}:{self.port}{resource}"
 
@@ -148,3 +160,45 @@ class ScyllaRESTAPIClient():
         """Initiate remove node of server_uuid in initiator initiator_ip"""
         resp = await self.client.post("/storage_service/decommission", host=node_ip)
         logger.debug("decommission_node status %s for %s", resp.status, node_ip)
+
+    async def get_gossip_generation_number(self, node_ip: str, target_ip: str) -> int:
+        """Get the current generation number of `target_ip` observed by `node_ip`."""
+        resp = await self.client.get(f"/gossiper/generation_number/{target_ip}", host=node_ip)
+        data = await resp.json()
+        assert(type(data) == int)
+        return data
+
+    async def enable_injection(self, node_ip: str, injection: str, one_shot: bool) -> None:
+        """Enable error injection named `injection` on `node_ip`. Depending on `one_shot`,
+           the injection will be executed only once or every time the process passes the injection point.
+           Note: this only has an effect in specific build modes: debug,dev,sanitize.
+        """
+        await self.client.post(f"/v2/error_injection/injection/{injection}",
+                               host=node_ip, params={"one_shot": str(one_shot)})
+
+    async def disable_injection(self, node_ip: str, injection: str) -> None:
+        await self.client.delete(f"/v2/error_injection/injection/{injection}", host=node_ip)
+
+    async def get_enabled_injections(self, node_ip: str) -> list[str]:
+        resp = await self.client.get("/v2/error_injection/injection", host=node_ip)
+        data = await resp.json()
+        assert(type(data) == list)
+        assert(type(e) == str for e in data)
+        return data
+
+
+@asynccontextmanager
+async def inject_error(api: ScyllaRESTAPIClient, node_ip: str, injection: str, one_shot: bool):
+    """Attempts to inject an error. Works only in specific build modes: debug,dev,sanitize.
+       It will trigger a test to be skipped if attempting to enable an injection has no effect.
+    """
+    await api.enable_injection(node_ip, injection, one_shot)
+    enabled = await api.get_enabled_injections(node_ip)
+    logging.info(f"Error injections enabled on {node_ip}: {enabled}")
+    if not enabled:
+        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+    try:
+        yield
+    finally:
+        logger.info(f"Disabling error injection {injection}")
+        await api.disable_injection(node_ip, injection)

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -126,7 +126,7 @@ class ScyllaRESTAPIClient():
         """Close session"""
         await self.client.close()
 
-    async def get_host_id(self, server_id: str):
+    async def get_host_id(self, server_id: str) -> str:
         """Get server id (UUID)"""
         host_uuid = await self.client.get_text("/storage_service/hostid/local", host=server_id)
         host_uuid = host_uuid.lstrip('"').rstrip('"')

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -277,9 +277,7 @@ class ScyllaServer:
                          protocol_version=4,
                          auth_provider=auth) as cluster:
                 with cluster.connect() as session:
-                    session.execute("CREATE KEYSPACE IF NOT EXISTS k WITH REPLICATION = {" +
-                                    "'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
-                    session.execute("DROP KEYSPACE k")
+                    session.execute("SELECT * FROM system.local")
                     self.control_cluster = Cluster(execution_profiles=
                                                         {EXEC_PROFILE_DEFAULT: profile},
                                                    contact_points=[self.hostname],

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -8,17 +8,131 @@ import asyncio
 import pytest
 import logging
 import time
+import functools
+from typing import Callable, Awaitable, Optional, TypeVar, Generic
 
-from cassandra.cluster import NoHostAvailable
+from cassandra.cluster import NoHostAvailable, Session
+from cassandra.pool import Host
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 
-@pytest.mark.asyncio
-async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):
-    start = time.time()
-    servers = await manager.running_servers()
 
+T = TypeVar('T')
+
+
+async def reconnect_driver(manager: ManagerClient) -> Session:
+    """Workaround for scylladb/python-driver#170:
+       the existing driver session may not reconnect, create a new one.
+    """
+    logging.info(f"Reconnecting driver")
+    manager.driver_close()
+    await manager.driver_connect()
+    cql = manager.cql
+    assert(cql)
+    return cql
+
+
+async def restart(manager: ManagerClient, srv: str) -> None:
+    logging.info(f"Stopping {srv} gracefully")
+    await manager.server_stop_gracefully(srv)
+    logging.info(f"Restarting {srv}")
+    await manager.server_start(srv)
+    logging.info(f"{srv} restarted")
+
+
+async def enable_raft(manager: ManagerClient, srv: str) -> None:
+    config = await manager.server_get_config(srv)
+    features = config['experimental_features']
+    assert(type(features) == list)
+    features.append('raft')
+    logging.info(f"Updating config of server {srv}")
+    await manager.server_update_config(srv, 'experimental_features', features)
+
+
+async def enable_raft_and_restart(manager: ManagerClient, srv: str) -> None:
+    await enable_raft(manager, srv)
+    await restart(manager, srv)
+
+
+async def wait_for(pred: Callable[[], Awaitable[Optional[T]]], deadline: float) -> T:
+    while True:
+        assert(time.time() < deadline), "Deadline exceeded, failing test."
+        res = await pred()
+        if res is not None:
+            return res
+        await asyncio.sleep(1)
+
+
+async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
+    async def cql_ready():
+        try:
+            await cql.run_async("select * from system.local", host=host)
+        except NoHostAvailable:
+            logging.info(f"Driver not connected to {host} yet")
+            return None
+        return True
+    await wait_for(cql_ready, deadline)
+
+
+async def wait_for_cql_and_get_hosts(cql: Session, ips: list[str], deadline: float) -> list[Host]:
+    """Wait until every ip in `ips` is available through `cql` and translate `ips` to `Host`s."""
+    ip_set = set(ips)
+    async def get_hosts() -> Optional[list[Host]]:
+        hosts = cql.cluster.metadata.all_hosts()
+        remaining = ip_set - {h.address for h in hosts}
+        if not remaining:
+            return hosts
+
+        logging.info(f"Driver hasn't yet learned about hosts: {remaining}")
+        return None
+    hosts = await wait_for(get_hosts, deadline)
+
+    # Take only hosts from `ip_set` (there may be more)
+    hosts = [h for h in hosts if h.address in ip_set]
+    await asyncio.gather(*(wait_for_cql(cql, h, deadline) for h in hosts))
+
+    return hosts
+
+
+async def wait_for_upgrade_state(state: str, cql: Session, host: Host, deadline: float) -> None:
+    """Wait until group 0 upgrade state reaches `state` on `host`, using `cql` to query it.  Warning: if the
+       upgrade procedure may progress beyond `state` this function may not notice when it entered `state` and
+       then time out.  Use it only if either `state` is the last state or the conditions of the test don't allow
+       the upgrade procedure to progress beyond `state` (e.g. a dead node causing the procedure to be stuck).
+    """
+    async def reached_state():
+        rs = await cql.run_async("select value from system.scylla_local where key = 'group0_upgrade_state'", host=host)
+        if rs:
+            value = rs[0].value
+            if value == state:
+                return True
+            else:
+                logging.info(f"Upgrade not yet in state {state} on server {host}, state: {value}")
+        else:
+            logging.info(f"Upgrade not yet in state {state} on server {host}, no state was written")
+        return None
+    await wait_for(reached_state, deadline)
+
+
+async def wait_until_upgrade_finishes(cql: Session, host: Host, deadline: float) -> None:
+    await wait_for_upgrade_state('use_post_raft_procedures', cql, host, deadline)
+
+
+def log_run_time(f):
+    @functools.wraps(f)
+    async def wrapped(*args, **kwargs):
+        start = time.time()
+        res = await f(*args, **kwargs)
+        logging.info(f"{f.__name__} took {int(time.time() - start)} seconds.")
+        return res
+    return wrapped
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):
+    servers = await manager.running_servers()
     cql = manager.cql
     assert(cql)
 
@@ -26,73 +140,21 @@ async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomT
     if await cql.run_async("select * from system_schema.tables where keyspace_name = 'system' and table_name = 'group0_history'"):
         assert(not (await cql.run_async("select * from system.group0_history")))
 
-    async def restart(srv):
-        logging.info(f"Stopping {srv} gracefully")
-        await manager.server_stop_gracefully(srv)
-        logging.info(f"Restarting {srv}")
-        await manager.server_start(srv)
-        logging.info(f"{srv} restarted")
-
-    restarts = []
-    for srv in servers:
-        config = await manager.server_get_config(srv)
-        features = config['experimental_features']
-        assert(type(features) == list)
-        features.append('raft')
-        logging.info(f"Updating config of server {srv}")
-        await manager.server_update_config(srv, 'experimental_features', features)
-        restarts.append(restart(srv))
-
-    await asyncio.gather(*restarts)
-
-    # Workaround for scylladb/python-driver#170: the existing driver session may not reconnect, create a new one
-    logging.info(f"Reconnecting driver")
-    manager.driver_close()
-    await manager.driver_connect()
-    cql = manager.cql
-
-    deadline = time.time() + 300
-    # Using `servers` doesn't work for the `host` parameter in `cql.run_async` (we need objects of type `Host`).
-    # Get the host list from the driver.
-    hosts = cql.cluster.metadata.all_hosts()
-    logging.info(f"Driver hosts: {hosts}")
+    logging.info(f"Enabling Raft on {servers} and restarting")
+    await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")
-    for host in hosts:
-        while True:
-            assert(time.time() < deadline), "Deadline exceeded, failing test."
-            try:
-                await cql.run_async("select * from system.local", host=host)
-            except NoHostAvailable:
-                logging.info(f"Driver not connected to {host} yet")
-            else:
-                break
-            await asyncio.sleep(1)
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
-    logging.info("Driver reconnected, waiting until upgrade finishes")
-    for host in hosts:
-        while True:
-            assert(time.time() < deadline), "Deadline exceeded, failing test."
-            rs = await cql.run_async("select value from system.scylla_local where key = 'group0_upgrade_state'", host=host)
-            if rs:
-                value = rs[0].value
-                if value == 'use_post_raft_procedures':
-                    break
-                else:
-                    logging.info(f"Upgrade not finished yet on server {host}, state: {value}")
-            else:
-                logging.info(f"Upgrade not finished yet on server {host}, no upgrade state written")
-            await asyncio.sleep(1)
+    logging.info(f"Driver reconnected, hosts: {hosts}. Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
 
     logging.info("Upgrade finished. Creating a new table")
-
     table = await random_tables.add_table(ncolumns=5)
-    table_name = table.full_name
 
     logging.info("Checking group0_history")
     rs = await cql.run_async("select * from system.group0_history")
     assert(rs)
     logging.info(f"group0_history entry description: '{rs[0].description}'")
-    assert(table_name in rs[0].description)
-
-    logging.info(f"{test_raft_upgrade_basic.__name__} took {int(time.time() - start)} seconds.")
+    assert(table.full_name in rs[0].description)

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -16,6 +16,7 @@ from cassandra.pool import Host
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
+from test.pylib.rest_client import ScyllaRESTAPIClient, inject_error
 
 
 T = TypeVar('T')
@@ -119,6 +120,28 @@ async def wait_until_upgrade_finishes(cql: Session, host: Host, deadline: float)
     await wait_for_upgrade_state('use_post_raft_procedures', cql, host, deadline)
 
 
+async def wait_for_gossip_gen_increase(api: ScyllaRESTAPIClient, gen: int, node_ip: str, target_ip: str, deadline: float):
+    """Wait until the generation number of `target_ip` increases above `gen` from the point of view of `node_ip`.
+       Can be used to wait until `node_ip` gossips with `target_ip` after `target_ip` was restarted
+       by saving the generation number of `target_ip` before restarting it and then calling this function
+       (nodes increase their generation numbers when they restart).
+    """
+    async def gen_increased() -> Optional[int]:
+        curr_gen = await api.get_gossip_generation_number(node_ip, target_ip)
+        if curr_gen <= gen:
+            logging.info(f"Gossip generation number of {target_ip} is {curr_gen} <= {gen} according to {node_ip}")
+            return None
+        return curr_gen
+    gen = await wait_for(gen_increased, deadline)
+    logging.info(f"Gossip generation number of {target_ip} is reached {gen} according to {node_ip}")
+
+
+async def delete_raft_data(cql: Session, host: Host) -> None:
+    await cql.run_async("truncate table system.discovery", host=host)
+    await cql.run_async("truncate table system.group0_history", host=host)
+    await cql.run_async("delete value from system.scylla_local where key = 'raft_group0_id'", host=host)
+
+
 def log_run_time(f):
     @functools.wraps(f)
     async def wrapped(*args, **kwargs):
@@ -132,6 +155,9 @@ def log_run_time(f):
 @pytest.mark.asyncio
 @log_run_time
 async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):
+    """
+    kbr-: the test takes about 7 seconds in dev mode on my laptop.
+    """
     servers = await manager.running_servers()
     cql = manager.cql
     assert(cql)
@@ -158,3 +184,204 @@ async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomT
     assert(rs)
     logging.info(f"group0_history entry description: '{rs[0].description}'")
     assert(table.full_name in rs[0].description)
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_raft_upgrade_with_node_remove(manager: ManagerClient, random_tables: RandomTables):
+    """
+    We enable Raft on every server but stop one server in the meantime.
+    The others will start Raft upgrade procedure but get stuck - all servers must be available to proceed.
+    We remove the stopped server and check that the procedure unblocks.
+
+    kbr-: the test takes about 19 seconds in dev mode on my laptop.
+    """
+    servers = await manager.running_servers()
+    srv1, *others = servers
+
+    srv1_gen = await manager.api.get_gossip_generation_number(others[0], srv1)
+    logging.info(f"Gossip generation number of {srv1} seen from {others[0]}: {srv1_gen}")
+
+    logging.info(f"Enabling Raft on {srv1} and restarting")
+    await enable_raft_and_restart(manager, srv1)
+
+    # Before continuing, ensure that another node has gossiped with srv1
+    # after srv1 has restarted. Then we know that the other node learned about srv1's
+    # supported features, including SUPPORTS_RAFT.
+    logging.info(f"Waiting until {others[0]} gossips with {srv1}")
+    await wait_for_gossip_gen_increase(manager.api, srv1_gen, others[0], srv1, time.time() + 60)
+
+    srv1_host_id = await manager.get_host_id(srv1)
+    logging.info(f"Obtained host ID of {srv1}: {srv1_host_id}")
+
+    logging.info(f"Stopping {srv1}")
+    await manager.server_stop_gracefully(srv1)
+
+    logging.info(f"Enabling Raft on {others} and restarting")
+    await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in others))
+    cql = await reconnect_driver(manager)
+
+    logging.info(f"Cluster restarted, waiting until driver reconnects to every server except {srv1}")
+    hosts = await wait_for_cql_and_get_hosts(cql, others, time.time() + 60)
+    logging.info(f"Driver reconnected, hosts: {hosts}")
+
+    logging.info(f"Removing {srv1} using {others[0]}")
+    await manager.remove_node(others[0], srv1, srv1_host_id)
+
+    logging.info("Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_recover_stuck_raft_upgrade(manager: ManagerClient, random_tables: RandomTables):
+    """
+    We enable Raft on every server and the upgrade procedure starts.  All servers join group 0. Then one
+    of them fails, the rest enter 'synchronize' state.  We assume the failed server cannot be recovered.
+    We cannot just remove it at this point; it's already part of group 0, `remove_from_group0` will wait
+    until upgrade procedure finishes - but the procedure is stuck.  To proceed we enter RECOVERY state on
+    the other servers, remove the failed one, and clear existing Raft data. After leaving RECOVERY the
+    remaining nodes will restart the procedure, establish a new group 0 and finish upgrade.
+
+    kbr-: the test takes about 26 seconds in dev mode on my laptop.
+    """
+    servers = await manager.running_servers()
+    srv1, *others = servers
+
+    logging.info(f"Enabling Raft on {srv1} and restarting")
+    await enable_raft_and_restart(manager, srv1)
+
+    # TODO error injection should probably be done through ScyllaClusterManager (we may need to mark the cluster as dirty).
+    # In this test the cluster is dirty anyway due to a restart so it's safe.
+    async with inject_error(manager.api, srv1, 'group0_upgrade_before_synchronize', one_shot=True):
+        logging.info(f"Enabling Raft on {others} and restarting")
+        await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in others))
+        cql = await reconnect_driver(manager)
+
+        logging.info(f"Cluster restarted, waiting until driver reconnects to {others}")
+        hosts = await wait_for_cql_and_get_hosts(cql, others, time.time() + 60)
+        logging.info(f"Driver reconnected, hosts: {hosts}")
+
+        logging.info(f"Waiting until {hosts} enter 'synchronize' state")
+        await asyncio.gather(*(wait_for_upgrade_state('synchronize', cql, h, time.time() + 60) for h in hosts))
+        logging.info(f"{hosts} entered synchronize")
+
+        # TODO ensure that srv1 failed upgrade - look at logs?
+        # '[shard 0] raft_group0_upgrade - Raft upgrade failed: std::runtime_error (error injection before group 0 upgrade enters synchronize).'
+
+    logging.info(f"Setting recovery state on {hosts}")
+    for host in hosts:
+        await cql.run_async("update system.scylla_local set value = 'recovery' where key = 'group0_upgrade_state'", host=host)
+
+    logging.info(f"Restarting {others}")
+    await asyncio.gather(*(restart(manager, srv) for srv in others))
+    cql = await reconnect_driver(manager)
+
+    logging.info(f"{others} restarted, waiting until driver reconnects to them")
+    hosts = await wait_for_cql_and_get_hosts(cql, others, time.time() + 60)
+
+    logging.info(f"Checking if {hosts} are in recovery state")
+    for host in hosts:
+        rs = await cql.run_async("select value from system.scylla_local where key = 'group0_upgrade_state'", host=host)
+        assert rs[0].value == 'recovery'
+
+    logging.info("Creating a table while in recovery state")
+    table = await random_tables.add_table(ncolumns=5)
+
+    srv1_host_id = await manager.get_host_id(srv1)
+    logging.info(f"Obtained host ID of {srv1}: {srv1_host_id}")
+
+    logging.info(f"Stopping {srv1}")
+    await manager.server_stop_gracefully(srv1)
+
+    logging.info(f"Removing {srv1} using {others[0]}")
+    await manager.remove_node(others[0], srv1, srv1_host_id)
+
+    logging.info(f"Deleting Raft data and upgrade state on {hosts} and restarting")
+    for host in hosts:
+        await delete_raft_data(cql, host)
+        await cql.run_async("delete from system.scylla_local where key = 'group0_upgrade_state'", host=host)
+
+    await asyncio.gather(*(restart(manager, srv) for srv in others))
+    cql = await reconnect_driver(manager)
+
+    logging.info(f"Cluster restarted, waiting until driver reconnects to {others}")
+    hosts = await wait_for_cql_and_get_hosts(cql, others, time.time() + 60)
+
+    logging.info(f"Driver reconnected, hosts: {hosts}, waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+    logging.info("Checking if previously created table still exists")
+    await cql.run_async(f"select * from {table.full_name}")
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_recovery_after_majority_loss(manager: ManagerClient, random_tables: RandomTables):
+    """
+    We successfully upgrade a cluster. Eventually however all servers but one fail - group 0
+    is left without a majority. We create a new group 0 by entering RECOVERY, using `removenode`
+    to get rid of the other servers, clearing Raft data and restarting. The Raft upgrade procedure
+    runs again to establish a single-node group 0. We also verify that schema changes performed
+    using the old group 0 are still there.
+    Note: in general there's no guarantee that all schema changes will be present; the minority
+    used to recover group 0 might have missed them. However in this test the driver waits
+    for schema agreement to complete before proceeding, so we know that every server learned
+    about the schema changes.
+
+    kbr-: the test takes about 22 seconds in dev mode on my laptop.
+    """
+    servers = await manager.running_servers()
+
+    logging.info(f"Enabling Raft on {servers} and restarting")
+    await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+
+    logging.info("Cluster restarted, waiting until driver reconnects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info(f"Driver reconnected, hosts: {hosts}. Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+    logging.info("Upgrade finished. Creating a bunch of tables")
+    tables = await asyncio.gather(*(random_tables.add_table(ncolumns=5) for _ in range(5)))
+
+    srv1, *others = servers
+    others_with_host_ids = [(srv, await manager.get_host_id(srv)) for srv in others]
+    logging.info(f"Obtained host IDs: {others_with_host_ids}")
+
+    logging.info(f"Killing all nodes except {srv1}")
+    await asyncio.gather(*(manager.server_stop(srv) for srv in others))
+
+    logging.info(f"Entering recovery state on {srv1}")
+    host1 = next(h for h in hosts if h.address == srv1)
+    await cql.run_async("update system.scylla_local set value = 'recovery' where key = 'group0_upgrade_state'", host=host1)
+    await restart(manager, srv1)
+    cql = await reconnect_driver(manager)
+
+    logging.info("Node restarted, waiting until driver connects")
+    host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
+
+    for i in range(len(others_with_host_ids)):
+        remove_ip, remove_host_id = others_with_host_ids[i]
+        ignore_dead_ips = [ip for (ip, _) in others_with_host_ids[i+1:]]
+        logging.info(f"Removing {remove_ip} using {srv1} with ignore_dead: {ignore_dead_ips}")
+        await manager.remove_node(srv1, remove_ip, remove_host_id, ignore_dead_ips)
+
+    logging.info(f"Deleting old Raft data and upgrade state on {host1} and restarting")
+    await delete_raft_data(cql, host1)
+    await cql.run_async("delete from system.scylla_local where key = 'group0_upgrade_state'", host=host1)
+    await restart(manager, srv1)
+    cql = await reconnect_driver(manager)
+
+    logging.info("Node restarted, waiting until driver connects")
+    host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
+
+    logging.info(f"Driver reconnected, host: {host1}. Waiting until upgrade finishes.")
+    await wait_until_upgrade_finishes(cql, host1, time.time() + 60)
+
+    logging.info("Checking if previously created tables still exist")
+    await asyncio.gather(*(cql.run_async(f"select * from {t.full_name}") for t in tables))
+
+    logging.info("Creating another table")
+    await random_tables.add_table(ncolumns=5)


### PR DESCRIPTION
Refactor the existing upgrade tests, extracting some common functionality to
helper functions.
    
Add more tests. They are checking the upgrade procedure and recovery from
failure in scenarios like when a node fails causing the procedure to get stuck
or when we lose a majority in a fully upgraded cluster.

Add some new functionalities to `ScyllaRESTAPIClient` like injecting errors and
obtaining gossip generation numbers.

Extend the removenode function to allow ignoring dead nodes.

Improve checking for CQL availability when starting nodes to speed up testing.
