### PR TITLE
Replace a misplaced period with a a bulleted list of items

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/create-cluster-multidc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/create-cluster-multidc.rst
@@ -27,11 +27,12 @@ endpoint_snitch        GossipingPropertyFileSnitch
 
 **Important**
 
-If the node has two physical network interfaces in a multi-datacenter installation.
-Set ``listen_address`` to this node's private IP or hostname.
-Set ``broadcast_address`` to the second IP or hostname (for communication between data centers).
-Set ``listen_on_broadcast_address`` to true.
-Open the storage_port or ssl_storage_port on the public IP firewall.
+If the node has two physical network interfaces in a multi-datacenter installation: 
+
+* Set ``listen_address`` to this node's private IP or hostname.
+* Set ``broadcast_address`` to the second IP or hostname (for communication between data centers).
+* Set ``listen_on_broadcast_address`` to true.
+* Open the storage_port or ssl_storage_port on the public IP firewall.
 
 -------------
 Prerequisites


### PR DESCRIPTION
That list of todo items is important enough to be in a bulleted list (and the period there was misplaced anyway)

Signed-Off-By: Yaniv Kaul <yaniv.kaul@scylladb.com>