### PR TITLE
storage_service: removenode: allow host_id to be either ip address or uuid

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1237,7 +1237,7 @@
                "parameters":[
                   {
                      "name":"host_id",
-                     "description":"Remove the node with host_id from the cluster",
+                     "description":"Remove the node with host_id (uuid or ip address) from the cluster",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1245,7 +1245,7 @@
                   },
                   {
                      "name":"ignore_nodes",
-                     "description":"List of dead nodes to ingore in removenode operation",
+                     "description":"List of dead nodes' ip addresses to ingore in removenode operation",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",


### PR DESCRIPTION
Our documentation https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/removenode.html
gives only ip address parameter as an example, yet the current code supports only node uuid to identify the node to be removed.

This change extends the support for both.

Fixes #11834
Refs #11830
