### PR TITLE
test: db: Add test for row merging involving many versions

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1877,6 +1877,26 @@ SEASTAR_TEST_CASE(test_commutativity_and_associativity) {
     return make_ready_future<>();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_row_merging) {
+    simple_schema table;
+    auto&& s = *table.schema();
+
+    row r1;
+    table.set_cell(r1, "v1");
+
+    row r2;
+    table.set_cell(r2, "v2");
+
+    row r3;
+    table.set_cell(r3, "v3");
+
+    r2.apply_monotonically(s, column_kind::regular_column, std::move(r1));
+
+    auto r3_backup = row(s, column_kind::regular_column, r3);
+    r1.apply_monotonically(s, column_kind::regular_column, std::move(r3));
+    BOOST_REQUIRE(r1.equal(column_kind::regular_column, s, r3_backup, s));
+}
+
 SEASTAR_TEST_CASE(test_continuity_merging) {
     return seastar::async([] {
         simple_schema table;

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -138,6 +138,15 @@ public:
         return t;
     }
 
+    api::timestamp_type set_cell(row& r, const sstring& v, api::timestamp_type t = api::missing_timestamp) {
+        if (t == api::missing_timestamp) {
+            t = new_timestamp();
+        }
+        const column_definition& v_def = get_v_def(*_s);
+        r.apply_monotonically(v_def, atomic_cell::make_live(*v_def.type, t, serialized(v)));
+        return t;
+    }
+
     std::pair<sstring, api::timestamp_type> get_value(const schema& s, const clustering_row& row) {
         const column_definition& v_def = get_v_def(s);
         auto cell = row.cells().find_cell(v_def.id);


### PR DESCRIPTION
The test verifies that a row which participated in earlier merge, and its cells lost on the timestamp check, behaves exactly like an empty row and can accept any mutation.

This wasn't the case in versions prior to f006acc.