### PR TITLE
[branch-4.6] multishard_mutation_query: don't unpop partition header of spent partition 

### DIFF
--- a/memtable-sstable.hh
+++ b/memtable-sstable.hh
@@ -30,6 +30,7 @@
 #include <seastar/core/io_priority_class.hh>
 
 class memtable;
+class reader_permit;
 class flat_mutation_reader;
 
 namespace sstables {

--- a/schema_upgrader.hh
+++ b/schema_upgrader.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "mutation_fragment.hh"
+#include "mutation_fragment_v2.hh"
 #include "converting_mutation_partition_applier.hh"
 
 // A StreamedMutationTransformer which transforms the stream to a different schema

--- a/test/cql-pytest/test_scan.py
+++ b/test/cql-pytest/test_scan.py
@@ -1,0 +1,29 @@
+# Copyright 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Tests for scanning SELECT requests (which read many rows and/or many
+# partitions).
+# We have a separate test file test_filtering.py for scans which also involve
+# filtering, and test_allow_filtering.py for checking when "ALLOW FILTERING"
+# is needed in scan. test_secondary_index.py also contains tests for scanning
+# using a secondary index.
+#############################################################################
+
+import pytest
+from util import new_test_table
+from cassandra.query import SimpleStatement
+
+# Regression test for #9482
+def test_scan_ending_with_static_row(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int, ck int, s int STATIC, v int, PRIMARY KEY (pk, ck)") as table:
+        stmt = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
+        for pk in range(100):
+            cql.execute(stmt, (0, pk))
+
+        statement = SimpleStatement(f"SELECT * FROM {table}", fetch_size=10)
+        # This will trigger an error in either processing or building the query
+        # results. The success criteria for this test is the query finishing
+        # without errors.
+        res = list(cql.execute(statement))

--- a/test/raft/future_set.hh
+++ b/test/raft/future_set.hh
@@ -25,6 +25,8 @@
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/condition-variable.hh>
 
+#include "test/raft/logical_timer.hh"
+
 using namespace seastar;
 
 // A set of futures that can be polled to obtain the result of some ready future in the set.

--- a/test/raft/logical_timer.hh
+++ b/test/raft/logical_timer.hh
@@ -26,6 +26,7 @@
 #include <seastar/core/future-util.hh>
 
 #include "raft/logical_clock.hh"
+#include "raft/raft.hh"
 
 using namespace seastar;
 

--- a/thrift/utils.hh
+++ b/thrift/utils.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <utility>
+#include <fmt/format.h>
 
 namespace thrift {
 

--- a/utils/entangled.hh
+++ b/utils/entangled.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <boost/intrusive/parent_from_member.hpp>
 
 //  A movable pointer-like object paired with exactly one other object of the same type. 

--- a/utils/immutable-collection.hh
+++ b/utils/immutable-collection.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 #include <type_traits>
+#include <utility>
 #include <seastar/util/concepts.hh>
 
 namespace utils {


### PR DESCRIPTION
When stopping the read, the multishard reader will dismantle the
compaction state, pushing back (unpopping) the currently processed
partition's header to its originating reader. This ensures that if the
reader stops in the middle of a partition, on the next page the
partition-header is re-emitted as the compactor (and everything
downstream from it) expects.
It can happen however that there is nothing more for the current
partition in the reader and the next fragment is another partition.
Since we only push back the partition header (without a partition-end)
this can result in two partitions being emitted without being separated
by a partition end.
We could just add the missing partition-end when needed but it is
pointless, if the partition has no more data, just drop the header, we
won't need it on the next page.

The missing partition-end can generate an "IDL frame truncated" message
as it ends up causing the query result writer to create a corrupt
partition entry.

Fixes: https://github.com/scylladb/scylladb/issues/9482