### PR TITLE
RFC: gossip: Add instance_id concept

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -384,6 +384,7 @@ public:
     const db::extensions& extensions() const;
 
     utils::UUID host_id;
+    utils::UUID instance_id;
 
     static const sstring default_tls_priority;
 private:

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -375,6 +375,10 @@ public:
      */
     future<utils::UUID> set_local_host_id(utils::UUID host_id);
 
+
+    future<utils::UUID> load_local_instance_id();
+    future<utils::UUID> set_local_instance_id(utils::UUID instance_id);
+
     static api::timestamp_type schema_creation_timestamp();
 
     /**

--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -38,6 +38,7 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::IGNORE_MSB_BITS,        "IGNOR_MSB_BITS"},
     {application_state::CDC_GENERATION_ID,      "CDC_STREAMS_TIMESTAMP"}, /* not named "CDC_GENERATION_ID" for backward compatibility */
     {application_state::SNITCH_NAME,            "SNITCH_NAME"},
+    {application_state::INSTANCE_ID,            "INSTANCE_ID"},
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m) {

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -39,7 +39,7 @@ enum class application_state {
     CDC_GENERATION_ID,
     SNITCH_NAME,
     // pad to allow adding new states to existing cluster
-    X10,
+    INSTANCE_ID,
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m);

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -151,6 +151,10 @@ public:
         return versioned_value(host_id.to_sstring());
     }
 
+    static versioned_value instance_id(const utils::UUID& instance_id) {
+        return versioned_value(instance_id.to_sstring());
+    }
+
     static versioned_value tokens(const std::unordered_set<dht::token>& tokens) {
         return versioned_value(make_full_token_string(tokens));
     }

--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -102,6 +102,8 @@ struct node_ops_cmd_request {
     std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<utils::UUID> repair_tables;
+    // Optional field, list the instance ids that should be blocked after this node ops
+    std::optional<std::list<utils::UUID>> instance_ids_to_block [[version 5.1]];
 };
 
 struct node_ops_cmd_response {

--- a/main.cc
+++ b/main.cc
@@ -1066,6 +1066,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // start, but we only have query processor started that late
             sys_ks.invoke_on_all(&db::system_keyspace::start).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+            cfg->instance_id = sys_ks.local().load_local_instance_id().get0();
+            gossiper.invoke_on_all([&cfg] (gms::gossiper& g) {
+                g.set_instance_id(cfg->instance_id);
+            }).get();
 
             db::sstables_format_selector sst_format_selector(gossiper.local(), feature_service, db);
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -993,70 +993,70 @@ future<> messaging_service::unregister_complete_message() {
     return unregister_handler(messaging_verb::COMPLETE_MESSAGE);
 }
 
-void messaging_service::register_gossip_echo(std::function<future<> (const rpc::client_info& cinfo, rpc::optional<int64_t> generation_number)>&& func) {
+void messaging_service::register_gossip_echo(std::function<future<> (const rpc::client_info& cinfo, rpc::optional<int64_t> generation_number, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_ECHO, std::move(func));
 }
 future<> messaging_service::unregister_gossip_echo() {
     return unregister_handler(netw::messaging_verb::GOSSIP_ECHO);
 }
-future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout) {
-    return send_message_timeout<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), timeout, generation_number);
+future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout, utils::UUID instance_id) {
+    return send_message_timeout<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), timeout, generation_number, std::move(instance_id));
 }
-future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_number, abort_source& as) {
-    return send_message_cancellable<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), as, generation_number);
+future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_number, abort_source& as, utils::UUID instance_id) {
+    return send_message_cancellable<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), as, generation_number, std::move(instance_id));
 }
 
-void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func) {
+void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(func));
 }
 future<> messaging_service::unregister_gossip_shutdown() {
     return unregister_handler(netw::messaging_verb::GOSSIP_SHUTDOWN);
 }
-future<> messaging_service::send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number) {
-    return send_message_oneway(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(id), std::move(from), generation_number);
+future<> messaging_service::send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number, utils::UUID instance_id) {
+    return send_message_oneway(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(id), std::move(from), generation_number, std::move(instance_id));
 }
 
 // gossip syn
