### PR TITLE
utils: crc: generate crc barrett fold tables at compile time

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -910,6 +910,7 @@ scylla_core = (['message/messaging_service.cc',
                 'utils/config_file.cc',
                 'utils/multiprecision_int.cc',
                 'utils/gz/crc_combine.cc',
+                'utils/gz/crc_combine_table.cc',
                 'gms/version_generator.cc',
                 'gms/versioned_value.cc',
                 'gms/gossiper.cc',
@@ -1323,8 +1324,6 @@ deps['test/raft/discovery_test'] =  ['test/raft/discovery_test.cc',
                                      'test/raft/helpers.cc',
                                      'test/lib/log.cc',
                                      'service/raft/discovery.cc'] + scylla_raft_dependencies
-
-deps['utils/gz/gen_crc_combine_table'] = ['utils/gz/gen_crc_combine_table.cc']
 
 
 warnings = [
@@ -1954,7 +1953,6 @@ with open(buildfile, 'w') as f:
                 ] + [
                     'abseil/' + x for x in abseil_libs
                 ]])
-                objs.append('$builddir/' + mode + '/gen/utils/gz/crc_combine_table.o')
                 if binary in tests:
                     local_libs = '$seastar_libs_{} $libs'.format(mode)
                     if binary in pure_boost_tests:
@@ -2003,12 +2001,6 @@ with open(buildfile, 'w') as f:
                     rust_libs[staticlib] = src
                 else:
                     raise Exception('No rule for ' + src)
