### PR TITLE
reader_concurrency_semaphore: fix waiter/inactive race

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -757,8 +757,6 @@ future<> reader_concurrency_semaphore::evict_inactive_reads_for_table(table_id i
         ++it;
         if (ir.reader.schema()->id() == id) {
             do_detach_inactive_reader(ir, evict_reason::manual);
-            ir.ttl_timer.cancel();
-            ir.unlink();
             evicted_readers.push_back(ir);
         }
     }
@@ -791,6 +789,8 @@ future<> reader_concurrency_semaphore::stop() noexcept {
 }
 
 void reader_concurrency_semaphore::do_detach_inactive_reader(inactive_read& ir, evict_reason reason) noexcept {
+    ir.unlink();
+    ir.ttl_timer.cancel();
     ir.detach();
     ir.reader.permit()._impl->on_evicted();
     try {

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -205,12 +205,12 @@ private:
     future<> do_wait_admission(reader_permit permit, read_func func = {});
 
     // Check whether permit can be admitted or not.
-    // Caller can specify whether wait list should be empty or not for admission
-    // to be possible. can_admit::maybe means admission might be possible if some
-    // of the inactive readers are evicted.
+    // The wait list is not taken into consideration, this is the caller's
+    // responsibility.
+    // A return value of can_admit::maybe means admission might be possible if
+    // some of the inactive readers are evicted.
     enum class can_admit { no, maybe, yes };
-    using require_empty_waitlist = bool_class<class require_empty_waitlist_tag>;
-    can_admit can_admit_read(const reader_permit& permit, require_empty_waitlist wait_list_empty) const noexcept;
+    can_admit can_admit_read(const reader_permit& permit) const noexcept;
 
     void maybe_admit_waiters() noexcept;
 


### PR DESCRIPTION
We recently (in 7fbad8de875816f0fb71ffa1965ba65543354629) made sure all admission paths can trigger the eviction of inactive reads. As reader eviction happens in the background, a mechanism was added to make sure only a single eviction fiber was running at any given time. This mechanism however had a preemption point between stopping the fiber and releasing the evict lock. This gave an opportunity for either new waiters or inactive readers to be added, without the fiber acting on it. Since it still held onto the lock, it also prevented from other eviction fibers to start. This could create a situation where the semaphore could admit new reads by evicting inactive ones, but it still has waiters. Since an empty waitlist is also an admission criteria, once one waiter is wrongly added, many more can accumulate.
This series fixes this by ensuring the lock is released in the instant the fiber decides there is no more work to do.
It also fixes the assert failure on recursive eviction and adds a detection to the inactive/waiter contradiction.

Fixes: #11923
Refs: #11770
