### PR TITLE
reader_permit: resources: remove operator bool and >=

### DIFF
--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -32,10 +32,6 @@ struct reader_resources {
         , memory(memory) {
     }
 
-    bool operator>=(const reader_resources& other) const {
-        return count >= other.count && memory >= other.memory;
-    }
-
     reader_resources operator-(const reader_resources& other) const {
         return reader_resources{count - other.count, memory - other.memory};
     }
@@ -56,7 +52,7 @@ struct reader_resources {
         return *this;
     }
 
-    explicit operator bool() const {
+    bool non_zero() const {
         return count > 0 || memory > 0;
     }
 };


### PR DESCRIPTION
These cannot be meaningfully define for a vector value like resources. To prevent instinctive misuse, remove them. Operator bool is replaced with `non_zero()` which hopefully better expresses what to expected. The comparison operator is just removed and inlined into its own user, which actually help said user's readability.