### PR TITLE
Update tombstones-flush.rst - remove dot from "nodetool compact" command

### DIFF
--- a/docs/kb/tombstones-flush.rst
+++ b/docs/kb/tombstones-flush.rst
@@ -42,7 +42,7 @@ Steps:
 
 .. code-block:: sh
    
-   nodetool compact <keyspace>.<mytable>;
+   nodetool compact <keyspace> <mytable>;
 
 5. Alter the table and change the grace period back to the original ``gc_grace_seconds`` value.
 


### PR DESCRIPTION
change syntax:

`nodetool compact <keyspace>.<mytable>;`
to
`nodetool compact <keyspace> <mytable>;`