### PR TITLE
Replicate `raft_address_map` non-expiring entries to other shards

### DIFF
--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -146,9 +146,11 @@ class raft_address_map : public peering_sharded_service<raft_address_map<Clock>>
         while (list_it != _expiring_list.rend() && list_it->expired(_expiry_period)) {
             // Remove from both LRU list and base storage
             auto map_it = _map.find(list_it->entry_id());
-            if (map_it != _map.end()) {
-                _map.erase(map_it);
+            if (map_it == _map.end()) {
+                on_internal_error(rslog, format(
+                    "raft_address_map::drop_expired_entries: missing entry with id {}", list_it->entry_id()));
             }
+            _map.erase(map_it);
             // Point at the oldest entry again
             list_it = _expiring_list.rbegin();
         }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -13,6 +13,7 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/util/log.hh>
 
 #include <boost/intrusive/list.hpp>
@@ -32,7 +33,7 @@ static constexpr raft_ticker_type::duration raft_tick_interval = std::chrono::mi
 // This class provides an abstraction of expirable server address mappings
 // used by the raft rpc module to store connection info for servers in a raft group.
 template <typename Clock = seastar::lowres_clock>
-class raft_address_map {
+class raft_address_map : public peering_sharded_service<raft_address_map<Clock>> {
 
     // Expiring mappings stay in the cache for 1 hour (if not accessed during this time period)
     static constexpr std::chrono::hours default_expiry_period{1};

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -70,10 +70,11 @@ public:
     }
 };
 
-raft_group_registry::raft_group_registry(bool is_enabled, netw::messaging_service& ms,
-        gms::gossiper& gossiper, direct_failure_detector::failure_detector& fd)
+raft_group_registry::raft_group_registry(bool is_enabled, raft_address_map<>& address_map,
+        netw::messaging_service& ms, gms::gossiper& gossiper, direct_failure_detector::failure_detector& fd)
     : _is_enabled(is_enabled)
     , _ms(ms)
+    , _srv_address_mappings{address_map}
     , _direct_fd(fd)
     , _direct_fd_proxy(make_shared<direct_fd_proxy>(gossiper.get_direct_fd_pinger(), _srv_address_mappings))
 {

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -57,7 +57,7 @@ private:
     // Currently ticking every 100ms.
     std::unordered_map<raft::group_id, raft_server_for_group> _servers;
     // inet_address:es for remote raft servers known to us
-    raft_address_map<> _srv_address_mappings;
+    raft_address_map<>& _srv_address_mappings;
 
     direct_failure_detector::failure_detector& _direct_fd;
     // Listens to notifications from direct failure detector.
@@ -78,7 +78,8 @@ private:
 
 public:
     // `is_enabled` must be `true` iff the local RAFT feature is enabled.
-    raft_group_registry(bool is_enabled, netw::messaging_service& ms, gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
+    raft_group_registry(bool is_enabled, raft_address_map<>&,
+            netw::messaging_service& ms, gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
     ~raft_group_registry();
 
     // Called manually at start

--- a/test/raft/raft_address_map_test.cc
+++ b/test/raft/raft_address_map_test.cc
@@ -16,13 +16,29 @@
 #include "gms/inet_address.hh"
 #include "utils/UUID.hh"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/manual_clock.hh>
+#include <seastar/util/later.hh>
 #include <seastar/util/defer.hh>
 
 using namespace raft;
 using namespace service;
 using namespace std::chrono_literals;
 using namespace seastar::testing;
+
+// Can be used to wait for delivery of messages that were sent to other shards.
+future<> ping_shards() {
+    if (smp::count == 1) {
+        co_return co_await seastar::yield();
+    }
+
+    // Submit an empty message to other shards 100 times to account for task reordering in debug mode.
+    for (int i = 0; i < 100; ++i) {
+        co_await parallel_for_each(boost::irange(0u, smp::count), [] (shard_id s) {
+            return smp::submit_to(s, [](){});
+        });
+    }
+}
 
 SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
     server_id id1{utils::UUID(0, 1)};
@@ -152,5 +168,89 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         m.set(id1, addr1, false);
         manual_clock::advance(expiration_time);
         BOOST_CHECK(!!m.find(id1) && *m.find(id1) == addr1);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_raft_address_map_replication) {
+    if (smp::count < 2) {
+        std::cerr << "Cannot run test " << get_name() << " with smp::count < 2" << std::endl;
+        return;
+    }
+
+    static const server_id id1{utils::UUID(0, 1)};
+    static const server_id id2{utils::UUID(0, 2)};
+    static const gms::inet_address addr1("127.0.0.1");
+    static const gms::inet_address addr2("127.0.0.2");
+    // Expiring entries stay in the cache for 1 hour, so take a bit larger value
+    // in order to trigger cleanup
+    static const auto expiration_time = 1h + 1s;
+
+    using seastar::manual_clock;
+
+    {
+        sharded<raft_address_map<manual_clock>> m_svc;
+        m_svc.start().get();
+        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto& m = m_svc.local();
+
+        // Replicate non-expiring entry, ensure it doesn't expire on the other shard
+        m.set(id1, addr1, false);
+        ping_shards().get();
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
+            manual_clock::advance(expiration_time);
+            BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
+        }).get();
+
+        // Set it to expiring, ensure it expires on both shards
+        m.set_expiring_flag(id1);
+        ping_shards().get();
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
+            manual_clock::advance(expiration_time);
+            BOOST_CHECK(!m.find(id1));
+        }).get();
+        ping_shards().get(); // so this shard notices the clock advance
+        BOOST_CHECK(!m.find(id1));
+
+        // Expiring entries are not replicated
+        m.set(id1, addr1, true);
+        ping_shards().get();
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            BOOST_CHECK(!m.find(id1));
+        }).get();
+
+        // Can't add non-expiring entries on shard other than 0
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            scoped_no_abort_on_internal_error abort_guard;
+            BOOST_CHECK_THROW(m.set(id2, addr2, false), std::runtime_error);
+        }).get();
+
+        // Can add expiring entries on shard other than 0 - and they indeed expire
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            m.set(id2, addr2, true);
+            BOOST_CHECK(m.find(id2) && *m.find(id2) == addr2);
+            manual_clock::advance(expiration_time);
+            BOOST_CHECK(!m.find(id2));
+        }).get();
+
+
+        // Add entry on two shards, make it non-expiring on shard 0,
+        // the non-expiration must be replicated
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            m.set(id2, addr2, true);
+        }).get();
+        m.set(id2, addr2, false);
+        ping_shards().get();
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            manual_clock::advance(expiration_time);
+            BOOST_CHECK(m.find(id2) && *m.find(id2) == addr2);
+        }).get();
+
+        // Cannot set it to expiring on shard 1
+        m_svc.invoke_on(1, [] (raft_address_map<manual_clock>& m) {
+            scoped_no_abort_on_internal_error abort_guard;
+            BOOST_CHECK_THROW(m.set_expiring_flag(id2), std::runtime_error);
+        }).get();
     }
 }


