### PR TITLE
Task manager shard repair tasks

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -551,21 +551,21 @@ get_sharder_for_tables(seastar::sharded<replica::database>& db, const sstring& k
 }
 
 shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::module_ptr module,
-    tasks::task_id id,
-    const sstring& keyspace,
-    std::string type,
-    std::exception_ptr ex,
-    repair_service& repair,
-    locator::effective_replication_map_ptr erm_,
-    const dht::token_range_vector& ranges_,
-    std::vector<table_id> table_ids_,
-    repair_uniq_id parent_id_,
-    const std::vector<sstring>& data_centers_,
-    const std::vector<sstring>& hosts_,
-    const std::unordered_set<gms::inet_address>& ignore_nodes_,
-    streaming::stream_reason reason_,
-    abort_source* as,
-    bool hints_batchlog_flushed)
+        tasks::task_id id,
+        const sstring& keyspace,
+        std::string type,
+        std::exception_ptr ex,
+        repair_service& repair,
+        locator::effective_replication_map_ptr erm_,
+        const dht::token_range_vector& ranges_,
+        std::vector<table_id> table_ids_,
+        repair_uniq_id parent_id_,
+        const std::vector<sstring>& data_centers_,
+        const std::vector<sstring>& hosts_,
+        const std::unordered_set<gms::inet_address>& ignore_nodes_,
+        streaming::stream_reason reason_,
+        abort_source* as,
+        bool hints_batchlog_flushed)
     : repair_task_impl(module, id, 0, keyspace, "", std::move(type), "", parent_id_.uuid())
     , _ex(std::move(ex))
     , rs(repair)
@@ -1231,13 +1231,13 @@ future<> user_requested_repair_task_impl::run() {
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
                     data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
-              std::exception_ptr ex;
+                std::exception_ptr ex;
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
-              auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}",
+                auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}",
                         streaming::stream_reason::repair), ex, local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, nullptr, hints_batchlog_flushed);
-              auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
-              co_await task->done();
+                auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
+                co_await task->done();
             });
             repair_results.push_back(std::move(f));
         }
@@ -1338,23 +1338,23 @@ future<> data_sync_repair_task_impl::run() {
         }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable -> future<> {
-              std::exception_ptr ex;
-              auto data_centers = std::vector<sstring>();
-              auto hosts = std::vector<sstring>();
-              auto ignore_nodes = std::unordered_set<gms::inet_address>();
-              bool hints_batchlog_flushed = false;
-              abort_source* asp;
-              try {
-                asp = ops_info ? ops_info->local_abort_source() : nullptr;
-              } catch (...) {
-                ex = std::current_exception();
-              }
-              auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
+                std::exception_ptr ex;
+                auto data_centers = std::vector<sstring>();
+                auto hosts = std::vector<sstring>();
+                auto ignore_nodes = std::unordered_set<gms::inet_address>();
+                bool hints_batchlog_flushed = false;
+                abort_source* asp;
+                try {
+                    asp = ops_info ? ops_info->local_abort_source() : nullptr;
+                } catch (...) {
+                    ex = std::current_exception();
+                }
+                auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
                         format("{}", streaming::stream_reason::repair), ex, local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
-              task_impl_ptr->neighbors = std::move(neighbors);
-              auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
-              co_await task->done();
+                task_impl_ptr->neighbors = std::move(neighbors);
+                auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
+                co_await task->done();
             });
             repair_results.push_back(std::move(f));
         }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -688,7 +688,7 @@ future<> shard_repair_task_impl::repair_range(const dht::token_range& range, ::t
             if (_ri->dropped_tables.contains(cf)) {
                 return make_ready_future<>();
             }
-            return repair_cf_range_row_level(*_ri, cf, table_id, range, neighbors).handle_exception_type([this, cf] (replica::no_such_column_family&) mutable {
+            return repair_cf_range_row_level(*this, cf, table_id, range, neighbors).handle_exception_type([this, cf] (replica::no_such_column_family&) mutable {
                 _ri->dropped_tables.insert(cf);
                 return make_ready_future<>();
             }).handle_exception([this] (std::exception_ptr ep) mutable {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1215,7 +1215,7 @@ future<> user_requested_repair_task_impl::run() {
 
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
-                    data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable {
+                    data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
               lw_shared_ptr<repair_info> ri;
               std::exception_ptr ex;
               auto task_id = id.uuid();
@@ -1228,9 +1228,8 @@ future<> user_requested_repair_task_impl::run() {
                 ex = std::current_exception();
               }
               auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}", streaming::stream_reason::repair), task_id, ri, ex);
-              return start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data).then([] (auto task) {
-                return task->done();
-              });
+              auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
+              co_await task->done();
             });
             repair_results.push_back(std::move(f));
         }
@@ -1330,7 +1329,7 @@ future<> data_sync_repair_task_impl::run() {
             throw std::runtime_error("aborted by user request");
         }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
-            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable {
+            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable -> future<> {
               lw_shared_ptr<repair_info> ri;
               std::exception_ptr ex;
               auto task_id = id.uuid();
@@ -1348,9 +1347,8 @@ future<> data_sync_repair_task_impl::run() {
                 ex = std::current_exception();
               }
               auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}", streaming::stream_reason::repair), task_id, ri, ex);
-              return start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data).then([] (auto task) {
-                return task->done();
-              });
+              auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
+              co_await task->done();
             });
             repair_results.push_back(std::move(f));
         }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -974,6 +974,11 @@ static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
     co_return;
 }
 
