### PR TITLE
forward_service: add debug logs

### DIFF
--- a/query-request.hh
+++ b/query-request.hh
@@ -414,7 +414,7 @@ struct forward_result {
     std::vector<bytes_opt> query_results;
 
     struct printer {
-        const std::vector<::shared_ptr<db::functions::aggregate_function>>& functions;
+        const std::vector<::shared_ptr<db::functions::aggregate_function>> functions;
         const query::forward_result& res;
     };
 };


### PR DESCRIPTION
Adds a few debug logs to see what is happening in https://github.com/scylladb/scylladb/issues/11684

The issue happens sometimes on the Jenkins and I didn't manage to reproduce the problem locally, the test was always passing. The logs are to determine whether the problem is with `forward_service`.

Referring: https://github.com/scylladb/scylladb/issues/11684