### PR TITLE
reader_concurrency_semaphore: add more layers of defense against OOM

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -842,6 +842,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , max_memory_for_unlimited_query_hard_limit(this, "max_memory_for_unlimited_query_hard_limit", "max_memory_for_unlimited_query", liveness::LiveUpdate, value_status::Used, (uint64_t(100) << 20),
             "Maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g. non-paged and reverse queries. "
             "This is the hard limit, queries violating this limit will be aborted.")
+    , reader_concurrency_semaphore_serialize_limit_multiplier(this, "reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
+            "Start serializing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
+    , reader_concurrency_semaphore_kill_limit_multiplier(this, "reader_concurrency_semaphore_kill_limit_multiplier", liveness::LiveUpdate, value_status::Used, 4,
+            "Start killing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , twcs_max_window_count(this, "twcs_max_window_count", liveness::LiveUpdate, value_status::Used, 50,
             "The maximum number of compaction windows allowed when making use of TimeWindowCompactionStrategy. A setting of 0 effectively disables the restriction.")
     , initial_sstable_loading_concurrency(this, "initial_sstable_loading_concurrency", value_status::Used, 4u,

--- a/db/config.hh
+++ b/db/config.hh
@@ -338,6 +338,8 @@ public:
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
     named_value<uint64_t> max_memory_for_unlimited_query_soft_limit;
     named_value<uint64_t> max_memory_for_unlimited_query_hard_limit;
+    named_value<uint32_t> reader_concurrency_semaphore_serialize_limit_multiplier;
+    named_value<uint32_t> reader_concurrency_semaphore_kill_limit_multiplier;
     named_value<uint32_t> twcs_max_window_count;
     named_value<unsigned> initial_sstable_loading_concurrency;
     named_value<bool> enable_3_1_0_compatibility_mode;

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -26,8 +26,12 @@ std::ostream& operator<<(std::ostream& os , const reader_resources& r) {
     return os;
 }
 
-reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res)
+reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res, already_consumed_tag)
     : _permit(std::move(permit)), _resources(res) {
+}
+
+reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res)
+    : _permit(std::move(permit)) {
     _permit.consume(res);
     _resources = res;
 }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -388,6 +388,10 @@ reader_concurrency_semaphore& reader_permit::semaphore() {
     return _impl->semaphore();
 }
 
