### PR TITLE
Allow each compaction group to have its own compaction backlog tracker

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -221,13 +221,13 @@ public:
 
     ~compaction_write_monitor() {
         if (_sst) {
-            _table_s.get_compaction_strategy().get_backlog_tracker().revert_charges(_sst);
+            _table_s.get_backlog_tracker().revert_charges(_sst);
         }
     }
 
     virtual void on_write_started(const sstables::writer_offset_tracker& tracker) override {
         _tracker = &tracker;
-        _table_s.get_compaction_strategy().get_backlog_tracker().register_partially_written_sstable(_sst, *this);
+        _table_s.get_backlog_tracker().register_partially_written_sstable(_sst, *this);
     }
 
     virtual void on_data_write_completed() override {
@@ -352,7 +352,7 @@ struct compaction_read_monitor_generator final : public read_monitor_generator {
     public:
         virtual void on_read_started(const sstables::reader_position_tracker& tracker) override {
             _tracker = &tracker;
-            _table_s.get_compaction_strategy().get_backlog_tracker().register_compacting_sstable(_sst, *this);
+            _table_s.get_backlog_tracker().register_compacting_sstable(_sst, *this);
         }
 
         virtual void on_read_completed() override {
@@ -371,7 +371,7 @@ struct compaction_read_monitor_generator final : public read_monitor_generator {
 
         void remove_sstable() {
             if (_sst) {
-                _table_s.get_compaction_strategy().get_backlog_tracker().revert_charges(_sst);
+                _table_s.get_backlog_tracker().revert_charges(_sst);
             }
             _sst = {};
         }
@@ -383,7 +383,7 @@ struct compaction_read_monitor_generator final : public read_monitor_generator {
             // We failed to finish handling this SSTable, so we have to update the backlog_tracker
             // about it.
             if (_sst) {
-                _table_s.get_compaction_strategy().get_backlog_tracker().revert_charges(_sst);
+                _table_s.get_backlog_tracker().revert_charges(_sst);
             }
         }
 

--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -67,6 +67,7 @@ public:
 
     compaction_backlog_tracker(std::unique_ptr<impl> impl) : _impl(std::move(impl)) {}
     compaction_backlog_tracker(compaction_backlog_tracker&&);
+    compaction_backlog_tracker& operator=(compaction_backlog_tracker&&) noexcept;
     compaction_backlog_tracker(const compaction_backlog_tracker&) = delete;
     ~compaction_backlog_tracker();
 

--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -74,7 +74,7 @@ public:
     void replace_sstables(const std::vector<sstables::shared_sstable>& old_ssts, const std::vector<sstables::shared_sstable>& new_ssts);
     void register_partially_written_sstable(sstables::shared_sstable sst, backlog_write_progress_manager& wp);
     void register_compacting_sstable(sstables::shared_sstable sst, backlog_read_progress_manager& rp);
-    void transfer_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges = true);
+    void copy_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges = true) const;
     void revert_charges(sstables::shared_sstable sst);
 
     void disable() {

--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -66,7 +66,7 @@ public:
     };
 
     compaction_backlog_tracker(std::unique_ptr<impl> impl) : _impl(std::move(impl)) {}
-    compaction_backlog_tracker(compaction_backlog_tracker&&) = default;
+    compaction_backlog_tracker(compaction_backlog_tracker&&);
     compaction_backlog_tracker(const compaction_backlog_tracker&) = delete;
     ~compaction_backlog_tracker();
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1817,3 +1817,8 @@ compaction_backlog_manager::~compaction_backlog_manager() {
         tracker->_manager = nullptr;
     }
 }
+
+compaction_backlog_tracker& compaction_manager::get_backlog_tracker(compaction::table_state& t) {
+    // FIXME: once tracker is decoupled from strategy, it will live in compaction_manager's per group state.
+    return t.get_compaction_strategy().get_backlog_tracker();
+}

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1761,7 +1761,7 @@ void compaction_backlog_tracker::register_compacting_sstable(sstables::shared_ss
     }
 }
 
