### PR TITLE
alternator: fix wrong 'where' condition for GSI range key

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -929,7 +929,7 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
             }
             sstring where_clause = "\"" + view_hash_key + "\" IS NOT NULL";
             if (!view_range_key.empty()) {
-                where_clause = where_clause + " AND \"" + view_hash_key + "\" IS NOT NULL";
+                where_clause = where_clause + " AND \"" + view_range_key + "\" IS NOT NULL";
             }
             where_clauses.push_back(std::move(where_clause));
             view_builders.emplace_back(std::move(view_builder));

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -34,6 +34,7 @@
 #include "expressions.hh"
 #include "conditions.hh"
 #include "cql3/constants.hh"
+#include "cql3/util.hh"
 #include <optional>
 #include "utils/overloaded_functor.hh"
 #include <seastar/json/json_elements.hh>
@@ -927,9 +928,10 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
             if  (!range_key.empty() && range_key != view_hash_key && range_key != view_range_key) {
                 add_column(view_builder, range_key, attribute_definitions, column_kind::clustering_key);
             }
-            sstring where_clause = "\"" + view_hash_key + "\" IS NOT NULL";
+            sstring where_clause = format("{} IS NOT NULL", cql3::util::maybe_quote(view_hash_key));
             if (!view_range_key.empty()) {
-                where_clause = where_clause + " AND \"" + view_range_key + "\" IS NOT NULL";
+                where_clause = format("{} AND {} IS NOT NULL", where_clause,
+                    cql3::util::maybe_quote(view_range_key));
             }
             where_clauses.push_back(std::move(where_clause));
             view_builders.emplace_back(std::move(view_builder));
@@ -984,9 +986,10 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
             // Note above we don't need to add virtual columns, as all
             // base columns were copied to view. TODO: reconsider the need
             // for virtual columns when we support Projection.
-            sstring where_clause = "\"" + view_hash_key + "\" IS NOT NULL";
+            sstring where_clause = format("{} IS NOT NULL", cql3::util::maybe_quote(view_hash_key));
             if (!view_range_key.empty()) {
-                where_clause = where_clause + " AND \"" + view_range_key + "\" IS NOT NULL";
+                where_clause = format("{} AND {} IS NOT NULL", where_clause,
+                    cql3::util::maybe_quote(view_range_key));
             }
             where_clauses.push_back(std::move(where_clause));
             view_builders.emplace_back(std::move(view_builder));

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -1244,7 +1244,7 @@ def test_gsi_list_tables(dynamodb, test_table_gsi_random_name):
 # skipped while filling the GSI - even if Scylla actually capable of
 # representing such empty view keys (see issue #9375).
 # Reproduces issue #5022 and #9424.
-@pytest.mark.xfail(reason="issue #5022, #9424")
+@pytest.mark.xfail(reason="issue #11567, #9424")
 def test_gsi_backfill_empty_string(dynamodb):
     # First create, and fill, a table without GSI:
     with new_test_table(dynamodb,

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -167,6 +167,24 @@ def test_gsi_empty_value(test_table_gsi_2):
     with pytest.raises(ClientError, match='ValidationException.*empty'):
         test_table_gsi_2.put_item(Item={'p': random_string(), 'x': ''})
 
+def test_gsi_empty_value_with_range_key(test_table_gsi_3):
+    with pytest.raises(ClientError, match='ValidationException.*empty'):
+        test_table_gsi_3.put_item(Item={'p': random_string(), 'a': '', 'b': random_string()})
+    with pytest.raises(ClientError, match='ValidationException.*empty'):
+        test_table_gsi_3.put_item(Item={'p': random_string(), 'a': random_string(), 'b': ''})
+
+# Dynamodb supports special way of setting NULL value.
+# It's different than non existing value.
+def test_gsi_null_value(test_table_gsi_2):
+    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+        test_table_gsi_2.put_item(Item={'p': random_string(), 'x': None})
+
+def test_gsi_null_value_with_range_key(test_table_gsi_3):
+    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+        test_table_gsi_3.put_item(Item={'p': random_string(), 'a': None, 'b': random_string()})
+    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+        test_table_gsi_3.put_item(Item={'p': random_string(), 'a': random_string(), 'b': None})
+
 # Verify that a GSI is correctly listed in describe_table
 def test_gsi_describe(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -242,7 +242,7 @@ def test_lsi_describe(test_table_lsi_4):
     assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_x1', 'hello_x2', 'hello_x3', 'hello_x4'])
     for lsi in lsis:
         assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/' + lsi['IndexName']
-    assert lsi['Projection'] == {'ProjectionType': 'ALL'}
+        assert lsi['Projection'] == {'ProjectionType': 'ALL'}
 
 # In addition to the basic listing of an LSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each LSI's


### PR DESCRIPTION
Contains fixes requested in the issue (and some tiny extras), together with analysis why they don't affect the users (see commit messages).

Fixes [ #11800](https://github.com/scylladb/scylladb/issues/11800)