### PR TITLE
replica: Pick new generation for SSTables being moved from staging dir

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2359,7 +2359,7 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
             // completed first.
             // The _sstable_deletion_sem prevents list update on off-strategy completion and move_sstables_from_staging()
             // from stepping on each other's toe.
-            co_await sst->move_to_new_dir(dir(), sst->generation(), false);
+            co_await sst->move_to_new_dir(dir(), calculate_generation_for_new_table(), false);
             // If view building finished faster, SSTable with repair origin still exists.
             // It can also happen the SSTable is not going through reshape, so it doesn't have a repair origin.
             // That being said, we'll only add this SSTable to tracker if its origin is other than repair.


### PR DESCRIPTION
When moving a SSTable from staging to base dir, we reused the generation under the assumption that no SSTable in base dir uses that same generation. But that's not always true.

When reshaping staging dir, reshape compaction can pick a generation taken by a SSTable in base dir. That's because staging dir is populated first and it doesn't have awareness of generations in base dir yet.

When that happens, view building will fail to move SSTable in staging which shares the same generation as another in base dir.

We could have played with order of population, populating base dir first than staging dir, but the fragility wouldn't be gone. Not future proof at all.
We can easily make this safe by picking a new generation for the SSTable being moved from staging, making sure no clash will ever happen.

Fixes #11789.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>