### PR TITLE
pytest: catch rare exception for random tables test

### DIFF
--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 import pytest
-from cassandra.protocol import InvalidRequest                            # type: ignore
+from cassandra.protocol import InvalidRequest, ReadFailure                         # type: ignore
 
 
 # Simple test of schema helper
@@ -24,7 +24,9 @@ async def test_new_table(manager, random_tables):
     assert len(res) == 1
     assert list(res[0])[:2] == vals
     await random_tables.drop_table(table)
-    with pytest.raises(InvalidRequest, match='unconfigured table'):
+    # NOTE: On rare occasions the exception is ReadFailure
+    with pytest.raises((InvalidRequest, ReadFailure),
+                       match='(unconfigured table|failed to execute read)'):
         await cql.run_async(f"SELECT * FROM {table}")
     await random_tables.verify_schema()
 


### PR DESCRIPTION
On rare occassions a `SELECT` on a `DROP`pped table throws `cassandra.ReadFailure` instead of `cassandra.InvalidRequest`. This could not be reproduced locally.

Catch both exceptions as the table is not present anyway and it's correctly marked as a failure.

Fixes https://github.com/scylladb/scylladb/issues/11806