### PR TITLE
cql3: expr: make it possible to evaluate expr::binary_operator

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -233,21 +233,6 @@ bool equal(const expression& lhs, const expression& rhs, const evaluation_inputs
     return equal(lhs, evaluate(rhs, inputs).to_managed_bytes_opt(), inputs);
 }
 
-/// True iff columns' values equal t.
-bool equal(const tuple_constructor& columns_tuple_lhs, const expression& t_rhs, const evaluation_inputs& inputs) {
-    const cql3::raw_value tup = evaluate(t_rhs, inputs);
-    const auto& rhs = get_tuple_elements(tup, *type_of(t_rhs));
-    if (rhs.size() != columns_tuple_lhs.elements.size()) {
-        throw exceptions::invalid_request_exception(
-                format("tuple equality size mismatch: {} elements on left-hand side, {} on right",
-                       columns_tuple_lhs.elements.size(), rhs.size()));
-    }
-    return boost::equal(columns_tuple_lhs.elements, rhs,
-    [&] (const expression& lhs, const managed_bytes_opt& b) {
-        return equal(lhs, b, inputs);
-    });
-}
-
 /// True iff lhs is limited by rhs in the manner prescribed by op.
 bool limits(managed_bytes_view lhs, oper_t op, managed_bytes_view rhs, const abstract_type& type) {
     const auto cmp = type.compare(lhs, rhs);

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1683,41 +1683,33 @@ cql3::raw_value evaluate(const binary_operator& binop, const evaluation_inputs& 
     bool_or_null binop_result(false);
 
     switch (binop.op) {
-        case oper_t::EQ: {
+        case oper_t::EQ:
             binop_result = equal(binop.lhs, binop.rhs, inputs);
             break;
-        }
-        case oper_t::NEQ: {
+        case oper_t::NEQ:
             binop_result = not_equal(binop.lhs, binop.rhs, inputs);
             break;
-        }
         case oper_t::LT:
         case oper_t::LTE:
         case oper_t::GT:
-        case oper_t::GTE: {
+        case oper_t::GTE:
             binop_result = limits(binop.lhs, binop.op, binop.rhs, inputs);
             break;
-        }
-        case oper_t::CONTAINS: {
+        case oper_t::CONTAINS:
             binop_result = contains(binop.lhs, binop.rhs, inputs);
             break;
-        }
-        case oper_t::CONTAINS_KEY: {
+        case oper_t::CONTAINS_KEY:
             binop_result = contains_key(binop.lhs, binop.rhs, inputs);
             break;
-        }
-        case oper_t::LIKE: {
+        case oper_t::LIKE:
             binop_result = like(binop.lhs, binop.rhs, inputs);
             break;
-        }
-        case oper_t::IN: {
+        case oper_t::IN:
             binop_result = is_one_of(binop.lhs, binop.rhs, inputs);
             break;
-        }
-        case oper_t::IS_NOT: {
+        case oper_t::IS_NOT:
             binop_result = is_not_null(binop.lhs, binop.rhs, inputs);
             break;
-        }
     };
 
     if (binop_result.is_null()) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -252,7 +252,7 @@ public:
 bool_or_null equal(const expression& lhs, const managed_bytes_opt& rhs_bytes, const evaluation_inputs& inputs) {
     raw_value lhs_value = evaluate(lhs, inputs);
     if (lhs_value.is_unset_value()) {
-        throw exceptions::invalid_request_exception("UNSET_VALUE found on left-hand side of an equality operator");
+        throw exceptions::invalid_request_exception("unset value found on left-hand side of an equality operator");
     }
     if (lhs_value.is_null() || !rhs_bytes.has_value()) {
         return bool_or_null::null();
@@ -271,11 +271,11 @@ static std::optional<std::pair<managed_bytes, managed_bytes>> evaluate_binop_sid
 
     if (lhs_value.is_unset_value()) {
         throw exceptions::invalid_request_exception(
-            format("UNSET_VALUE found on left-hand side of a binary operator with operation {}", op));
+            format("unset value found on left-hand side of a binary operator with operation {}", op));
     }
     if (rhs_value.is_unset_value()) {
         throw exceptions::invalid_request_exception(
-            format("UNSET_VALUE found on right-hand side of a binary operator with operation {}", op));
+            format("unset value found on right-hand side of a binary operator with operation {}", op));
     }
     if (lhs_value.is_null() || rhs_value.is_null()) {
         return std::nullopt;
@@ -493,12 +493,12 @@ bool_or_null is_one_of(const expression& lhs, const expression& rhs, const evalu
 bool is_not_null(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
     cql3::raw_value lhs_val = evaluate(lhs, inputs);
     if (lhs_val.is_unset_value()) {
-        throw exceptions::invalid_request_exception("UNSET_VALUE found on left hand side of IS NOT operator");
+        throw exceptions::invalid_request_exception("unset value found on left hand side of IS NOT operator");
     }
 
     cql3::raw_value rhs_val = evaluate(rhs, inputs);
     if (rhs_val.is_unset_value()) {
-        throw exceptions::invalid_request_exception("UNSET_VALUE found on right hand side of IS NOT operator");
+        throw exceptions::invalid_request_exception("unset value found on right hand side of IS NOT operator");
     }
     if (!rhs_val.is_null()) {
         throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
@@ -555,7 +555,7 @@ bool is_satisfied_by(const binary_operator& opr, const evaluation_inputs& inputs
         return false;
     }
     if (binop_eval_result.is_unset_value()) {
-        on_internal_error(expr_logger, format("is_satisfied_by: binary operator evaluated to UNSET_VALUE: {}", opr));
+        on_internal_error(expr_logger, format("is_satisfied_by: binary operator evaluated to unset value: {}", opr));
     }
     if (binop_eval_result.is_empty_value()) {
         on_internal_error(expr_logger, format("is_satisfied_by: binary operator evaluated to EMPTY_VALUE: {}", opr));

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -362,10 +362,11 @@ bool contains(const data_value& collection, const raw_value_view& value) {
 }
 
 /// True iff a column is a collection containing value.
-bool contains(const column_value& col, const raw_value_view& value, const evaluation_inputs& inputs) {
-    const auto collection = get_value(col, inputs);
-    if (collection) {
-        return contains(col.col->type->deserialize(managed_bytes_view(*collection)), value);
+bool contains(const expression& collection_val, const raw_value_view& value, const evaluation_inputs& inputs) {
+    const data_type collection_type = type_of(collection_val);
+    const managed_bytes_opt collection_bytes = evaluate(collection_val, inputs).to_managed_bytes_opt();
+    if (collection_bytes) {
+        return contains(collection_type->deserialize(managed_bytes_view(*collection_bytes)), value);
     } else {
         return false;
     }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1770,8 +1770,21 @@ cql3::raw_value evaluate(const binary_operator& binop, const evaluation_inputs& 
             binop_result = is_one_of(binop.lhs, binop.rhs, inputs);
             break;
         }
-        default: {
-            throw exceptions::unsupported_operation_exception(format("Unhandled binary_operator: {}", binop));
+        case oper_t::IS_NOT: {
+            cql3::raw_value lhs_val = evaluate(binop.lhs, inputs);
+            if (lhs_val.is_unset_value()) {
+                throw exceptions::invalid_request_exception("UNSET_VALUE found on left hand side of IS NOT operator");
+            }
+
+            cql3::raw_value rhs_val = evaluate(binop.rhs, inputs);
+            if (rhs_val.is_unset_value()) {
+                throw exceptions::invalid_request_exception("UNSET_VALUE found on right hand side of IS NOT operator");
+            }
+            if (!rhs_val.is_null()) {
+                throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
+            }
+            binop_result = !lhs_val.is_null();
+            break;
         }
     };
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1728,10 +1728,60 @@ std::optional<bool> get_bool_value(const constant& constant_val) {
     return constant_val.view().deserialize<bool>(*boolean_type);
 }
 
+cql3::raw_value evaluate(const binary_operator& binop, const evaluation_inputs& inputs) {
+    if (binop.order == comparison_order::clustering) {
+        throw exceptions::invalid_request_exception("Can't evaluate a binary operator with SCYLLA_CLUSTERING_BOUND");
+    }
+
+    bool binop_result;
+
+    switch (binop.op) {
+        case oper_t::EQ: {
+            binop_result = equal(binop.lhs, binop.rhs, inputs);
+            break;
+        }
+        case oper_t::NEQ: {
+            binop_result = !equal(binop.lhs, binop.rhs, inputs);
+            break;
+        }
+        case oper_t::LT:
+        case oper_t::LTE:
+        case oper_t::GT:
+        case oper_t::GTE: {
+            binop_result = limits(binop.lhs, binop.op, binop.rhs, inputs);
+            break;
+        }
+        case oper_t::CONTAINS: {
+            cql3::raw_value val = evaluate(binop.rhs, inputs);
+            binop_result = contains(binop.lhs, val.view(), inputs);
+            break;
+        }
+        case oper_t::CONTAINS_KEY: {
+            cql3::raw_value val = evaluate(binop.rhs, inputs);
+            binop_result = contains_key(binop.lhs, val.view(), inputs);
+            break;
+        }
+        case oper_t::LIKE: {
+            cql3::raw_value val = evaluate(binop.rhs, inputs);
+            binop_result = like(binop.lhs, val.view(), inputs);
+            break;
+        }
+        case oper_t::IN: {
+            binop_result = is_one_of(binop.lhs, binop.rhs, inputs);
+            break;
+        }
+        default: {
+            throw exceptions::unsupported_operation_exception(format("Unhandled binary_operator: {}", binop));
+        }
+    };
+
+    return raw_value::make_value(boolean_type->decompose(binop_result));
+}
+
 cql3::raw_value evaluate(const expression& e, const evaluation_inputs& inputs) {
     return expr::visit(overloaded_functor {
-        [](const binary_operator&) -> cql3::raw_value {
-            on_internal_error(expr_logger, "Can't evaluate a binary_operator");
+        [&](const binary_operator& binop) -> cql3::raw_value {
+            return evaluate(binop, inputs);
         },
         [](const conjunction&) -> cql3::raw_value {
             on_internal_error(expr_logger, "Can't evaluate a conjunction");

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2566,3 +2566,20 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_eq) {
 
     test_evaluate_binop_null_unset(oper_t::EQ, make_int_const(123), make_int_const(456));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_neq) {
+    expression true_neq_binop = binary_operator(make_int_const(1), oper_t::NEQ, make_int_const(1000));
+    BOOST_REQUIRE_EQUAL(evaluate(true_neq_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_neq_binop = binary_operator(make_int_const(2), oper_t::NEQ, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_neq_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_neq_empty =
+        binary_operator(make_empty_const(int32_type), oper_t::NEQ, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_neq_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_neq_0 = binary_operator(make_empty_const(int32_type), oper_t::NEQ, make_int_const(0));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_neq_0, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::NEQ, make_int_const(123), make_int_const(456));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2603,3 +2603,24 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lt) {
 
     test_evaluate_binop_null_unset(oper_t::LT, make_int_const(123), make_int_const(456));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lte) {
+    expression true_lte_binop = binary_operator(make_int_const(1), oper_t::LTE, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lte_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression true_lte_binop2 = binary_operator(make_int_const(12), oper_t::LTE, make_int_const(12));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lte_binop2, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_lte_binop = binary_operator(make_int_const(123), oper_t::LTE, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lte_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_lte_empty =
+        binary_operator(make_empty_const(int32_type), oper_t::LTE, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_lte_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression empty_lte_int_min =
+        binary_operator(make_empty_const(int32_type), oper_t::LT, make_int_const(std::numeric_limits<int32_t>::min()));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_lte_int_min, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::LTE, make_int_const(123), make_int_const(456));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2780,3 +2780,34 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains) {
 
     test_evaluate_binop_null_unset(oper_t::CONTAINS, map_val, make_int_const(5));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains_key) {
+    expression map_val = make_int_int_map_const({{1, 2}, {3, 4}, {5, 6}});
+
+    expression true_contains_key_binop = binary_operator(map_val, oper_t::CONTAINS_KEY, make_int_const(5));
+    BOOST_REQUIRE_EQUAL(evaluate(true_contains_key_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_contains_key_binop = binary_operator(map_val, oper_t::CONTAINS_KEY, make_int_const(6));
+    BOOST_REQUIRE_EQUAL(evaluate(false_contains_key_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression map_contains_key_empty = binary_operator(map_val, oper_t::CONTAINS_KEY, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_key_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression map_with_empty =
+        make_map_const({{make_empty_const(int32_type), make_int_const(2)}, {make_int_const(3), make_int_const(4)}},
+                       int32_type, int32_type);
+    expression map_with_empty_contains_key_empty =
+        binary_operator(map_with_empty, oper_t::CONTAINS_KEY, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_key_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression map_with_empty_contains_key_existing_int =
+        binary_operator(map_with_empty, oper_t::CONTAINS_KEY, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_key_existing_int, evaluation_inputs{}), make_bool_raw(true));
+
+    expression map_with_empty_contains_key_nonexisting_int =
+        binary_operator(map_with_empty, oper_t::CONTAINS_KEY, make_int_const(4));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_key_nonexisting_int, evaluation_inputs{}),
+                        make_bool_raw(false));
+
+    test_evaluate_binop_null_unset(oper_t::CONTAINS_KEY, map_val, make_int_const(5));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2692,3 +2692,91 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in) {
 
     test_evaluate_binop_null_unset(oper_t::IN, make_int_const(5), in_list);
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_list_contains) {
+    expression list_val = make_int_list_const({1, 3, 5});
+
+    expression list_contains_true = binary_operator(list_val, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(list_contains_true, evaluation_inputs{}), make_bool_raw(true));
+
+    expression list_contains_false = binary_operator(list_val, oper_t::CONTAINS, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(list_contains_false, evaluation_inputs{}), make_bool_raw(false));
+
+    expression list_contains_empty = binary_operator(list_val, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(list_contains_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression list_with_empty =
+        make_list_const({make_int_const(1), make_empty_const(int32_type), make_int_const(3)}, int32_type);
+    expression list_with_empty_contains_empty =
+        binary_operator(list_with_empty, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(list_with_empty_contains_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression list_with_empty_contains_existing_int =
+        binary_operator(list_with_empty, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(list_with_empty_contains_existing_int, evaluation_inputs{}), make_bool_raw(true));
+
+    expression list_with_empty_contains_nonexisting_int =
+        binary_operator(list_with_empty, oper_t::CONTAINS, make_int_const(321));
+    BOOST_REQUIRE_EQUAL(evaluate(list_with_empty_contains_nonexisting_int, evaluation_inputs{}), make_bool_raw(false));
+
+    test_evaluate_binop_null_unset(oper_t::CONTAINS, list_val, make_int_const(5));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_set_contains) {
+    expression set_val = make_int_set_const({1, 3, 5});
+
+    expression set_contains_true = binary_operator(set_val, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(set_contains_true, evaluation_inputs{}), make_bool_raw(true));
+
+    expression set_contains_false = binary_operator(set_val, oper_t::CONTAINS, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(set_contains_false, evaluation_inputs{}), make_bool_raw(false));
+
+    expression set_contains_empty = binary_operator(set_val, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(set_contains_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression set_with_empty =
+        make_set_const({make_empty_const(int32_type), make_int_const(2), make_int_const(3)}, int32_type);
+    expression set_with_empty_contains_empty =
+        binary_operator(set_with_empty, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(set_with_empty_contains_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression set_with_empty_contains_existing_int =
+        binary_operator(set_with_empty, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(set_with_empty_contains_existing_int, evaluation_inputs{}), make_bool_raw(true));
+
+    expression set_with_empty_contains_nonexisting_int =
+        binary_operator(set_with_empty, oper_t::CONTAINS, make_int_const(321));
+    BOOST_REQUIRE_EQUAL(evaluate(set_with_empty_contains_nonexisting_int, evaluation_inputs{}), make_bool_raw(false));
+
+    test_evaluate_binop_null_unset(oper_t::CONTAINS, set_val, make_int_const(5));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains) {
+    expression map_val = make_int_int_map_const({{1, 2}, {3, 4}, {5, 6}});
+
+    expression map_contains_true = binary_operator(map_val, oper_t::CONTAINS, make_int_const(4));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_true, evaluation_inputs{}), make_bool_raw(true));
+
+    expression map_contains_false = binary_operator(map_val, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_false, evaluation_inputs{}), make_bool_raw(false));
+
+    expression map_contains_empty = binary_operator(map_val, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(map_contains_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression map_with_empty =
+        make_map_const({{make_int_const(1), make_empty_const(int32_type)}, {make_int_const(3), make_int_const(4)}},
+                       int32_type, int32_type);
+    expression map_with_empty_contains_empty =
+        binary_operator(map_with_empty, oper_t::CONTAINS, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression map_with_empty_contains_existing_int =
+        binary_operator(map_with_empty, oper_t::CONTAINS, make_int_const(4));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_existing_int, evaluation_inputs{}), make_bool_raw(true));
+
+    expression map_with_empty_contains_nonexisting_int =
+        binary_operator(map_with_empty, oper_t::CONTAINS, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(evaluate(map_with_empty_contains_nonexisting_int, evaluation_inputs{}), make_bool_raw(false));
+
+    test_evaluate_binop_null_unset(oper_t::CONTAINS, map_val, make_int_const(5));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2583,3 +2583,23 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_neq) {
 
     test_evaluate_binop_null_unset(oper_t::NEQ, make_int_const(123), make_int_const(456));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lt) {
+    expression true_lt_binop = binary_operator(make_int_const(1), oper_t::LT, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(true_lt_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_lt_binop = binary_operator(make_int_const(10), oper_t::LT, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lt_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression false_lt_binop2 = binary_operator(make_int_const(2), oper_t::LT, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_lt_binop2, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_lt_empty = binary_operator(make_empty_const(int32_type), oper_t::LT, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_lt_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_lt_int_min =
+        binary_operator(make_empty_const(int32_type), oper_t::LT, make_int_const(std::numeric_limits<int32_t>::min()));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_lt_int_min, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::LT, make_int_const(123), make_int_const(456));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2839,3 +2839,27 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
         binary_operator(constant::make_unset_value(int32_type), oper_t::IS_NOT, constant::make_unset_value(int32_type));
     BOOST_REQUIRE_THROW(evaluate(unset_is_not_unset, evaluation_inputs{}), exceptions::invalid_request_exception);
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_like) {
+    expression true_like_binop = binary_operator(make_text_const("some_text"), oper_t::LIKE, make_text_const("some_%"));
+    BOOST_REQUIRE_EQUAL(evaluate(true_like_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_like_binop =
+        binary_operator(make_text_const("some_text"), oper_t::LIKE, make_text_const("some_other_%"));
+    BOOST_REQUIRE_EQUAL(evaluate(false_like_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    // Binary representation of an empty value is the same as empty string
+    BOOST_REQUIRE_EQUAL(make_text_raw(""), make_empty_raw());
+
+    expression empty_like_text = binary_operator(make_empty_const(utf8_type), oper_t::LIKE, make_text_const("%"));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_like_text, evaluation_inputs{}), make_bool_raw(true));
+
+    expression text_like_empty = binary_operator(make_text_const(""), oper_t::LIKE, make_empty_const(utf8_type));
+    BOOST_REQUIRE_EQUAL(evaluate(text_like_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression empty_like_empty =
+        binary_operator(make_empty_const(utf8_type), oper_t::LIKE, make_empty_const(utf8_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_like_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::LIKE, make_text_const("some_text"), make_text_const("some_%"));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2644,3 +2644,24 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gt) {
 
     test_evaluate_binop_null_unset(oper_t::GT, make_int_const(234), make_int_const(-3434));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gte) {
+    expression true_gte_binop = binary_operator(make_int_const(20), oper_t::GTE, make_int_const(10));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gte_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression true_gte_binop2 = binary_operator(make_int_const(10), oper_t::GTE, make_int_const(10));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gte_binop2, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_gte_binop = binary_operator(make_int_const(-10), oper_t::GTE, make_int_const(10));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gte_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_gte_empty =
+        binary_operator(make_empty_const(int32_type), oper_t::GTE, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_gte_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression int_min_gte_empty =
+        binary_operator(make_int_const(std::numeric_limits<int32_t>::min()), oper_t::GTE, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(int_min_gte_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::GTE, make_int_const(234), make_int_const(-3434));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2811,3 +2811,31 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_map_contains_key) {
 
     test_evaluate_binop_null_unset(oper_t::CONTAINS_KEY, map_val, make_int_const(5));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
+    expression true_is_not_binop = binary_operator(make_int_const(1), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_is_not_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_is_not_binop =
+        binary_operator(constant::make_null(int32_type), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_is_not_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression forbidden_is_not_binop = binary_operator(make_int_const(1), oper_t::IS_NOT, make_int_const(2));
+    BOOST_REQUIRE_THROW(evaluate(forbidden_is_not_binop, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression empty_is_not_null =
+        binary_operator(make_empty_const(int32_type), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_is_not_null, evaluation_inputs{}), make_bool_raw(true));
+
+    expression unset_is_not_null =
+        binary_operator(constant::make_unset_value(int32_type), oper_t::IS_NOT, constant::make_null(int32_type));
+    BOOST_REQUIRE_THROW(evaluate(unset_is_not_null, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression int_is_not_unset =
+        binary_operator(make_int_const(123), oper_t::IS_NOT, constant::make_unset_value(int32_type));
+    BOOST_REQUIRE_THROW(evaluate(int_is_not_unset, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression unset_is_not_unset =
+        binary_operator(constant::make_unset_value(int32_type), oper_t::IS_NOT, constant::make_unset_value(int32_type));
+    BOOST_REQUIRE_THROW(evaluate(unset_is_not_unset, evaluation_inputs{}), exceptions::invalid_request_exception);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2624,3 +2624,23 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_lte) {
 
     test_evaluate_binop_null_unset(oper_t::LTE, make_int_const(123), make_int_const(456));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gt) {
+    expression true_gt_binop = binary_operator(make_int_const(2), oper_t::GT, make_int_const(1));
+    BOOST_REQUIRE_EQUAL(evaluate(true_gt_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_gt_binop = binary_operator(make_int_const(1), oper_t::GT, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gt_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression false_gt_binop2 = binary_operator(make_int_const(2), oper_t::GT, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(evaluate(false_gt_binop2, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_gt_empty = binary_operator(make_empty_const(int32_type), oper_t::GT, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_gt_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression int_min_gt_empty =
+        binary_operator(make_int_const(std::numeric_limits<int32_t>::min()), oper_t::GT, make_empty_const(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(int_min_gt_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null_unset(oper_t::GT, make_int_const(234), make_int_const(-3434));
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2665,3 +2665,30 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_gte) {
 
     test_evaluate_binop_null_unset(oper_t::GTE, make_int_const(234), make_int_const(-3434));
 }
+
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in) {
+    // IN expects a list as its rhs, sets are not allowed
+    expression in_list = make_int_list_const({1, 3, 5});
+
+    expression true_in_binop = binary_operator(make_int_const(3), oper_t::IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(true_in_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression false_in_binop = binary_operator(make_int_const(2), oper_t::IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(false_in_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression empty_in_list = binary_operator(make_empty_const(int32_type), oper_t::IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(empty_in_list, evaluation_inputs{}), make_bool_raw(false));
+
+    expression list_with_empty =
+        make_list_const({make_int_const(1), make_empty_const(int32_type), make_int_const(3)}, int32_type);
+    expression empty_in_list_with_empty = binary_operator(make_empty_const(int32_type), oper_t::IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(empty_in_list_with_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression existing_int_in_list_with_empty = binary_operator(make_int_const(3), oper_t::IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(existing_int_in_list_with_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    expression nonexisting_int_in_list_with_empty = binary_operator(make_int_const(321), oper_t::IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(nonexisting_int_in_list_with_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    test_evaluate_binop_null_unset(oper_t::IN, make_int_const(5), in_list);
+}

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -305,10 +305,10 @@ def testListWithUnsetValues(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT l FROM %s WHERE k = 10"), [l])
 
         # select with in clause
-        assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * FROM %s WHERE k IN ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * FROM %s WHERE k IN ?", UNSET_VALUE)
         # The following cannot be tested with the Python driver because it
         # captures this case before sending it to the server.
-        #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * FROM %s WHERE k IN (?)", UNSET_VALUE)
+        #assert_invalid_message(cql, table, "unset value", "SELECT * FROM %s WHERE k IN (?)", UNSET_VALUE)
 
 def testSetWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s set<text>)") as table:

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -496,24 +496,24 @@ def testWithUnsetValues(cql, test_keyspace):
         # Test commented out because the Python driver can't send an
         # UNSET_VALUE for the partition key (it is needed to decide
         # which coordinator to send the request to!)
-        #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * from %s WHERE k = ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * from %s WHERE k IN ?", UNSET_VALUE)
+        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN ?", UNSET_VALUE)
         # Test commented out because the Python driver can't send an
         # UNSET_VALUE for the partition key (it is needed to decide
         # which coordinator to send the request to!)
-        #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * from %s WHERE k IN(?)", UNSET_VALUE)
-        #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * from %s WHERE k IN(?,?)", 1, UNSET_VALUE)
+        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?)", UNSET_VALUE)
+        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?,?)", 1, UNSET_VALUE)
         # clustering column
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE k = 1 AND i = ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE k = 1 AND i IN ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE k = 1 AND i IN(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE k = 1 AND i IN(?,?)", 1, UNSET_VALUE)
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE i = ? ALLOW FILTERING", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i = ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN(?)", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN(?,?)", 1, UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE i = ? ALLOW FILTERING", UNSET_VALUE)
         # indexed column
-        assert_invalid_message(cql, table, "Unsupported unset value for column s", "SELECT * from %s WHERE s = ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE s = ?", UNSET_VALUE)
         # range
-        assert_invalid_message(cql, table, "Invalid unset value for column i", "SELECT * from %s WHERE k = 1 AND i > ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i > ?", UNSET_VALUE)
 
 def testInvalidSliceRestrictionOnPartitionKey(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c text)") as table:

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -240,7 +240,7 @@ def testSetContainsWithIndex(cql, test_keyspace):
             #assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "Unsupported unset value for column categories",
+            assert_invalid_message(cql, table, "unset value",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
 
             assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -270,7 +270,7 @@ def testListContainsWithIndex(cql, test_keyspace):
             #assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "Unsupported unset value for column categories",
+            assert_invalid_message(cql, table, "unset value",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
 
             assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -315,7 +315,7 @@ def testMapKeyContainsWithIndex(cql, test_keyspace):
             #assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "Unsupported unset value for column categories",
+            assert_invalid_message(cql, table, "unset value",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, UNSET_VALUE)
 
             assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -352,7 +352,7 @@ def testMapValueContainsWithIndex(cql, test_keyspace):
             #assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "Unsupported unset value for column categories",
+            assert_invalid_message(cql, table, "unset value",
                                  "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
 
             assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -1021,13 +1021,13 @@ def testFilteringWithoutIndices(cql, test_keyspace):
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column s",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE s = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
                              UNSET_VALUE)
 
@@ -1106,16 +1106,16 @@ def testFilteringWithoutIndicesWithCollections(cql, test_keyspace):
 
         # Checks filtering with unset
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column d",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
                              UNSET_VALUE)
         assert_invalid_message(cql, table, "Unsupported unset map key for column e",
@@ -1257,25 +1257,25 @@ def testFilteringWithoutIndicesWithFrozenCollections(cql, test_keyspace):
 
         # Checks filtering with unset
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column d",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE d = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column d",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE e = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
                              UNSET_VALUE)
         assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
@@ -1416,10 +1416,10 @@ def testAllowFilteringOnPartitionKey(cql, test_keyspace):
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "Unsupported unset value for column a",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a = ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column a",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a > ? ALLOW FILTERING",
                              UNSET_VALUE)
 
@@ -1635,16 +1635,16 @@ def testAllowFilteringOnPartitionKeyWithoutIndicesWithCollections(cql, test_keys
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "Unsupported unset value for column c",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND c CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column d",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND d CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS ? ALLOW FILTERING",
                              UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset value for column e",
+        assert_invalid_message(cql, table, "unset value",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS KEY ? ALLOW FILTERING",
                              UNSET_VALUE)
         assert_invalid_message(cql, table, "Unsupported unset map key for column e",

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -1125,7 +1125,6 @@ def testFilteringWithoutIndicesWithCollections(cql, test_keyspace):
                              "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
                              UNSET_VALUE)
 
-@pytest.mark.xfail(reason="#10358")
 def testFilteringWithoutIndicesWithFrozenCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, d frozen<set<int>>, e frozen<map<int, int>>, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
@@ -1348,7 +1347,6 @@ def testAllowFilteringOnPartitionKeyWithDistinct(cql, test_keyspace):
             assert_invalid_message(cql, table, "queries must only request partition key columns",
                     "SELECT DISTINCT pk0, pk1, ck0 FROM %s ALLOW FILTERING")
 
-@pytest.mark.xfail(reason="#10358")
 def testAllowFilteringOnPartitionKey(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c))") as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 12, 13, 14)")


### PR DESCRIPTION
As a part of CQL rewrite we want to be able to perform filtering by calling `evaluate()` on an expression and checking if it evaluates to `true`. Currently trying to do that for a binary operator would result in an error.

Right now checking if a binary operation like `col1 = 123` is true is done using `is_satisfied_by`, which is able to check if a binary operation evaluates to true for a small set of predefined cases.

Eventually once the grammar is relaxed we will be able to write expressions like: `(col1 < col2) = (1 > ?)`, which doesn't fit with what `is_satisfied_by` is supposed to do.
Additionally expressions like `1 = NULL` should evaluate to `NULL`, not `true` or `false`. `is_satsified_by` is not able to express that properly.

The proper way to go is implementing `evaluate(binary_operator)`, which takes a binary operation and returns what the result of it would be.

Implementing `prepare_expression` for `binary_operator` requires us to be able to evaluate it first. In the next PR I will add support for `prepare_expression`.