### PR TITLE
[branch 5.1 backport] docs: a single 5.0 -> 5.1 upgrade guide

### DIFF
--- a/docs/upgrade/upgrade-opensource/index.rst
+++ b/docs/upgrade/upgrade-opensource/index.rst
@@ -5,6 +5,7 @@ Upgrade ScyllaDB Open Source
 .. toctree::
    :hidden:
 
+   ScyllaDB 5.0 to 5.1 <upgrade-guide-from-5.0-to-5.1/index>
    ScyllaDB 5.x maintenance release <upgrade-guide-from-5.x.y-to-5.x.z/index>
    ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/index>
    ScyllaDb 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/index>
@@ -35,6 +36,7 @@ Upgrade ScyllaDB Open Source
 
   Procedures for upgrading to a newer version of ScyllaDB Open Source.
 
+  * :doc:`Upgrade Guide - ScyllaDB 5.0 to 5.1 <upgrade-guide-from-5.0-to-5.1/index>`
   * :doc:`Upgrade Guide - ScyllaDB 5.x maintenance releases <upgrade-guide-from-5.x.y-to-5.x.z/index>`
   * :doc:`Upgrade Guide - ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/index>`
   * :doc:`Upgrade Guide - ScyllaDB 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/index>`

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/index.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/index.rst
@@ -1,0 +1,21 @@
+====================================
+Upgrade Guide - ScyllaDB 5.0 to 5.1
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   ScyllaDB <upgrade-guide-from-5.0-to-5.1-generic>
+   Metrics <metric-update-5.0-to-5.1>
+
+.. panel-box::
+  :title: Upgrade Scylla
+  :id: "getting-started"
+  :class: my-panel
+
+
+  Upgrade guides are available for:
+
+  * :doc:`Upgrade ScyllaDB from 5.0.x to 5.1.y <upgrade-guide-from-5.0-to-5.1-generic>`
+  * :doc:`ScyllaDB Metrics Update - Scylla 5.0 to 5.1 <metric-update-5.0-to-5.1>`

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/metric-update-5.0-to-5.1.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/metric-update-5.0-to-5.1.rst
@@ -1,0 +1,122 @@
+Scylla Metric Update - Scylla 5.0 to 5.1
+========================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+Scylla 5.1 Dashboards are available as part of the latest |mon_root|.
+
+The following metrics are new in Scylla 5.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 150
+   :header-rows: 1
+
+   * - Metric
+     - Description
+   * - scylla_cache_rows_compacted_with_tombstones
+     - Number of rows dropped in the cache by a tombstone write
+   * - scylla_cache_rows_dropped_by_tombstones
+     - Total number of rows in memtables that were dropped during a cache update on memtable flush
+   * - scylla_commitlog_active_allocations
+     - Current number of active allocations
+   * - scylla_commitlog_blocked_on_new_segment
+     - Number of allocations blocked on acquiring a new segment
+   * - scylla_commitlog_bytes_flush_requested
+     - Number of bytes requested to be flushed (persisted)
+   * - scylla_commitlog_bytes_released
+     - Number of bytes released from disk (deleted/recycled
+   * - scylla_compaction_manager_completed_compactions
+     - Number of completed compaction tasks
+   * - scylla_compaction_manager_failed_compactions
+     - Number of failed compaction tasks
+   * - scylla_compaction_manager_normalized_backlog
+     - Sum of normalized compaction backlog for all tables in the system. Backlog is normalized by dividing backlog by the shard's available memory.
+   * - scylla_compaction_manager_postponed_compactions
+     - Number of tables with postponed compaction
+   * - scylla_compaction_manager_validation_errors
+     - Number of encountered validation errors
+   * - scylla_cql_select_parallelized
+     - Number of parallelized aggregation SELECT query executions
+   * - scylla_database_total_reads_rate_limited
+     - Number of read operations that were rejected on the replica side because the per-partition limit was reached
+   * - scylla_database_total_writes_rate_limited
+     - Number of write operations that were rejected on the replica side because the per-partition limit was reached
+   * - scylla_forward_service_requests_dispatched_to_other_nodes
+     - Number of forward requests that were dispatched to other nodes
+   * - scylla_forward_service_requests_dispatched_to_own_shards
+     - Number of forward requests that were dispatched to local shards
+   * - scylla_forward_service_requests_executed
+     - Number of forward requests that were executed
+   * - scylla_gossip_live
+     - Number of live nodes the current node sees
+   * - scylla_gossip_unreachable
+     - Number of unreachable nodes the current node sees
+   * - scylla_io_queue_adjusted_consumption
+     - Consumed disk capacity units adjusted for class shares and idling preemption
+   * - scylla_io_queue_consumption
+     - Accumulated disk capacity units consumed by this class; an increment per-second rate indicates full utilization
+   * - scylla_io_queue_total_split_bytes
+     - Total number of bytes split
+   * - scylla_io_queue_total_split_ops
+     - Total number of requests split
+   * - scylla_per_partition_rate_limiter_allocations
+     - Number of times an entry was allocated over an empty/expired entry
+   * - scylla_per_partition_rate_limiter_failed_allocations
+     - Number of times the rate limiter gave up trying to allocate
+   * - scylla_per_partition_rate_limiter_load_factor
+     - Current load factor of the hash table (upper bound, may be overestimated)
+   * - scylla_per_partition_rate_limiter_probe_count
+     - Number of probes made during lookups
+   * - scylla_per_partition_rate_limiter_successful_lookups
+     - Number of times a lookup returned an already allocated entry
+   * - scylla_reactor_aio_outsizes
+     - Total number of AIO operations that exceed IO limit
+   * - scylla_schema_commitlog_active_allocations
+     - Current number of active allocations
+   * - scylla_schema_commitlog_alloc
+     - Number of not closed segments that still have some free space. This value should not get too high.
+   * - scylla_schema_commitlog_allocating_segments
+     - Number of times a new mutation has been added to a segment. Divide bytes_written by this value to get the average number of bytes per mutation written to the disk.
+   * - scylla_schema_commitlog_blocked_on_new_segment
+     - Number of allocations blocked on acquiring a new segment
+   * - scylla_schema_commitlog_bytes_flush_requested
+     - Number of bytes requested to be flushed (persisted)
+   * - scylla_schema_commitlog_bytes_released
+     - Number of bytes released from disk (deleted/recycled)
+   * - scylla_schema_commitlog_bytes_written
+     - Number of bytes written to disk. Divide this value by "alloc" to get the average number of bytes per mutation written to the disk.
+   * - scylla_schema_commitlog_cycle
+     - Number of commitlog write cycles - when the data is written from the internal memory buffer to the disk
+   * - scylla_schema_commitlog_disk_active_bytes
+     - Size of disk space in bytes used for data so far. A too high value indicates that there is a bottleneck in writing to SStable paths.
+   * - scylla_schema_commitlog_disk_slack_end_bytes
+     - Size of disk space (in bytes) unused because of segment switching (end slack). A too high value indicates that not enough data is written to each segment.
+   * - scylla_schema_commitlog_disk_total_bytes
+     - Size of disk space (in bytes) reserved for data so far. A too high value indicates that there is a bottleneck in writing to SStable paths.
+   * - scylla_schema_commitlog_flush
+     - Number of times the flush() method was called for a file
+   * - scylla_schema_commitlog_flush_limit_exceeded
+     - Number of times a flush limit was exceeded. A non-zero value indicates that there are too many pending flush operations (see pending_flushes), and some of them will be blocked till the total amount of pending flush operations drops below 5.
+   * - scylla_schema_commitlog_memory_buffer_bytes
+     - Total number of bytes in internal memory buffers
+   * - scylla_schema_commitlog_pending_allocations
+     - Number of currently pending allocations. A non-zero value indicates that there is a bottleneck in the disk write flow.
+   * - scylla_schema_commitlog_pending_flushes
+     - Number of currently pending flushes. See the related ``flush_limit_exceeded`` metric.
+   * - scylla_schema_commitlog_requests_blocked_memory
+     - Number of requests blocked due to memory pressure. A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests.
+   * - scylla_schema_commitlog_segments
+     - Current number of segments
+   * - scylla_schema_commitlog_slack
+     - Number of unused bytes written to the disk due to disk segment alignment
+   * - scylla_schema_commitlog_unused_segments
+     - Current number of unused segments. A non-zero value indicates that the disk write path became temporarily slow.
+   * - scylla_sstables_pi_auto_scale_events
+     - Number of promoted index auto-scaling events
+   * - scylla_storage_proxy_coordinator_read_rate_limited
+     - Number of read requests that were rejected by replicas because the rate limit for the partition was reached
+   * - scylla_storage_proxy_coordinator_write_rate_limited
+     - Number of write requests that were rejected by replicas because the rate limit for the partition was reached

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
@@ -1,0 +1,359 @@
+.. |SCYLLA_NAME| replace:: ScyllaDB
+
+.. |SRC_VERSION| replace:: 5.0
+.. |NEW_VERSION| replace:: 5.1
+
+.. |DEBIAN_SRC_REPO| replace:: Debian
+.. _DEBIAN_SRC_REPO: https://www.scylladb.com/download/?platform=debian-10&version=scylla-5.0
+
+.. |UBUNTU_SRC_REPO| replace:: Ubuntu
+.. _UBUNTU_SRC_REPO: https://www.scylladb.com/download/?platform=ubuntu-20.04&version=scylla-5.0
+
+.. |SCYLLA_DEB_SRC_REPO| replace:: ScyllaDB deb repo (|DEBIAN_SRC_REPO|_, |UBUNTU_SRC_REPO|_)
+
+.. |SCYLLA_RPM_SRC_REPO| replace:: ScyllaDB rpm repo
+.. _SCYLLA_RPM_SRC_REPO: https://www.scylladb.com/download/?platform=centos&version=scylla-5.0
+
+.. |DEBIAN_NEW_REPO| replace:: Debian
+.. _DEBIAN_NEW_REPO: https://www.scylladb.com/download/?platform=debian-10&version=scylla-5.1
+
+.. |UBUNTU_NEW_REPO| replace:: Ubuntu
+.. _UBUNTU_NEW_REPO: https://www.scylladb.com/download/?platform=ubuntu-20.04&version=scylla-5.1
+
+.. |SCYLLA_DEB_NEW_REPO| replace:: ScyllaDB deb repo (|DEBIAN_NEW_REPO|_, |UBUNTU_NEW_REPO|_)
+
+.. |SCYLLA_RPM_NEW_REPO| replace:: ScyllaDB rpm repo
+.. _SCYLLA_RPM_NEW_REPO: https://www.scylladb.com/download/?platform=centos&version=scylla-5.1
+
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: ./#rollback-procedure
+
+.. |SCYLLA_METRICS| replace:: Scylla Metrics Update - Scylla 5.0 to 5.1
+.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+
+=============================================================================
+Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION|
+=============================================================================
+
+This document is a step by step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|, and rollback to version |SRC_VERSION| if required.
+
+This guide covers upgrading Scylla on Red Hat Enterprise Linux (RHEL) 7/8, CentOS 7/8, Debian 10 and Ubuntu 20.04. It also applies when using ScyllaDB official image on EC2, GCP, or Azure; the image is based on Ubuntu 20.04.
+
+See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
+
+Upgrade Procedure
+=================
+
+A ScyllaDB upgrade is a rolling procedure which does **not** require full cluster shutdown.
+For each of the nodes in the cluster, serially (i.e. one node at a time), you will:
+
+* Check that the cluster's schema is synchronized
+* Drain the node and backup the data
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use the new |NEW_VERSION| features
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See `sctool <https://manager.docs.scylladb.com/stable/sctool/>`_ for suspending ScyllaDB Manager (only available for ScyllaDB Enterprise) scheduled or running repairs.
+* Not to apply schema changes
+
+.. note:: Before upgrading, make sure to use the latest `ScyllaDB Monitoring <https://monitoring.docs.scylladb.com/>`_ stack.
+
+Upgrade Steps
+=============
+Check the cluster schema
+-------------------------
+Make sure that all nodes have the schema synchronized before upgrade. The upgrade procedure will fail if there is a schema disagreement between nodes.
+
+.. code:: sh
+
+   nodetool describecluster
+
+Drain the nodes and backup the data
+-----------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In Scylla, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having that name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, remove the snapshot with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
+
+Backup the configuration file
+------------------------------
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-src
+
+Gracefully stop the node
+------------------------
+
+.. code:: sh
+
+   sudo service scylla-server stop
+
+Download and install the new release
+------------------------------------
+
+.. tabs::
+
+   .. group-tab:: Debian/Ubuntu
+
+        Before upgrading, check what version you are running now using ``dpkg -s scylla-server``. You should use the same version as this version in case you want to |ROLLBACK|_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+
+        **To upgrade ScyllaDB:**
+
+        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|.
+
+        #. Install the new ScyllaDB version:
+
+            .. code-block:: console
+
+               sudo apt-get clean all
+               sudo apt-get update
+               sudo apt-get dist-upgrade scylla
+
+
+        Answer ‘y’ to the first two questions.
+
+   .. group-tab:: RHEL/CentOS
+
+        Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to |ROLLBACK|_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+
+        **To upgrade ScyllaDB:**
+
+        #. Update the |SCYLLA_RPM_NEW_REPO|_  to |NEW_VERSION|.
+        #. Install the new ScyllaDB version:
+
+            .. code:: sh
+
+               sudo yum clean all
+               sudo yum update scylla\* -y
+
+   .. group-tab:: EC2/GCP/Azure Ubuntu Image
+
+        Before upgrading, check what version you are running now using ``dpkg -s scylla-server``. You should use the same version as this version in case you want to |ROLLBACK|_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+
+        There are two alternative upgrade procedures:
+
+        * :ref:`Upgrading ScyllaDB and simultaneously updating 3rd party and OS packages <upgrade-image-recommended-procedure>`. It is recommended if you are running a ScyllaDB official image (EC2 AMI, GCP, and Azure images), which is based on Ubuntu 20.04.
+
+        * :ref:`Upgrading ScyllaDB without updating any external packages <upgrade-image-upgrade-guide-regular-procedure>`.
+
+        .. _upgrade-image-recommended-procedure:
+
+        **To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
+
+        Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command.
+
+        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|.
+
+        #. Load the new repo:
+
+            .. code:: sh
+
+               sudo apt-get update
+
+
+        #. Run the following command to update the manifest file:
+
+            .. code:: sh
+
+               cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get install -y
+
+            Where:
+
+              * ``<version>`` - The ScyllaDB version to which you are upgrading ( |NEW_VERSION| ).
+              * ``<arch>`` - Architecture type: ``x86_64`` or ``aarch64``.
+
+            The file is included in the ScyllaDB packages downloaded in the previous step. The file location is ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
+
+            Example:
+
+                .. code:: sh
+
+                   cat scylla-packages-5.1.2-x86_64.txt | sudo xargs -n1 apt-get install -y
+
+                .. note::
+
+                   Alternatively, you can update the manifest file with the following command:
+
+                   ``sudo apt-get install $(awk '{print $1'} scylla-packages-<version>-<arch>.txt) -y``
+
+        .. _upgrade-image-upgrade-guide-regular-procedure:
+
+        **To upgrade ScyllaDB:**
+
+        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|.
+
+        #. Install the new ScyllaDB version:
+
+            .. code-block:: console
+
+               sudo apt-get clean all
+               sudo apt-get update
+               sudo apt-get dist-upgrade scylla
+
+
+        Answer ‘y’ to the first two questions.
+
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-server start
+
+Validate
+--------
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in ``UN`` status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version. Validate that the version matches the one you upgraded to.
+#. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no new errors in the log.
+#. Check again after two minutes, to validate no new issues are introduced.
+
+Once you are sure the node upgrade was successful, move to the next node in the cluster.
+
+See |Scylla_METRICS|_ for more information..
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from |SCYLLA_NAME| |NEW_VERSION|.x to |SRC_VERSION|.y. Apply this procedure if an upgrade from |SRC_VERSION| to |NEW_VERSION| failed before completing on all nodes. Use this procedure only for nodes you upgraded to |NEW_VERSION|.
+
+ScyllaDB rollback is a rolling procedure which does **not** require full cluster shutdown.
+For each of the nodes you rollback to |SRC_VERSION|, serially (i.e. one node at a time), you will:
+
+* Drain the node and stop Scylla
+* Retrieve the old ScyllaDB packages
+* Restore the configuration file
+* Restore system tables
+* Reload systemd configuration
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the rollback was successful and the node is up and running the old version.
+
+Rollback Steps
+==============
+Drain and gracefully stop the node
+----------------------------------
+
+.. code:: sh
+
+   nodetool drain
+   sudo service scylla-server stop
+
+Download and install the old release
+------------------------------------
+
+..
+    TODO: downgrade for 3rd party packages in EC2/GCP/Azure - like in the upgrade section?
+
+.. tabs::
+
+   .. group-tab:: Debian/Ubuntu
+
+        #. Remove the old repo file.
+
+            .. code:: sh
+
+               sudo rm -rf /etc/apt/sources.list.d/scylla.list
+
+        #. Update the |SCYLLA_DEB_SRC_REPO| to |SRC_VERSION|.
+        #. Install:
+
+            .. code-block::
+
+               sudo apt-get update
+               sudo apt-get remove scylla\* -y
+               sudo apt-get install scylla
+
+        Answer ‘y’ to the first two questions.
+
+   .. group-tab:: RHEL/CentOS
+
+        #. Remove the old repo file.
+
+            .. code:: sh
+
+               sudo rm -rf /etc/yum.repos.d/scylla.repo
+
+        #. Update the |SCYLLA_RPM_SRC_REPO|_  to |SRC_VERSION|.
+        #. Install:
+
+            .. code:: console
+
+               sudo yum clean all
+               sudo rm -rf /var/cache/yum
+               sudo yum remove scylla\\*tools-core
+               sudo yum downgrade scylla\\* -y
+               sudo yum install scylla
+
+   .. group-tab:: EC2/GCP/Azure Ubuntu Image
+
+        #. Remove the old repo file.
+
+            .. code:: sh
+
+               sudo rm -rf /etc/apt/sources.list.d/scylla.list
+
+        #. Update the |SCYLLA_DEB_SRC_REPO| to |SRC_VERSION|.
+        #. Install:
+
+            .. code-block::
+
+               sudo apt-get update
+               sudo apt-get remove scylla\* -y
+               sudo apt-get install scylla
+
+        Answer ‘y’ to the first two questions.
+
+Restore the configuration file
+------------------------------
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-src | /etc/scylla/scylla.yaml
+
+Restore system tables
+---------------------
+
+Restore all tables of **system** and **system_schema** from the previous snapshot because |NEW_VERSION| uses a different set of system tables. See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` for reference.
+
+.. code:: sh
+
+    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
+    sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
+    sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/
+
+Reload systemd configuration
+----------------------------
+
+You must reload the unit file if the systemd unit file is changed.
+
+.. code:: sh
+
+   sudo systemctl daemon-reload
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-server start
+
+Validate
+--------
+Check the upgrade instructions above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.


### PR DESCRIPTION
This is a backport of https://github.com/scylladb/scylladb/pull/11891.

Funnily, the 5.1 branch did not have the upgrade guide to 5.1 at all. It was only in `master`. So the backport does not remove files, only adds new ones.

I also had to add:
- an additional link in the upgrade-opensource index to the 5.1 upgrade page (it was already in upstream `master` when the cherry-picked commit was added)
- index page for 5.0->5.1 upgrades
- the list of new metrics, which was also completely missing in branch-5.1.