### PR TITLE
test.py: support node replace operation

### DIFF
--- a/test.py
+++ b/test.py
@@ -356,8 +356,8 @@ class PythonTestSuite(TestSuite):
             server = ScyllaServer(
                 exe=self.scylla_exe,
                 vardir=os.path.join(self.options.tmpdir, self.mode),
-                host_registry=self.hosts,
                 cluster_name=create_cfg.cluster_name,
+                ip_addr=create_cfg.ip_addr,
                 seeds=create_cfg.seeds,
                 cmdline_options=cmdline_options,
                 config_options=config_options)
@@ -365,7 +365,7 @@ class PythonTestSuite(TestSuite):
             return server
 
         async def create_cluster() -> ScyllaCluster:
-            cluster = ScyllaCluster(cluster_size, create_server)
+            cluster = ScyllaCluster(self.hosts, cluster_size, create_server)
 
             async def stop() -> None:
                 await cluster.stop()

--- a/test.py
+++ b/test.py
@@ -336,7 +336,7 @@ class PythonTestSuite(TestSuite):
         self.clusters = Pool(pool_size, self.create_cluster)
 
     def get_cluster_factory(self, cluster_size: int) -> Callable[[], Awaitable]:
-        def create_server(cluster_name: str, seeds: List[str], config_from_test: dict[str, str]):
+        def create_server(create_cfg: ScyllaCluster.CreateServerParams):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])
             if type(cmdline_options) == str:
                 cmdline_options = [cmdline_options]
@@ -351,14 +351,14 @@ class PythonTestSuite(TestSuite):
                      "authorizer": "CassandraAuthorizer"}
             config_options = default_config_options | \
                              self.cfg.get("extra_scylla_config_options", {}) | \
-                             config_from_test
+                             create_cfg.config_from_test
 
             server = ScyllaServer(
                 exe=self.scylla_exe,
                 vardir=os.path.join(self.options.tmpdir, self.mode),
                 host_registry=self.hosts,
-                cluster_name=cluster_name,
-                seeds=seeds,
+                cluster_name=create_cfg.cluster_name,
+                seeds=create_cfg.seeds,
                 cmdline_options=cmdline_options,
                 config_options=config_options)
 

--- a/test/pylib/artifact_registry.py
+++ b/test/pylib/artifact_registry.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 from typing import Protocol
-from typing import Callable, Awaitable, List, Dict, Optional
+from typing import Callable, Coroutine, List, Dict, Optional
 import asyncio
 import logging
 
-Artifact = Awaitable
+Artifact = Coroutine
 
 
 class Suite(Protocol):
@@ -33,7 +33,7 @@ class ArtifactRegistry:
         logging.info("Cleaning up before exit...")
         for artifacts in self.suite_artifacts.values():
             for artifact in artifacts:
-                artifact.close()  # type: ignore
+                artifact.close()
             await asyncio.gather(*artifacts, return_exceptions=True)
         self.suite_artifacts = {}
         for artifacts in self.exit_artifacts.values():

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -14,6 +14,7 @@ import logging
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient
 from test.pylib.util import wait_for
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo
+from test.pylib.scylla_cluster import ReplaceConfig
 from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 import aiohttp
@@ -146,10 +147,11 @@ class ManagerClient():
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
-    async def server_add(self) -> ServerInfo:
+    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None) -> ServerInfo:
         """Add a new server"""
         try:
-            server_info = await self.client.put_json("/cluster/addserver", {}, response_type="json")
+            data = {'replace_cfg': replace_cfg._asdict()} if replace_cfg else {}
+            server_info = await self.client.put_json("/cluster/addserver", data, response_type="json")
         except Exception as exc:
             raise Exception("Failed to add server") from exc
         try:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -149,7 +149,7 @@ class ManagerClient():
     async def server_add(self) -> ServerInfo:
         """Add a new server"""
         try:
