### PR TITLE
Simplify sstable_directory configuration

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -352,7 +352,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
                   global_table->get_sstables_manager().get_highest_supported_format(),
                   sstables::sstable::format_types::big,
                   &error_handler_gen_for_upload_dir);
-        }, sstables::sstable_directory::default_sstable_filter()).get();
+        }, [] (const sstables::shared_sstable&) { return true; }).get();
 
         const bool use_view_update_path = db::view::check_needs_view_update_path(sys_dist_ks.local(), *global_table, streaming::stream_reason::repair).get0();
 

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -20,6 +20,7 @@
 #include "seastarx.hh"
 #include "compaction/compaction_descriptor.hh"
 #include "db/system_keyspace.hh"
+#include "sstables/sstable_directory.hh"
 
 namespace replica {
 class database;
@@ -40,7 +41,6 @@ namespace sstables {
 
 class entry_descriptor;
 class foreign_sstable_open_info;
-class sstable_directory;
 
 }
 
@@ -68,7 +68,7 @@ class distributed_loader {
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
             sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter);
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator);
-    static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, bool sort_sstables_according_to_owner = true);
+    static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags);
     static future<> lock_table(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring cf_name);
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -33,19 +33,11 @@ sstable_directory::sstable_directory(fs::path sstable_dir,
         ::io_priority_class io_prio,
         unsigned load_parallelism,
         semaphore& load_semaphore,
-        need_mutate_level need_mutate_level,
-        lack_of_toc_fatal throw_on_missing_toc,
-        enable_dangerous_direct_import_of_cassandra_counters eddiocc,
-        allow_loading_materialized_view allow_mv,
         sstable_object_from_existing_fn sstable_from_existing)
     : _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
     , _load_parallelism(load_parallelism)
     , _load_semaphore(load_semaphore)
-    , _need_mutate_level(need_mutate_level)
-    , _throw_on_missing_toc(throw_on_missing_toc)
-    , _enable_dangerous_direct_import_of_cassandra_counters(eddiocc)
-    , _allow_loading_materialized_view(allow_mv)
     , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))
     , _unshared_remote_sstables(smp::count)
 {}
@@ -79,18 +71,18 @@ sstable_directory::handle_component(scan_state& state, sstables::entry_descripto
     }
 }
 
