### PR TITLE
zstd: share context buffers between compressor instances

### DIFF
--- a/compress.cc
+++ b/compress.cc
@@ -22,7 +22,7 @@ public:
     size_t uncompress(const char* input, size_t input_len, char* output,
                     size_t output_len) const override;
     size_t compress(const char* input, size_t input_len, char* output,
-                    size_t output_len) const override;
+                    size_t output_len) override;
     size_t compress_max_size(size_t input_len) const override;
 };
 
@@ -33,7 +33,7 @@ public:
     size_t uncompress(const char* input, size_t input_len, char* output,
                     size_t output_len) const override;
     size_t compress(const char* input, size_t input_len, char* output,
-                    size_t output_len) const override;
+                    size_t output_len) override;
     size_t compress_max_size(size_t input_len) const override;
 };
 
@@ -44,7 +44,7 @@ public:
     size_t uncompress(const char* input, size_t input_len, char* output,
                     size_t output_len) const override;
     size_t compress(const char* input, size_t input_len, char* output,
-                    size_t output_len) const override;
+                    size_t output_len) override;
     size_t compress_max_size(size_t input_len) const override;
 };
 
@@ -225,7 +225,7 @@ size_t lz4_processor::uncompress(const char* input, size_t input_len,
 }
 
 size_t lz4_processor::compress(const char* input, size_t input_len,
-                char* output, size_t output_len) const {
+                char* output, size_t output_len) {
     if (output_len < LZ4_COMPRESSBOUND(input_len) + 4) {
         throw std::runtime_error("LZ4 compression failure: length of output is too small");
     }
@@ -275,7 +275,7 @@ size_t deflate_processor::uncompress(const char* input,
 }
 
 size_t deflate_processor::compress(const char* input,
-                size_t input_len, char* output, size_t output_len) const {
+                size_t input_len, char* output, size_t output_len) {
     z_stream zs;
     zs.zalloc = Z_NULL;
     zs.zfree = Z_NULL;
@@ -324,7 +324,7 @@ size_t snappy_processor::uncompress(const char* input, size_t input_len,
 }
 
 size_t snappy_processor::compress(const char* input, size_t input_len,
-                char* output, size_t output_len) const {
+                char* output, size_t output_len) {
     auto ret = snappy_compress(input, input_len, output, &output_len);
     if (ret != SNAPPY_OK) {
         throw std::runtime_error("snappy compression failure: snappy_compress() failed");

--- a/compress.hh
+++ b/compress.hh
@@ -36,7 +36,7 @@ public:
      * exception is thrown. Maximum required size is obtained via "compress_max_size"
      */
     virtual size_t compress(const char* input, size_t input_len, char* output,
-                    size_t output_len) const = 0;
+                    size_t output_len) = 0;
     /**
      * Returns the maximum output size for compressing data on "input_len" size.
      */

--- a/configure.py
+++ b/configure.py
@@ -500,6 +500,7 @@ scylla_tests = set([
     'test/boost/expr_test',
     'test/boost/exceptions_optimized_test',
     'test/boost/exceptions_fallback_test',
+    'test/boost/zstd_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -33,7 +33,7 @@ enum class mask_type : uint8_t {
 
 // size_bits cannot be >= 64
 static inline uint64_t make_mask(uint8_t size_bits, uint8_t offset, mask_type t) noexcept {
-    const uint64_t mask = ((1 << size_bits) - 1) << offset;
+    const uint64_t mask = ((uint64_t(1) << size_bits) - 1) << offset;
     return t == mask_type::set ? mask : ~mask;
 }
 

--- a/test/boost/zstd_test.cc
+++ b/test/boost/zstd_test.cc
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "compress.hh"
+#include <seastar/core/memory.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <bit>
+
+shared_ptr<compressor> make_compressor(int level, size_t chunk_size_kb) {
+    return compressor::create({
+        {"sstable_compression", "org.apache.cassandra.io.compress.ZstdCompressor"},
+        {"compression_level", std::to_string(level)},
+        {"chunk_length_in_kb", std::to_string(chunk_size_kb)}
+    });
+}
+
+std::vector<char> get_random_data(size_t size) {
+    std::vector<char> v(size);
+    for (size_t i = 0; i < size; ++i) {
+        v[i] = i % 128;
+    }
+    return v;
+}
+
+std::vector<char> compress(compressor& c, const std::vector<char>& in) {
+    auto out = std::vector<char>(c.compress_max_size(in.size()));
+    size_t out_size = c.compress(in.data(), in.size(), out.data(), out.size());
+    BOOST_CHECK_LT(out_size, out.size());
+    out.resize(out_size);
+    return out;
+}
+
+std::vector<char> uncompress(const compressor& c, const std::vector<char>& in, size_t out_size) {
+    auto out = std::vector<char>(out_size);
+    size_t actual_out_size = c.uncompress(in.data(), in.size(), out.data(), out.size());
+    BOOST_CHECK_EQUAL(actual_out_size, out.size());
+    return out;
+}
+
+void test_roundtrip(compressor& c, size_t input_size) {
+    auto raw = get_random_data(input_size);
+    auto compressed = compress(c, raw);
+    auto uncompressed = uncompress(c, compressed, raw.size());
+    BOOST_CHECK_EQUAL(raw, uncompressed);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_buffer_correctness) {
+    for (int level : {3, 22}) {
+        std::vector<shared_ptr<compressor>> compressors;
+        for (size_t chunk_size_kb : {4, 64, 16, 2*1024, 128, 4, 4*1024, 1024}) {
+            compressors.push_back(make_compressor(level, chunk_size_kb));
+            test_roundtrip(*compressors.back(), chunk_size_kb * 1024);
+            for (auto& c : compressors) {
+                test_roundtrip(*c, 1024);
+            }
+        }
+        compressors.clear();
+    }
+}
+
+#ifndef SEASTAR_DEFAULT_ALLOCATOR
+SEASTAR_THREAD_TEST_CASE(test_buffer_reuse) {
+    constexpr int level = 3;
+    constexpr int chunk_size_kb = 4;
+    auto c = make_compressor(level, chunk_size_kb);
+    test_roundtrip(*c, 4*1024);
+
+    size_t allocs_before = seastar::memory::stats().mallocs();
+    test_roundtrip(*c, 4*1024);
+    size_t allocs_after = seastar::memory::stats().mallocs();
+
+    size_t expected_allocs = allocs_before + 3; // 3 allocs for the raw, compressed and uncompressed buffers, 0 allocs for the compressor.
+    BOOST_CHECK_EQUAL(allocs_after, expected_allocs);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decompressor_buffer_sharing) {
+    constexpr int level = 3;
+    constexpr int chunk_size_kb = 4;
+    auto raw = get_random_data(chunk_size_kb*1024);
+    auto compressed = compress(*make_compressor(level, chunk_size_kb), raw);
+
+    std::vector<shared_ptr<compressor>> compressors;
+    compressors.reserve(1000);
+    size_t memory_before = seastar::memory::stats().allocated_memory();
+    for (size_t i = 0; i < 1000; ++i) {
+        compressors.push_back(make_compressor(level, 1024));
+        auto uncompressed = uncompress(*compressors.back(), compressed, raw.size());
+        BOOST_CHECK_EQUAL(raw, uncompressed);
+    }
+    size_t memory_after = seastar::memory::stats().allocated_memory();
+    BOOST_CHECK_LT(memory_after, memory_before + 1024*1024);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_compressor_buffer_sharing) {
+    constexpr int level = 3;
+    constexpr int chunk_size_kb = 4;
+    auto raw = get_random_data(chunk_size_kb*1024);
+
+    std::vector<shared_ptr<compressor>> compressors;
+    compressors.reserve(1000);
+    size_t memory_before = seastar::memory::stats().allocated_memory();
+    for (size_t i = 0; i < 1000; ++i) {
+        compressors.push_back(make_compressor(level, 1024));
+        compress(*compressors.back(), raw);
+        size_t memory_after = seastar::memory::stats().allocated_memory();
+    }
+    size_t memory_after = seastar::memory::stats().allocated_memory();
+    BOOST_CHECK_LT(memory_after, memory_before + 4*1024*1024);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decompressor_doesnt_allocate_cctx) {
+    constexpr int level = 22;
+    constexpr int chunk_size_kb = 4*1024;
+    size_t memory_start = seastar::memory::stats().allocated_memory();
+    {
+        auto raw = get_random_data(1024);
+        auto compressed = compress(*make_compressor(level, chunk_size_kb), raw);
+        size_t memory_before = seastar::memory::stats().allocated_memory();
+        auto decompressor = make_compressor(level, chunk_size_kb);
+        uncompress(*decompressor, compressed, raw.size());
+        // Check that decompressor doesn't allocate compression contexts.
+        size_t memory_after = seastar::memory::stats().allocated_memory();
+        BOOST_CHECK_LT(memory_after, memory_before + 1024*1024);
+    }
+    size_t memory_end = seastar::memory::stats().allocated_memory();
+    // Check that there are no big leftovers from a big compression context.
+    BOOST_CHECK_LT(memory_end, memory_start + 4*1024*1024);
+}
+#endif

--- a/zstd.cc
+++ b/zstd.cc
@@ -37,7 +37,7 @@ public:
     size_t uncompress(const char* input, size_t input_len, char* output,
                     size_t output_len) const override;
     size_t compress(const char* input, size_t input_len, char* output,
-                    size_t output_len) const override;
+                    size_t output_len) override;
     size_t compress_max_size(size_t input_len) const override;
 
     std::set<sstring> option_names() const override;


### PR DESCRIPTION
Every stream from/to a compressed SSTable has its own instance of compressor. In zstd's case, each compressor has its own buffer for the compression and decompression context. These buffers can be quite large -- their typical sizes are between 100 KiB and 1 MiB range, so they provide a stall hazard and an OOM hazard, given that thousands of concurrent SSTable reads are possible.

This patch fixes that hazard by making all ZSTD compressors use using a single buffer for all ZSTD compressors. This is somewhat risky, because the buffer is resized up when needed, but is never resized down. If a huge buffer appears, e.g. due to malformed compression settings, it will stay in memory forever (until node restart), even if compression settings get fixed. To prevent this, readers which need abnormally large buffers do not use the shared buffer, but use a private one.

Fixes #11733.