### PR TITLE
test.py: topology fix ssl var and improve pylint score

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -92,7 +92,7 @@ Session.run_async = run_async
 
 
 # cluster_con helper: set up client object for communicating with the CQL API.
-def cluster_con(hosts: List[str], port: int, ssl: bool):
+def cluster_con(hosts: List[str], port: int, use_ssl: bool):
     """Create a CQL Cluster connection object according to configuration.
        It does not .connect() yet."""
     assert len(hosts) > 0, "python driver connection needs at least one host to connect to"
@@ -107,7 +107,7 @@ def cluster_con(hosts: List[str], port: int, ssl: bool):
         # See issue #11289.
         # NOTE: request_timeout is the main cause of timeouts, even if logs say heartbeat
         request_timeout=200)
-    if ssl:
+    if use_ssl:
         # Scylla does not support any earlier TLS protocol. If you try,
         # you will get mysterious EOF errors (see issue #6971) :-(
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
@@ -148,8 +148,8 @@ async def manager_internal(event_loop, request):
        Test cases (functions) should not use this fixture.
     """
     port = int(request.config.getoption('port'))
-    ssl = bool(request.config.getoption('ssl'))
-    manager_int = ManagerClient(request.config.getoption('manager_api'), port, ssl, cluster_con)
+    use_ssl = bool(request.config.getoption('ssl'))
+    manager_int = ManagerClient(request.config.getoption('manager_api'), port, use_ssl, cluster_con)
     yield manager_int
     await manager_int.stop()  # Stop client session and close driver after last test
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -8,17 +8,15 @@
 
 import asyncio
 import logging
-import pathlib
 import ssl
-import sys
 from typing import List
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 import pytest
-from cassandra.cluster import Session, ResponseFuture                    # type: ignore
-from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore
-from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore
+from cassandra.cluster import Session, ResponseFuture                    # type: ignore # pylint: disable=no-name-in-module
+from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore # pylint: disable=no-name-in-module
 from cassandra.policies import RoundRobinPolicy                          # type: ignore
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
@@ -190,7 +188,8 @@ def check_pre_raft(manager):
 @pytest.fixture(scope="function")
 def fails_without_raft(request, check_pre_raft):
     if check_pre_raft:
-        request.node.add_marker(pytest.mark.xfail(reason='Test expected to fail without Raft experimental feature on'))
+        request.node.add_marker(pytest.mark.xfail(reason="Test expected to fail without Raft "
+                                                         "experimental feature on"))
 
 
 # "random_tables" fixture: Creates and returns a temporary RandomTables object


### PR DESCRIPTION
When code was moved to the new directory, a bug was reintroduced with `ssl` local hiding `ssl` module. Fix again.