-void sstable_directory::validate(sstables::shared_sstable sst) const {
+void sstable_directory::validate(sstables::shared_sstable sst, process_flags flags) const {
     schema_ptr s = sst->get_schema();
     if (s->is_counter() && !sst->has_scylla_component()) {
         sstring error = "Direct loading non-Scylla SSTables containing counters is not supported.";
-        if (_enable_dangerous_direct_import_of_cassandra_counters) {
+        if (flags.enable_dangerous_direct_import_of_cassandra_counters) {
             dirlog.info("{} But trying to continue on user's request.", error);
         } else {
             dirlog.error("{} Use sstableloader instead.", error);
             throw std::runtime_error(fmt::format("{} Use sstableloader instead.", error));
         }
     }
-    if (s->is_view() && !_allow_loading_materialized_view) {
+    if (s->is_view() && !flags.allow_loading_materialized_view) {
         throw std::runtime_error("Loading Materialized View SSTables is not supported. Re-create the view instead.");
     }
     if (!sst->is_uploaded()) {
@@ -105,9 +97,9 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc, process_f
     }
 
     auto sst = _sstable_object_from_existing_sstable(_sstable_dir, desc.generation, desc.version, desc.format);
-    return sst->load(_io_priority).then([this, sst] {
-        validate(sst);
-        if (_need_mutate_level) {
+    return sst->load(_io_priority).then([this, sst, flags] {
+        validate(sst, flags);
+        if (flags.need_mutate_level) {
             dirlog.trace("Mutating {} to level 0\n", sst->get_filename());
             return sst->mutate_sstable_level(0);
         } else {
@@ -225,7 +217,7 @@ sstable_directory::process_sstable_dir(process_flags flags) {
     // we refuse to proceed. If this coming from, say, an import, then we just delete,
     // log and proceed.
     for (auto& path : state.generations_found | boost::adaptors::map_values) {
-        if (_throw_on_missing_toc) {
+        if (flags.throw_on_missing_toc) {
             throw sstables::malformed_sstable_exception(format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _sstable_dir.native(), path.native()));
         } else {
             dirlog.info("Found incomplete SSTable {} at directory {}. Removing", path.native(), _sstable_dir.native());

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -48,6 +48,12 @@ public:
     // favor chunked vectors when dealing with file lists: they can grow to hundreds of thousands
     // of elements.
     using sstable_info_vector = utils::chunked_vector<sstables::foreign_sstable_open_info>;
+
+    // Flags below control how to behave when scanning new SSTables.
+    struct process_flags {
+        bool sort_sstables_according_to_owner = true;
+    };
+
 private:
     using scan_multimap = std::unordered_multimap<generation_type, std::filesystem::path>;
     using scan_descriptors = utils::chunked_vector<sstables::entry_descriptor>;
@@ -106,7 +112,7 @@ private:
     // the amount of data resharded per shard, so a coordinator may redistribute this.
     sstable_info_vector _shared_sstable_info;
 
-    future<> process_descriptor(sstables::entry_descriptor desc, bool sort_sstables_according_to_owner = true);
+    future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst) const;
     void handle_component(scan_state& state, sstables::entry_descriptor desc, std::filesystem::path filename);
     future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
@@ -156,7 +162,7 @@ public:
     // This function doesn't change on-storage state. If files are to be removed, a separate call
     // (commit_file_removals()) has to be issued. This is to make sure that all instances of this
     // class in a sharded service have the opportunity to validate its files.
-    future<> process_sstable_dir(bool sort_sstables_according_to_owner = true);
+    future<> process_sstable_dir(process_flags flags);
 
     // Sort the sstable according to owner
     future<> sort_sstable(sstables::shared_sstable sst);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -177,19 +177,13 @@ public:
     future<> reshard(sstable_info_vector info, compaction_manager& cm, replica::table& table,
                      unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator);
 
-    // Default filter will include all sstables
     using sstable_filter_func_t = std::function<bool (const sstables::shared_sstable&)>;
-    static sstable_filter_func_t default_sstable_filter() {
-        return [] (const sstables::shared_sstable&) {
-            return true;
-        };
-    }
 
     // reshapes a collection of SSTables, and returns the total amount of bytes reshaped.
     future<uint64_t> reshape(compaction_manager& cm, replica::table& table,
                      sstables::compaction_sstable_creator_fn creator,
                      sstables::reshape_mode mode,
-                     sstable_filter_func_t sstable_filter = default_sstable_filter());
+                     sstable_filter_func_t sstable_filter);
 
     // Store a phased operation. Usually used to keep an object alive while the directory is being
     // processed. One example is preventing table drops concurrent to the processing of this

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -132,10 +132,6 @@ highest_generation_seen(sharded<sstables::sstable_directory>& dir) {
 static void with_sstable_directory(
     std::filesystem::path path,
     unsigned load_parallelism,
-    sstable_directory::need_mutate_level need_mutate,
-    sstable_directory::lack_of_toc_fatal fatal_nontoc,
-    sstable_directory::enable_dangerous_direct_import_of_cassandra_counters eddiocc,
-    sstable_directory::allow_loading_materialized_view almv,
     sstable_directory::sstable_object_from_existing_fn sstable_from_existing,
     noncopyable_function<void (sharded<sstable_directory>&)> func) {
 
@@ -157,7 +153,7 @@ static void with_sstable_directory(
         return sstable_from_existing(std::move(dir), gen, v, f);
     };
 
-    sstdir.start(std::move(path), default_priority_class(), load_parallelism, std::ref(sstdir_sem), need_mutate, fatal_nontoc, eddiocc, almv, std::move(wrapped_sfe)).get();
+    sstdir.start(std::move(path), default_priority_class(), load_parallelism, std::ref(sstdir_sem), std::move(wrapped_sfe)).get();
 
     func(sstdir);
 }
@@ -172,10 +168,6 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
     f.close().get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
     distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
@@ -197,10 +189,6 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) {
     remove_file(sst->filename(sstables::component_type::Statistics)).get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
     auto expect_malformed_sstable = distributed_loader_for_tests::process_sstable_dir(sstdir, {});
@@ -222,10 +210,6 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_scan_invalid_file) {
         f.close().get();
 
         with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
                 auto expect_malformed_sstable = distributed_loader_for_tests::process_sstable_dir(sstdir, {});
@@ -242,13 +226,9 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_temporary_toc) {
     rename_file(sst->filename(sstables::component_type::TOC), sst->filename(sstables::component_type::TemporaryTOC)).get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::yes,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
-    auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, {});
+    auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true });
     BOOST_REQUIRE_NO_THROW(expect_ok.get());
    });
   });
@@ -262,13 +242,9 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_extra_temporary_toc) {
         link_file(sst->filename(sstables::component_type::TOC), sst->filename(sstables::component_type::TemporaryTOC)).get();
 
         with_sstable_directory(dir.path(), 1,
-                sstable_directory::need_mutate_level::no,
-                sstable_directory::lack_of_toc_fatal::yes,
-                sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-                sstable_directory::allow_loading_materialized_view::no,
                 sstable_from_existing_file(env),
                 [] (sharded<sstables::sstable_directory>& sstdir) {
-            auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, {});
+            auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true });
             BOOST_REQUIRE_NO_THROW(expect_ok.get());
         });
     });
