### PR TITLE
service/raft: specialized verb for failure detector pinger

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -432,14 +432,14 @@ public:
     static future<utils::UUID> get_raft_group0_id();
 
     // Load this server id from scylla.local
-    static future<utils::UUID> get_raft_server_id();
+    future<utils::UUID> get_raft_server_id();
 
     // Persist Raft Group 0 id. Should be a TIMEUUID.
     static future<> set_raft_group0_id(utils::UUID id);
 
     // Called once at fresh server startup to make sure every server
     // has a Raft ID
-    static future<> set_raft_server_id(utils::UUID id);
+    future<> set_raft_server_id(utils::UUID id);
 
     // Save advertised gossip feature set to system.local
     static future<> save_local_supported_features(const std::set<std::string_view>& feats);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -99,8 +99,7 @@ gossiper::gossiper(abort_source& as, feature_service& features, const locator::s
         , _sys_ks(sys_ks)
         , _failure_detector_timeout_ms(cfg.failure_detector_timeout_in_ms)
         , _force_gossip_generation(cfg.force_gossip_generation)
-        , _gcfg(std::move(gcfg))
-        , _echo_pinger(*this) {
+        , _gcfg(std::move(gcfg)) {
     // Gossiper's stuff below runs only on CPU0
     if (this_shard_id() != 0) {
         return;
@@ -970,7 +969,6 @@ void gossiper::run() {
                 }).get();
             }
 
-            _echo_pinger.update_generation_number(_endpoint_state_map[get_broadcast_address()].get_heart_beat_state().get_generation()).get();
     }).then_wrapped([this] (auto&& f) {
         try {
             f.get();
@@ -1852,7 +1850,6 @@ future<> gossiper::start_gossiping(int generation_nbr, std::map<application_stat
     co_await container().invoke_on_all([] (gms::gossiper& g) {
         g._failure_detector_loop_done = g.failure_detector_loop();
     });
-    co_await _echo_pinger.update_generation_number(generation_nbr);
 }
 
 future<std::unordered_map<gms::inet_address, int32_t>>
@@ -2540,20 +2537,6 @@ future<> gossiper::maybe_enable_features() {
 
 locator::token_metadata_ptr gossiper::get_token_metadata_ptr() const noexcept {
     return _shared_token_metadata.get();
-}
-
-future<> echo_pinger::update_generation_number(int64_t n) {
-    if (n <= _generation_number) {
-        return make_ready_future<>();
-    }
-
-    return _gossiper.container().invoke_on_all([n] (gossiper& g) {
-        g._echo_pinger._generation_number = n;
-    });
-}
-
-future<> echo_pinger::ping(const gms::inet_address& addr, abort_source& as) {
-    return _gossiper._messaging.send_gossip_echo(netw::msg_addr(addr), _generation_number, as);
 }
 
 } // namespace gms

--- a/idl/raft.idl.hh
+++ b/idl/raft.idl.hh
@@ -106,3 +106,17 @@ verb [[with_client_info, with_timeout]] raft_add_entry (raft::group_id, raft::se
 verb [[with_client_info, with_timeout]] raft_modify_config (raft::group_id gid, raft::server_id from_id, raft::server_id dst_id, std::vector<raft::config_member> add, std::vector<raft::server_id> del) -> raft::add_entry_reply;
 
 } // namespace raft
+
+namespace service {
+
+struct wrong_destination {
+    raft::server_id reached_id;
+};
+
+struct direct_fd_ping_reply {
+    std::variant<std::monostate, service::wrong_destination> result;
+};
+
+verb [[with_client_info, cancellable]] direct_fd_ping (raft::server_id dst_id) -> service::direct_fd_ping_reply;
+
+} // namespace service

--- a/main.cc
+++ b/main.cc
@@ -926,7 +926,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             static sharded<service::direct_fd_pinger> fd_pinger;
             supervisor::notify("starting direct failure detector pinger service");
-            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper)), std::ref(raft_address_map)).get();
+            fd_pinger.start(std::ref(messaging), std::ref(raft_address_map)).get();
 
             auto stop_fd_pinger = defer_verbose_shutdown("fd_pinger", [] {
                 fd_pinger.stop().get();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -562,6 +562,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::RAFT_EXECUTE_READ_BARRIER_ON_LEADER:
     case messaging_verb::RAFT_ADD_ENTRY:
     case messaging_verb::RAFT_MODIFY_CONFIG:
+    case messaging_verb::DIRECT_FD_PING:
         return 2;
     case messaging_verb::MUTATION_DONE:
     case messaging_verb::MUTATION_FAILED:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -179,7 +179,8 @@ enum class messaging_verb : int32_t {
     REPAIR_FLUSH_HINTS_BATCHLOG = 60,
     FORWARD_REQUEST = 61,
     GET_GROUP0_UPGRADE_STATE = 62,
-    LAST = 63,
+    DIRECT_FD_PING = 63,
+    LAST = 64,
 };
 
 } // namespace netw

--- a/service/raft/group0_fwd.hh
+++ b/service/raft/group0_fwd.hh
@@ -71,4 +71,12 @@ inline constexpr uint8_t group0_upgrade_state_last = 3;
 
 std::ostream& operator<<(std::ostream&, group0_upgrade_state);
 
+struct wrong_destination {
+    raft::server_id reached_id;
+};
+
+struct direct_fd_ping_reply {
+    std::variant<std::monostate, wrong_destination> result;
+};
+
 } // namespace service

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -160,10 +160,12 @@ public:
     // We'll look for the other node's Raft ID in the group 0 configuration.
     future<> remove_from_group0(gms::inet_address host);
 