-void messaging_service::register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_syn)>&& func) {
+void messaging_service::register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_syn, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_DIGEST_SYN, std::move(func));
 }
 future<> messaging_service::unregister_gossip_digest_syn() {
     return unregister_handler(netw::messaging_verb::GOSSIP_DIGEST_SYN);
 }
-future<> messaging_service::send_gossip_digest_syn(msg_addr id, gossip_digest_syn msg) {
-    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_SYN, std::move(id), std::move(msg));
+future<> messaging_service::send_gossip_digest_syn(msg_addr id, gossip_digest_syn msg, utils::UUID instance_id) {
+    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_SYN, std::move(id), std::move(msg), std::move(instance_id));
 }
 
 // gossip ack
-void messaging_service::register_gossip_digest_ack(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_ack)>&& func) {
+void messaging_service::register_gossip_digest_ack(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_ack, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_DIGEST_ACK, std::move(func));
 }
 future<> messaging_service::unregister_gossip_digest_ack() {
     return unregister_handler(netw::messaging_verb::GOSSIP_DIGEST_ACK);
 }
-future<> messaging_service::send_gossip_digest_ack(msg_addr id, gossip_digest_ack msg) {
-    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_ACK, std::move(id), std::move(msg));
+future<> messaging_service::send_gossip_digest_ack(msg_addr id, gossip_digest_ack msg, utils::UUID instance_id) {
+    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_ACK, std::move(id), std::move(msg), std::move(instance_id));
 }
 
 // gossip ack2
-void messaging_service::register_gossip_digest_ack2(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_ack2)>&& func) {
+void messaging_service::register_gossip_digest_ack2(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gossip_digest_ack2, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_DIGEST_ACK2, std::move(func));
 }
 future<> messaging_service::unregister_gossip_digest_ack2() {
     return unregister_handler(netw::messaging_verb::GOSSIP_DIGEST_ACK2);
 }
-future<> messaging_service::send_gossip_digest_ack2(msg_addr id, gossip_digest_ack2 msg) {
-    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_ACK2, std::move(id), std::move(msg));
+future<> messaging_service::send_gossip_digest_ack2(msg_addr id, gossip_digest_ack2 msg, utils::UUID instance_id) {
+    return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_ACK2, std::move(id), std::move(msg), std::move(instance_id));
 }
 
-void messaging_service::register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request)>&& func) {
+void messaging_service::register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request, rpc::optional<utils::UUID> instance_id)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_GET_ENDPOINT_STATES, std::move(func));
 }
 future<> messaging_service::unregister_gossip_get_endpoint_states() {
     return unregister_handler(messaging_verb::GOSSIP_GET_ENDPOINT_STATES);
 }
-future<gms::gossip_get_endpoint_states_response> messaging_service::send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request) {
-    return send_message_timeout<future<gms::gossip_get_endpoint_states_response>>(this, messaging_verb::GOSSIP_GET_ENDPOINT_STATES, std::move(id), std::move(timeout), std::move(request));
+future<gms::gossip_get_endpoint_states_response> messaging_service::send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request, utils::UUID instance_id) {
+    return send_message_timeout<future<gms::gossip_get_endpoint_states_response>>(this, messaging_verb::GOSSIP_GET_ENDPOINT_STATES, std::move(id), std::move(timeout), std::move(request), std::move(instance_id));
 }
 
 void messaging_service::register_definitions_update(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm,

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -436,35 +436,35 @@ public:
     future<node_ops_cmd_response> send_node_ops_cmd(msg_addr id, node_ops_cmd_request);
 
     // Wrapper for GOSSIP_ECHO verb
-    void register_gossip_echo(std::function<future<> (const rpc::client_info& cinfo, rpc::optional<int64_t> generation_number)>&& func);
+    void register_gossip_echo(std::function<future<> (const rpc::client_info& cinfo, rpc::optional<int64_t> generation_number, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_echo();
-    future<> send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout);
-    future<> send_gossip_echo(msg_addr id, int64_t generation_number, abort_source&);
+    future<> send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout, utils::UUID instance_id);
+    future<> send_gossip_echo(msg_addr id, int64_t generation_number, abort_source&, utils::UUID instance_id);
 
     // Wrapper for GOSSIP_SHUTDOWN
-    void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func);
+    void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_shutdown();
-    future<> send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number);
+    future<> send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number, utils::UUID instance_id);
 
     // Wrapper for GOSSIP_DIGEST_SYN
