### PR TITLE
Abort repair tasks

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -63,28 +63,6 @@ void node_ops_info::check_abort() {
     }
 }
 
-future<> node_ops_info::start() {
-    if (as) {
-        co_await _sas.start();
-        _abort_subscription = as->subscribe([this] () noexcept {
-            _abort_done = _sas.invoke_on_all([] (abort_source& as) noexcept {
-                as.request_abort();
-            });
-        });
-    }
-}
-
-future<> node_ops_info::stop() noexcept {
-    if (as) {
-        co_await std::exchange(_abort_done, make_ready_future<>());
-        co_await _sas.stop();
-    }
-}
-
-abort_source* node_ops_info::local_abort_source() {
-    return as ? &_sas.local() : nullptr;
-}
-
 node_ops_metrics::node_ops_metrics(shared_ptr<repair_module> module)
     : _module(module)
 {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1309,7 +1309,7 @@ future<> data_sync_repair_task_impl::run() {
 
     auto id = get_repair_uniq_id();
     rlogger.info("repair[{}]: sync data for keyspace={}, status=started", id.uuid(), keyspace);
-    co_await module->run(id, [this, &rs, id, &db, keyspace, germs = std::move(germs), &ranges = _ranges, &neighbors = _neighbors, reason = _reason, ops_info = _ops_info] () mutable {
+    co_await module->run(id, [this, &rs, id, &db, keyspace, germs = std::move(germs), &ranges = _ranges, &neighbors = _neighbors, reason = _reason] () mutable {
         auto cfs = list_column_families(db, keyspace);
         if (cfs.empty()) {
             rlogger.warn("repair[{}]: sync data for keyspace={}, no table in this keyspace", id.uuid(), keyspace);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -553,7 +553,6 @@ get_sharder_for_tables(seastar::sharded<replica::database>& db, const sstring& k
 shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::module_ptr module,
         tasks::task_id id,
         const sstring& keyspace,
-        std::exception_ptr ex,
         repair_service& repair,
         locator::effective_replication_map_ptr erm_,
         const dht::token_range_vector& ranges_,
@@ -563,10 +562,8 @@ shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::module_ptr m
         const std::vector<sstring>& hosts_,
         const std::unordered_set<gms::inet_address>& ignore_nodes_,
         streaming::stream_reason reason_,
-        abort_source* as,
         bool hints_batchlog_flushed)
     : repair_task_impl(module, id, 0, keyspace, "", "", parent_id_.uuid(), reason_)
-    , _ex(std::move(ex))
     , rs(repair)
     , db(repair.get_db())
     , messaging(repair.get_messaging().container())
@@ -586,11 +583,7 @@ shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::module_ptr m
     , total_rf(erm->get_replication_factor())
     , nr_ranges_total(ranges.size())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed))
-{
-    if (as != nullptr) {
-        _abort_subscription = as->subscribe([this] () noexcept { abort_repair_info(); });
-    }
-}
+{ }
 
 void shard_repair_task_impl::check_failed_ranges() {
     rlogger.info("repair[{}]: shard {} stats: repair_reason={}, keyspace={}, tables={}, ranges_nr={}, {}",
@@ -993,10 +986,6 @@ future<> shard_repair_task_impl::do_repair_ranges() {
 // is assumed to be a indivisible in the sense that all the tokens in has the
 // same nodes as replicas.
 future<> shard_repair_task_impl::run() {
-    if (_ex) {
-        return make_exception_future(_ex);
-    }
-
     rs.get_repair_module().add_shard_task_id(id.id, _status.id);
     return do_repair_ranges().then([this] {
         check_failed_ranges();
@@ -1229,11 +1218,10 @@ future<> user_requested_repair_task_impl::run() {
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
                     data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
-                std::exception_ptr ex;
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
                 auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
-                        ex, local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, nullptr, hints_batchlog_flushed);
+                        local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, hints_batchlog_flushed);
                 auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
                 co_await task->done();
             });
@@ -1334,21 +1322,14 @@ future<> data_sync_repair_task_impl::run() {
             throw std::runtime_error("aborted by user request");
         }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
-            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_info, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable -> future<> {
-                std::exception_ptr ex;
+            auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable -> future<> {
                 auto data_centers = std::vector<sstring>();
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
                 bool hints_batchlog_flushed = false;
-                abort_source* asp;
-                try {
-                    asp = ops_info ? ops_info->local_abort_source() : nullptr;
-                } catch (...) {
-                    ex = std::current_exception();
-                }
                 auto task_impl_ptr = std::make_unique<shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
-                        ex, local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
+                        local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, hints_batchlog_flushed);
                 task_impl_ptr->neighbors = std::move(neighbors);
                 auto task = co_await start_repair_task(std::move(task_impl_ptr), local_repair._repair_module, parent_data);
                 co_await task->done();

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -88,22 +88,12 @@ public:
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
 
-private:
-    optimized_optional<abort_source::subscription> _abort_subscription;
-    sharded<abort_source> _sas;
-    future<> _abort_done = make_ready_future<>();
-
 public:
     node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
 
-    future<> start();
-    future<> stop() noexcept;
-
     void check_abort();
-
-    abort_source* local_abort_source();
 };
 
 // NOTE: repair_start() can be run on any node, but starts a node-global

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -128,9 +128,7 @@ public:
         return tasks::is_internal::yes;
     }
     void check_failed_ranges();
-    void abort_repair_info() noexcept;
-    void check_in_abort();
-    void check_in_shutdown();
+    void check_in_abort_or_shutdown();
     repair_neighbors get_repair_neighbors(const dht::token_range& range);
     void update_statistics(const repair_stats& stats) {
         _stats.add(stats);

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -63,17 +63,15 @@ class data_sync_repair_task_impl : public repair_task_impl {
 private:
     dht::token_range_vector _ranges;
     std::unordered_map<dht::token_range, repair_neighbors> _neighbors;
-    shared_ptr<node_ops_info> _ops_info;
     optimized_optional<abort_source::subscription> _abort_subscription;
 public:
     data_sync_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, dht::token_range_vector ranges, std::unordered_map<dht::token_range, repair_neighbors> neighbors, streaming::stream_reason reason, shared_ptr<node_ops_info> ops_info)
         : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), reason)
         , _ranges(std::move(ranges))
         , _neighbors(std::move(neighbors))
-        , _ops_info(ops_info) 
     {
-        if (_ops_info && _ops_info->as) {
-            _abort_subscription = _ops_info->as->subscribe([this] () noexcept {
+        if (ops_info && ops_info->as) {
+            _abort_subscription = ops_info->as->subscribe([this] () noexcept {
                 (void)abort();
             });
         }

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -64,13 +64,20 @@ private:
     dht::token_range_vector _ranges;
     std::unordered_map<dht::token_range, repair_neighbors> _neighbors;
     shared_ptr<node_ops_info> _ops_info;
+    optimized_optional<abort_source::subscription> _abort_subscription;
 public:
     data_sync_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, dht::token_range_vector ranges, std::unordered_map<dht::token_range, repair_neighbors> neighbors, streaming::stream_reason reason, shared_ptr<node_ops_info> ops_info)
         : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), reason)
         , _ranges(std::move(ranges))
         , _neighbors(std::move(neighbors))
         , _ops_info(ops_info) 
-    {}
+    {
+        if (_ops_info && _ops_info->as) {
+            _abort_subscription = _ops_info->as->subscribe([this] () noexcept {
+                (void)abort();
+            });
+        }
+    }
 protected:
     future<> run() override;
 

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -53,6 +53,10 @@ public:
         , _data_centers(std::move(data_centers))
         , _ignore_nodes(std::move(ignore_nodes))
     {}
+
+    virtual tasks::is_abortable is_abortable() const noexcept override {
+        return tasks::is_abortable::yes;
+    }
 protected:
     future<> run() override;
 
@@ -75,6 +79,10 @@ public:
                 (void)abort();
             });
         }
+    }
+
+    virtual tasks::is_abortable is_abortable() const noexcept override {
+        return tasks::is_abortable(!_abort_subscription);
     }
 protected:
     future<> run() override;

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -85,8 +85,6 @@ protected:
 };
 
 class shard_repair_task_impl : public repair_task_impl {
-private:
-    std::exception_ptr _ex;
 public:
     repair_service& rs;
     seastar::sharded<replica::database>& db;
@@ -113,13 +111,11 @@ public:
     int ranges_index = 0;
     repair_stats _stats;
     std::unordered_set<sstring> dropped_tables;
-    optimized_optional<abort_source::subscription> _abort_subscription;
     bool _hints_batchlog_flushed = false;
 public:
     shard_repair_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             const sstring& keyspace,
-            std::exception_ptr ex,
             repair_service& repair,
             locator::effective_replication_map_ptr erm_,
             const dht::token_range_vector& ranges_,
@@ -129,7 +125,6 @@ public:
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ignore_nodes_,
             streaming::stream_reason reason_,
-            abort_source* as,
             bool hints_batchlog_flushed);
     virtual tasks::is_internal is_internal() const noexcept override {
         return tasks::is_internal::yes;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2496,8 +2496,7 @@ private:
 
     // Step A: Negotiate sync boundary to use
     op_status negotiate_sync_boundary(repair_meta& master) {
-        _shard_task.check_in_shutdown();
-        _shard_task.check_in_abort();
+        _shard_task.check_in_abort_or_shutdown();
         _sync_boundaries.clear();
         _combined_hashes.clear();
         _zero_rows = false;
@@ -2556,8 +2555,7 @@ private:
 
     // Step B: Get missing rows from peer nodes so that local node contains all the rows
     op_status get_missing_rows_from_follower_nodes(repair_meta& master) {
-        _shard_task.check_in_shutdown();
-        _shard_task.check_in_abort();
+        _shard_task.check_in_abort_or_shutdown();
         // `combined_hashes` contains the combined hashes for the
         // `_working_row_buf`. Like `_row_buf`, `_working_row_buf` contains
         // rows which are within the (_last_sync_boundary, _current_sync_boundary]
@@ -2688,8 +2686,7 @@ private:
     void send_missing_rows_to_follower_nodes(repair_meta& master) {
         // At this time, repair master contains all the rows between (_last_sync_boundary, _current_sync_boundary]
         // So we can figure out which rows peer node are missing and send the missing rows to them
-        _shard_task.check_in_shutdown();
-        _shard_task.check_in_abort();
+        _shard_task.check_in_abort_or_shutdown();
         repair_hash_set local_row_hash_sets = master.working_row_hashes().get0();
         auto sz = _all_live_peer_nodes.size();
         std::vector<repair_hash_set> set_diffs(sz);
@@ -2759,8 +2756,7 @@ private:
 public:
     future<> run() {
         return seastar::async([this] {
-            _shard_task.check_in_shutdown();
-            _shard_task.check_in_abort();
+            _shard_task.check_in_abort_or_shutdown();
             auto repair_meta_id = _shard_task.rs.get_next_repair_meta_id().get0();
             auto algorithm = get_common_diff_detect_algorithm(_shard_task.messaging.local(), _all_live_peer_nodes);
             auto max_row_buf_size = get_max_row_buf_size(algorithm);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2556,7 +2556,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
-            meta.start().get();
             _node_ops.emplace(ops_uuid, std::move(meta));
         } else if (req.cmd == node_ops_cmd::removenode_heartbeat) {
             slogger.debug("removenode[{}]: Updated heartbeat from coordinator={}", req.ops_uuid,  coordinator);
@@ -2607,7 +2606,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 });
             },
             [this, ops_uuid] () mutable { node_ops_singal_abort(ops_uuid); });
-            meta.start().get();
             _node_ops.emplace(ops_uuid, std::move(meta));
         } else if (req.cmd == node_ops_cmd::decommission_heartbeat) {
             slogger.debug("decommission[{}]: Updated heartbeat from coordinator={}", req.ops_uuid,  coordinator);
@@ -2652,7 +2650,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
-            meta.start().get();
             _node_ops.emplace(ops_uuid, std::move(meta));
         } else if (req.cmd == node_ops_cmd::replace_prepare_mark_alive) {
             // Wait for local node has marked replacing node as alive
@@ -2707,7 +2704,6 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 });
             },
             [this, ops_uuid ] { node_ops_singal_abort(ops_uuid); });
-            meta.start().get();
             _node_ops.emplace(ops_uuid, std::move(meta));
         } else if (req.cmd == node_ops_cmd::bootstrap_heartbeat) {
             slogger.debug("bootstrap[{}]: Updated heartbeat from coordinator={}", req.ops_uuid, coordinator);
@@ -3645,14 +3641,6 @@ node_ops_meta_data::node_ops_meta_data(
     _watchdog.arm(_watchdog_interval);
 }
 
-future<> node_ops_meta_data::start() {
-    return _ops ? _ops->start() : make_ready_future<>();
-}
-
-future<> node_ops_meta_data::stop() noexcept {
-    return _ops ? _ops->stop() : make_ready_future<>();
-}
-
 future<> node_ops_meta_data::abort() {
     slogger.debug("node_ops_meta_data: ops_uuid={} abort", _ops_uuid);
     _watchdog.cancel();
@@ -3698,7 +3686,6 @@ future<> storage_service::node_ops_done(utils::UUID ops_uuid) {
     if (it != _node_ops.end()) {
         node_ops_meta_data& meta = it->second;
         meta.cancel_watchdog();
-        co_await meta.stop();
         _node_ops.erase(it);
     }
 }
@@ -3718,7 +3705,6 @@ future<> storage_service::node_ops_abort(utils::UUID ops_uuid) {
 
         for (auto it = _node_ops.begin(); it != _node_ops.end(); it = _node_ops.erase(it)) {
             node_ops_meta_data& meta = it->second;
-            co_await meta.stop();
         }
 
         co_return;
@@ -3732,7 +3718,6 @@ future<> storage_service::node_ops_abort(utils::UUID ops_uuid) {
         if (as && !as->abort_requested()) {
             as->request_abort();
         }
-        co_await meta.stop();
         _node_ops.erase(it);
     }
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -106,8 +106,6 @@ public:
             std::list<gms::inet_address> ignore_nodes,
             std::function<future<> ()> abort_func,
             std::function<void ()> signal_func);
-    future<> start();
-    future<> stop() noexcept;
     shared_ptr<node_ops_info> get_ops_info();
     shared_ptr<abort_source> get_abort_source();
     future<> abort();

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -27,7 +27,14 @@ task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_
         })
     , _parent_id(parent_id)
     , _module(module)
-{}
+{
+    // Child tasks do not need to subscribe to abort source because they will be aborted recursively by their parents.
+    if (!parent_id) {
+        _shutdown_subscription = module->get_task_manager()._as.subscribe([this] () noexcept {
+            (void)abort();
+        });
+    }
+}
 
 future<task_manager::task::progress> task_manager::task::impl::get_progress() const {
     if (!_children.empty()) {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -98,6 +98,7 @@ public:
             shared_promise<> _done;
             module_ptr _module;
             abort_source _as;
+            optimized_optional<abort_source::subscription> _shutdown_subscription;
         public:
             impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept;
             virtual ~impl() = default;


### PR DESCRIPTION
Aborting of repair operation is fully managed by task manager.
Repair tasks are aborted:
- on shutdown; top level repair tasks subscribe to global abort source. On shutdown all tasks are aborted recursively
- through node operations (applies to data_sync_repair_task_impls and their descendants only); data_sync_repair_task_impl subscribes to node_ops_info abort source
- with task manager api (top level tasks are abortable)
- with storage_service api and on failure; these cases were modified to be aborted the same way as the ones from above are.