### PR TITLE
[branch 5.1 backport] doc: add the upgrade guide from 5.0 to 2022.1

### DIFF
--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -96,17 +96,7 @@ To upgrade:
    CentOS only:
    
    If you use a cloud image with a preinstalled version of ScyllaDB (for example, AMI), you need to install an additional 
-   package ``scylla-enterprise-machine-image`` with the ``sudo yum install scylla-enterprise-machine-image`` command:
-
-    .. code:: sh
-
-       sudo yum clean all
-       sudo rm -rf /var/cache/yum
-       sudo yum remove scylla\*
-       sudo yum install scylla-enterprise-machine-image
-       sudo yum install scylla-enterprise 
-       for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) /etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; do sudo cp -v $conf.backup-5.0 $conf; done
-
+   package ``scylla-enterprise-machine-image`` with the ``sudo yum install scylla-enterprise-machine-image`` command.
 
 Start the node
 --------------

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -95,9 +95,8 @@ To upgrade:
 
    CentOS only:
    
-   If you first installed an earlier version of ScyllaDB Open Source using a ScyllaDB image (for example, AMI) and 
-   then upgraded to version 5.0, you need to run an additional command ``sudo yum install scylla-enterprise-machine-image``
-   to upgrade to ScyllaDB Enterprise 2022.1:
+   If you use a cloud image with a preinstalled version of ScyllaDB (for example, AMI), you need to install an additional 
+   package ``scylla-enterprise-machine-image`` with the ``sudo yum install scylla-enterprise-machine-image`` command:
 
     .. code:: sh
 

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -93,6 +93,22 @@ To upgrade:
    If you use a cloud image with a preinstalled version of ScyllaDB (for example, AMI), you need to install an additional 
    package ``scylla-enterprise-machine-image`` with the ``sudo yum install scylla-enterprise-machine-image`` command.
 
+   CentOS only:
+   
+   If you first installed an earlier version of ScyllaDB Open Source using a ScyllaDB image (for example, AMI) and 
+   then upgraded to version 5.0, you need to run an additional command ``sudo yum install scylla-enterprise-machine-image``
+   to upgrade to ScyllaDB Enterprise 2022.1:
+
+    .. code:: sh
+
+       sudo yum clean all
+       sudo rm -rf /var/cache/yum
+       sudo yum remove scylla\*
+       sudo yum install scylla-enterprise-machine-image
+       sudo yum install scylla-enterprise 
+       for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) /etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; do sudo cp -v $conf.backup-5.0 $conf; done
+
+
 Start the node
 --------------
 

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-18-04.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-18-04.rst
@@ -1,0 +1,8 @@
+.. |OS| replace:: Ubuntu 18.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-18-04/#id4
+.. |APT| replace:: ScyllaDB deb repo
+.. _APT: https://www.scylladb.com/download/?platform=ubuntu-16.04&version=scylla-5.0
+.. |APT_ENTERPRISE| replace:: ScyllaDB Enterprise Deb repo
+.. _APT_ENTERPRISE: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-18.04&version=stable-release-2022.1
+.. include:: /upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-20-04.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-20-04.rst
@@ -1,0 +1,8 @@
+.. |OS| replace:: Ubuntu 20.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-ubuntu-20-04/#id4
+.. |APT| replace:: ScyllaDB deb repo
+.. _APT: http://www.scylladb.com/download/
+.. |APT_ENTERPRISE| replace:: Scylla Enterprise Deb repo
+.. _APT_ENTERPRISE: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. include:: /upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst


### PR DESCRIPTION
This is a backport of https://github.com/scylladb/scylladb/pull/11108.