### PR TITLE
test.py: don't stop cluster's site if not started

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -734,7 +734,9 @@ class ScyllaClusterManager:
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
         logging.info("ScyllaManager stopping for test %s", self.test_uname)
-        await self.site.stop()
+        if hasattr(self, "site"):
+            await self.site.stop()
+            del self.site
         if not self.cluster.is_dirty:
             logging.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
             await self.clusters.put(self.cluster)


### PR DESCRIPTION
Check `ScyllaCluster.site` is present before calling `stop()`. This might happen due to bad starts when `ScyllaCluster.stop()` is called but `ScyllaCluster.start()` failed.