### PR TITLE
alternator: ttl: do not copy mutation while constructing a vector

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -282,7 +282,9 @@ static future<> expire_item(service::storage_proxy& proxy,
         auto ck = clustering_key::from_exploded(exploded_ck);
         m.partition().clustered_row(*schema, ck).apply(tombstone(ts, gc_clock::now()));
     }
-    return proxy.mutate(std::vector<mutation>{std::move(m)},
+    std::vector<mutation> mutations;
+    mutations.push_back(std::move(m));
+    return proxy.mutate(std::move(mutations),
         db::consistency_level::LOCAL_QUORUM,
         executor::default_timeout(), // FIXME - which timeout?
         qs.get_trace_state(), qs.get_permit(),


### PR DESCRIPTION
The vector(initializer_list<T>) constructor copies the T since initializer_list is read-only. Move the mutation instead.

This happens to fix a use-after-return on clang 15 on aarch64. I'm fairly sure that's a miscompile, but the fix is worthwhile regardless.