### PR TITLE
service/raft: simplify `raft_address_map`

### DIFF
--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -135,10 +135,6 @@ class raft_address_map {
     // so the list must still exist.
     mutable map_type _map;
 
-    expiring_list_iterator to_list_iterator(timestamped_entry& e) const {
-        return _expiring_list.iterator_to(*e._lru_entry);
-    }
-
     // Timer that executes the cleanup procedure to erase expired
     // entries from the mappings container.
     //
@@ -192,7 +188,7 @@ public:
         auto& entry = it->second;
         if (entry.expiring()) {
             // Touch the entry to update it's access timestamp and move it to the front of LRU list
-            to_list_iterator(entry)->touch();
+            entry._lru_entry->touch();
         }
         return entry._addr;
     }
@@ -236,7 +232,7 @@ public:
                 entry._lru_entry = nullptr;
             } else {
                 // Update timestamp of expiring entry
-                to_list_iterator(entry)->touch(); // Re-insert in the front of _expiring_list
+                entry._lru_entry->touch(); // Re-insert in the front of _expiring_list
             }
         }
         // No action needed when a regular entry is updated
@@ -251,7 +247,7 @@ public:
         auto& entry = it->second;
         if (entry.expiring()) {
             // Update timestamp of expiring entry
-            to_list_iterator(entry)->touch(); // Re-insert in the front of _expiring_list
+            entry._lru_entry->touch(); // Re-insert in the front of _expiring_list
         } else {
             add_expiring_entry(it->first, entry);
         }


### PR DESCRIPTION
The `raft_address_map` code was "clever": it used two intrusive data structures and did a lot of manual lifetime management; raw pointer manipulation, manual deletion of objects... It wasn't clear who owns which object, who is responsible for deleting what. And there was a lot of code.

In this PR we replace one of the intrusive data structures with a good old `std::unordered_map` and make ownership clear by replacing the raw pointers with `std::unique_ptr`. Furthermore, some invariants which were not clear and enforced in runtime are now encoded in the type system.

The code also became shorter: we reduced its length from ~360 LOC to ~260 LOC.