### PR TITLE
doc: set the documentation version 5.1 as default (latest)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath(".."))
 TAGS = []
 BRANCHES = ["master", "branch-5.1"]
 # Set the latest version.
-LATEST_VERSION = "master"
+LATEST_VERSION = "branch-5.1"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated


### PR DESCRIPTION
I've verified that the published documentation for version 5.1 looks as expected and is added to the version drop-down. Currently, it's not set as the default/latest version, so the warning message pops up.
This PR sets 5.1 as the default/latest version and is the final step of the documentation release procedure.

It should be merged to master; no need to backport to branch-5.1
