### PR TITLE
cql3: expr: add unit tests for prepare_expression

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -687,9 +687,13 @@ bind_variable_test_assignment(const bind_variable& bv, data_dictionary::database
 }
 
 static
-bind_variable
+std::optional<bind_variable>
 bind_variable_prepare_expression(const bind_variable& bv, data_dictionary::database db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver)
 {   
+    if (!receiver) {
+        return std::nullopt;
+    }
+
     return bind_variable {
         .bind_index = bv.bind_index,
         .receiver = receiver

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -246,6 +246,12 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
 
     auto key_spec = maps::key_spec_of(*receiver);
     auto value_spec = maps::value_spec_of(*receiver);
+    const map_type_impl* map_type = dynamic_cast<const map_type_impl*>(&receiver->type->without_reversed());
+    if (map_type == nullptr) {
+        on_internal_error(expr_logger,
+                          format("map_prepare_expression bad non-map receiver type: {}", receiver->type->name()));
+    }
+    data_type map_element_tuple_type = tuple_type_impl::get_instance({map_type->get_keys_type(), map_type->get_values_type()});
     std::vector<expression> values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
@@ -264,7 +270,7 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
 
         values.emplace_back(tuple_constructor {
             .elements = {std::move(k), std::move(v)},
-            .type = entry_tuple.type
+            .type = map_element_tuple_type
         });
     }
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -492,10 +492,7 @@ BOOST_AUTO_TEST_CASE(evaluate_bind_variable) {
                                                         },
                                                         {make_int_raw(123)});
 
-    expression bind_var = bind_variable{
-        .bind_index = 0,
-        .receiver = ::make_lw_shared<column_specification>(
-            "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var_0", true), int32_type)};
+    expression bind_var = bind_variable{.bind_index = 0, .receiver = make_receiver(int32_type, "bind_var_0")};
 
     raw_value val = evaluate(bind_var, inputs);
     BOOST_REQUIRE_EQUAL(val, make_int_raw(123));
@@ -512,15 +509,9 @@ BOOST_AUTO_TEST_CASE(evaluate_two_bind_variables) {
                                                         },
                                                         {make_int_raw(123), make_int_raw(456)});
 
-    expression bind_variable0 =
-        bind_variable{.bind_index = 0,
-                      .receiver = ::make_lw_shared<column_specification>(
-                          "test_ks", "test_cf", ::make_shared<column_identifier>("bind_var_0", true), int32_type)};
+    expression bind_variable0 = bind_variable{.bind_index = 0, .receiver = make_receiver(int32_type, "bind_var_0")};
 
-    expression bind_variable1 =
-        bind_variable{.bind_index = 1,
-                      .receiver = ::make_lw_shared<column_specification>(
-                          "test_ks", "test_cf", ::make_shared<column_identifier>("bind_var_1", true), int32_type)};
+    expression bind_variable1 = bind_variable{.bind_index = 1, .receiver = make_receiver(int32_type, "bind_var_1")};
 
     raw_value val0 = evaluate(bind_variable0, inputs);
     BOOST_REQUIRE_EQUAL(val0, make_int_raw(123));
@@ -535,10 +526,7 @@ BOOST_AUTO_TEST_CASE(evaluate_bind_variable_performs_validation) {
 
     raw_value invalid_int_value = make_bool_raw(true);
 
-    expression bind_var =
-        bind_variable{.bind_index = 0,
-                      .receiver = ::make_lw_shared<column_specification>(
-                          "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var", true), int32_type)};
+    expression bind_var = bind_variable{.bind_index = 0, .receiver = make_receiver(int32_type, "bind_var")};
 
     auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {{"pk", make_int_raw(123)}}, {invalid_int_value});
     BOOST_REQUIRE_THROW(evaluate(bind_var, inputs), exceptions::invalid_request_exception);
