### PR TITLE
db: config: disable global index page caching by default

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -907,7 +907,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,
         "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
     , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 10, "Time for which information about finished task stays in memory.")
-    , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,
+    , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, false,
         "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions.")
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)


### PR DESCRIPTION
Global index page caching, as introduced in 4.6
(078a6e422b96 and 9f957f1cf99a) has proven to be misdesigned, because it poses a risk of catastrophic performance regressions in common workloads by flooding the cache with useless index entries. Because of that risk, it should be disabled by default.

Refs #11202
Fixes #11889