### PR TITLE
Topology: add get_datacenters

### DIFF
--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -61,8 +61,8 @@ static std::map<sstring, sstring> prepare_options(
             }
         }
 
-        for (const auto& dc : tm.get_topology().get_datacenter_endpoints()) {
-            options.emplace(dc.first, rf);
+        for (const auto& dc : tm.get_topology().get_datacenters()) {
+            options.emplace(dc, rf);
         }
     }
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -267,12 +267,8 @@ void network_topology_strategy::validate_options() const {
 }
 
 std::optional<std::unordered_set<sstring>> network_topology_strategy::recognized_options(const topology& topology) const {
-    std::unordered_set<sstring> datacenters;
-    for (const auto& [dc_name, endpoints] : topology.get_datacenter_endpoints()) {
-        datacenters.insert(dc_name);
-    }
     // We only allow datacenter names as options
-    return datacenters;
+    return topology.get_datacenters();
 }
 
 using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, const replication_strategy_config_options&>;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -69,6 +69,10 @@ public:
         return _dc_racks;
     }
 
+    const std::unordered_set<sstring>& get_datacenters() const noexcept {
+        return _datacenters;
+    }
+
     const endpoint_dc_rack& get_location(const inet_address& ep) const;
     sstring get_rack() const;
     sstring get_rack(inet_address ep) const;
@@ -119,6 +123,11 @@ private:
     std::unordered_map<inet_address, endpoint_dc_rack> _pending_locations;
 
     bool _sort_by_proximity = true;
+
+    // pre-calculated
+    std::unordered_set<sstring> _datacenters;
+
+    void calculate_datacenters();
 };
 
 } // namespace locator


### PR DESCRIPTION
Returns an unordered set of datacenter names
to be used by network_topology_replication_strategy
and for ks_prop_defs.

The set is kept in sync with _dc_endpoints.