@@ -998,10 +986,7 @@ static void check_bind_variable_evaluate(constant check_value, expected_invalid_
                                  .with_column("r", check_value.type, column_kind::regular_column)
                                  .build();
 
-    expression bind_var = bind_variable{
-        .bind_index = 0,
-        .receiver = ::make_lw_shared<column_specification>(
-            "test_ks", "test_cf", ::make_shared<cql3::column_identifier>("bind_var", true), check_value.type)};
+    expression bind_var = bind_variable{.bind_index = 0, .receiver = make_receiver(check_value.type, "bind_var")};
 
     auto [inputs, inputs_data] = make_evaluation_inputs(
         test_schema, {{"pk", make_int_raw(0)}, {"r", raw_value::make_null()}}, {check_value.value});

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1573,3 +1573,100 @@ BOOST_AUTO_TEST_CASE(prepare_bind_variable_no_receiver) {
     BOOST_REQUIRE_THROW(prepare_expression(bind_var, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_no_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337"};
+
+    // Can't infer type
+    BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr),
+                        exceptions::invalid_request_exception);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bool) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(boolean_type));
+    expression expected = make_bool_const(true);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int8) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "13"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(byte_type));
+    expression expected = make_tinyint_const(13);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int16) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(short_type));
+    expression expected = make_smallint_const(1337);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int32) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped =
+        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "13377331"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(int32_type));
+    expression expected = make_int_const(13377331);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int64) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped =
+        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337733113377331"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(long_type));
+    expression expected = make_bigint_const(1337733113377331);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_text) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped =
+        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "scylla_is_the_best"};
+
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(utf8_type));
+    expression expected = make_text_const("scylla_is_the_best");
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bad_int) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression untyped =
+        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "not_integer_text"};
+
+    BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(int32_type)),
+                        exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1871,3 +1871,134 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_null) {
     BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(list_type)),
                         exceptions::invalid_request_exception);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor = collection_constructor{
+        .style = collection_constructor::style_type::set,
+        .elements =
+            {
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+            },
+        .type = nullptr};
+
+    data_type set_type = set_type_impl::get_instance(short_type, true);
+
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(set_type));
+    expression expected =
+        make_set_const({make_smallint_const(123), make_smallint_const(456), make_smallint_const(789)}, short_type);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+// preparing empty nonfrozen collections results in null
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_empty_nonfrozen) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor =
+        collection_constructor{.style = collection_constructor::style_type::set, .elements = {}, .type = nullptr};
+
+    data_type set_type = set_type_impl::get_instance(short_type, true);
+
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(set_type));
+    expression expected = constant::make_null(set_type);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_empty_frozen) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor =
+        collection_constructor{.style = collection_constructor::style_type::set, .elements = {}, .type = nullptr};
+
+    data_type set_type = set_type_impl::get_instance(short_type, false);
+
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(set_type));
+    expression expected = constant(make_set_raw({}), set_type);
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_no_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor = collection_constructor{
+        .style = collection_constructor::style_type::set,
+        .elements =
+            {
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+            },
+        .type = nullptr};
+
+    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
+                        exceptions::invalid_request_exception);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_bind_var) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor = collection_constructor{
+        .style = collection_constructor::style_type::set,
+        .elements =
+            {
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                bind_variable{.bind_index = 1, .receiver = nullptr},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+            },
+        .type = nullptr};
+
+    data_type set_type = set_type_impl::get_instance(long_type, true);
+
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(set_type));
+
+    // Can't directly compare because the bind variable receiver is created inside prepare_expression
+    // prepared bind_variable contains a receiver which we need to extract
+    // in order to prepare an equal expected value.
+    collection_constructor* prepared_constructor = as_if<collection_constructor>(&prepared);
+    BOOST_REQUIRE(prepared_constructor != nullptr);
+    BOOST_REQUIRE_EQUAL(prepared_constructor->elements.size(), 3);
+
+    bind_variable* prepared_bind_var = as_if<bind_variable>(&prepared_constructor->elements[1]);
+    BOOST_REQUIRE(prepared_bind_var != nullptr);
+
+    ::lw_shared_ptr<column_specification> bind_var_receiver = prepared_bind_var->receiver;
+    BOOST_REQUIRE(bind_var_receiver.get() != nullptr);
+    BOOST_REQUIRE(bind_var_receiver->type == long_type);
+
+    expression expected = collection_constructor{
+        .style = collection_constructor::style_type::set,
+        .elements = {make_bigint_const(789), bind_variable{.bind_index = 1, .receiver = bind_var_receiver},
+                     make_bigint_const(123)},
+        .type = set_type};
+}
+
+BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_null) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression constructor = collection_constructor{
+        .style = collection_constructor::style_type::set,
+        .elements =
+            {
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                null{},
+                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+            },
+        .type = nullptr};
+
+    data_type set_type = set_type_impl::get_instance(short_type, true);
+
+    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), make_receiver(set_type)),
+                        exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1304,3 +1304,55 @@ BOOST_AUTO_TEST_CASE(evaluate_bind_variable_validates_empty_value_in_maps_recurs
     constant map_with_empty_value2 = create_nested_map_with_value(make_int_const(1), make_empty_const(int32_type));
     check_bind_variable_evaluate(map_with_empty_value2, expected_valid);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_partition_column_unresolved_identifier) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression pk_unresolved_identifier =
