### PR TITLE
tools: toolchain: prepare: use real bash associative array

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -25,14 +25,15 @@ fi
 archs=(amd64 arm64 s390x)
 
 # docker arch has a diffrent spelling than uname arch
-arch_uname_amd64=x86_64
-arch_uname_arm64=aarch64
-arch_uname_s390x=s390x
+declare -A arch_unames=(
+    [amd64]=x86_64
+    [arm64]=aarch64
+    [s390x]=s390x
+)
 
 for arch in "${archs[@]}"; do
     # translate from docker arch to uname arch
-    indirect="arch_uname_${arch}"
-    arch_uname="${!indirect}"
+    arch_uname="${arch_unames[$arch]}"
     if [[ "$(uname -m)" == "${arch_uname}" ]]; then
         continue
     fi


### PR DESCRIPTION
When we translate from docker/go arch names to the kernel arch names, we use an associative array hack using computed variable names "{$!variable_name}". But it turns out bash has real associative arrays, introduced with "declare -A". Use the to make the code a little clearer.