+reader_permit::state reader_permit::get_state() const {
+    return _impl->get_state();
+}
+
 bool reader_permit::needs_readmission() const {
     return _impl->needs_readmission();
 }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -256,8 +256,8 @@ public:
     }
 
     void consume(reader_resources res) {
-        _resources += res;
         _semaphore.consume(res);
+        _resources += res;
     }
 
     void signal(reader_resources res) {

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -727,6 +727,10 @@ uint64_t reader_concurrency_semaphore::get_serialize_limit() const {
     return _initial_resources.memory * _serialize_limit_multiplier();
 }
 
+void reader_concurrency_semaphore::consume(resources r) {
+    _resources -= r;
+}
+
 void reader_concurrency_semaphore::signal(const resources& r) noexcept {
     _resources += r;
     maybe_admit_waiters();

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1241,6 +1241,12 @@ std::string reader_concurrency_semaphore::dump_diagnostics(unsigned max_lines) c
     return os.str();
 }
 
+void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(const reader_permit&)> func) {
+    for (auto& p : _permit_list) {
+        func(reader_permit(p.shared_from_this()));
+    }
+}
+
 // A file that tracks the memory usage of buffers resulting from read
 // operations.
 class tracking_file_impl : public file_impl {

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1281,8 +1281,10 @@ public:
     }
 
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc) override {
-        return get_file_impl(_tracked_file)->dma_read_bulk(offset, range_size, pc).then([this, units = _permit.consume_memory(range_size)] (temporary_buffer<uint8_t> buf) {
-            return make_ready_future<temporary_buffer<uint8_t>>(make_tracked_temporary_buffer(std::move(buf), _permit));
+        return _permit.request_memory(range_size).then([this, offset, range_size, &pc] (reader_permit::resource_units units) {
+            return get_file_impl(_tracked_file)->dma_read_bulk(offset, range_size, pc).then([this, units = std::move(units)] (temporary_buffer<uint8_t> buf) mutable {
+                return make_ready_future<temporary_buffer<uint8_t>>(make_tracked_temporary_buffer(std::move(buf), std::move(units)));
+            });
         });
     }
 };

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -26,9 +26,10 @@ std::ostream& operator<<(std::ostream& os , const reader_resources& r) {
     return os;
 }
 
-reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res) noexcept
+reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res)
     : _permit(std::move(permit)), _resources(res) {
     _permit.consume(res);
+    _resources = res;
 }
 
 reader_permit::resource_units::resource_units(resource_units&& o) noexcept

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -63,7 +63,9 @@ void reader_permit::resource_units::add(resource_units&& o) {
 }
 
 void reader_permit::resource_units::reset(reader_resources res) {
-    _permit.consume(res);
+    if (res.non_zero()) {
+        _permit.consume(res);
+    }
     if (_resources.non_zero()) {
         _permit.signal(_resources);
     }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -288,6 +288,9 @@ private:
 
     uint64_t get_serialize_limit() const;
 
+    void consume(resources r);
+    void signal(const resources& r) noexcept;
+
 public:
     struct no_limits { };
 
@@ -484,10 +487,6 @@ public:
     const resources consumed_resources() const {
         return _initial_resources - _resources;
     }
-
-    void consume(resources r);
-
-    void signal(const resources& r) noexcept;
 
     size_t waiters() const {
         return _wait_list.size();

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -526,4 +526,6 @@ public:
     uint64_t active_reads() const noexcept {
         return _stats.current_permits - _stats.inactive_reads - waiters();
     }
+
+    void foreach_permit(noncopyable_function<void(const reader_permit&)> func);
 };

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/expiring_fifo.hh>
 #include "reader_permit.hh"
 #include "readers/flat_mutation_reader_v2.hh"
+#include "utils/updateable_value.hh"
 
 namespace bi = boost::intrusive;
 
@@ -182,6 +183,8 @@ private:
 
     sstring _name;
     size_t _max_queue_length = std::numeric_limits<size_t>::max();
+    utils::updateable_value<uint32_t> _serialize_limit_multiplier;
+    utils::updateable_value<uint32_t> _kill_limit_multiplier;
     inactive_reads_type _inactive_reads;
     stats _stats;
     permit_list_type _permit_list;
@@ -243,7 +246,9 @@ public:
     reader_concurrency_semaphore(int count,
             ssize_t memory,
             sstring name,
-            size_t max_queue_length);
+            size_t max_queue_length,
+            utils::updateable_value<uint32_t> serialize_limit_multiplier,
+            utils::updateable_value<uint32_t> kill_limit_multiplier);
 
     /// Create a semaphore with practically unlimited count and memory.
     ///
@@ -258,8 +263,10 @@ public:
     reader_concurrency_semaphore(for_tests, sstring name,
             int count = std::numeric_limits<int>::max(),
             ssize_t memory = std::numeric_limits<ssize_t>::max(),
-            size_t max_queue_length = std::numeric_limits<size_t>::max())
-        : reader_concurrency_semaphore(count, memory, std::move(name), max_queue_length)
+            size_t max_queue_length = std::numeric_limits<size_t>::max(),
+            utils::updateable_value<uint32_t> serialize_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+            utils::updateable_value<uint32_t> kill_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()))
+        : reader_concurrency_semaphore(count, memory, std::move(name), max_queue_length, std::move(serialize_limit_multipler), std::move(kill_limit_multipler))
     {}
 
     virtual ~reader_concurrency_semaphore();

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -178,7 +178,28 @@ private:
     resources _initial_resources;
     resources _resources;
 
