### PR TITLE
compaction: request abort only once in compaction_data::stop

### DIFF
--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -80,8 +80,10 @@ struct compaction_data {
     }
 
     void stop(sstring reason) {
-        stop_requested = std::move(reason);
-        abort.request_abort();
+        if (!abort.abort_requested()) {
+            stop_requested = std::move(reason);
+            abort.request_abort();
+        }
     }
 };
 


### PR DESCRIPTION
compaction_manager::task (and thus compaction_data) can be stopped 
because of many different reasons. Thus, abort can be requested more 
than once on compaction_data abort source causing a crash.

To prevent this before each request_abort() we check whether an abort
was requested before.

Fixes: #12002