### PR TITLE
test: mutation-test: fix off-by-one in test_large_collection_allocation

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -428,7 +428,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
         const bytes blob(blob_size, 'a');
 
         const auto stats_before = memory::stats();
-        const memory::scoped_large_allocation_warning_threshold _{128 * 1024};
+        const memory::scoped_large_allocation_warning_threshold _{128 * 1024 + 1};
 
         const api::timestamp_type ts1 = 1;
         const api::timestamp_type ts2 = 2;


### PR DESCRIPTION
The test wants to see that no allocations larger than 128k are present, but sets the warning threshold to exactly 128k. Due to an off-by-one in Seastar, this went unnoticed. However, now that the off-by-one in Seastar is fixed [1], this test starts to fail.

Fix by setting the warning threshold to 128k + 1.

[1] https://github.com/scylladb/seastar/commit/429efb50863e5427b03eff4cc1bb52c153cc787f