-            server_info = await self.client.get_json("/cluster/addserver")
+            server_info = await self.client.put_json("/cluster/addserver", {}, response_type="json")
         except Exception as exc:
             raise Exception("Failed to add server") from exc
         try:

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -95,9 +95,11 @@ class RESTClient(metaclass=ABCMeta):
                           json = json)
 
     async def put_json(self, resource_uri: str, data: Mapping, host: Optional[str] = None,
-                       port: Optional[int] = None, params: Optional[dict[str, str]] = None) -> None:
-        await self._fetch("PUT", resource_uri, host = host, port = port, params = params,
-                          json = data)
+                       port: Optional[int] = None, params: Optional[dict[str, str]] = None,
+                       response_type: Optional[str] = None) -> Any:
+        ret = await self._fetch("PUT", resource_uri, response_type = response_type, host = host,
+                                port = port, params = params, json = data)
+        return ret
 
     async def delete(self, resource_uri: str, host: Optional[str] = None,
                      port: Optional[int] = None, params: Optional[dict[str, str]] = None,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -459,7 +459,7 @@ class ScyllaCluster:
         data: dict = {}
 
     def __init__(self, replicas: int,
-                 create_server: Callable[[str, List[str]], ScyllaServer]) -> None:
+                 create_server: Callable[[str, List[str], dict[str, str]], ScyllaServer]) -> None:
         self.name = str(uuid.uuid1())
         self.replicas = replicas
         self.create_server = create_server
@@ -528,7 +528,8 @@ class ScyllaCluster:
 
     async def add_server(self) -> ServerInfo:
         """Add a new server to the cluster"""
-        server = self.create_server(self.name, self._seeds())
+        extra_config: dict[str, str] = {}
+        server = self.create_server(self.name, self._seeds(), extra_config)
         self.is_dirty = True
         try:
             logging.info("Cluster %s adding server...", self)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -22,7 +22,7 @@ import uuid
 from io import BufferedWriter
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
-from test.pylib.manager_client import ServerNum, IPAddress, HostID, ServerInfo
+from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo
 import aiohttp
 import aiohttp.web
 import yaml

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -769,7 +769,7 @@ class ScyllaClusterManager:
                            self._cluster_server_stop_gracefully)
         app.router.add_get('/cluster/server/{server_id}/start', self._cluster_server_start)
         app.router.add_get('/cluster/server/{server_id}/restart', self._cluster_server_restart)
-        app.router.add_get('/cluster/addserver', self._cluster_server_add)
+        app.router.add_put('/cluster/addserver', self._cluster_server_add)
         app.router.add_put('/cluster/remove-node/{initiator}', self._cluster_remove_node)
         app.router.add_get('/cluster/decommission-node/{server_id}',
                            self._cluster_decommission_node)
@@ -862,7 +862,7 @@ class ScyllaClusterManager:
         ret = await self.cluster.server_restart(server_id)
         return aiohttp.web.Response(status=200 if ret[0] else 500, text=ret[1])
 
-    async def _cluster_server_add(self, _request) -> aiohttp.web.Response:
+    async def _cluster_server_add(self, request) -> aiohttp.web.Response:
         """Add a new server"""
         assert self.cluster
         s_info = await self.cluster.add_server()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -459,8 +459,13 @@ class ScyllaCluster:
         msg: str = ""
         data: dict = {}
 
+    class CreateServerParams(NamedTuple):
+        cluster_name: str
+        seeds: List[str]
+        config_from_test: dict[str, str]
+
     def __init__(self, replicas: int,
-                 create_server: Callable[[str, List[str], dict[str, str]], ScyllaServer]) -> None:
+                 create_server: Callable[[CreateServerParams], ScyllaServer]) -> None:
         self.name = str(uuid.uuid1())
         self.replicas = replicas
         self.create_server = create_server
@@ -529,8 +534,12 @@ class ScyllaCluster:
 
     async def add_server(self) -> ServerInfo:
         """Add a new server to the cluster"""
-        extra_config: dict[str, str] = {}
-        server = self.create_server(self.name, self._seeds(), extra_config)
+        params = ScyllaCluster.CreateServerParams(
+            cluster_name = self.name,
+            seeds = self._seeds(),
+            config_from_test = {}
+        )
+        server = self.create_server(params)
         self.is_dirty = True
         try:
             logging.info("Cluster %s adding server...", self)


### PR DESCRIPTION
The `add_server` function now takes an optional `ReplaceConfig` struct
(implemented using `NamedTuple`), which specifies the ID of the replaced
server and whether to reuse the IP address.

If we want to reuse the IP address, we don't allocate one using the host
registry. This required certain refactors: moving the code responsible
for allocation of IPs outside `ScyllaServer`, into `ScyllaCluster`.

Add two tests, but they are now skipped: one of them is failing (unability
for new node to join group 0) and both suffer from a hardcoded 60-second sleep
in Scylla.
