### PR TITLE
docs, alternator: mention S3 Import feature in compatibility.md

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -286,3 +286,7 @@ they should be easy to detect. Here is a list of these unimplemented features:
 * Alternator does not support the new DynamoDB feature "export to S3",
   and its operations DescribeExport, ExportTableToPointInTime, ListExports.
   <https://github.com/scylladb/scylla/issues/8789>
+
+* Alternator does not support the new DynamoDB feature "import from S3",
+  and its operations ImportTable, DescribeImport, ListImports.
+  <https://github.com/scylladb/scylla/issues/11739>


### PR DESCRIPTION
In August 2022, DynamoDB added a "S3 Import" feature, which we don't yet support - so let's document this missing feature in the compatibility document.

Refs #11739.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>