### PR TITLE
raft: test_remove_node_with_concurrent_ddl

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -149,6 +149,20 @@ class ScyllaRESTAPIClient():
         host_uuid = host_uuid.lstrip('"').rstrip('"')
         return host_uuid
 
+    async def get_host_id_map(self, dst_server_id: str) -> list:
+        """Retrieve the mapping of endpoint to host ID"""
+        response = await self.client.get("/storage_service/host_id", dst_server_id)
+        result = await response.json()
+        assert(type(result) == list)
+        return result
+
+    async def get_down_endpoints(self, dst_server_id: str) -> list:
+        """Retrieve down endpoints from gossiper's point of view """
+        response = await self.client.get("/gossiper/endpoint/down/", dst_server_id)
+        result = await response.json()
+        assert(type(result) == list)
+        return result
+
     async def remove_node(self, initiator_ip: str, server_uuid: str, ignore_dead: list[str]) -> None:
         """Initiate remove node of server_uuid in initiator initiator_ip"""
         resp = await self.client.post("/storage_service/remove_node",

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -100,6 +100,10 @@ SCYLLA_CMDLINE_OPTIONS = [
     '--max-networking-io-control-blocks', '100',
     '--unsafe-bypass-fsync', '1',
     '--kernel-page-cache', '1',
+    '--abort-on-lsa-bad-alloc', '1',
+    '--abort-on-seastar-bad-alloc',
+    '--abort-on-internal-error', '1',
+    '--abort-on-ebadf', '1'
 ]
 
 

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -4,8 +4,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 import time
+import asyncio
+from typing import Callable, Awaitable, Optional, TypeVar, Generic
 
 unique_name_prefix = 'test_'
+T = TypeVar('T')
 
 
 def unique_name():
@@ -15,6 +18,15 @@ def unique_name():
         current_ms = unique_name.last_ms + 1
     unique_name.last_ms = current_ms
     return unique_name_prefix + str(current_ms)
+
+
+async def wait_for(pred: Callable[[], Awaitable[Optional[T]]], deadline: float) -> T:
+    while True:
+        assert(time.time() < deadline), "Deadline exceeded, failing test."
+        res = await pred()
+        if res is not None:
+            return res
+        await asyncio.sleep(1)
 
 
 unique_name.last_ms = 0

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -7,6 +7,11 @@
 Test consistency of schema changes with topology changes.
 """
 import pytest
+import logging
+import asyncio
+import random
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
@@ -62,3 +67,68 @@ async def test_decommission_node_add_column(manager, random_tables):
     await manager.decommission_node(servers[1])             # Decommission [1]
     await table.add_column()
     await random_tables.verify_schema()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="Wait for @slow attribute, #11713")
+async def test_remove_node_with_concurrent_ddl(manager, random_tables):
+    stopped = False
+    ddl_failed = False
+
+    async def do_ddl():
+        nonlocal ddl_failed
+        iteration = 0
+        while not stopped:
+            logger.debug(f'ddl, iteration {iteration} started')
+            try:
+                # If the node was removed, the driver may retry "create table" on another node,
+                # but the request might have already been completed.
+                # The same applies to drop_table.
+
+                await random_tables.add_tables(5, 5, if_not_exists=True)
+                await random_tables.verify_schema()
+                while len(random_tables.tables) > 0:
+                    await random_tables.drop_table(random_tables.tables[-1], if_exists=True)
+                logger.debug(f'ddl, iteration {iteration} finished')
+            except:
+                logger.exception(f'ddl, iteration {iteration} failed')
+                ddl_failed = True
+                raise
+            iteration += 1
+
+    async def do_remove_node():
+        for i in range(10):
+            logger.debug(f'do_remove_node [{i}], iteration started')
+            if ddl_failed:
+                logger.debug(f'do_remove_node [{i}], ddl failed, exiting')
+                break
+            server_ids = await manager.running_servers()
+            host_ids = await asyncio.gather(*(manager.get_host_id(s) for s in server_ids))
+            initiator_index, target_index = random.sample(range(len(server_ids)), 2)
+            initiator_ip = server_ids[initiator_index]
+            target_ip = server_ids[target_index]
+            target_host_id = host_ids[target_index]
+            logger.info(f'do_remove_node [{i}], running remove_node, '
+                        f'initiator server [{initiator_ip}], target ip [{target_ip}], '
+                        f'target host id [{target_host_id}]')
+            await manager.wait_for_host_known(initiator_ip, target_host_id)
+            logger.info(f'do_remove_node [{i}], stopping target server [{target_ip}], host_id [{target_host_id}]')
+            await manager.server_stop_gracefully(target_ip)
+            logger.info(f'do_remove_node [{i}], target server [{target_ip}] stopped, '
+                        f'waiting for it to be down on [{initiator_ip}]')
+            await manager.wait_for_host_down(initiator_ip, target_ip)
+            logger.info(f'do_remove_node [{i}], invoking remove_node')
+            await manager.remove_node(initiator_ip, target_ip, target_host_id)
+            logger.info(f'do_remove_node [{i}], remove_node done')
+            new_server_ip = await manager.server_add()
+            logger.info(f'do_remove_node [{i}], server_add [{new_server_ip}] done')
+            logger.info(f'do_remove_node [{i}], iteration finished')
+
+    ddl_task = asyncio.create_task(do_ddl())
+    try:
+        await do_remove_node()
+    finally:
+        logger.debug("do_remove_node finished, waiting for ddl fiber")
+        stopped = True
+        await ddl_task
+        logger.debug("ddl fiber done, finished")

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -17,9 +17,7 @@ from cassandra.pool import Host
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import ScyllaRESTAPIClient, inject_error
-
-
-T = TypeVar('T')
+from test.pylib.util import wait_for
 
 
 async def reconnect_driver(manager: ManagerClient) -> Session:
@@ -54,15 +52,6 @@ async def enable_raft(manager: ManagerClient, srv: str) -> None:
 async def enable_raft_and_restart(manager: ManagerClient, srv: str) -> None:
     await enable_raft(manager, srv)
     await restart(manager, srv)
-
-
-async def wait_for(pred: Callable[[], Awaitable[Optional[T]]], deadline: float) -> T:
-    while True:
-        assert(time.time() < deadline), "Deadline exceeded, failing test."
-        res = await pred()
-        if res is not None:
-            return res
-        await asyncio.sleep(1)
 
 
 async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:


### PR DESCRIPTION
The test runs `remove_node` command with background ddl workload. It was written in an attempt to reproduce #11228 but seems to have value on its own.

The `if_exists` parameter has been added to the `add_table` and `drop_table` functions, since the driver could retry the request sent to a removed node, but that request might have already been completed.

Function `wait_for_host_known` waits until the information about the node reaches the destination node. Since we add new nodes at each iteration in main, this can take some time.

A number of abort-related options was added `SCYLLA_CMDLINE_OPTIONS` as it simplifies nailing down problems.