-    void register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_syn)>&& func);
+    void register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_syn, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_digest_syn();
-    future<> send_gossip_digest_syn(msg_addr id, gms::gossip_digest_syn msg);
+    future<> send_gossip_digest_syn(msg_addr id, gms::gossip_digest_syn msg, utils::UUID instance_id);
 
     // Wrapper for GOSSIP_DIGEST_ACK
-    void register_gossip_digest_ack(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack)>&& func);
+    void register_gossip_digest_ack(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_digest_ack();
-    future<> send_gossip_digest_ack(msg_addr id, gms::gossip_digest_ack msg);
+    future<> send_gossip_digest_ack(msg_addr id, gms::gossip_digest_ack msg, utils::UUID instance_id);
 
     // Wrapper for GOSSIP_DIGEST_ACK2
-    void register_gossip_digest_ack2(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack2)>&& func);
+    void register_gossip_digest_ack2(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack2, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_digest_ack2();
-    future<> send_gossip_digest_ack2(msg_addr id, gms::gossip_digest_ack2 msg);
+    future<> send_gossip_digest_ack2(msg_addr id, gms::gossip_digest_ack2 msg, utils::UUID instance_id);
 
     // Wrapper for GOSSIP_GET_ENDPOINT_STATES
-    void register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request)>&& func);
+    void register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request, rpc::optional<utils::UUID> instance_id)>&& func);
     future<> unregister_gossip_get_endpoint_states();
-    future<gms::gossip_get_endpoint_states_response> send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request);
+    future<gms::gossip_get_endpoint_states_response> send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request, utils::UUID instance_id);
 
     // Wrapper for DEFINITIONS_UPDATE
     void register_definitions_update(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm,

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -387,20 +387,25 @@ struct node_ops_cmd_request {
     std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<utils::UUID> repair_tables;
+    // Optional field, list the instance ids that should be blocked after this node ops
+    std::optional<std::list<utils::UUID>> instance_ids_to_block;
     node_ops_cmd_request(node_ops_cmd command,
             utils::UUID uuid,
             std::list<gms::inet_address> ignore = {},
             std::list<gms::inet_address> leaving = {},
             std::unordered_map<gms::inet_address, gms::inet_address> replace = {},
             std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap = {},
-            std::list<utils::UUID> tables = {})
+            std::list<utils::UUID> tables = {},
+            std::optional<std::list<utils::UUID>> instance_ids = {})
         : cmd(command)
         , ops_uuid(std::move(uuid))
         , ignore_nodes(std::move(ignore))
         , leaving_nodes(std::move(leaving))
         , replace_nodes(std::move(replace))
         , bootstrap_nodes(std::move(bootstrap))
-        , repair_tables(std::move(tables)) {
+        , repair_tables(std::move(tables))
+        , instance_ids_to_block(std::move(instance_ids))
+    {
     }
 };
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -117,6 +117,11 @@ public:
     void cancel_watchdog();
 };
 
