### PR TITLE
raft: mark removed servers as expiring instead of dropping them

### DIFF
--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -156,7 +156,7 @@ void raft_rpc::add_server(raft::server_address addr) {
 }
 
 void raft_rpc::remove_server(raft::server_id id) {
-    if (auto inet_addr = _address_map.erase(id)) {
+    if (auto inet_addr = _address_map.set_expiring_flag(id)) {
         _on_server_update(*inet_addr, id, false);
     }
 }

--- a/test/raft/raft_address_map_test.cc
+++ b/test/raft/raft_address_map_test.cc
@@ -35,21 +35,33 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
     using seastar::manual_clock;
 
     {
-        // Set + erase regular entry works as expected
+        // Set regular entry + set_expiring_flag works as expected
         raft_address_map<manual_clock> m;
         m.set(id1, addr1, false);
-        auto found = m.find(id1);
-        BOOST_CHECK(!!found && *found == addr1);
-        m.erase(id1);
+        {
+            const auto found = m.find(id1);
+            BOOST_CHECK(!!found && *found == addr1);
+        }
+        {
+            const auto found = m.set_expiring_flag(id1);
+            BOOST_CHECK(!!found && *found == addr1);
+        }
+        manual_clock::advance(expiration_time);
         BOOST_CHECK(!m.find(id1));
     }
     {
-        // Set expiring + erase works as expected
+        // Set expiring entry + set_expiring_flag works as expected
         raft_address_map<manual_clock> m;
         m.set(id1, addr1, true);
-        auto found = m.find(id1);
-        BOOST_CHECK(!!found && *found == addr1);
-        m.erase(id1);
+        {
+            const auto found = m.find(id1);
+            BOOST_CHECK(!!found && *found == addr1);
+        }
+        {
+            const auto found = m.set_expiring_flag(id1);
+            BOOST_CHECK(!!found && *found == addr1);
+        }
+        manual_clock::advance(expiration_time);
         BOOST_CHECK(!m.find(id1));
     }
     {


### PR DESCRIPTION
There is a flaw in how the raft rpc endpoints are currently managed. The `io_fiber in raft::server` is supposed to first add new servers to rpc, then send all the messages and then remove the servers which have been excluded from the configuration. The problem is that the `send_messages` function isn't synchronous, it schedules `send_append_entries` to run after all the current requests to the target server, which can happen after we have already removed the server from `address_map`.

In this patch the `remove_server` function is changed to mark the `server_id` as expiring rather than synchronously dropping it. This means all currently scheduled requests to that server will still be able to resolve the ip address for that `server_id`.

Fixes: #11228