### PR TITLE
Transport server error handling fixes

### DIFF
--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -177,6 +177,10 @@ public:
         return _remote_address.port();
     }
 
+    const socket_address& get_remote_address() const {
+        return _remote_address;
+    }
+
     const timeout_config& get_timeout_config() const {
         return _timeout_config;
     }

--- a/test/cql-pytest/test_batch.py
+++ b/test/cql-pytest/test_batch.py
@@ -7,8 +7,10 @@
 # Tests for batch operations
 #############################################################################
 from cassandra import InvalidRequest
-
+from cassandra.cluster import NoHostAvailable
 from util import new_test_table
+from rest_api import scylla_inject_error
+
 
 import pytest
 
@@ -50,3 +52,27 @@ def test_error_is_raised_for_batch_size_above_threshold(cql, table1):
     from scylla.yaml."""
     with pytest.raises(InvalidRequest, match="Batch too large"):
         cql.execute(generate_big_batch(table1, 1025))
+
+# Test checks unexpected errors handling in CQL server.
+#
+# The original problem was that std::bad_alloc exception occurred while parsing a large batch request.
+# This exception was caught by try/catch in cql_server::connection::process_request_one and
+# an attempt was made to construct the error response message via make_error function.
+# This attempt failed since the error message contained entire query and exceeded the limit of 64K
+# in cql_server::response::write_string, causing "Value too large" exception to be thrown.
+# This new exception reached the general handler in cql_server::connection::process_request, where
+# it was just logged and no information about the problem was sent to the client.
+# As a result, the client received a timeout exception after a while and
+# no other information about the cause of the error.
+#
+# It is quite difficult to reproduce OOM in a test, so we use error injection instead.
+# Passing injection_key in the body of the request ensures that the exception will be
+# thrown only for this test request and will not affect other requests that
+# the driver may send in the background.
+@pytest.mark.asyncio
+async def test_batch_with_error(cql, table1):
+    injection_key = 'query_processor-parse_statement-test_failure'
+    with scylla_inject_error(cql, injection_key, one_shot=False):
+        # exceptions::exception_code::SERVER_ERROR, it gets converted to NoHostAvailable by the driver
+        with pytest.raises(NoHostAvailable, match="Value too large"):
+            cql.execute(generate_big_batch(table1, 100) + injection_key)

--- a/test/cql-pytest/test_shedding.py
+++ b/test/cql-pytest/test_shedding.py
@@ -7,9 +7,10 @@
 #############################################################################
 
 import pytest
-import re
+from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import InvalidRequest
-from util import unique_name
+from util import unique_name, new_cql
+import requests
 
 
 @pytest.fixture(scope="module")
@@ -31,12 +32,47 @@ def table1(cql, test_keyspace):
 # 5. Hence, a 30MiB request will be estimated to take around 60MiB RAM,
 #    which is enough to trigger shedding.
 # See also #8193.
-@pytest.mark.skip(reason="highly depends on configuration")
+#
+# Big request causes the entire connection to be closed (see #8800 for the reasons),
+# this results in NoHostAvailable on the client.
+# We check that there are no unexpected protocol_errors using Scylla Prometheus API.
+# Such errors occurred before, when before closing the connection, the remaining
+# bytes of the current request were not read to the end and were treated as
+# the beginning of the next request.
+#
+# Have no idea why, but on CI the actual memory limit for CQL requests is ~100MiB,
+# so we use ~60MiB request (which is estimated to take ~120MiB according to the logic above)
+# to guarantee shedding.
 def test_shed_too_large_request(cql, table1, scylla_only):
-    prepared = cql.prepare(f"INSERT INTO {table1} (p,t1,t2,t3,t4,t5,t6) VALUES (42,?,?,?,?,?,?)")
-    a_5mb_string = 'x'*5*1024*1024
-    with pytest.raises(InvalidRequest, match=re.compile('large', re.IGNORECASE)):
-        cql.execute(prepared, [a_5mb_string]*6)
+    def get_protocol_errors():
+        result = 0
+        for line in requests.get(f'http://{cql.cluster.contact_points[0]}:9180/metrics').text.split('\n'):
+            if not line.startswith('scylla_transport_cql_errors_total') or 'protocol_error' not in line:
+                continue
+            result += int(line.split(' ')[1])
+        return result
+
+    # protocol_errors metric is always non-zero, since the
+    # cassandra python driver use these errors to negotiate the protocol version
+    protocol_errors_before = get_protocol_errors()
+
+    # separate session is needed due to the cql_test_connection fixture,
+    # which checks that the session is not broken at the end of the test
+    with new_cql(cql) as ncql:
+        prepared = ncql.prepare(f"INSERT INTO {table1} (p,t1,t2,t3,t4,t5,t6) VALUES (42,?,?,?,?,?,?)")
+
+        # With release builds of Scylla, information that the socket is closed reaches the client driver
+        # before it has time to process the error message written by Scylla to the socket.
+        # The driver ignores unread bytes from the socket (this looks like a bug),
+        # tries to establish a connection with another node, and throws a NoHostAvailable exception if it fails.
+        # In the debug builds, the driver can have time to grab the error from the socket,
+        # and we get InvalidRequest exception.
+        with pytest.raises((NoHostAvailable, InvalidRequest),
+                           match="request size too large|Unable to complete the operation against any hosts"):
+            a_5mb_string = 'x'*10*1024*1024
+            ncql.execute(prepared, [a_5mb_string]*6)
+    protocol_errors_after = get_protocol_errors()
+    assert protocol_errors_after == protocol_errors_before
     cql.execute(prepared, ["small_string"]*6)
     res = [row for row in cql.execute(f"SELECT p, t3 FROM {table1}")]
     assert len(res) == 1 and res[0].p == 42 and res[0].t3 == "small_string"

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -694,14 +694,23 @@ future<> cql_server::connection::process_request() {
                     _process_request_stage(this, istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit) :
                     process_request_one(istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit);
 
-            future<> request_response_future = request_process_future.then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave)] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
-                    try {
+            future<> request_response_future = request_process_future.then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave), stream] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
+                try {
+                    if (response_f.failed()) {
+                        const auto message = format("request processing failed, error [{}]", response_f.get_exception());
+                        clogger.error("{}: {}", _client_state.get_remote_address(), message);
+                        write_response(make_error(stream, exceptions::exception_code::SERVER_ERROR,
+                                                  message,
+                                                  tracing::trace_state_ptr()));
+                    } else {
                         write_response(response_f.get0(), std::move(mem_permit), _compression);
-                        _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
-                    } catch (...) {
-                        clogger.error("request processing failed: {}", std::current_exception());
                     }
-                });
+                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
+                } catch (...) {
+                    clogger.error("{}: request processing failed: {}",
+                                  _client_state.get_remote_address(), std::current_exception());
+                }
+            });
 
             if (should_paralelize) {
                 return make_ready_future<>();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -34,6 +34,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/util/lazy.hh>
+#include <seastar/util/short_streams.hh>
 #include <seastar/core/execution_stage.hh>
 #include "utils/result_try.hh"
 #include "utils/result_combinators.hh"
@@ -627,9 +628,9 @@ future<> cql_server::connection::process_request() {
                 f.length, mem_estimate, _server._max_request_size);
             clogger.debug("{}: {}, request dropped", _client_state.get_remote_address(), message);
             write_response(make_error(stream, exceptions::exception_code::INVALID, message, tracing::trace_state_ptr()));
-            return std::exchange(_ready_to_respond, make_ready_future<>()).then([this, length = f.length] {
-                return _read_buf.close();
-            });
+            return std::exchange(_ready_to_respond, make_ready_future<>())
+                .then([this] { return _read_buf.close(); })
+                .then([this] { return util::skip_entire_stream(_read_buf); });
         }
 
         if (_server._stats.requests_serving > _server._max_concurrent_requests) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -445,33 +445,53 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             tracing::set_response_size(trace_state, response->size());
             return response;
         },  utils::result_catch<exceptions::unavailable_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in unavailable_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state);
         }), utils::result_catch<exceptions::read_timeout_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in read_timeout_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state);
         }), utils::result_catch<exceptions::read_failure_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in read_failure_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state);
         }), utils::result_catch<exceptions::mutation_write_timeout_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in mutation_write_timeout_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state);
         }), utils::result_catch<exceptions::mutation_write_failure_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in mutation_write_failure_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state);
         }), utils::result_catch<exceptions::already_exists_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in already_exists_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state);
         }), utils::result_catch<exceptions::prepared_query_not_found_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in unprepared_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state);
         }), utils::result_catch<exceptions::function_execution_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in function_failure_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state);
         }), utils::result_catch<exceptions::rate_limit_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in rate_limit_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state);
         }), utils::result_catch<exceptions::cassandra_exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in cassandra_error, stream {}, code {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.code(), ex.what());
             // Note: the CQL protocol specifies that many types of errors have
             // mandatory parameters. These cassandra_exception subclasses MUST
             // be handled above. This default "cassandra_exception" case is
@@ -482,6 +502,8 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
             return make_error(stream, ex.code(), ex.what(), trace_state);
         }), utils::result_catch<std::exception>([&] (const auto& ex) {
+            clogger.debug("{}: request resulted in error, stream {}, message [{}]",
+                _client_state.get_remote_address(), stream, ex.what());
             try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
             sstring msg = ex.what();
             try {
@@ -493,6 +515,8 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             }
             return make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state);
         }), utils::result_catch_dots([&] () {
+            clogger.debug("{}: request resulted in unknown error, stream {}",
+                _client_state.get_remote_address(), stream);
             try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
             return make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state);
         })));
@@ -550,12 +574,15 @@ void cql_server::connection::handle_error(future<>&& f) {
     try {
         f.get();
     } catch (const exceptions::cassandra_exception& ex) {
+        clogger.debug("{}: connection error, code {}, message [{}]", _client_state.get_remote_address(), ex.code(), ex.what());
         try { ++_server._stats.errors[ex.code()]; } catch(...) {}
         write_response(make_error(0, ex.code(), ex.what(), tracing::trace_state_ptr()));
     } catch (std::exception& ex) {
+        clogger.debug("{}: connection error, message [{}]", _client_state.get_remote_address(), ex.what());
         try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
         write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, ex.what(), tracing::trace_state_ptr()));
     } catch (...) {
+        clogger.debug("{}: connection error, unknown error", _client_state.get_remote_address());
         try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
         write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, "unknown error", tracing::trace_state_ptr()));
     }


### PR DESCRIPTION
CQL transport sever error handling fixes and improvements:
  * log failed requests with `DEBUG` level for easier debugging;
  * in case of unhandled errors, deliver them to the client as `SERVER_ERROR`'s
  * fix for `protocol_error`'s in case of shedded big requests;
  * explicit tests have been written for the error handling problems above.