### PR TITLE
Improve verbosity of gossiper::send_gossip()

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -551,11 +551,11 @@ future<> gossiper::send_gossip(gossip_digest_syn message, std::set<inet_address>
     inet_address to = __live_endpoints[index];
     auto id = get_msg_addr(to);
     logger.trace("Sending a GossipDigestSyn to {} ...", id);
-    return _messaging.send_gossip_digest_syn(id, std::move(message)).handle_exception([id, kind = std::move(kind)] (auto ep) {
+    return _messaging.send_gossip_digest_syn(id, std::move(message)).handle_exception([this, id, kind = std::move(kind)] (auto ep) {
         // It is normal to reach here because it is normal that a node
         // tries to send a SYN message to a peer node which is down before
         // failure_detector thinks that peer node is down.
-        logger.trace("Fail to send GossipDigestSyn to {} {}: {}", kind, id, ep);
+        logger.log(log_level::warn, _send_warning_rl, "Fail to send GossipDigestSyn to {} {}: {}", kind, id, ep);
     });
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -917,9 +917,7 @@ void gossiper::run() {
                     logger.debug("Talk to live nodes: {}", live_nodes);
                     for (auto& ep: live_nodes) {
                         // Do it in the background.
-                        (void)do_gossip_to_live_member(message, ep).handle_exception([] (auto ep) {
-                            logger.trace("Failed to do_gossip_to_live_member: {}", ep);
-                        });
+                        (void)do_gossip_to_live_member(message, ep);
                     }
                 } else {
                     logger.debug("No one to talk with");
@@ -927,9 +925,7 @@ void gossiper::run() {
 
                 /* Gossip to some unreachable member with some probability to check if he is back up */
                 // Do it in the background.
-                (void)do_gossip_to_unreachable_member(message).handle_exception([] (auto ep) {
-                    logger.trace("Faill to do_gossip_to_unreachable_member: {}", ep);
-                });
+                (void)do_gossip_to_unreachable_member(message);
 
                 do_status_check().get();
             }

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -369,7 +369,7 @@ private:
      * @param epSet   a set of endpoint from which a random endpoint is chosen.
      * @return true if the chosen endpoint is also a seed.
      */
-    future<> send_gossip(gossip_digest_syn message, std::set<inet_address> epset);
+    future<> send_gossip(gossip_digest_syn message, std::set<inet_address> epset, sstring kind);
 
     /* Sends a Gossip message to a live member */
     future<> do_gossip_to_live_member(gossip_digest_syn message, inet_address ep);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -226,6 +226,7 @@ private:
 
     std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
     utils::chunked_vector<inet_address> _shadow_live_endpoints;
+    logger::rate_limit _send_warning_rl = logger::rate_limit(std::chrono::seconds(30));
 
     void run();
     // Replicates given endpoint_state to all other shards.


### PR DESCRIPTION
When gossiper fails to send heartbeats to peers it tries to .trace() several error messages. Some of them are in fact never printed, because .handle_exception()s don't stack-up. Those messages that have chances to get logged don't tell if the pinged node was considered to be live or unreachable. And the worse, trace()ing gossiper liveness probes errors is not very useful -- if an error occurs it's good to know what it is, rather than just observing peers being marked as unreachable/down.

This set improves all three.

refs: #11609