### PR TITLE
storage_service: handle_state_normal: always update_topology before update_normal_tokens

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -985,9 +985,6 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
             on_internal_error_noexcept(slogger, format("endpoint={} is not marked for removal but owns no tokens", endpoint));
         }
 
-        // Update pending ranges after update of normal tokens immediately to avoid
-        // a race where natural endpoint was updated to contain node A, but A was
-        // not yet removed from pending endpoints
         if (!is_normal_token_owner) {
             auto dc_rack = get_dc_rack_for(endpoint);
             slogger.debug("handle_state_normal: update_topology: endpoint={} dc={} rack={}", endpoint, dc_rack.dc, dc_rack.rack);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -986,11 +986,10 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
         }
 
         if (!is_normal_token_owner) {
-            auto dc_rack = get_dc_rack_for(endpoint);
-            slogger.debug("handle_state_normal: update_topology: endpoint={} dc={} rack={}", endpoint, dc_rack.dc, dc_rack.rack);
-            tmptr->update_topology(endpoint, std::move(dc_rack));
             do_notify_joined = true;
         }
+
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
         co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
     }
 


### PR DESCRIPTION
update_normal_tokens checks that that the endpoint is in topology. Currently we call update_topology on this path only if it's not a normal_token_owner, but there are paths when the endpoint could be a normal token owner but still
be pending in topology so always update it, just in case.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>