### PR TITLE
Quarantine hosts using system.quarantined

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2783,7 +2783,7 @@ future<locator::host_id> system_keyspace::load_local_host_id() {
     sstring req = format("SELECT host_id FROM system.{} WHERE key=?", LOCAL);
     auto msg = co_await execute_cql(req, sstring(LOCAL));
     if (msg->empty() || !msg->one().has("host_id")) {
-        co_return co_await set_local_host_id(locator::host_id::create_random_id());
+        co_return co_await set_local_random_host_id();
     } else {
         auto host_id = locator::host_id(msg->one().get_as<utils::UUID>("host_id"));
         slogger.info("Loaded local host id: {}", host_id);
@@ -2791,7 +2791,8 @@ future<locator::host_id> system_keyspace::load_local_host_id() {
     }
 }
 
-future<locator::host_id> system_keyspace::set_local_host_id(locator::host_id host_id) {
+future<locator::host_id> system_keyspace::set_local_random_host_id() {
+    auto host_id = locator::host_id::create_random_id();
     slogger.info("Setting local host id to {}", host_id);
 
     sstring req = format("INSERT INTO system.{} (key, host_id) VALUES (?, ?)", LOCAL);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -380,12 +380,12 @@ public:
      * none exists.
      */
     future<locator::host_id> load_local_host_id();
-
+private:
     /**
-     * Sets the local host ID explicitly.  Should only be called outside of SystemTable when replacing a node.
+     * Sets the local host ID explicitly.  Used only internally when intializing the host_id
      */
-    future<locator::host_id> set_local_host_id(locator::host_id host_id);
-
+    future<locator::host_id> set_local_random_host_id();
+public:
     static api::timestamp_type schema_creation_timestamp();
 
     /**

--- a/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
@@ -131,7 +131,7 @@ Procedure
          /192.168.1.203
          generation:1553759866
          heartbeat:2147483647
-        HOST_ID:655ae64d-e3fb-45cc-9792-2b648b151b67
+        HOST_ID:675ed9f4-6564-6dbd-can8-43fddce952gy
          STATUS:shutdown,true
          RELEASE_VERSION:3.0.8
          X3:3
@@ -155,7 +155,7 @@ Procedure
        --  Address        Load       Tokens  Owns (effective)                         Host ID         Rack
        UN  192.168.1.201  112.82 KB  256     32.7%             8d5ed9f4-7764-4dbd-bad8-43fddce94b7c   B1
        UN  192.168.1.202  91.11 KB   256     32.9%             125ed9f4-7777-1dbn-mac8-43fddce9123e   B1
-       UN  192.168.1.204  124.42 KB  256     32.6%             675ed9f4-6564-6dbd-can8-43fddce952gy   B1 
+       UN  192.168.1.204  124.42 KB  256     32.6%             655ae64d-e3fb-45cc-9792-2b648b151b67   B1 
 
 #. Run the ``nodetool repair`` command on the node that was replaced to make sure that the data is synced with the other nodes in the cluster. You can use `Scylla Manager <https://manager.docs.scylladb.com/>`_ to run the repair.
 

--- a/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
@@ -105,7 +105,7 @@ Procedure
        |/ State=Normal/Leaving/Joining/Moving
        --  Address    Load       Tokens       Owns    Host ID                               Rack
            UN  192.168.1.201  112.82 KB  256     32.7%             8d5ed9f4-7764-4dbd-bad8-43fddce94b7c   B1
-       UN  192.168.1.202  91.11 KB   256     32.9%             125ed9f4-7777-1dbn-mac8-43fddce9123e   B1
+           UN  192.168.1.202  91.11 KB   256     32.9%             125ed9f4-7777-1dbn-mac8-43fddce9123e   B1
    
     Use ``nodetool gossipinfo`` to see ``192.168.1.204`` is in HIBERNATE status.
 


### PR DESCRIPTION
We want to always be able to distinguish between
the replacing node and the replacee by using different,
unique, host identifiers.
    
This will allow us to use the host_id authoritatively
to identify the node (rather then its endpoint ip address)
for token mapping and node operations.
    
Also, it can be used, to never allow the replaced
node to rejoin the cluster, as its host_id should never be reused.

This series adds a system.quarantined_hosts table
that record host_id of nodes that were removed the ring (via e.g. remove or replace)
and are not allowed to rejoin it.

Refs #11217
Refs #5523
Refs #11868

Refs #6403
Refs #9839
Refs #12040