### PR TITLE
repair: harden effective replication map

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1394,9 +1394,9 @@ static std::optional<gms::inet_address>
 get_view_natural_endpoint(const sstring& keyspace_name,
         const dht::token& base_token, const dht::token& view_token) {
     auto &db = service::get_local_storage_proxy().local_db();
-    auto& topology = service::get_local_storage_proxy().get_token_metadata_ptr()->get_topology();
     auto& ks = db.find_keyspace(keyspace_name);
     auto erm = ks.get_effective_replication_map();
+    auto& topology = erm->get_token_metadata_ptr()->get_topology();
     auto my_address = utils::fb_utilities::get_broadcast_address();
     auto my_datacenter = topology.get_datacenter();
     bool network_topology = dynamic_cast<const locator::network_topology_strategy*>(&ks.get_replication_strategy());

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -407,7 +407,7 @@ public:
     // using the schema_tables merge_lock.
     //
     // Must be called on shard 0.
-    future<token_metadata_lock> get_lock() noexcept {
+    future<token_metadata_lock> get_lock() const noexcept {
         return _lock_func();
     }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -562,6 +562,7 @@ repair_info::repair_info(repair_service& repair,
     , gossiper(repair.get_gossiper())
     , sharder(get_sharder_for_tables(db, keyspace_, table_ids_))
     , keyspace(keyspace_)
+    , erm(db.local().find_keyspace(keyspace).get_effective_replication_map())
     , ranges(ranges_)
     , cfs(get_table_names(db.local(), table_ids_))
     , table_ids(std::move(table_ids_))
@@ -570,7 +571,7 @@ repair_info::repair_info(repair_service& repair,
     , hosts(hosts_)
     , ignore_nodes(ignore_nodes_)
     , reason(reason_)
-    , total_rf(db.local().find_keyspace(keyspace).get_effective_replication_map()->get_replication_factor())
+    , total_rf(erm->get_replication_factor())
     , nr_ranges_total(ranges.size())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed)) {
     if (as != nullptr) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1267,17 +1267,8 @@ future<> repair_service::sync_data_using_repair(
     if (ranges.empty()) {
         return make_ready_future<>();
     }
-    return container().invoke_on(0, [keyspace = std::move(keyspace), ranges = std::move(ranges), neighbors = std::move(neighbors), reason, ops_info] (repair_service& local_repair) mutable {
-        return local_repair.do_sync_data_using_repair(std::move(keyspace), std::move(ranges), std::move(neighbors), reason, ops_info);
-    });
-}
 
-future<> repair_service::do_sync_data_using_repair(
-        sstring keyspace,
-        dht::token_range_vector ranges,
-        std::unordered_map<dht::token_range, repair_neighbors> neighbors,
-        streaming::stream_reason reason,
-        shared_ptr<node_ops_info> ops_info) {
+    assert(this_shard_id() == 0);
     auto& db = get_db().local();
 
     repair_uniq_id id = get_repair_module().new_repair_uniq_id();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1034,7 +1034,8 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
             ranges = erm->get_primary_ranges(utils::fb_utilities::get_broadcast_address());
         }
     } else {
-        ranges = db.get_keyspace_local_ranges(keyspace);
+        // get keyspace local ranges
+        ranges = erm->get_ranges(utils::fb_utilities::get_broadcast_address());
     }
 
     if (!options.data_centers.empty() && !options.hosts.empty()) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1336,6 +1336,7 @@ future<> repair_service::do_sync_data_using_repair(
 }
 
 future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens) {
+    assert(this_shard_id() == 0);
     using inet_address = gms::inet_address;
     return seastar::async([this, tmptr = std::move(tmptr), tokens = std::move(bootstrap_tokens)] () mutable {
         auto& db = get_db().local();
@@ -1510,6 +1511,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
 }
 
 future<> repair_service::do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops) {
+    assert(this_shard_id() == 0);
     using inet_address = gms::inet_address;
     return seastar::async([this, tmptr = std::move(tmptr), leaving_node = std::move(leaving_node), ops] () mutable {
         auto& db = get_db().local();
@@ -1702,10 +1704,12 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
 }
 
 future<> repair_service::decommission_with_repair(locator::token_metadata_ptr tmptr) {
+    assert(this_shard_id() == 0);
     return do_decommission_removenode_with_repair(std::move(tmptr), utils::fb_utilities::get_broadcast_address(), {});
 }
 
 future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops) {
+    assert(this_shard_id() == 0);
     return do_decommission_removenode_with_repair(std::move(tmptr), std::move(leaving_node), std::move(ops)).then([this] {
         rlogger.debug("Triggering off-strategy compaction for all non-system tables on removenode completion");
         seastar::sharded<replica::database>& db = get_db();
@@ -1718,6 +1722,7 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
 }
 
 future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes) {
+    assert(this_shard_id() == 0);
     return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto& db = get_db().local();
         auto ks_erms = db.get_non_local_strategy_keyspaces_erms();
@@ -1801,6 +1806,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
 }
 
 future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc) {
+    assert(this_shard_id() == 0);
     auto op = sstring("rebuild_with_repair");
     if (source_dc.empty()) {
         auto& topology = tmptr->get_topology();
@@ -1816,6 +1822,7 @@ future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, 
 }
 
 future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::list<gms::inet_address> ignore_nodes) {
+    assert(this_shard_id() == 0);
     auto cloned_tm = co_await tmptr->clone_async();
     auto op = sstring("replace_with_repair");
     auto& topology = tmptr->get_topology();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1265,7 +1265,7 @@ future<> repair_service::sync_data_using_repair(
         streaming::stream_reason reason,
         shared_ptr<node_ops_info> ops_info) {
     if (ranges.empty()) {
-        return make_ready_future<>();
+        co_return;
     }
 
     assert(this_shard_id() == 0);
@@ -1273,7 +1273,7 @@ future<> repair_service::sync_data_using_repair(
 
     repair_uniq_id id = get_repair_module().new_repair_uniq_id();
     rlogger.info("repair[{}]: sync data for keyspace={}, status=started", id.uuid(), keyspace);
-    return get_repair_module().run(id, [this, id, &db, keyspace, ranges = std::move(ranges), neighbors = std::move(neighbors), reason, ops_info] () mutable {
+    co_await get_repair_module().run(id, [this, id, &db, keyspace, ranges = std::move(ranges), neighbors = std::move(neighbors), reason, ops_info] () mutable {
         auto cfs = list_column_families(db, keyspace);
         if (cfs.empty()) {
             rlogger.warn("repair[{}]: sync data for keyspace={}, no table in this keyspace", id.uuid(), keyspace);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -544,6 +544,7 @@ get_sharder_for_tables(seastar::sharded<replica::database>& db, const sstring& k
 
 repair_info::repair_info(repair_service& repair,
     const sstring& keyspace_,
+    locator::effective_replication_map_ptr erm_,
     const dht::token_range_vector& ranges_,
     std::vector<table_id> table_ids_,
     repair_uniq_id id_,
@@ -562,7 +563,7 @@ repair_info::repair_info(repair_service& repair,
     , gossiper(repair.get_gossiper())
     , sharder(get_sharder_for_tables(db, keyspace_, table_ids_))
     , keyspace(keyspace_)
-    , erm(db.local().find_keyspace(keyspace).get_effective_replication_map())
+    , erm(std::move(erm_))
     , ranges(ranges_)
     , cfs(get_table_names(db.local(), table_ids_))
     , table_ids(std::move(table_ids_))
@@ -993,9 +994,11 @@ static future<> repair_ranges(lw_shared_ptr<repair_info> ri) {
 // itself does very little (mainly tell other nodes and CPUs what to do).
 future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map) {
     get_repair_module().check_in_shutdown();
-    auto& db = get_db().local();
-    auto erm = db.find_keyspace(keyspace).get_effective_replication_map();
-    auto& topology = erm->get_token_metadata().get_topology();
+    auto& sharded_db = get_db();
+    auto& db = sharded_db.local();
+    auto germs = make_lw_shared(co_await locator::make_global_effective_replication_map(sharded_db, keyspace));
+    auto& erm = germs->get();
+    auto& topology = erm.get_token_metadata().get_topology();
 
     repair_options options(options_map);
 
@@ -1028,15 +1031,15 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
             // but instead of each range being assigned just one primary owner
             // across the entire cluster, here each range is assigned a primary
             // owner in each of the DCs.
-            ranges = erm->get_primary_ranges_within_dc(utils::fb_utilities::get_broadcast_address());
+            ranges = erm.get_primary_ranges_within_dc(utils::fb_utilities::get_broadcast_address());
         } else if (options.data_centers.size() > 0 || options.hosts.size() > 0) {
             throw std::runtime_error("You need to run primary range repair on all nodes in the cluster.");
         } else {
-            ranges = erm->get_primary_ranges(utils::fb_utilities::get_broadcast_address());
+            ranges = erm.get_primary_ranges(utils::fb_utilities::get_broadcast_address());
         }
     } else {
         // get keyspace local ranges
-        ranges = erm->get_ranges(utils::fb_utilities::get_broadcast_address());
+        ranges = erm.get_ranges(utils::fb_utilities::get_broadcast_address());
     }
 
     if (!options.data_centers.empty() && !options.hosts.empty()) {
@@ -1097,7 +1100,7 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
     }
 
     // Do it in the background.
-    (void)get_repair_module().run(id, [this, &db, id, keyspace = std::move(keyspace),
+    (void)get_repair_module().run(id, [this, &db, id, keyspace = std::move(keyspace), germs = std::move(germs),
             cfs = std::move(cfs), ranges = std::move(ranges), options = std::move(options), ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto uuid = id.uuid();
 
@@ -1193,10 +1196,10 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
 
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
-                    data_centers = options.data_centers, hosts = options.hosts, ignore_nodes] (repair_service& local_repair) mutable {
+                    data_centers = options.data_centers, hosts = options.hosts, ignore_nodes, germs] (repair_service& local_repair) mutable {
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
                 auto ri = make_lw_shared<repair_info>(local_repair,
-                        std::move(keyspace), std::move(ranges), std::move(table_ids),
+                        std::move(keyspace), germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, nullptr, hints_batchlog_flushed);
                 return repair_ranges(ri);
             });
@@ -1260,6 +1263,7 @@ future<> repair_service::abort_all() {
 
 future<> repair_service::sync_data_using_repair(
         sstring keyspace,
+        locator::effective_replication_map_ptr erm,
         dht::token_range_vector ranges,
         std::unordered_map<dht::token_range, repair_neighbors> neighbors,
         streaming::stream_reason reason,
@@ -1269,11 +1273,13 @@ future<> repair_service::sync_data_using_repair(
     }
 
     assert(this_shard_id() == 0);
-    auto& db = get_db().local();
+    auto& sharded_db = get_db();
+    auto& db = sharded_db.local();
+    auto germs = make_lw_shared(co_await locator::make_global_effective_replication_map(sharded_db, keyspace));
 
     repair_uniq_id id = get_repair_module().new_repair_uniq_id();
     rlogger.info("repair[{}]: sync data for keyspace={}, status=started", id.uuid(), keyspace);
-    co_await get_repair_module().run(id, [this, id, &db, keyspace, ranges = std::move(ranges), neighbors = std::move(neighbors), reason, ops_info] () mutable {
+    co_await get_repair_module().run(id, [this, id, &db, keyspace, germs = std::move(germs), ranges = std::move(ranges), neighbors = std::move(neighbors), reason, ops_info] () mutable {
         auto cfs = list_column_families(db, keyspace);
         if (cfs.empty()) {
             rlogger.warn("repair[{}]: sync data for keyspace={}, no table in this keyspace", id.uuid(), keyspace);
@@ -1286,14 +1292,14 @@ future<> repair_service::sync_data_using_repair(
             throw std::runtime_error("aborted by user request");
         }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
-            auto f = container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info] (repair_service& local_repair) mutable {
+            auto f = container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs] (repair_service& local_repair) mutable {
                 auto data_centers = std::vector<sstring>();
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
                 bool hints_batchlog_flushed = false;
                 abort_source* asp = ops_info ? ops_info->local_abort_source() : nullptr;
                 auto ri = make_lw_shared<repair_info>(local_repair,
-                        std::move(keyspace), std::move(ranges), std::move(table_ids),
+                        std::move(keyspace), germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
                 ri->neighbors = std::move(neighbors);
                 return repair_ranges(ri);
@@ -1494,7 +1500,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                 }
             }
             auto nr_ranges = desired_ranges.size();
-            sync_data_using_repair(keyspace_name, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
+            sync_data_using_repair(keyspace_name, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges);
         }
         rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | boost::adaptors::map_keys);
@@ -1686,7 +1692,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                 ranges.swap(ranges_for_removenode);
             }
             auto nr_ranges_synced = ranges.size();
-            sync_data_using_repair(keyspace_name, std::move(ranges), std::move(range_sources), reason, ops).get();
+            sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, ops).get();
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
                 op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced, nr_ranges_skipped);
         }
@@ -1789,7 +1795,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
                 }).get();
             }
             auto nr_ranges = ranges.size();
-            sync_data_using_repair(keyspace_name, std::move(ranges), std::move(range_sources), reason, nullptr).get();
+            sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc, nr_ranges);
         }
         rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | boost::adaptors::map_keys, source_dc);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1011,9 +1011,9 @@ static future<> repair_ranges(lw_shared_ptr<repair_info> ri) {
 // repairs). It is fine to always do this on one CPU, because the function
 // itself does very little (mainly tell other nodes and CPUs what to do).
 int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map) {
+    get_repair_module().check_in_shutdown();
     auto& db = get_db().local();
     auto& topology = db.get_token_metadata().get_topology();
-    get_repair_module().check_in_shutdown();
 
     repair_options options(options_map);
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -20,6 +20,7 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
 
+#include "locator/abstract_replication_strategy.hh"
 #include "replica/database_fwd.hh"
 #include "frozen_mutation.hh"
 #include "utils/UUID.hh"
@@ -180,6 +181,7 @@ public:
     gms::gossiper& gossiper;
     const dht::sharder& sharder;
     sstring keyspace;
+    locator::effective_replication_map_ptr erm;
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;
     std::vector<table_id> table_ids;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -204,6 +204,7 @@ public:
 public:
     repair_info(repair_service& repair,
             const sstring& keyspace_,
+            locator::effective_replication_map_ptr erm_,
             const dht::token_range_vector& ranges_,
             std::vector<table_id> table_ids_,
             repair_uniq_id id_,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -13,6 +13,7 @@
 #include "repair/repair.hh"
 #include "repair/repair_task.hh"
 #include "tasks/task_manager.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/util/bool_class.hh>
 
@@ -148,6 +149,7 @@ private:
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,
+            locator::effective_replication_map_ptr erm,
             dht::token_range_vector ranges,
             std::unordered_map<dht::token_range, repair_neighbors> neighbors,
             streaming::stream_reason reason,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -146,13 +146,8 @@ private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
     future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes);
 
+    // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,
-            dht::token_range_vector ranges,
-            std::unordered_map<dht::token_range, repair_neighbors> neighbors,
-            streaming::stream_reason reason,
-            shared_ptr<node_ops_info> ops_info);
-
-    future<> do_sync_data_using_repair(sstring keyspace,
             dht::token_range_vector ranges,
             std::unordered_map<dht::token_range, repair_neighbors> neighbors,
             streaming::stream_reason reason,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -136,6 +136,7 @@ public:
     int do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map);
 
     // The tokens are the tokens assigned to the bootstrap node.
+    // all repair-based node operation entry points must be called on shard 0
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -133,7 +133,7 @@ public:
     future<> cleanup_history(tasks::task_id repair_id);
     future<> load_history();
 
-    int do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map);
+    future<int> do_repair_start(sstring keyspace, std::unordered_map<sstring, sstring> options_map);
 
     // The tokens are the tokens assigned to the bootstrap node.
     // all repair-based node operation entry points must be called on shard 0


### PR DESCRIPTION
As described in #11993 per-shard repair_info instances get the effective_replication_map on their own with no centralized synchronization.

This series ensures that the effective replication maps used by repair (and other associated structures like the token metadata and topology) are all in sync with the one used to initiate the repair operation.

While at at, the series includes other cleanups in this area in repair and view that are not fixes as the calls happen in synchronous functions that do not yield.

Fixes #11993