+        unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("pk", true)};
+    expression prepared = prepare_expression(pk_unresolved_identifier, db, "test_ks", table_schema.get(), nullptr);
+
+    expression expected = column_value(table_schema->get_column_definition("pk"));
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_clustering_column_unresolved_identifier) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression ck_unresolved_identifier =
+        unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("ck", true)};
+    expression prepared = prepare_expression(ck_unresolved_identifier, db, "test_ks", table_schema.get(), nullptr);
+
+    expression expected = column_value(table_schema->get_column_definition("ck"));
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_regular_column_unresolved_identifier) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression r_unresolved_identifier =
+        unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)};
+    expression prepared = prepare_expression(r_unresolved_identifier, db, "test_ks", table_schema.get(), nullptr);
+
+    expression expected = column_value(table_schema->get_column_definition("r"));
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_static_column_unresolved_identifier) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression s_unresolved_identifier =
+        unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("s", true)};
+    expression prepared = prepare_expression(s_unresolved_identifier, db, "test_ks", table_schema.get(), nullptr);
+
+    expression expected = column_value(table_schema->get_column_definition("s"));
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1524,3 +1524,24 @@ BOOST_AUTO_TEST_CASE(prepare_cast_text_int) {
     BOOST_REQUIRE_THROW(prepare_expression(cast_expr, db, "test_ks", table_schema.get(), receiver),
                         exceptions::invalid_request_exception);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_null) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression null_expr = null{};
