### PR TITLE
test/cql-pytest: fix test_permissions.py when running with "--ssl"

### DIFF
--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -196,7 +196,7 @@ def new_user(cql, username=''):
 @contextmanager
 def new_session(cql, username):
     endpoint = cql.hosts[0].endpoint
-    with cql_session(host=endpoint.address, port=endpoint.port, is_ssl=False, username=username, password=username) as session:
+    with cql_session(host=endpoint.address, port=endpoint.port, is_ssl=(cql.cluster.ssl_context is not None), username=username, password=username) as session:
         yield session
         session.shutdown()
 


### PR DESCRIPTION
The tests in test_permissions.py use the new_session() utility function to create a new connection with a different logged-in user.

It models the new connection on the existing one, but incorrectly assumed that the connection is NOT ssl. This made this test failed with cql-pytest/run is passed the "--ssl" option.

In this patch we correctly infer the is_ssl state from the existing cql fixture, instead of assuming it is false. After this pass, "cql-pytest/run --ssl" works as expected for this test.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>