-    expiring_fifo<entry, expiry_handler, db::timeout_clock> _wait_list;
+    class wait_queue {
+        expiring_fifo<entry, expiry_handler, db::timeout_clock> _admission_queue;
+    public:
+        wait_queue(expiry_handler eh) : _admission_queue(eh) { }
+        size_t size() const {
+            return _admission_queue.size();
+        }
+        bool empty() const {
+            return _admission_queue.empty();
+        }
+        void push_back(entry&& e, db::timeout_clock::time_point timeout) {
+            _admission_queue.push_back(std::move(e), timeout);
+        }
+        entry& front() {
+            return _admission_queue.front();
+        }
+        void pop_front() {
+            _admission_queue.pop_front();
+        }
+    };
+
+    wait_queue _wait_list;
     queue<entry> _ready_list;
 
     sstring _name;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -485,9 +485,7 @@ public:
         return _initial_resources - _resources;
     }
 
-    void consume(resources r) {
-        _resources -= r;
-    }
+    void consume(resources r);
 
     void signal(const resources& r) noexcept;
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -72,6 +72,8 @@ public:
         uint64_t total_failed_reads = 0;
         // Total number of reads rejected because the admission queue reached its max capacity
         uint64_t total_reads_shed_due_to_overload = 0;
+        // Total number of reads killed due to the memory consumption reaching the kill limit.
+        uint64_t total_reads_killed_due_to_kill_limit = 0;
         // Total number of reads admitted, via all admission paths.
         uint64_t reads_admitted = 0;
         // Total number of reads enqueued to wait for admission.
@@ -287,8 +289,10 @@ private:
     future<> execution_loop() noexcept;
 
     uint64_t get_serialize_limit() const;
+    uint64_t get_kill_limit() const;
 
-    void consume(resources r);
+    // Throws std::bad_alloc if memory consumed is oom_kill_limit_multiply_threshold more than the memory limit.
+    void consume(reader_permit::impl& permit, resources r);
     void signal(const resources& r) noexcept;
 
 public:

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -243,6 +243,11 @@ temporary_buffer<Char> make_tracked_temporary_buffer(temporary_buffer<Char> buf,
             make_deleter(buf.release(), [units = permit.consume_memory(buf.size())] () mutable { units.reset(); }));
 }
 
+inline temporary_buffer<char> make_new_tracked_temporary_buffer(size_t size, reader_permit& permit) {
+    auto buf = temporary_buffer<char>(size);
+    return temporary_buffer<char>(buf.get_write(), buf.size(), make_object_deleter(buf.release(), permit.consume_memory(size)));
+}
+
 file make_tracked_file(file f, reader_permit p);
 
 template <typename T>

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -79,7 +79,8 @@ public:
     class blocked_guard;
 
     enum class state {
-        waiting, // waiting for admission
+        waiting_for_admission,
+        waiting_for_memory,
         active_unused,
         active_used,
         active_blocked,
@@ -100,8 +101,12 @@ private:
     explicit reader_permit(reader_concurrency_semaphore& semaphore, const schema* const schema, sstring&& op_name,
             reader_resources base_resources, db::timeout_clock::time_point timeout);
 
-    void on_waiting();
+    void on_waiting_for_admission();
+    void on_waiting_for_memory(future<> f);
     void on_admission();
+    void on_granted_memory();
+
+    future<> get_memory_future();
 
     void mark_used() noexcept;
 
@@ -144,6 +149,8 @@ public:
     resource_units consume_memory(size_t memory = 0);
 
     resource_units consume_resources(reader_resources res);
+
+    future<resource_units> request_memory(size_t memory);
 
     reader_resources consumed_resources() const;
 

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -169,6 +169,8 @@ public:
 
     void on_start_sstable_read() noexcept;
     void on_finish_sstable_read() noexcept;
+
+    uintptr_t id() { return reinterpret_cast<uintptr_t>(_impl.get()); }
 };
 
 using reader_permit_opt = optimized_optional<reader_permit>;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -197,6 +197,8 @@ public:
     reader_resources resources() const { return _resources; }
 };
 