+future<> shard_repair_task_impl::run() {
+    // TODO: impletment
+    return make_ready_future<>();
+}
+
 // repair_ranges repairs a list of token ranges, each assumed to be a token
 // range for which this node holds a replica, and, importantly, each range
 // is assumed to be a indivisible in the sense that all the tokens in has the

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -410,15 +410,15 @@ void repair_module::check_in_shutdown() {
     abort_source().check();
 }
 
-void repair_module::add_repair_info(int id, tasks::task_id uuid) {
+void repair_module::add_shard_task_id(int id, tasks::task_id uuid) {
     _repairs.emplace(id, uuid);
 }
 
-void repair_module::remove_repair_info(int id) {
+void repair_module::remove_shard_task_id(int id) {
     _repairs.erase(id);
 }
 
-tasks::task_manager::task_ptr repair_module::get_repair_info(int id) {
+tasks::task_manager::task_ptr repair_module::get_shard_task_ptr(int id) {
     auto it = _repairs.find(id);
     if (it != _repairs.end()) {
         auto task_it = _tasks.find(it->second);
@@ -1018,13 +1018,13 @@ future<> shard_repair_task_impl::run() {
     }
 
     auto& ri = _ri;
-    ri->rs.get_repair_module().add_repair_info(ri->id.id, _status.id);
+    ri->rs.get_repair_module().add_shard_task_id(ri->id.id, _status.id);
     return do_repair_ranges().then([ri] {
         ri->check_failed_ranges();
-        ri->rs.get_repair_module().remove_repair_info(ri->id.id);
+        ri->rs.get_repair_module().remove_shard_task_id(ri->id.id);
         return make_ready_future<>();
     }).handle_exception([this, ri] (std::exception_ptr eptr) {
-        ri->rs.get_repair_module().remove_repair_info(_status.sequence_number);
+        ri->rs.get_repair_module().remove_shard_task_id(_status.sequence_number);
         return make_exception_future<>(std::move(eptr));
     });
 }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -952,7 +952,8 @@ static future<tasks::task_manager::task_ptr> start_repair_task(tasks::task_manag
     co_return task;
 }
 
-static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
+future<> shard_repair_task_impl::do_repair_ranges() {
+    lw_shared_ptr<repair_info> ri = _ri;
     // Repair tables in the keyspace one after another
     assert(ri->table_names().size() == ri->table_ids.size());
     for (int idx = 0; idx < ri->table_ids.size(); idx++) {
@@ -1015,7 +1016,7 @@ future<> shard_repair_task_impl::run() {
 
     auto& ri = _ri;
     ri->rs.get_repair_module().add_repair_info(ri->id.id, ri);
-    return do_repair_ranges(ri).then([ri] {
+    return do_repair_ranges().then([ri] {
         ri->check_failed_ranges();
         ri->rs.get_repair_module().remove_repair_info(ri->id.id);
         return make_ready_future<>();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -974,16 +974,16 @@ static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
     co_return;
 }
 
-future<> shard_repair_task_impl::run() {
-    // TODO: impletment
-    return make_ready_future<>();
-}
-
-// repair_ranges repairs a list of token ranges, each assumed to be a token
+// Repairs a list of token ranges, each assumed to be a token
 // range for which this node holds a replica, and, importantly, each range
 // is assumed to be a indivisible in the sense that all the tokens in has the
 // same nodes as replicas.
-static future<> repair_ranges(lw_shared_ptr<repair_info> ri) {
+future<> shard_repair_task_impl::run() {
+    if (_ex) {
+        return make_exception_future(_ex);
+    }
+
+    auto& ri = _ri;
     ri->rs.get_repair_module().add_repair_info(ri->id.id, ri);
     return do_repair_ranges(ri).then([ri] {
         ri->check_failed_ranges();
@@ -1215,12 +1215,22 @@ future<> user_requested_repair_task_impl::run() {
 
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
-                    data_centers, hosts, ignore_nodes, germs] (repair_service& local_repair) mutable {
+                    data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable {
+              lw_shared_ptr<repair_info> ri;
+              std::exception_ptr ex;
+              auto task_id = id.uuid();
+              try {
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
-                auto ri = make_lw_shared<repair_info>(local_repair,
+                ri = make_lw_shared<repair_info>(local_repair,
                         std::move(keyspace), germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, nullptr, hints_batchlog_flushed);
-                return repair_ranges(ri);
+              } catch (...) {
+                ex = std::current_exception();
+              }
+              auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}", streaming::stream_reason::repair), task_id, ri, ex);
+              return start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data).then([] (auto task) {
+                return task->done();
+              });
             });
             repair_results.push_back(std::move(f));
         }
@@ -1320,7 +1330,11 @@ future<> data_sync_repair_task_impl::run() {
             throw std::runtime_error("aborted by user request");
         }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
-            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs] (repair_service& local_repair) mutable {
+            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable {
+              lw_shared_ptr<repair_info> ri;
+              std::exception_ptr ex;
+              auto task_id = id.uuid();
+              try {
                 auto data_centers = std::vector<sstring>();
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
@@ -1330,7 +1344,13 @@ future<> data_sync_repair_task_impl::run() {
                         std::move(keyspace), germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
                 ri->neighbors = std::move(neighbors);
-                return repair_ranges(ri);
+              } catch (...) {
+                ex = std::current_exception();
+              }
+              auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace, format("{}", streaming::stream_reason::repair), task_id, ri, ex);
+              return start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data).then([] (auto task) {
+                return task->done();
+              });
             });
             repair_results.push_back(std::move(f));
         }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -215,7 +215,7 @@ public:
             abort_source* as,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
-    void abort() noexcept;
+    void abort_repair_info() noexcept;
     void check_in_abort();
     void check_in_shutdown();
     repair_neighbors get_repair_neighbors(const dht::token_range& range);

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -212,25 +212,7 @@ public:
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
-            abort_source* as,
             bool hints_batchlog_flushed);
-    void check_failed_ranges();
-    void abort_repair_info() noexcept;
-    void check_in_abort();
-    void check_in_shutdown();
-    repair_neighbors get_repair_neighbors(const dht::token_range& range);
-    void update_statistics(const repair_stats& stats) {
-        _stats.add(stats);
-    }
-    const std::vector<sstring>& table_names() {
-        return cfs;
-    }
-
-    bool hints_batchlog_flushed() const {
-        return _hints_batchlog_flushed;
-    }
-
-    size_t ranges_size();
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, const sstring& keyspace,

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -230,8 +230,6 @@ public:
         return _hints_batchlog_flushed;
     }
 
-    future<> repair_range(const dht::token_range& range, table_id);
-
     size_t ranges_size();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -170,51 +170,6 @@ public:
     }
 };
 
-class repair_info {
-public:
-    repair_service& rs;
-    seastar::sharded<replica::database>& db;
-    seastar::sharded<netw::messaging_service>& messaging;
-    sharded<db::system_distributed_keyspace>& sys_dist_ks;
-    sharded<db::view::view_update_generator>& view_update_generator;
-    service::migration_manager& mm;
-    gms::gossiper& gossiper;
-    const dht::sharder& sharder;
-    sstring keyspace;
-    locator::effective_replication_map_ptr erm;
-    dht::token_range_vector ranges;
-    std::vector<sstring> cfs;
-    std::vector<table_id> table_ids;
-    repair_uniq_id id;
-    std::vector<sstring> data_centers;
-    std::vector<sstring> hosts;
-    std::unordered_set<gms::inet_address> ignore_nodes;
-    streaming::stream_reason reason;
-    std::unordered_map<dht::token_range, repair_neighbors> neighbors;
-    size_t total_rf;
-    uint64_t nr_ranges_finished = 0;
-    uint64_t nr_ranges_total;
-    size_t nr_failed_ranges = 0;
-    bool aborted = false;
-    int ranges_index = 0;
-    repair_stats _stats;
-    std::unordered_set<sstring> dropped_tables;
-    optimized_optional<abort_source::subscription> _abort_subscription;
-    bool _hints_batchlog_flushed = false;
-public:
-    repair_info(repair_service& repair,
-            const sstring& keyspace_,
-            locator::effective_replication_map_ptr erm_,
-            const dht::token_range_vector& ranges_,
-            std::vector<table_id> table_ids_,
-            repair_uniq_id id_,
-            const std::vector<sstring>& data_centers_,
-            const std::vector<sstring>& hosts_,
-            const std::unordered_set<gms::inet_address>& ingore_nodes_,
-            streaming::stream_reason reason_,
-            bool hints_batchlog_flushed);
-};
-
 future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, const sstring& keyspace,
         const sstring& cf, const dht::token_range& range);
 

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -72,6 +72,26 @@ protected:
     // TODO: implement progress for data-sync repairs
 };
 
+class shard_repair_task_impl : public repair_task_impl {
+private:
+    lw_shared_ptr<repair_info> _ri;
+    std::exception_ptr _ex;
+public:
+    shard_repair_task_impl(tasks::task_manager::module_ptr module,
+            tasks::task_id id,
+            std::string keyspace,
+            std::string type,
+            tasks::task_id parent_id,
+            lw_shared_ptr<repair_info> ri,
+            std::exception_ptr ex)
+        : repair_task_impl(module, id, 0, std::move(keyspace), "", std::move(type), "", parent_id)
+        , _ri(std::move(ri))
+        , _ex(std::move(ex))
+    {}
+protected:
+    future<> run() override;
+};
+
 // The repair_module tracks ongoing repair operations and their progress.
 // A repair which has already finished successfully is dropped from this
 // table, but a failed repair will remain in the table forever so it can

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -109,6 +109,7 @@ public:
 
     size_t ranges_size();
 protected:
+    future<> do_repair_ranges();
     future<> run() override;
 };
 

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -89,6 +89,9 @@ public:
         , _ex(std::move(ex))
     {}
 
+    lw_shared_ptr<repair_info> get_repair_info() const noexcept {
+        return _ri;
+    }
     void check_failed_ranges();
     void abort_repair_info() noexcept;
     void check_in_abort();

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -129,7 +129,7 @@ private:
     // but aren't listed as running or failed the status map.
     std::unordered_map<int, repair_status> _status;
     // Map repair id into repair_info.
-    std::unordered_map<int, lw_shared_ptr<repair_info>> _repairs;
+    std::unordered_map<int, tasks::task_id> _repairs;
     std::unordered_set<tasks::task_id> _pending_repairs;
     std::unordered_set<tasks::task_id> _aborted_pending_repairs;
     // The semaphore used to control the maximum
@@ -156,9 +156,9 @@ public:
 
     repair_status get(int id) const;
     void check_in_shutdown();
-    void add_repair_info(int id, lw_shared_ptr<repair_info> ri);
+    void add_repair_info(int id, tasks::task_id ri);
     void remove_repair_info(int id);
-    lw_shared_ptr<repair_info> get_repair_info(int id);
+    tasks::task_manager::task_ptr get_repair_info(int id);
     std::vector<int> get_active() const;
     size_t nr_running_repair_jobs();
     void abort_all_repairs();

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -156,9 +156,9 @@ public:
 
     repair_status get(int id) const;
     void check_in_shutdown();
-    void add_repair_info(int id, tasks::task_id ri);
-    void remove_repair_info(int id);
-    tasks::task_manager::task_ptr get_repair_info(int id);
+    void add_shard_task_id(int id, tasks::task_id ri);
+    void remove_shard_task_id(int id);
+    tasks::task_manager::task_ptr get_shard_task_ptr(int id);
     std::vector<int> get_active() const;
     size_t nr_running_repair_jobs();
     void abort_all_repairs();

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -88,6 +88,26 @@ public:
         , _ri(std::move(ri))
         , _ex(std::move(ex))
     {}
+
+    void check_failed_ranges();
+    void abort_repair_info() noexcept;
+    void check_in_abort();
+    void check_in_shutdown();
+    repair_neighbors get_repair_neighbors(const dht::token_range& range);
+    void update_statistics(const repair_stats& stats) {
+        _ri->update_statistics(stats);
+    }
+    const std::vector<sstring>& table_names() {
+        return _ri->table_names();
+    }
+
+    bool hints_batchlog_flushed() const {
+        return _ri->hints_batchlog_flushed();
+    }
+
+    future<> repair_range(const dht::token_range& range, table_id);
+
+    size_t ranges_size();
 protected:
     future<> run() override;
 };

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2689,7 +2689,7 @@ private:
             co_return;
         }
         // Update repair_history table only if both hints and batchlog have been flushed.
