### PR TITLE
utils: config_src: add set_value_on_all_shards functions

### DIFF
--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -99,7 +99,7 @@ void set_task_manager_test(http_context& ctx, routes& r, db::config& cfg) {
 
     tmt::get_and_update_ttl.set(r, [&ctx, &cfg] (std::unique_ptr<request> req) -> future<json::json_return_type> {
         uint32_t ttl = cfg.task_ttl_seconds();
-        cfg.task_ttl_seconds.set(boost::lexical_cast<uint32_t>(req->query_parameters["ttl"]));
+        co_await cfg.task_ttl_seconds.set_value_on_all_shards(req->query_parameters["ttl"], utils::config_file::config_source::API);
         co_return json::json_return_type(ttl);
     });
 }

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -136,15 +136,21 @@ async def test_task_manager_wait(rest_api):
 def test_task_manager_ttl(rest_api):
     with new_test_module(rest_api):
         args0 = {"keyspace": "keyspace0", "table": "table0"}
+        args1 = {"keyspace": "keyspace0", "table": "table0", "shard": "1"}
         with new_test_task(rest_api, args0) as task0:
             print(f"created test task {task0}")
-            ttl = 2
-            with set_tmp_task_ttl(rest_api, ttl):
-                resp = rest_api.send("POST", f"task_manager_test/finish_test_task/{task0}")
-                resp.raise_for_status()
+            with new_test_task(rest_api, args1) as task1:
+                print(f"created test task {task1}")
+                ttl = 2
+                with set_tmp_task_ttl(rest_api, ttl):
+                    resp = rest_api.send("POST", f"task_manager_test/finish_test_task/{task0}")
+                    resp.raise_for_status()
+                    resp = rest_api.send("POST", f"task_manager_test/finish_test_task/{task1}")
+                    resp.raise_for_status()
 
-                time.sleep(ttl + 1)
-                assert_task_does_not_exist(rest_api, task0)
+                    time.sleep(ttl + 1)
+                    assert_task_does_not_exist(rest_api, task0)
+                    assert_task_does_not_exist(rest_api, task1)
 
 def test_task_manager_sequence_number(rest_api):
     with new_test_module(rest_api):

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -423,6 +423,8 @@ sstring utils::config_file::config_src::source_name() const noexcept {
         return "internal";
     case utils::config_file::config_source::CQL:
         return "cql";
+    case utils::config_file::config_source::API:
+        return "api";
     }
 
     __builtin_unreachable();

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -81,7 +81,8 @@ public:
         SettingsFile,
         CommandLine,
         CQL,
-        Internal
+        Internal,
+        API,
     };
 
     struct config_src {

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -127,6 +127,8 @@ public:
         virtual void add_command_line_option(bpo::options_description_easy_init&) = 0;
         virtual void set_value(const YAML::Node&) = 0;
         virtual bool set_value(sstring, config_source = config_source::Internal) = 0;
+        virtual future<> set_value_on_all_shards(const YAML::Node&) = 0;
+        virtual future<bool> set_value_on_all_shards(sstring, config_source = config_source::Internal) = 0;
         virtual value_status status() const noexcept = 0;
         virtual config_source source() const noexcept = 0;
         sstring source_name() const noexcept;
@@ -234,6 +236,11 @@ public:
         void add_command_line_option(bpo::options_description_easy_init&) override;
         void set_value(const YAML::Node&) override;
         bool set_value(sstring, config_source = config_source::Internal) override;
+        // For setting a single value on all shards,
+        // without having to call broadcast_to_all_shards
+        // that broadcasts all values to all shards.
+        future<> set_value_on_all_shards(const YAML::Node&) override;
+        future<bool> set_value_on_all_shards(sstring, config_source = config_source::Internal) override;
     };
 
     typedef std::reference_wrapper<config_src> cfg_ref;


### PR DESCRIPTION
Currently when we set a single value we need
to call broadcast_to_all_shards to let observers on all
shards get notified of the new value.

However, the latter broadcasts all value to all shards
so it's terribly inefficient.

Instead, add async set_value_on_all_shards functions
to broadcast a value to all shards.

Use those in system_keyspace for db_config_table virtual table
and in task_manager_test to update the task_manager ttl.
    
Refs #7316