+std::ostream& operator<<(std::ostream& os, reader_permit::state s);
+
 /// Mark a permit as used.
 ///
 /// Conceptually, a permit is considered used, when at least one reader

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -171,7 +171,8 @@ class reader_permit::resource_units {
     friend class reader_permit;
     friend class reader_concurrency_semaphore;
 private:
-    resource_units(reader_permit permit, reader_resources res) noexcept;
+    class already_consumed_tag {};
+    resource_units(reader_permit permit, reader_resources res);
 public:
     resource_units(const resource_units&) = delete;
     resource_units(resource_units&&) noexcept;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -172,6 +172,7 @@ class reader_permit::resource_units {
     friend class reader_concurrency_semaphore;
 private:
     class already_consumed_tag {};
+    resource_units(reader_permit permit, reader_resources res, already_consumed_tag);
     resource_units(reader_permit permit, reader_resources res);
 public:
     resource_units(const resource_units&) = delete;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -130,6 +130,8 @@ public:
 
     reader_concurrency_semaphore& semaphore();
 
+    state get_state() const;
+
     bool needs_readmission() const;
 
     // Call only when needs_readmission() = true.

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -245,9 +245,8 @@ public:
 };
 
 template <typename Char>
-temporary_buffer<Char> make_tracked_temporary_buffer(temporary_buffer<Char> buf, reader_permit& permit) {
-    return temporary_buffer<Char>(buf.get_write(), buf.size(),
-            make_deleter(buf.release(), [units = permit.consume_memory(buf.size())] () mutable { units.reset(); }));
+temporary_buffer<Char> make_tracked_temporary_buffer(temporary_buffer<Char> buf, reader_permit::resource_units units) {
+    return temporary_buffer<Char>(buf.get_write(), buf.size(), make_object_deleter(buf.release(), std::move(units)));
 }
 
 inline temporary_buffer<char> make_new_tracked_temporary_buffer(size_t size, reader_permit& permit) {

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4285,7 +4285,7 @@ class scylla_generate_object_graph(gdb.Command):
     at. The generated graph is an image, which allows the visual inspection of the
     object graph.
 
-    The graph is generated with the help of `graphwiz`. The command
+    The graph is generated with the help of `graphviz`. The command
     generates `.dot` files which can be converted to images with the help of
     the `dot` utility. The command can do this if the output file is one of
     the supported image formats (e.g. `png`), otherwise only the `.dot` file
@@ -4398,7 +4398,7 @@ class scylla_generate_object_graph(gdb.Command):
                 help="Output file. Supported extensions are: dot, png, jpg, jpeg, svg and pdf."
                 " Regardless of the extension, a `.dot` file will always be generated."
                 " If the output is one of the graphic formats the command will convert the `.dot` file using the `dot` utility."
-                " In this case the dot utility from the graphwiz suite has to be installed on the machine."
+                " In this case the dot utility from the graphviz suite has to be installed on the machine."
                 " To manually convert the `.dot` file do: `dot -Tpng graph.dot -o graph.png`.")
         parser.add_argument("-d", "--max-depth", action="store", type=int, default=5,
                 help="Maximum depth to traverse the object graph. Set to -1 for unlimited depth. Default is 5.")

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -134,7 +134,7 @@ private:
                 return read_status::ready;
             } else {
                 _read_bytes.clear();
-                _read_bytes.push_back(make_tracked_temporary_buffer(temporary_buffer<char>(len), _permit));
+                _read_bytes.push_back(make_new_tracked_temporary_buffer(len, _permit));
                 std::copy(data.begin(), data.end(), _read_bytes.front().get_write());
                 _read_bytes_len = len;
                 _pos = data.size();
@@ -208,7 +208,7 @@ public:
         } else {
             // copy what we have so far, read the rest later
             _read_bytes.clear();
-            _read_bytes.push_back(make_tracked_temporary_buffer(temporary_buffer<char>(len), _permit));
+            _read_bytes.push_back(make_new_tracked_temporary_buffer(len, _permit));
             std::copy(data.begin(), data.end(),_read_bytes.front().get_write());
             _read_bytes_len = len;
             _read_bytes_where_contiguous = &where;
@@ -273,7 +273,7 @@ public:
                 return read_bytes_contiguous(data, static_cast<uint32_t>(_u64), where);
             } else {
                 _read_bytes.clear();
-                _read_bytes.push_back(make_tracked_temporary_buffer(temporary_buffer<char>(len), _permit));
+                _read_bytes.push_back(make_new_tracked_temporary_buffer(len, _permit));
                 std::copy(data.begin(), data.end(),_read_bytes.front().get_write());
                 _read_bytes_len = len;
                 _pos = data.size();
@@ -298,7 +298,7 @@ public:
                 return read_bytes(data, static_cast<uint32_t>(_u64), where);
             } else {
                 _read_bytes.clear();
-                _read_bytes.push_back(make_tracked_temporary_buffer(temporary_buffer<char>(len), _permit));
+                _read_bytes.push_back(make_new_tracked_temporary_buffer(len, _permit));
                 std::copy(data.begin(), data.end(),_read_bytes.front().get_write());
                 _read_bytes_len = len;
                 _pos = data.size();

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -25,7 +25,9 @@ sstables_manager::sstables_manager(
         max_count_sstable_metadata_concurrent_reads,
         max_memory_sstable_metadata_concurrent_reads(available_memory),
         "sstable_metadata_concurrency_sem",
-        std::numeric_limits<size_t>::max())
+        std::numeric_limits<size_t>::max(),
+        utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+        utils::updateable_value(std::numeric_limits<uint32_t>::max()))
     , _dir_semaphore(dir_sem)
 {
 }

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -31,6 +31,6 @@ custom_args:
     cql_query_test:
         - '-c2 -m2G --fail-on-abandoned-failed-futures=true'
     reader_concurrency_semaphore_test:
-        - '-c1 -m1G'
+        - '-c1 -m256M'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -550,11 +550,8 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         }).get0();
 
         // consume all units except what is needed to admit a single reader.
