### PR TITLE
Do not run aborted tasks

### DIFF
--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -221,7 +221,6 @@ public:
 
         void start() {
             _impl->_status.start_time = db_clock::now();
-            _impl->_status.state = task_manager::task_state::running;
 
             try {
                 // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
@@ -234,6 +233,8 @@ public:
                         module->unregister_task(id);
                     });
                 });
+                _impl->_as.check();
+                _impl->_status.state = task_manager::task_state::running;
                 _impl->run_to_completion();
             } catch (...) {
                 _impl->finish_failed(std::current_exception());

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -359,7 +359,6 @@ public:
         // from a parent and set. Otherwise, it must be set by caller.
         future<task_ptr> make_task(task::task_impl_ptr task_impl_ptr, task_info parent_d = task_info{}) {
             auto task = make_lw_shared<task_manager::task>(std::move(task_impl_ptr));
-            foreign_task_ptr parent;
             bool abort = false;
             if (parent_d) {
                 task->get_status().sequence_number = co_await _tm.container().invoke_on(parent_d.shard, [id = parent_d.id, task = make_foreign(task), &abort] (task_manager& tm) mutable {


### PR DESCRIPTION
task_manager::task::impl contains an abort source which can
be used to check whether it is aborted and an abort method 
which aborts the task (request_abort on abort_source) and all 
its descendants recursively.

When the start method is called after the task was aborted,
then its state is set to failed and the task does not run.

Fixes: #11995