### PR TITLE
build: support fmt 9 ostream formatter deprecation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -653,6 +653,7 @@ if args.list_artifacts:
 
 defines = ['XXH_PRIVATE_API',
            'SEASTAR_TESTING_MAIN',
+           'FMT_DEPRECATED_OSTREAM',
 ]
 
 scylla_raft_core = [


### PR DESCRIPTION
fmt 9 deprecates automatic fallback to std::ostream formatting. We should migrate, but in order to do so incrementally, first enable the deprecated fallback so the code continues to compile.