### PR TITLE
doc: document the Alternator TTL feature as GA

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -173,7 +173,7 @@ feature's implementation is still subject to change and upgrades may not be
 possible if such a feature is used. For these reasons, experimental features
 are not recommended for mission-critical uses, and they need to be
 individually enabled with the "--experimental-features" configuration option.
-See [Enabling Experimental Features](https://docs.scylladb.com/stable/operating-scylla/admin.html#enabling-experimental-features) for details.
+See [Enabling Experimental Features](/operating-scylla/admin#enabling-experimental-features) for details.
 
 In this release, the following DynamoDB API features are considered
 experimental:

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -155,17 +155,7 @@ In Alternator, the expiration delay is configurable - it  can it can be be set
 with the `--alternator-ttl-period-in-seconds` configuration option.
 The default is 24 hours.
 
- <!--- REMOVE IN FUTURE VERSIONS - Remove the note below in version 5.2. -->
----
-
-**NOTE**
-
-In ScyllaDB versions 5.0 and earlier, DynamoDB's TTL feature 
-is experimental and needs to be enabled explicitly with the
-`--experimental-features=alternator-ttl` configuration option.
-See [Enabling Experimental Features](https://docs.scylladb.com/stable/operating-scylla/admin.html#enabling-experimental-features) for details.
-
-One thing that the experimental implementation is missing is that expiration
+One thing the implementation is missing is that expiration
 events appear in the Streams API as normal deletions - without the
 distinctive marker on deletions which are really expirations.
 See <https://github.com/scylladb/scylla/issues/5060>.

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -163,7 +163,7 @@ The default is 24 hours.
 In ScyllaDB versions 5.0 and earlier, DynamoDB's TTL feature 
 is experimental and needs to be enabled explicitly with the
 `--experimental-features=alternator-ttl` configuration option.
-See [Enabling Experimental Features](#yaml_enabling_experimental_features) for details.
+See [Enabling Experimental Features](https://docs.scylladb.com/stable/operating-scylla/admin.html#enabling-experimental-features) for details.
 
 One thing that the experimental implementation is missing is that expiration
 events appear in the Streams API as normal deletions - without the
@@ -183,7 +183,7 @@ feature's implementation is still subject to change and upgrades may not be
 possible if such a feature is used. For these reasons, experimental features
 are not recommended for mission-critical uses, and they need to be
 individually enabled with the "--experimental-features" configuration option.
-See [Enabling Experimental Features](#yaml_enabling_experimental_features) for details.
+See [Enabling Experimental Features](https://docs.scylladb.com/stable/operating-scylla/admin.html#enabling-experimental-features) for details.
 
 In this release, the following DynamoDB API features are considered
 experimental:

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -151,7 +151,7 @@ time will not disappear exactly at that time, but only after some delay.
 DynamoDB guarantees that the expiration delay will be less than 48 hours
 (though for small tables the delay is often much shorter).
 
-In Alternator, the expiration delay is configurable - it  can it can be be set
+In Alternator, the expiration delay is configurable - it can be set
 with the `--alternator-ttl-period-in-seconds` configuration option.
 The default is 24 hours.
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -183,6 +183,7 @@ feature's implementation is still subject to change and upgrades may not be
 possible if such a feature is used. For these reasons, experimental features
 are not recommended for mission-critical uses, and they need to be
 individually enabled with the "--experimental-features" configuration option.
+See [Enabling Experimental Features](#yaml_enabling_experimental_features) for details.
 
 In this release, the following DynamoDB API features are considered
 experimental:

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -144,6 +144,35 @@ This monitoring stack is different from DynamoDB's offering - but Scylla's
 is significantly more powerful and gives the user better insights on
 the internals of the database and its performance.
 
+## Time To Live (TTL)
+
+Like in DynamoDB, Alternator items which are set to expire at a certain
+time will not disappear exactly at that time, but only after some delay.
+DynamoDB guarantees that the expiration delay will be less than 48 hours
+(though for small tables the delay is often much shorter).
+
+In Alternator, the expiration delay is configurable - it  can it can be be set
+with the `--alternator-ttl-period-in-seconds` configuration option.
+The default is 24 hours.
+
+ <!--- REMOVE IN FUTURE VERSIONS - Remove the note below in version 5.2. -->
+---
+
+**NOTE**
+
+In ScyllaDB versions 5.0 and earlier, DynamoDB's TTL feature 
+is experimental and needs to be enabled explicitly with the
+`--experimental-features=alternator-ttl` configuration option.
+See [Enabling Experimental Features](#yaml_enabling_experimental_features) for details.
+
+One thing that the experimental implementation is missing is that expiration
+events appear in the Streams API as normal deletions - without the
+distinctive marker on deletions which are really expirations.
+See <https://github.com/scylladb/scylla/issues/5060>.
+
+---
+
+
 ## Experimental API features
 
 Some DynamoDB API features are supported by Alternator, but considered
@@ -157,24 +186,6 @@ individually enabled with the "--experimental-features" configuration option.
 
 In this release, the following DynamoDB API features are considered
 experimental:
-
-* DynamoDB's TTL (item expiration) feature is supported, but in this release
-  still considered experimental and needs to be enabled explicitly with the
-  `--experimental-features=alternator-ttl` configuration option.
-  The experimental implementation is mostly complete, but not throughly
-  tested or optimized.
-
-  Like in DynamoDB, Alternator items which are set to expire at a certain
-  time will not disappear exactly at that time, but only after some delay.
-  DynamoDB guarantees that the expiration delay will be less than 48 hours
-  (though for small tables the delay is often much shorter). In Alternator,
-  the expiration delay is configurable - it defaults to 24 hours but can
-  be set with the `--alternator-ttl-period-in-seconds` configuration option.
-
-  One thing that this implementation is still missing is that expiration
-  events appear in the Streams API as normal deletions - without the
-  distinctive marker on deletions which are really expirations.
-  <https://github.com/scylladb/scylla/issues/5060>
 
 * The DynamoDB Streams API for capturing change is supported, but still
   considered experimental so needs to be enabled explicitly with the


### PR DESCRIPTION
Currently, TTL is listed as one of the experimental features: https://docs.scylladb.com/stable/alternator/compatibility.html#experimental-api-features

This PR moves the feature description from the Experimental Features section to a separate section.
I've also added some links and improved the formatting.

@tzach I've relied on your release notes for RC1.

Refs: https://github.com/scylladb/scylladb/issues/5060