### PR TITLE
service/raft: failure detector: ping `raft::server_id`s, not `gms::inet_address`es

### DIFF
--- a/direct_failure_detector/failure_detector.hh
+++ b/direct_failure_detector/failure_detector.hh
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include "utils/UUID.hh"
+
 #include <seastar/core/sharded.hh>
 
 using namespace seastar;
@@ -21,7 +23,7 @@ class pinger {
 public:
     // Opaque endpoint ID.
     // A specific implementation of `pinger` maps those IDs to 'real' addresses.
-    using endpoint_id = unsigned;
+    using endpoint_id = utils::UUID;
 
     // Send a message to `ep` and wait until it responds.
     // The wait can be aborted using `as`.

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -623,49 +623,12 @@ private:
     future<> update_live_endpoints_version();
 
 public:
-    // Implementation of `direct_failure_detector::pinger` which uses gossip echo messages for pinging.
-    // The gossip echo message must be provided this node's gossip generation number.
-    // It's an integer incremented when the node restarts or when the gossip subsystem restarts.
-    // We cache the generation number inside `echo_pinger` on every shard and update it in the `gossiper` main loop.
-    //
-    // We also store a mapping between `direct_failure_detector::pinger::endpoint_id`s and `inet_address`es.
-    class direct_fd_pinger : public direct_failure_detector::pinger {
-        friend class gossiper;
-        echo_pinger& _echo_pinger;
-        gossiper& _gossiper;
-
-        // Only used on shard 0 by `allocate_id`.
-        direct_failure_detector::pinger::endpoint_id _next_allocated_id{0};
-
-        // The mappings are created on shard 0 and lazily replicated to other shards:
-        // when `ping` or `get_address` is called with an unknown ID on a different shard, it will fetch the ID from shard 0.
-        std::unordered_map<direct_failure_detector::pinger::endpoint_id, inet_address> _id_to_addr;
-
-        // Used to quickly check if given address already has an assigned ID.
-        // Used only on shard 0, not replicated.
-        std::unordered_map<inet_address, direct_failure_detector::pinger::endpoint_id> _addr_to_id;
-
-        direct_fd_pinger(echo_pinger& pinger, gossiper& g) : _echo_pinger(pinger), _gossiper(g) {}
-
-    public:
-        direct_fd_pinger(const direct_fd_pinger&) = delete;
-
-        // Allocate a new endpoint_id for `addr`, or if one already exists, return it.
-        // Call only on shard 0.
-        direct_failure_detector::pinger::endpoint_id allocate_id(gms::inet_address addr);
-
-        // Precondition: `id` was returned from `allocate_id` on shard 0 earlier.
-        future<gms::inet_address> get_address(direct_failure_detector::pinger::endpoint_id id);
-
-        future<bool> ping(direct_failure_detector::pinger::endpoint_id id, abort_source& as) override;
-    };
-    direct_fd_pinger& get_direct_fd_pinger() { return _direct_fd_pinger; }
     echo_pinger& get_echo_pinger() { return _echo_pinger; }
 
 private:
     echo_pinger _echo_pinger;
-    direct_fd_pinger _direct_fd_pinger;
 };
+
 
 struct gossip_get_endpoint_states_request {
     // Application states the sender requested
@@ -677,11 +640,3 @@ struct gossip_get_endpoint_states_response {
 };
 
 } // namespace gms
-
-// XXX: find a better place to put this?
-struct direct_fd_clock : public direct_failure_detector::clock {
-    using base = std::chrono::steady_clock;
-
-    direct_failure_detector::clock::timepoint_t now() noexcept override;
-    future<> sleep_until(direct_failure_detector::clock::timepoint_t tp, abort_source& as) override;
-};

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -82,6 +82,23 @@ struct gossip_config {
     uint32_t skip_wait_for_gossip_to_settle = -1;
 };
 
