### PR TITLE
cql: fix column-name aliases in SELECT JSON

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1604,11 +1604,16 @@ void select_statement::maybe_jsonize_select_clause(data_dictionary::database db,
         std::vector<data_type> selector_types;
         std::vector<const column_definition*> defs;
         selector_names.reserve(_select_clause.size());
+        selector_types.reserve(_select_clause.size());
         auto selectables = selection::raw_selector::to_selectables(_select_clause, *schema);
         selection::selector_factories factories(selection::raw_selector::to_selectables(_select_clause, *schema), db, schema, defs);
         auto selectors = factories.new_instances();
         for (size_t i = 0; i < selectors.size(); ++i) {
-            selector_names.push_back(selectables[i]->to_string());
+            if (_select_clause[i]->alias) {
+                selector_names.push_back(_select_clause[i]->alias->to_string());
+            } else {
+                selector_names.push_back(selectables[i]->to_string());
+            }
             selector_types.push_back(selectors[i]->get_type());
         }
 

--- a/test/cql-pytest/cassandra_tests/validation/entities/json_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/json_test.py
@@ -951,7 +951,7 @@ def testJsonWithGroupBy(cql, test_keyspace):
                 ["{\"count\": 1}"])
 
 # Reproduces issues #8077, #8078
-@pytest.mark.xfail(reason="issues #8077, #8078")
+@pytest.mark.xfail(reason="issues #8077")
 def testSelectJsonSyntax(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # tests SELECT JSON statements
@@ -982,12 +982,14 @@ def testSelectJsonSyntax(cql, test_keyspace):
                 ["{\"foo\": null, \"k\": 0}"],
                 ["{\"foo\": null, \"k\": 1}"])
 
+        # Reproduces #8077:
         assert_rows(execute(cql, table, "SELECT JSON count(*) FROM %s"),
                 ["{\"count\": 2}"])
 
         assert_rows(execute(cql, table, "SELECT JSON count(*) as foo FROM %s"),
                 ["{\"foo\": 2}"])
 
+        # Reproduces #8077:
         assert_rows_ignoring_order(execute(cql, table, "SELECT JSON toJson(blobAsInt(intAsBlob(v))) FROM %s"),
                 ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"0\"}"],
                 ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"1\"}"])
@@ -1058,8 +1060,8 @@ def testInsertJsonSyntaxDefaultUnset(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s JSON '{\"k\": 2}' DEFAULT NULL")
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=2"), [2, None, None])
 
-# Reproduces issues #8078, #8086`
-@pytest.mark.xfail(reason="issues #8078, #8086")
+# Reproduces issues #8078, #8086
+@pytest.mark.xfail(reason="issues #8086")
 def testCaseSensitivity(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, \"Foo\" int)") as table:
         execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"\\\"Foo\\\"\": 0}")


### PR DESCRIPTION
The SELECT JSON statement, just like SELECT, allows the user to rename selected columns using an "AS" specification. E.g., "SELECT JSON v AS foo". This specification was not honored: We simply forgot to look at the alias in SELECT JSON's implementation (we did it correctly in regular SELECT). So this patch fixes this bug.

We had two tests in cassandra_tests/validation/entities/json_test.py that reproduced this bug. The checks in those tests now pass, but these two tests still continue to fail after this patch because of two other unrelated bugs that were discovered by the same tests. So in this patch I also add a new test just for this specific issue - to serve as a regression test.

Fixes #8078

Signed-off-by: Nadav Har'El <nyh@scylladb.com>