### PR TITLE
doc: improve the documentation landing page 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,6 @@
   <div class="topics-grid topics-grid--products">
 
       <h2 class="topics-grid__title">Our Products</h2>
-      <p class="topics-grid__text">Choose a product from the list below to view its documentation.</p>
 
       <div class="grid-container full">
           <div class="grid-x grid-margin-x">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,17 +38,17 @@
   :title: Let us manage your DB
   :link: https://cloud.docs.scylladb.com
   :class: large-4
-  :anchor: Get Started with Scylla Cloud
+  :anchor: ScyllaDB Cloud Documentation
 
-  Take advantage of Scylla Cloud, a fully-managed database-as-a-service.
+  Simplify application development with ScyllaDB Cloud - a fully managed database-as-a-service.
 
 .. topic-box::
   :title: Manage your own DB
   :link: getting-started
   :class: large-4
-  :anchor: Get Started with Scylla
+  :anchor: ScyllaDB Open Source and Enterprise Documentation
 
-  Provision and manage a Scylla cluster in your environment.
+  Deploy and manage your database in your own environment.
 
 
 .. raw:: html
@@ -59,8 +59,8 @@
 
   <div class="topics-grid topics-grid--products">
 
-      <h2 class="topics-grid__title">Our Product List</h2>
-      <p class="topics-grid__text">To begin choose a product from the list below</p>
+      <h2 class="topics-grid__title">Our Products</h2>
+      <p class="topics-grid__text">Choose a product from the list below to view its documentation.</p>
 
       <div class="grid-container full">
           <div class="grid-x grid-margin-x">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,15 @@
   <div class="grid-x grid-margin-x hs">
 
 .. topic-box::
+  :title: New to ScyllaDB? Start here!
+  :link: https://cloud.docs.scylladb.com/stable/scylladb-basics/
+  :class: large-4
+  :anchor: ScyllaDB Basics
+
+  Learn the essentials of ScyllaDB.
+
+
+.. topic-box::
   :title: Let us manage your DB
   :link: https://cloud.docs.scylladb.com
   :class: large-4
@@ -41,13 +50,6 @@
 
   Provision and manage a Scylla cluster in your environment.
 
-.. topic-box::
-  :title: Connect your application to Scylla
-  :link: using-scylla/drivers
-  :class: large-4
-  :anchor: Choose a Driver
-
-  Use high performance Scylla drivers to connect your application to a Scylla cluster.
 
 .. raw:: html
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@
           <div class="grid-x grid-margin-x">
 
 .. topic-box::
-  :title: Scylla Enterprise
+  :title: ScyllaDB Enterprise
   :link: getting-started
   :image: /_static/img/mascots/scylla-enterprise.svg
   :class: topic-box--product,large-3,small-6
@@ -74,7 +74,7 @@
   ScyllaDB’s most stable high-performance enterprise-grade NoSQL database.
 
 .. topic-box::
-  :title: Scylla Open Source
+  :title: ScyllaDB Open Source
   :link: getting-started
   :image: /_static/img/mascots/scylla-opensource.svg
   :class: topic-box--product,large-3,small-6
@@ -82,15 +82,15 @@
   A high-performance NoSQL database with a close-to-the-hardware, shared-nothing approach.
 
 .. topic-box::
-  :title: Scylla Cloud
+  :title: ScyllaDB Cloud
   :link: https://cloud.docs.scylladb.com
   :image: /_static/img/mascots/scylla-cloud.svg
   :class: topic-box--product,large-3,small-6
 
-  A fully managed NoSQL database as a service powered by Scylla Enterprise.
+  A fully managed NoSQL database as a service powered by ScyllaDB Enterprise.
 
 .. topic-box::
-  :title: Scylla Alternator
+  :title: ScyllaDB Alternator
   :link: https://docs.scylladb.com/stable/alternator/alternator.html
   :image: /_static/img/mascots/scylla-alternator.svg
   :class: topic-box--product,large-3,small-6
@@ -98,23 +98,23 @@
   Open source Amazon DynamoDB-compatible API.
 
 .. topic-box::
-  :title: Scylla Monitoring Stack
+  :title: ScyllaDB Monitoring Stack
   :link: https://monitoring.docs.scylladb.com
   :image: /_static/img/mascots/scylla-monitor.svg
   :class: topic-box--product,large-3,small-6
 
-  Complete open source monitoring solution for your Scylla clusters.
+  Complete open source monitoring solution for your ScyllaDB clusters.
 
 .. topic-box::
-  :title: Scylla Manager
+  :title: ScyllaDB Manager
   :link: https://manager.docs.scylladb.com
   :image: /_static/img/mascots/scylla-manager.svg
   :class: topic-box--product,large-3,small-6
 
-  Hassle-free Scylla NoSQL database management for scale-out clusters.
+  Hassle-free ScyllaDB NoSQL database management for scale-out clusters.
 
 .. topic-box::
-  :title: Scylla Drivers
+  :title: ScyllaDB Drivers
   :link: https://docs.scylladb.com/stable/using-scylla/drivers/
   :image: /_static/img/mascots/scylla-drivers.svg
   :class: topic-box--product,large-3,small-6
@@ -122,12 +122,12 @@
   Shard-aware drivers for superior performance. 
 
 .. topic-box::
-  :title: Scylla Operator
+  :title: ScyllaDB Operator
   :link: https://operator.docs.scylladb.com
   :image: /_static/img/mascots/scylla-enterprise.svg
   :class: topic-box--product,large-3,small-6
 
-  Easily run and manage your Scylla Cluster on Kubernetes.
+  Easily run and manage your ScyllaDB cluster on Kubernetes.
 
 .. raw:: html
 
@@ -137,19 +137,19 @@
 
   <div class="topics-grid">
 
-      <h2 class="topics-grid__title">Learn More About Scylla</h2>
+      <h2 class="topics-grid__title">Learn More About ScyllaDB</h2>
       <p class="topics-grid__text"></p>
       <div class="grid-container full">
           <div class="grid-x grid-margin-x">
 
 .. topic-box::
-  :title: Attend Scylla University
+  :title: Attend ScyllaDB University
   :link: https://university.scylladb.com/
   :image: /_static/img/mascots/scylla-university.png
   :class: large-6,small-12
   :anchor: Find a Class
 
-  | Register to take a *free* class at Scylla University.
+  | Register to take a *free* class at ScyllaDB University.
   | There are several learning paths to choose from.
 
 .. topic-box::
@@ -180,9 +180,9 @@
   architecture/index
   troubleshooting/index
   kb/index
-  Scylla University <https://university.scylladb.com/>
+  ScyllaDB University <https://university.scylladb.com/>
   faq
-  Contribute to Scylla <contribute>
+  Contribute to ScyllaDB <contribute>
   glossary
   alternator/alternator
 


### PR DESCRIPTION
This PR introduces the following changes to the documentation landing page:

- The " New to ScyllaDB? Start here!" box is added.
- The "Connect your application to Scylla" box is removed.
- Some wording has been improved.
- "Scylla" has been replaced with "ScyllaDB".