-    // Loads server id for group 0 from disk if present,
-    // otherwise randomly generates a new one and persists it.
-    // Execute on shard 0 only.
-    future<raft::server_id> load_or_create_my_id();
+    // Assumes that this node's Raft server ID is already initialized and returns it.
+    // It's a fatal error if the id is missing.
+    //
+    // The returned ID is not empty.
+    const raft::server_id& load_my_id();
+
 private:
     void init_rpc_verbs();
     future<> uninit_rpc_verbs();
@@ -174,14 +176,6 @@ private:
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
 
     raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_id my_id);
-
-    // Assumes server id for group 0 is already persisted and loads it from disk.
-    // It's a fatal error if the id is missing.
-    //
-    // Execute on shard 0 only.
-    //
-    // The returned ID is not empty.
-    future<raft::server_id> load_my_id();
 
     // Run the discovery algorithm.
     //

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -137,10 +137,10 @@ public:
 
 future<raft::server_id> load_or_create_my_raft_id(db::system_keyspace& sys_ks) {
     assert(this_shard_id() == 0);
-    auto id = raft::server_id{co_await db::system_keyspace::get_raft_server_id()};
+    auto id = raft::server_id{co_await sys_ks.get_raft_server_id()};
     if (id == raft::server_id{}) {
         id = raft::server_id::create_random_id();
-        co_await db::system_keyspace::set_raft_server_id(id.id);
+        co_await sys_ks.set_raft_server_id(id.id);
     }
     co_return id;
 }

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -19,7 +19,6 @@
 
 namespace gms {
 class gossiper;
-class echo_pinger;
 }
 
 namespace db {
@@ -144,16 +143,15 @@ public:
     bool is_enabled() const { return _is_enabled; }
 };
 
-// Implementation of `direct_failure_detector::pinger` which uses gossip echo messages for pinging.
+// Implementation of `direct_failure_detector::pinger` which uses DIRECT_FD_PING verb for pinging.
 // Translates `raft::server_id`s to `gms::inet_address`es before pinging.
