### PR TITLE
test/cql-pytest: remove "xfail" from passing test

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -944,7 +944,6 @@ def testIndexOnFrozenUDT(cql, test_keyspace):
             assert_invalid_message(cql, table, "ALLOW FILTERING",
                              "SELECT * FROM %s WHERE v = ?", udt1)
 
-@pytest.mark.xfail(reason="issues #8745")
 def testIndexOnFrozenCollectionOfUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as t:
         with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v frozen<set<frozen<{t}>>>)") as table:


### PR DESCRIPTION
We had a test that used to fail because of issue #8745. But this issue was alread fixed, and we forgot to remove the "xfail" marker. The test now passes, so let's remove the xfail marker.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>