### PR TITLE
test.py: use internal id to manage servers

### DIFF
--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""Internal types for handling Scylla test servers.
+"""
+
+from typing import NewType, NamedTuple
+
+
+ServerNum = NewType('ServerNum', int)
+IPAddress = NewType('IPAddress', str)
+HostID = NewType('HostID', str)
+
+
+class ServerInfo(NamedTuple):
+    """Server id (test local) and IP address"""
+    server_id: ServerNum
+    ip_addr: IPAddress
+    def __str__(self):
+        return f"Server({self.server_id}, {self.ip_addr})"

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -9,10 +9,11 @@
    Manages driver refresh when cluster is cycled.
 """
 
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, NamedTuple
 import logging
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient
 from test.pylib.util import wait_for
+from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo
 from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 import aiohttp
@@ -30,7 +31,8 @@ class ManagerClient():
     # pylint: disable=too-many-public-methods
 
     def __init__(self, sock_path: str, port: int, use_ssl: bool,
-                 con_gen: Optional[Callable[[List[str], int, bool], CassandraSession]]) -> None:
+                 con_gen: Optional[Callable[[List[IPAddress], int, bool], CassandraSession]]) \
+                         -> None:
         self.port = port
         self.use_ssl = use_ssl
         self.con_gen = con_gen
@@ -47,7 +49,7 @@ class ManagerClient():
     async def driver_connect(self) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:
-            servers = await self.running_servers()
+            servers = [s_info.ip_addr for s_info in await self.running_servers()]
             logger.debug("driver connecting to %s", servers)
             self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
             self.cql = self.ccluster.connect()
@@ -106,73 +108,80 @@ class ManagerClient():
         resp = await self.client.get_text("/cluster/replicas")
         return int(resp)
 
-    async def running_servers(self) -> List[str]:
-        """Get list of running servers"""
-        host_list = await self.client.get_text("/cluster/running-servers")
-        return host_list.split(",")
+    async def running_servers(self) -> List[ServerInfo]:
+        """Get List of server info (id and IP address) of running servers"""
+        try:
+            server_info_list = await self.client.get_json("/cluster/running-servers")
+        except RuntimeError as exc:
+            raise Exception("Failed to get list of running servers") from exc
+        assert isinstance(server_info_list, list), "running_servers got unknown data type"
+        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]))
+                for info in server_info_list]
 
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
         await self.client.get_text("/cluster/mark-dirty")
 
-    async def server_stop(self, server_id: str) -> None:
+    async def server_stop(self, server_id: ServerNum) -> None:
         """Stop specified server"""
         logger.debug("ManagerClient stopping %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/stop")
 
-    async def server_stop_gracefully(self, server_id: str) -> None:
+    async def server_stop_gracefully(self, server_id: ServerNum) -> None:
         """Stop specified server gracefully"""
         logger.debug("ManagerClient stopping gracefully %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/stop_gracefully")
 
-    async def server_start(self, server_id: str) -> None:
+    async def server_start(self, server_id: ServerNum) -> None:
         """Start specified server"""
         logger.debug("ManagerClient starting %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/start")
         self._driver_update()
 
-    async def server_restart(self, server_id: str) -> None:
+    async def server_restart(self, server_id: ServerNum) -> None:
         """Restart specified server"""
         logger.debug("ManagerClient restarting %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
-    async def server_add(self) -> str:
+    async def server_add(self) -> ServerInfo:
         """Add a new server"""
-        server_id = await self.client.get_text("/cluster/addserver")
+        try:
+            server_info = await self.client.get_json("/cluster/addserver")
+        except Exception as exc:
+            raise Exception("Failed to add server") from exc
+        try:
+            s_info = ServerInfo(ServerNum(int(server_info["server_id"])),
+                                IPAddress(server_info["ip_addr"]))
+        except Exception as exc:
+            raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
+        logger.debug("ManagerClient added %s", s_info)
         self._driver_update()
-        logger.debug("ManagerClient added %s", server_id)
-        return server_id
+        return s_info
 
-    # TODO: only pass UUID
-    async def remove_node(self, initiator_ip: str,
-                          to_remove_ip: str, to_remove_host_id: str, ignore_dead: list[str] = []) -> None:
+    async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
+                          ignore_dead: List[IPAddress] = []) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
-        logger.debug("ManagerClient remove node %s %s on initiator %s", to_remove_ip,
-                     to_remove_host_id, initiator_ip)
-        data = {"to_remove_ip": to_remove_ip, "to_remove_host_id": to_remove_host_id, "ignore_dead": ignore_dead}
-        await self.client.put_json(f"/cluster/remove-node/{initiator_ip}", data)
+        logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
+        data = {"server_id": server_id, "ignore_dead": ignore_dead}
+        await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data)
         self._driver_update()
 
