### PR TITLE
storage_service: Retry when unknown gossip status node is found

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1613,7 +1613,15 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
                 for (auto& x : _gossiper.get_endpoint_states()) {
                     auto state = _gossiper.get_gossip_status(x.second);
                     if (state == sstring(versioned_value::STATUS_UNKNOWN)) {
-                        throw std::runtime_error(format("Node {} has gossip status=UNKNOWN. Try fixing it before adding new node to the cluster.", x.first));
+                        if (gms::gossiper::clk::now() > t + std::chrono::seconds(60)) {
+                            throw std::runtime_error(format("Node {} has gossip status=UNKNOWN. Try fixing it before adding new node to the cluster.", x.first));
+                        } else {
+                            found_bootstrapping_node = true;
+                            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(gms::gossiper::clk::now() - t).count();
+                            slogger.info("Node {} has gossip status=UNKNOWN. Sleep 1 second and check again ({} seconds elapsed) (check_for_endpoint_collision)", x.first, elapsed);
+                            sleep_abortable(std::chrono::seconds(1), _abort_source).get();
+                            break;
+                        }
                     }
                     auto addr = x.first;
                     slogger.debug("Checking bootstrapping/leaving/moving nodes: node={}, status={} (check_for_endpoint_collision)", addr, state);


### PR DESCRIPTION
In 4cefc0151e7375192b91b605c3acaf90a2e346f8 (storage_service: Reject to bootstrap new node when node has unknown gossip status), the bootstrap is rejected immediately when a node with unknown gossip status is found.

This patch adds retry logic to make it a bit more user-friendly.

Fixes #11853