### PR TITLE
test/pylib: scylla_cluster: use server ID to name workdir and log file, not IP address

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -75,7 +75,8 @@ class ManagerClient():
         if dirty:
             self.driver_close()  # Close driver connection to old cluster
         try:
-            await self.client.get(f"/cluster/before-test/{test_case_name}")
+            cluster_str = await self.client.get_text(f"/cluster/before-test/{test_case_name}")
+            logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
         except aiohttp.ClientError as exc:
             raise RuntimeError(f"Failed before test check {exc}") from exc
         if self.cql is None:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -188,16 +188,13 @@ class ScyllaServer:
         self.ip_addr = await self.host_registry.lease_host()
         if not self.seeds:
             self.seeds = [self.ip_addr]
-        # Use the last part in host IP 127.151.3.27 -> 27
-        # There can be no duplicates within the same test run
-        # thanks to how host registry registers subnets, and
-        # different runs use different vardirs.
-        shortname = pathlib.Path(f"scylla-{self.ip_addr.rsplit('.', maxsplit=1)[-1]}")
+
+        shortname = f"scylla-{self.server_id}"
         self.workdir = self.vardir / shortname
 
         logging.info("installing Scylla server in %s...", self.workdir)
 
-        self.log_filename = self.vardir / shortname.with_suffix(".log")
+        self.log_filename = (self.vardir / shortname).with_suffix(".log")
 
         self.config_filename = self.workdir / "conf/scylla.yaml"
 


### PR DESCRIPTION
Since recently the framework uses a separate set of unique IDs to
identify servers, but the log file and workdir is still named using the
last part of the IP address.

This is confusing: the test logs sometimes don't provide the IP addr
(only the ID), and even if they do, the reader of the test log may not
know that they need to look at the last part of the IP to find the
node's log/workdir.

Also using ID will be necessary if we want to reuse IP addresses (e.g.
during node replace, or simply not to run out of IP addresses during
testing).

So use the ID instead to name the workdir and log file.

Also, when starting a test case, print the used cluster. This will make
it easier to map server IDs to their IP addresses when browsing through
the test logs.