-    async def decommission_node(self, to_remove_ip: str) -> None:
+    async def decommission_node(self, server_id: ServerNum) -> None:
         """Tell a node to decommission with Scylla REST API"""
-        logger.debug("ManagerClient decommission node %s", to_remove_ip)
-        await self.client.get_text(f"/cluster/decommission-node/{to_remove_ip}")
+        logger.debug("ManagerClient decommission %s", server_id)
+        await self.client.get_text(f"/cluster/decommission-node/{server_id}")
         self._driver_update()
 
-    async def server_get_config(self, server_id: str) -> dict[str, object]:
+    async def server_get_config(self, server_id: ServerNum) -> dict[str, object]:
         data = await self.client.get_json(f"/cluster/server/{server_id}/get_config")
         assert isinstance(data, dict), f"server_get_config: got {type(data)} expected dict"
         return data
 
-    async def server_update_config(self, server_id: str, key: str, value: object) -> None:
+    async def server_update_config(self, server_id: ServerNum, key: str, value: object) -> None:
         await self.client.put_json(f"/cluster/server/{server_id}/update_config",
                                    {"key": key, "value": value})
-
-    async def get_host_id(self, server_id: str) -> str:
-        """Get host id through Scylla REST API"""
-        return await self.api.get_host_id(server_id)
 
     async def wait_for_host_known(self, dst_server_id: str, expect_host_id: str,
                                   deadline: Optional[float] = None) -> None:
@@ -190,3 +199,19 @@ class ManagerClient():
             return True if server_id in down_endpoints else None
 
         return await wait_for(host_is_down, deadline or (time() + 30))
+
+    async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
+        """Get host IP Address"""
+        try:
+            server_ip = await self.client.get_text(f"/cluster/host-ip/{server_id}")
+        except Exception as exc:
+            raise Exception(f"Failed to get host IP address for server {server_id}") from exc
+        return IPAddress(server_ip)
+
+    async def get_host_id(self, server_id: ServerNum) -> HostID:
+        """Get local host id of a server"""
+        try:
+            host_id = await self.client.get_text(f"/cluster/host-id/{server_id}")
+        except Exception as exc:
+            raise Exception(f"Failed to get local host id address for server {server_id}") from exc
+        return HostID(host_id)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -493,7 +493,7 @@ class ScyllaCluster:
             for _ in range(self.replicas):
                 await self.add_server()
             self.keyspace_count = self._get_keyspace_count()