+class gossiper;
+
+// Caches the gossiper's generation number, which is required for sending gossip echo messages.
+// Call `ping` to send a gossip echo message to the given address using the last known generation number.
+// The generation number is updated by gossiper's loop and replicated to every shard.
+class echo_pinger {
+    friend class gossiper;
+    gossiper& _gossiper;
+    int64_t _generation_number{0};
+
+    future<> update_generation_number(int64_t n);
+    echo_pinger(gossiper& g) : _gossiper(g) {}
+
+public:
+    future<> ping(const gms::inet_address&, abort_source&);
+};
+
 /**
  * This module is responsible for Gossiping information for the local endpoint. This abstraction
  * maintains the list of live and dead endpoints. Periodically i.e. every 1 second this module
@@ -95,6 +112,7 @@ struct gossip_config {
  * the Failure Detector.
  */
 class gossiper : public seastar::async_sharded_service<gossiper>, public seastar::peering_sharded_service<gossiper> {
+    friend class echo_pinger;
 public:
     using clk = seastar::lowres_system_clock;
     using ignore_features_of_local_node = bool_class<class ignore_features_of_local_node_tag>;
@@ -608,11 +626,12 @@ public:
     // Implementation of `direct_failure_detector::pinger` which uses gossip echo messages for pinging.
     // The gossip echo message must be provided this node's gossip generation number.
     // It's an integer incremented when the node restarts or when the gossip subsystem restarts.
-    // We cache the generation number inside `direct_fd_pinger` on every shard and update it in the `gossiper` main loop.
+    // We cache the generation number inside `echo_pinger` on every shard and update it in the `gossiper` main loop.
     //
     // We also store a mapping between `direct_failure_detector::pinger::endpoint_id`s and `inet_address`es.
     class direct_fd_pinger : public direct_failure_detector::pinger {
         friend class gossiper;
+        echo_pinger& _echo_pinger;
         gossiper& _gossiper;
 
         // Only used on shard 0 by `allocate_id`.
@@ -626,12 +645,7 @@ public:
         // Used only on shard 0, not replicated.
         std::unordered_map<inet_address, direct_failure_detector::pinger::endpoint_id> _addr_to_id;
 
-        // This node's gossip generation number, updated by gossiper's loop and replicated to every shard.
-        int64_t _generation_number{0};
-
-        future<> update_generation_number(int64_t n);
-
-        direct_fd_pinger(gossiper& g) : _gossiper(g) {}
+        direct_fd_pinger(echo_pinger& pinger, gossiper& g) : _echo_pinger(pinger), _gossiper(g) {}
 
     public:
         direct_fd_pinger(const direct_fd_pinger&) = delete;
@@ -645,10 +659,11 @@ public:
 
         future<bool> ping(direct_failure_detector::pinger::endpoint_id id, abort_source& as) override;
     };
-
     direct_fd_pinger& get_direct_fd_pinger() { return _direct_fd_pinger; }
+    echo_pinger& get_echo_pinger() { return _echo_pinger; }
 
 private:
+    echo_pinger _echo_pinger;
     direct_fd_pinger _direct_fd_pinger;
 };
 

--- a/main.cc
+++ b/main.cc
@@ -924,13 +924,20 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 raft_address_map.stop().get();
             });
 
-            static direct_fd_clock fd_clock;
+            static sharded<service::direct_fd_pinger> fd_pinger;
+            supervisor::notify("starting direct failure detector pinger service");
+            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper))).get();
+
+            auto stop_fd_pinger = defer_verbose_shutdown("fd_pinger", [] {
+                fd_pinger.stop().get();
+            });
+
+            static service::direct_fd_clock fd_clock;
             static sharded<direct_failure_detector::failure_detector> fd;
             supervisor::notify("starting direct failure detector service");
             fd.start(
-                sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_direct_fd_pinger()); }, std::ref(gossiper)),
-                std::ref(fd_clock),
-                direct_fd_clock::base::duration{std::chrono::milliseconds{100}}.count()).get();
+                std::ref(fd_pinger), std::ref(fd_clock),
+                service::direct_fd_clock::base::duration{std::chrono::milliseconds{100}}.count()).get();
 
             auto stop_fd = defer_verbose_shutdown("direct_failure_detector", [] {
                 fd.stop().get();
@@ -1077,7 +1084,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // engine().at_exit([&proxy] { return proxy.stop(); });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
-                std::ref(raft_address_map), std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();
+                std::ref(raft_address_map), std::ref(messaging), std::ref(gossiper), std::ref(fd_pinger), std::ref(fd)).get();
 
             // group0 client exists only on shard 0.
             // The client has to be created before `stop_raft` since during

--- a/main.cc
+++ b/main.cc
@@ -1084,7 +1084,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // engine().at_exit([&proxy] { return proxy.stop(); });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
-                std::ref(raft_address_map), std::ref(messaging), std::ref(gossiper), std::ref(fd_pinger), std::ref(fd)).get();
+                std::ref(raft_address_map), std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();
 
             // group0 client exists only on shard 0.
             // The client has to be created before `stop_raft` since during

--- a/main.cc
+++ b/main.cc
@@ -926,7 +926,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             static sharded<service::direct_fd_pinger> fd_pinger;
             supervisor::notify("starting direct failure detector pinger service");
