### PR TITLE
treewide: improve compatibility with gcc 12

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -457,7 +457,9 @@ public:
             _begin.ptr->size = _size;
             _current = nullptr;
             _size = 0;
-            return managed_bytes(std::exchange(_begin.ptr, {}));
+            auto begin_ptr = _begin.ptr;
+            _begin.ptr = nullptr;
+            return managed_bytes(begin_ptr);
         } else {
             return managed_bytes();
         }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1045,7 +1045,7 @@ future<> compaction_manager::maybe_wait_for_sstable_count_reduction(compaction::
             desc.sstables
             | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::run_identifier))).size();
     };
-    const auto threshold = std::max(schema->max_compaction_threshold(), 32);
+    const auto threshold = size_t(std::max(schema->max_compaction_threshold(), 32));
     auto count = num_runs_for_compaction();
     if (count <= threshold) {
         cmlog.trace("No need to wait for sstable count reduction in {}.{}: {} <= {}",

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -232,10 +232,6 @@ void create_index_statement::validate_not_full_index(const index_target& target)
 
 void create_index_statement::validate_for_collection(const index_target& target, const column_definition& cd) const
 {
-    auto throw_exception = [&] {
-        const char* msg_format = "Cannot create secondary index on {} of non-frozen collection column {}";
-        throw exceptions::invalid_request_exception(format(msg_format, to_sstring(target.type), cd.name_as_text()));
-    };
     switch (target.type) {
         case index_target::target_type::full:
             throw std::logic_error("invalid target type(full) in validate_for_collection");

--- a/db/per_partition_rate_limit_options.hh
+++ b/db/per_partition_rate_limit_options.hh
@@ -41,6 +41,7 @@ public:
         case operation_type::read:
             return _max_reads_per_second;
         }
+        std::abort(); // compiler will error before we reach here
     }
 
     inline void set_max_writes_per_second(std::optional<uint32_t> v) {

--- a/direct_failure_detector/failure_detector.cc
+++ b/direct_failure_detector/failure_detector.cc
@@ -48,7 +48,7 @@ struct listeners_liveness {
     std::vector<listener_info> listeners;
 
     // For each endpoint managed by this shard, the liveness state of this endpoint shared by all listeners in `listeners`.
-    std::unordered_map<pinger::endpoint_id, endpoint_liveness> endpoint_liveness;
+    std::unordered_map<pinger::endpoint_id, direct_failure_detector::endpoint_liveness> endpoint_liveness;
 };
 
 enum class endpoint_update {

--- a/mutation_fragment.cc
+++ b/mutation_fragment.cc
@@ -45,6 +45,7 @@ std::string_view to_string(partition_region r) {
         case partition_region::clustered: return "clustered";
         case partition_region::partition_end: return "partition_end";
     }
+    std::abort(); // compiler will error before we reach here
 }
 
 partition_region parse_partition_region(std::string_view s) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1413,9 +1413,6 @@ uint32_t mutation_partition::do_compact(const schema& s,
     auto should_purge_tombstone = [&] (const tombstone& t) {
         return t.deletion_time < gc_before && can_gc(t);
     };
-    auto should_purge_row_tombstone = [&] (const row_tombstone& t) {
-        return t.max_deletion_time() < gc_before && can_gc(t.tomb());
-    };
 
     bool static_row_live = _static_row.compact_and_expire(s, column_kind::static_column, row_tombstone(_tombstone),
         query_time, can_gc, gc_before);

--- a/raft/log.cc
+++ b/raft/log.cc
@@ -244,7 +244,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
     } else {
         auto entries_to_remove = _log.size() - (last_idx() - idx);
         size_t trailing_bytes = 0;
-        for (int i = 0; i < max_trailing_entries && entries_to_remove > 0; ++i) {
+        for (size_t i = 0; i < max_trailing_entries && entries_to_remove > 0; ++i) {
             trailing_bytes += memory_usage_of(*_log[entries_to_remove - 1], _max_command_size);
             if (trailing_bytes > max_trailing_bytes) {
                 break;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1961,7 +1961,7 @@ future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::t
 
     writers.reserve(muts.size());
 
-    for (auto i = 0; i < muts.size(); ++i) {
+    for (size_t i = 0; i < muts.size(); ++i) {
         auto s = local_schema_registry().get(muts[i].schema_version());
         auto&& cf = find_column_family(muts[i].column_family_id());
 
@@ -1995,7 +1995,7 @@ future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::t
     std::vector<rp_handle> handles = co_await cl->add_entries(std::move(writers), timeout);
 
     // FIXME: Memtable application is not atomic so reads may observe mutations partially applied until restart.
-    for (auto i = 0; i < muts.size(); ++i) {
+    for (size_t i = 0; i < muts.size(); ++i) {
         auto&& cf = find_column_family(muts[i].column_family_id());
         auto s = local_schema_registry().get(muts[i].schema_version());
         co_await apply_in_memory(muts[i], s, std::move(handles[i]), timeout);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -727,6 +727,7 @@ public:
         case db::operation_type::read:
             return _rate_limiter_label_for_reads;
         }
+        std::abort(); // compiler will error if we get here
     }
 
     db::rate_limiter::label& get_rate_limiter_label_for_writes() {

--- a/schema.cc
+++ b/schema.cc
@@ -1774,8 +1774,6 @@ void collection_column_computation::operate_on_collection_entries(
 
     const column_definition* cdef = schema.get_column_definition(_collection_name);
 
-    auto get_cell = [](auto& kv) -> collection_kv::second_type& { return kv->second; };
-
     decltype(collection_mutation_view_description::cells) update_cells, existing_cells;
 
     const auto* update_cell = update.cells().find_cell(cdef->id);

--- a/schema.cc
+++ b/schema.cc
@@ -1854,6 +1854,7 @@ std::vector<db::view::view_key_and_action> collection_column_computation::comput
                 bytes_opt elements[] = {bytes(key), value.value().linearize()};
                 return tuple_type_impl::build_value(elements);
         }
+        std::abort(); // compiler will error
     };
 
     std::vector<db::view::view_key_and_action> ret;

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -47,7 +47,7 @@ string_type to_sstring(sstables::generation_type generation) {
 namespace std {
 template <>
 struct hash<sstables::generation_type> {
-    constexpr size_t operator()(const sstables::generation_type& generation) const noexcept {
+    size_t operator()(const sstables::generation_type& generation) const noexcept {
         return hash<int64_t>{}(generation.value());
     }
 };

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -44,7 +44,7 @@ private:
     task_map _all_tasks;
     modules _modules;
     config _cfg;
-    abort_source& _as;
+    seastar::abort_source& _as;
     serialized_action _update_task_ttl_action;
     utils::observer<uint32_t> _task_ttl_observer;
     uint32_t _task_ttl;
@@ -101,8 +101,8 @@ public:
             impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string type, std::string entity, task_id parent_id) noexcept;
 
             virtual future<task_manager::task::progress> get_progress() const;
-            virtual is_abortable is_abortable() const noexcept;
-            virtual is_internal is_internal() const noexcept;
+            virtual tasks::is_abortable is_abortable() const noexcept;
+            virtual tasks::is_internal is_internal() const noexcept;
             virtual future<> abort() noexcept;
         protected:
             virtual future<> run() = 0;
@@ -130,8 +130,8 @@ public:
         std::string get_module_name() const noexcept;
         module_ptr get_module() const noexcept;
         future<progress> get_progress() const;
-        is_abortable is_abortable() const noexcept;
-        is_internal is_internal() const noexcept;
+        tasks::is_abortable is_abortable() const noexcept;
+        tasks::is_internal is_internal() const noexcept;
         future<> abort() noexcept;
         bool abort_requested() const noexcept;
         future<> done() const noexcept;
@@ -153,7 +153,7 @@ public:
 
         uint64_t new_sequence_number() noexcept;
         task_manager& get_task_manager() noexcept;
-        virtual abort_source& abort_source() noexcept;
+        virtual seastar::abort_source& abort_source() noexcept;
         gate& async_gate() noexcept;
         const std::string& get_name() const noexcept;
         task_manager::task_map& get_tasks() noexcept;
@@ -198,7 +198,7 @@ public:
     template<typename T>
     static future<T> invoke_on_task(sharded<task_manager>& tm, task_id id, std::function<future<T> (task_manager::task_ptr)> func);
 protected:
-    abort_source& abort_source() noexcept;
+    seastar::abort_source& abort_source() noexcept;
     std::chrono::seconds get_task_ttl() const noexcept;
 private:
     future<> update_task_ttl() noexcept {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -727,7 +727,7 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
                     if (ret < 0) {
                         throw std::runtime_error("CQL frame LZ4 uncompression failure");
                     }
-                    if (ret != out.size()) {
+                    if (size_t(ret) != out.size()) {  // ret is known to be positive here
                         throw std::runtime_error("Malformed CQL frame - provided uncompressed size different than real uncompressed size");
                     }
                     return static_cast<size_t>(ret);

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -436,7 +436,7 @@ class segment_pool;
 struct reclaim_timer;
 
 class tracker::impl {
-    std::unique_ptr<segment_pool> _segment_pool;
+    std::unique_ptr<logalloc::segment_pool> _segment_pool;
     std::optional<background_reclaimer> _background_reclaimer;
     std::vector<region::impl*> _regions;
     seastar::metrics::metric_groups _metrics;
@@ -477,7 +477,7 @@ public:
     void enable_reclaim() noexcept {
         --_reclaiming_disabled_depth;
     }
-    segment_pool& segment_pool() {
+    logalloc::segment_pool& segment_pool() {
         return *_segment_pool;
     }
     void register_region(region::impl*);
@@ -963,7 +963,7 @@ public:
 // We prefer using high-address segments, and returning low-address segments to the seastar
 // allocator in order to segregate lsa and non-lsa memory, to reduce fragmentation.
 class segment_pool {
-    tracker::impl& _tracker;
+    logalloc::tracker::impl& _tracker;
     segment_store _store;
     std::vector<segment_descriptor> _segments;
     size_t _segments_in_use{};
@@ -1025,8 +1025,8 @@ private:
     }
     bool compact_segment(segment* seg);
 public:
-    explicit segment_pool(tracker::impl& tracker);
-    tracker::impl& tracker() { return _tracker; }
+    explicit segment_pool(logalloc::tracker::impl& tracker);
+    logalloc::tracker::impl& tracker() { return _tracker; }
     void prime(size_t available_memory, size_t min_free_memory);
     void use_standard_allocator_segment_pool_backend(size_t available_memory);
     segment* new_segment(region::impl* r);

--- a/utils/observable.hh
+++ b/utils/observable.hh
@@ -143,7 +143,7 @@ using observer = typename observable<Args...>::observer;
 
 template <typename... Args>
 inline observer<Args...> dummy_observer() {
-    return observer<Args...>(nullptr, noncopyable_function<void(Args...)>());
+    return observer<Args...>(nullptr, seastar::noncopyable_function<void(Args...)>());
 }
 
 }


### PR DESCRIPTION
Fix some issues found with gcc 12. Note we can't fully compile with gcc yet, due to [1].

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98056