### PR TITLE
cql-pytest: translate a few small Cassandra tests

### DIFF
--- a/test/cql-pytest/cassandra_tests/porting.py
+++ b/test/cql-pytest/cassandra_tests/porting.py
@@ -125,6 +125,10 @@ def assert_invalid_message(cql, table, message, cmd, *args):
     with pytest.raises(InvalidRequest, match=re.escape(message)):
         execute(cql, table, cmd, *args)
 
+def assert_invalid_syntax_message(cql, table, message, cmd, *args):
+    with pytest.raises(SyntaxException, match=re.escape(message)):
+        execute(cql, table, cmd, *args)
+
 def assert_invalid_message_re(cql, table, message, cmd, *args):
     with pytest.raises(InvalidRequest, match=message):
         execute(cql, table, cmd, *args)
@@ -148,6 +152,8 @@ def assert_row_count(result, expected):
 def assert_empty(result):
     assert len(list(result)) == 0
 
+assertEmpty = assert_empty
+
 # Result objects contain some strange types specific to the CQL driver, which
 # normally compare well against normal Python types, but in some cases of nested
 # types they do not, and require some cleanup:
@@ -167,6 +173,8 @@ def assert_rows(result, *expected):
     for r,e in zip(allresults, expected):
         r = [result_cleanup(col) for col in r]
         assert r == e
+
+assertRows = assert_rows
 
 # To compare two lists of items (each is a dict) without regard for order,
 # The following function, multiset() converts the list into a multiset
@@ -200,6 +208,8 @@ def assert_rows_ignoring_order(result, *expected):
     allresults = list(result)
     assert len(allresults) == len(expected)
     assert multiset(allresults) == multiset(expected)
+
+assertRowsIgnoringOrder = assert_rows_ignoring_order
 
 # Unfortunately, collections.Counter objects don't implement comparison
 # operators <, <=, >, >=, as sets do. Lets implement the c1 <= c2:
@@ -271,3 +281,7 @@ def wait_for_index(cql, table, index):
 # The number of arguments is assumed to be even.
 def user_type(*args):
     return collections.namedtuple('user_type', args[::2])(*args[1::2])
+
+# a row(...) used in assertRows can simply be a list
+def row(*args):
+    return list(args)

--- a/test/cql-pytest/cassandra_tests/validation/operations/drop_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/drop_test.py
@@ -1,0 +1,40 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testNonExistingOnes(cql, test_keyspace):
+    # The specific error message that Scylla and Cassandra print in these
+    # error cases are different. But they both list the non-existent table
+    # or keyspace.
+    assert_invalid_message(cql, test_keyspace, "table_does_not_exist",  "DROP TABLE " + test_keyspace + ".table_does_not_exist")
+    assert_invalid_message(cql, test_keyspace, "keyspace_does_not_exist", "DROP TABLE keyspace_does_not_exist.table_does_not_exist")
+    execute(cql, test_keyspace, "DROP TABLE IF EXISTS " + test_keyspace + ".table_does_not_exist")
+    execute(cql, test_keyspace, "DROP TABLE IF EXISTS keyspace_does_not_exist.table_does_not_exist")
+
+def testDropTableWithDroppedColumns(cql, test_keyspace):
+    # CASSANDRA-13730: entry should be removed from dropped_columns table when table is dropped
+    with create_table(cql, test_keyspace, "(k1 int, c1 int, v1 int, v2 int, PRIMARY KEY(k1, c1))") as table:
+        execute(cql, table, "ALTER TABLE %s DROP v2")
+        cf = table.split('.')[1]
+    assertRowsIgnoringOrder(execute(cql, table, "select * from system_schema.dropped_columns where keyspace_name = '"
+                + test_keyspace
+                + "' and table_name = '" + cf + "'"))

--- a/test/cql-pytest/cassandra_tests/validation/operations/truncate_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/truncate_test.py
@@ -1,0 +1,39 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testTruncate(cql, test_keyspace):
+    for arg in ["", "TABLE"]:
+        with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY(a,b))") as table:
+            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, 0)
+            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 1, 1)
+
+            flush(cql, table)
+
+            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 0, 2)
+            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 3)
+
+            assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, 0, 2), row(1, 1, 3), row(0, 0, 0), row(0, 1, 1))
+
+            execute(cql, table, "TRUNCATE " + arg + " %s")
+
+            assertEmpty(execute(cql, table, "SELECT * FROM %s"))

--- a/test/cql-pytest/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
@@ -1,0 +1,65 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testAddUDTField(cql, test_keyspace):
+    with create_type(cql, test_keyspace, "(foo text)") as typename:
+        with create_table(cql, test_keyspace, f"(pk int, ck frozen<{typename}>, , v int, PRIMARY KEY(pk, ck))") as table:
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\"}'), 0);")
+            execute(cql, table, "ALTER TYPE " + typename + " ADD bar text;")
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\"}'), 1);")
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\", \"bar\": null}'), 2);")
+            flush(cql, table)
+            compact(cql, table)
+            assertRows(execute(cql, table, "select v from %s where pk = 0 and ck=system.fromjson('{\"foo\": \"foo\"}')"),
+                   row(2))
+            assertRows(execute(cql, table, "select v from %s where pk = 0"),
+                   row(2))
+
+def testFieldWithData(cql, test_keyspace):
+    with create_type(cql, test_keyspace, "(foo text)") as typename:
+        with create_table(cql, test_keyspace, f"(pk int, ck frozen<{typename}>, , v int, PRIMARY KEY(pk, ck))") as table:
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\"}'), 1);")
+            execute(cql, table, "ALTER TYPE " + typename + " ADD bar text;")
+            # this row becomes inaccessible by primary key but remains visible through select *
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\", \"bar\": \"bar\"}'), 2);")
+            flush(cql, table)
+            compact(cql, table)
+            assertRows(execute(cql, table, "select v from %s where pk = 0"),
+                   row(1),
+                   row(2))
+
+def testAddUDTFields(cql, test_keyspace):
+    with create_type(cql, test_keyspace, "(foo text)") as typename:
+        with create_table(cql, test_keyspace, f"(pk int, ck frozen<{typename}>, , v int, PRIMARY KEY(pk, ck))") as table:
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\"}'), 0);")
+            execute(cql, table, "ALTER TYPE " + typename + " ADD bar text;")
+            execute(cql, table, "ALTER TYPE " + typename + " ADD bar2 text;")
+            execute(cql, table, "ALTER TYPE " + typename + " ADD bar3 text;")
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\"}'), 1);")
+            execute(cql, table, "insert into %s (pk, ck, v) values (0, system.fromjson('{\"foo\": \"foo\", \"bar\": null, \"bar2\": null, \"bar3\": null}'), 2);")
+            flush(cql, table)
+            compact(cql, table)
+            assertRows(execute(cql, table, "select v from %s where pk = 0 and ck=system.fromjson('{\"foo\": \"foo\"}')"),
+                   row(2))
+            assertRows(execute(cql, table, "select v from %s where pk = 0"),
+                   row(2))

--- a/test/cql-pytest/cassandra_tests/validation/operations/use_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/use_test.py
@@ -1,0 +1,25 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testUseStatementWithBindVariable(cql, test_keyspace):
+    assert_invalid_syntax_message(cql, test_keyspace, "Bind variables cannot be used for keyspace names", "USE ?")


### PR DESCRIPTION
This patch includes a translation of several additional small test files from Cassandra's CQL unit test directory cql3/validation/operations.

All tests included here pass on both Cassandra and Scylla, so they did not discover any new Scylla bugs, but can be useful in the future as regression tests.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>