### PR TITLE
db: make_forwardable::reader: Do not emit range_tombstone_change with position past the range

### DIFF
--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -126,7 +126,7 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
         }
         void maybe_emit_end_tombstone() {
             if (_active_tombstone) {
-                push_mutation_fragment(*_schema, _permit, range_tombstone_change(position_in_partition_view::after_key(_current.end()), {}));
+                push_mutation_fragment(*_schema, _permit, range_tombstone_change(position_in_partition_view::before_key(_current.end()), {}));
             }
         }
     public:

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1444,6 +1444,21 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
                                   mutation_reader::forwarding::no))
             .produces_partition_start(pkey)
             .produces_end_of_stream()
+            .fast_forward_to(position_range(
+                    position_in_partition::after_key(s.make_ckey(0)),
+                    position_in_partition::for_key(s.make_ckey(2))))
+            .produces_range_tombstone_change(range_tombstone_change(position_in_partition_view::before_key(s.make_ckey(1)), t1))
+            .produces_range_tombstone_change(range_tombstone_change(position_in_partition_view::before_key(s.make_ckey(2)), {}))
+            .produces_end_of_stream();
+
+    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+                                  s.schema()->full_slice(),
+                                  default_priority_class(),
+                                  nullptr,
+                                  streamed_mutation::forwarding::yes,
+                                  mutation_reader::forwarding::no))
+            .produces_partition_start(pkey)
+            .produces_end_of_stream()
 
             .fast_forward_to(position_range(
                     position_in_partition::before_key(s.make_ckey(0)),


### PR DESCRIPTION
Since the end bound is exclusive, the end position should be before_key(), not after_key().

Affects only tests, as far as I know, only there we can get an end bound which is a clustering row position.

Would cause failures once row cache is switched to v2 representation because of violated assumptions about positions.

Introduced in 76ee3f029c581a83afe9cb271dd52593e4c31046