### PR TITLE
mutation_fragment_stream_validator: avoid allocation when stream is correct

### DIFF
--- a/mutation_fragment_stream_validator.hh
+++ b/mutation_fragment_stream_validator.hh
@@ -165,8 +165,14 @@ struct invalid_mutation_fragment_stream : public std::runtime_error {
 /// Implements the FlattenedConsumerFilter concept.
 class mutation_fragment_stream_validating_filter {
     mutation_fragment_stream_validator _validator;
-    sstring _name;
+    sstring _name_storage;
+    std::string_view _name_view; // always valid
     mutation_fragment_stream_validation_level _validation_level;
+
+private:
+    sstring full_name() const;
+
+    mutation_fragment_stream_validating_filter(const char* name_literal, sstring name_value, const schema& s, mutation_fragment_stream_validation_level level);
 
 public:
     /// Constructor.
@@ -174,7 +180,11 @@ public:
     /// \arg name is used in log messages to identify the validator, the
     ///     schema identity is added automatically
     /// \arg compare_keys enable validating clustering key monotonicity
-    mutation_fragment_stream_validating_filter(sstring_view name, const schema& s, mutation_fragment_stream_validation_level level);
+    mutation_fragment_stream_validating_filter(sstring name, const schema& s, mutation_fragment_stream_validation_level level);
+    mutation_fragment_stream_validating_filter(const char* name, const schema& s, mutation_fragment_stream_validation_level level);
+
+    mutation_fragment_stream_validating_filter(mutation_fragment_stream_validating_filter&&) = delete;
+    mutation_fragment_stream_validating_filter(const mutation_fragment_stream_validating_filter&) = delete;
 
     bool operator()(const dht::decorated_key& dk);
     bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -210,22 +210,32 @@ bool mutation_fragment_stream_validating_filter::operator()(const dht::decorated
             return true;
         }
         on_validation_error(mrlog, format("[validator {} for {}] Unexpected token: previous {}, current {}",
-                static_cast<void*>(this), _name, _validator.previous_token(), dk.token()));
+                static_cast<void*>(this), full_name(), _validator.previous_token(), dk.token()));
     } else {
         if (_validator(dk)) {
             return true;
         }
         on_validation_error(mrlog, format("[validator {} for {}] Unexpected partition key: previous {}, current {}",
-                static_cast<void*>(this), _name, _validator.previous_partition_key(), dk));
+                static_cast<void*>(this), full_name(), _validator.previous_partition_key(), dk));
     }
 }
 
-mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(sstring_view name, const schema& s,
+sstring mutation_fragment_stream_validating_filter::full_name() const {
+    const auto& s = _validator.schema();
+    return format("{} ({}.{} {})", _name_view, s.ks_name(), s.cf_name(), s.id());
+}
+
+mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(const char* name_literal, sstring name_value, const schema& s,
         mutation_fragment_stream_validation_level level)
     : _validator(s)
-    , _name(format("{} ({}.{} {})", name, s.ks_name(), s.cf_name(), s.id()))
+    , _name_storage(std::move(name_value))
     , _validation_level(level)
 {
+    if (name_literal) {
+        _name_view = name_literal;
+    } else {
+        _name_view = _name_storage;
+    }
     if (mrlog.is_enabled(log_level::debug)) {
         std::string_view what;
         switch (_validation_level) {
@@ -242,9 +252,19 @@ mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_
                 what = "partition region, partition key and clustering key";
                 break;
         }
-        mrlog.debug("[validator {} for {}] Will validate {} monotonicity.", static_cast<void*>(this), _name, what);
+        mrlog.debug("[validator {} for {}] Will validate {} monotonicity.", static_cast<void*>(this), full_name(), what);
     }
 }
+
+mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(sstring name, const schema& s,
+        mutation_fragment_stream_validation_level level)
+    : mutation_fragment_stream_validating_filter(nullptr, std::move(name), s, level)
+{ }
+
+mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(const char* name, const schema& s,
+        mutation_fragment_stream_validation_level level)
+    : mutation_fragment_stream_validating_filter(name, {}, s, level)
+{ }
 
 bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos,
         std::optional<tombstone> new_current_tombstone) {
@@ -261,16 +281,16 @@ bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2
     if (__builtin_expect(!valid, false)) {
         if (_validation_level >= mutation_fragment_stream_validation_level::clustering_key) {
             on_validation_error(mrlog, format("[validator {} for {}] Unexpected mutation fragment: partition key {}: previous {}:{}, current {}:{}",
-                    static_cast<void*>(this), _name, _validator.previous_partition_key(), _validator.previous_mutation_fragment_kind(), _validator.previous_position(), kind, pos));
+                    static_cast<void*>(this), full_name(), _validator.previous_partition_key(), _validator.previous_mutation_fragment_kind(), _validator.previous_position(), kind, pos));
         } else if (_validation_level >= mutation_fragment_stream_validation_level::partition_key) {
             on_validation_error(mrlog, format("[validator {} for {}] Unexpected mutation fragment: partition key {}: previous {}, current {}",
-                    static_cast<void*>(this), _name, _validator.previous_partition_key(), _validator.previous_mutation_fragment_kind(), kind));
+                    static_cast<void*>(this), full_name(), _validator.previous_partition_key(), _validator.previous_mutation_fragment_kind(), kind));
         } else if (kind == mutation_fragment_v2::kind::partition_end && _validator.current_tombstone()) {
             on_validation_error(mrlog, format("[validator {} for {}] Partition ended with active tombstone: {}",
-                    static_cast<void*>(this), _name, _validator.current_tombstone()));
+                    static_cast<void*>(this), full_name(), _validator.current_tombstone()));
         } else {
             on_validation_error(mrlog, format("[validator {} for {}] Unexpected mutation fragment: previous {}, current {}",
-                    static_cast<void*>(this), _name, _validator.previous_mutation_fragment_kind(), kind));
+                    static_cast<void*>(this), full_name(), _validator.previous_mutation_fragment_kind(), kind));
         }
     }
 
@@ -316,7 +336,7 @@ bool mutation_fragment_stream_validating_filter::on_end_of_partition() {
 void mutation_fragment_stream_validating_filter::on_end_of_stream() {
     mrlog.debug("[validator {}] EOS", static_cast<const void*>(this));
     if (!_validator.on_end_of_stream()) {
-        on_validation_error(mrlog, format("[validator {} for {}] Stream ended with unclosed partition: {}", static_cast<const void*>(this), _name,
+        on_validation_error(mrlog, format("[validator {} for {}] Stream ended with unclosed partition: {}", static_cast<const void*>(this), full_name(),
                 _validator.previous_mutation_fragment_kind()));
     }
 }


### PR DESCRIPTION
Currently the ctor of said class always allocates as it copies the provided name string and it creates a new name via format(). We want to avoid this, now that the validator is used on the read path. So defer creating the formatted name to when we actually want to log something, which is either when log level is debug or when an error is found. We don't care about performance in either case, but we do care about it on the happy path.
Further to the above, provide a constructor for string literal names and when this is used, don't copy the name string, just save a view to it.

Refs: #11174