### PR TITLE
Make sstable_directory call sstable_manager for sstables' components

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -513,7 +513,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     sharded<netw::messaging_service> messaging;
     sharded<cql3::query_processor> qp;
     sharded<db::batchlog_manager> bm;
-    sharded<semaphore> sst_dir_semaphore;
+    sharded<sstables::directory_semaphore> sst_dir_semaphore;
     sharded<service::raft_group_registry> raft_gr;
     sharded<service::memory_limiter> service_memory_limiter;
     sharded<repair_service> repair;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -355,8 +355,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_rows_count_warning_threshold,
               _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
-    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
+    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -307,7 +307,7 @@ public:
 };
 
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-        compaction_manager& cm, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
+        compaction_manager& cm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
     , _cl_stats(std::make_unique<cell_locker_stats>())

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -91,6 +91,7 @@ class compaction_completion_desc;
 class sstables_manager;
 class compaction_data;
 class sstable_set;
+class directory_semaphore;
 
 }
 
@@ -1345,7 +1346,7 @@ private:
     std::vector<std::any> _listeners;
     const locator::shared_token_metadata& _shared_token_metadata;
 
-    sharded<semaphore>& _sst_dir_semaphore;
+    sharded<sstables::directory_semaphore>& _sst_dir_semaphore;
 
     std::unique_ptr<wasm::engine> _wasm_engine;
     utils::cross_shard_barrier _stop_barrier;
@@ -1429,7 +1430,7 @@ public:
 
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            compaction_manager& cm, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            compaction_manager& cm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 
@@ -1702,7 +1703,7 @@ public:
 
     bool is_internal_query() const;
 