-        const auto consumed_resources = sem.initial_resources() - reader_resources{1, replica::new_reader_base_cost};
-        sem.consume(consumed_resources);
-        auto release_resources = defer([&sem, consumed_resources] {
-            sem.signal(consumed_resources);
-        });
+        auto sponge_permit = sem.make_tracking_only_permit(s.get(), "sponge", db::no_timeout);
+        auto resources = sponge_permit.consume_resources(sem.available_resources() - reader_resources{1, replica::new_reader_base_cost});
 
         testlog.info("res = [.count={}, .memory={}]", sem.available_resources().count, sem.available_resources().memory);
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -493,6 +493,12 @@ public:
                 debug::the_database = nullptr;
             });
             auto cfg = cfg_in.db_config;
+            if (!cfg->reader_concurrency_semaphore_serialize_limit_multiplier.is_set()) {
+                cfg->reader_concurrency_semaphore_serialize_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
+            }
+            if (!cfg->reader_concurrency_semaphore_kill_limit_multiplier.is_set()) {
+                cfg->reader_concurrency_semaphore_kill_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
+            }
             tmpdir data_dir;
             auto data_dir_path = data_dir.path().string();
             if (!cfg->data_file_directories.is_set()) {

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -96,6 +96,9 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
 
         'permissions_update_interval_in_ms': 100,
         'permissions_validity_in_ms': 100,
+
+        'reader_concurrency_semaphore_serialize_limit_multiplier': 0,
+        'reader_concurrency_semaphore_kill_limit_multiplier': 0,
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
The reader concurrency semaphore has no mechanism to limit the memory consumption of already admitted read. Once memory collective memory consumption of all the admitted reads is above the limit, all it can do is to not admit any more. Sometimes this is not enough and the memory consumption of the already admitted reads balloons to the point of OOMing the node. This pull-request offers a solution to this: it introduces two more layers of defense above this: a soft and a hard limit. Both are multipliers applied on the semaphores normal memory limit.
When the soft limit threshold is surpassed, all readers but one are blocked via a new blocking `request_memory()` call which is used by the `tracking_file_impl`. The reader to be allowed to proceed is chosen at random, it is the first reader which happens to request memory after the limit is surpassed. This is both very simple and should avoid situations where the algorithm choosing the reader to be allowed to proceed chooses a reader which will then always time out.
When the hard limit threshold is surpassed, `reader_concurrency_semaphore::consume()` starts throwing `std::bad_alloc`. This again will result in eliminating whichever reader was unlucky enough to request memory at the right moment.

With this, the semaphore is now effectively enforcing an upper bound for memory consumption, defined by the hard limit.

Refs: https://github.com/scylladb/scylladb/issues/11927