### PR DESCRIPTION
Replicating `raft_address_map` entries is needed for the following use
cases:
- the direct failure detector - currently it assumes a static mapping of
  `raft::server_id`s to `gms::inet_address`es, which is obtained on Raft
  group 0 configuration changes. To handle dynamic mappings we need to
  modify the failure detector so it pings `raft::server_id`s and obtains
  the `gms::inet_address` before sending the message from
  `raft_address_map`. The failure detector is sharded, so we need the
  mappings to be available on all shards.
- in the future we'll have multiple Raft groups running on different
  shards. To send messages they'll need `raft_address_map`.

Initially I tried to replicate all entries - expiring and non-expiring.
The implementation turned out to be very complex - we need to handle
dropping expired entries and refreshing expiring entries' timestamps
across shards, and doing this correctly while accounting for possible
races is quite problematic.

Eventually I arrived at the conclusion that replicating only
non-expiring entries, and furthermore allowing non-expiring entries to
be added only on shard 0, is good enough for our use cases:
- The direct failure detector is pinging group 0 members only; group
  0 members correspond exactly to the non-expiring entries.
- Group 0 configuration changes are handled on shard 0, so non-expiring
  entries are added/removed on shard 0.
- When we have multiple Raft groups, we can reuse a single Raft server
  ID for all Raft servers running on a single node belonging to
  different groups; they are 'namespaced' by the group IDs. Furthermore,
  every node has a server that belongs to group 0. Thus for every Raft
  server in every group, it has a corresponding server in group 0 with
  the same ID, which has a non-expiring entry in `raft_address_map`,
  which is replicated to all shards; so every group will be able to
  deliver its messages.

With these assumptions the implementation is short and simple.
We can always complicate it in the future if we find that the
assumptions are too strong.

