### PR TITLE
docker: prevent hostname -i failure when --listen-address specified

### DIFF
--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -68,7 +68,12 @@ class ScyllaSetup:
 
     def cqlshrc(self):
         home = os.environ['HOME']
-        hostname = subprocess.check_output(['hostname', '-i']).decode('ascii').strip()
+        if self._rpcAddress:
+            hostname = self._rpcAddress
+        elif self._listenAddress:
+            hostname = self._listenAddress
+        else:
+            hostname = subprocess.check_output(['hostname', '-i']).decode('ascii').strip()
         with open("%s/.cqlshrc" % home, "w") as cqlshrc:
             cqlshrc.write("[connection]\nhostname = %s\n" % hostname)
 


### PR DESCRIPTION
On some docker instance configuration, hostname resolution does not work, so our script will fail on startup because we use hostname -i to construct cqlshrc.
To prevent the error, we can use --listen-address for the address since it should be same.

Fixes #12011