### PR TITLE
test: work around modern pytest rejecting site-packages

### DIFF
--- a/test.py
+++ b/test.py
@@ -613,7 +613,7 @@ class CQLApprovalTest(Test):
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         # Path to cql_repl driver, in the given build mode
-        self.path = "pytest"
+        self.path = "./test/pytest"
         self.cql = suite.suite_path / (self.shortname + ".cql")
         self.result = suite.suite_path / (self.shortname + ".result")
         self.tmpfile = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".reject")
@@ -769,7 +769,7 @@ class PythonTest(Test):
 
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
-        self.path = "pytest"
+        self.path = "./test/pytest"
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None

--- a/test/pytest
+++ b/test/pytest
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# Modern pytest excludes site-packages, so it doesn't see scylla-driver.
+# This script is a workaround.
+
+exec python -m pytest "$@"
+


### PR DESCRIPTION
Modern (as of Fedora 37) pytest has the "-sP" flags in the Python command line, as found in /usr/bin/pytest. This means it will reject the site-packages directory, where we install the Scylla Python driver. This causes all the tests to fail.

Work around it by supplying an alternative pytest script that does not have this change.