### PR TITLE
db/view/view_updating_consumer: reuse baseline reader across partitions

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2418,7 +2418,7 @@ view_updating_consumer::view_updating_consumer(schema_ptr schema, reader_permit 
     : view_updating_consumer(std::move(schema), std::move(permit), as, staging_reader_handle,
             [table = table.shared_from_this(), excluded_sstables = std::move(excluded_sstables)] (mutation m) mutable {
         auto s = m.schema();
-        return table->stream_view_replica_updates(std::move(s), std::move(m), db::no_timeout, excluded_sstables);
+        return table->stream_view_replica_updates(std::move(s), std::move(m), db::no_timeout, table->as_mutation_source_excluding(excluded_sstables));
     })
 { }
 

--- a/readers/slicing_forwarding.hh
+++ b/readers/slicing_forwarding.hh
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "interval.hh"
+
+class flat_mutation_reader_v2;
+
+namespace query {
+class partition_slice;
+}
+
+/// A reader which applies slicing on another reader, which was created with schema::full_slice()
+///
+/// The slicing is applied with fast-forwarding the reader the clustering ranges,
+/// so it has to be created with streamed_mutation::forwarding::yes
+/// Intended to allow use-cases where a single reader is reused across multiple
+/// partitions, reading a different slice from each one.
+flat_mutation_reader_v2 make_slicing_forwarding_reader(
+        flat_mutation_reader_v2 rd,
+        const query::partition_slice& ps);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1007,8 +1007,7 @@ public:
     future<row_locker::lock_holder> push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const;
     future<row_locker::lock_holder>
-    stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
-            std::vector<sstables::shared_sstable>& excluded_sstables) const;
+    stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout, mutation_source ms) const;
 
     void add_coordinator_read_latency(utils::estimated_histogram::duration latency);
     std::chrono::milliseconds get_coordinator_read_latency_percentile(double percentile);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2455,13 +2455,12 @@ future<row_locker::lock_holder> table::push_view_replica_updates(const schema_pt
 }
 
 future<row_locker::lock_holder>
-table::stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
-        std::vector<sstables::shared_sstable>& excluded_sstables) const {
+table::stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout, mutation_source ms) const {
     return do_push_view_replica_updates(
             s,
             std::move(m),
             timeout,
-            as_mutation_source_excluding(excluded_sstables),
+            std::move(ms),
             tracing::trace_state_ptr(),
             *_config.streaming_read_concurrency_semaphore,
             service::get_local_streaming_priority(),


### PR DESCRIPTION
Currently the baseline reader -- the reader which provides the base against which the diff with the new writes is calculated -- is created and thrown away after each partition or chunk of partition the view updating consumer consumes. This is very inefficient as with many small partitions the cost of creating/destroying the reader can add very significant overhead. As we are iterating over partitions in their natural order, we can reuse a reader across all the partitions, fast-forwarding it to the current partition.

Fixes: https://github.com/scylladb/scylladb/issues/11708