-    sharded<semaphore>& get_sharded_sst_dir_semaphore() {
+    sharded<sstables::directory_semaphore>& get_sharded_sst_dir_semaphore() {
         return _sst_dir_semaphore;
     }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -313,6 +313,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
         auto upload = fs::path(global_table->dir()) / sstables::upload_dir;
         directory.start(
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
+            sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
@@ -382,6 +383,7 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
 
         directory.start(
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
+            sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
@@ -552,6 +554,7 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
     auto& db = _db;
     co_await directory.start(
         sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
+        sharded_parameter([&global_table] { return global_table->schema(); }),
         fs::path(sstdir), default_priority_class(),
         [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
             return global_table->make_sstable(dir.native(), gen, v, f);

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -312,7 +312,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
         sharded<sstables::sstable_directory> directory;
         auto upload = fs::path(global_table->dir()) / sstables::upload_dir;
         directory.start(upload, service::get_local_streaming_priority(),
-            db.local().get_config().initial_sstable_loading_concurrency(), std::ref(db.local().get_sharded_sst_dir_semaphore()),
+            std::ref(db.local().get_sharded_sst_dir_semaphore()),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -380,7 +380,7 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
         auto upload = fs::path(global_table->dir()) / sstables::upload_dir;
 
         directory.start(upload, service::get_local_streaming_priority(),
-            db.local().get_config().initial_sstable_loading_concurrency(), std::ref(db.local().get_sharded_sst_dir_semaphore()),
+            std::ref(db.local().get_sharded_sst_dir_semaphore()),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -549,7 +549,7 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
     auto& global_table = _global_table;
     auto& db = _db;
     co_await directory.start(fs::path(sstdir), default_priority_class(),
-        db.local().get_config().initial_sstable_loading_concurrency(), std::ref(db.local().get_sharded_sst_dir_semaphore()),
+        std::ref(db.local().get_sharded_sst_dir_semaphore()),
         [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
             return global_table->make_sstable(dir.native(), gen, v, f);
     });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -314,7 +314,6 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
         directory.start(
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             upload, service::get_local_streaming_priority(),
-            std::ref(db.local().get_sharded_sst_dir_semaphore()),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -384,7 +383,6 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
         directory.start(
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             upload, service::get_local_streaming_priority(),
-            std::ref(db.local().get_sharded_sst_dir_semaphore()),
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -555,7 +553,6 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
     co_await directory.start(
         sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
         fs::path(sstdir), default_priority_class(),
-        std::ref(db.local().get_sharded_sst_dir_semaphore()),
         [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
             return global_table->make_sstable(dir.native(), gen, v, f);
     });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -315,6 +315,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
+            &error_handler_gen_for_upload_dir,
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -385,6 +386,7 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
+            &error_handler_gen_for_upload_dir,
             [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
@@ -556,6 +558,7 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
         sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
         sharded_parameter([&global_table] { return global_table->schema(); }),
         fs::path(sstdir), default_priority_class(),
+        default_io_error_handler_gen(),
         [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
             return global_table->make_sstable(dir.native(), gen, v, f);
     });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -315,11 +315,8 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
-            &error_handler_gen_for_upload_dir,
-            [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-                return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
-
-        }).get();
+            &error_handler_gen_for_upload_dir
+        ).get();
 
         auto stop = deferred_stop(directory);
 
@@ -386,11 +383,8 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
             sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
             sharded_parameter([&global_table] { return global_table->schema(); }),
             upload, service::get_local_streaming_priority(),
-            &error_handler_gen_for_upload_dir,
-            [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-                return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
-
-        }).get();
+            &error_handler_gen_for_upload_dir
+        ).get();
 
         auto stop = deferred_stop(directory);
 
@@ -558,10 +552,8 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
         sharded_parameter([&global_table] { return std::ref(global_table->get_sstables_manager()); }),
         sharded_parameter([&global_table] { return global_table->schema(); }),
         fs::path(sstdir), default_priority_class(),
-        default_io_error_handler_gen(),
-        [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-            return global_table->make_sstable(dir.native(), gen, v, f);
-    });
+        default_io_error_handler_gen()
+    );
 
     // directory must be stopped using table_population_metadata::stop below
     _sstable_directories[subdir] = dptr;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1497,9 +1497,9 @@ future<table::snapshot_file_set> table::take_snapshot(database& db, sstring json
     auto table_names = std::make_unique<std::unordered_set<sstring>>();
 
     co_await io_check([&jsondir] { return recursive_touch_directory(jsondir); });
-    co_await max_concurrent_for_each(tables, db.get_config().initial_sstable_loading_concurrency(), [&db, &jsondir, &table_names] (sstables::shared_sstable sstable) {
+    co_await max_concurrent_for_each(tables, db.get_sharded_sst_dir_semaphore().local()._concurrency, [&db, &jsondir, &table_names] (sstables::shared_sstable sstable) {
         table_names->insert(sstable->component_basename(sstables::component_type::Data));
-        return with_semaphore(db.get_sharded_sst_dir_semaphore().local(), 1, [&jsondir, sstable] {
+        return with_semaphore(db.get_sharded_sst_dir_semaphore().local()._sem, 1, [&jsondir, sstable] {
             return io_check([sstable, &dir = jsondir] {
                 return sstable->create_links(dir);
             });

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -35,11 +35,13 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
         fs::path sstable_dir,
         ::io_priority_class io_prio,
+        io_error_handler_gen error_handler_gen,
         sstable_object_from_existing_fn sstable_from_existing)
     : _manager(manager)
     , _schema(std::move(schema))
     , _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
+    , _error_handler_gen(error_handler_gen)
     , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))
     , _unshared_remote_sstables(smp::count)
 {}

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -180,7 +180,7 @@ sstable_directory::process_sstable_dir(process_flags flags) {
 
     scan_state state;
 
-    components_lister sstable_dir_lister(_sstable_dir);
+    auto sstable_dir_lister = _manager.get_components_lister(_sstable_dir);
     std::exception_ptr ex;
     try {
         while (true) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -35,14 +35,12 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
         fs::path sstable_dir,
         ::io_priority_class io_prio,
-        io_error_handler_gen error_handler_gen,
-        sstable_object_from_existing_fn sstable_from_existing)
+        io_error_handler_gen error_handler_gen)
     : _manager(manager)
     , _schema(std::move(schema))
     , _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
     , _error_handler_gen(error_handler_gen)
-    , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))
     , _unshared_remote_sstables(smp::count)
 {}
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -34,12 +34,10 @@ bool manifest_json_filter(const fs::path&, const directory_entry& entry) {
 sstable_directory::sstable_directory(sstables_manager& manager,
         fs::path sstable_dir,
         ::io_priority_class io_prio,
-        directory_semaphore& load_semaphore,
         sstable_object_from_existing_fn sstable_from_existing)
     : _manager(manager)
     , _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
-    , _load_semaphore(load_semaphore)
     , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))
     , _unshared_remote_sstables(smp::count)
 {}
@@ -439,8 +437,8 @@ template <typename Container, typename Func>
 future<>
 sstable_directory::parallel_for_each_restricted(Container&& C, Func&& func) {
     return do_with(std::move(C), std::move(func), [this] (Container& c, Func& func) mutable {
-      return max_concurrent_for_each(c, _load_semaphore._concurrency, [this, &func] (auto& el) mutable {
-        return with_semaphore(_load_semaphore._sem, 1, [this, &func,  el = std::move(el)] () mutable {
+      return max_concurrent_for_each(c, _manager.dir_semaphore()._concurrency, [this, &func] (auto& el) mutable {
+        return with_semaphore(_manager.dir_semaphore()._sem, 1, [this, &func,  el = std::move(el)] () mutable {
             return func(el);
         });
       });

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -31,11 +31,13 @@ bool manifest_json_filter(const fs::path&, const directory_entry& entry) {
     return true;
 }
 
-sstable_directory::sstable_directory(fs::path sstable_dir,
+sstable_directory::sstable_directory(sstables_manager& manager,
+        fs::path sstable_dir,
         ::io_priority_class io_prio,
         directory_semaphore& load_semaphore,
         sstable_object_from_existing_fn sstable_from_existing)
-    : _sstable_dir(std::move(sstable_dir))
+    : _manager(manager)
+    , _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
     , _load_semaphore(load_semaphore)
     , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -32,10 +32,12 @@ bool manifest_json_filter(const fs::path&, const directory_entry& entry) {
 }
 
 sstable_directory::sstable_directory(sstables_manager& manager,
+        schema_ptr schema,
         fs::path sstable_dir,
         ::io_priority_class io_prio,
         sstable_object_from_existing_fn sstable_from_existing)
     : _manager(manager)
+    , _schema(std::move(schema))
     , _sstable_dir(std::move(sstable_dir))
     , _io_priority(std::move(io_prio))
     , _sstable_object_from_existing_sstable(std::move(sstable_from_existing))

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -28,6 +28,7 @@ class compaction_manager;
 
 namespace sstables {
 
+class sstables_manager;
 bool manifest_json_filter(const std::filesystem::path&, const directory_entry& entry);
 
 class directory_semaphore {
@@ -88,6 +89,7 @@ private:
     // Will be destroyed when this object is destroyed.
     std::optional<utils::phased_barrier::operation> _operation_barrier;
 
+    sstables_manager& _manager;
     std::filesystem::path _sstable_dir;
     ::io_priority_class _io_priority;
 
@@ -133,7 +135,8 @@ private:
 
     std::vector<sstables::shared_sstable> _unsorted_sstables;
 public:
-    sstable_directory(std::filesystem::path sstable_dir,
+    sstable_directory(sstables_manager& manager,
+            std::filesystem::path sstable_dir,
             ::io_priority_class io_prio,
             directory_semaphore& load_semaphore,
             sstable_object_from_existing_fn sstable_from_existing);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -93,10 +93,6 @@ private:
     std::filesystem::path _sstable_dir;
     ::io_priority_class _io_priority;
 
-    // We may have hundreds of thousands of files to load. To protect against OOMs we will limit
-    // how many of them we process at the same time.
-    directory_semaphore& _load_semaphore;
-
     // How to create an SSTable object from an existing SSTable file (respecting generation, etc)
     sstable_object_from_existing_fn _sstable_object_from_existing_sstable;
 
@@ -138,7 +134,6 @@ public:
     sstable_directory(sstables_manager& manager,
             std::filesystem::path sstable_dir,
             ::io_priority_class io_prio,
-            directory_semaphore& load_semaphore,
             sstable_object_from_existing_fn sstable_from_existing);
 
     std::vector<sstables::shared_sstable>& get_unsorted_sstables() {

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -50,12 +50,6 @@ public:
 // or the main directory.
 class sstable_directory {
 public:
-    using sstable_object_from_existing_fn =
-        noncopyable_function<sstables::shared_sstable(std::filesystem::path,
-                                                      sstables::generation_type,
-                                                      sstables::sstable_version_types,
-                                                      sstables::sstable_format_types)>;
-
     // favor chunked vectors when dealing with file lists: they can grow to hundreds of thousands
     // of elements.
     using sstable_info_vector = utils::chunked_vector<sstables::foreign_sstable_open_info>;
@@ -96,9 +90,6 @@ private:
     ::io_priority_class _io_priority;
     io_error_handler_gen _error_handler_gen;
 
-    // How to create an SSTable object from an existing SSTable file (respecting generation, etc)
-    sstable_object_from_existing_fn _sstable_object_from_existing_sstable;
-
     generation_type _max_generation_seen = generation_from_value(0);
     sstables::sstable_version_types _max_version_seen = sstables::sstable_version_types::ka;
 
@@ -138,8 +129,7 @@ public:
             schema_ptr schema,
             std::filesystem::path sstable_dir,
             ::io_priority_class io_prio,
-            io_error_handler_gen error_handler_gen,
-            sstable_object_from_existing_fn sstable_from_existing);
+            io_error_handler_gen error_handler_gen);
 
     std::vector<sstables::shared_sstable>& get_unsorted_sstables() {
         return _unsorted_sstables;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -90,6 +90,7 @@ private:
     std::optional<utils::phased_barrier::operation> _operation_barrier;
 
     sstables_manager& _manager;
+    schema_ptr _schema;
     std::filesystem::path _sstable_dir;
     ::io_priority_class _io_priority;
 
@@ -132,6 +133,7 @@ private:
     std::vector<sstables::shared_sstable> _unsorted_sstables;
 public:
     sstable_directory(sstables_manager& manager,
+            schema_ptr schema,
             std::filesystem::path sstable_dir,
             ::io_priority_class io_prio,
             sstable_object_from_existing_fn sstable_from_existing);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -22,6 +22,7 @@
 #include "sstables/open_info.hh"                 // for entry_descriptor and foreign_sstable_open_info, chunked_vector wants to know if they are move constructible
 #include "utils/chunked_vector.hh"
 #include "utils/phased_barrier.hh"
+#include "utils/disk-error-handler.hh"
 #include "sstables/generation_type.hh"
 
 class compaction_manager;
@@ -93,6 +94,7 @@ private:
     schema_ptr _schema;
     std::filesystem::path _sstable_dir;
     ::io_priority_class _io_priority;
+    io_error_handler_gen _error_handler_gen;
 
     // How to create an SSTable object from an existing SSTable file (respecting generation, etc)
     sstable_object_from_existing_fn _sstable_object_from_existing_sstable;
@@ -136,6 +138,7 @@ public:
             schema_ptr schema,
             std::filesystem::path sstable_dir,
             ::io_priority_class io_prio,
+            io_error_handler_gen error_handler_gen,
             sstable_object_from_existing_fn sstable_from_existing);
 
     std::vector<sstables::shared_sstable>& get_unsorted_sstables() {

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -23,6 +23,7 @@
 #include "utils/chunked_vector.hh"
 #include "utils/phased_barrier.hh"
 #include "utils/disk-error-handler.hh"
+#include "utils/lister.hh"
 #include "sstables/generation_type.hh"
 
 class compaction_manager;
@@ -61,6 +62,14 @@ public:
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
         bool allow_loading_materialized_view = false;
         bool sort_sstables_according_to_owner = true;
+    };
+
+    class components_lister {
+        directory_lister _lister;
+    public:
+        future<sstring> get();
+        components_lister(std::filesystem::path dir);
+        future<> close();
     };
 
 private:

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -19,13 +19,15 @@ namespace sstables {
 logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
-    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory)
+    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem)
     : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
     , _sstable_metadata_concurrency_sem(
         max_count_sstable_metadata_concurrent_reads,
         max_memory_sstable_metadata_concurrent_reads(available_memory),
         "sstable_metadata_concurrency_sem",
-        std::numeric_limits<size_t>::max()) {
+        std::numeric_limits<size_t>::max())
+    , _dir_semaphore(dir_sem)
+{
 }
 
 sstables_manager::~sstables_manager() {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -105,4 +105,8 @@ future<> sstables_manager::close() {
     co_await _sstable_metadata_concurrency_sem.stop();
 }
 
+sstable_directory::components_lister sstables_manager::get_components_lister(std::filesystem::path dir) {
+    return sstable_directory::components_lister(std::move(dir));
+}
+
 }   // namespace sstables

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -20,6 +20,7 @@
 #include "sstables/sstables.hh"
 #include "sstables/version.hh"
 #include "sstables/component_type.hh"
+#include "sstables/sstable_directory.hh"
 #include "db/cache_tracker.hh"
 #include "locator/host_id.hh"
 #include "reader_concurrency_semaphore.hh"
@@ -84,6 +85,8 @@ public:
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
+
+    sstable_directory::components_lister get_components_lister(std::filesystem::path dir);
 
     virtual sstable_writer_config configure_writer(sstring origin) const;
     const db::config& config() const { return _db_config; }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -37,6 +37,7 @@ namespace gms { class feature_service; }
 
 namespace sstables {
 
+class directory_semaphore;
 using schema_ptr = lw_shared_ptr<const schema>;
 using shareable_components_ptr = lw_shared_ptr<shareable_components>;
 
@@ -69,8 +70,9 @@ private:
     cache_tracker& _cache_tracker;
 
     reader_concurrency_semaphore _sstable_metadata_concurrency_sem;
+    directory_semaphore& _dir_semaphore;
 public:
-    explicit sstables_manager(db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory);
+    explicit sstables_manager(db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem);
     virtual ~sstables_manager();
 
     // Constructs a shared sstable

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -105,6 +105,7 @@ public:
     // Note that close() will not complete until all references to all
     // sstables have been destroyed.
     future<> close();
+    directory_semaphore& dir_semaphore() noexcept { return _dir_semaphore; }
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -156,7 +156,8 @@ static void with_sstable_directory(
 
     sstdir.start(seastar::sharded_parameter([&sstable_from_existing] { return std::ref(sstable_from_existing.get_manager()); }),
             seastar::sharded_parameter([] { return test_table_schema(); }),
-            std::move(path), default_priority_class(), std::move(wrapped_sfe)).get();
+            std::move(path), default_priority_class(),
+            default_io_error_handler_gen(), std::move(wrapped_sfe)).get();
 
     func(sstdir);
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -106,9 +106,6 @@ public:
     explicit sstable_from_existing_file(sharded<sstables::test_env>& env) : _get_mgr([s = &env] { return &s->local().manager(); }) {}
     // This variant this transportable across shards
     explicit sstable_from_existing_file(cql_test_env& env) : _get_mgr([&env] { return &env.db().local().get_user_sstables_manager(); }) {}
-    sstables::shared_sstable operator()(fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) const {
-        return _get_mgr()->make_sstable(test_table_schema(), dir.native(), gen, v, f, gc_clock::now(), default_io_error_handler_gen(), default_sstable_buffer_size);
-    }
     sstables_manager& get_manager() { return *_get_mgr(); }
 };
 
@@ -150,14 +147,10 @@ static void with_sstable_directory(
         }
     });
 
-    auto wrapped_sfe = [&sstable_from_existing] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-        return sstable_from_existing(std::move(dir), gen, v, f);
-    };
-
     sstdir.start(seastar::sharded_parameter([&sstable_from_existing] { return std::ref(sstable_from_existing.get_manager()); }),
             seastar::sharded_parameter([] { return test_table_schema(); }),
             std::move(path), default_priority_class(),
-            default_io_error_handler_gen(), std::move(wrapped_sfe)).get();
+            default_io_error_handler_gen()).get();
 
     func(sstdir);
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -135,7 +135,7 @@ static void with_sstable_directory(
     sstable_directory::sstable_object_from_existing_fn sstable_from_existing,
     noncopyable_function<void (sharded<sstable_directory>&)> func) {
 
-    sharded<semaphore> sstdir_sem;
+    sharded<sstables::directory_semaphore> sstdir_sem;
     sstdir_sem.start(load_parallelism).get();
     auto stop_sstdir_sem = defer([&sstdir_sem] {
         sstdir_sem.stop().get();
@@ -153,7 +153,7 @@ static void with_sstable_directory(
         return sstable_from_existing(std::move(dir), gen, v, f);
     };
 
-    sstdir.start(std::move(path), default_priority_class(), load_parallelism, std::ref(sstdir_sem), std::move(wrapped_sfe)).get();
+    sstdir.start(std::move(path), default_priority_class(), std::ref(sstdir_sem), std::move(wrapped_sfe)).get();
 
     func(sstdir);
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -155,7 +155,7 @@ static void with_sstable_directory(
     };
 
     sstdir.start(seastar::sharded_parameter([&sstable_from_existing] { return std::ref(sstable_from_existing.get_manager()); }),
-            std::move(path), default_priority_class(), std::ref(sstdir_sem), std::move(wrapped_sfe)).get();
+            std::move(path), default_priority_class(), std::move(wrapped_sfe)).get();
 
     func(sstdir);
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -495,10 +495,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
         }
 
       with_sstable_directory(upload_path, 1,
-                [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-                    auto& cf = e.local_db().find_column_family("ks", "cf");
-                    return cf.make_sstable(dir.native(), gen, v, f);
-                },
+                sstable_from_existing_file(e),
                 [&e, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
         distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();
@@ -540,10 +537,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
         }
 
       with_sstable_directory(upload_path, 1,
-                [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-                    auto& cf = e.local_db().find_column_family("ks", "cf");
-                    return cf.make_sstable(dir.native(), gen, v, f);
-                },
+                sstable_from_existing_file(e),
                 [&e, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
         distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();
@@ -585,10 +579,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
         }
 
       with_sstable_directory(upload_path, 1,
-                [&e] (fs::path dir, generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-                    auto& cf = e.local_db().find_column_family("ks", "cf");
-                    return cf.make_sstable(dir.native(), gen, v, f);
-                },
+                sstable_from_existing_file(e),
                 [&, upload_path] (sharded<sstables::sstable_directory>& sstdir) {
         distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
         verify_that_all_sstables_are_local(sstdir, 0).get();

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -155,6 +155,7 @@ static void with_sstable_directory(
     };
 
     sstdir.start(seastar::sharded_parameter([&sstable_from_existing] { return std::ref(sstable_from_existing.get_manager()); }),
+            seastar::sharded_parameter([] { return test_table_schema(); }),
             std::move(path), default_priority_class(), std::move(wrapped_sfe)).get();
 
     func(sstdir);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -652,7 +652,7 @@ public:
             stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(ms), std::ref(mm), std::ref(gossiper)).get();
             auto stop_streaming = defer([&stream_manager] { stream_manager.stop().get(); });
 
-            sharded<semaphore> sst_dir_semaphore;
+            sharded<sstables::directory_semaphore> sst_dir_semaphore;
             sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
             auto stop_sst_dir_sem = defer([&sst_dir_semaphore] {
                 sst_dir_semaphore.stop().get();

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -17,6 +17,7 @@
 #include "db/large_data_handler.hh"
 #include "gms/feature_service.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstable_directory.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/test_services.hh"
 #include "test/lib/log.hh"
@@ -47,6 +48,7 @@ struct test_env_config {
 class test_env {
     struct impl {
         db::config db_config;
+        directory_semaphore dir_sem;
         cache_tracker cache_tracker;
         gms::feature_service feature_service;
         db::nop_large_data_handler nop_ld_handler;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -149,8 +149,9 @@ future<> table_for_tests::stop() {
 namespace sstables {
 
 test_env::impl::impl(test_env_config cfg)
-    : feature_service(gms::feature_config_from_db_config(db_config))
-    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, memory::stats().total_memory())
+    : dir_sem(1)
+    , feature_service(gms::feature_config_from_db_config(db_config))
+    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -25,6 +25,7 @@
 #include "schema_builder.hh"
 #include "sstables/index_reader.hh"
 #include "sstables/sstables_manager.hh"
+#include "sstables/sstable_directory.hh"
 #include "sstables/open_info.hh"
 #include "types/user.hh"
 #include "types/set.hh"
@@ -3234,7 +3235,8 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
             cache_tracker tracker;
             dbcfg.host_id = locator::host_id::create_random_id();
-            sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory());
+            sstables::directory_semaphore dir_sem(1);
+            sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem);
             auto close_sst_man = deferred_close(sst_man);
 
             std::vector<sstables::shared_sstable> sstables;


### PR DESCRIPTION
This PR hits two goals for "object storage" effort

1. Sstables loader "knows" that sstables components are stored in a Linux directory and uses utils/lister to access it. This is not going to work with sstables over object storage, the loader should be abstracted from the underlying storage.

2. Currently class keyspace and class column_family carry "datadir" and "all_datadirs" on board which are path on local filesystem where sstable files are stored (those usually started with /var/lib/scylla/data). The paths include subsdirs like "snapshots", "staging", etc. This is not going to look nice for obejct storage, the /var/lib/ prefix is excessive and meaningless in this case. Instead, ks and cf should know their "location" and some other component should know the directory where in which the files are stored.


Said that, this PR prepares distributed_loader and sstables_directly to stop using Linux paths explicitly by making both call sstables_manager to list and open sstables object. After it will be possible to teach manager to list sstables from object storage. Also this opens the way to removing paths from keyspace and column_family classes and replacing those with relative "location"s.