### PR TITLE
repair: fix double start of data sync repair task

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1288,7 +1288,6 @@ future<> repair_service::sync_data_using_repair(
     assert(this_shard_id() == 0);
     auto task_impl_ptr = std::make_unique<data_sync_repair_task_impl>(_repair_module, _repair_module->new_repair_uniq_id(), std::move(keyspace), format("{}", reason), "", std::move(ranges), std::move(neighbors), reason, ops_info);
     auto task = co_await start_repair_task(std::move(task_impl_ptr), _repair_module);
-    task->start();
     co_await task->done();
 }
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -130,6 +130,9 @@ void task_manager::task::add_child(foreign_task_ptr&& child) {
 }
 
 void task_manager::task::start() {
+    if (_impl->_status.state != task_state::created) {
+        on_fatal_internal_error(tmlogger, format("{} task with id = {} was started twice", _impl->_module->get_name(), id()));
+    }
     _impl->_status.start_time = db_clock::now();
 
     try {


### PR DESCRIPTION
Currently, each data sync repair task is started (and hence run) twice. 
Thus, when two running operations happen within a time frame long 
enough, the following situation may occur:
- the first run finishes
- after some time (ttl) the task is unregistered from the task manager
- the second run finishes and attempts to finish the task which does
  not exist anymore
- memory access causes a segfault.

The second call to start is deleted. An assertion is added to the start 
method to ensure that each task is started at most once.

Fixes: #12089