### PR TITLE
doc: add the "Scylladb Enterprise" label to the Enterprise-only fearues

### DIFF
--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -255,7 +255,9 @@ The following options only apply to IncrementalCompactionStrategy:
 
 ``space_amplification_goal`` (default: null)
 
-.. versionadded:: 2020.1.6 Scylla Enterprise
+:label-tip:`ScyllaDB Enterprise`
+
+   .. versionadded:: 2020.1.6 
 
    This is a threshold of the ratio of the sum of the sizes of the two largest tiers to the size of the largest tier,
    above which ICS will automatically compact the second largest and largest tiers together to eliminate stale data that may have been overwritten, expired, or deleted.

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -2,7 +2,7 @@
 Scylla Auditing Guide
 =====================
 
-.. include:: /rst_include/enterprise-only-note.rst
+:label-tip:`ScyllaDB Enterprise`
 
 
 Auditing allows the administrator to monitor activities on a Scylla cluster, including queries and data changes. 

--- a/docs/operating-scylla/security/ldap-authentication.rst
+++ b/docs/operating-scylla/security/ldap-authentication.rst
@@ -7,9 +7,9 @@ LDAP Authentication
 
    saslauthd
 
-.. include:: /rst_include/enterprise-only-note.rst
+:label-tip:`ScyllaDB Enterprise`
 
-.. versionadded:: Scylla Enterprise 2021.1.2
+.. versionadded:: 2021.1.2
 
 Scylla supports user authentication via an LDAP server by leveraging the SaslauthdAuthenticator.
 By configuring saslauthd correctly against your LDAP server, you enable Scylla to check the user’s credentials through it.

--- a/docs/operating-scylla/security/ldap-authorization.rst
+++ b/docs/operating-scylla/security/ldap-authorization.rst
@@ -2,13 +2,13 @@
 LDAP Authorization (Role Management)
 =====================================
 
-.. include:: /rst_include/enterprise-only-note.rst
+:label-tip:`ScyllaDB Enterprise`
+
+.. versionadded:: 2021.1.2
 
 Scylla Enterprise customers can manage and authorize users’ privileges via an :abbr:`LDAP (Lightweight Directory Access Protocol)` server.
 LDAP is an open, vendor-neutral, industry-standard protocol for accessing and maintaining distributed user access control over a standard IP network.
 If your users are already stored in an LDAP directory, you can now use the same LDAP server to regulate their roles in Scylla.
-
-.. versionadded:: Scylla Enterprise 2021.1.2
 
 
 Introduction

--- a/docs/rst_include/enterprise-only-note.rst
+++ b/docs/rst_include/enterprise-only-note.rst
@@ -1,1 +1,0 @@
-.. note:: This feature is only available with Scylla Enterprise. If you are using Scylla Open Source, this feature will not be available.

--- a/docs/using-scylla/in-memory.rst
+++ b/docs/using-scylla/in-memory.rst
@@ -2,10 +2,9 @@
 Scylla in-memory tables
 =========================
 
+:label-tip:`ScyllaDB Enterprise`
 
-.. versionadded:: 2018.1.7 Scylla Enterprise
-
-.. include:: /rst_include/enterprise-only-note.rst
+.. versionadded:: 2018.1.7
 
 Overview
 ========

--- a/docs/using-scylla/workload-prioritization.rst
+++ b/docs/using-scylla/workload-prioritization.rst
@@ -2,9 +2,7 @@
 Workload Prioritization
 ========================
 
-
-
-.. include:: /rst_include/enterprise-only-note.rst
+:label-tip:`ScyllaDB Enterprise`
 
 In a typical database there are numerous workloads running at the same time.
 Each workload type dictates a different acceptable level of latency and throughput.


### PR DESCRIPTION
This PR is a follow-up to https://github.com/scylladb/scylladb/pull/11918.

With this PR:
- The "ScyllaDB Enterprise" label is added to all the features that are only available in ScyllaDB Enterprise.
- The previous Enterprise-only note is removed (it was included in multiple files as _/rst_include/enterprise-only-note.rst_ - this file is removed as it is no longer used anywhere in the docs).
- "Scylla Enterprise" was removed from `versionadded `because now it's clear that the feature was added for Enterprise.
