### PR TITLE
build: disable -Og in debug mode to avoid coroutine asan breakage

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -289,7 +289,8 @@ modes = {
         'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*40,
-        'optimization-level': 'g',
+        # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
+        'optimization-level': ('0' if platform.machine() == 'aarch64' else 'g'),
         'per_src_extra_cxxflags': {},
         'cmake_build_type': 'Debug',
         'can_have_debug_info': True,


### PR DESCRIPTION
Coroutines and asan don't mix well on aarch64. This was seen in 22f13e7ca3 (" Revert "Merge 'cql3: select_statement: coroutinize indexed_table_select_statement::do_execute_base_query()' from Avi Kivity"") where a routine coroutinization was reverted due to failures on aarch64 debug mode.

In clang 15 this is even worse, the existing code starts failing. However, if we disable optimization (-O0 rather than -Og), things begin to work again. In fact we can reinstate the patch reverted above even with clang 12.

Fix (or rather workaround) the problem by avoiding -Og on aarch64 debug mode. There's the lingering fear that release mode is miscompiled too, but all the tests pass on clang 15 in release mode so it appears related to asan.