### PR TITLE
storage_proxy: Don't use default-initialized endpoint in get_read_executor()

### DIFF
--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -237,7 +237,7 @@ filter_for_query(consistency_level cl,
                  const inet_address_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
-                 gms::inet_address* extra,
+                 std::optional<gms::inet_address>* extra,
                  replica::column_family* cf) {
     size_t local_count;
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -53,7 +53,7 @@ filter_for_query(consistency_level cl,
                  const inet_address_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
-                 gms::inet_address* extra,
+                 std::optional<gms::inet_address>* extra,
                  replica::column_family* cf);
 
 inet_address_vector_replica_set filter_for_query(consistency_level cl,


### PR DESCRIPTION
After calling filter_for_query() the extra_replica to speculate to may be left default-initialized which is :0 ipv6 address. Later below this address is used as-is to check if it belongs to the same DC or not which is not nice, as :0 is not an address of any existing endpoint.

Recent move of dc/rack data onto topology made this place reveal itself by emitting the internal error due to :0 not being present on the topology's collection of endpoints. Prior to this move the dc filter would count :0 as belonging to "default_dc" datacenter which may or may not match with the dc of the local node.

The fix is to explicitly tell set extra_replica from unset one.

fixes: #11825

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>