### PR TITLE
cql3: expr: fold `null` into untyped_constant/constant

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1513,7 +1513,7 @@ value returns [expression value]
     | l=collectionLiteral  { $value = std::move(l); }
     | u=usertypeLiteral    { $value = std::move(u); }
     | t=tupleLiteral       { $value = std::move(t); }
-    | K_NULL               { $value = null(); }
+    | K_NULL               { $value = make_untyped_null(); }
     | e=marker             { $value = std::move(e); }
     ;
 
@@ -1678,7 +1678,7 @@ relation returns [expression e]
     | K_TOKEN l=tupleOfIdentifiers type=relationType t=term
         { $e = binary_operator(token{std::move(l.elements)}, type, std::move(t)); }
     | name=cident K_IS K_NOT K_NULL {
-          $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, null()); }
+          $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, make_untyped_null()); }
     | name=cident K_IN marker1=marker
         { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN, std::move(marker1)); }
     | name=cident K_IN in_values=singleColumnInValues

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -309,7 +309,7 @@ column_condition::raw::prepare(data_dictionary::database db, const sstring& keys
 
     if (_op == expr::oper_t::LIKE) {
         auto literal_term = expr::as_if<expr::untyped_constant>(&*_value);
-        if (literal_term) {
+        if (literal_term && literal_term->partial_type != expr::untyped_constant::type_class::null) {
             // Pass matcher object
             const sstring& pattern = literal_term->raw_text;
             return column_condition::condition(receiver, std::move(collection_element_expression),

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -144,7 +144,7 @@ void preliminary_binop_vaidation_checks(const binary_operator& binop) {
     }
 
     if (binop.op == oper_t::IS_NOT) {
-        bool rhs_is_null = is<null>(binop.rhs)
+        bool rhs_is_null = (is<untyped_constant>(binop.rhs) && as<untyped_constant>(binop.rhs).partial_type == untyped_constant::type_class::null)
                            || (is<constant>(binop.rhs) && as<constant>(binop.rhs).is_null());
         if (!rhs_is_null) {
             throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {}", pretty_binop_printer));

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -153,10 +153,6 @@ static std::vector<expr::expression> extract_partition_range(
             on_internal_error(rlogger, "extract_partition_range(field_selection)");
         }
 
-        void operator()(const null&) {
-            on_internal_error(rlogger, "extract_partition_range(null)");
-        }
-
         void operator()(const bind_variable&) {
             on_internal_error(rlogger, "extract_partition_range(bind_variable)");
         }
@@ -276,10 +272,6 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const field_selection&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(field_selection)");
-        }
-
-        void operator()(const null&) {
-            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(null)");
         }
 
         void operator()(const bind_variable&) {
@@ -1237,10 +1229,6 @@ struct multi_column_range_accumulator {
 
     void operator()(const field_selection&) {
         on_internal_error(rlogger, "field selection encountered outside binary operator");
-    }
-
-    void operator()(const null&) {
-        on_internal_error(rlogger, "null encountered outside binary operator");
     }
 
     void operator()(const bind_variable&) {

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -222,9 +222,6 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             return make_shared<selectable::with_field_selection>(prepare_selectable(s, fs.structure),
                     fs.field->prepare(s));
         },
-        [&] (const expr::null&) -> shared_ptr<selectable> {
-            on_internal_error(slogger, "null found its way to selector context");
-        },
         [&] (const expr::bind_variable&) -> shared_ptr<selectable> {
             on_internal_error(slogger, "bind_variable found its way to selector context");
         },
@@ -282,9 +279,6 @@ selectable_processes_selection(const expr::expression& raw_selectable) {
         },
         [&] (const expr::field_selection& fs) -> bool {
             return true;
-        },
-        [&] (const expr::null&) -> bool {
-            on_internal_error(slogger, "null found its way to selector context");
         },
         [&] (const expr::bind_variable&) -> bool {
             on_internal_error(slogger, "bind_variable found its way to selector context");

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1529,7 +1529,7 @@ BOOST_AUTO_TEST_CASE(prepare_null) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression null_expr = null{};
+    expression null_expr = make_untyped_null();
 
     expression prepared = prepare_expression(null_expr, db, "test_ks", table_schema.get(), make_receiver(int32_type));
     expression expected = constant::make_null(int32_type);
@@ -1541,7 +1541,7 @@ BOOST_AUTO_TEST_CASE(prepare_null_no_type_fails) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression null_expr = null{};
+    expression null_expr = make_untyped_null();
     BOOST_REQUIRE_THROW(prepare_expression(null_expr, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
 }
@@ -1863,7 +1863,7 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_null) {
         .style = collection_constructor::style_type::list,
         .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
                      untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
-                     null{}},
+                     make_untyped_null()},
         .type = nullptr};
 
     data_type list_type = list_type_impl::get_instance(long_type, true);
@@ -1992,7 +1992,7 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_null) {
         .elements =
             {
                 untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
-                null{},
+                make_untyped_null(),
                 untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
             },
         .type = nullptr};
@@ -2250,7 +2250,8 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_null_key) {
                              untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "30"}},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {null{}, untyped_constant{.partial_type = untyped_constant::type_class::integer,
+                        .elements = {make_untyped_null(),
+                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
                                                               .raw_text = "-20"}},
                         .type = nullptr},
                     tuple_constructor{
@@ -2283,7 +2284,7 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_null_value) {
                                   .type = nullptr},
                 tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
                                                                 .raw_text = "2"},
-                                               null{}},
+                                               make_untyped_null()},
                                   .type = nullptr},
                 tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
                                                                 .raw_text = "1"},
@@ -2358,7 +2359,7 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_null) {
     constructor_elements.emplace(
         column_identifier("field1", true),
         untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
-    constructor_elements.emplace(column_identifier("field2", true), null{});
+    constructor_elements.emplace(column_identifier("field2", true), make_untyped_null());
     constructor_elements.emplace(
         column_identifier("field3", true),
         untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});


### PR DESCRIPTION
Our `null` expression, after the prepare stage, is redundant with a `constant` expression containing the value NULL.

Remove it. Its role in the unprepared stage is taken over by untyped_constant, which gains a new type_class enumeration to represent it.

Some subtleties:
 - Usually, handling of null and untyped_constant, or null and constant was the same, so they are just folded into each other
 - LWT "like" operator now has to discriminate between a literal string and a literal NULL
 - prepare and test_assignment were folded into the corresponing untyped_constant functions. Some care had to be taken to preserve error messages.