### PR TITLE
scylla-gdb.py: $downcast_vptr(): add multiple inheritance support

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5049,13 +5049,10 @@ class scylla_gdb_func_downcast_vptr(gdb.Function):
 
     def __init__(self):
         super(scylla_gdb_func_downcast_vptr, self).__init__('downcast_vptr')
-        self._symbol_pattern = re.compile('vtable for (.*) \+ 16.*')
+        self._symbol_pattern = re.compile('vtable for (.*) \+ ([0-9]+).*')
         self._vptr_type = gdb.lookup_type('uintptr_t').pointer()
 
-    def invoke(self, ptr):
-        if not isinstance(ptr, gdb.Value):
-            ptr = gdb.parse_and_eval(ptr)
-
+    def _check_vptr(self, ptr):
         symbol_name = resolve(ptr.reinterpret_cast(self._vptr_type).dereference(), startswith='vtable for ')
         if symbol_name is None:
             raise ValueError("Failed to resolve first word of virtual object @ {} as a vtable symbol".format(int(ptr)))
@@ -5064,9 +5061,35 @@ class scylla_gdb_func_downcast_vptr(gdb.Function):
         if m is None:
             raise ValueError("Failed to extract type name from symbol name `{}'".format(symbol_name))
 
-        actual_type = gdb.lookup_type(m.group(1)).pointer()
-        return ptr.reinterpret_cast(actual_type)
+        return m
 
+    def invoke(self, ptr):
+        if not isinstance(ptr, gdb.Value):
+            ptr = gdb.parse_and_eval(ptr)
+
+        m = self._check_vptr(ptr)
+
+        actual_type = gdb.lookup_type(m.group(1))
+        actual_type_ptr = actual_type.pointer()
+
+        if int(m.group(2)) == 16:
+            return ptr.reinterpret_cast(actual_type_ptr)
+
+        # We are most likely dealing with multiple inheritance and a pointer to a
+        # non-first base-class type.
+        base_class_field = actual_type.fields()[0]
+        assert(base_class_field.is_base_class)
+        base_classes = list(base_class_field.type.fields())
+
+        # The pointer is surely not to the first base-class, we would have found
+        # the expected m.group(2) == 16 offset otherwise.
+        for bc in base_classes[1:]:
+            speculative_ptr = gdb.Value(int(ptr) - int(bc.bitpos / 8))
+            m = self._check_vptr(speculative_ptr)
+            if int(m.group(2)) == 16:
+                return speculative_ptr.reinterpret_cast(actual_type_ptr)
+
+        return None
 
 class reference_wrapper:
     def __init__(self, ref):


### PR DESCRIPTION
When a class inherits from multiple virtual base classes, pointers to instances of this class via one of its base classes, might point to somewhere into the object, not at its beginning. Therefore, the simple method employed currently by $downcast_vptr() of casting the provided pointer to the type extracted from the vtable name fails. Instead when this situation is detected (detectable by observing that the symbol name of the partial vtable is not to an offset of +16, but larger), $downcast_vptr() will iterate over the base classes, adjusting the pointer with their offsets, hoping to find the true start of the object. In the one instance I tested this with, this method worked well. At the very least, the method will now yield a null pointer when it fails, instead of a badly casted object with corrupt content (which the developer might or might not attribute to the bad cast).