### PR TITLE
doc: add the amplify.yml file to enable previewing documentation PRs

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,15 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        build:
+          commands:
+            - make setupenv
+            - make dirhtml
+      artifacts:
+        baseDirectory: _build/dirhtml
+        files:
+          - '**/*'
+      cache:
+        paths: []
+    appRoot: docs


### PR DESCRIPTION
This PR adds the _amplify.yml_ file to the root of this project. The file is required to enable [previewing documentation PRs](https://sphinx-theme.scylladb.com/stable/deployment/previews.html).
See Step 1 in the [Installation](https://sphinx-theme.scylladb.com/stable/deployment/previews.html#installation) procedure for details.