### PR TITLE
doc: enable publishing of the documentation for version 5.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Build documentation for the following tags and branches
 TAGS = []
-BRANCHES = ["master"]
+BRANCHES = ["master", "branch-5.1"]
 # Set the latest version.
 LATEST_VERSION = "master"
 # Set which versions are not released yet.


### PR DESCRIPTION
This PR enables publishing of the documentation for ScyllaDB 5.1.

It does NOT make 5.1 the default version. I'll send another PR to set 5.1 as the default after all the critical PRs are successfully backported. 
By merging this PR, we'll be able to verify that everything works as expected when the docs for branch 5.1 are published.

This PR needs to be merged to master. No need to backport to branch-5.1