-void compaction_backlog_tracker::transfer_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges) {
+void compaction_backlog_tracker::copy_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges) const {
     for (auto&& w : _ongoing_writes) {
         new_bt.register_partially_written_sstable(w.first, *w.second);
     }
@@ -1771,8 +1771,6 @@ void compaction_backlog_tracker::transfer_ongoing_charges(compaction_backlog_tra
             new_bt.register_compacting_sstable(w.first, *w.second);
         }
     }
-    _ongoing_writes = {};
-    _ongoing_compactions = {};
 }
 
 void compaction_backlog_tracker::revert_charges(sstables::shared_sstable sst) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1785,6 +1785,19 @@ compaction_backlog_tracker::compaction_backlog_tracker(compaction_backlog_tracke
         , _manager(std::exchange(other._manager, nullptr)) {
 }
 
+compaction_backlog_tracker&
+compaction_backlog_tracker::operator=(compaction_backlog_tracker&& x) noexcept {
+    if (this != &x) {
+        if (auto manager = std::exchange(_manager, x._manager)) {
+            manager->remove_backlog_tracker(this);
+        }
+        _impl = std::move(x._impl);
+        _ongoing_writes = std::move(x._ongoing_writes);
+        _ongoing_compactions = std::move(x._ongoing_compactions);
+    }
+    return *this;
+}
+
 compaction_backlog_tracker::~compaction_backlog_tracker() {
     if (_manager) {
         _manager->remove_backlog_tracker(this);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1778,6 +1778,13 @@ void compaction_backlog_tracker::revert_charges(sstables::shared_sstable sst) {
     _ongoing_compactions.erase(sst);
 }
 
+compaction_backlog_tracker::compaction_backlog_tracker(compaction_backlog_tracker&& other)
+        : _impl(std::move(other._impl))
+        , _ongoing_writes(std::move(other._ongoing_writes))
+        , _ongoing_compactions(std::move(other._ongoing_compactions))
+        , _manager(std::exchange(other._manager, nullptr)) {
+}
+
 compaction_backlog_tracker::~compaction_backlog_tracker() {
     if (_manager) {
         _manager->remove_backlog_tracker(this);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -83,7 +83,9 @@ private:
         // Signaled whenever a compaction task completes.
         condition_variable compaction_done;
 
-        compaction_state() = default;
+        compaction_backlog_tracker backlog_tracker;
+
+        explicit compaction_state(table_state& t);
         compaction_state(compaction_state&&) = default;
         ~compaction_state();
 
@@ -524,6 +526,7 @@ public:
     void register_backlog_tracker(compaction_backlog_tracker& backlog_tracker) {
         _backlog_manager.register_backlog_tracker(backlog_tracker);
     }
+    void register_backlog_tracker(compaction::table_state& t, compaction_backlog_tracker new_backlog_tracker);
 
     compaction_backlog_tracker& get_backlog_tracker(compaction::table_state& t);
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -525,6 +525,8 @@ public:
         _backlog_manager.register_backlog_tracker(backlog_tracker);
     }
 
+    compaction_backlog_tracker& get_backlog_tracker(compaction::table_state& t);
+
     static sstables::compaction_data create_compaction_data();
 
     compaction::strategy_control& get_strategy_control() const noexcept;

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -106,7 +106,7 @@ public:
 
     sstable_set make_sstable_set(schema_ptr schema) const;
 
-    compaction_backlog_tracker& get_backlog_tracker();
+    compaction_backlog_tracker make_backlog_tracker();
 
     uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate);
 

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -22,8 +22,6 @@ class strategy_control;
 
 namespace sstables {
 
-compaction_backlog_tracker& get_unimplemented_backlog_tracker();
-
 class sstable_set_impl;
 class resharding_descriptor;
 

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -68,7 +68,7 @@ public:
     // droppable tombstone histogram and gc_before.
     bool worth_dropping_tombstones(const shared_sstable& sst, gc_clock::time_point compaction_time, const tombstone_gc_state& gc_state);
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() = 0;
 
     virtual uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate);
 

--- a/compaction/date_tiered_compaction_strategy.hh
+++ b/compaction/date_tiered_compaction_strategy.hh
@@ -259,7 +259,6 @@ namespace sstables {
 
 class date_tiered_compaction_strategy : public compaction_strategy_impl {
     date_tiered_manifest _manifest;
-    compaction_backlog_tracker _backlog_tracker;
 public:
     date_tiered_compaction_strategy(const std::map<sstring, sstring>& options);
     virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::vector<sstables::shared_sstable> candidates) override;
@@ -272,9 +271,7 @@ public:
         return compaction_strategy_type::date_tiered;
     }
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() override {
-        return _backlog_tracker;
-    }
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() override;
 };
 
 }

--- a/compaction/leveled_compaction_strategy.hh
+++ b/compaction/leveled_compaction_strategy.hh
@@ -35,7 +35,6 @@ class leveled_compaction_strategy : public compaction_strategy_impl {
     std::optional<std::vector<std::optional<dht::decorated_key>>> _last_compacted_keys;
     std::vector<int> _compaction_counter;
     size_tiered_compaction_strategy_options _stcs_options;
-    compaction_backlog_tracker _backlog_tracker;
     int32_t calculate_max_sstable_size_in_mb(std::optional<sstring> option_value) const;
 public:
     static unsigned ideal_level_for_input(const std::vector<sstables::shared_sstable>& input, uint64_t max_sstable_size);
@@ -64,9 +63,7 @@ public:
     }
     virtual std::unique_ptr<sstable_set_impl> make_sstable_set(schema_ptr schema) const override;
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() override {
-        return _backlog_tracker;
-    }
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() override;
 
     virtual compaction_descriptor get_reshaping_job(std::vector<shared_sstable> input, schema_ptr schema, const ::io_priority_class& iop, reshape_mode mode) override;
 };

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -82,7 +82,6 @@ public:
 
 class size_tiered_compaction_strategy : public compaction_strategy_impl {
     size_tiered_compaction_strategy_options _options;
-    compaction_backlog_tracker _backlog_tracker;
 
     // Return a list of pair of shared_sstable and its respective size.
     static std::vector<std::pair<sstables::shared_sstable, uint64_t>> create_sstable_and_length_pairs(const std::vector<sstables::shared_sstable>& sstables);
@@ -128,9 +127,7 @@ public:
     most_interesting_bucket(const std::vector<sstables::shared_sstable>& candidates, int min_threshold, int max_threshold,
         size_tiered_compaction_strategy_options options = {});
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() override {
-        return _backlog_tracker;
-    }
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() override;
 
     virtual compaction_descriptor get_reshaping_job(std::vector<shared_sstable> input, schema_ptr schema, const ::io_priority_class& iop, reshape_mode mode) override;
 

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -15,6 +15,7 @@
 #include "compaction_descriptor.hh"
 
 class reader_permit;
+class compaction_backlog_tracker;
 
 namespace sstables {
 class compaction_strategy;
@@ -43,6 +44,7 @@ public:
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
+    virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
 };
 
 }

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -73,7 +73,6 @@ class time_window_compaction_strategy : public compaction_strategy_impl {
     // Keep track of all recent active windows that still need to be compacted into a single SSTable
     std::unordered_set<timestamp_type> _recent_active_windows;
     size_tiered_compaction_strategy_options _stcs_options;
-    compaction_backlog_tracker _backlog_tracker;
 public:
     // The maximum amount of buckets we segregate data into when writing into sstables.
     // To prevent an explosion in the number of sstables we cap it.
@@ -156,9 +155,7 @@ public:
 
     virtual std::unique_ptr<sstable_set_impl> make_sstable_set(schema_ptr schema) const override;
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() override {
-        return _backlog_tracker;
-    }
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() override;
 
     virtual uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate) override;
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -53,6 +53,8 @@ private:
     lw_shared_ptr<sstables::sstable_set>
     do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, sstables::shared_sstable sstable,
                    enable_backlog_tracker backlog_tracker);
