### PR TITLE
Fix LWT insert crash if clustering key is null

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1945,7 +1945,7 @@ sstring statement_restrictions::to_string() const {
 static void validate_primary_key_restrictions(const query_options& options, const std::vector<expr::expression>& restrictions) {
     for (const auto& r: restrictions) {
         for_each_expression<binary_operator>(r, [&](const binary_operator& binop) {
-            if (binop.op != oper_t::EQ) {
+            if (binop.op != oper_t::EQ && binop.op != oper_t::IN) {
                 return;
             }
             const auto* c = as_if<column_value>(&binop.lhs);

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -240,6 +240,15 @@ public:
      * @return <code>true</code> if the clustering key has some unrestricted components, <code>false</code> otherwise.
      */
     bool has_unrestricted_clustering_columns() const;
+
+    /**
+     * Returns the first unrestricted column for restrictions of the specified kind.
+     * It's an error to call this function if there are no such columns.
+     *
+     * @param kind supported values are column_kind::partition_key and column_kind::clustering_key;
+     * @return the <code>column_definition</code> for the unrestricted column.
+     */
+    const column_definition& unrestricted_column(column_kind kind) const;
 private:
     void add_restriction(const expr::binary_operator& restr, schema_ptr schema, bool allow_filtering, bool for_view);
     void add_is_not_restriction(const expr::binary_operator& restr, schema_ptr schema, bool for_view);

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -534,8 +534,8 @@ public:
 
     sstring to_string() const;
 
-    /// True iff the partition range or slice is empty specifically due to a =NULL restriction.
-    bool range_or_slice_eq_null(const query_options& options) const;
+    /// Checks that the primary key restrictions don't contain null values, throws invalid_request_exception otherwise.
+    void validate_primary_key(const query_options& options) const;
 };
 
 }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -262,7 +262,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
         throw new InvalidRequestException("Invalid empty serial consistency level");
 #endif
     for (size_t i = 0; i < _statements.size(); ++i) {
-        _statements[i].statement->validate_primary_key_restrictions(options.for_statement(i));
+        _statements[i].statement->restrictions().validate_primary_key(options.for_statement(i));
     }
 
     if (_has_conditions) {

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -261,6 +261,10 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
     if (options.getSerialConsistency() == null)
         throw new InvalidRequestException("Invalid empty serial consistency level");
 #endif
+    for (size_t i = 0; i < _statements.size(); ++i) {
+        _statements[i].statement->validate_primary_key_restrictions(options.for_statement(i));
+    }
+
     if (_has_conditions) {
         ++_stats.cas_batches;
         _stats.statements_in_cas_batches += _statements.size();

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -250,6 +250,12 @@ modification_statement::execute_without_checking_exception_message(query_process
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 
+void modification_statement::validate_primary_key_restrictions(const query_options& options) const {
+    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
+        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
+    }
+}
+
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
     if (has_conditions() && options.get_protocol_version() == 1) {
@@ -260,9 +266,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
 
     inc_cql_stats(qs.get_client_state().is_internal());
 
-    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
-        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
-    }
+    validate_primary_key_restrictions(options);
 
     if (has_conditions()) {
         return execute_with_condition(qp, qs, options);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -419,24 +419,23 @@ modification_statement::process_where_clause(data_dictionary::database db, expr:
         // Those tables don't have clustering columns so we wouldn't reach this code, thus
         // the check seems redundant.
         if (require_full_clustering_key()) {
-            auto& col = s->column_at(column_kind::clustering_key, _restrictions->clustering_columns_restrictions_size());
-            throw exceptions::invalid_request_exception(format("Missing mandatory PRIMARY KEY part {}", col.name_as_text()));
+            throw exceptions::invalid_request_exception(format("Missing mandatory PRIMARY KEY part {}",
+                _restrictions->unrestricted_column(column_kind::clustering_key).name_as_text()));
         }
         // In general, we can't modify specific columns if not all clustering columns have been specified.
         // However, if we modify only static columns, it's fine since we won't really use the prefix anyway.
         if (!has_slice(ck_restrictions)) {
-            auto& col = s->column_at(column_kind::clustering_key, _restrictions->clustering_columns_restrictions_size());
             for (auto&& op : _column_operations) {
                 if (!op->column.is_static()) {
                     throw exceptions::invalid_request_exception(format("Primary key column '{}' must be specified in order to modify column '{}'",
-                        col.name_as_text(), op->column.name_as_text()));
+                        _restrictions->unrestricted_column(column_kind::clustering_key).name_as_text(), op->column.name_as_text()));
                 }
             }
         }
     }
     if (_restrictions->has_partition_key_unrestricted_components()) {
-        auto& col = s->column_at(column_kind::partition_key, _restrictions->partition_key_restrictions_size());
-        throw exceptions::invalid_request_exception(format("Missing mandatory PRIMARY KEY part {}", col.name_as_text()));
+        throw exceptions::invalid_request_exception(format("Missing mandatory PRIMARY KEY part {}",
+            _restrictions->unrestricted_column(column_kind::partition_key).name_as_text()));
     }
     if (has_conditions()) {
         validate_where_clause_for_conditions();

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -251,9 +251,7 @@ modification_statement::execute_without_checking_exception_message(query_process
 }
 
 void modification_statement::validate_primary_key_restrictions(const query_options& options) const {
-    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
-        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
-    }
+    _restrictions->validate_primary_key(options);
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -112,9 +112,6 @@ future<> modification_statement::check_access(query_processor& qp, const service
 
 future<std::vector<mutation>>
 modification_statement::get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs) const {
-    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
-        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
-    }
     auto cl = options.get_consistency();
     auto json_cache = maybe_prepare_json_cache(options);
     auto keys = build_partition_keys(options, json_cache);
@@ -262,6 +259,10 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     tracing::add_table_name(qs.get_trace_state(), keyspace(), column_family());
 
     inc_cql_stats(qs.get_client_state().is_internal());
+
+    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
+        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
+    }
 
     if (has_conditions()) {
         return execute_with_condition(qp, qs, options);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -250,10 +250,6 @@ modification_statement::execute_without_checking_exception_message(query_process
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 
-void modification_statement::validate_primary_key_restrictions(const query_options& options) const {
-    _restrictions->validate_primary_key(options);
-}
-
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
     if (has_conditions() && options.get_protocol_version() == 1) {
@@ -264,7 +260,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
 
     inc_cql_stats(qs.get_client_state().is_internal());
 
-    validate_primary_key_restrictions(options);
+    _restrictions->validate_primary_key(options);
 
     if (has_conditions()) {
         return execute_with_condition(qp, qs, options);

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -231,6 +231,8 @@ public:
     // True if this statement needs to read only static column values to check if it can be applied.
     bool has_only_static_column_conditions() const { return !_has_regular_column_conditions && _has_static_column_conditions; }
 
+    void validate_primary_key_restrictions(const query_options& options) const;
+
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;
 

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -231,8 +231,6 @@ public:
     // True if this statement needs to read only static column values to check if it can be applied.
     bool has_only_static_column_conditions() const { return !_has_regular_column_conditions && _has_static_column_conditions; }
 
-    void validate_primary_key_restrictions(const query_options& options) const;
-
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;
 

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -176,6 +176,8 @@ def test_delete_null_key(cql, table1):
         cql.execute(f"DELETE FROM {table1} WHERE p='p' AND c=null")
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(cql.prepare(f"DELETE FROM {table1} WHERE p='p' AND c=?"), [None])
+    with pytest.raises(InvalidRequest, match='null value.*p'):
+        cql.execute(cql.prepare(f"DELETE FROM {table1} WHERE p IN ?"), [None])
 
 # Test what SELECT does with the restriction "WHERE v=NULL".
 # In SQL, "WHERE v=NULL" doesn't match anything - because nothing is equal

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -19,6 +19,20 @@ def table1(cql, test_keyspace):
     yield table
     cql.execute("DROP TABLE " + table)
 
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (id text, a int, b int, c list<int>, PRIMARY KEY((id),a,b))")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
+@pytest.fixture(scope="module")
+def table3(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (id1 text, id2 text, a int, c list<int>, PRIMARY KEY((id1,id2),a))")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
 # An item cannot be inserted without a key. Verify that before we get into
 # the really interesting test below - trying to pass "null" as the value of
 # the key.
@@ -64,6 +78,51 @@ def test_insert_null_key_lwt(cql, table1):
         cql.execute(stmt, [s, None])
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [None, s])
+
+# INSERT statements must specify all components of the primary key,
+# and the corresponding query parameters, if any, must not be null.
+# If INSERT or DELETE statement is missing a non-last element of
+# the primary key, the error message generated contained
+# an invalid column name (#12046).
+# The problem occurred if the query contains a column with the list type,
+# otherwise statement_restrictions::process_clustering_columns_restrictions
+# checks that all the components of the key are specified.
+def test_insert_with_list_column_and_missing_clustering_key_part(cql, table2):
+    key = unique_key_string()
+    with pytest.raises(InvalidRequest,
+                       match='Missing mandatory PRIMARY KEY part a|Some clustering keys are missing: a'):
+        cql.execute(cql.prepare(f"INSERT INTO {table2} (id,b,c) VALUES ('{key}',1,null)"))
+    with pytest.raises(InvalidRequest,
+                       match='Missing mandatory PRIMARY KEY part b|Some clustering keys are missing: b'):
+        cql.execute(cql.prepare(f"INSERT INTO {table2} (id,a,c) VALUES ('{key}',1,null)"))
+
+# The same as test_insert_with_list_column_and_missing_clustering_key_part but for
+# different code path in modification_statement::process_where_clause.
+# We need DELETE here to have require_full_clustering_key() == false.
+# We use DELETE c FROM t syntax to make list column c mentioned in the statement
+# (it's also important to trigger the relevant code path), but
+# also to not bother with providing condition for it in the WHERE clause.
+def test_delete_with_list_column_and_missing_clustering_key_part(cql, table2):
+    key = unique_key_string()
+    cql.execute(cql.prepare(f"INSERT INTO {table2} (id,a,b,c) VALUES ('{key}',1,1,[1])"))
+    assert list(cql.execute(f"SELECT c FROM {table2} WHERE id='{key}' AND a=1 AND b=1"))[0][0] == [1]
+    with pytest.raises(InvalidRequest,
+                       match="Primary key column 'a' must be specified in order to modify column 'c'|"
+                             'PRIMARY KEY column "b" cannot be restricted as preceding column "a" is not restricted'):
+        cql.execute(cql.prepare(f"DELETE c FROM {table2} WHERE id='{key}' AND b=1"))
+    cql.execute(cql.prepare(f"DELETE c FROM {table2} WHERE id='{key}' AND a=1 AND b=1"))
+    assert list(cql.execute(f"SELECT c FROM {table2} WHERE id='{key}' AND a=1 AND b=1"))[0][0] is None
+
+# The same as test_insert_with_list_column_and_missing_clustering_key_part but
+# for partition key.
+def test_insert_with_list_column_and_missing_partition_key_part(cql, table3):
+    key = unique_key_string()
+    with pytest.raises(InvalidRequest,
+                       match='Missing mandatory PRIMARY KEY part id1|Some partition key parts are missing: id1'):
+        cql.execute(cql.prepare(f"INSERT INTO {table3} (id2,a,c) VALUES ('{key}',1,[1])"))
+    with pytest.raises(InvalidRequest,
+                       match='Missing mandatory PRIMARY KEY part id2|Some partition key parts are missing: id2'):
+        cql.execute(cql.prepare(f"INSERT INTO {table3} (id1,a,c) VALUES ('{key}',1,[1])"))
 
 # Tests handling of "key_column in ?" where ? is bound to null.
 # Reproduces issue #8265.

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -52,7 +52,6 @@ def test_insert_null_key(cql, table1):
 
 # Same as test_insert_null_key() above, just adds IF NOT EXISTS and
 # reproduces issue #11954.
-@pytest.mark.skip(reason="#11954 crashes Scylla")
 def test_insert_null_key_lwt(cql, table1):
     s = unique_key_string()
     with pytest.raises(InvalidRequest, match='null value'):

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -51,9 +51,9 @@ def test_insert_missing_key(cql, table1):
 # This reproduces issue #7852.
 def test_insert_null_key(cql, table1):
     s = unique_key_string()
-    with pytest.raises(InvalidRequest, match='null value'):
+    with pytest.raises(InvalidRequest, match='Invalid null value in condition for column c'):
         cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('{s}', null)")
-    with pytest.raises(InvalidRequest, match='null value'):
+    with pytest.raises(InvalidRequest, match='Invalid null value in condition for column p'):
         cql.execute(f"INSERT INTO {table1} (p,c) VALUES (null, '{s}')")
     # Try the same thing with prepared statement, where a "None" stands for
     # a null. Note that this is completely different from UNSET_VALUE - only

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -79,6 +79,31 @@ def test_insert_null_key_lwt(cql, table1):
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [None, s])
 
+# Contains the same checks as test_insert_null_key() and test_insert_null_key_lwt() above, just inside a batch
+def test_insert_null_key_in_batch(cql, table1):
+    s = unique_key_string()
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES ('{s}', null);APPLY BATCH;")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES ('{s}', null) IF NOT EXISTS;APPLY BATCH;")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES (null, '{s}');APPLY BATCH;")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES (null, '{s}') IF NOT EXISTS;APPLY BATCH;")
+
+    # Try the same thing with prepared statement.
+    stmt = cql.prepare(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES (?, ?);APPLY BATCH;")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(stmt, [s, None])
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(stmt, [None, s])
+
+    stmt = cql.prepare(f"BEGIN BATCH INSERT INTO {table1} (p,c) VALUES (?, ?) IF NOT EXISTS;APPLY BATCH;")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(stmt, [s, None])
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(stmt, [None, s])
+
 # INSERT statements must specify all components of the primary key,
 # and the corresponding query parameters, if any, must not be null.
 # If INSERT or DELETE statement is missing a non-last element of


### PR DESCRIPTION
[PR](https://github.com/scylladb/scylladb/pull/9314) fixed a similar issue with regular insert statements
but missed the LWT code path.

It's expected behaviour of
`modification_statement::create_clustering_ranges` to return an
empty range in this case, since `possible_lhs_values` it
uses explicitly returns `empty_value_set` if it evaluates `rhs`
to null, and it has a comment about it (All NULL
comparisons fail; no column values match.) On the other hand,
all components of the primary key are required to be set,
this is checked at the prepare phase, in
`modification_statement::process_where_clause`. So the only
problem was `modification_statement::execute_with_condition`
was not expecting an empty `clustering_range` in case of
a null clustering key.

Also this patch contains a fix for the problem with wrong
column name in Scylla error messages. If `INSERT` or `DELETE`
statement is missing a non-last element of
the primary key, the error message generated contains
an invalid column name.

The problem occurs if the query contains a column with the list type,
otherwise
`statement_restrictions::process_clustering_columns_restrictions`
checks that all the components of the key are specified.
