### PR TITLE
build: switched to packaged libdeflate rather than a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,9 +6,6 @@
 	path = swagger-ui
 	url = ../scylla-swagger-ui
 	ignore = dirty
-[submodule "libdeflate"]
-	path = libdeflate
-	url = ../libdeflate
 [submodule "abseil"]
 	path = abseil
 	url = ../abseil-cpp

--- a/configure.py
+++ b/configure.py
@@ -1604,8 +1604,6 @@ if args.target != '':
     seastar_cflags += ' -march=' + args.target
 seastar_ldflags = args.user_ldflags
 
-libdeflate_cflags = seastar_cflags
-
 # cmake likes to separate things with semicolons
 def semicolon_separated(*flags):
     # original flags may be space separated, so convert to string still
@@ -1739,6 +1737,7 @@ libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-l
                  maybe_static(True, '-lzstd'),
                  maybe_static(args.staticboost, '-lboost_date_time -lboost_regex -licuuc -licui18n'),
                  '-lxxhash',
+                 '-ldeflate',
                 ])
 if has_wasmtime:
     print("Found wasmtime dependency, linking with libwasmtime")
@@ -1949,8 +1948,6 @@ with open(buildfile, 'w') as f:
                 f.write('build $builddir/{}/{}: ar.{} {}\n'.format(mode, binary, mode, str.join(' ', objs)))
             else:
                 objs.extend(['$builddir/' + mode + '/' + artifact for artifact in [
-                    'libdeflate/libdeflate.a',
-                ] + [
                     'abseil/' + x for x in abseil_libs
                 ]])
                 if binary in tests:
@@ -2142,10 +2139,6 @@ with open(buildfile, 'w') as f:
         f.write(f'  mode = {mode}\n')
         f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-unified-package-{scylla_version}-{scylla_release}.tar.gz: copy $builddir/{mode}/dist/tar/{scylla_product}-unified-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
         f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-unified-{arch}-package-{scylla_version}-{scylla_release}.tar.gz: copy $builddir/{mode}/dist/tar/{scylla_product}-unified-{scylla_version}-{scylla_release}.{arch}.tar.gz\n')
-        f.write('rule libdeflate.{mode}\n'.format(**locals()))
-        f.write('  command = make -C libdeflate BUILD_DIR=../$builddir/{mode}/libdeflate/ CFLAGS="{libdeflate_cflags}" CC={args.cc} ../$builddir/{mode}/libdeflate//libdeflate.a\n'.format(**locals()))
-        f.write('build $builddir/{mode}/libdeflate/libdeflate.a: libdeflate.{mode}\n'.format(**locals()))
-        f.write('  pool = submodule_pool\n')
 
         for lib in abseil_libs:
             f.write('build $builddir/{mode}/abseil/{lib}: ninja $builddir/{mode}/abseil/build.ninja\n'.format(**locals()))

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -45,6 +45,7 @@ debian_base_packages=(
     pigz
     libunistring-dev
     libzstd-dev
+    libdeflate-dev
 )
 
 fedora_packages=(
@@ -58,6 +59,7 @@ fedora_packages=(
     jsoncpp-devel
     rapidjson-devel
     snappy-devel
+    libdeflate-devel
     systemd-devel
     git
     python

--- a/sstables/checksum_utils.hh
+++ b/sstables/checksum_utils.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <zlib.h>
-#include "libdeflate/libdeflate.h"
+#include <libdeflate.h>
 #include "utils/gz/crc_combine.hh"
 
 template<typename Checksum>

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20221115
+docker.io/scylladb/scylla-toolchain:fedora-37-20221116


### PR DESCRIPTION
Now that our toolchain is based on Fedora 37, we can rely on its libdeflate rather than have to carry our own in a submodule.

Frozen toolchain is regenerated.