### PR TITLE
scylla-sstable: data-dump improvements

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2562,7 +2562,7 @@ $PARTITION := {
     },
     "tombstone: $TOMBSTONE, // optional
     "static_row": $COLUMNS, // optional
-    "clustering_fragments": [
+    "clustering_elements": [
         $CLUSTERING_ROW | $RANGE_TOMBSTONE_CHANGE,
         ...
     ]

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -452,7 +452,7 @@ class dumping_consumer : public sstable_consumer {
                 }
                 _writer.EndArray();
             } else {
-                _writer.String("<unknown>");
+                _writer.Null();
             }
 
             _writer.EndObject();
@@ -465,7 +465,7 @@ class dumping_consumer : public sstable_consumer {
                     write(mv, cdef.type);
                 });
             } else {
-                _writer.String("<unknown>");
+                _writer.Null();
             }
         }
         void write(const row& r, column_kind kind) {


### PR DESCRIPTION
This series contains a mixed bag of improvements to  `scylla sstable dump-data`. These improvements are mostly aimed at making the json output clearer, getting rid of any ambiguities.