### PR TITLE
Avoid 0.0.0.0 (and :0) as preferred IP

### DIFF
--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -46,6 +46,10 @@ gossiping_property_file_snitch::gossiping_property_file_snitch(const snitch_conf
     if (this_shard_id() == _file_reader_cpu_id) {
         io_cpu_id() = _file_reader_cpu_id;
     }
+    if (_listen_address->addr().is_addr_any()) {
+        logger().warn("Not gossiping INADDR_ANY as internal IP");
+        _listen_address.reset();
+    }
 }
 
 future<> gossiping_property_file_snitch::start() {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -104,12 +104,15 @@ void gossiping_property_file_snitch::periodic_reader_callback() {
 }
 
 std::list<std::pair<gms::application_state, gms::versioned_value>> gossiping_property_file_snitch::get_app_states() const {
-    sstring ip = format("{}", _listen_address);
-    return {
+    std::list<std::pair<gms::application_state, gms::versioned_value>> ret = {
         {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
         {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},
-        {gms::application_state::INTERNAL_IP, gms::versioned_value::internal_ip(std::move(ip))},
     };
+    if (_listen_address.has_value()) {
+        sstring ip = format("{}", *_listen_address);
+        ret.emplace_back(gms::application_state::INTERNAL_IP, gms::versioned_value::internal_ip(std::move(ip)));
+    }
+    return ret;
 }
 
 future<> gossiping_property_file_snitch::read_property_file() {

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -93,7 +93,7 @@ private:
     unsigned _file_reader_cpu_id;
     snitch_signal_t _reconfigured;
     promise<> _io_is_stopped;
-    gms::inet_address _listen_address;
+    std::optional<gms::inet_address> _listen_address;
 
     void reset_io_state() {
         // Reset the promise to allow repeating

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -664,22 +664,22 @@ gms::inet_address messaging_service::get_preferred_ip(gms::inet_address ep) {
 }
 
 void messaging_service::init_local_preferred_ip_cache(const std::unordered_map<gms::inet_address, gms::inet_address>& ips_cache) {
-    _preferred_ip_cache = ips_cache;
+    _preferred_ip_cache.clear();
     _preferred_to_endpoint.clear();
-    //
-    // Reset the connections to the endpoints that have entries in
-    // _preferred_ip_cache so that they reopen with the preferred IPs we've
-    // just read.
-    //
-    for (auto& p : _preferred_ip_cache) {
-        this->remove_rpc_client(msg_addr(p.first));
-        _preferred_to_endpoint[p.second] = p.first;
+    for (auto& p : ips_cache) {
+        cache_preferred_ip(p.first, p.second);
     }
 }
 
 void messaging_service::cache_preferred_ip(gms::inet_address ep, gms::inet_address ip) {
     _preferred_ip_cache[ep] = ip;
     _preferred_to_endpoint[ip] = ep;
+    //
+    // Reset the connections to the endpoints that have entries in
+    // _preferred_ip_cache so that they reopen with the preferred IPs we've
+    // just read.
+    //
+    remove_rpc_client(msg_addr(ep));
 }
 
 gms::inet_address messaging_service::get_public_endpoint_for(const gms::inet_address& ip) const {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -672,6 +672,11 @@ void messaging_service::init_local_preferred_ip_cache(const std::unordered_map<g
 }
 
 void messaging_service::cache_preferred_ip(gms::inet_address ep, gms::inet_address ip) {
+    if (ip.addr().is_addr_any()) {
+        mlogger.warn("Cannot set INADDR_ANY as preferred IP for endpoint {}", ep);
+        return;
+    }
+
     _preferred_ip_cache[ep] = ip;
     _preferred_to_endpoint[ip] = ep;
     //

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1236,7 +1236,6 @@ future<> storage_service::maybe_reconnect_to_preferred_ip(inet_address ep, inet_
         slogger.debug("Initiated reconnect to an Internal IP {} for the {}", local_ip, ep);
         co_await _messaging.invoke_on_all([ep, local_ip] (auto& local_ms) {
             local_ms.cache_preferred_ip(ep, local_ip);
-            local_ms.remove_rpc_client(netw::msg_addr(ep));
         });
     }
 }


### PR DESCRIPTION
Despite docs discourage from using INADDR_ANY as listen address, this is not disabled in code. Worse -- some snitch drivers may gossip it around as the INTERNAL_IP state. This set prevents this from happening and also adds a sanity check not to use this value if it somehow sneaks in.