### PR TITLE
build: mark abseil as a system header

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1762,7 +1762,7 @@ if any(filter(thrift_version.startswith, thrift_boost_versions)):
 for pkg in pkgs:
     args.user_cflags += ' ' + pkg_config(pkg, '--cflags')
     libs += ' ' + pkg_config(pkg, '--libs')
-args.user_cflags += ' -Iabseil'
+args.user_cflags += ' -isystem abseil'
 user_cflags = args.user_cflags + ' -fvisibility=hidden'
 user_ldflags = args.user_ldflags + ' -fvisibility=hidden'
 if args.staticcxx:


### PR DESCRIPTION
Abseil is not under our control, so if a header generates a warning, we can do nothing about it. So far this wasn't a problem, but under clang 15 it spews a harmless deprecation warning. Silence the warning by treating the header as a system header (which it is, for us).