+    // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
+    void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
 public:
     compaction_group(table& t);
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -8,11 +8,11 @@
 
 #include "database_fwd.hh"
 #include "compaction/compaction_descriptor.hh"
+#include "compaction/compaction_backlog_manager.hh"
 #include "sstables/sstable_set.hh"
 
 #pragma once
 
-class compaction_backlog_tracker;
 namespace compaction {
 class table_state;
 }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -12,6 +12,7 @@
 
 #pragma once
 
+class compaction_backlog_tracker;
 namespace compaction {
 class table_state;
 }
@@ -83,6 +84,8 @@ public:
     lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
 
     const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept;
+
+    compaction_backlog_tracker& get_backlog_tracker();
 
     compaction::table_state& as_table_state() const noexcept;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -538,15 +538,6 @@ private:
     }
     void update_stats_for_new_sstable(uint64_t disk_space_used_by_sstable) noexcept;
     future<> do_add_sstable_and_update_cache(sstables::shared_sstable sst, sstables::offstrategy offstrategy);
-    // Adds new sstable to the set of sstables
-    // Doesn't update the cache. The cache must be synchronized in order for reads to see
-    // the writes contained in this sstable.
-    // Cache must be synchronized atomically with this, otherwise write atomicity may not be respected.
-    // Doesn't trigger compaction.
-    // Strong exception guarantees.
-    lw_shared_ptr<sstables::sstable_set>
-    do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, sstables::shared_sstable sstable,
-        enable_backlog_tracker backlog_tracker);
     // Helpers which add sstable on behalf of a compaction group and refreshes compound set.
     void add_sstable(compaction_group& cg, sstables::shared_sstable sstable);
     void add_maintenance_sstable(compaction_group& cg, sstables::shared_sstable sst);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -543,8 +543,6 @@ private:
     void add_maintenance_sstable(compaction_group& cg, sstables::shared_sstable sst);
     static void add_sstable_to_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable);
     static void remove_sstable_from_backlog_tracker(compaction_backlog_tracker& tracker, sstables::shared_sstable sstable);
