### PR TITLE
cql3: expr: Add unit tests for evaluate()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1299,7 +1299,7 @@ deps['test/boost/linearizing_input_stream_test'] = [
     "test/boost/linearizing_input_stream_test.cc",
     "test/lib/log.cc",
 ]
-deps['test/boost/expr_test'] = ['test/boost/expr_test.cc'] + scylla_core
+deps['test/boost/expr_test'] = ['test/boost/expr_test.cc', 'test/lib/expr_test_utils.cc'] + scylla_core
 deps['test/boost/rate_limiter_test'] = ['test/boost/rate_limiter_test.cc', 'db/rate_limiter.cc']
 deps['test/boost/exceptions_optimized_test'] = ['test/boost/exceptions_optimized_test.cc', 'utils/exceptions.cc']
 deps['test/boost/exceptions_fallback_test'] = ['test/boost/exceptions_fallback_test.cc', 'utils/exceptions.cc']

--- a/cql3/values.cc
+++ b/cql3/values.cc
@@ -78,4 +78,8 @@ bool operator==(const raw_value& v1, const raw_value& v2) {
     return false;
 }
 
+std::ostream& operator<<(std::ostream& os, const raw_value& value) {
+    return os << value.view();
+}
+
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -307,6 +307,7 @@ public:
     friend class raw_value_view;
 
     friend bool operator==(const raw_value& v1, const raw_value& v2);
+    friend std::ostream& operator<<(std::ostream& os, const raw_value& value);
 };
 
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -85,6 +85,14 @@ public:
     bool is_unset_value() const {
         return std::holds_alternative<unset_value>(_data);
     }
+    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty int value can be created in CQL using blobasint(0x).
+    bool is_empty_value() const {
+        if (is_null() || is_unset_value()) {
+            return false;
+        }
+        return size_bytes() == 0;
+    }
     bool is_value() const {
         return _data.index() <= 1;
     }
