### PR TITLE
repair: fix bad cast in tasks::task_id parsing

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2895,7 +2895,7 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
     sstring req = format("SELECT * from system.{} WHERE table_uuid = {}", REPAIR_HISTORY, table_id);
     co_await _qp.local().query_internal(req, [&f] (const cql3::untyped_result_set::row& row) mutable -> future<stop_iteration> {
         repair_history_entry ent;
-        ent.id = row.get_as<tasks::task_id>("repair_uuid");
+        ent.id = tasks::task_id(row.get_as<utils::UUID>("repair_uuid"));
         ent.table_uuid = ::table_id(row.get_as<utils::UUID>("table_uuid"));
         ent.range_start = row.get_as<int64_t>("range_start");
         ent.range_end = row.get_as<int64_t>("range_end");

--- a/types.hh
+++ b/types.hh
@@ -1042,12 +1042,6 @@ shared_ptr<const abstract_type> data_type_for<cql_duration>() {
     return duration_type;
 }
 
-template <>
-inline
-shared_ptr<const abstract_type> data_type_for<tasks::task_id>() {
-    return uuid_type;
-}
-
 namespace std {
 
 template <>


### PR DESCRIPTION
In system_keyspace::get_repair_history value of repair_uuid is got from row as tasks::task_id.
tasks::task_id is represented by an abstract_type specific for utils::UUID. Thus, since their typeids differ, bad_cast is thrown.

repair_uuid is got from row as utils::UUID and then cast. Since no longer needed, data_type_for<tasks::task_id> is deleted.

Fixes: #11966