### PR TITLE
test/alternator: increase timeout on TTL tests

### DIFF
--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -348,7 +348,7 @@ def test_ttl_expiration_with_rangekey(dynamodb, waits_for_expiration):
     # Note that unlike test_ttl_expiration, this test doesn't have a fixed
     # duration - it finishes as soon as the item we expect to be expired
     # is expired.
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
@@ -386,7 +386,7 @@ def test_ttl_expiration_with_rangekey(dynamodb, waits_for_expiration):
 # Just like test_ttl_expiration() above, these tests are extremely slow
 # on AWS because DynamoDB delays expiration by around 10 minutes.
 def test_ttl_expiration_hash(dynamodb, waits_for_expiration):
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -418,7 +418,7 @@ def test_ttl_expiration_hash(dynamodb, waits_for_expiration):
         assert check_expired()
 
 def test_ttl_expiration_range(dynamodb, waits_for_expiration):
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
@@ -490,7 +490,7 @@ def test_ttl_expiration_gsi_lsi(dynamodb, waits_for_expiration):
     # items are expired with significant delay. Whereas a 10 minute delay
     # for regular tables was typical, in the table we have here we saw
     # a typical delay of 30 minutes before items expired.
-    max_duration = 3600 if is_aws(dynamodb) else 120
+    max_duration = 3600 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[
@@ -576,7 +576,7 @@ def test_ttl_expiration_gsi_lsi(dynamodb, waits_for_expiration):
 def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
     # In my experiments, a 30-minute (1800 seconds) is the typical delay
     # for expiration in this test for DynamoDB
-    max_duration = 3600 if is_aws(dynamodb) else 120
+    max_duration = 3600 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[


### PR DESCRIPTION
Some of the tests in test/alternator/test_ttl.py need an expiration scan pass to complete and expire items. In development builds on developer machines, this usually takes less than a second (our scanning period is set to half a second). However, in debug builds on Jenkins each scan often takes up to 100 (!) seconds (this is the record we've seen so far). This is why we set the tests' timeout to 120.

But recently we saw another test run failing. I think the problem is that in some case, we need not one, but *two* scanning passes to complete before the timeout: It is possible that the test writes an item right after the current scan passed it, so it doesn't get expired, and then we a second scan at a random position, possibly making that item we mention one of the last items to be considered - so in total we need to wait for two scanning periods, not one, for the item to expire.

So this patch increases the timeout from 120 seconds to 240 seconds - more than twice the highest scanning time we ever saw (100 seconds).

Note that this timeout is just a timeout, it's not the typical test run time: The test can finish much more quickly, as little as one second, if items expire quickly on a fast build and machine.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>