### PR TITLE
doc: add the information about AArch64 support to Requirements

### DIFF
--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -91,7 +91,7 @@ Time-window Compaction Strategy (TWCS)  50%          70%
 Incremental Compaction Strategy (ICS)   70%          80%
 ======================================  ===========  ============
 
-Use the default ICS (DBScylla Enterprise) or STCS  (ScyllaDB Open Source) unless you'll have a clear understanding that another strategy is better for your use case. More on :doc:`choosing a Compaction Strategy </architecture/compaction/compaction-strategies>`.
+Use the default ICS (ScyllaDB Enterprise) or STCS  (ScyllaDB Open Source) unless you'll have a clear understanding that another strategy is better for your use case. More on :doc:`choosing a Compaction Strategy </architecture/compaction/compaction-strategies>`.
 In order to maintain a high level of service availability, keep 50% to 20% free disk space at all times!
 
 .. _system-requirements-network:

--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -18,19 +18,19 @@ Hardware Requirements
 
 It’s recommended to have a balanced setup. If there are only 4-8 :term:`Logical Cores <Logical Core (lcore)>`, large disks or 10Gbps networking may not be needed.
 This works in the opposite direction as well.
-Scylla can be used in many types of installation environments.
+ScyllaDB can be used in many types of installation environments.
 
-To see which system would best suit your workload requirements, use the `Scylla Sizing Calculator <https://price-calc.gh.scylladb.com/>`_ to customize Scylla for your usage.
+To see which system would best suit your workload requirements, use the `ScyllaDB Sizing Calculator <https://price-calc.gh.scylladb.com/>`_ to customize ScyllaDB for your usage.
 
 
 
 Core Requirements 
 -----------------
-Scylla tries to maximize the resource usage of all system components. The shard-per-core approach allows linear scale-up with the number of cores. As you have more cores, it makes sense to balance the other resources, from memory to network.
+ScyllaDB tries to maximize the resource usage of all system components. The shard-per-core approach allows linear scale-up with the number of cores. As you have more cores, it makes sense to balance the other resources, from memory to network.
 
 CPU
 ^^^
-Scylla requires modern Intel CPUs that support the SSE4.2 instruction set and will not boot without it.
+ScyllaDB requires modern Intel CPUs that support the SSE4.2 instruction set and will not boot without it.
 
 The following CPUs are supported by Scylla:
 
@@ -40,17 +40,17 @@ The following CPUs are supported by Scylla:
 * AMD standard: Bulldozer or later (2011)
 
 
-In terms of the number of cores, any number will work since Scylla scales up with the number of cores. 
+In terms of the number of cores, any number will work since ScyllaDB scales up with the number of cores. 
 A practical approach is to use a large number of cores as long as the hardware price remains reasonable. 
 Between 20-60 logical cores (including hyperthreading) is a recommended number. However, any number will fit. 
 When using virtual machines, containers, or the public cloud, remember that each virtual CPU is mapped to a single logical core, or thread. 
-Allow Scylla to run independently without any additional CPU intensive tasks on the same server/cores as Scylla.
+Allow ScyllaDB to run independently without any additional CPU intensive tasks on the same server/cores as Scylla.
 
 .. _system-requirements-memory:
 
 Memory Requirements
 -------------------
-The more memory available, the better Scylla performs, as Scylla uses all of the available memory for caching. The wider the rows are in the schema, the more memory will be required. 64 GB-256 GB is the recommended range for a medium to high workload. Memory requirements are calculated based on the number of :abbr:`lcores (logical cores)` you are using in your system. 
+The more memory available, the better ScyllaDB performs, as ScyllaDB uses all of the available memory for caching. The wider the rows are in the schema, the more memory will be required. 64 GB-256 GB is the recommended range for a medium to high workload. Memory requirements are calculated based on the number of :abbr:`lcores (logical cores)` you are using in your system. 
 
 * Recommended size: 16 GB or 2GB per lcore (whichever is higher)
 * Maximum: 1 TiB per lcore, up to 256 lcores
@@ -66,7 +66,7 @@ Disk Requirements
 
 SSD
 ^^^
-We highly recommend SSD and local disks. Scylla is built for a large volume of data and large storage per node.
+We highly recommend SSD and local disks. ScyllaDB is built for a large volume of data and large storage per node.
 You can use up to 100:1 Disk/RAM ratio, with 30:1 Disk/RAM ratio as a good rule of thumb; for example, 30 TB of storage requires 1 TB of RAM.
 We recommend a RAID-0 setup and a replication factor of 3 within the local datacenter (RF=3) when there are multiple drives.  
 
@@ -76,7 +76,7 @@ HDDs are supported but may become a bottleneck. Some workloads may work with HDD
 
 Disk Space
 ^^^^^^^^^^
