### PR TITLE
test: loading_cache_test: fix use-after-free in test_loading_cache_remove_leaves_no_old_entries_behind

### DIFF
--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -703,7 +703,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
         //
 
         auto f = loading_cache.get_ptr(0, [&](auto key) {
-            return yield().then([&] {
+            return yield().then([&load_v1, key] {
                 return load_v1(key);
             });
         });
@@ -740,7 +740,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
         // Test remove_if() concurrent with loading
         //
         auto f = loading_cache.get_ptr(0, [&](auto key) {
-            return yield().then([&] {
+            return yield().then([&load_v1, key] {
                 return load_v1(key);
             });
         });


### PR DESCRIPTION
We capture `key` by reference, but it is in a another continuation.

Capture it by value, and avoid the default capture specification.

Found by clang 15 + asan + aarch64.