### PR TITLE
alternator: make Alternator TTL feature no longer "experimental"

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1065,7 +1065,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"udf", feature::UDF},
         {"cdc", feature::UNUSED},
         {"alternator-streams", feature::ALTERNATOR_STREAMS},
-        {"alternator-ttl", feature::ALTERNATOR_TTL},
+        {"alternator-ttl", feature::UNUSED },
         {"raft", feature::RAFT},
         {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},

--- a/db/config.hh
+++ b/db/config.hh
@@ -84,7 +84,7 @@ struct experimental_features_t {
     // NOTE: RAFT and BROADCAST_TABLES features are not enabled via `experimental` umbrella flag.
     // These options should be enabled explicitly.
     // RAFT feature has to be enabled if BROADCAST_TABLES is enabled.
-    enum class feature { UNUSED, UDF, ALTERNATOR_STREAMS, ALTERNATOR_TTL, RAFT,
+    enum class feature { UNUSED, UDF, ALTERNATOR_STREAMS, RAFT,
             BROADCAST_TABLES, KEYSPACE_STORAGE_OPTIONS };
     static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -60,9 +60,6 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
     if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
         fcfg._disabled_features.insert("ALTERNATOR_STREAMS"s);
     }
-    if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_TTL)) {
-        fcfg._disabled_features.insert("ALTERNATOR_TTL"s);
-    }
     if (!cfg.check_experimental(db::experimental_features_t::feature::RAFT)) {
         fcfg._disabled_features.insert("SUPPORTS_RAFT_CLUSTER_MANAGEMENT"s);
     }

--- a/main.cc
+++ b/main.cc
@@ -1638,17 +1638,15 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 // only Alternator uses it for its TTL feature. But in the
                 // future if we add a CQL interface to it, we may want to
                 // start this outside the Alternator if().
-                if (cfg->check_experimental(db::experimental_features_t::feature::ALTERNATOR_TTL)) {
-                    supervisor::notify("starting the expiration service");
-                    es.start(seastar::sharded_parameter([] (const replica::database& db) { return db.as_data_dictionary(); }, std::ref(db)),
-                             std::ref(proxy), std::ref(gossiper)).get();
-                    stop_expiration_service = defer_verbose_shutdown("expiration service", [&es] {
-                        es.stop().get();
-                    });
-                    with_scheduling_group(maintenance_scheduling_group, [&es] {
-                        return es.invoke_on_all(&alternator::expiration_service::start);
-                    }).get();
-                }
+                supervisor::notify("starting the expiration service");
+                es.start(seastar::sharded_parameter([] (const replica::database& db) { return db.as_data_dictionary(); }, std::ref(db)),
+                         std::ref(proxy), std::ref(gossiper)).get();
+                stop_expiration_service = defer_verbose_shutdown("expiration service", [&es] {
+                    es.stop().get();
+                });
+                with_scheduling_group(maintenance_scheduling_group, [&es] {
+                    return es.invoke_on_all(&alternator::expiration_service::start);
+                }).get();
             }
             ss.local().register_protocol_server(alternator_ctl);
 

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -49,7 +49,6 @@ def run_alternator_cmd(pid, dir):
         # We only list here Alternator-specific experimental features - CQL
         # ones are listed in test/cql-pytest/run.py.
         '--experimental-features=alternator-streams',
-        '--experimental-features=alternator-ttl',
     ]
     if '--https' in sys.argv:
         run.setup_ssl_certificate(dir)


### PR DESCRIPTION
Until now, the Alternator TTL feature was considered "experimental", and had to be manually enabled on all nodes of the cluster to be usable.

This patch removes this requirement and in essence GAs this feature.

Even after this patch, Alternator TTL is still a "cluster feature", i.e., for this feature to be usable every node in the cluster needs to support it. If any of the nodes is old and does not yet support this feature, the UpdateTimeToLive request will not be accepted, so although the expiration-scanning threads may exist on the newer nodes, they will not do anything because none of the tables can be marked as having expiration enabled.

This patch does not contain documentation fixes - the documentation still suggests that the Alternator TTL feature is experimental. The documentation patch will come separately.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>