-        except (RuntimeError, NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:
+        except Exception as exc:
             # If start fails, swallow the error to throw later,
             # at test time.
             self.start_exception = exc
@@ -745,7 +745,6 @@ class ScyllaClusterManager:
         """Stop, cycle last cluster if not dirty and present"""
         logging.info("ScyllaManager stopping for test %s", self.test_uname)
         await self.site.stop()
-        await self.api.close()
         if not self.cluster.is_dirty:
             logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
             await self.clusters.put(self.cluster)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -485,6 +485,7 @@ class ScyllaCluster:
         self.is_dirty: bool = False
         self.start_exception: Optional[Exception] = None
         self.keyspace_count = 0
+        self.api = ScyllaRESTAPIClient()
 
     async def install_and_start(self) -> None:
         """Setup initial servers and start them.
@@ -717,7 +718,6 @@ class ScyllaClusterManager:
         app = aiohttp.web.Application()
         self._setup_routes(app)
         self.runner = aiohttp.web.AppRunner(app)
-        self.api = ScyllaRESTAPIClient()
 
     async def start(self) -> None:
         """Get first cluster, setup API"""
@@ -879,7 +879,7 @@ class ScyllaClusterManager:
 
         # initate remove
         try:
-            await self.api.remove_node(initiator_ip, to_remove_host_id, ignore_dead)
+            await self.cluster.api.remove_node(initiator_ip, to_remove_host_id, ignore_dead)
         except RuntimeError as exc:
             logging.error("_cluster_remove_node failed initiator %s server %s %s ignore_dead %s, check log at %s",
                           initiator_ip, to_remove_ip, to_remove_host_id, ignore_dead,
@@ -901,7 +901,7 @@ class ScyllaClusterManager:
 
         # initate decommission
         try:
-            await self.api.decommission_node(to_decommission_ip)
+            await self.cluster.api.decommission_node(to_decommission_ip)
         except RuntimeError as exc:
             logging.error("_cluster_decommission_node %s, check log at %s", to_decommission_ip,
                           self.cluster.running[to_decommission_ip].log_filename)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -714,9 +714,9 @@ class ScyllaClusterManager:
         # NOTE: need to make a safe temp dir as tempfile can't make a safe temp sock name
         self.manager_dir: str = tempfile.mkdtemp(prefix="manager-", dir=base_dir)
         self.sock_path: str = f"{self.manager_dir}/api"
-        self.app = aiohttp.web.Application()
-        self._setup_routes()
-        self.runner = aiohttp.web.AppRunner(self.app)
+        app = aiohttp.web.Application()
+        self._setup_routes(app)
+        self.runner = aiohttp.web.AppRunner(app)
         self.api = ScyllaRESTAPIClient()
 
     async def start(self) -> None:
@@ -763,26 +763,26 @@ class ScyllaClusterManager:
         logging.info("Getting new Scylla cluster %s", self.cluster)
 
 
-    def _setup_routes(self) -> None:
-        self.app.router.add_get('/up', self._manager_up)
-        self.app.router.add_get('/cluster/up', self._cluster_up)
-        self.app.router.add_get('/cluster/is-dirty', self._is_dirty)
-        self.app.router.add_get('/cluster/replicas', self._cluster_replicas)
-        self.app.router.add_get('/cluster/running-servers', self._cluster_running_servers)
-        self.app.router.add_get('/cluster/before-test/{test_case_name}', self._before_test_req)
-        self.app.router.add_get('/cluster/after-test', self._after_test)
-        self.app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
-        self.app.router.add_get('/cluster/server/{id}/stop', self._cluster_server_stop)
-        self.app.router.add_get('/cluster/server/{id}/stop_gracefully',
-                                self._cluster_server_stop_gracefully)
-        self.app.router.add_get('/cluster/server/{id}/start', self._cluster_server_start)
-        self.app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
-        self.app.router.add_get('/cluster/addserver', self._cluster_server_add)
+    def _setup_routes(self, app: aiohttp.web.Application) -> None:
+        app.router.add_get('/up', self._manager_up)
+        app.router.add_get('/cluster/up', self._cluster_up)
+        app.router.add_get('/cluster/is-dirty', self._is_dirty)
+        app.router.add_get('/cluster/replicas', self._cluster_replicas)
+        app.router.add_get('/cluster/running-servers', self._cluster_running_servers)
+        app.router.add_get('/cluster/before-test/{test_case_name}', self._before_test_req)
+        app.router.add_get('/cluster/after-test', self._after_test)
+        app.router.add_get('/cluster/mark-dirty', self._mark_dirty)
+        app.router.add_get('/cluster/server/{id}/stop', self._cluster_server_stop)
+        app.router.add_get('/cluster/server/{id}/stop_gracefully',
+                           self._cluster_server_stop_gracefully)
+        app.router.add_get('/cluster/server/{id}/start', self._cluster_server_start)
+        app.router.add_get('/cluster/server/{id}/restart', self._cluster_server_restart)
+        app.router.add_get('/cluster/addserver', self._cluster_server_add)
         # TODO: only pass UUID
-        self.app.router.add_put('/cluster/remove-node/{initiator}', self._cluster_remove_node)
-        self.app.router.add_get('/cluster/decommission-node/{ip}', self._cluster_decommission_node)
-        self.app.router.add_get('/cluster/server/{id}/get_config', self._server_get_config)
-        self.app.router.add_put('/cluster/server/{id}/update_config', self._server_update_config)
+        app.router.add_put('/cluster/remove-node/{initiator}', self._cluster_remove_node)
+        app.router.add_get('/cluster/decommission-node/{ip}', self._cluster_decommission_node)
+        app.router.add_get('/cluster/server/{id}/get_config', self._server_get_config)
+        app.router.add_put('/cluster/server/{id}/update_config', self._server_update_config)
 
     async def _manager_up(self, _request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -12,7 +12,7 @@ import ssl
 from typing import List
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
-from test.pylib.manager_client import ManagerClient
+from test.pylib.manager_client import ManagerClient, IPAddress
 import pytest
 from cassandra.cluster import Session, ResponseFuture                    # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore # pylint: disable=no-name-in-module
@@ -90,7 +90,7 @@ Session.run_async = run_async
 
 
 # cluster_con helper: set up client object for communicating with the CQL API.
-def cluster_con(hosts: List[str], port: int, use_ssl: bool):
+def cluster_con(hosts: List[IPAddress], port: int, use_ssl: bool):
     """Create a CQL Cluster connection object according to configuration.
        It does not .connect() yet."""
     assert len(hosts) > 0, "python driver connection needs at least one host to connect to"

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -29,7 +29,7 @@ async def test_stop_server_add_column(manager, random_tables):
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
     await manager.server_add()
-    await manager.server_stop(servers[1])
+    await manager.server_stop(servers[1].server_id)
     await table.add_column()
     await random_tables.verify_schema()
 
@@ -39,7 +39,7 @@ async def test_restart_server_add_column(manager, random_tables):
     """Add a node, stop an original node, add a column"""
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
-    ret = await manager.server_restart(servers[1])
+    ret = await manager.server_restart(servers[1].server_id)
     await table.add_column()
     await random_tables.verify_schema()
 
@@ -50,9 +50,8 @@ async def test_remove_node_add_column(manager, random_tables):
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
     await manager.server_add()
-    server_uuid = await manager.get_host_id(servers[1])              # get uuid [1]
-    await manager.server_stop_gracefully(servers[1])                 # stop     [1]
-    await manager.remove_node(servers[0], servers[1], server_uuid)   # Remove   [1]
+    await manager.server_stop_gracefully(servers[1].server_id)              # stop     [1]
+    await manager.remove_node(servers[0].server_id, servers[1].server_id)   # Remove   [1]
     await table.add_column()
     await random_tables.verify_schema()
 
@@ -64,7 +63,7 @@ async def test_decommission_node_add_column(manager, random_tables):
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
     await manager.server_add()
-    await manager.decommission_node(servers[1])             # Decommission [1]
+    await manager.decommission_node(servers[1].server_id)             # Decommission [1]
     await table.add_column()
     await random_tables.verify_schema()
 

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -11,10 +11,10 @@ import time
 import functools
 from typing import Callable, Awaitable, Optional, TypeVar, Generic
 
-from cassandra.cluster import NoHostAvailable, Session
-from cassandra.pool import Host
+from cassandra.cluster import NoHostAvailable, Session  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.pool import Host                         # type: ignore # pylint: disable=no-name-in-module
 
-from test.pylib.manager_client import ManagerClient
+from test.pylib.manager_client import ManagerClient, IPAddress, ServerInfo
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import ScyllaRESTAPIClient, inject_error
 from test.pylib.util import wait_for
@@ -32,26 +32,26 @@ async def reconnect_driver(manager: ManagerClient) -> Session:
     return cql
 
 
-async def restart(manager: ManagerClient, srv: str) -> None:
-    logging.info(f"Stopping {srv} gracefully")
-    await manager.server_stop_gracefully(srv)
-    logging.info(f"Restarting {srv}")
-    await manager.server_start(srv)
-    logging.info(f"{srv} restarted")
+async def restart(manager: ManagerClient, server: ServerInfo) -> None:
+    logging.info(f"Stopping {server} gracefully")
+    await manager.server_stop_gracefully(server.server_id)
+    logging.info(f"Restarting {server}")
+    await manager.server_start(server.server_id)
+    logging.info(f"{server} restarted")
 
 
-async def enable_raft(manager: ManagerClient, srv: str) -> None:
-    config = await manager.server_get_config(srv)
+async def enable_raft(manager: ManagerClient, server: ServerInfo) -> None:
+    config = await manager.server_get_config(server.server_id)
     features = config['experimental_features']
     assert(type(features) == list)
     features.append('raft')
-    logging.info(f"Updating config of server {srv}")
-    await manager.server_update_config(srv, 'experimental_features', features)
+    logging.info(f"Updating config of server {server}")
+    await manager.server_update_config(server.server_id, 'experimental_features', features)
 
 
-async def enable_raft_and_restart(manager: ManagerClient, srv: str) -> None:
-    await enable_raft(manager, srv)
-    await restart(manager, srv)
+async def enable_raft_and_restart(manager: ManagerClient, server: ServerInfo) -> None:
+    await enable_raft(manager, server)
+    await restart(manager, server)
 
 
 async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
@@ -65,9 +65,12 @@ async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
     await wait_for(cql_ready, deadline)
 
 
-async def wait_for_cql_and_get_hosts(cql: Session, ips: list[str], deadline: float) -> list[Host]:
-    """Wait until every ip in `ips` is available through `cql` and translate `ips` to `Host`s."""
-    ip_set = set(ips)
+async def wait_for_cql_and_get_hosts(cql: Session, servers: list[ServerInfo], deadline: float) \
+        -> list[Host]:
+    """Wait until every server in `servers` is available through `cql`
+       and translate `servers` to a list of Cassandra `Host`s.
+    """
+    ip_set = set(str(srv.ip_addr) for srv in servers)
     async def get_hosts() -> Optional[list[Host]]:
         hosts = cql.cluster.metadata.all_hosts()
         remaining = ip_set - {h.address for h in hosts}
@@ -109,7 +112,8 @@ async def wait_until_upgrade_finishes(cql: Session, host: Host, deadline: float)
     await wait_for_upgrade_state('use_post_raft_procedures', cql, host, deadline)
 
 
-async def wait_for_gossip_gen_increase(api: ScyllaRESTAPIClient, gen: int, node_ip: str, target_ip: str, deadline: float):
+async def wait_for_gossip_gen_increase(api: ScyllaRESTAPIClient, gen: int, node_ip: IPAddress,
+                                       target_ip: IPAddress, deadline: float):
     """Wait until the generation number of `target_ip` increases above `gen` from the point of view of `node_ip`.
        Can be used to wait until `node_ip` gossips with `target_ip` after `target_ip` was restarted
        by saving the generation number of `target_ip` before restarting it and then calling this function
@@ -188,7 +192,7 @@ async def test_raft_upgrade_with_node_remove(manager: ManagerClient, random_tabl
     servers = await manager.running_servers()
     srv1, *others = servers
 
-    srv1_gen = await manager.api.get_gossip_generation_number(others[0], srv1)
+    srv1_gen = await manager.api.get_gossip_generation_number(others[0].ip_addr, srv1.ip_addr)
     logging.info(f"Gossip generation number of {srv1} seen from {others[0]}: {srv1_gen}")
 
     logging.info(f"Enabling Raft on {srv1} and restarting")
@@ -198,13 +202,10 @@ async def test_raft_upgrade_with_node_remove(manager: ManagerClient, random_tabl
     # after srv1 has restarted. Then we know that the other node learned about srv1's
     # supported features, including SUPPORTS_RAFT.
     logging.info(f"Waiting until {others[0]} gossips with {srv1}")
-    await wait_for_gossip_gen_increase(manager.api, srv1_gen, others[0], srv1, time.time() + 60)
-
-    srv1_host_id = await manager.get_host_id(srv1)
-    logging.info(f"Obtained host ID of {srv1}: {srv1_host_id}")
+    await wait_for_gossip_gen_increase(manager.api, srv1_gen, others[0].ip_addr, srv1.ip_addr, time.time() + 60)
 
     logging.info(f"Stopping {srv1}")
-    await manager.server_stop_gracefully(srv1)
+    await manager.server_stop_gracefully(srv1.server_id)
 
     logging.info(f"Enabling Raft on {others} and restarting")
     await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in others))
@@ -215,7 +216,7 @@ async def test_raft_upgrade_with_node_remove(manager: ManagerClient, random_tabl
     logging.info(f"Driver reconnected, hosts: {hosts}")
 
     logging.info(f"Removing {srv1} using {others[0]}")
-    await manager.remove_node(others[0], srv1, srv1_host_id)
+    await manager.remove_node(others[0].server_id, srv1.server_id)
 
     logging.info("Waiting until upgrade finishes")
     await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
@@ -242,7 +243,8 @@ async def test_recover_stuck_raft_upgrade(manager: ManagerClient, random_tables:
 
     # TODO error injection should probably be done through ScyllaClusterManager (we may need to mark the cluster as dirty).
     # In this test the cluster is dirty anyway due to a restart so it's safe.
-    async with inject_error(manager.api, srv1, 'group0_upgrade_before_synchronize', one_shot=True):
+    async with inject_error(manager.api, srv1.ip_addr, 'group0_upgrade_before_synchronize',
+                            one_shot=True):
         logging.info(f"Enabling Raft on {others} and restarting")
         await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in others))
         cql = await reconnect_driver(manager)
@@ -277,14 +279,11 @@ async def test_recover_stuck_raft_upgrade(manager: ManagerClient, random_tables:
     logging.info("Creating a table while in recovery state")
     table = await random_tables.add_table(ncolumns=5)
 
-    srv1_host_id = await manager.get_host_id(srv1)
-    logging.info(f"Obtained host ID of {srv1}: {srv1_host_id}")
-
     logging.info(f"Stopping {srv1}")
-    await manager.server_stop_gracefully(srv1)
+    await manager.server_stop_gracefully(srv1.server_id)
 
     logging.info(f"Removing {srv1} using {others[0]}")
-    await manager.remove_node(others[0], srv1, srv1_host_id)
+    await manager.remove_node(others[0].server_id, srv1.server_id)
 
     logging.info(f"Deleting Raft data and upgrade state on {hosts} and restarting")
     for host in hosts:
@@ -336,14 +335,12 @@ async def test_recovery_after_majority_loss(manager: ManagerClient, random_table
     tables = await asyncio.gather(*(random_tables.add_table(ncolumns=5) for _ in range(5)))
 
     srv1, *others = servers
-    others_with_host_ids = [(srv, await manager.get_host_id(srv)) for srv in others]
-    logging.info(f"Obtained host IDs: {others_with_host_ids}")
 
     logging.info(f"Killing all nodes except {srv1}")
-    await asyncio.gather(*(manager.server_stop(srv) for srv in others))
+    await asyncio.gather(*(manager.server_stop(srv.server_id) for srv in others))
 
     logging.info(f"Entering recovery state on {srv1}")
-    host1 = next(h for h in hosts if h.address == srv1)
+    host1 = next(h for h in hosts if h.address == srv1.ip_addr)
     await cql.run_async("update system.scylla_local set value = 'recovery' where key = 'group0_upgrade_state'", host=host1)
     await restart(manager, srv1)
     cql = await reconnect_driver(manager)
@@ -351,11 +348,11 @@ async def test_recovery_after_majority_loss(manager: ManagerClient, random_table
     logging.info("Node restarted, waiting until driver connects")
     host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
 
-    for i in range(len(others_with_host_ids)):
-        remove_ip, remove_host_id = others_with_host_ids[i]
-        ignore_dead_ips = [ip for (ip, _) in others_with_host_ids[i+1:]]
-        logging.info(f"Removing {remove_ip} using {srv1} with ignore_dead: {ignore_dead_ips}")
-        await manager.remove_node(srv1, remove_ip, remove_host_id, ignore_dead_ips)
+    for i in range(len(others)):
+        to_remove = others[i]
+        ignore_dead_ips = [srv.ip_addr for srv in others[i+1:]]
+        logging.info(f"Removing {to_remove} using {srv1} with ignore_dead: {ignore_dead_ips}")
+        await manager.remove_node(srv1.server_id, to_remove.server_id, ignore_dead_ips)
 
     logging.info(f"Deleting old Raft data and upgrade state on {host1} and restarting")
     await delete_raft_data(cql, host1)


### PR DESCRIPTION
Instead of using assigned IP addresses, use a local integer ID for managing servers. IP address can be reused by a different server.

While there, get host ID (UUID). This can also be reused with `node replace` so it's not good enough for tracking.