-            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper))).get();
+            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper)), std::ref(raft_address_map)).get();
 
             auto stop_fd_pinger = defer_verbose_shutdown("fd_pinger", [] {
                 fd_pinger.stop().get();
@@ -1104,6 +1104,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_raft = defer_verbose_shutdown("Raft", [&raft_gr] {
                 raft_gr.stop().get();
             });
+
             if (cfg->check_experimental(db::experimental_features_t::feature::RAFT)) {
                 supervisor::notify("starting Raft Group Registry service");
             } else {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -161,15 +161,13 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     _raft_gr.address_map().set(my_addr);
     auto state_machine = std::make_unique<group0_state_machine>(_client, _mm, _qp.proxy());
     auto rpc = std::make_unique<raft_rpc>(*state_machine, _ms, _raft_gr.address_map(), gid, my_id,
-            [this] (gms::inet_address addr, raft::server_id raft_id, bool added) {
-                // FIXME: we should eventually switch to UUID-based (not IP-based) node identification/communication scheme.
-                // See #6403.
-                auto fd_id = _raft_gr.get_fd_pinger().allocate_id(addr);
+            [this] (raft::server_id raft_id, bool added) {
+                auto fd_id = _raft_gr.get_fd_pinger().allocate_id(raft_id);
                 if (added) {
-                    group0_log.info("Added {} (address: {}) to group 0 RPC map", raft_id, addr);
+                    group0_log.info("Added Raft server {} to failure detector (endpoint id: {})", raft_id, fd_id);
                     _raft_gr.direct_fd().add_endpoint(fd_id);
                 } else {
-                    group0_log.info("Removed {} (address: {}) from group 0 RPC map", raft_id, addr);
+                    group0_log.info("Removed Raft server {} from failure detector (endpoint id: {})", raft_id, fd_id);
                     _raft_gr.direct_fd().remove_endpoint(fd_id);
                 }
             });

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -162,12 +162,12 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto state_machine = std::make_unique<group0_state_machine>(_client, _mm, _qp.proxy());
     auto rpc = std::make_unique<raft_rpc>(*state_machine, _ms, _raft_gr.address_map(), gid, my_id,
             [this] (raft::server_id raft_id, bool added) {
-                auto fd_id = _raft_gr.get_fd_pinger().allocate_id(raft_id);
+                auto fd_id = raft_id.uuid();
                 if (added) {
-                    group0_log.info("Added Raft server {} to failure detector (endpoint id: {})", raft_id, fd_id);
+                    group0_log.info("Added Raft server {} to failure detector", raft_id);
                     _raft_gr.direct_fd().add_endpoint(fd_id);
                 } else {
-                    group0_log.info("Removed Raft server {} from failure detector (endpoint id: {})", raft_id, fd_id);
+                    group0_log.info("Removed Raft server {} from failure detector", raft_id);
                     _raft_gr.direct_fd().remove_endpoint(fd_id);
                 }
             });

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -164,7 +164,7 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
             [this] (gms::inet_address addr, raft::server_id raft_id, bool added) {
                 // FIXME: we should eventually switch to UUID-based (not IP-based) node identification/communication scheme.
                 // See #6403.
-                auto fd_id = _gossiper.get_direct_fd_pinger().allocate_id(addr);
+                auto fd_id = _raft_gr.get_fd_pinger().allocate_id(addr);
                 if (added) {
                     group0_log.info("Added {} (address: {}) to group 0 RPC map", raft_id, addr);
                     _raft_gr.direct_fd().add_endpoint(fd_id);

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -126,6 +126,7 @@ public:
 // The actual pinging is performed by `echo_pinger`.
 class direct_fd_pinger : public seastar::peering_sharded_service<direct_fd_pinger>, public direct_failure_detector::pinger {
     gms::echo_pinger& _echo_pinger;
+    raft_address_map<>& _address_map;
 
     // Only used on shard 0 by `allocate_id`.
     direct_failure_detector::pinger::endpoint_id _next_allocated_id{0};
@@ -139,7 +140,8 @@ class direct_fd_pinger : public seastar::peering_sharded_service<direct_fd_pinge
     std::unordered_map<gms::inet_address, direct_failure_detector::pinger::endpoint_id> _addr_to_id;
 
 public:
-    direct_fd_pinger(gms::echo_pinger& pinger) : _echo_pinger(pinger) {}
+    direct_fd_pinger(gms::echo_pinger& pinger, raft_address_map<>& address_map)
+            : _echo_pinger(pinger), _address_map(address_map) {}
 
     direct_fd_pinger(const direct_fd_pinger&) = delete;
     direct_fd_pinger(direct_fd_pinger&&) = delete;

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -26,7 +26,7 @@ class raft_rpc : public raft::rpc {
     raft::server_id _server_id;
     netw::messaging_service& _messaging;
     raft_address_map<>& _address_map;
-    noncopyable_function<void(gms::inet_address, raft::server_id, bool added)> _on_server_update;
+    noncopyable_function<void(raft::server_id, bool added)> _on_server_update;
     seastar::gate _shutdown_gate;
 
     raft_ticker_type::time_point timeout() {
@@ -37,7 +37,7 @@ public:
     explicit raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
             raft_address_map<>& address_map, raft::group_id gid, raft::server_id srv_id,
             // Called when a server is added or removed from the RPC configuration.
-            noncopyable_function<void(gms::inet_address, raft::server_id, bool added)> on_server_update);
+            noncopyable_function<void(raft::server_id, bool added)> on_server_update);
 
     future<raft::snapshot_reply> send_snapshot(raft::server_id server_id, const raft::install_snapshot& snap, seastar::abort_source& as) override;
     future<> send_append_entries(raft::server_id id, const raft::append_request& append_request) override;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -646,7 +646,7 @@ public:
             });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
-                std::ref(raft_address_map), std::ref(ms), std::ref(gossiper), std::ref(fd_pinger), std::ref(fd)).get();
+                std::ref(raft_address_map), std::ref(ms), std::ref(gossiper), std::ref(fd)).get();
             auto stop_raft_gr = deferred_stop(raft_gr);
             raft_gr.invoke_on_all(&service::raft_group_registry::start).get();
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -633,7 +633,7 @@ public:
 
 
             static sharded<service::direct_fd_pinger> fd_pinger;
-            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper))).get();
+            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper)), std::ref(raft_address_map)).get();
             auto stop_fd_pinger = defer([] { fd_pinger.stop().get(); });
 
             service::direct_fd_clock fd_clock;

