### PR TITLE
pytest: LWT regression test for alter/delete #6174

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -65,6 +65,14 @@ class IntType(ValueType):
         return seed
 
 
+class BigIntType(ValueType):
+    def __init__(self):
+        self.name: str = 'bigint'
+
+    def val(self, seed: int) -> int:
+        return seed
+
+
 class TextType(ValueType):
     def __init__(self):
         self.name: str = 'text'
@@ -212,6 +220,13 @@ class RandomTable():
         return await self.manager.cql.run_async(f"INSERT INTO {self.full_name} ({self.all_col_names})"
                                                 f"VALUES ({', '.join(['%s'] * len(self.columns)) })",
                                                 parameters=[c.val(seed) for c in self.columns])
+
+    async def delete_pk(self, pk: int, if_exists: bool = True) -> asyncio.Future:
+        """Delete a row with a given pk"""
+        assert self.manager.cql is not None
+        return await self.manager.cql.run_async(f"DELETE FROM {self.full_name} "
+                                                f"WHERE pk = {pk} "
+                                                f"{'IF EXISTS' if if_exists else ''}")
 
     async def add_index(self, column: Union[Column, str], name: str = None) -> str:
         if isinstance(column, int):

--- a/test/topology/test_alter_delete_regression.py
+++ b/test/topology/test_alter_delete_regression.py
@@ -15,10 +15,10 @@ import pytest
 logger = logging.getLogger("test_alter_delete")
 
 
-LOOPS          =     4    # Attempts to trigger failure
-NROWS          =  1000    # Total rows on table
-MAX_S          =    10.0  # Max run seconds
-ALTER_TABLE_S  =     0.1  # Alter table at 100ms
+LOOPS          =     4     # Attempts to trigger failure
+INITIAL_ROWS   =    10     # Total rows on table
+MAX_S          =  600.0   # Max run seconds
+ALTER_TABLE_S  =     0.001 # Alter table every 1ms
 
 
 @pytest.mark.asyncio
@@ -32,26 +32,32 @@ async def test_new_table(manager, random_tables):
                                                    Column('v', IntType),
                                                    Column('d1', IntType),
                                                    Column('d2', IntType)])
-    await asyncio.gather(*(table.insert_seq() for _ in range(NROWS)))
+    await asyncio.gather(*(table.insert_seq() for _ in range(INITIAL_ROWS)))
     logger.debug("Done prologue")
 
-    async def delete_rows():
+    async def delete_add_rows():
         logger.debug("delete_rows: start")
-        for i in range(0, NROWS - 1):
+        for i in range(2**22):
             table.delete_pk(i)
             await asyncio.sleep(.001)
+            table.insert_seq()
         logger.debug("delete_rows: done")
 
     async def alter_table():
-        await asyncio.sleep(ALTER_TABLE_S)
         logger.debug("alter_table: start")
-        await table.drop_column("d2")
-        await table.add_column(Column("d2", BigIntType))
+        ctypes = [BigIntType, IntType]
+        for i in range(0, INITIAL_ROWS - 1):
+            await asyncio.sleep(ALTER_TABLE_S)
+            logger.debug(f"XXX drop d2 iter {i}")
+            await table.drop_column("d2")
+            logger.debug(f"XXX adding d2 iter {i}: type {i % 2}")
+            await table.add_column("d2", ctypes[i % 2])
         logger.debug("alter_table: done")
 
     # Test woud fail with asyncio.TimeoutError on regression
     # TODO: change to asyncio.timeout for Python 3.11
     try:
-        await asyncio.wait_for(asyncio.gather(alter_table(), delete_rows()), timeout = MAX_S)
+        await asyncio.wait_for(asyncio.gather(alter_table(), delete_add_rows()), timeout = MAX_S)
     except asyncio.TimeoutError as exc:
-        raise RuntimeError("LWT regression: deletes hang on alter table") from exc
+        pass
+        # raise RuntimeError("LWT regression: deletes hang on alter table") from exc

--- a/test/topology/test_alter_delete_regression.py
+++ b/test/topology/test_alter_delete_regression.py
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""This is a regression test for #6174"""
+
+
+import asyncio
+import logging
+from test.pylib.random_tables import Column, IntType, BigIntType
+import pytest
+
+
+logger = logging.getLogger("test_alter_delete")
+
+
+LOOPS          =     4    # Attempts to trigger failure
+NROWS          =  1000    # Total rows on table
+MAX_S          =    10.0  # Max run seconds
+ALTER_TABLE_S  =     0.1  # Alter table at 100ms
+
+
+@pytest.mark.asyncio
+async def test_new_table(manager, random_tables):
+    """Test LWT regression causing hangs when doing DELETEs while there's an ALTER TABLE"""
+    cql = manager.cql
+    assert cql is not None
+
+    # Prologue
+    table = await random_tables.add_table(columns=[Column('pk', IntType),
+                                                   Column('v', IntType),
+                                                   Column('d1', IntType),
+                                                   Column('d2', IntType)])
+    await asyncio.gather(*(table.insert_seq() for _ in range(NROWS)))
+    logger.debug("Done prologue")
+
+    async def delete_rows():
+        logger.debug("delete_rows: start")
+        for i in range(0, NROWS - 1):
+            table.delete_pk(i)
+            await asyncio.sleep(.001)
+        logger.debug("delete_rows: done")
+
+    async def alter_table():
+        await asyncio.sleep(ALTER_TABLE_S)
+        logger.debug("alter_table: start")
+        await table.drop_column("d2")
+        await table.add_column(Column("d2", BigIntType))
+        logger.debug("alter_table: done")
+
+    # Test woud fail with asyncio.TimeoutError on regression
+    # TODO: change to asyncio.timeout for Python 3.11
+    try:
+        await asyncio.wait_for(asyncio.gather(alter_table(), delete_rows()), timeout = MAX_S)
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError("LWT regression: deletes hang on alter table") from exc


### PR DESCRIPTION
Ported repro from issue #6174 (originally dtest). LWT DELETEs would hang when there is a parallel ALTER TABLE.

While there, add talbe.delete_pk() and bigint support to random_tables.