+
+    expression prepared = prepare_expression(null_expr, db, "test_ks", table_schema.get(), make_receiver(int32_type));
+    expression expected = constant::make_null(int32_type);
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+// null can't be prepared without a receiver because we are unable to infer the type.
+BOOST_AUTO_TEST_CASE(prepare_null_no_type_fails) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression null_expr = null{};
+    BOOST_REQUIRE_THROW(prepare_expression(null_expr, db, "test_ks", table_schema.get(), nullptr),
+                        exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1545,3 +1545,31 @@ BOOST_AUTO_TEST_CASE(prepare_null_no_type_fails) {
     BOOST_REQUIRE_THROW(prepare_expression(null_expr, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_bind_variable) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression bind_var = bind_variable{.bind_index = 1, .receiver = nullptr};
+
+    ::lw_shared_ptr<column_specification> receiver = make_receiver(int32_type);
+
+    expression prepared = prepare_expression(bind_var, db, "test_ks", table_schema.get(), receiver);
+
+    expression expected = bind_variable{
+        .bind_index = 1,
+        .receiver = receiver,
+    };
+
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_bind_variable_no_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression bind_var = bind_variable{.bind_index = 1, .receiver = nullptr};
+
+    BOOST_REQUIRE_THROW(prepare_expression(bind_var, db, "test_ks", table_schema.get(), nullptr),
+                        exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1478,3 +1478,49 @@ BOOST_AUTO_TEST_CASE(prepare_token_no_args) {
 
     BOOST_REQUIRE_EQUAL(tok, prepared);
 }
+
+BOOST_AUTO_TEST_CASE(prepare_cast_int_int) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+             .type = cql3_type::raw::from(int32_type)};
+
+    ::lw_shared_ptr<column_specification> receiver = make_receiver(int32_type);
+
+    expression prepared = prepare_expression(cast_expr, db, "test_ks", table_schema.get(), receiver);
+
+    expression expected = cast{.arg = make_int_const(123), .type = int32_type};
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_cast_int_short) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+             .type = cql3_type::raw::from(short_type)};
+
+    ::lw_shared_ptr<column_specification> receiver = make_receiver(short_type);
+
+    expression prepared = prepare_expression(cast_expr, db, "test_ks", table_schema.get(), receiver);
+
+    expression expected = cast{.arg = make_smallint_const(123), .type = short_type};
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+BOOST_AUTO_TEST_CASE(prepare_cast_text_int) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "123"},
+             .type = cql3_type::raw::from(short_type)};
+
+    ::lw_shared_ptr<column_specification> receiver = make_receiver(short_type);
+
+    BOOST_REQUIRE_THROW(prepare_expression(cast_expr, db, "test_ks", table_schema.get(), receiver),
+                        exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1356,3 +1356,13 @@ BOOST_AUTO_TEST_CASE(prepare_static_column_unresolved_identifier) {
 
     BOOST_REQUIRE_EQUAL(prepared, expected);
 }
+
+// prepare_expression for a column_value should do nothing
+BOOST_AUTO_TEST_CASE(prepare_column_value) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cval = column_value(table_schema->get_column_definition("pk"));
+    expression prepared = prepare_expression(cval, db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(cval, prepared);
+}

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -38,6 +38,10 @@ raw_value make_int_raw(int32_t val) {
     return make_raw(val);
 }
 
+raw_value make_bigint_raw(int64_t val) {
+    return make_raw(val);
+}
+
 raw_value make_text_raw(const sstring_view& text) {
     return raw_value::make_value(utf8_type->decompose(text));
 }
@@ -65,6 +69,10 @@ constant make_smallint_const(int16_t val) {
 }
 
 constant make_int_const(int32_t val) {
+    return make_const(val);
+}
+
+constant make_bigint_const(int64_t val) {
     return make_const(val);
 }
 

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -26,6 +26,10 @@ raw_value make_bool_raw(bool val) {
     return make_raw(val);
 }
 
+raw_value make_smallint_raw(int16_t val) {
+    return make_raw(val);
+}
+
 raw_value make_int_raw(int32_t val) {
     return make_raw(val);
 }
@@ -45,6 +49,10 @@ constant make_empty_const(data_type type) {
 }
 
 constant make_bool_const(bool val) {
+    return make_const(val);
+}
+
+constant make_smallint_const(int16_t val) {
     return make_const(val);
 }
 

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -26,6 +26,10 @@ raw_value make_bool_raw(bool val) {
     return make_raw(val);
 }
 
+raw_value make_tinyint_raw(int8_t val) {
+    return make_raw(val);
+}
+
 raw_value make_smallint_raw(int16_t val) {
     return make_raw(val);
 }
@@ -49,6 +53,10 @@ constant make_empty_const(data_type type) {
 }
 
 constant make_bool_const(bool val) {
+    return make_const(val);
+}
+
+constant make_tinyint_const(int8_t val) {
     return make_const(val);
 }
 

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -389,6 +389,110 @@ std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evalu
     return std::pair(std::move(inputs), std::move(data));
 }
 
