### PR TITLE
Introduce reverse vector_deserializer.

### DIFF
--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -791,11 +791,11 @@ unknown_variant_type deserialize(Input& in, boost::type<unknown_variant_type>) {
 // using a range.
 // Use begin() and end() to iterate through the frozen vector,
 // deserializing (or skipping) one element at a time.
-template <typename T, typename InputStream = utils::input_stream>
+template <typename T>
 class vector_deserializer {
 public:
     using value_type = T;
-    using input_stream = InputStream;
+    using input_stream = utils::input_stream;
 
 private:
     input_stream _in;


### PR DESCRIPTION
As indicated in #11816, we'd like to enable deserializing vectors in reverse. 
The forward deserialization is achieved by reading from an input_stream. The
input stream internally is a singly linked list with complicated logic. In order to 
allow for going through it in reverse, instead when creating the reverse vector
initializer, we scan the stream and store substreams to all the places that are a
starting point for a next element. The iterator itself just deserializes elements 
from the remembered substreams, this time in reverse.
 
Fixes
#11816

CC @bhalevy 