-Scylla is flushing memtables to SSTable data files for persistent storage. SSTables are periodically compacted to improve performance by merging and rewriting data and discarding the old one. Depending on compaction strategy, disk space utilization temporarily increases during compaction. For this reason, you should leave an adequate amount of free disk space available on a node.
+ScyllaDB is flushing memtables to SSTable data files for persistent storage. SSTables are periodically compacted to improve performance by merging and rewriting data and discarding the old one. Depending on compaction strategy, disk space utilization temporarily increases during compaction. For this reason, you should leave an adequate amount of free disk space available on a node.
 Use the following table as a guidelines for the minimum disk space requirements based on the compaction strategy:
 
 ======================================  ===========  ============  
@@ -91,7 +91,7 @@ Time-window Compaction Strategy (TWCS)  50%          70%
 Incremental Compaction Strategy (ICS)   70%          80%
 ======================================  ===========  ============
 
-Use the default ICS (Scylla Enterprise) or STCS  (Scylla Open Source) unless you'll have a clear understanding that another strategy is better for your use case. More on :doc:`choosing a Compaction Strategy </architecture/compaction/compaction-strategies>`.
+Use the default ICS (DBScylla Enterprise) or STCS  (ScyllaDB Open Source) unless you'll have a clear understanding that another strategy is better for your use case. More on :doc:`choosing a Compaction Strategy </architecture/compaction/compaction-strategies>`.
 In order to maintain a high level of service availability, keep 50% to 20% free disk space at all times!
 
 .. _system-requirements-network:
@@ -99,7 +99,7 @@ In order to maintain a high level of service availability, keep 50% to 20% free 
 Network Requirements
 ====================
 
-A network speed of 10 Gbps or more is recommended, especially for large nodes. To tune the interrupts and their queues, run the Scylla setup scripts.
+A network speed of 10 Gbps or more is recommended, especially for large nodes. To tune the interrupts and their queues, run the ScyllaDB setup scripts.
 
 
 Cloud Instance Recommendations
@@ -142,13 +142,13 @@ i3.metal New in version 2.3  72 :sup:`*`  512           8 x 1.9 NVMe SSD
 
 Source: `Amazon EC2 I3 Instances <https://aws.amazon.com/ec2/instance-types/i3/>`_
 
-More on using Scylla with `i3.metal vs i3.16xlarge <https://www.scylladb.com/2018/06/21/impact-virtualization-database/>`_ 
+More on using ScyllaDB with `i3.metal vs i3.16xlarge <https://www.scylladb.com/2018/06/21/impact-virtualization-database/>`_ 
 
 i3en instances
 ^^^^^^^^^^^^^^
 i3en instances have up to 4x the networking bandwidth of i3 instances, enabling up to 100 Gbps of sustained network bandwidth. 
 
-i3en support is available for Scylla Enterprise 2019.1.1 and higher and Scylla Open Source 3.1 and higher. 
+i3en support is available for ScyllaDB Enterprise 2019.1.1 and higher and ScyllaDB Open Source 3.1 and higher. 
 
 
 ===========================  ===========  ============  =====================
@@ -222,7 +222,7 @@ Google Compute Engine (GCE)
 -----------------------------------
 
 Pick a zone where Haswell CPUs are found. Local SSD performance offers, according to Google, less than 1 ms of latency and up to 680,000 read IOPS and 360,000 write IOPS.
-Image with NVMe disk interface is recommended, CentOS 7 for Scylla Enterprise 2020.1 and older, and Ubuntu 20 for 2021.1 and later.  
+Image with NVMe disk interface is recommended, CentOS 7 for ScyllaDB Enterprise 2020.1 and older, and Ubuntu 20 for 2021.1 and later.  
 (`More info <https://cloud.google.com/compute/docs/disks/local-ssd>`_)
 
 Recommended instances types are `n1-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines>`_ and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines>`_

--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -8,7 +8,7 @@ Supported Platforms
 ===================
 ScyllaDB runs on 64-bit Linux. The x86_64 and AArch64 architectures are supported (AArch64 support includes AWS EC2 Graviton).
 
-See OS :doc:`Support by Platform and Version <</getting-started/os-support>` for information about 
+See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about 
 supported operating systems, distros, and versions.
 
 .. _system-requirements-hardware:

--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -6,8 +6,10 @@ System Requirements
 
 Supported Platforms
 ===================
+ScyllaDB runs on 64-bit Linux. The x86_64 and AArch64 architectures are supported (AArch64 support includes AWS EC2 Graviton).
 
-Scylla runs on 64-bit Linux. Here, you can find which :doc:`operating systems, distros, and versions </getting-started/os-support>` are supported.
+See OS :doc:`Support by Platform and Version <</getting-started/os-support>` for information about 
+supported operating systems, distros, and versions.
 
 .. _system-requirements-hardware:
 


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-doc-issues/issues/864

This PR:
- updates the introduction to add information about AArch64 and rewrite the content.
- replaces "Scylla" with "ScyllaDB".