### PR TITLE
Add support for timeuuid v7

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1280,7 +1280,7 @@ deps['test/boost/bytes_ostream_test'] = [
     "test/lib/log.cc",
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
-deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'hashers.cc']
+deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'hashers.cc', "bytes.cc"]
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -93,7 +93,7 @@ The following table gives additional information on the native data types and wh
                          :token:`string`       :ref:`times` below for details
  ``timestamp``           :token:`integer`,     A timestamp (date and time) with millisecond precision. See :ref:`timestamps`
                          :token:`string`       below for details
- ``timeuuid``            :token:`uuid`         Version 1 UUID_, generally used as a “conflict-free” timestamp. See `Working with UUIDs`_ for details
+ ``timeuuid``            :token:`uuid`         A time UUID_ (Version 1 or 7), generally used as a “conflict-free” timestamp. See `Working with UUIDs`_ for details
  ``tinyint``             :token:`integer`      8-bit signed int
  ``uuid``                :token:`uuid`         A UUID_ (of any version). See `Working with UUIDs`_ for details
  ``varint``              :token:`integer`      Arbitrary-precision integer

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 #include <utility>
 #include "utils/UUID_gen.hh"
+#include "utils/UUID_cmp.hh"
 #include "types.hh"
 
 BOOST_AUTO_TEST_CASE(test_generation_of_name_based_UUID) {

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -120,8 +120,8 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_msb_is_monotonic) {
         auto prev = first;
         for (int64_t i = 1; i < 3697; i += step) {
             auto next =  UUID(UUID_gen::create_time(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
-            bool t1 = utils::timeuuid_tri_compare(next, prev) > 0;
-            bool t2 = utils::timeuuid_tri_compare(next, first) > 0;
+            bool t1 = utils::timeuuid_cmp(next, prev).tri_compare() > 0;
+            bool t2 = utils::timeuuid_cmp(next, first).tri_compare() > 0;
             if (!t1 || !t2) {
                 BOOST_CHECK_MESSAGE(t1 && t2, format("a UUID {}{} later is not great than at test start: {} {}", i, str(scale), t1, t2));
             }
@@ -146,8 +146,8 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_tri_compare_legacy) {
         auto prev = first;
         for (int64_t i = 1; i < 3697; i += step) {
             auto next =  UUID(UUID_gen::create_time(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
-            bool t1 = utils::timeuuid_tri_compare(next, prev) == timeuuid_legacy_tri_compare(next, prev);
-            bool t2 = utils::timeuuid_tri_compare(next, first) == timeuuid_legacy_tri_compare(next, first);
+            bool t1 = utils::timeuuid_cmp(next, prev).tri_compare() == timeuuid_legacy_tri_compare(next, prev);
+            bool t2 = utils::timeuuid_cmp(next, first).tri_compare() == timeuuid_legacy_tri_compare(next, first);
             if (!t1 || !t2) {
                 BOOST_CHECK_MESSAGE(t1 && t2, format("a UUID {}{} later violates compare order", i, str(scale)));
             }
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_submicro_is_monotonic) {
                 std::chrono::microseconds{micros}, i);
         check_is_valid_timeuuid(UUID_gen::get_UUID(uuid.data()));
         // UUID submicro part grows monotonically
-        BOOST_CHECK(utils::timeuuid_tri_compare({uuid.data(), 16}, {prev.data(), 16}) > 0);
+        BOOST_CHECK(utils::timeuuid_cmp({uuid.data(), 16}, {prev.data(), 16}).tri_compare() > 0);
         prev = uuid;
     }
     BOOST_CHECK_EXCEPTION(UUID_gen::get_time_UUID_bytes_from_micros_and_submicros(std::chrono::microseconds{micros}, 2 * maxsubmicro),

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -105,7 +105,7 @@ std::strong_ordering timeuuid_legacy_tri_compare(bytes_view o1, bytes_view o2) {
     return res;
 }
 
-BOOST_AUTO_TEST_CASE(test_timeuuid_msb_is_monotonic) {
+BOOST_AUTO_TEST_CASE(test_timeuuid_v1_msb_is_monotonic) {
     using utils::UUID, utils::UUID_gen;
     auto uuid = UUID_gen::get_time_UUID();
     auto first = uuid.serialize();
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_msb_is_monotonic) {
         int step = 1; /* + (random() % 169) ; */
         auto prev = first;
         for (int64_t i = 1; i < 3697; i += step) {
-            auto next =  UUID(UUID_gen::create_time(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
+            auto next =  UUID(UUID_gen::create_time_v1(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
             bool t1 = utils::timeuuid_cmp(next, prev).tri_compare() > 0;
             bool t2 = utils::timeuuid_cmp(next, first).tri_compare() > 0;
             if (!t1 || !t2) {
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_msb_is_monotonic) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_timeuuid_tri_compare_legacy) {
+BOOST_AUTO_TEST_CASE(test_timeuuid_v1_tri_compare_legacy) {
     using utils::UUID, utils::UUID_gen;
     auto uuid = UUID_gen::get_time_UUID();
     auto first = uuid.serialize();
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_tri_compare_legacy) {
         int step = 1; /* + (random() % 169) ; */
         auto prev = first;
         for (int64_t i = 1; i < 3697; i += step) {
-            auto next =  UUID(UUID_gen::create_time(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
+            auto next =  UUID(UUID_gen::create_time_v1(UUID_gen::decimicroseconds{uuid.timestamp() + (i * *scale)}), 0).serialize();
             bool t1 = utils::timeuuid_cmp(next, prev).tri_compare() == timeuuid_legacy_tri_compare(next, prev);
             bool t2 = utils::timeuuid_cmp(next, first).tri_compare() == timeuuid_legacy_tri_compare(next, first);
             if (!t1 || !t2) {

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -170,6 +170,13 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_type_string_conversions) {
     test_parsing_fails(timeuuid_type, utils::make_random_uuid().to_sstring());
 }
 
+BOOST_AUTO_TEST_CASE(test_timeuuid_v7_type_string_conversions) {
+    auto now = utils::UUID_gen::get_time_UUID_v7();
+    BOOST_REQUIRE(timeuuid_type->equal(timeuuid_type->from_string(now.to_sstring()), timeuuid_type->decompose(now)));
+    auto uuid = utils::UUID(sstring("00003efe-9930-7000-8cb8-afff034bd362"));
+    BOOST_REQUIRE(timeuuid_type->equal(timeuuid_type->from_string("00003eFE-9930-7000-8Cb8-afff034bD362"), timeuuid_type->decompose(uuid)));
+}
+
 BOOST_AUTO_TEST_CASE(test_simple_date_type_string_conversions) {
     BOOST_REQUIRE(simple_date_type->equal(simple_date_type->from_string("1970-01-01"), serialized(simple_date_native_type{0x80000000})));
     BOOST_REQUIRE_EQUAL(simple_date_type->to_string(serialized(simple_date_native_type{0x80000000})), "1970-01-01");

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -685,6 +685,13 @@ SEASTAR_TEST_CASE(test_user_function_timeuuid_return) {
         e.execute_cql("CREATE FUNCTION my_func2(val int) CALLED ON NULL INPUT RETURNS timeuuid LANGUAGE Lua AS 'return \"d18648bc-cf83-21e9-9820-107b4493b787\"';").get();
         auto fut = e.execute_cql("SELECT my_func2(val) FROM my_table;");
         BOOST_REQUIRE_EXCEPTION(fut.get(), marshal_exception, message_equals("marshaling error: Unsupported UUID version (2)"));
+
+        // Test returning timeuuid v7.
+        e.execute_cql("CREATE FUNCTION my_func3(val int) CALLED ON NULL INPUT RETURNS timeuuid LANGUAGE Lua AS 'return \"ffffd065-6385-7000-8a11-1f27a7a0e5e8\"';").get();
+        res = e.execute_cql("SELECT my_func3(val) FROM my_table;").get0();
+        assert_that(res).is_rows().with_rows({
+            {serialized(timeuuid_native_type{utils::UUID("ffffd065-6385-7000-8a11-1f27a7a0e5e8")})}
+        });
     });
 }
 

--- a/types.cc
+++ b/types.cc
@@ -2315,12 +2315,11 @@ struct compare_visitor {
             return std::strong_ordering::greater;
         }
 
-        // FIXME: indentation
-            return with_linearized(v1, [&] (bytes_view v1) {
-                return with_linearized(v2, [&] (bytes_view v2) {
-                    return utils::timeuuid_cmp(v1, v2).uuid_tri_compare();
-                });
+        return with_linearized(v1, [&] (bytes_view v1) {
+            return with_linearized(v2, [&] (bytes_view v2) {
+                return utils::timeuuid_cmp(v1, v2).uuid_tri_compare();
             });
+        });
     }
     std::strong_ordering operator()(const empty_type_impl&) { return std::strong_ordering::equal; }
     std::strong_ordering operator()(const tuple_type_impl& t) { return compare_aux(t, v1, v2); }

--- a/types.cc
+++ b/types.cc
@@ -46,6 +46,7 @@
 #include "utils/ascii.hh"
 #include "utils/fragment_range.hh"
 #include "utils/managed_bytes.hh"
+#include "utils/UUID_cmp.hh"
 #include "mutation_partition.hh"
 
 #include "types/user.hh"

--- a/types.cc
+++ b/types.cc
@@ -2291,7 +2291,7 @@ struct compare_visitor {
       return with_empty_checks([&] {
         return with_linearized(v1, [&] (bytes_view v1) {
             return with_linearized(v2, [&] (bytes_view v2) {
-                return utils::timeuuid_tri_compare(v1, v2);
+                return utils::timeuuid_cmp(v1, v2).tri_compare();
             });
         });
       });
@@ -2324,7 +2324,7 @@ struct compare_visitor {
         if (c1 == 1) {
             return with_linearized(v1, [&] (bytes_view v1) {
                 return with_linearized(v2, [&] (bytes_view v2) {
-                    return utils::uuid_tri_compare_timeuuid(v1, v2);
+                    return utils::timeuuid_cmp(v1, v2).uuid_tri_compare();
                 });
             });
         }

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -53,19 +53,30 @@ public:
         return version() == 1;
     }
 
-    bool is_timestamp() const noexcept {
-        return is_timestamp_v1();
+    bool is_timestamp_v7() const noexcept {
+        return version() == 7;
     }
 
-    int64_t timestamp() const noexcept {
-        //if (version() != 1) {
-        //     throw new UnsupportedOperationException("Not a time-based UUID");
-        //}
-        assert(is_timestamp());
+    bool is_timestamp() const noexcept {
+        return is_timestamp_v1() || is_timestamp_v7();
+    }
 
+    // Return the uuid timestamp in decimicroseconds.
+    int64_t timestamp() const noexcept {
+      switch (version()) {
+      case 1:
         return ((most_sig_bits & 0xFFF) << 48) |
                (((most_sig_bits >> 16) & 0xFFFF) << 32) |
                (((uint64_t)most_sig_bits) >> 32);
+      case 7:
+        return (most_sig_bits >> 16) * 10000 +
+               (most_sig_bits & 0xfff);
+      default:
+        //if (version() != 1) {
+        //     throw new UnsupportedOperationException("Not a time-based UUID");
+        //}
+        not_a_time_uuid();
+      }
 
     }
 
@@ -141,6 +152,9 @@ public:
         serialize_int64(out, most_sig_bits);
         serialize_int64(out, least_sig_bits);
     }
+
+private:
+    [[noreturn]] void not_a_time_uuid() const;
 };
 
 inline UUID null_uuid() noexcept {
@@ -148,6 +162,9 @@ inline UUID null_uuid() noexcept {
 }
 
 UUID make_random_uuid() noexcept;
+
+[[noreturn]] void not_a_time_uuid(UUID uuid);
+[[noreturn]] void not_a_time_uuid(bytes_view);
 
 template<typename Tag>
 struct tagged_uuid {

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -145,69 +145,6 @@ inline UUID null_uuid() noexcept {
 
 UUID make_random_uuid() noexcept;
 
-inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept {
-    return a <=> b;
-}
-
-// Read 8 most significant bytes of timeuuid from serialized bytes
-inline uint64_t timeuuid_read_msb(const int8_t *b) noexcept {
-    // cast to unsigned to avoid sign-compliment during shift.
-    auto u64 = [](uint8_t i) -> uint64_t { return i; };
-    // Scylla and Cassandra use a standard UUID memory layout for MSB:
-    // 4 bytes    2 bytes    2 bytes
-    // time_low - time_mid - time_hi_and_version
-    //
-    // The storage format uses network byte order.
-    // Reorder bytes to allow for an integer compare.
-    return u64(b[6] & 0xf) << 56 | u64(b[7]) << 48 |
-           u64(b[4]) << 40 | u64(b[5]) << 32 |
-           u64(b[0]) << 24 | u64(b[1]) << 16 |
-           u64(b[2]) << 8  | u64(b[3]);
-}
-
-inline uint64_t uuid_read_lsb(const int8_t *b) noexcept {
-    auto u64 = [](uint8_t i) -> uint64_t { return i; };
-    return u64(b[8]) << 56 | u64(b[9]) << 48 |
-           u64(b[10]) << 40 | u64(b[11]) << 32 |
-           u64(b[12]) << 24 | u64(b[13]) << 16 |
-           u64(b[14]) << 8  | u64(b[15]);
-}
-
-// Compare two values of timeuuid type.
-// Cassandra legacy requires:
-// - using signed compare for least significant bits.
-// - masking off UUID version during compare, to
-// treat possible non-version-1 UUID the same way as UUID.
-//
-// To avoid breaking ordering in existing sstables, Scylla preserves
-// Cassandra compare order.
-//
-inline std::strong_ordering timeuuid_tri_compare(bytes_view o1, bytes_view o2) noexcept {
-    auto timeuuid_read_lsb = [](bytes_view o) -> uint64_t {
-        return uuid_read_lsb(o.begin()) ^ 0x8080808080808080;
-    };
-    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
-    if (res == 0) {
-        res = uint64_t_tri_compare(timeuuid_read_lsb(o1), timeuuid_read_lsb(o2));
-    }
-    return res;
-}
-
-// Compare two values of UUID type, if they happen to be
-// both of Version 1 (timeuuids).
-//
-// This function uses memory order for least significant bits,
-// which is both faster and monotonic, so should be preferred
-// to @timeuuid_tri_compare() used for all new features.
-//
-inline std::strong_ordering uuid_tri_compare_timeuuid(bytes_view o1, bytes_view o2) noexcept {
-    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
-    if (res == 0) {
-        res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));
-    }
-    return res;
-}
-
 template<typename Tag>
 struct tagged_uuid {
     utils::UUID id;

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -49,8 +49,12 @@ public:
         return (most_sig_bits >> 12) & 0xf;
     }
 
-    bool is_timestamp() const noexcept {
+    bool is_timestamp_v1() const noexcept {
         return version() == 1;
+    }
+
+    bool is_timestamp() const noexcept {
+        return is_timestamp_v1();
     }
 
     int64_t timestamp() const noexcept {

--- a/utils/UUID_cmp.hh
+++ b/utils/UUID_cmp.hh
@@ -16,7 +16,7 @@ class timeuuid_cmp {
 
 private:
     static inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept;
-    static inline uint64_t timeuuid_read_msb(const int8_t* b) noexcept;
+    static inline uint64_t timeuuid_v1_read_msb(const int8_t* b) noexcept;
     static inline uint64_t uuid_read_lsb(const int8_t* b) noexcept;
 
 public:
@@ -31,7 +31,7 @@ inline std::strong_ordering timeuuid_cmp::uint64_t_tri_compare(uint64_t a, uint6
 }
 
 // Read 8 most significant bytes of timeuuid from serialized bytes
-inline uint64_t timeuuid_cmp::timeuuid_read_msb(const int8_t* b) noexcept {
+inline uint64_t timeuuid_cmp::timeuuid_v1_read_msb(const int8_t* b) noexcept {
     // cast to unsigned to avoid sign-compliment during shift.
     auto u64 = [](uint8_t i) -> uint64_t { return i; };
     // Scylla and Cassandra use a standard UUID memory layout for MSB:
@@ -69,7 +69,7 @@ inline std::strong_ordering timeuuid_cmp::tri_compare() noexcept {
     auto timeuuid_read_lsb = [](bytes_view o) -> uint64_t {
         return uuid_read_lsb(o.begin()) ^ 0x8080808080808080;
     };
-    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
+    auto res = uint64_t_tri_compare(timeuuid_v1_read_msb(o1.begin()), timeuuid_v1_read_msb(o2.begin()));
     if (res == 0) {
         res = uint64_t_tri_compare(timeuuid_read_lsb(o1), timeuuid_read_lsb(o2));
     }
@@ -86,7 +86,7 @@ inline std::strong_ordering timeuuid_cmp::tri_compare() noexcept {
 inline std::strong_ordering timeuuid_cmp::uuid_tri_compare() noexcept {
     const bytes_view& o1 = _o1;
     const bytes_view& o2 = _o2;
-    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
+    auto res = uint64_t_tri_compare(timeuuid_v1_read_msb(o1.begin()), timeuuid_v1_read_msb(o2.begin()));
     if (res == 0) {
         res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));
     }

--- a/utils/UUID_cmp.hh
+++ b/utils/UUID_cmp.hh
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+namespace utils {
+
+inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept {
+    return a <=> b;
+}
+
+// Read 8 most significant bytes of timeuuid from serialized bytes
+inline uint64_t timeuuid_read_msb(const int8_t *b) noexcept {
+    // cast to unsigned to avoid sign-compliment during shift.
+    auto u64 = [](uint8_t i) -> uint64_t { return i; };
+    // Scylla and Cassandra use a standard UUID memory layout for MSB:
+    // 4 bytes    2 bytes    2 bytes
+    // time_low - time_mid - time_hi_and_version
+    //
+    // The storage format uses network byte order.
+    // Reorder bytes to allow for an integer compare.
+    return u64(b[6] & 0xf) << 56 | u64(b[7]) << 48 |
+           u64(b[4]) << 40 | u64(b[5]) << 32 |
+           u64(b[0]) << 24 | u64(b[1]) << 16 |
+           u64(b[2]) << 8  | u64(b[3]);
+}
+
+inline uint64_t uuid_read_lsb(const int8_t *b) noexcept {
+    auto u64 = [](uint8_t i) -> uint64_t { return i; };
+    return u64(b[8]) << 56 | u64(b[9]) << 48 |
+           u64(b[10]) << 40 | u64(b[11]) << 32 |
+           u64(b[12]) << 24 | u64(b[13]) << 16 |
+           u64(b[14]) << 8  | u64(b[15]);
+}
+
+// Compare two values of timeuuid type.
+// Cassandra legacy requires:
+// - using signed compare for least significant bits.
+// - masking off UUID version during compare, to
+// treat possible non-version-1 UUID the same way as UUID.
+//
+// To avoid breaking ordering in existing sstables, Scylla preserves
+// Cassandra compare order.
+//
+inline std::strong_ordering timeuuid_tri_compare(bytes_view o1, bytes_view o2) noexcept {
+    auto timeuuid_read_lsb = [](bytes_view o) -> uint64_t {
+        return uuid_read_lsb(o.begin()) ^ 0x8080808080808080;
+    };
+    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
+    if (res == 0) {
+        res = uint64_t_tri_compare(timeuuid_read_lsb(o1), timeuuid_read_lsb(o2));
+    }
+    return res;
+}
+
+// Compare two values of UUID type, if they happen to be
+// both of Version 1 (timeuuids).
+//
+// This function uses memory order for least significant bits,
+// which is both faster and monotonic, so should be preferred
+// to @timeuuid_tri_compare() used for all new features.
+//
+inline std::strong_ordering uuid_tri_compare_timeuuid(bytes_view o1, bytes_view o2) noexcept {
+    auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
+    if (res == 0) {
+        res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));
+    }
+    return res;
+}
+
+} // namespace utils

--- a/utils/UUID_cmp.hh
+++ b/utils/UUID_cmp.hh
@@ -10,12 +10,28 @@
 
 namespace utils {
 
-inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept {
+class timeuuid_cmp {
+    bytes_view _o1;
+    bytes_view _o2;
+
+private:
+    static inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept;
+    static inline uint64_t timeuuid_read_msb(const int8_t* b) noexcept;
+    static inline uint64_t uuid_read_lsb(const int8_t* b) noexcept;
+
+public:
+    timeuuid_cmp(bytes_view o1, bytes_view o2) noexcept : _o1(o1), _o2(o2) {}
+
+    std::strong_ordering tri_compare() noexcept;
+    std::strong_ordering uuid_tri_compare() noexcept;
+};
+
+inline std::strong_ordering timeuuid_cmp::uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept {
     return a <=> b;
 }
 
 // Read 8 most significant bytes of timeuuid from serialized bytes
-inline uint64_t timeuuid_read_msb(const int8_t *b) noexcept {
+inline uint64_t timeuuid_cmp::timeuuid_read_msb(const int8_t* b) noexcept {
     // cast to unsigned to avoid sign-compliment during shift.
     auto u64 = [](uint8_t i) -> uint64_t { return i; };
     // Scylla and Cassandra use a standard UUID memory layout for MSB:
@@ -30,7 +46,7 @@ inline uint64_t timeuuid_read_msb(const int8_t *b) noexcept {
            u64(b[2]) << 8  | u64(b[3]);
 }
 
-inline uint64_t uuid_read_lsb(const int8_t *b) noexcept {
+inline uint64_t timeuuid_cmp::uuid_read_lsb(const int8_t* b) noexcept {
     auto u64 = [](uint8_t i) -> uint64_t { return i; };
     return u64(b[8]) << 56 | u64(b[9]) << 48 |
            u64(b[10]) << 40 | u64(b[11]) << 32 |
@@ -47,7 +63,9 @@ inline uint64_t uuid_read_lsb(const int8_t *b) noexcept {
 // To avoid breaking ordering in existing sstables, Scylla preserves
 // Cassandra compare order.
 //
-inline std::strong_ordering timeuuid_tri_compare(bytes_view o1, bytes_view o2) noexcept {
+inline std::strong_ordering timeuuid_cmp::tri_compare() noexcept {
+    const bytes_view& o1 = _o1;
+    const bytes_view& o2 = _o2;
     auto timeuuid_read_lsb = [](bytes_view o) -> uint64_t {
         return uuid_read_lsb(o.begin()) ^ 0x8080808080808080;
     };
@@ -65,7 +83,9 @@ inline std::strong_ordering timeuuid_tri_compare(bytes_view o1, bytes_view o2) n
 // which is both faster and monotonic, so should be preferred
 // to @timeuuid_tri_compare() used for all new features.
 //
-inline std::strong_ordering uuid_tri_compare_timeuuid(bytes_view o1, bytes_view o2) noexcept {
+inline std::strong_ordering timeuuid_cmp::uuid_tri_compare() noexcept {
+    const bytes_view& o1 = _o1;
+    const bytes_view& o2 = _o2;
     auto res = uint64_t_tri_compare(timeuuid_read_msb(o1.begin()), timeuuid_read_msb(o2.begin()));
     if (res == 0) {
         res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));

--- a/utils/UUID_cmp.hh
+++ b/utils/UUID_cmp.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/UUID_gen.hh"
+
 namespace utils {
 
 class timeuuid_cmp {
@@ -18,6 +20,8 @@ private:
     static inline std::strong_ordering uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept;
     static inline uint64_t timeuuid_v1_read_msb(const int8_t* b) noexcept;
     static inline uint64_t uuid_read_lsb(const int8_t* b) noexcept;
+    std::strong_ordering unix_timestamp_tri_compare() noexcept;
+    std::strong_ordering tri_compare_v7() noexcept;
 
 public:
     timeuuid_cmp(bytes_view o1, bytes_view o2) noexcept : _o1(o1), _o2(o2) {}
@@ -28,6 +32,14 @@ public:
 
 inline std::strong_ordering timeuuid_cmp::uint64_t_tri_compare(uint64_t a, uint64_t b) noexcept {
     return a <=> b;
+}
+
+inline std::strong_ordering int64_t_tri_compare(int64_t a, int64_t b) noexcept {
+    return a <=> b;
+}
+
+inline unsigned timeuuid_read_version(const int8_t* b) noexcept {
+    return static_cast<uint8_t>(b[6]) >> 4;
 }
 
 // Read 8 most significant bytes of timeuuid from serialized bytes
@@ -54,21 +66,68 @@ inline uint64_t timeuuid_cmp::uuid_read_lsb(const int8_t* b) noexcept {
            u64(b[14]) << 8  | u64(b[15]);
 }
 
+inline std::strong_ordering timeuuid_cmp::unix_timestamp_tri_compare() noexcept {
+    auto u1 = UUID_gen::get_UUID_from_msb(_o1.begin());
+    auto t1 = UUID_gen::normalized_timestamp(u1).count();
+    auto u2 = UUID_gen::get_UUID_from_msb(_o2.begin());
+    auto t2 = UUID_gen::normalized_timestamp(u2).count();
+    auto res = int64_t_tri_compare(t1, t2);
+    if (res != 0) {
+        return res;
+    }
+    // Compare the random least-significant bytes as unsigned bytes
+    auto lsb1 = bytes_view(_o1.begin() + 8, 8);
+    auto lsb2 = bytes_view(_o2.begin() + 8, 8);
+    return compare_unsigned(lsb1, lsb2);
+}
+
+inline std::strong_ordering timeuuid_cmp::tri_compare_v7() noexcept {
+    int8_t b1 = *_o1.begin();
+    int8_t b2 = *_o2.begin();
+    // If both uuids start with the same sign (common case)
+    // Just use unsigned memory compare.
+    if (!((b1 ^ b2) & 0x80)) [[likely]] {
+        return compare_unsigned(_o1, _o2);
+    } else {
+        // Otherwise, it's enough to compare only the first bytes
+        // as signed 8-bit values, since we know they are different
+        // already, in their sign.
+        return b1 <=> b2;
+    }
+}
+
 // Compare two values of timeuuid type.
-// Cassandra legacy requires:
+// Cassandra legacy requires the following for v1 timeuuid values:
 // - using signed compare for least significant bits.
 // - masking off UUID version during compare, to
-// treat possible non-version-1 UUID the same way as UUID.
+// treat possible non-version-1 or 7 UUID the same way as UUID.
 //
 // To avoid breaking ordering in existing sstables, Scylla preserves
 // Cassandra compare order.
 //
+// If both values are of version 7, the function uses signed comparison
+// in memory order for all bits.
+//
+// For mixed versions, the function first compares the derived timestamp
+// and then the least significant bits.
 inline std::strong_ordering timeuuid_cmp::tri_compare() noexcept {
     const bytes_view& o1 = _o1;
     const bytes_view& o2 = _o2;
     auto timeuuid_read_lsb = [](bytes_view o) -> uint64_t {
         return uuid_read_lsb(o.begin()) ^ 0x8080808080808080;
     };
+    auto v1 = timeuuid_read_version(o1.begin());
+    auto v2 = timeuuid_read_version(o2.begin());
+    // For backward compatibility reasons,
+    // only timeuuid v7 is special handled.
+    switch (v1 + v2) {
+    case 14: // 7 vs. 7
+        return tri_compare_v7();
+    case 7:  // 7 vs. 0
+        return o1 <=> o2;
+    case 8:  // 7 vs. 1
+        return unix_timestamp_tri_compare();
+    }
     auto res = uint64_t_tri_compare(timeuuid_v1_read_msb(o1.begin()), timeuuid_v1_read_msb(o2.begin()));
     if (res == 0) {
         res = uint64_t_tri_compare(timeuuid_read_lsb(o1), timeuuid_read_lsb(o2));
@@ -77,20 +136,40 @@ inline std::strong_ordering timeuuid_cmp::tri_compare() noexcept {
 }
 
 // Compare two values of UUID type, if they happen to be
-// both of Version 1 (timeuuids).
+// both of Version 1 or 7 (timeuuids).
 //
 // This function uses memory order for least significant bits,
 // which is both faster and monotonic, so should be preferred
 // to @timeuuid_tri_compare() used for all new features.
 //
+// If both values are of version 7, the function uses signed comparison
+// in memory order for all bits.
+//
+// For mixed versions, the function first compares the derived timestamp
+// and then the least significant bits, in memory order.
 inline std::strong_ordering timeuuid_cmp::uuid_tri_compare() noexcept {
     const bytes_view& o1 = _o1;
     const bytes_view& o2 = _o2;
-    auto res = uint64_t_tri_compare(timeuuid_v1_read_msb(o1.begin()), timeuuid_v1_read_msb(o2.begin()));
-    if (res == 0) {
-        res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));
+    auto v1 = timeuuid_read_version(o1.begin());
+    auto v2 = timeuuid_read_version(o2.begin());
+    if (v1 != v2) {
+        // 7 vs. 1
+        if (v1 + v2 == 8) {
+            return unix_timestamp_tri_compare();
+        }
+        return o1 <=> o2;
     }
-    return res;
+    if (v1 == 1) {
+        auto res = uint64_t_tri_compare(timeuuid_v1_read_msb(o1.begin()), timeuuid_v1_read_msb(o2.begin()));
+        if (res == 0) {
+            res = uint64_t_tri_compare(uuid_read_lsb(o1.begin()), uuid_read_lsb(o2.begin()));
+        }
+        return res;
+    }
+    if (v1 == 7) {
+        return tri_compare_v7();
+    }
+    return compare_unsigned(o1, o2);
 }
 
 } // namespace utils

--- a/utils/UUID_gen.cc
+++ b/utils/UUID_gen.cc
@@ -163,4 +163,8 @@ const thread_local int64_t UUID_gen::spoof_node = make_thread_local_node(make_ra
 const thread_local int64_t UUID_gen::clock_seq_and_node = make_clock_seq_and_node();
 thread_local UUID_gen UUID_gen::_instance;
 
+void not_a_time_uuid(bytes_view v) {
+    not_a_time_uuid(UUID_gen::get_UUID(v.begin()));
+}
+
 } // namespace utils

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -239,6 +239,13 @@ public:
         return UUID(net::ntoh(t.msb), net::ntoh(t.lsb));
     }
 
+    /** creates uuid from raw bytes. src must point to a region of 8 bytes*/
+    static UUID get_UUID_from_msb(const int8_t* src) {
+        struct tmp { uint64_t msb; } t;
+        std::copy(src, src + 8, reinterpret_cast<char*>(&t));
+        return UUID(net::ntoh(t.msb), 0);
+    }
+
     /**
      * Creates a type 3 (name based) UUID based on the specified byte array.
      */

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -318,7 +318,7 @@ public:
      * @param uuid
      * @return milliseconds since Unix epoch
      */
-    static decimicroseconds normalized_timestamp(UUID uuid)
+    static decimicroseconds normalized_timestamp(const UUID& uuid)
     {
         auto epoch = START_EPOCH_V1;
         return decimicroseconds(uuid.timestamp()) + epoch;
@@ -328,7 +328,7 @@ public:
      * @param uuid
      * @return milliseconds since Unix epoch
      */
-    static milliseconds unix_timestamp(UUID uuid)
+    static milliseconds unix_timestamp(const UUID& uuid)
     {
         return duration_cast<milliseconds>(normalized_timestamp(uuid));
     }
@@ -337,7 +337,7 @@ public:
      * @param uuid
      * @return seconds since Unix epoch
      */
-    static std::chrono::seconds unix_timestamp_in_sec(UUID uuid)
+    static std::chrono::seconds unix_timestamp_in_sec(const UUID& uuid)
     {
         using namespace std::chrono;
         return duration_cast<seconds>(static_cast<milliseconds>(unix_timestamp(uuid)));
@@ -347,7 +347,7 @@ public:
      * @param uuid
      * @return microseconds since Unix epoch
      */
-    static int64_t micros_timestamp(UUID uuid)
+    static int64_t micros_timestamp(const UUID& uuid)
     {
         return (uuid.timestamp() + START_EPOCH_V1.count())/10;
     }

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -318,9 +318,19 @@ public:
      * @param uuid
      * @return milliseconds since Unix epoch
      */
+    static decimicroseconds normalized_timestamp(UUID uuid)
+    {
+        auto epoch = START_EPOCH_V1;
+        return decimicroseconds(uuid.timestamp()) + epoch;
+    }
+
+    /**
+     * @param uuid
+     * @return milliseconds since Unix epoch
+     */
     static milliseconds unix_timestamp(UUID uuid)
     {
-        return duration_cast<milliseconds>(decimicroseconds(uuid.timestamp()) + START_EPOCH_V1);
+        return duration_cast<milliseconds>(normalized_timestamp(uuid));
     }
 
     /**

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -41,12 +41,15 @@ public:
     // of 1/10 of a microsecond since the beginning of GMT epoch.
     using decimicroseconds = std::chrono::duration<int64_t, std::ratio<1, 10'000'000>>;
     using milliseconds = std::chrono::milliseconds;
+    using microseconds = std::chrono::microseconds;
 private:
     // A grand day! millis at 00:00:00.000 15 Oct 1582.
     static constexpr decimicroseconds START_EPOCH_V1 = decimicroseconds{-122192928000000000L};
     // UUID time must fit in 60 bits
     static constexpr milliseconds UUID_UNIXTIME_MAX_V1 = duration_cast<milliseconds>(
         decimicroseconds{0x0fffffffffffffffL} + START_EPOCH_V1);
+
+    static constexpr decimicroseconds START_EPOCH_V7 = decimicroseconds{0};
 
     // A random mac address for use in timeuuids
     // where we can not use clockseq to randomize the physical
@@ -78,6 +81,10 @@ private:
 
     decimicroseconds _last_used_time = decimicroseconds{0};
 
+    // For time uuid v7 generation
+    milliseconds _last_used_millis = milliseconds{0};
+    unsigned _last_used_submillis;
+
     UUID_gen()
     {
         // make sure someone didn't whack the clockSeqAndNode by changing the order of instantiation.
@@ -104,6 +111,27 @@ private:
         return create_time_v1(when);
     }
 
+    // Return decimicrosecond time based on the system time,
+    // in milliseconds. If the current millisecond hasn't change
+    // from the previous call, increment the previously used
+    // value by one decimicrosecond.
+    // NOTE: In the original Java code this function was
+    // "synchronized". This isn't needed since in Scylla we do not
+    // need monotonicity between time UUIDs created at different
+    // shards and UUID code uses thread local state on each shard.
+    int64_t create_time_v7_safe() {
+        using std::chrono::system_clock;
+        auto millis = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+        if (millis > _last_used_millis) {
+            _last_used_millis = millis;
+            _last_used_submillis = 0;
+        } else if (++_last_used_submillis >= 0x1000) {
+            ++_last_used_millis;
+            _last_used_submillis = 0;
+        }
+        return create_time_v7(_last_used_millis, _last_used_submillis);
+    }
+
 public:
     // We have only 17 timeuuid bits available to store this
     // value.
@@ -121,6 +149,19 @@ public:
     }
 
     /**
+     * Creates a type 7 UUID (time-based UUID).
+     * See https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04
+     *
+     * @return a UUID instance
+     */
+    static UUID get_time_UUID_v7()
+    {
+        auto uuid = UUID(_instance.create_time_v7_safe(), clock_seq_and_node);
+        assert(uuid.is_timestamp_v7());
+        return uuid;
+    }
+
+    /**
      * Creates a type 1 UUID (time-based UUID) with the wall clock time point @param tp.
      *
      * @return a UUID instance
@@ -133,6 +174,19 @@ public:
     }
 
     /**
+     * Creates a type 7 UUID (time-based UUID) with the wall clock time point @param tp.
+     *
+     * @return a UUID instance
+     */
+    static UUID get_time_UUID_v7(std::chrono::system_clock::time_point tp)
+    {
+        auto micros = std::chrono::duration_cast<microseconds>(tp.time_since_epoch()).count();
+        auto uuid = UUID(create_time_v7(milliseconds(micros / 1000), micros % 1000), clock_seq_and_node);
+        assert(uuid.is_timestamp_v7());
+        return uuid;
+    }
+
+    /**
      * Creates a type 1 UUID (time-based UUID) with the timestamp of @param when, in milliseconds.
      *
      * @return a UUID instance
@@ -141,6 +195,18 @@ public:
     {
         auto uuid = UUID(create_time_v1(from_unix_timestamp_v1(when)), clock_seq_and_node);
         assert(uuid.is_timestamp_v1());
+        return uuid;
+    }
+
+    /**
+     * Creates a type 7 UUID (time-based UUID) with the timestamp of @param when, in milliseconds.
+     *
+     * @return a UUID instance
+     */
+    static UUID get_time_UUID_v7(milliseconds when, int64_t clock_seq_and_node = UUID_gen::clock_seq_and_node)
+    {
+        auto uuid = UUID(create_time_v7(when), clock_seq_and_node);
+        assert(uuid.is_timestamp_v7());
         return uuid;
     }
 
@@ -327,7 +393,7 @@ public:
      */
     static decimicroseconds normalized_timestamp(const UUID& uuid)
     {
-        auto epoch = START_EPOCH_V1;
+        auto epoch = uuid.is_timestamp_v1() ? START_EPOCH_V1 : START_EPOCH_V7;
         return decimicroseconds(uuid.timestamp()) + epoch;
     }
 
@@ -356,7 +422,8 @@ public:
      */
     static int64_t micros_timestamp(const UUID& uuid)
     {
-        return (uuid.timestamp() + START_EPOCH_V1.count())/10;
+        auto epoch = uuid.is_timestamp_v1() ? START_EPOCH_V1 : START_EPOCH_V7;
+        return (uuid.timestamp() + epoch.count()) / 10;
     }
 
     template <std::intmax_t N, std::intmax_t D>
@@ -385,6 +452,22 @@ public:
                (0x0000ffff00000000UL & msb) >> 16 |
                (0x0fff000000000000UL & msb) >> 48 |
                 0x0000000000001000L); // sets the version to 1.
+    }
+
+    // std::chrono typeaware wrapper around create_time().
+    // Creates a timeuuid compatible time (decimicroseconds since
+    // the start of GMT epoch) in UUID v7 format.
+    static int64_t create_time_v7(milliseconds ms, uint64_t sub_millis = 0) {
+        int64_t millis = ms.count();
+        // timeuuid milliseconds must fit in 48 bits
+        static constexpr int64_t min_millis = 0xffff800000000000L;
+        static constexpr int64_t max_millis = ~min_millis;
+        assert(millis >= min_millis && millis <= max_millis);
+        // timeuuid sub-milliseconds must fit in 12 bits
+        assert(!(0xfffffffffffff000UL & sub_millis));
+        return ((millis << 16) |
+                0x0000000000007000L | // sets the version to 7.
+                (sub_millis & 0xfff));
     }
 
     // Produce an UUID which is derived from this UUID in a reversible manner

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -233,7 +233,7 @@ public:
     }
 
     /** creates uuid from raw bytes. src must point to a region of 16 bytes*/
-    static UUID get_UUID(int8_t* src) {
+    static UUID get_UUID(const int8_t* src) {
         struct tmp { uint64_t msb, lsb; } t;
         std::copy(src, src + 16, reinterpret_cast<char*>(&t));
         return UUID(net::ntoh(t.msb), net::ntoh(t.lsb));

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -8,6 +8,7 @@
 
 
 #include "UUID.hh"
+#include <seastar/core/on_internal_error.hh>
 #include <seastar/net/byteorder.hh>
 #include <random>
 #include <boost/iterator/function_input_iterator.hpp>
@@ -16,8 +17,11 @@
 #include <seastar/core/sstring.hh>
 #include "utils/serialization.hh"
 #include "marshal_exception.hh"
+#include "log.hh"
 
 namespace utils {
+
+logging::logger uuidlog("uuid");
 
 UUID
 make_random_uuid() noexcept {
@@ -49,6 +53,14 @@ UUID::UUID(sstring_view uuid) {
     int base = 16;
     this->most_sig_bits = std::stoull(most, nullptr, base);
     this->least_sig_bits = std::stoull(least, nullptr, base);
+}
+
+void not_a_time_uuid(UUID uuid) {
+    on_internal_error(uuidlog, format("UUID {} v{} is not a time-uuid", uuid, uuid.version()));
+}
+
+void UUID::not_a_time_uuid() const {
+    utils::not_a_time_uuid(*this);
 }
 
 }


### PR DESCRIPTION
Based on https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04

UUID Version 7 as defined in the above Internet Draft provides benefits over the exiting time uuid format (v1).
It is easier and faster to construct and and compare as it begins (in memory order) with the unix timestamp in milleseconds encoded using 48 bits, unlike uuid v1 which requires scrambling of the timestamp part of the uuid.

In addition, the string representation of uuid v7 also sorts lexicographically for uuids with unique timestamps (in milliseconds, and having the same sign) making them more suitable to be used as unique sstable generations.

The downside of using time uuid v7 is that its sub-milliseconds resolution is inferior to v1.  v7 has only 12 bits set for the sub-milliseconds part, which we use in this series to store a unique sequence number for repeated calls to get_time_UUID_v7, while v1 has 14 bits that are used in theory to count decimicroseconds (100 ns) units, yet we use them for uniqueness in a similar way and base even the v1 time uuids on the system clock in milliseconds resolution.

This series allows users to store and retrieve timeuuid values in uuid v7 format.
These can be compared in an interchangeable way with time uuid v1 values.

v1 <=> v1 comparisons retain the existing comparison algorithm.
v7 <=> v7 comparisons use the optimized, byte-level unsigned compare.
v1 <=> v7 comparisons compute a normalized timestamp from the two values and compare them as signed int64_t offsets from the unix epoch.

Fixes #11055
