### PR TITLE
scylla-node-exporter: remove collector.interrupts from node_exporter

### DIFF
--- a/dist/common/sysconfig/scylla-node-exporter
+++ b/dist/common/sysconfig/scylla-node-exporter
@@ -1,1 +1,1 @@
-SCYLLA_NODE_EXPORTER_ARGS="--collector.interrupts"
+SCYLLA_NODE_EXPORTER_ARGS=""


### PR DESCRIPTION
The collector.interrupts responsible for 90% of all node_exporter metrics. In a big cluster, this is a significant overhead with little value.

Remove it for better performance.

Fixes #11881

This is an example from a 33 nodes cluster with 1300 cores.

![image](https://user-images.githubusercontent.com/2118079/199752442-68d65ac5-c09a-4e4e-bec3-fde0197e4139.png)

With newer Scylla versions most of this top 10 list will be reduced dramatically, but the number of interrupts will remain
Signed-off-by: Amnon Heiman <amnon@scylladb.com>