### PR TITLE
Add rust/Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ compile_commands.json
 .ccls-cache/
 .mypy_cache
 .envrc
+rust/Cargo.lock


### PR DESCRIPTION
The file appears after build

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>