-        if (!_shard_task.get_repair_info()->hints_batchlog_flushed()) {
+        if (!_shard_task.hints_batchlog_flushed()) {
             co_return;
         }
         repair_service& rs = _shard_task.get_repair_info()->rs;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2369,7 +2369,7 @@ static void add_to_repair_meta_for_followers(repair_meta& rm) {
 }
 
 class row_level_repair {
-    repair_info& _ri;
+    shard_repair_task_impl& _shard_task;
     sstring _cf_name;
     table_id _table_id;
     dht::token_range _range;
@@ -2418,17 +2418,17 @@ class row_level_repair {
     gc_clock::time_point _start_time;
 
 public:
-    row_level_repair(repair_info& ri,
+    row_level_repair(shard_repair_task_impl& shard_task,
             sstring cf_name,
             table_id table_id,
             dht::token_range range,
             std::vector<gms::inet_address> all_live_peer_nodes)
-        : _ri(ri)
+        : _shard_task(shard_task)
         , _cf_name(std::move(cf_name))
         , _table_id(std::move(table_id))
         , _range(std::move(range))
         , _all_live_peer_nodes(sort_peer_nodes(all_live_peer_nodes))
-        , _cf(_ri.db.local().find_column_family(_table_id))
+        , _cf(_shard_task.get_repair_info()->db.local().find_column_family(_table_id))
         , _seed(get_random_seed())
         , _start_time(gc_clock::now()) {
     }
@@ -2443,7 +2443,7 @@ private:
     inet_address_vector_replica_set sort_peer_nodes(const std::vector<gms::inet_address>& nodes) {
         auto myip = utils::fb_utilities::get_broadcast_address();
         inet_address_vector_replica_set sorted_nodes(nodes.begin(), nodes.end());
-        _ri.db.local().get_token_metadata().get_topology().sort_by_proximity(myip, sorted_nodes);
+        _shard_task.get_repair_info()->db.local().get_token_metadata().get_topology().sort_by_proximity(myip, sorted_nodes);
         return sorted_nodes;
     }
 
@@ -2454,8 +2454,8 @@ private:
 
     // Step A: Negotiate sync boundary to use
     op_status negotiate_sync_boundary(repair_meta& master) {
-        _ri.check_in_shutdown();
-        _ri.check_in_abort();
+        _shard_task.check_in_shutdown();
+        _shard_task.check_in_abort();
         _sync_boundaries.clear();
         _combined_hashes.clear();
         _zero_rows = false;
@@ -2514,8 +2514,8 @@ private:
 
     // Step B: Get missing rows from peer nodes so that local node contains all the rows
     op_status get_missing_rows_from_follower_nodes(repair_meta& master) {
-        _ri.check_in_shutdown();
-        _ri.check_in_abort();
+        _shard_task.check_in_shutdown();
+        _shard_task.check_in_abort();
         // `combined_hashes` contains the combined hashes for the
         // `_working_row_buf`. Like `_row_buf`, `_working_row_buf` contains
         // rows which are within the (_last_sync_boundary, _current_sync_boundary]
@@ -2646,8 +2646,8 @@ private:
     void send_missing_rows_to_follower_nodes(repair_meta& master) {
         // At this time, repair master contains all the rows between (_last_sync_boundary, _current_sync_boundary]
         // So we can figure out which rows peer node are missing and send the missing rows to them
-        _ri.check_in_shutdown();
-        _ri.check_in_abort();
+        _shard_task.check_in_shutdown();
+        _shard_task.check_in_abort();
         repair_hash_set local_row_hash_sets = master.working_row_hashes().get0();
         auto sz = _all_live_peer_nodes.size();
         std::vector<repair_hash_set> set_diffs(sz);
@@ -2678,37 +2678,37 @@ private:
     // Update system.repair_history table
     future<> update_system_repair_table() {
         // Update repair_history table only if it is a reguar repair.
-        if (_ri.reason != streaming::stream_reason::repair) {
+        if (_shard_task.get_repair_info()->reason != streaming::stream_reason::repair) {
             co_return;
         }
         // Update repair_history table only if all replicas have been repaired
         size_t repaired_replicas = _all_live_peer_nodes.size() + 1;
-        if (_ri.total_rf != repaired_replicas){
+        if (_shard_task.get_repair_info()->total_rf != repaired_replicas){
             rlogger.debug("repair[{}]: Skipped to update system.repair_history total_rf={}, repaired_replicas={}, local={}, peers={}",
-                    _ri.id.uuid(), _ri.total_rf, repaired_replicas, utils::fb_utilities::get_broadcast_address(), _all_live_peer_nodes);
+                    _shard_task.get_repair_info()->id.uuid(), _shard_task.get_repair_info()->total_rf, repaired_replicas, utils::fb_utilities::get_broadcast_address(), _all_live_peer_nodes);
             co_return;
         }
         // Update repair_history table only if both hints and batchlog have been flushed.
-        if (!_ri.hints_batchlog_flushed()) {
+        if (!_shard_task.get_repair_info()->hints_batchlog_flushed()) {
             co_return;
         }
-        repair_service& rs = _ri.rs;
-        std::optional<gc_clock::time_point> repair_time_opt = co_await rs.update_history(_ri.id.uuid(), _table_id, _range, _start_time);
+        repair_service& rs = _shard_task.get_repair_info()->rs;
+        std::optional<gc_clock::time_point> repair_time_opt = co_await rs.update_history(_shard_task.get_repair_info()->id.uuid(), _table_id, _range, _start_time);
         if (!repair_time_opt) {
             co_return;
         }
         auto repair_time = repair_time_opt.value();
-        repair_update_system_table_request req{_ri.id.uuid(), _table_id, _ri.keyspace, _cf_name, _range, repair_time};
+        repair_update_system_table_request req{_shard_task.get_repair_info()->id.uuid(), _table_id, _shard_task.get_repair_info()->keyspace, _cf_name, _range, repair_time};
         auto all_nodes = _all_live_peer_nodes;
         all_nodes.push_back(utils::fb_utilities::get_broadcast_address());
         co_await coroutine::parallel_for_each(all_nodes, [this, req] (gms::inet_address node) -> future<> {
             try {
-                auto& ms = _ri.messaging.local();
+                auto& ms = _shard_task.get_repair_info()->messaging.local();
                 repair_update_system_table_response resp = co_await ser::partition_checksum_rpc_verbs::send_repair_update_system_table(&ms, netw::messaging_service::msg_addr(node), req);
                 (void)resp;  // nothing to do with the response yet
-                rlogger.debug("repair[{}]: Finished to update system.repair_history table of node {}", _ri.id.uuid(), node);
+                rlogger.debug("repair[{}]: Finished to update system.repair_history table of node {}", _shard_task.get_repair_info()->id.uuid(), node);
             } catch (...) {
-                rlogger.warn("repair[{}]: Failed to update system.repair_history table of node {}: {}", _ri.id.uuid(), node, std::current_exception());
+                rlogger.warn("repair[{}]: Failed to update system.repair_history table of node {}: {}", _shard_task.get_repair_info()->id.uuid(), node, std::current_exception());
             }
         });
         co_return;
@@ -2717,33 +2717,33 @@ private:
 public:
     future<> run() {
         return seastar::async([this] {
-            _ri.check_in_shutdown();
-            _ri.check_in_abort();
-            auto repair_meta_id = _ri.rs.get_next_repair_meta_id().get0();
-            auto algorithm = get_common_diff_detect_algorithm(_ri.messaging.local(), _all_live_peer_nodes);
+            _shard_task.check_in_shutdown();
+            _shard_task.check_in_abort();
+            auto repair_meta_id = _shard_task.get_repair_info()->rs.get_next_repair_meta_id().get0();
+            auto algorithm = get_common_diff_detect_algorithm(_shard_task.get_repair_info()->messaging.local(), _all_live_peer_nodes);
             auto max_row_buf_size = get_max_row_buf_size(algorithm);
             auto master_node_shard_config = shard_config {
                     this_shard_id(),
-                    _ri.sharder.shard_count(),
-                    _ri.sharder.sharding_ignore_msb()
+                    _shard_task.get_repair_info()->sharder.shard_count(),
+                    _shard_task.get_repair_info()->sharder.sharding_ignore_msb()
             };
             auto s = _cf.schema();
             auto schema_version = s->version();
             bool table_dropped = false;
 
-            auto& mem_sem = _ri.rs.memory_sem();
-            auto max = _ri.rs.max_repair_memory();
+            auto& mem_sem = _shard_task.get_repair_info()->rs.memory_sem();
+            auto max = _shard_task.get_repair_info()->rs.max_repair_memory();
             auto wanted = (_all_live_peer_nodes.size() + 1) * repair_module::max_repair_memory_per_range;
             wanted = std::min(max, wanted);
             rlogger.trace("repair[{}]: Started to get memory budget, wanted={}, available={}, max_repair_memory={}",
-                    _ri.id.uuid(), wanted, mem_sem.current(), max);
+                    _shard_task.get_repair_info()->id.uuid(), wanted, mem_sem.current(), max);
             auto mem_permit = seastar::get_units(mem_sem, wanted).get0();
             rlogger.trace("repair[{}]: Finished to get memory budget, wanted={}, available={}, max_repair_memory={}",
-                    _ri.id.uuid(), wanted, mem_sem.current(), max);
+                    _shard_task.get_repair_info()->id.uuid(), wanted, mem_sem.current(), max);
 
-            auto permit = _ri.db.local().obtain_reader_permit(_cf, "repair-meta", db::no_timeout).get0();
+            auto permit = _shard_task.get_repair_info()->db.local().obtain_reader_permit(_cf, "repair-meta", db::no_timeout).get0();
 
-            repair_meta master(_ri.rs,
+            repair_meta master(_shard_task.get_repair_info()->rs,
                     _cf,
                     s,
                     std::move(permit),
@@ -2753,7 +2753,7 @@ public:
                     _seed,
                     repair_master::yes,
                     repair_meta_id,
-                    _ri.reason,
+                    _shard_task.get_repair_info()->reason,
                     std::move(master_node_shard_config),
                     _all_live_peer_nodes,
                     _all_live_peer_nodes.size(),
@@ -2765,7 +2765,7 @@ public:
             });
 
             rlogger.debug(">>> Started Row Level Repair (Master): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, schema_version={}, range={}, seed={}, max_row_buf_size={}",
-                    master.myip(), _all_live_peer_nodes, master.repair_meta_id(), _ri.keyspace, _cf_name, schema_version, _range, _seed, max_row_buf_size);
+                    master.myip(), _all_live_peer_nodes, master.repair_meta_id(), _shard_task.get_repair_info()->keyspace, _cf_name, schema_version, _range, _seed, max_row_buf_size);
 
 
             std::vector<gms::inet_address> nodes_to_stop;
@@ -2774,7 +2774,7 @@ public:
                 parallel_for_each(master.all_nodes(), [&, this] (repair_node_state& ns) {
                     const auto& node = ns.node;
                     ns.state = repair_state::row_level_start_started;
-                    return master.repair_row_level_start(node, _ri.keyspace, _cf_name, _range, schema_version, _ri.reason).then([&] () {
+                    return master.repair_row_level_start(node, _shard_task.get_repair_info()->keyspace, _cf_name, _range, schema_version, _shard_task.get_repair_info()->reason).then([&] () {
                         ns.state = repair_state::row_level_start_finished;
                         nodes_to_stop.push_back(node);
                         ns.state = repair_state::get_estimated_partitions_started;
@@ -2811,43 +2811,43 @@ public:
             } catch (replica::no_such_column_family& e) {
                 table_dropped = true;
                 rlogger.warn("repair[{}]: shard={}, keyspace={}, cf={}, range={}, got error in row level repair: {}",
-                        _ri.id.uuid(), this_shard_id(), _ri.keyspace, _cf_name, _range, e);
+                        _shard_task.get_repair_info()->id.uuid(), this_shard_id(), _shard_task.get_repair_info()->keyspace, _cf_name, _range, e);
                 _failed = true;
             } catch (std::exception& e) {
                 rlogger.warn("repair[{}]: shard={}, keyspace={}, cf={}, range={}, got error in row level repair: {}",
-                        _ri.id.uuid(), this_shard_id(), _ri.keyspace, _cf_name, _range, e);
+                        _shard_task.get_repair_info()->id.uuid(), this_shard_id(), _shard_task.get_repair_info()->keyspace, _cf_name, _range, e);
                 // In case the repair process fail, we need to call repair_row_level_stop to clean up repair followers
                 _failed = true;
             }
 
             parallel_for_each(nodes_to_stop, [&] (const gms::inet_address& node) {
                 master.set_repair_state(repair_state::row_level_stop_started, node);
-                return master.repair_row_level_stop(node, _ri.keyspace, _cf_name, _range).then([node, &master] {
+                return master.repair_row_level_stop(node, _shard_task.get_repair_info()->keyspace, _cf_name, _range).then([node, &master] {
                     master.set_repair_state(repair_state::row_level_stop_finished, node);
                 });
             }).get();
 
-            _ri.update_statistics(master.stats());
+            _shard_task.update_statistics(master.stats());
             if (_failed) {
                 if (table_dropped) {
-                    throw replica::no_such_column_family(_ri.keyspace,  _cf_name);
+                    throw replica::no_such_column_family(_shard_task.get_repair_info()->keyspace,  _cf_name);
                 } else {
-                    throw std::runtime_error(format("Failed to repair for keyspace={}, cf={}, range={}", _ri.keyspace, _cf_name, _range));
+                    throw std::runtime_error(format("Failed to repair for keyspace={}, cf={}, range={}", _shard_task.get_repair_info()->keyspace, _cf_name, _range));
                 }
             } else {
                 update_system_repair_table().get();
             }
             rlogger.debug("<<< Finished Row Level Repair (Master): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, range={}, tx_hashes_nr={}, rx_hashes_nr={}, tx_row_nr={}, rx_row_nr={}, row_from_disk_bytes={}, row_from_disk_nr={}",
-                    master.myip(), _all_live_peer_nodes, master.repair_meta_id(), _ri.keyspace, _cf_name, _range, master.stats().tx_hashes_nr, master.stats().rx_hashes_nr, master.stats().tx_row_nr, master.stats().rx_row_nr, master.stats().row_from_disk_bytes, master.stats().row_from_disk_nr);
+                    master.myip(), _all_live_peer_nodes, master.repair_meta_id(), _shard_task.get_repair_info()->keyspace, _cf_name, _range, master.stats().tx_hashes_nr, master.stats().rx_hashes_nr, master.stats().tx_row_nr, master.stats().rx_row_nr, master.stats().row_from_disk_bytes, master.stats().row_from_disk_nr);
         });
     }
 };
 
-future<> repair_cf_range_row_level(repair_info& ri,
+future<> repair_cf_range_row_level(shard_repair_task_impl& shard_task,
         sstring cf_name, table_id table_id, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes) {
-    return seastar::futurize_invoke([&ri, cf_name = std::move(cf_name), table_id = std::move(table_id), range = std::move(range), &all_peer_nodes] () mutable {
-        auto repair = row_level_repair(ri, std::move(cf_name), std::move(table_id), std::move(range), all_peer_nodes);
+    return seastar::futurize_invoke([&shard_task, cf_name = std::move(cf_name), table_id = std::move(table_id), range = std::move(range), &all_peer_nodes] () mutable {
+        auto repair = row_level_repair(shard_task, std::move(cf_name), std::move(table_id), std::move(range), all_peer_nodes);
         return do_with(std::move(repair), [] (row_level_repair& repair) {
             return repair.run();
         });

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -240,7 +240,7 @@ class repair_row;
 class repair_hasher;
 class repair_writer;
 
-future<> repair_cf_range_row_level(repair_info& ri,
+future<> repair_cf_range_row_level(shard_repair_task_impl& shard_task,
         sstring cf_name, table_id table_id, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes);
 future<std::list<repair_row>> to_repair_rows_list(repair_rows_on_wire rows,

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -20,6 +20,8 @@
 #include "utils/serialized_action.hh"
 #include "utils/updateable_value.hh"
 
+class repair_module;
+
 namespace tasks {
 
 using is_abortable = bool_class <struct abortable_tag>;
@@ -282,6 +284,7 @@ public:
         }
 
         friend class test_task;
+        friend class ::repair_module;
     };
 
     class module : public enable_shared_from_this<module> {


### PR DESCRIPTION
The PR introduces shard_repair_task_impl which represents a repair task
that spans over a single shard repair.

repair_info is replaced with shard_repair_task_impl, since both serve 
similar purpose.