### PR TITLE
test: (pytest) fix the pytest wrapper to work on Ubuntu

### DIFF
--- a/test/pytest
+++ b/test/pytest
@@ -3,5 +3,5 @@
 # Modern pytest excludes site-packages, so it doesn't see scylla-driver.
 # This script is a workaround.
 
-exec python -m pytest "$@"
+exec python3 -m pytest "$@"
 


### PR DESCRIPTION
Ubuntu doesn't have python, only python2 and python3.