@@ -232,6 +240,14 @@ public:
     }
     bool is_null_or_unset() const {
         return !is_value();
+    }
+    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty int value can be created in CQL using blobasint(0x).
+    bool is_empty_value() const {
+        if (is_null_or_unset()) {
+            return false;
+        }
+        return view().size_bytes() == 0;
     }
     bool is_value() const {
         return _data.index() <= 1;

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -15,7 +15,7 @@
 #include "cql3/query_options.hh"
 #include "types/set.hh"
 #include "types/user.hh"
-#include "expr_test_utils.hh"
+#include "test/lib/expr_test_utils.hh"
 
 using namespace cql3;
 using namespace cql3::expr;

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -767,3 +767,37 @@ BOOST_AUTO_TEST_CASE(evaluate_tuple_constructor_with_prefix_fields) {
                                               {int32_type, utf8_type, int32_type, double_type});
     BOOST_REQUIRE_EQUAL(evaluate(tuple, evaluation_inputs{}), make_tuple_raw({make_int_raw(1), make_text_raw("12")}));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor_empty) {
+    expression empty_usertype = make_usertype_constructor({});
+    BOOST_REQUIRE_EQUAL(evaluate(empty_usertype, evaluation_inputs{}), make_tuple_raw({}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor) {
+    expression usertype = make_usertype_constructor(
+        {{"field1", make_int_const(123)}, {"field2", make_text_const("field2val")}, {"field3", make_bool_const(true)}});
+    BOOST_REQUIRE_EQUAL(evaluate(usertype, evaluation_inputs{}),
+                        make_tuple_raw({make_int_raw(123), make_text_raw("field2val"), make_bool_raw(true)}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor_with_null) {
+    expression usertype_with_null = make_usertype_constructor({{"field1", make_int_const(123)},
+                                                               {"field2", constant::make_null(utf8_type)},
+                                                               {"field3", make_bool_const(true)}});
+    BOOST_REQUIRE_EQUAL(evaluate(usertype_with_null, evaluation_inputs{}),
+                        make_tuple_raw({make_int_raw(123), raw_value::make_null(), make_bool_raw(true)}));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor_with_unset) {
+    expression usertype_with_unset = make_usertype_constructor({{"field1", make_int_const(123)},
+                                                                {"field2", constant::make_unset_value(utf8_type)},
+                                                                {"field3", make_bool_const(true)}});
+    BOOST_REQUIRE_THROW(evaluate(usertype_with_unset, evaluation_inputs{}), exceptions::invalid_request_exception);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_usertype_constructor_with_empty) {
+    expression usertype_with_null = make_usertype_constructor(
+        {{"field1", make_int_const(123)}, {"field2", make_empty_const(utf8_type)}, {"field3", make_bool_const(true)}});
+    BOOST_REQUIRE_EQUAL(evaluate(usertype_with_null, evaluation_inputs{}),
+                        make_tuple_raw({make_int_raw(123), make_empty_raw(), make_bool_raw(true)}));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -374,3 +374,32 @@ BOOST_AUTO_TEST_CASE(boolean_factors_test) {
         )
     );
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_null) {
+    expression constant_null = constant::make_null();
+    BOOST_REQUIRE_EQUAL(evaluate(constant_null, evaluation_inputs{}), raw_value::make_null());
+
+    expression constant_null_with_type = constant::make_null(int32_type);
+    BOOST_REQUIRE_EQUAL(evaluate(constant_null_with_type, evaluation_inputs{}), raw_value::make_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_unset) {
+    expression constant_unset = constant::make_unset_value();
+    BOOST_REQUIRE_EQUAL(evaluate(constant_unset, evaluation_inputs{}), raw_value::make_unset_value());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_empty) {
+    expression constant_empty_bool = constant(raw_value::make_value(bytes()), boolean_type);
+    BOOST_REQUIRE(evaluate(constant_empty_bool, evaluation_inputs{}).is_empty_value());
+
+    expression constant_empty_int = constant(raw_value::make_value(bytes()), int32_type);
+    BOOST_REQUIRE(evaluate(constant_empty_int, evaluation_inputs{}).is_empty_value());
+
+    expression constant_empty_text = constant(raw_value::make_value(bytes()), utf8_type);
+    BOOST_REQUIRE_EQUAL(evaluate(constant_empty_text, evaluation_inputs{}), make_text_raw(""));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_constant_int) {
+    expression const_int = make_int_const(723);
+    BOOST_REQUIRE_EQUAL(evaluate(const_int, evaluation_inputs{}), make_int_raw(723));
+}

--- a/test/boost/expr_test_utils.hh
+++ b/test/boost/expr_test_utils.hh
@@ -278,6 +278,19 @@ inline tuple_constructor make_tuple_constructor(std::vector<expression> elements
                              .type = tuple_type_impl::get_instance(std::move(element_types))};
 }
 
+inline usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values) {
+    usertype_constructor::elements_map_type elements_map;
+    std::vector<bytes> field_names;
+    std::vector<data_type> field_types;
+    for (auto& [field_name, field_value] : field_values) {
+        field_names.push_back(field_name.data());
+        field_types.push_back(field_value.type);
+        elements_map.emplace(column_identifier(sstring(field_name), true), field_value);
+    }
+    data_type type = user_type_impl::get_instance("test_ks", "test_user_type", field_names, field_types, true);
+    return usertype_constructor{.elements = std::move(elements_map), .type = std::move(type)};
+}
+
 struct evaluation_inputs_data {
     std::vector<bytes> partition_key;
     std::vector<bytes> clustering_key;

--- a/test/boost/expr_test_utils.hh
+++ b/test/boost/expr_test_utils.hh
@@ -241,6 +241,18 @@ inline raw_value make_int_int_map_raw(const std::vector<std::pair<int32_t, int32
     return make_map_raw(to_raw_value_pairs(values));
 }
 
+inline constant make_int_list_const(const std::vector<int32_t>& values) {
+    return constant(make_int_list_raw(values), list_type_impl::get_instance(int32_type, true));
+}
+
+inline constant make_int_set_const(const std::vector<int32_t>& values) {
+    return constant(make_int_set_raw(values), set_type_impl::get_instance(int32_type, true));
+}
+
+inline constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& values) {
+    return constant(make_int_int_map_raw(values), map_type_impl::get_instance(int32_type, int32_type, true));
+}
+
 inline collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type) {
     return collection_constructor{.style = collection_constructor::style_type::list,
                                   .elements = std::move(elements),

--- a/test/boost/expr_test_utils.hh
+++ b/test/boost/expr_test_utils.hh
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "cql3/expr/expression.hh"
+#include "cql3/query_options.hh"
+#include "cql3/selection/selection.hh"
+#include "data_dictionary/data_dictionary.hh"
+#include "data_dictionary/impl.hh"
+#include "data_dictionary/keyspace_metadata.hh"
+#include "db/config.hh"
+#include "types/list.hh"
+#include "types/map.hh"
+#include "types/set.hh"
+
+namespace cql3 {
+namespace expr {
+namespace test_utils {
+
+template <class T>
+raw_value make_raw(T t) {
+    data_type val_type = data_type_for<T>();
+    data_value data_val(t);
+    return raw_value::make_value(val_type->decompose(data_val));
+}
+
+inline raw_value make_empty_raw() {
+    return raw_value::make_value(managed_bytes());
+}
+
+inline raw_value make_bool_raw(bool val) {
+    return make_raw(val);
+}
+
+inline raw_value make_int_raw(int32_t val) {
+    return make_raw(val);
+}
+
+inline raw_value make_text_raw(const sstring_view& text) {
+    return raw_value::make_value(utf8_type->decompose(text));
+}
+
+template <class T>
+constant make_const(T t) {
+    data_type val_type = data_type_for<T>();
+    return constant(make_raw(t), val_type);
+}
+
+inline constant make_empty_const(data_type type) {
+    return constant(make_empty_raw(), type);
+}
+
+inline constant make_bool_const(bool val) {
+    return make_const(val);
+}
+
+inline constant make_int_const(int32_t val) {
+    return make_const(val);
+}
+
+inline constant make_text_const(const sstring_view& text) {
+    return constant(make_text_raw(text), utf8_type);
+}
+
+}  // namespace test_utils
+}  // namespace expr
+}  // namespace cql3

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -6,23 +6,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#pragma once
-
-#include "cql3/expr/expression.hh"
-#include "cql3/query_options.hh"
-#include "cql3/selection/selection.hh"
-#include "data_dictionary/data_dictionary.hh"
-#include "data_dictionary/impl.hh"
-#include "data_dictionary/keyspace_metadata.hh"
-#include "db/config.hh"
-#include "types/list.hh"
-#include "types/map.hh"
-#include "types/set.hh"
+#include "expr_test_utils.hh"
 
 namespace cql3 {
 namespace expr {
 namespace test_utils {
-
 template <class T>
 raw_value make_raw(T t) {
     data_type val_type = data_type_for<T>();
@@ -30,19 +18,19 @@ raw_value make_raw(T t) {
     return raw_value::make_value(val_type->decompose(data_val));
 }
 
-inline raw_value make_empty_raw() {
+raw_value make_empty_raw() {
     return raw_value::make_value(managed_bytes());
 }
 
-inline raw_value make_bool_raw(bool val) {
+raw_value make_bool_raw(bool val) {
     return make_raw(val);
 }
 
-inline raw_value make_int_raw(int32_t val) {
+raw_value make_int_raw(int32_t val) {
     return make_raw(val);
 }
 
-inline raw_value make_text_raw(const sstring_view& text) {
+raw_value make_text_raw(const sstring_view& text) {
     return raw_value::make_value(utf8_type->decompose(text));
 }
 
@@ -52,27 +40,26 @@ constant make_const(T t) {
     return constant(make_raw(t), val_type);
 }
 
-inline constant make_empty_const(data_type type) {
+constant make_empty_const(data_type type) {
     return constant(make_empty_raw(), type);
 }
 
-inline constant make_bool_const(bool val) {
+constant make_bool_const(bool val) {
     return make_const(val);
 }
 
-inline constant make_int_const(int32_t val) {
+constant make_int_const(int32_t val) {
     return make_const(val);
 }
 
-inline constant make_text_const(const sstring_view& text) {
+constant make_text_const(const sstring_view& text) {
     return constant(make_text_raw(text), utf8_type);
 }
 
 // This function implements custom serialization of collection values.
 // Some tests require the collection to contain unset_value or an empty value,
 // which is impossible to express using the existing code.
-inline cql3::raw_value make_collection_raw(size_t size_to_write,
-                                           const std::vector<cql3::raw_value>& elements_to_write) {
+cql3::raw_value make_collection_raw(size_t size_to_write, const std::vector<cql3::raw_value>& elements_to_write) {
     cql_serialization_format sf = cql_serialization_format::latest();
 
     size_t serialized_len = 0;
@@ -102,15 +89,15 @@ inline cql3::raw_value make_collection_raw(size_t size_to_write,
     return cql3::raw_value::make_value(b);
 }
 
-inline raw_value make_list_raw(const std::vector<raw_value>& values) {
+raw_value make_list_raw(const std::vector<raw_value>& values) {
     return make_collection_raw(values.size(), values);
 }
 
-inline raw_value make_set_raw(const std::vector<raw_value>& values) {
+raw_value make_set_raw(const std::vector<raw_value>& values) {
     return make_collection_raw(values.size(), values);
 }
 
-inline raw_value make_map_raw(const std::vector<std::pair<raw_value, raw_value>>& values) {
+raw_value make_map_raw(const std::vector<std::pair<raw_value, raw_value>>& values) {
     std::vector<raw_value> flattened_values;
     for (const std::pair<raw_value, raw_value>& pair_val : values) {
         flattened_values.push_back(pair_val.first);
@@ -122,7 +109,7 @@ inline raw_value make_map_raw(const std::vector<std::pair<raw_value, raw_value>>
 // This function implements custom serialization of tuples.
 // Some tests require the tuple to contain unset_value or an empty value,
 // which is impossible to express using the existing code.
-inline raw_value make_tuple_raw(const std::vector<raw_value>& values) {
+raw_value make_tuple_raw(const std::vector<raw_value>& values) {
     size_t serialized_len = 0;
     for (const raw_value& val : values) {
         serialized_len += 4;
@@ -168,7 +155,7 @@ concept ToRawValue = requires(T t) {
 || std::same_as<T, constant> || std::same_as<T, raw_value>;
 
 template <ToRawValue T>
-inline std::vector<raw_value> to_raw_values(const std::vector<T>& values) {
+std::vector<raw_value> to_raw_values(const std::vector<T>& values) {
     std::vector<raw_value> raw_vals;
     for (const T& val : values) {
         raw_vals.push_back(to_raw_value(val));
@@ -177,7 +164,7 @@ inline std::vector<raw_value> to_raw_values(const std::vector<T>& values) {
 }
 
 template <ToRawValue T1, ToRawValue T2>
-inline std::vector<std::pair<raw_value, raw_value>> to_raw_value_pairs(const std::vector<std::pair<T1, T2>>& values) {
+std::vector<std::pair<raw_value, raw_value>> to_raw_value_pairs(const std::vector<std::pair<T1, T2>>& values) {
     std::vector<std::pair<raw_value, raw_value>> raw_vals;
     for (const std::pair<T1, T2>& val : values) {
         raw_vals.emplace_back(to_raw_value(val.first), to_raw_value(val.second));
@@ -185,97 +172,97 @@ inline std::vector<std::pair<raw_value, raw_value>> to_raw_value_pairs(const std
     return raw_vals;
 }
 
-inline constant make_list_const(const std::vector<raw_value>& vals, data_type elements_type) {
+constant make_list_const(const std::vector<raw_value>& vals, data_type elements_type) {
     raw_value raw_list = make_list_raw(vals);
     data_type list_type = list_type_impl::get_instance(elements_type, true);
     return constant(std::move(raw_list), std::move(list_type));
 }
 
-inline constant make_list_const(const std::vector<constant>& vals, data_type elements_type) {
+constant make_list_const(const std::vector<constant>& vals, data_type elements_type) {
     return make_list_const(to_raw_values(vals), elements_type);
 }
 
-inline constant make_set_const(const std::vector<raw_value>& vals, data_type elements_type) {
+constant make_set_const(const std::vector<raw_value>& vals, data_type elements_type) {
     raw_value raw_set = make_set_raw(vals);
     data_type set_type = set_type_impl::get_instance(elements_type, true);
     return constant(std::move(raw_set), std::move(set_type));
 }
 
-inline constant make_set_const(const std::vector<constant>& vals, data_type elements_type) {
+constant make_set_const(const std::vector<constant>& vals, data_type elements_type) {
     return make_set_const(to_raw_values(vals), elements_type);
 }
 
-inline constant make_map_const(const std::vector<std::pair<raw_value, raw_value>>& vals,
-                               data_type key_type,
-                               data_type value_type) {
+constant make_map_const(const std::vector<std::pair<raw_value, raw_value>>& vals,
+                        data_type key_type,
+                        data_type value_type) {
     raw_value raw_map = make_map_raw(vals);
     data_type map_type = map_type_impl::get_instance(key_type, value_type, true);
     return constant(std::move(raw_map), std::move(map_type));
 }
 
-inline constant make_map_const(const std::vector<std::pair<constant, constant>>& vals,
-                               data_type key_type,
-                               data_type value_type) {
+constant make_map_const(const std::vector<std::pair<constant, constant>>& vals,
+                        data_type key_type,
+                        data_type value_type) {
     return make_map_const(to_raw_value_pairs(vals), key_type, value_type);
 }
 
-inline constant make_tuple_const(const std::vector<raw_value>& vals, const std::vector<data_type>& element_types) {
+constant make_tuple_const(const std::vector<raw_value>& vals, const std::vector<data_type>& element_types) {
     raw_value raw_tuple = make_tuple_raw(vals);
     data_type tuple_type = tuple_type_impl::get_instance(element_types);
     return constant(std::move(raw_tuple), std::move(tuple_type));
 }
 
-inline constant make_tuple_const(const std::vector<constant>& vals, const std::vector<data_type>& element_types) {
+constant make_tuple_const(const std::vector<constant>& vals, const std::vector<data_type>& element_types) {
     return test_utils::make_tuple_const(to_raw_values(vals), element_types);
 }
 
-inline raw_value make_int_list_raw(const std::vector<int32_t>& values) {
+raw_value make_int_list_raw(const std::vector<int32_t>& values) {
     return make_list_raw(to_raw_values(values));
 }
 
-inline raw_value make_int_set_raw(const std::vector<int32_t>& values) {
+raw_value make_int_set_raw(const std::vector<int32_t>& values) {
     return make_set_raw(to_raw_values(values));
 }
 
-inline raw_value make_int_int_map_raw(const std::vector<std::pair<int32_t, int32_t>>& values) {
+raw_value make_int_int_map_raw(const std::vector<std::pair<int32_t, int32_t>>& values) {
     return make_map_raw(to_raw_value_pairs(values));
 }
 
-inline constant make_int_list_const(const std::vector<int32_t>& values) {
+constant make_int_list_const(const std::vector<int32_t>& values) {
     return constant(make_int_list_raw(values), list_type_impl::get_instance(int32_type, true));
 }
 
-inline constant make_int_set_const(const std::vector<int32_t>& values) {
+constant make_int_set_const(const std::vector<int32_t>& values) {
     return constant(make_int_set_raw(values), set_type_impl::get_instance(int32_type, true));
 }
 
-inline constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& values) {
+constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& values) {
     return constant(make_int_int_map_raw(values), map_type_impl::get_instance(int32_type, int32_type, true));
 }
 
-inline collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type) {
+collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type) {
     return collection_constructor{.style = collection_constructor::style_type::list,
                                   .elements = std::move(elements),
                                   .type = list_type_impl::get_instance(elements_type, true)};
 }
 
-inline collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type) {
+collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type) {
     return collection_constructor{.style = collection_constructor::style_type::set,
                                   .elements = std::move(elements),
                                   .type = set_type_impl::get_instance(elements_type, true)};
 }
 
-inline collection_constructor make_map_constructor(const std::vector<expression> elements,
-                                                   data_type key_type,
-                                                   data_type element_type) {
+collection_constructor make_map_constructor(const std::vector<expression> elements,
+                                            data_type key_type,
+                                            data_type element_type) {
     return collection_constructor{.style = collection_constructor::style_type::map,
                                   .elements = std::move(elements),
                                   .type = map_type_impl::get_instance(key_type, element_type, true)};
 }
 
-inline collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
-                                                   data_type key_type,
-                                                   data_type element_type) {
+collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
+                                            data_type key_type,
+                                            data_type element_type) {
     std::vector<expression> map_element_pairs;
     for (const std::pair<expression, expression>& element : elements) {
         map_element_pairs.push_back(tuple_constructor{.elements = {element.first, element.second},
@@ -284,13 +271,12 @@ inline collection_constructor make_map_constructor(const std::vector<std::pair<e
     return make_map_constructor(map_element_pairs, key_type, element_type);
 }
 
-inline tuple_constructor make_tuple_constructor(std::vector<expression> elements,
-                                                std::vector<data_type> element_types) {
+tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types) {
     return tuple_constructor{.elements = std::move(elements),
                              .type = tuple_type_impl::get_instance(std::move(element_types))};
 }
 
-inline usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values) {
+usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values) {
     usertype_constructor::elements_map_type elements_map;
     std::vector<bytes> field_names;
     std::vector<data_type> field_types;
@@ -303,20 +289,11 @@ inline usertype_constructor make_usertype_constructor(std::vector<std::pair<sstr
     return usertype_constructor{.elements = std::move(elements_map), .type = std::move(type)};
 }
 
-struct evaluation_inputs_data {
-    std::vector<bytes> partition_key;
-    std::vector<bytes> clustering_key;
-    std::vector<managed_bytes_opt> static_and_regular_columns;
-    ::shared_ptr<selection::selection> selection;
-    query_options options;
-};
-using column_values = std::map<sstring, raw_value>;
-
 // Creates evaluation_inputs that can be used to evaluate columns and bind variables using evaluate()
-inline std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
+std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
     const schema_ptr& table_schema,
     const column_values& column_vals,
-    const std::vector<raw_value>& bind_marker_values = {}) {
+    const std::vector<raw_value>& bind_marker_values) {
     auto throw_error = [&](const auto&... fmt_args) -> sstring {
         sstring error_msg = format(fmt_args...);
         sstring final_msg = format("make_evaluation_inputs error: {}. (table_schema: {}, column_vals: {})", error_msg,

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "cql3/expr/expression.hh"
+#include "cql3/query_options.hh"
+#include "cql3/selection/selection.hh"
+#include "data_dictionary/data_dictionary.hh"
+#include "data_dictionary/impl.hh"
+#include "data_dictionary/keyspace_metadata.hh"
+#include "db/config.hh"
+#include "types/list.hh"
+#include "types/map.hh"
+#include "types/set.hh"
+
+namespace cql3 {
+namespace expr {
+namespace test_utils {
+
+raw_value make_empty_raw();
+raw_value make_bool_raw(bool val);
+raw_value make_int_raw(int32_t val);
+raw_value make_text_raw(const sstring_view& text);
+
+constant make_empty_const(data_type type);
+constant make_bool_const(bool val);
+constant make_int_const(int32_t val);
+constant make_text_const(const sstring_view& text);
+
+// This function implements custom serialization of collection values.
+// Some tests require the collection to contain unset_value or an empty value,
+// which is impossible to express using the existing code.
+cql3::raw_value make_collection_raw(size_t size_to_write, const std::vector<cql3::raw_value>& elements_to_write);
+
+raw_value make_list_raw(const std::vector<raw_value>& values);
+raw_value make_set_raw(const std::vector<raw_value>& values);
+raw_value make_map_raw(const std::vector<std::pair<raw_value, raw_value>>& values);
+
+// This function implements custom serialization of tuples.
+// Some tests require the tuple to contain unset_value or an empty value,
+// which is impossible to express using the existing code.
+raw_value make_tuple_raw(const std::vector<raw_value>& values);
+
+constant make_list_const(const std::vector<raw_value>& vals, data_type elements_type);
+constant make_list_const(const std::vector<constant>& vals, data_type elements_type);
+
+constant make_set_const(const std::vector<raw_value>& vals, data_type elements_type);
+constant make_set_const(const std::vector<constant>& vals, data_type elements_type);
+
+constant make_map_const(const std::vector<std::pair<raw_value, raw_value>>& vals,
+                        data_type key_type,
+                        data_type value_type);
+
+constant make_map_const(const std::vector<std::pair<constant, constant>>& vals,
+                        data_type key_type,
+                        data_type value_type);
+
+constant make_tuple_const(const std::vector<raw_value>& vals, const std::vector<data_type>& element_types);
+constant make_tuple_const(const std::vector<constant>& vals, const std::vector<data_type>& element_types);
+
+raw_value make_int_list_raw(const std::vector<int32_t>& values);
+raw_value make_int_set_raw(const std::vector<int32_t>& values);
+
+raw_value make_int_int_map_raw(const std::vector<std::pair<int32_t, int32_t>>& values);
+
+constant make_int_list_const(const std::vector<int32_t>& values);
+constant make_int_set_const(const std::vector<int32_t>& values);
+constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& values);
+
+collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type);
+collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type);
+collection_constructor make_map_constructor(const std::vector<expression> elements,
+                                            data_type key_type,
+                                            data_type element_type);
+collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
+                                            data_type key_type,
+                                            data_type element_type);
+tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types);
+usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values);
+
+struct evaluation_inputs_data {
+    std::vector<bytes> partition_key;
+    std::vector<bytes> clustering_key;
+    std::vector<managed_bytes_opt> static_and_regular_columns;
+    ::shared_ptr<selection::selection> selection;
+    query_options options;
+};
+using column_values = std::map<sstring, raw_value>;
+
+// Creates evaluation_inputs that can be used to evaluate columns and bind variables using evaluate()
+std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
+    const schema_ptr& table_schema,
+    const column_values& column_vals,
+    const std::vector<raw_value>& bind_marker_values = {});
+}  // namespace test_utils
+}  // namespace expr
+}  // namespace cql3


### PR DESCRIPTION
This PR adds some unit tests for the `expr::evaluate()` function.

At first I wanted to add the unit tests as part of #11658, but their size grew and grew, until I decided that they deserve their own pull request.

I found a few places where I think it would be better to behave in a different way, but nothing serious.