### PR TITLE
abstract_replication_strategy: recognized_options: return unordered_set

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -101,7 +101,7 @@ public:
 
     virtual inet_address_vector_replica_set get_natural_endpoints(const token& search_token, const effective_replication_map& erm) const;
     virtual void validate_options() const = 0;
-    virtual std::optional<std::set<sstring>> recognized_options(const topology&) const = 0;
+    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const = 0;
     virtual size_t get_replication_factor(const token_metadata& tm) const = 0;
     // Decide if the replication strategy allow removing the node being
     // replaced from the natural endpoints when a node is being replaced in the

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -24,7 +24,7 @@ public:
 
     virtual void validate_options() const override { /* noop */ }
 
-    std::optional<std::set<sstring>> recognized_options(const topology&) const override {
+    std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override {
         // We explicitely allow all options
         return std::nullopt;
     }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -24,7 +24,7 @@ future<endpoint_set> local_strategy::calculate_natural_endpoints(const token& t,
 void local_strategy::validate_options() const {
 }
 
-std::optional<std::set<sstring>> local_strategy::recognized_options(const topology&) const {
+std::optional<std::unordered_set<sstring>> local_strategy::recognized_options(const topology&) const {
     // LocalStrategy doesn't expect any options.
     return {};
 }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -33,7 +33,7 @@ public:
 
     virtual void validate_options() const override;
 
-    virtual std::optional<std::set<sstring>> recognized_options(const topology&) const override;
+    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
 
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return false;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -266,8 +266,8 @@ void network_topology_strategy::validate_options() const {
     }
 }
 
-std::optional<std::set<sstring>> network_topology_strategy::recognized_options(const topology& topology) const {
-    std::set<sstring> datacenters;
+std::optional<std::unordered_set<sstring>> network_topology_strategy::recognized_options(const topology& topology) const {
+    std::unordered_set<sstring> datacenters;
     for (const auto& [dc_name, endpoints] : topology.get_datacenter_endpoints()) {
         datacenters.insert(dc_name);
     }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -49,7 +49,7 @@ protected:
 
     virtual void validate_options() const override;
 
-    virtual std::optional<std::set<sstring>> recognized_options(const topology&) const override;
+    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
 
 private:
     // map: data centers -> replication factor

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -75,7 +75,7 @@ void simple_strategy::validate_options() const {
     validate_replication_factor(it->second);
 }
 
-std::optional<std::set<sstring>>simple_strategy::recognized_options(const topology&) const {
+std::optional<std::unordered_set<sstring>>simple_strategy::recognized_options(const topology&) const {
     return {{ "replication_factor" }};
 }
 

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -21,7 +21,7 @@ public:
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options() const override;
-    virtual std::optional<std::set<sstring>> recognized_options(const topology&) const override;
+    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return true;
     }


### PR DESCRIPTION
An unordered_set is more efficient and there is no need to return an ordered set for this purpose.

This change facilitates a follow-up change of adding topology::get_datacenters(), returning an unordered_set of datacenter names.

Refs #11987

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>