### PR TITLE
hints: host_filter: check topology::has_endpoint if enabled_selectively

### DIFF
--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -33,7 +33,7 @@ bool host_filter::can_hint_for(const locator::topology& topo, gms::inet_address 
     case enabled_kind::enabled_for_all:
         return true;
     case enabled_kind::enabled_selectively:
-        return _dcs.contains(topo.get_datacenter(ep));
+        return topo.has_endpoint(ep, locator::topology::pending::yes) && _dcs.contains(topo.get_datacenter(ep));
     case enabled_kind::disabled_for_all:
         return false;
     }


### PR DESCRIPTION
Don't call get_datacenter(ep) without checking
first has_endpoint(ep) since the former may abort
on internal error if the endpoint is not listed
in topology.

Refs #11870

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>