-    // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
-    void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
     lw_shared_ptr<memtable> new_memtable();
     future<> try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtable> memt, sstable_write_permit&& permit);
     // Caller must keep m alive.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -395,8 +395,8 @@ inline void table::remove_sstable_from_backlog_tracker(compaction_backlog_tracke
     tracker.replace_sstables({std::move(sstable)}, {});
 }
 
-void table::backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables) {
-    auto& tracker = _compaction_strategy.get_backlog_tracker();
+void compaction_group::backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables) {
+    auto& tracker = get_backlog_tracker();
     tracker.replace_sstables(old_sstables, new_sstables);
 }
 
@@ -991,7 +991,7 @@ compaction_group::update_sstable_lists_on_off_strategy_completion(sstables::comp
             _cg.set_maintenance_sstables(std::move(_new_maintenance_list));
             _t.refresh_compound_sstable_set();
             // Input sstables aren't not removed from backlog tracker because they come from the maintenance set.
-            _t.backlog_tracker_adjust_charges({}, _new_main);
+            _cg.backlog_tracker_adjust_charges({}, _new_main);
         }
         static std::unique_ptr<row_cache::external_updater_impl> make(compaction_group& cg, table::sstable_list_builder::permit_t permit, const sstables_t& old_maintenance, const sstables_t& new_main) {
             return std::make_unique<sstable_lists_updater>(cg, std::move(permit), old_maintenance, new_main);
@@ -1066,7 +1066,7 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
         virtual void execute() override {
             _cg.set_main_sstables(std::move(_new_sstables));
             _t.refresh_compound_sstable_set();
-            _t.backlog_tracker_adjust_charges(_desc.old_sstables, _desc.new_sstables);
+            _cg.backlog_tracker_adjust_charges(_desc.old_sstables, _desc.new_sstables);
         }
         static std::unique_ptr<row_cache::external_updater_impl> make(compaction_group& cg, table::sstable_list_builder::permit_t permit, sstables::compaction_completion_desc& d) {
             return std::make_unique<sstable_list_updater>(cg, std::move(permit), d);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1158,20 +1158,37 @@ void table::set_compaction_strategy(sstables::compaction_strategy_type strategy)
     auto new_cs = make_compaction_strategy(strategy, _schema->compaction_strategy_options());
 
     // FIXME: decouple backlog_tracker from compaction_strategy, so each group can have its own tracker.
-    _compaction_manager.register_backlog_tracker(new_cs.get_backlog_tracker());
-    auto move_read_charges = new_cs.type() == _compaction_strategy.type();
-    _compaction_strategy.get_backlog_tracker().copy_ongoing_charges(new_cs.get_backlog_tracker(), move_read_charges);
 
-    compaction_group& cg = *_compaction_group;
-    auto new_sstables = make_lw_shared<sstables::sstable_set>(new_cs.make_sstable_set(_schema));
-    cg.main_sstables()->for_each_sstable([&] (const sstables::shared_sstable& s) {
-        add_sstable_to_backlog_tracker(new_cs.get_backlog_tracker(), s);
-        new_sstables->insert(s);
-    });
+    struct compaction_group_sstable_set_updater {
+        table& t;
+        compaction_group& cg;
+        lw_shared_ptr<sstables::sstable_set> new_sstables;
+
+        compaction_group_sstable_set_updater(table& t, compaction_group& cg) : t(t), cg(cg) {}
+
+        void prepare(sstables::compaction_strategy& new_cs, compaction_backlog_tracker& new_bt) {
+            auto move_read_charges = new_cs.type() == t._compaction_strategy.type();
+            cg.get_backlog_tracker().copy_ongoing_charges(new_bt, move_read_charges);
+
+            new_sstables = make_lw_shared<sstables::sstable_set>(new_cs.make_sstable_set(t._schema));
+            cg.main_sstables()->for_each_sstable([this, &new_bt] (const sstables::shared_sstable& s) {
+                add_sstable_to_backlog_tracker(new_bt, s);
+                new_sstables->insert(s);
+            });
+        }
+
+        void execute(compaction_backlog_tracker& new_bt) noexcept {
+            t._compaction_manager.register_backlog_tracker(new_bt);
+            cg.set_main_sstables(std::move(new_sstables));
+        }
+    };
+    compaction_group_sstable_set_updater cg_set_updater(*this, *_compaction_group);
+
+    cg_set_updater.prepare(new_cs, new_cs.get_backlog_tracker());
 
     // now exception safe:
     _compaction_strategy = std::move(new_cs);
-    cg.set_main_sstables(std::move(new_sstables));
+    cg_set_updater.execute(_compaction_strategy.get_backlog_tracker());
     refresh_compound_sstable_set();
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1160,7 +1160,7 @@ void table::set_compaction_strategy(sstables::compaction_strategy_type strategy)
     // FIXME: decouple backlog_tracker from compaction_strategy, so each group can have its own tracker.
     _compaction_manager.register_backlog_tracker(new_cs.get_backlog_tracker());
     auto move_read_charges = new_cs.type() == _compaction_strategy.type();
-    _compaction_strategy.get_backlog_tracker().transfer_ongoing_charges(new_cs.get_backlog_tracker(), move_read_charges);
+    _compaction_strategy.get_backlog_tracker().copy_ongoing_charges(new_cs.get_backlog_tracker(), move_read_charges);
 
     compaction_group& cg = *_compaction_group;
     auto new_sstables = make_lw_shared<sstables::sstable_set>(new_cs.make_sstable_set(_schema));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2558,7 +2558,14 @@ public:
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _t.get_compaction_manager().get_tombstone_gc_state();
     }
+    compaction_backlog_tracker& get_backlog_tracker() override {
+        return _t._compaction_manager.get_backlog_tracker(*this);
+    }
 };