+struct replacement_info {
+    std::unordered_set<dht::token> tokens;
+    std::optional<utils::UUID> instance_id;
+};
+
 /**
  * This abstraction contains the token/identifier of this node
  * on the identifier space. This token gets gossiped around.
@@ -293,7 +298,6 @@ private:
     future<> shutdown_protocol_servers();
 
     // Tokens and the CDC streams timestamp of the replaced node.
-    using replacement_info = std::unordered_set<token>;
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
@@ -770,6 +774,9 @@ private:
 public:
     future<bool> is_cleanup_allowed(sstring keyspace);
     bool is_repair_based_node_ops_enabled(streaming::stream_reason reason);
+
+private:
+    std::optional<utils::UUID> _instance_id_of_node_to_be_replaced;
 };
 
 }


### PR DESCRIPTION
Consider the following:

1) replaced node  goes back to cluster

- 3 nodes cluster, n1, n2, n3
- n3 is dead
- n3 is replaced with another node n4
- the replaced node goes back to the cluster

2) removed node goes back to cluster

- 3 nodes cluster, n1, n2, n3
- n3 is dead
- n3 is removed with nodetool removenode
- the removenode node goes back to the cluster

In commit 12ab2c3d8d6925a14(storage_service: Prevent removed node to restart and join the cluster), we fixed the restart case. This patch goes one step further to fix  more cases.

Scylla does not allow the replaced or removed node to go back to the cluster. In cloud environments, it is hard to guarantee this never happens.

In this patch, the instance_id concept is introduced to solve this problem.

When a scylla node starts, a random and unique instance_id is created. Unlike host_id, the instance_id is unique even if the host_id is the same. For example, a new node is started to replace an old dead node during the replace operation.

When the node operation like replace or removenode is performed, we mark the instance_id as blocked.

When the node with the blocked instance_id comes back to the cluster, it won't be able to communicate to other nodes with gossip, as if the node was not back to the cluster.

For example, when n3 is marked as blocked and comes back:

n1:
```
gossip - The instance_id e76618a2-a2eb-4021-9a38-81a4a1ec3681
for node 127.0.0.3 is blocked by node 127.0.0.1. Mark node 127.0.0.3 as
DOWN.

UN  127.0.0.1  544 KB     256          ?  781b9ae2-63a6-4f6f-ade2-8ee6b30e2786  rack1
UN  127.0.0.2  764 KB     256          ?  295bc7fb-a59a-48de-b5bd-23fd771c0578  rack1
DN  127.0.0.3  1.62 MB    256          ?  eecba8ab-95f9-4e58-8934-6fd9bf19c773  rack1
```

n2:
```
gossip - The instance_id e76618a2-a2eb-4021-9a38-81a4a1ec3681 for node
127.0.0.3 is blocked by node 127.0.0.2. Mark node 127.0.0.3 as DOWN

UN  127.0.0.1  544 KB     256          ?  781b9ae2-63a6-4f6f-ade2-8ee6b30e2786  rack1
UN  127.0.0.2  764 KB     256          ?  295bc7fb-a59a-48de-b5bd-23fd771c0578  rack1
DN  127.0.0.3  1.62 MB    256          ?  eecba8ab-95f9-4e58-8934-6fd9bf19c773  rack1
```

n3:
```
gossip - failure_detector_loop: Send echo to node 127.0.0.1, status =
failed: seastar::rpc::remote_verb_error (The instance_id
e76618a2-a2eb-4021-9a38-81a4a1ec3681 for node 127.0.0.3 is blocked by
node 127.0.0.1)

gossip - failure_detector_loop: Send echo to node 127.0.0.2, status =
failed: seastar::rpc::remote_verb_error (The instance_id
e76618a2-a2eb-4021-9a38-81a4a1ec3681 for node 127.0.0.3 is blocked by
node 127.0.0.2)
gossip - failure_detector_loop: Mark node 127.0.0.2 as DOWN
gossip - failure_detector_loop: Mark node 127.0.0.1 as DOWN
gossip - InetAddress 127.0.0.1 is now DOWN, status = NORMAL
gossip - InetAddress 127.0.0.2 is now DOWN, status = NORMAL

DN  127.0.0.1  544 KB     256          ?  781b9ae2-63a6-4f6f-ade2-8ee6b30e2786  rack1
DN  127.0.0.2  764 KB     256          ?  295bc7fb-a59a-48de-b5bd-23fd771c0578  rack1
UN  127.0.0.3  1.62 MB    256          ?  eecba8ab-95f9-4e58-8934-6fd9bf19c773  rack1
```

When n3 restarts:

```
[shard 0] init - Startup failed: seastar::rpc::remote_verb_error (The
instance_id e76618a2-a2eb-4021-9a38-81a4a1ec3681 for node 127.0.0.3 is
blocked by node 127.0.0.1)
```

TODO:

- Persistent the blocked instance ID. It is a small amount of data. Even if we locked 10000 instances in the history of the cluster, it is only 128 bit * 10000 of data.

- To be more safe and prevent any damanage to the cluster, we can even make the node stop itself when it knows it is blocked by others.

Fixes #11217