### PR TITLE
distributed_loader: detect highest generation before populating column families

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -274,6 +274,7 @@ using sstable_list = sstables::sstable_list;
 namespace replica {
 
 class distributed_loader;
+struct table_population_metadata;
 
 // The CF has a "stats" structure. But we don't want all fields here,
 // since some of them are fairly complex for exporting to collectd. Also,
@@ -1085,6 +1086,7 @@ public:
     friend class ::column_family_test;
 
     friend class distributed_loader;
+    friend class table_population_metadata;
 
 private:
     timer<> _off_strategy_trigger;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -475,15 +475,14 @@ public:
 
     future<> start() {
         assert(this_shard_id() == 0);
-        // FIXME: indentation
-            for (auto subdir : { "", sstables::staging_dir, sstables::quarantine_dir }) {
-                co_await start_subdir(subdir);
-            }
+        for (auto subdir : { "", sstables::staging_dir, sstables::quarantine_dir }) {
+            co_await start_subdir(subdir);
+        }
 
-            co_await smp::invoke_on_all([this] {
-                _global_table->update_sstables_known_generation(_highest_generation);
-                return _global_table->disable_auto_compaction();
-            });
+        co_await smp::invoke_on_all([this] {
+            _global_table->update_sstables_known_generation(_highest_generation);
+            return _global_table->disable_auto_compaction();
+        });
     }
 
     future<> stop() {

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -59,8 +59,11 @@ class distributed_loader_for_tests;
 
 namespace replica {
 
+class table_population_metadata;
+
 class distributed_loader {
     friend class ::distributed_loader_for_tests;
+    friend class table_population_metadata;
 
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
             sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter);
@@ -72,7 +75,7 @@ class distributed_loader {
             std::filesystem::path datadir, sstring ks, sstring cf);
     using allow_offstrategy_compaction = bool_class<struct allow_offstrategy_compaction_tag>;
     using must_exist = bool_class<struct must_exist_tag>;
-    static future<> populate_column_family(distributed<replica::database>& db, sstring sstdir, sstring ks, sstring cf, allow_offstrategy_compaction, must_exist = must_exist::yes);
+    static future<> populate_column_family(table_population_metadata& metadata, sstring subdir, allow_offstrategy_compaction, must_exist = must_exist::yes);
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
     static future<> cleanup_column_family_temp_sst_dirs(sstring sstdir);
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);


### PR DESCRIPTION
We should scan all sstables in the table directory and its
subdirectories to determine the highest sstable version and generation
before using it for creating new sstables (via reshard or reshape).

Otherwise, the generations of new sstables created when populating staging (via reshard or reshape) may collide with generations in the base directory, leading to https://github.com/scylladb/scylladb/issues/11789
    
Refs scylladb/scylladb#11789
Fixes scylladb/scylladb#11793
