### PR TITLE
install.sh: Skip systemd existance check when --without-systemd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,7 @@ upgrade=false
 supervisor=false
 supervisor_log_to_stdout=false
 without_systemd=false
+skip_systemd_check=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -99,6 +100,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--packaging")
             packaging=true
+            skip_systemd_check=true
             shift 1
             ;;
         "--upgrade")
@@ -107,6 +109,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--supervisor")
             supervisor=true
+            skip_systemd_check=true
             shift 1
             ;;
         "--supervisor-log-to-stdout")
@@ -115,6 +118,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--without-systemd")
             without_systemd=true
+            skip_systemd_check=true
             shift 1
             ;;
         "--help")
@@ -246,7 +250,7 @@ supervisor_conf() {
     fi
 }
 
-if ! $packaging && [ ! -d /run/systemd/system/ ] && ! $supervisor; then
+if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     echo "systemd is not detected, unsupported distribution."
     exit 1
 fi
@@ -566,7 +570,7 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    if ! $supervisor && ! $packaging && ! $without_systemd && check_usermode_support; then
+    if ! $without_systemd_check && check_usermode_support; then
         systemctl --user daemon-reload
     fi
     echo "Scylla non-root install completed."

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -46,6 +46,7 @@ supervisor=false
 supervisor_log_to_stdout=false
 without_systemd=false
 debuginfo=false
+skip_systemd_check=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -75,6 +76,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--supervisor")
             supervisor=true
+            skip_systemd_check=true
             shift 1
             ;;
         "--supervisor-log-to-stdout")
@@ -83,6 +85,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--without-systemd")
             without_systemd=true
+            skip_systemd_check=true
             shift 1
             ;;
         "--debuginfo")
@@ -99,7 +102,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ ! -d /run/systemd/system/ ] && ! $supervisor; then
+if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     echo "systemd is not detected, unsupported distribution."
     exit 1
 fi
@@ -179,6 +182,6 @@ fi
 
 install -m755 uninstall.sh -Dt "$rprefix"
 
-if ! $supervisor && $nonroot && ! check_usermode_support; then
+if $nonroot && ! $without_systemd_check && ! check_usermode_support; then
     echo "WARNING: This distribution does not support systemd user mode, please configure and launch Scylla manually."
 fi


### PR DESCRIPTION
When --without-systemd specified, install.sh should skip systemd existance check.

Fixes #11898