### PR TITLE
topology: Be less restrictive about missing endpoints

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -12,6 +12,7 @@
 
 #include "log.hh"
 #include "locator/topology.hh"
+#include "locator/production_snitch_base.hh"
 #include "utils/stall_free.hh"
 #include "utils/fb_utilities.hh"
 
@@ -140,7 +141,16 @@ const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
         return _pending_locations.at(ep);
     }
 
-    on_internal_error(tlogger, format("Node {} is not in topology", ep));
+    // FIXME -- this shouldn't happen. After topology is stable and is
+    // correctly populated with endpoints, this should be replaced with
+    // on_internal_error()
+    static thread_local endpoint_dc_rack default_location = {
+        .dc = locator::production_snitch_base::default_dc,
+        .rack = locator::production_snitch_base::default_rack,
+    };
+
+    tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
+    return default_location;
 }
 
 // FIXME -- both methods below should rather return data from the


### PR DESCRIPTION
Recent changes in topology restricted the get_dc/get_rack calls. Older code was trying to locate the endpoint in gossiper, then in system keyspace cache and if the endpoint was not found in both -- returned "default" location.

New code generates internal error in this case. This approach already helped to spot several BUGs in code that had been eventually fixed, but echoes of that change still pop up.

This patch relaxes the "missing endpoint" case by printing a warning in logs and returning back the "default" location like old code did.

tests: update_cluster_layout_tests.py::*
       hintedhandoff_additional_test.py::TestHintedHandoff::test_hintedhandoff_rebalance
       bootstrap_test.py::TestBootstrap::test_decommissioned_wiped_node_can_join
       bootstrap_test.py::TestBootstrap::test_failed_bootstap_wiped_node_can_join
       materialized_views_test.py::TestMaterializedViews::test_decommission_node_during_mv_insert_4_nodes

CI: https://jenkins.scylladb.com/job/releng/job/Scylla-CI/3095/

Also need feedback from @roydahan if it fixes failures of long-running tests
This is a replacement for #12065 

refs: #11900
refs: #12054
fixes: #11870

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>