### PR TITLE
De-static system_keyspace::get_{saved|local}_tokens()

### DIFF
--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -187,7 +187,7 @@ static system_keyspace::range_estimates estimate(const replica::column_family& c
  * Returns the primary ranges for the local node.
  */
 static future<std::vector<token_range>> get_local_ranges(replica::database& db, db::system_keyspace& sys_ks) {
-    return db::system_keyspace::get_local_tokens().then([&db] (auto&& tokens) {
+    return sys_ks.get_local_tokens().then([&db] (auto&& tokens) {
         auto ranges = db.get_token_metadata().get_primary_ranges_for(std::move(tokens));
         std::vector<token_range> local_ranges;
         auto to_bytes = [](const std::optional<dht::token_range::bound>& b) {

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -222,14 +222,15 @@ future<std::vector<token_range>> test_get_local_ranges(replica::database& db) {
     return get_local_ranges(db);
 }
 
-size_estimates_mutation_reader::size_estimates_mutation_reader(replica::database& db, schema_ptr schema, reader_permit permit, const dht::partition_range& prange,
+size_estimates_mutation_reader::size_estimates_mutation_reader(replica::database& db, db::system_keyspace& sys_ks, schema_ptr schema, reader_permit permit, const dht::partition_range& prange,
         const query::partition_slice& slice, streamed_mutation::forwarding fwd)
             : impl(std::move(schema), std::move(permit))
             , _db(db)
+            , _sys_ks(sys_ks)
             , _prange(&prange)
             , _slice(slice)
             , _fwd(fwd)
-    { }
+    { (void)_sys_ks; }
 
 future<> size_estimates_mutation_reader::get_next_partition() {
     if (!_keyspaces) {

--- a/db/size_estimates_virtual_reader.hh
+++ b/db/size_estimates_virtual_reader.hh
@@ -71,7 +71,7 @@ struct virtual_reader {
     virtual_reader(replica::database& db_, db::system_keyspace& sys_ks_) noexcept : db(db_), sys_ks(sys_ks_) {}
 };
 
-future<std::vector<token_range>> test_get_local_ranges(replica::database& db);
+future<std::vector<token_range>> test_get_local_ranges(replica::database& db, db::system_keyspace& sys_ks);
 
 } // namespace size_estimates
 

--- a/db/size_estimates_virtual_reader.hh
+++ b/db/size_estimates_virtual_reader.hh
@@ -29,6 +29,7 @@ struct token_range {
 
 class size_estimates_mutation_reader final : public flat_mutation_reader_v2::impl {
     replica::database& _db;
+    db::system_keyspace& _sys_ks;
     const dht::partition_range* _prange;
     const query::partition_slice& _slice;
     using ks_range = std::vector<sstring>;
@@ -37,7 +38,7 @@ class size_estimates_mutation_reader final : public flat_mutation_reader_v2::imp
     streamed_mutation::forwarding _fwd;
     flat_mutation_reader_v2_opt _partition_reader;
 public:
-    size_estimates_mutation_reader(replica::database& db, schema_ptr, reader_permit, const dht::partition_range&, const query::partition_slice&, streamed_mutation::forwarding);
+    size_estimates_mutation_reader(replica::database& db, db::system_keyspace& sys_ks, schema_ptr, reader_permit, const dht::partition_range&, const query::partition_slice&, streamed_mutation::forwarding);
 
     virtual future<> fill_buffer() override;
     virtual future<> next_partition() override;
@@ -54,6 +55,7 @@ private:
 
 struct virtual_reader {
     replica::database& db;
+    db::system_keyspace& sys_ks;
 
     flat_mutation_reader_v2 operator()(schema_ptr schema,
             reader_permit permit,
@@ -63,10 +65,10 @@ struct virtual_reader {
             tracing::trace_state_ptr trace_state,
             streamed_mutation::forwarding fwd,
             mutation_reader::forwarding fwd_mr) {
-        return make_flat_mutation_reader_v2<size_estimates_mutation_reader>(db, std::move(schema), std::move(permit), range, slice, fwd);
+        return make_flat_mutation_reader_v2<size_estimates_mutation_reader>(db, sys_ks, std::move(schema), std::move(permit), range, slice, fwd);
     }
 
-    virtual_reader(replica::database& db_) noexcept : db(db_) {}
+    virtual_reader(replica::database& db_, db::system_keyspace& sys_ks_) noexcept : db(db_), sys_ks(sys_ks_) {}
 };
 
 future<std::vector<token_range>> test_get_local_ranges(replica::database& db);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2721,7 +2721,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
 }
 
 static void install_virtual_readers(db::system_keyspace& sys_ks, replica::database& db) {
-    db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db)));
+    db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db, sys_ks)));
     db.find_column_family(system_keyspace::v3::views_builds_in_progress()).set_virtual_reader(mutation_source(db::view::build_progress_virtual_reader(db)));
     db.find_column_family(system_keyspace::built_indexes()).set_virtual_reader(mutation_source(db::index::built_indexes_virtual_reader(db)));
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2720,7 +2720,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
     return r;
 }
 
-static void install_virtual_readers(replica::database& db) {
+static void install_virtual_readers(db::system_keyspace& sys_ks, replica::database& db) {
     db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db)));
     db.find_column_family(system_keyspace::v3::views_builds_in_progress()).set_virtual_reader(mutation_source(db::view::build_progress_virtual_reader(db)));
     db.find_column_family(system_keyspace::built_indexes()).set_virtual_reader(mutation_source(db::index::built_indexes_virtual_reader(db)));
@@ -2738,7 +2738,7 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
             || s == system_keyspace::raft();
 }
 
-future<> system_keyspace_make(distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, db::config& cfg, table_selector& tables) {
+future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, db::config& cfg, table_selector& tables) {
     if (tables.contains_keyspace(system_keyspace::NAME)) {
         register_virtual_tables(dist_db, dist_ss, dist_gossiper, cfg);
     }
@@ -2772,12 +2772,12 @@ future<> system_keyspace_make(distributed<replica::database>& dist_db, distribut
     }
 
     if (tables.contains_keyspace(system_keyspace::NAME)) {
-        install_virtual_readers(db);
+        install_virtual_readers(sys_ks, db);
     }
 }
 
 future<> system_keyspace::make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, table_selector& tables) {
-    return system_keyspace_make(db, ss, g, cfg, tables);
+    return system_keyspace_make(*this, db, ss, g, cfg, tables);
 }
 
 future<locator::host_id> system_keyspace::load_local_host_id() {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1723,7 +1723,7 @@ future<> system_keyspace::check_health() {
 
 future<std::unordered_set<dht::token>> system_keyspace::get_saved_tokens() {
     sstring req = format("SELECT tokens FROM system.{} WHERE key = ?", LOCAL);
-    return qctx->execute_cql(req, sstring(LOCAL)).then([] (auto msg) {
+    return execute_cql(req, sstring(LOCAL)).then([] (auto msg) {
         if (msg->empty() || !msg->one().has("tokens")) {
             return make_ready_future<std::unordered_set<dht::token>>();
         }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -352,13 +352,13 @@ public:
      * Read this node's tokens stored in the LOCAL table.
      * Used to initialize a restarting node.
      */
-    static future<std::unordered_set<dht::token>> get_saved_tokens();
+    future<std::unordered_set<dht::token>> get_saved_tokens();
 
     /*
      * Gets this node's non-empty set of tokens.
      * TODO: maybe get this data from token_metadata instance?
      */
-    static future<std::unordered_set<dht::token>> get_local_tokens();
+    future<std::unordered_set<dht::token>> get_local_tokens();
 
     static future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -478,6 +478,4 @@ private:
     }
 }; // class system_keyspace
 
-future<> system_keyspace_make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, table_selector&);
-
 } // namespace db

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -252,7 +252,7 @@ public:
     static future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
-    static future<> make(distributed<replica::database>& db,
+    future<> make(distributed<replica::database>& db,
                          distributed<service::storage_service>& ss,
                          sharded<gms::gossiper>& g,
                          db::config& cfg,

--- a/main.cc
+++ b/main.cc
@@ -1035,7 +1035,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
             auto system_keyspace_sel = db::table_selector::all_in_keyspace(db::system_keyspace::NAME);
-            replica::distributed_loader::init_system_keyspace(db, ss, gossiper, *cfg, *system_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, *system_keyspace_sel).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
@@ -1160,7 +1160,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Needs to be before system_keyspace::setup(), which writes to schema tables.
             supervisor::notify("loading system_schema sstables");
             auto schema_keyspace_sel = db::table_selector::all_in_keyspace(db::schema_tables::NAME);
-            replica::distributed_loader::init_system_keyspace(db, ss, gossiper, *cfg, *schema_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, *schema_keyspace_sel).get();
 
             // schema migration, if needed, is also done on shard 0
             db::legacy_schema_migrator::migrate(proxy, db, qp.local()).get();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -117,7 +117,7 @@ class large_data_handler;
 class system_keyspace;
 class table_selector;
 
-future<> system_keyspace_make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
 
 }
 
@@ -1387,7 +1387,7 @@ private:
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    friend future<> db::system_keyspace_make(distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -581,10 +581,10 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     });
 }
 
-future<> distributed_loader::init_system_keyspace(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector& tables) {
+future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector& tables) {
     population_started = true;
 
-    return seastar::async([&db, &ss, &cfg, &g, &tables] {
+    return seastar::async([&sys_ks, &db, &ss, &cfg, &g, &tables] {
         db.invoke_on_all([&db, &ss, &cfg, &g, &tables] (replica::database&) {
             return db::system_keyspace::make(db, ss, g, cfg, tables);
         }).get();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -585,8 +585,8 @@ future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& 
     population_started = true;
 
     return seastar::async([&sys_ks, &db, &ss, &cfg, &g, &tables] {
-        db.invoke_on_all([&db, &ss, &cfg, &g, &tables] (replica::database&) {
-            return db::system_keyspace::make(db, ss, g, cfg, tables);
+        sys_ks.invoke_on_all([&db, &ss, &cfg, &g, &tables] (auto& sys_ks) {
+            return sys_ks.make(db, ss, g, cfg, tables);
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -78,7 +78,7 @@ class distributed_loader {
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);
 
 public:
-    static future<> init_system_keyspace(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -356,7 +356,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     co_await db::system_keyspace::save_local_supported_features(features);
 
     // If this is a restarting node, we should update tokens before gossip starts
-    auto my_tokens = co_await db::system_keyspace::get_saved_tokens();
+    auto my_tokens = co_await _sys_ks.local().get_saved_tokens();
     bool restarting_normal_node = _sys_ks.local().bootstrap_complete() && !is_replacing() && !my_tokens.empty();
     if (restarting_normal_node) {
         slogger.info("Restarting a node in NORMAL status");
@@ -476,7 +476,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
             }
             slogger.info("getting bootstrap token");
             if (resume_bootstrap) {
-                bootstrap_tokens = co_await db::system_keyspace::get_saved_tokens();
+                bootstrap_tokens = co_await _sys_ks.local().get_saved_tokens();
                 if (!bootstrap_tokens.empty()) {
                     slogger.info("Using previously saved tokens = {}", bootstrap_tokens);
                 } else {
@@ -521,7 +521,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     } else {
         supervisor::notify("starting system distributed keyspace");
         co_await sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
-        bootstrap_tokens = co_await db::system_keyspace::get_saved_tokens();
+        bootstrap_tokens = co_await _sys_ks.local().get_saved_tokens();
         if (bootstrap_tokens.empty()) {
             bootstrap_tokens = boot_strapper::get_bootstrap_tokens(get_token_metadata_ptr(), _db.local().get_config(), dht::check_token_endpoint::no);
             co_await _sys_ks.local().update_tokens(bootstrap_tokens);
@@ -1847,7 +1847,7 @@ future<> storage_service::start_gossiping() {
                     cdc_log.warn("CDC generation timestamp missing when starting gossip");
                 }
                 co_await set_gossip_tokens(ss._gossiper,
-                        co_await db::system_keyspace::get_local_tokens(),
+                        co_await ss._sys_ks.local().get_local_tokens(),
                         cdc_gen_ts);
                 ss._gossiper.force_newer_generation();
                 co_await ss._gossiper.start_gossiping(utils::get_generation_number());
@@ -3011,7 +3011,7 @@ future<> storage_service::leave_ring() {
 
     auto expire_time = _gossiper.compute_expire_time().time_since_epoch().count();
     co_await _gossiper.add_local_application_state(gms::application_state::STATUS,
-            versioned_value::left(co_await db::system_keyspace::get_local_tokens(), expire_time));
+            versioned_value::left(co_await _sys_ks.local().get_local_tokens(), expire_time));
     auto delay = std::max(get_ring_delay(), gms::gossiper::INTERVAL);
     slogger.info("Announcing that I have left the ring for {}ms", delay.count());
     co_await sleep_abortable(delay, _abort_source);
@@ -3045,7 +3045,7 @@ storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multim
 }
 
 future<> storage_service::start_leaving() {
-    co_await _gossiper.add_local_application_state(application_state::STATUS, versioned_value::leaving(co_await db::system_keyspace::get_local_tokens()));
+    co_await _gossiper.add_local_application_state(application_state::STATUS, versioned_value::leaving(co_await _sys_ks.local().get_local_tokens()));
     co_await mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
         auto endpoint = get_broadcast_address();
         tmptr->add_leaving_endpoint(endpoint);

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -33,7 +33,7 @@ using namespace std::literals::chrono_literals;
 
 SEASTAR_TEST_CASE(test_query_size_estimates_virtual_table) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db()).get0();
+        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db(), e.get_system_keyspace()).get0();
         auto start_token1 = utf8_type->to_string(ranges[3].start);
         auto start_token2 = utf8_type->to_string(ranges[5].start);
         auto end_token1 = utf8_type->to_string(ranges[3].end);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -747,7 +747,7 @@ public:
                 std::ref(bm)).get();
             auto stop_storage_service = defer([&ss] { ss.stop().get(); });
 
-            replica::distributed_loader::init_system_keyspace(db, ss, gossiper, *cfg, db::table_selector::all()).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, db::table_selector::all()).get();
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
             parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -136,6 +136,7 @@ private:
     sharded<gms::gossiper>& _gossiper;
     service::raft_group0_client& _group0_client;
     sharded<service::raft_group_registry>& _group0_registry;
+    sharded<db::system_keyspace>& _sys_ks;
 
 private:
     struct core_local_state {
@@ -188,7 +189,8 @@ public:
             sharded<db::batchlog_manager>& batchlog_manager,
             sharded<gms::gossiper>& gossiper,
             service::raft_group0_client& client,
-            sharded<service::raft_group_registry>& group0_registry)
+            sharded<service::raft_group_registry>& group0_registry,
+            sharded<db::system_keyspace>& sys_ks)
             : _db(db)
             , _qp(qp)
             , _auth_service(auth_service)
@@ -201,6 +203,7 @@ public:
             , _gossiper(gossiper)
             , _group0_client(client)
             , _group0_registry(group0_registry)
+            , _sys_ks(sys_ks)
     {
         adjust_rlimit();
     }
@@ -422,6 +425,10 @@ public:
 
     virtual sharded<service::raft_group_registry>& get_raft_group_registry() override {
         return _group0_registry;
+    }
+
+    virtual db::system_keyspace& get_system_keyspace() override {
+        return _sys_ks.local();
     }
 
     virtual future<> refresh_client_state() override {
@@ -877,7 +884,7 @@ public:
                 // The default user may already exist if this `cql_test_env` is starting with previously populated data.
             }
 
-            single_node_cql_env env(db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, group0_client, raft_gr);
+            single_node_cql_env env(db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, group0_client, raft_gr, sys_ks);
             env.start().get();
             auto stop_env = defer([&env] { env.stop().get(); });
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -169,6 +169,8 @@ public:
 
     virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
+    virtual db::system_keyspace& get_system_keyspace() = 0;
+
     data_dictionary::database data_dictionary();
 };
 


### PR DESCRIPTION
Yet another user of global qctx object. Making the method(s) non-static requires pushing the system_keyspace all the way down to size_estimate_virtual_reader and a small update of the cql_test_env