### PR TITLE
doc: fix the command to create and sign a certificate 

### DIFF
--- a/docs/operating-scylla/security/generate-certificate.rst
+++ b/docs/operating-scylla/security/generate-certificate.rst
@@ -86,7 +86,7 @@ Then we can finally create and sign our certificate:
 
 .. code-block:: shell
 
-   openssl x509 -req -in db.csr -CA cadb.pem -CAkey cadb.key -CAcreateserial  -out db.crt -days 365
+   openssl x509 -req -in db.csr -CA cadb.pem -CAkey cadb.key -CAcreateserial  -out db.crt -days 365 -sha256
 
 As a result, we should now have:
 


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-doc-issues/issues/853

The currently documented command creates the SHA1 certificate, which is not secure. 
This PR updates the command to create a secure SHA256 certificate.