### PR TITLE
Revert "configure: temporarily disable wasm support for aarch64"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1414,12 +1414,8 @@ if not has_wasmtime:
     has_wasmtime = os.path.isfile('/usr/lib64/libwasmtime.a') and os.path.isdir('/usr/local/include/wasmtime')
 
 if has_wasmtime:
-    if platform.machine() == 'aarch64':
-        print("wasmtime is temporarily not supported on aarch64. Ref: issue #9387")
-        has_wasmtime = False
-    else:
-        for mode in modes:
-            modes[mode]['cxxflags'] += ' -DSCYLLA_ENABLE_WASMTIME'
+    for mode in modes:
+        modes[mode]['cxxflags'] += ' -DSCYLLA_ENABLE_WASMTIME'
 else:
     print("wasmtime not found - WASM support will not be enabled in this build")
 


### PR DESCRIPTION
This reverts commit e2fe8559cab648883ac6d3baab26a8377a2302a7. I ran all the release mode tests on aarch64 with it reverted, and it passes. So it looks like whatever problems we had with it were fixed.