### PR TITLE
storage_service, repair: use per-shard abort_source

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -64,11 +64,25 @@ void node_ops_info::check_abort() {
 }
 
 future<> node_ops_info::start() {
-    co_return;  // for now
+    if (as) {
+        co_await _sas.start();
+        _abort_subscription = as->subscribe([this] () noexcept {
+            _abort_done = _sas.invoke_on_all([] (abort_source& as) noexcept {
+                as.request_abort();
+            });
+        });
+    }
 }
 
 future<> node_ops_info::stop() noexcept {
-    co_return;  // for now
+    if (as) {
+        co_await std::exchange(_abort_done, make_ready_future<>());
+        co_await _sas.stop();
+    }
+}
+
+abort_source* node_ops_info::local_abort_source() {
+    return as ? &_sas.local() : nullptr;
 }
 
 node_ops_metrics::node_ops_metrics(tracker& tracker)
@@ -546,7 +560,7 @@ repair_info::repair_info(repair_service& repair,
     const std::vector<sstring>& hosts_,
     const std::unordered_set<gms::inet_address>& ignore_nodes_,
     streaming::stream_reason reason_,
-    shared_ptr<abort_source> as,
+    abort_source* as,
     bool hints_batchlog_flushed)
     : rs(repair)
     , db(repair.get_db())
@@ -1309,9 +1323,10 @@ future<> repair_service::do_sync_data_using_repair(
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
                 bool hints_batchlog_flushed = false;
+                abort_source* asp = ops_info ? ops_info->local_abort_source() : nullptr;
                 auto ri = make_lw_shared<repair_info>(local_repair,
                         std::move(keyspace), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, ops_info ? ops_info->as : nullptr, hints_batchlog_flushed);
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
                 ri->neighbors = std::move(neighbors);
                 return repair_ranges(ri);
             });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -63,6 +63,14 @@ void node_ops_info::check_abort() {
     }
 }
 
+future<> node_ops_info::start() {
+    co_return;  // for now
+}
+
+future<> node_ops_info::stop() noexcept {
+    co_return;  // for now
+}
+
 node_ops_metrics::node_ops_metrics(tracker& tracker)
     : _tracker(tracker)
 {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -49,6 +49,12 @@
 
 logging::logger rlogger("repair");
 
+node_ops_info::node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept
+    : ops_uuid(ops_uuid_)
+    , as(std::move(as_))
+    , ignore_nodes(std::move(ignore_nodes_))
+{}
+
 void node_ops_info::check_abort() {
     if (as && as->abort_requested()) {
         auto msg = format("Node operation with ops_uuid={} is aborted", ops_uuid);

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -71,6 +71,11 @@ struct node_ops_info {
     utils::UUID ops_uuid;
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
+
+    node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
+    node_ops_info(const node_ops_info&) = delete;
+    node_ops_info(node_ops_info&&) = delete;
+
     void check_abort();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -76,6 +76,9 @@ struct node_ops_info {
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
 
+    future<> start();
+    future<> stop() noexcept;
+
     void check_abort();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -67,11 +67,18 @@ struct repair_uniq_id {
 };
 std::ostream& operator<<(std::ostream& os, const repair_uniq_id& x);
 
-struct node_ops_info {
+class node_ops_info {
+public:
     utils::UUID ops_uuid;
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
 
+private:
+    optimized_optional<abort_source::subscription> _abort_subscription;
+    sharded<abort_source> _sas;
+    future<> _abort_done = make_ready_future<>();
+
+public:
     node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
@@ -80,6 +87,8 @@ struct node_ops_info {
     future<> stop() noexcept;
 
     void check_abort();
+
+    abort_source* local_abort_source();
 };
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
@@ -187,7 +196,7 @@ public:
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
-            shared_ptr<abort_source> as,
+            abort_source* as,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
     void abort() noexcept;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3756,6 +3756,7 @@ future<> storage_service::node_ops_abort_thread() {
             auto uuid_opt = _node_ops_abort_queue.front();
             _node_ops_abort_queue.pop_front();
             if (!uuid_opt) {
+                slogger.info("Stopped node_ops_abort_thread");
                 co_return;
             }
             try {
@@ -3765,7 +3766,7 @@ future<> storage_service::node_ops_abort_thread() {
             }
         }
     }
-    slogger.info("Stopped node_ops_abort_thread");
+    __builtin_unreachable();
 }
 
 } // namespace service

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2925,7 +2925,7 @@ future<> storage_service::removenode_with_stream(gms::inet_address leaving_node,
 future<> storage_service::restore_replica_count(inet_address endpoint, inet_address notify_endpoint) {
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::removenode)) {
         auto ops_uuid = utils::make_random_uuid();
-        auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, nullptr, std::list<gms::inet_address>()});
+        auto ops = seastar::make_shared<node_ops_info>(ops_uuid, nullptr, std::list<gms::inet_address>());
         return _repair.local().removenode_with_repair(get_token_metadata_ptr(), endpoint, ops).finally([this, notify_endpoint] () {
             return send_replication_notification(notify_endpoint);
         });
@@ -3658,7 +3658,7 @@ node_ops_meta_data::node_ops_meta_data(
     , _abort(std::move(abort_func))
     , _abort_source(seastar::make_shared<abort_source>())
     , _signal(std::move(signal_func))
-    , _ops(seastar::make_shared<node_ops_info>({_ops_uuid, _abort_source, std::move(ignore_nodes)}))
+    , _ops(seastar::make_shared<node_ops_info>(_ops_uuid, _abort_source, std::move(ignore_nodes)))
     , _watchdog([sig = _signal] { sig(); }) {
     _watchdog.arm(_watchdog_interval);
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3668,11 +3668,11 @@ node_ops_meta_data::node_ops_meta_data(
 }
 
 future<> node_ops_meta_data::start() {
-    return make_ready_future<>(); // for now
+    return _ops ? _ops->start() : make_ready_future<>();
 }
 
 future<> node_ops_meta_data::stop() noexcept {
-    return make_ready_future<>(); // for now
+    return _ops ? _ops->stop() : make_ready_future<>();
 }
 
 future<> node_ops_meta_data::abort() {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -105,6 +105,8 @@ public:
             std::list<gms::inet_address> ignore_nodes,
             std::function<future<> ()> abort_func,
             std::function<void ()> signal_func);
+    future<> start();
+    future<> stop() noexcept;
     shared_ptr<node_ops_info> get_ops_info();
     shared_ptr<abort_source> get_abort_source();
     future<> abort();


### PR DESCRIPTION
Prevent copying shared_ptr across shards
in do_sync_data_using_repair by allocating
a shared_ptr<abort_source> per shard in
node_ops_meta_data and respectively in node_ops_info.

Fixes #11826

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>