### PR TITLE
topology: copy sort_by_proximity

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1271,6 +1271,7 @@ topology::topology(const topology& other)
         , _dc_racks(other._dc_racks)
         , _current_locations(other._current_locations)
         , _pending_locations(other._pending_locations)
+        , _sort_by_proximity(other._sort_by_proximity)
 {
 }
 


### PR DESCRIPTION
The _sort_by_proximity member is currently not copied by the copy constructor.
This series makes sure to copy it and follows up with coroutinizing the code path that uses the copy constructor
and then introduce an async copy_gently function to perform the copy, maybe yielding if necessary.

Fixes #11962
