### PR TITLE
doc: remove the LWT page from the index of Enterpise features

### DIFF
--- a/docs/using-scylla/features-ent.rst
+++ b/docs/using-scylla/features-ent.rst
@@ -6,7 +6,6 @@ Scylla Enterprise Features
    :maxdepth: 2
    :hidden:
 
-   Lightweight Transactions </using-scylla/lwt/>
    Workload Prioritization </using-scylla/workload-prioritization/>
    In-memory tables </using-scylla/in-memory/>
    Global Secondary Indexes </using-scylla/secondary-indexes/>


### PR DESCRIPTION
Related: https://github.com/scylladb/scylladb/issues/12036 

LWT is not an Enterprise-only feature and shouldn't appear in the Enterprise Features section.