--- a/test/raft/failure_detector_test.cc
+++ b/test/raft/failure_detector_test.cc
@@ -134,8 +134,8 @@ SEASTAR_TEST_CASE(failure_detector_test) {
     auto sub1 = co_await fd.local().register_listener(l1, 95);
     auto sub2 = co_await fd.local().register_listener(l2, 45);
 
-    direct_failure_detector::pinger::endpoint_id ep1{1};
-    direct_failure_detector::pinger::endpoint_id ep2{2};
+    direct_failure_detector::pinger::endpoint_id ep1{0, 1};
+    direct_failure_detector::pinger::endpoint_id ep2{0, 2};
 
     BOOST_REQUIRE(!l1.is_alive(ep1));
     BOOST_REQUIRE(!l2.is_alive(ep1));


### PR DESCRIPTION
Whenever a Raft configuration change is performed, `raft::server` calls
`raft_rpc::add_server`/`raft_rpc::remove_server`. Our `raft_rpc`
implementation has a function, `_on_server_update`, passed in the
constructor, which it called in `add_server`/`remove_server`;
that function would update the set of endpoints detected by the
direct failure detector. `_on_server_update` was passed an IP address
and that address was added to / removed from the failure detector set
(there's another translation layer between the IP addresses and internal
failure detector 'endpoint ID's; but we can ignore it for the purposes
of this commit).

Therefore: the failure detector was pinging a certain set of IP
addresses. These IP addresses were updated during Raft configuration
changes.

To implement the `is_alive(raft::server_id)` function (required by
`raft::failure_detector` interface), we would translate the ID using
the Raft address map, which is currently also updated during
configuration changes, to an IP address, and check if that IP address is
alive according to the direct failure detector (which maintained an
`_alive_set` of type `unordered_set<gms::inet_address>`).

This all works well but it assumes that servers can be identified using
IP addresses - it doesn't play well with the fact that servers may
change their IP addresses. The only immutable identifier we have for a
server is `raft::server_id`. In the future, Raft configurations will not
associate IP addresses with Raft servers; instead we will assume that IP
addresses can change at any time, and there will be a different
mechanism that eventually updates the Raft address map with the latest
IP address for each `raft::server_id`.

To prepare us for that future, in this commit we no longer operate in
terms of IP addresses in the failure detector, but in terms of
`raft::server_id`s. Most of the commit is boilerplate, changing
`gms::inet_address` to `raft::server_id` and function/variable names.
The interesting changes are:
- in `is_alive`, we no longer need to translate the `raft::server_id` to
  an IP address, because now the stored `_alive_set` already contains
  `raft::server_id`s instead of `gms::inet_address`es.
- the `ping` function now takes a `raft::server_id` instead of
  `gms::inet_address`. To send the ping message, we need to translate
  this to IP address; we do it by the `raft_address_map` pointer
  introduced in an earlier commit.

Thus, there is still a point where we have to translate between
`raft::server_id` and `gms::inet_address`; but observe we now do it at
the last possible moment - just before sending the message. If we
have no translation, we consider the `ping` to have failed - it's
equivalent to a network failure where no route to a given address was
found.

