### PR TITLE
test/topology: reenable test_remove_node_add_column

### DIFF
--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -40,7 +40,6 @@ async def test_restart_server_add_column(manager, random_tables):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Flaky -- see #11691 for a potential fix")
 async def test_remove_node_add_column(manager, random_tables):
     """Add a node, remove an original node, add a column"""
     servers = await manager.running_servers()


### PR DESCRIPTION
After #11691 was merged the test should no longer be flaky. Reenable it.