@@ -283,21 +259,13 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_missing_toc) {
     remove_file(sst->filename(sstables::component_type::TOC)).get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::yes,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir_fatal) {
-    auto expect_malformed_sstable  = distributed_loader_for_tests::process_sstable_dir(sstdir_fatal, {});
+    auto expect_malformed_sstable  = distributed_loader_for_tests::process_sstable_dir(sstdir_fatal, { .throw_on_missing_toc = true });
     BOOST_REQUIRE_THROW(expect_malformed_sstable.get(), sstables::malformed_sstable_exception);
    });
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir_ok) {
     auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir_ok, {});
@@ -320,10 +288,6 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
     auto tempstat = fs::canonical(fs::path(tempstr));
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [&dir, &tempstat] (sharded<sstables::sstable_directory>& sstdir_ok) {
     auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir_ok, {});
@@ -337,10 +301,6 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
     remove_file(sst->filename(sstables::component_type::Statistics)).get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir_fatal) {
     auto expect_malformed_sstable  = distributed_loader_for_tests::process_sstable_dir(sstdir_fatal, {});
@@ -358,13 +318,9 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
     rename_file(sst->filename(sstables::component_type::TOC), sst->filename(sstables::component_type::TemporaryTOC)).get();
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::yes,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
-    distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+    distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
     int64_t max_generation_seen = highest_generation_seen(sstdir).get0();
     BOOST_REQUIRE_EQUAL(max_generation_seen, 3333);
    });
@@ -404,13 +360,9 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_matched_gene
     }
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::yes,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
-    distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+    distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
     verify_that_all_sstables_are_local(sstdir, smp::count).get();
    });
   }).get();
@@ -432,13 +384,9 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_unmatched_ge
     }
 
    with_sstable_directory(dir.path(), 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::yes,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(env),
             [] (sharded<sstables::sstable_directory>& sstdir) {
-    distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+    distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
     verify_that_all_sstables_are_local(sstdir, smp::count).get();
    });
   }).get();
@@ -463,10 +411,6 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_lock_works) {
         }).get();
 
         with_sstable_directory(path, 1,
-            sstable_directory::need_mutate_level::no,
-            sstable_directory::lack_of_toc_fatal::no,
-            sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-            sstable_directory::allow_loading_materialized_view::no,
             sstable_from_existing_file(e),
         [&] (sharded<sstable_directory>& sstdir) {
             distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
@@ -551,16 +495,12 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
         }
 
       with_sstable_directory(upload_path, 1,
-                sstable_directory::need_mutate_level::no,
-                sstable_directory::lack_of_toc_fatal::yes,
-                sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-                sstable_directory::allow_loading_materialized_view::no,
                 [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                     auto& cf = e.local_db().find_column_family("ks", "cf");
                     return cf.make_sstable(dir.native(), gen, v, f);
                 },
                 [&e, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
-        distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+        distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         int64_t max_generation_seen = highest_generation_seen(sstdir).get0();
@@ -600,16 +540,12 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
         }
 
       with_sstable_directory(upload_path, 1,
-                sstable_directory::need_mutate_level::no,
-                sstable_directory::lack_of_toc_fatal::yes,
-                sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-                sstable_directory::allow_loading_materialized_view::no,
                 [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                     auto& cf = e.local_db().find_column_family("ks", "cf");
                     return cf.make_sstable(dir.native(), gen, v, f);
                 },
                 [&e, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
-        distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+        distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         int64_t max_generation_seen = highest_generation_seen(sstdir).get0();
@@ -649,16 +585,12 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
         }
 
       with_sstable_directory(upload_path, 1,
-                sstable_directory::need_mutate_level::no,
-                sstable_directory::lack_of_toc_fatal::yes,
-                sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
-                sstable_directory::allow_loading_materialized_view::no,
                 [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                     auto& cf = e.local_db().find_column_family("ks", "cf");
                     return cf.make_sstable(dir.native(), gen, v, f);
                 },
                 [&, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
-        distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
+        distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         int64_t max_generation_seen = highest_generation_seen(sstdir).get0();


### PR DESCRIPTION
When started the sstable_directory is constructed with a bunch of booleans that control the way its process_sstable_dir method works. It's shorter and simpler to pass these booleans into method directly, all the more so there's another flag that's already passed like this.