-        compiles['$builddir/' + mode + '/gen/utils/gz/crc_combine_table.o'] = '$builddir/' + mode + '/gen/utils/gz/crc_combine_table.cc'
-        compiles['$builddir/' + mode + '/utils/gz/gen_crc_combine_table.o'] = 'utils/gz/gen_crc_combine_table.cc'
-        f.write('build {}: run {}\n'.format('$builddir/' + mode + '/gen/utils/gz/crc_combine_table.cc',
-                                            '$builddir/' + mode + '/utils/gz/gen_crc_combine_table'))
-        f.write('build {}: link_build.{} {}\n'.format('$builddir/' + mode + '/utils/gz/gen_crc_combine_table', mode,
-                                                '$builddir/' + mode + '/utils/gz/gen_crc_combine_table.o'))
         f.write('   libs = $seastar_libs_{}\n'.format(mode))
         f.write(
             'build {mode}-objects: phony {objs}\n'.format(

--- a/test/boost/crc_test.cc
+++ b/test/boost/crc_test.cc
@@ -10,8 +10,28 @@
 
 #include <boost/test/unit_test.hpp>
 #include "utils/crc.hh"
+#include "utils/clmul.hh"
+#include "utils/gz/barett.hh"
 #include <seastar/core/print.hh>
 
+constexpr uint32_t input_32_1_c = 0x12345678;
+uint32_t input_32_1 = input_32_1_c; // NOT constexpr
+
+constexpr uint32_t input_32_2_c = 0xabcdef12;
+uint32_t input_32_2 = input_32_2_c; // NOT constexpr
+
+constexpr uint64_t input_64_1_c = 0x1234567890abcdef;
+uint64_t input_64_1 = input_64_1_c; // NOT constexpr
+
+BOOST_AUTO_TEST_CASE(clmul_u32_constexpr_equals_native) {
+    constexpr auto constexpr_result = clmul(input_32_1_c, input_32_2_c);
+    BOOST_REQUIRE_EQUAL(clmul(input_32_1, input_32_2), constexpr_result);
+}
+
+BOOST_AUTO_TEST_CASE(barrett_fold_constexpr_equals_native) {
+    constexpr auto constexpr_result = crc32_fold_barett_u64(input_64_1_c);
+    BOOST_REQUIRE_EQUAL(crc32_fold_barett_u64(input_64_1), constexpr_result);
+}
 inline
 uint32_t
 do_compute_crc(utils::crc32& c) {

--- a/utils/clmul.hh
+++ b/utils/clmul.hh
@@ -21,6 +21,16 @@ constexpr uint64_t clmul_u32_constexpr(uint32_t p1, uint32_t p2) {
     return result;
 }
 
+// returns the low half of the result
+inline
+constexpr uint64_t clmul_u64_low_constexpr(uint64_t p1, uint64_t p2) {
+    uint64_t result = 0;
+    for (unsigned i = 0; i < 64; ++i) {
+        result ^= (((p1 >> i) & 1) * p2) << i;
+    }
+    return result;
+}
+
 #if defined(__x86_64__) || defined(__i386__)
 
 #include <wmmintrin.h>

--- a/utils/clmul.hh
+++ b/utils/clmul.hh
@@ -10,6 +10,16 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
+
+inline
+constexpr uint64_t clmul_u32_constexpr(uint32_t p1, uint32_t p2) {
+    uint64_t result = 0;
+    for (unsigned i = 0; i < 32; ++i) {
+        result ^= (((p1 >> i) & 1) * uint64_t(p2)) << i;
+    }
+    return result;
+}
 
 #if defined(__x86_64__) || defined(__i386__)
 
@@ -24,9 +34,10 @@ uint64_t clmul_u32(uint32_t p1, uint32_t p2) {
     return _mm_extract_epi64(p, 0);
 }
 
+constexpr
 inline
 uint64_t clmul(uint32_t p1, uint32_t p2) {
-    return clmul_u32(p1, p2);
+    return std::is_constant_evaluated() ? clmul_u32_constexpr(p1, p2) : clmul_u32(p1, p2);
 }
 
 #elif defined(__aarch64__)
@@ -39,9 +50,10 @@ uint64_t clmul_u32(uint32_t p1, uint32_t p2) {
     return vmull_p64(p1, p2);
 }
 
+constexpr
 inline
 uint64_t clmul(uint32_t p1, uint32_t p2) {
-    return clmul_u32(p1, p2);
+    return std::is_constant_evaluated() ? clmul_u32_constexpr(p1, p2) : clmul_u32(p1, p2);
 }
 
 #endif

--- a/utils/gz/barett.hh
+++ b/utils/gz/barett.hh
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include "utils/clmul.hh"
 
+inline
 constexpr uint64_t barrett_reduction_constants[2] = { 0x00000001F7011641, 0x00000001DB710641 };
 
 /*
@@ -54,6 +55,7 @@ inline constexpr uint32_t crc32_fold_barett_u64_constexpr(uint64_t p) {
 
 #include <wmmintrin.h>
 
+inline
 uint32_t crc32_fold_barett_u64_in_m128(__m128i x0) {
     __m128i x1;
     const __m128i mask32 = (__m128i)(__v4si){ int32_t(0xFFFFFFFF) };
@@ -109,6 +111,7 @@ uint32_t crc32_fold_barett_u64_in_m128(__m128i x0) {
     return _mm_cvtsi128_si32(_mm_srli_si128(x0 ^ x1, 4));
 }
 
+inline
 uint32_t crc32_fold_barett_u64_native(uint64_t p) {
     return crc32_fold_barett_u64_in_m128(_mm_set_epi64x(0, p));
 }
@@ -117,6 +120,7 @@ uint32_t crc32_fold_barett_u64_native(uint64_t p) {
 
 #include <arm_neon.h>
 
+inline
 uint32_t crc32_fold_barett_u64_in_u64x2(uint64x2_t x0) {
     uint64x2_t x1;
     const uint64_t barrett_reduction_constant_lo = barrett_reduction_constants[0];
@@ -132,6 +136,7 @@ uint32_t crc32_fold_barett_u64_in_u64x2(uint64x2_t x0) {
     return vgetq_lane_u64(vshrq_n_u64(x0 ^ x1, 32), 0);
 }
 
+inline
 uint32_t crc32_fold_barett_u64_native(uint64_t p) {
     return crc32_fold_barett_u64_in_u64x2(
             vcombine_u64((uint64x1_t)p, (uint64x1_t)0UL));

--- a/utils/gz/barett.hh
+++ b/utils/gz/barett.hh
@@ -44,12 +44,6 @@ inline uint32_t crc32_fold_barett_u64(uint64_t p);
 
 #include <wmmintrin.h>
 
-inline uint32_t crc32_fold_barett_u64_in_m128(__m128i);
-
-uint32_t crc32_fold_barett_u64(uint64_t p) {
-    return crc32_fold_barett_u64_in_m128(_mm_set_epi64x(0, p));
-}
-
 uint32_t crc32_fold_barett_u64_in_m128(__m128i x0) {
     __m128i x1;
     const __m128i mask32 = (__m128i)(__v4si){ int32_t(0xFFFFFFFF) };
@@ -105,16 +99,13 @@ uint32_t crc32_fold_barett_u64_in_m128(__m128i x0) {
     return _mm_cvtsi128_si32(_mm_srli_si128(x0 ^ x1, 4));
 }
 
+uint32_t crc32_fold_barett_u64(uint64_t p) {
+    return crc32_fold_barett_u64_in_m128(_mm_set_epi64x(0, p));
+}
+
 #elif defined(__aarch64__)
 
 #include <arm_neon.h>
-
-inline uint32_t crc32_fold_barett_u64_in_u64x2(uint64x2_t);
-
-uint32_t crc32_fold_barett_u64(uint64_t p) {
-    return crc32_fold_barett_u64_in_u64x2(
-            vcombine_u64((uint64x1_t)p, (uint64x1_t)0UL));
-}
 
 uint32_t crc32_fold_barett_u64_in_u64x2(uint64x2_t x0) {
     uint64x2_t x1;
@@ -129,6 +120,11 @@ uint32_t crc32_fold_barett_u64_in_u64x2(uint64x2_t x0) {
             vmull_p64(vgetq_lane_u32(vreinterpretq_u32_u64(x0), 0),
                       barrett_reduction_constant_hi));
     return vgetq_lane_u64(vshrq_n_u64(x0 ^ x1, 32), 0);
+}
+
+uint32_t crc32_fold_barett_u64(uint64_t p) {
+    return crc32_fold_barett_u64_in_u64x2(
+            vcombine_u64((uint64x1_t)p, (uint64x1_t)0UL));
 }
 
 #else

--- a/utils/gz/crc_combine_table.cc
+++ b/utils/gz/crc_combine_table.cc
@@ -7,14 +7,13 @@
  *
  */
 
-#include <iostream>
-
 #if defined(__x86_64__) || defined(__i386__) || defined(__aarch64__)
 
+#include <array>
+
+#include "crc_combine_table.hh"
 #include "utils/clmul.hh"
 #include "barett.hh"
-
-#include <seastar/core/print.hh>
 
 template <int bits>
 static
@@ -59,51 +58,8 @@ constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8 = make_crc3
 constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16 = make_crc32_table(16, radix_bits, one, pows);
 constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24 = make_crc32_table(24, radix_bits, one, pows);
 
-int main() {
-    std::array<const std::array<uint32_t, 256>*, 4> tables = {
-        &crc32_x_pow_radix_8_table_base_0,
-        &crc32_x_pow_radix_8_table_base_8,
-        &crc32_x_pow_radix_8_table_base_16,
-        &crc32_x_pow_radix_8_table_base_24,
-    };
-
-    std::cout << "/*\n"
-                 " * Generated with gen_crc_combine_table.cc\n"
-                 " * DO NOT EDIT!\n"
-                 " */\n"
-                 "\n"
-                  "#include \"utils/gz/crc_combine_table.hh\"\n"
-                 "\n";
-
-
-    for (int base = 0; base < bits; base += radix_bits) {
-        std::cout << "std::array<uint32_t, " << (1<<radix_bits) << "> crc32_x_pow_radix_8_table_base_" << base << " = {";
-
-        auto& table = *tables[base / radix_bits];
-
-        for (int i = 0; i < (1 << radix_bits); ++i) {
-            if (i % 4 == 0) {
-                std::cout << "\n    ";
-            }
-            auto product = table[i];
-            std::cout << seastar::format(" 0x{:0>8x},", product);
-        }
-
-        std::cout << "\n};\n\n";
-    }
-}
-
 #else
 
-int main() {
-    std::cout << "/*\n"
-                 " * Generated with gen_crc_combine_table.cc\n"
-                 " * DO NOT EDIT!\n"
-                 " */\n"
-                 "\n"
-                 "/* Not implemented for this CPU architecture. */\n"
-                 "\n";
-    return 0;
-}
+#error "Not implemented for this CPU architecture."
 
 #endif

--- a/utils/gz/crc_combine_table.hh
+++ b/utils/gz/crc_combine_table.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+#include <array>
 
 /*
  * Let t_i be the following polynomial depending on i and u:
@@ -36,7 +37,7 @@
  *                                                (u >> 6) & 1,
  *                                                (u >> 7) & 1)
  */
-extern uint32_t crc32_x_pow_radix_8_table_base_0[256];
-extern uint32_t crc32_x_pow_radix_8_table_base_8[256];
-extern uint32_t crc32_x_pow_radix_8_table_base_16[256];
-extern uint32_t crc32_x_pow_radix_8_table_base_24[256];
+extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_0;
+extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8;
+extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16;
+extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24;

--- a/utils/gz/gen_crc_combine_table.cc
+++ b/utils/gz/gen_crc_combine_table.cc
@@ -26,7 +26,7 @@ int main() {
                  " * DO NOT EDIT!\n"
                  " */\n"
                  "\n"
-                 "#include \"utils/gz/crc_combine_table.hh\"\n"
+                  "#include \"utils/gz/crc_combine_table.hh\"\n"
                  "\n";
 
     uint32_t pows[bits]; // pows[i] = x^(2^i*8) mod G(x)
@@ -39,7 +39,7 @@ int main() {
     }
 
     for (int base = 0; base < bits; base += radix_bits) {
-        std::cout << "uint32_t crc32_x_pow_radix_8_table_base_" << base << "[" << (1<<radix_bits) << "] = {";
+        std::cout << "std::array<uint32_t, " << (1<<radix_bits) << "> crc32_x_pow_radix_8_table_base_" << base << " = {";
 
         for (int i = 0; i < (1 << radix_bits); ++i) {
             uint32_t product = one;


### PR DESCRIPTION
We use Barrett tables (misspelled in the code unfortunately) to fold
crc computations of multiple buffers into a single crc. This is important
because it turns out to be faster to compute crc of three different buffers
in parallel rather than compute the crc of one large buffer, since the crc
instruction has latency 3.

Currently, we have a separate code generation step to compute the
fold tables. The step generates a new C++ source files with the tables.
But modern C++ allows us to do this computation at compile time, avoiding
the code generation step. This simplifies the build.

This series does that. There is some complication in that the code uses
compiler intrinsics for the computation, and these are not constexpr friendly.
So we first introduce constexpr-friendly alternatives and use them. 

To prove the transformation is correct, I compared the generated code from
before the series and from just before the last step (where we use constexpr
evaluation but still retain the generated file) and saw no difference in the values.

Note that constexpr is not strictly needed - we could have run the code in the
global variables' initializer. But that would cause a crash if we run on a pre-clmul
machine, and is not as fun.