-// The actual pinging is performed by `echo_pinger`.
 class direct_fd_pinger : public seastar::peering_sharded_service<direct_fd_pinger>, public direct_failure_detector::pinger {
-    gms::echo_pinger& _echo_pinger;
+    netw::messaging_service& _ms;
     raft_address_map& _address_map;
 
 public:
-    direct_fd_pinger(gms::echo_pinger& pinger, raft_address_map& address_map)
-            : _echo_pinger(pinger), _address_map(address_map) {}
+    direct_fd_pinger(netw::messaging_service& ms, raft_address_map& address_map)
+            : _ms(ms), _address_map(address_map) {}
 
     direct_fd_pinger(const direct_fd_pinger&) = delete;
     direct_fd_pinger(direct_fd_pinger&&) = delete;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -406,7 +406,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     app_states.emplace(gms::application_state::HOST_ID, versioned_value::host_id(local_host_id));
     app_states.emplace(gms::application_state::RPC_ADDRESS, versioned_value::rpcaddress(broadcast_rpc_address));
     if (_group0->is_raft_enabled()) {
-        auto my_id = co_await _group0->load_or_create_my_id();
+        auto my_id = _group0->load_my_id();
         app_states.emplace(gms::application_state::RAFT_SERVER_ID, versioned_value::raft_server_id(my_id.id));
     }
     app_states.emplace(gms::application_state::RELEASE_VERSION, versioned_value::release_version());

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -648,7 +648,6 @@ public:
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::feature::RAFT),
                 std::ref(raft_address_map), std::ref(ms), std::ref(gossiper), std::ref(fd)).get();
             auto stop_raft_gr = deferred_stop(raft_gr);
-            raft_gr.invoke_on_all(&service::raft_group_registry::start).get();
 
             stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(ms), std::ref(mm), std::ref(gossiper)).get();
             auto stop_streaming = defer([&stream_manager] { stream_manager.stop().get(); });
@@ -785,6 +784,13 @@ public:
                     t.enable_auto_compaction();
                 }
             }).get();
+
+            if (raft_gr.local().is_enabled()) {
+                auto my_raft_id = service::load_or_create_my_raft_id(sys_ks.local()).get();
+                raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {
+                    return raft_gr.start(my_raft_id);
+                }).get();
+            }
 
             group0_client.init().get();
             auto stop_system_keyspace = defer([&sys_ks] {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -633,7 +633,7 @@ public:
 
 
             static sharded<service::direct_fd_pinger> fd_pinger;
-            fd_pinger.start(sharded_parameter([] (gms::gossiper& g) { return std::ref(g.get_echo_pinger()); }, std::ref(gossiper)), std::ref(raft_address_map)).get();
+            fd_pinger.start(std::ref(ms), std::ref(raft_address_map)).get();
             auto stop_fd_pinger = defer([] { fd_pinger.stop().get(); });
 
             service::direct_fd_clock fd_clock;


### PR DESCRIPTION
We used GOSSIP_ECHO verb to perform failure detection. Now we use
a special verb DIRECT_FD_PING introduced for this purpose.

There are multiple reasons to do so.

One minor reason: we want to use the same connection as other Raft
verbs: if we can't deliver Raft append_entries or vote messages
somewhere, that endpoint should be marked dead; if we can, the
endpoint should be marked alive. So putting pings on the same
connection as the other Raft verbs is important when dealing with
weird situations where some connections are available but others are
not. Observe that in `do_get_rpc_client_idx`, we put the new verb in
the right place.

Another minor reason: we remove the awkward gossiper `echo_pinger`
abstraction which required storing and updating gossiper generation
numbers. This also removes one dependency from Raft service code to
gossiper.

Major reason 1: the gossip echo handler has a weird mechanism where a
replacing node returns errors during the replace operation to some of
the nodes. In Raft however, we want to mark servers as alive when they
are alive, including a server running on a node that's replacing
another node.

Major reason 2, related to the previous one: when server B is
replacing server A with the same IP, the failure detector will try to
ping both servers. Both servers are mapped to the same IP by the
address map, so pings to both servers will reach server B. We want
server B to respond to the pings destined for server B, but not to
pings destined for server A, so the sender can mark B alive but keep A
marked dead.

To do this, we include the destination's Raft ID in our RPCs. The
destination compares the received ID with its own. If it's different,
it returns a `wrong_destination` response, and the failure detector
knows that the ping did not reach the destination (it reached someone
else).

Yet another reason: removes "Not ready to respond gossip echo
message" log spam during replace.