+
+compaction_backlog_tracker& compaction_group::get_backlog_tracker() {
+    return as_table_state().get_backlog_tracker();
+}
 
 compaction::table_state& compaction_group::as_table_state() const noexcept {
     return *_table_state;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2372,7 +2372,7 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
             // That being said, we'll only add this SSTable to tracker if its origin is other than repair.
             // Otherwise, we can count on off-strategy completion to add it when updating lists.
             if (sst->get_origin() != sstables::repair_origin) {
-                add_sstable_to_backlog_tracker(_compaction_strategy.get_backlog_tracker(), sst);
+                add_sstable_to_backlog_tracker(compaction_group_for_sstable(sst).get_backlog_tracker(), sst);
             }
         } catch (...) {
             tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), std::current_exception());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1681,9 +1681,9 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
     })).then([this, p]() mutable {
         rebuild_statistics();
 
-        return parallel_for_each(p->remove, [this](pruner::removed_sstable& r) {
+        return parallel_for_each(p->remove, [this, p] (pruner::removed_sstable& r) {
             if (r.enable_backlog_tracker) {
-                remove_sstable_from_backlog_tracker(_compaction_strategy.get_backlog_tracker(), r.sst);
+                remove_sstable_from_backlog_tracker(p->cg.get_backlog_tracker(), r.sst);
             }
             return sstables::delete_atomically({r.sst});
         }).then([p] {

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
@@ -55,7 +55,7 @@ compaction_strategy_type sstable_run_based_compaction_strategy_for_tests::type()
     throw std::runtime_error("unimplemented");
 }
 
-compaction_backlog_tracker& sstable_run_based_compaction_strategy_for_tests::get_backlog_tracker() {
+std::unique_ptr<compaction_backlog_tracker::impl> sstable_run_based_compaction_strategy_for_tests::make_backlog_tracker() {
     throw std::runtime_error("unimplemented");
 }
 

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
@@ -28,7 +28,7 @@ public:
 
     virtual compaction_strategy_type type() const override;
 
-    virtual compaction_backlog_tracker& get_backlog_tracker() override;
+    virtual std::unique_ptr<compaction_backlog_tracker::impl> make_backlog_tracker() override;
 };
 
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -117,6 +117,9 @@ public:
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _tombstone_gc_state;
     }
+    compaction_backlog_tracker& get_backlog_tracker() override {
+        return get_compaction_strategy().get_backlog_tracker();
+    }
 };
 
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -57,6 +57,7 @@ class table_for_tests::table_state : public compaction::table_state {
     sstables::sstables_manager& _sstables_manager;
     std::vector<sstables::shared_sstable> _compacted_undeleted;
     tombstone_gc_state _tombstone_gc_state;
+    mutable compaction_backlog_tracker _backlog_tracker;
 private:
     replica::table& table() const noexcept {
         return *_data.cf;
@@ -66,6 +67,7 @@ public:
             : _data(data)
             , _sstables_manager(sstables_manager)
             , _tombstone_gc_state(nullptr)
+            , _backlog_tracker(get_compaction_strategy().make_backlog_tracker())
     {
     }
     const schema_ptr& schema() const noexcept override {
@@ -118,7 +120,7 @@ public:
         return _tombstone_gc_state;
     }
     compaction_backlog_tracker& get_backlog_tracker() override {
-        return get_compaction_strategy().get_backlog_tracker();
+        return _backlog_tracker;
     }
 };
 


### PR DESCRIPTION
Today, compaction_backlog_tracker is managed in each compaction_strategy
implementation. So every compaction strategy is managing its own
tracker and providing a reference to it through get_backlog_tracker().

But this prevents each group from having its own tracker, because
there's only a single compaction_strategy instance per table.
To remove this limitation, compaction_strategy impl will no longer
manage trackers but will instead provide an interface for trackers
to be created, such that each compaction_group will be allowed to
create its own tracker and manage it by itself.

Now table's backlog will be the sum of all compaction_group backlogs.
The normalization factor is applied on the sum, so we don't have
to adjust each individual backlog to any factor.