### PR TITLE
Improve repair shutdown sequence

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1650,10 +1650,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("serving");
             // Register at_exit last, so that storage_service::drain_on_shutdown will be called first
 
-            auto stop_repair = defer_verbose_shutdown("repair", [&repair] {
-                repair.invoke_on_all(&repair_service::shutdown).get();
-            });
-
             auto drain_sl_controller = defer_verbose_shutdown("service level controller update loop", [&lifecycle_notifier] {
                 sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {
                     return lifecycle_notifier.local().unregister_subscriber(&controller);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -445,16 +445,6 @@ void tracker::abort_all_repairs() {
     rlogger.info0("Aborted {} repair job(s), aborted={}", _aborted_pending_repairs.size(), _aborted_pending_repairs);
 }
 
-void tracker::abort_repair_node_ops(utils::UUID ops_uuid) {
-    for (auto& x : _repairs) {
-        auto& ri = x.second;
-        if (ri->ops_uuid() && ri->ops_uuid().value() == ops_uuid) {
-            rlogger.info0("Aborted repair jobs for ops_uuid={}", ops_uuid);
-            ri->abort();
-        }
-    }
-}
-
 float tracker::report_progress(streaming::stream_reason reason) {
     uint64_t nr_ranges_finished = 0;
     uint64_t nr_ranges_total = 0;
@@ -1718,12 +1708,6 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
                 table->trigger_offstrategy_compaction();
             }
         });
-    });
-}
-
-future<> repair_service::abort_repair_node_ops(utils::UUID ops_uuid) {
-    return container().invoke_on_all([ops_uuid] (repair_service& rs) {
-        rs.repair_tracker().abort_repair_node_ops(ops_uuid);
     });
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -383,6 +383,7 @@ repair_uniq_id tracker::next_repair_command() {
 }
 
 future<> tracker::shutdown() {
+    abort_all_repairs();
     _shutdown.store(true, std::memory_order_relaxed);
     return _gate.close();
 }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -254,7 +254,6 @@ public:
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
     float report_progress(streaming::stream_reason reason);
-    void abort_repair_node_ops(utils::UUID ops_uuid);
     bool is_aborted(const utils::UUID& uuid);
 };
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -198,8 +198,6 @@ public:
     // Abort all the repairs
     future<> abort_all();
 
-    future<> abort_repair_node_ops(utils::UUID ops_uuid);
-
     std::unordered_map<node_repair_meta_id, repair_meta_ptr>& repair_meta_map() noexcept {
         return _repair_metas;
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3720,7 +3720,6 @@ future<> storage_service::node_ops_abort(utils::UUID ops_uuid) {
         if (as && !as->abort_requested()) {
             as->request_abort();
         }
-        co_await _repair.local().abort_repair_node_ops(ops_uuid);
         _node_ops.erase(it);
     }
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2718,6 +2718,8 @@ future<> storage_service::do_drain() {
 
     co_await _db.invoke_on_all(&replica::database::drain);
     co_await _sys_ks.invoke_on_all(&db::system_keyspace::shutdown);
+
+    co_await _repair.invoke_on_all(&repair_service::shutdown);
 }
 
 future<> storage_service::rebuild(sstring source_dc) {


### PR DESCRIPTION
This mainly fixes misordered repair vs storage-service stop. The storage_service::stop() calls repair_service::abort_repair_node_ops() but at that time the sharded<repair_service> is already stopped and call .local() on it just crashes (#10284). After the fix it becomes possible to remove some dead code from repair. Also, mainly "while at it", the repair_service::shutdown() is moved from main deferred action into general do_drain() call.