### PR TITLE
test/cql-pytest: add regression test for old issue

### DIFF
--- a/test/cql-pytest/test_clustering_order.py
+++ b/test/cql-pytest/test_clustering_order.py
@@ -21,6 +21,13 @@ def table_int_desc(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, schema, order) as table:
         yield table
 
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    schema="p int, c1 int, c2 int, PRIMARY KEY (p, c1, c2)"
+    order="WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC)"
+    with new_test_table(cql, test_keyspace, schema, order) as table:
+        yield table
+
 # Verify that if a table is created with descending order for its
 # clustering key, the default ordering of SELECT is changed to descending
 # order. This was contrary to our documentation which used to suggest
@@ -46,3 +53,15 @@ def test_select_default_order(cql, table_int_desc):
     assert reverse_rows == list(cql.execute(f'SELECT c FROM {table_int_desc} WHERE k = {k} LIMIT {N}'))
     assert rows == list(cql.execute(f'SELECT c FROM {table_int_desc} WHERE k = {k} ORDER BY c ASC LIMIT {N}'))
     assert reverse_rows == list(cql.execute(f'SELECT c FROM {table_int_desc} WHERE k = {k} ORDER BY c DESC LIMIT {N}'))
+
+# Reproduce issue #65: Test SELECT with a compound clustering key c1,c2
+# and a multi-column relation (c1, c2) >= (1,1) when one of the clustering
+# column has reversed order. We need to uphold the correct inequality (not
+# reversed), just return results in a the reversed order.
+def test_multi_column_relation_desc(cql, table2):
+    k = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c1, c2) VALUES (?, ?, ?)')
+    cql.execute(stmt, [0, 1, 0])
+    cql.execute(stmt, [0, 1, 1])
+    cql.execute(stmt, [0, 1, 2])
+    assert [(1, 2), (1, 1)] == list(cql.execute(f'SELECT c1,c2 FROM {table2} WHERE p = 0 AND (c1, c2) >= (1, 1)'))


### PR DESCRIPTION
This patch adds a regression test for the old issue #65 which is about a multi-column (tuple) clustering-column relation in a SELECT when one these columns has reversed order. It turns out that we didn't notice, but this issue was already solved - but we didn't have a regression test for it. So this patch adds just a regression test. The test confirms that Scylla now behaves like was desired when that issue was opened. The test also passes on Cassandra, confirming that Scylla and Cassandra behave the same for such requests.

Fixes #65

Signed-off-by: Nadav Har'El <nyh@scylladb.com>