+// A mock implementation of data_dictionary::database, used in tests
+class mock_database_impl : public data_dictionary::impl {
+    schema_ptr _table_schema;
+    ::lw_shared_ptr<data_dictionary::keyspace_metadata> _keyspace_metadata;
+
+    db::config _config;
+
+public:
+    explicit mock_database_impl(schema_ptr table_schema)
+        : _table_schema(table_schema),
+          _keyspace_metadata(data_dictionary::keyspace_metadata::new_keyspace(_table_schema->ks_name(),
+                                                                              "MockReplicationStrategy",
+                                                                              {},
+                                                                              false,
+                                                                              {_table_schema})) {}
+
+    static std::pair<data_dictionary::database, std::unique_ptr<mock_database_impl>> make(schema_ptr table_schema) {
+        std::unique_ptr<mock_database_impl> mock_db = std::make_unique<mock_database_impl>(table_schema);
+        data_dictionary::database db = make_database(mock_db.get(), nullptr);
+        return std::pair(std::move(db), std::move(mock_db));
+    }
+
+    virtual std::optional<data_dictionary::keyspace> try_find_keyspace(data_dictionary::database db,
+                                                                       std::string_view name) const override {
+        if (_table_schema->ks_name() == name) {
+            return make_keyspace(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual std::vector<data_dictionary::keyspace> get_keyspaces(data_dictionary::database db) const override {
+        return {make_keyspace(this, nullptr)};
+    }
+    virtual std::vector<data_dictionary::table> get_tables(data_dictionary::database db) const override {
+        return {make_table(this, nullptr)};
+    }
+    virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db,
+                                                                 std::string_view ks,
+                                                                 std::string_view tab) const override {
+        if (_table_schema->ks_name() == ks && _table_schema->cf_name() == tab) {
+            return make_table(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db,
+                                                                 table_id id) const override {
+        if (_table_schema->id() == id) {
+            return make_table(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual const secondary_index::secondary_index_manager& get_index_manager(data_dictionary::table t) const override {
+        throw std::bad_function_call();
+    }
+    virtual schema_ptr get_table_schema(data_dictionary::table t) const override { return _table_schema; }
+    virtual lw_shared_ptr<data_dictionary::keyspace_metadata> get_keyspace_metadata(
+        data_dictionary::keyspace ks) const override {
+        return _keyspace_metadata;
+    }
+
+    virtual bool is_internal(data_dictionary::keyspace ks) const override { return false; }
+    virtual const locator::abstract_replication_strategy& get_replication_strategy(
+        data_dictionary::keyspace ks) const override {
+        throw std::bad_function_call();
+    }
+    virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {
+        return {view_ptr(_table_schema)};
+    }
+    virtual sstring get_available_index_name(data_dictionary::database db,
+                                             std::string_view ks_name,
+                                             std::string_view table_name,
+                                             std::optional<sstring> index_name_root) const override {
+        return {};
+    }
+    virtual std::set<sstring> existing_index_names(data_dictionary::database db,
+                                                   std::string_view ks_name,
+                                                   std::string_view cf_to_exclude = {}) const override {
+        return {};
+    }
+    virtual schema_ptr find_indexed_table(data_dictionary::database db,
+                                          std::string_view ks_name,
+                                          std::string_view index_name) const override {
+        return nullptr;
+    }
+    virtual schema_ptr get_cdc_base_table(data_dictionary::database db, const schema&) const override {
+        return nullptr;
+    }
+    virtual const db::config& get_config(data_dictionary::database db) const override { return _config; }
+    virtual const db::extensions& get_extensions(data_dictionary::database db) const override {
+        return _config.extensions();
+    }
+    virtual const gms::feature_service& get_features(data_dictionary::database db) const override {
+        throw std::bad_function_call();
+    }
+    virtual replica::database& real_database(data_dictionary::database db) const override {
+        throw std::bad_function_call();
+    }
+
+    virtual ~mock_database_impl() = default;
+};
+
+std::pair<data_dictionary::database, std::unique_ptr<data_dictionary::impl>> make_data_dictionary_database(
+    const schema_ptr& table_schema) {
+    return mock_database_impl::make(table_schema);
+}
 }  // namespace test_utils
 }  // namespace expr
 }  // namespace cql3

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -297,6 +297,11 @@ usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_vie
     return usertype_constructor{.elements = std::move(elements_map), .type = std::move(type)};
 }
 
+::lw_shared_ptr<column_specification> make_receiver(data_type receiver_type, sstring receiver_name) {
+    return ::make_lw_shared<column_specification>(
+        "test_ks", "test_cf", ::make_shared<cql3::column_identifier>(receiver_name, true), receiver_type);
+}
+
 // Creates evaluation_inputs that can be used to evaluate columns and bind variables using evaluate()
 std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
     const schema_ptr& table_schema,

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -28,6 +28,7 @@ raw_value make_bool_raw(bool val);
 raw_value make_tinyint_raw(int8_t val);
 raw_value make_smallint_raw(int16_t val);
 raw_value make_int_raw(int32_t val);
+raw_value make_bigint_raw(int64_t val);
 raw_value make_text_raw(const sstring_view& text);
 
 constant make_empty_const(data_type type);
@@ -35,6 +36,7 @@ constant make_bool_const(bool val);
 constant make_tinyint_const(int8_t val);
 constant make_smallint_const(int16_t val);
 constant make_int_const(int32_t val);
+constant make_bigint_const(int64_t val);
 constant make_text_const(const sstring_view& text);
 
 // This function implements custom serialization of collection values.

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -25,11 +25,13 @@ namespace test_utils {
 
 raw_value make_empty_raw();
 raw_value make_bool_raw(bool val);
+raw_value make_smallint_raw(int16_t val);
 raw_value make_int_raw(int32_t val);
 raw_value make_text_raw(const sstring_view& text);
 
 constant make_empty_const(data_type type);
 constant make_bool_const(bool val);
+constant make_smallint_const(int16_t val);
 constant make_int_const(int32_t val);
 constant make_text_const(const sstring_view& text);
 

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -25,12 +25,14 @@ namespace test_utils {
 
 raw_value make_empty_raw();
 raw_value make_bool_raw(bool val);
+raw_value make_tinyint_raw(int8_t val);
 raw_value make_smallint_raw(int16_t val);
 raw_value make_int_raw(int32_t val);
 raw_value make_text_raw(const sstring_view& text);
 
 constant make_empty_const(data_type type);
 constant make_bool_const(bool val);
+constant make_tinyint_const(int8_t val);
 constant make_smallint_const(int16_t val);
 constant make_int_const(int32_t val);
 constant make_text_const(const sstring_view& text);

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -86,6 +86,8 @@ collection_constructor make_map_constructor(const std::vector<std::pair<expressi
 tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types);
 usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values);
 
+::lw_shared_ptr<column_specification> make_receiver(data_type receiver_type, sstring name = "receiver_name");
+
 struct evaluation_inputs_data {
     std::vector<bytes> partition_key;
     std::vector<bytes> clustering_key;

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -98,6 +98,11 @@ std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evalu
     const schema_ptr& table_schema,
     const column_values& column_vals,
     const std::vector<raw_value>& bind_marker_values = {});
+
+// Creates a mock implementation of data_dictionary::database, useful in tests.
+std::pair<data_dictionary::database, std::unique_ptr<data_dictionary::impl>> make_data_dictionary_database(
+    const schema_ptr& table_schema);
+
 }  // namespace test_utils
 }  // namespace expr
 }  // namespace cql3


### PR DESCRIPTION
Adds unit tests for the function `expr::prepare_expression`.

Three minor bugs were found by these tests, both fixed in this PR.
1. When preparing a map, the type for tuple constructor was taken from an unprepared tuple, which has `nullptr` as its type.
2. Preparing an empty nonfrozen list or set resulted in `null`, but preparing a map didn't. Fixed this inconsistency.
3. Preparing a `bind_variable` with `nullptr` receiver was allowed. The `bind_variable` ended up with a `nullptr` type, which is incorrect. Changed it to throw an exception,