### PR TITLE
db/view: Add visibility to view updating of Staging SSTables

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -30,11 +30,11 @@ private:
     std::unordered_map<lw_shared_ptr<replica::table>, std::vector<sstables::shared_sstable>> _sstables_with_tables;
     std::unordered_map<lw_shared_ptr<replica::table>, std::vector<sstables::shared_sstable>> _sstables_to_move;
     metrics::metric_groups _metrics;
+    class progress_tracker;
+    std::unique_ptr<progress_tracker> _progress_tracker;
 public:
-    view_update_generator(replica::database& db) : _db(db) {
-        setup_metrics();
-        discover_staging_sstables();
-    }
+    view_update_generator(replica::database& db);
+    ~view_update_generator();
 
     future<> start();
     future<> stop();


### PR DESCRIPTION
Today, we're completely blind about the progress of view updating on Staging files. We don't know how long it will take, nor how much progress we've made.

This patch adds visibility with a new metric that will inform the number of bytes to be processed from Staging files. Before any work is done, the metric tell us the total size to be processed. As view updating progresses, the metric value is expected to decrease, unless work is being produced faster than we can consume them.

We're piggybacking on read_monitor, which allows the metric to be updated whenever an individual SSTable reader is exhausted. That granularity works even better on staging files as they tend to have small degree of overlapping among them. If only a subset of files being processed overlap one another, that's also fine because readers will be incrementally exhausted, so the metric will be likewise incrementally adjusted.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>