### PR TITLE
utils/gs/barrett.hh: aarch64: s/brarett/barrett/

### DIFF
--- a/utils/gz/barrett.hh
+++ b/utils/gz/barrett.hh
@@ -137,7 +137,7 @@ uint32_t crc32_fold_barrett_u64_in_u64x2(uint64x2_t x0) {
 }
 
 inline
-uint32_t crc32_fold_brarett_u64_native(uint64_t p) {
+uint32_t crc32_fold_barrett_u64_native(uint64_t p) {
     return crc32_fold_barrett_u64_in_u64x2(
             vcombine_u64((uint64x1_t)p, (uint64x1_t)0UL));
 }


### PR DESCRIPTION
Fix a typo introduced by the the recent patch fixing the spelling of Barrett. The patch introduced a typo in the aarch64 version of the code, which wasn't found by promotion, as that only builds on X86_64.