### PR TITLE
gossip: Improve get_live_token_owners and get_unreachable_token_owners

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1020,10 +1020,10 @@ std::set<inet_address> gossiper::get_live_members() const {
 
 std::set<inet_address> gossiper::get_live_token_owners() const {
     std::set<inet_address> token_owners;
-    for (auto& member : get_live_members()) {
-        auto es = get_endpoint_state_for_endpoint_ptr(member);
-        if (es && !is_dead_state(*es) && get_token_metadata_ptr()->is_member(member)) {
-            token_owners.insert(member);
+    auto normal_token_owners = get_token_metadata_ptr()->get_all_endpoints();
+    for (auto& node: normal_token_owners) {
+        if (is_alive(node)) {
+            token_owners.insert(node);
         }
     }
     return token_owners;
@@ -1031,10 +1031,10 @@ std::set<inet_address> gossiper::get_live_token_owners() const {
 
 std::set<inet_address> gossiper::get_unreachable_token_owners() const {
     std::set<inet_address> token_owners;
-    for (auto&& x : _unreachable_endpoints) {
-        auto& endpoint = x.first;
-        if (get_token_metadata_ptr()->is_member(endpoint)) {
-            token_owners.insert(endpoint);
+    auto normal_token_owners = get_token_metadata_ptr()->get_all_endpoints();
+    for (auto& node: normal_token_owners) {
+        if (!is_alive(node)) {
+            token_owners.insert(node);
         }
     }
     return token_owners;


### PR DESCRIPTION
The get_live_token_owners returns the nodes that are part of the ring and live.

The get_unreachable_token_owners returns the nodes that are part of the ring and is not alive.

The token_metadata::get_all_endpoints returns nodes that are part of the ring.

The patch changes both functions to use the more authoritative source to get the nodes that are part of the ring and call is_alive to check if the node is up or down. So that the correctness does not depend on any derived information.

This patch fixes a truncate issue in storage_proxy::truncate_blocking where it calls get_live_token_owners and get_unreachable_token_owners to decide the nodes to talk with for truncate operation. The truncate failed because incorrect nodes were returned.

Fixes #10296
Fixes #11928