### PR TITLE
treewide: use non-experimental std::source_location

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -10,7 +10,7 @@
 #include <vector>
 #include <unordered_set>
 #include <functional>
-#include <experimental/source_location>
+#include <source_location>
 #include <boost/container/deque.hpp>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/future.hh>
@@ -289,7 +289,7 @@ struct timeout_error : public error {
 };
 
 struct state_machine_error: public error {
-    state_machine_error(std::experimental::source_location l = std::experimental::source_location::current())
+    state_machine_error(std::source_location l = std::source_location::current())
         : error(fmt::format("State machine error at {}:{}", l.file_name(), l.line())) {}
 };
 

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -21,7 +21,7 @@
 #include <boost/intrusive/list.hpp>
 
 #include <chrono>
-#include <experimental/source_location>
+#include <source_location>
 
 namespace bi = boost::intrusive;
 
@@ -173,7 +173,7 @@ class raft_address_map : public peering_sharded_service<raft_address_map<Clock>>
     }
 
     template <std::invocable<raft_address_map&> F>
-    void replicate(F f, std::experimental::source_location l = std::experimental::source_location::current()) {
+    void replicate(F f, std::source_location l = std::source_location::current()) {
         if (!_replication_fiber) {
             return;
         }

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -5,7 +5,7 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-#include <experimental/source_location>
+#include <source_location>
 
 #include "service/raft/raft_group0.hh"
 #include "service/raft/raft_rpc.hh"
@@ -439,8 +439,8 @@ struct group0_members {
     const raft_address_map<>& _address_map;
 
 
-    std::vector<gms::inet_address> get_inet_addrs(std::experimental::source_location l =
-            std::experimental::source_location::current()) const {
+    std::vector<gms::inet_address> get_inet_addrs(std::source_location l =
+            std::source_location::current()) const {
         const raft::config_member_set& members = _group0_server.get_configuration().current;
         std::vector<gms::inet_address> ret;
         std::vector<raft::server_id> missing;

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -12,7 +12,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <experimental/source_location>
+#include <source_location>
 
 #include <seastar/net/inet_address.hh>
 

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -12,7 +12,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <experimental/source_location>
+#include <source_location>
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -12,7 +12,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <experimental/source_location>
+#include <source_location>
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -13,7 +13,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <experimental/source_location>
+#include <source_location>
 
 #include <seastar/net/inet_address.hh>
 
@@ -1663,7 +1663,7 @@ SEASTAR_TEST_CASE(test_tuples) {
 
 namespace {
 
-using std::experimental::source_location;
+using std::source_location;
 
 auto validate_request_failure(
         cql_test_env& env,
@@ -4335,7 +4335,7 @@ shared_ptr<cql_transport::messages::result_message> cql_func_require_nofail(
         const seastar::sstring& fct,
         const seastar::sstring& inp,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const std::experimental::source_location& loc = std::experimental::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     auto res = shared_ptr<cql_transport::messages::result_message>(nullptr);
     auto query = format("SELECT {}({}) FROM t;", fct, inp);
     try {
@@ -4360,7 +4360,7 @@ void cql_func_require_throw(
         const seastar::sstring& fct,
         const seastar::sstring& inp,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const std::experimental::source_location& loc = std::experimental::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     auto query = format("SELECT {}({}) FROM t;", fct, inp);
     try {
         if (qo) {
@@ -5468,11 +5468,11 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         e.execute_cql("CREATE TABLE null_in_col (p int primary key, l list<int>, s set<int>, m map<int, int>);").get();
 
         // The predicate that checks the message has to be a lambda to preserve source_location
-        auto check_null_msg = [](std::experimental::source_location loc = std::experimental::source_location::current()) {
+        auto check_null_msg = [](std::source_location loc = std::source_location::current()) {
             return exception_predicate::message_equals("null is not supported inside collections", loc);
         };
 
-        auto check_unset_msg = [](std::experimental::source_location loc = std::experimental::source_location::current()) {
+        auto check_unset_msg = [](std::source_location loc = std::source_location::current()) {
             return exception_predicate::message_equals("unset value is not supported inside collections", loc);
         };
 
@@ -5671,7 +5671,7 @@ SEASTAR_TEST_CASE(test_bind_variable_type_checking) {
         e.execute_cql("CREATE TABLE tab1 (p int primary key, a int, b text, c int)").get();
 
         // The predicate that checks the message has to be a lambda to preserve source_location
-        auto check_type_conflict = [](std::experimental::source_location loc = std::experimental::source_location::current()) {
+        auto check_type_conflict = [](std::source_location loc = std::source_location::current()) {
             return exception_predicate::message_contains("variable :var has type", loc);
         };
 

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -7,7 +7,7 @@
  */
 
 
-#include <experimental/source_location>
+#include <source_location>
 
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/uniqued.hpp>

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -23,7 +23,7 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <experimental/source_location>
+#include <source_location>
 
 #include <boost/range/algorithm/sort.hpp>
 
@@ -39,7 +39,7 @@ static uint64_t aggregate_querier_cache_stat(distributed<replica::database>& db,
 }
 
 static void check_cache_population(distributed<replica::database>& db, size_t queriers,
-        std::experimental::source_location sl = std::experimental::source_location::current()) {
+        std::source_location sl = std::source_location::current()) {
     testlog.info("{}() called from {}() {}:{:d}", __FUNCTION__, sl.function_name(), sl.file_name(), sl.line());
 
     parallel_for_each(boost::irange(0u, smp::count), [queriers, &db] (unsigned shard) {
@@ -51,7 +51,7 @@ static void check_cache_population(distributed<replica::database>& db, size_t qu
 }
 
 static void require_eventually_empty_caches(distributed<replica::database>& db,
-        std::experimental::source_location sl = std::experimental::source_location::current()) {
+        std::source_location sl = std::source_location::current()) {
     testlog.info("{}() called from {}() {}:{:d}", __FUNCTION__, sl.function_name(), sl.file_name(), sl.line());
 
     auto aggregated_population_is_zero = [&] () mutable {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -9,7 +9,7 @@
 
 #include <list>
 #include <random>
-#include <experimental/source_location>
+#include <source_location>
 
 #include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
@@ -248,7 +248,7 @@ SEASTAR_THREAD_TEST_CASE(test_combined_reader_range_tombstone_change_merging) {
     struct output {
         std::vector<range_tombstone_change> rtcs;
     };
-    auto check = [&] (const char* desc, std::vector<input> in, output out, std::experimental::source_location sl = std::experimental::source_location::current()) {
+    auto check = [&] (const char* desc, std::vector<input> in, output out, std::source_location sl = std::source_location::current()) {
         testlog.info("check() {} @ {}:{}", desc, sl.file_name(), sl.line());
         std::vector<flat_mutation_reader_v2> readers;
         for (auto& i : in) {
@@ -1376,7 +1376,7 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
             .build();
 
     const auto check = [&schema] (std::vector<range> ranges, key key, std::vector<range> output_ranges, bool reversed = false,
-            std::experimental::source_location sl = std::experimental::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         auto actual_ranges = ranges::to<query::clustering_row_ranges>(ranges | boost::adaptors::transformed(
                     [&] (const range& r) { return r.to_clustering_range(*schema); }));
 
@@ -1393,7 +1393,7 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
         }
     };
     const auto check_reversed = [&schema, &check] (std::vector<range> ranges, key key, std::vector<range> output_ranges, bool reversed = false,
-            std::experimental::source_location sl = std::experimental::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         return check(std::move(ranges), std::move(key), std::move(output_ranges), true, sl);
     };
 

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/range/adaptors.hpp>
-#include <experimental/source_location>
+#include <source_location>
 #include <fmt/format.h>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -24,7 +24,7 @@
 
 namespace {
 
-using std::experimental::source_location;
+using std::source_location;
 using boost::adaptors::transformed;
 
 std::unique_ptr<cql3::query_options> to_options(
@@ -44,7 +44,7 @@ void require_rows(cql_test_env& e,
                   std::optional<std::vector<sstring_view>> names,
                   const std::vector<bytes_opt>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const std::experimental::source_location& loc = source_location::current()) {
+                  const std::source_location& loc = source_location::current()) {
     // This helps compiler pick the right overload for make_value:
     const auto rvals = values | transformed([] (const bytes_opt& v) { return cql3::raw_value::make_value(v); });
     cql3::cql_config cfg(cql3::cql_config::default_tag{});

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1259,7 +1259,7 @@ SEASTAR_TEST_CASE(test_indexing_paging_and_aggregation) {
 void assert_select_count_and_select_rows_has_size(
         cql_test_env& e, 
         const sstring& rest_of_query, int64_t expected_count, 
-        const std::experimental::source_location& loc = std::experimental::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     eventually([&] { 
         require_rows(e, "SELECT count(*) " + rest_of_query, {
             { long_type->decompose(expected_count) }

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -368,7 +368,7 @@ static bool expression_eq(const expr::expression& e1, const expr::expression& e2
 static void assert_expr_vec_eq(
     const std::vector<expr::expression>& v1,
     const std::vector<expr::expression>& v2,
-    const std::experimental::source_location& loc = std::experimental::source_location::current()) {
+    const std::source_location& loc = std::source_location::current()) {
 
     if (std::equal(v1.begin(), v1.end(), v2.begin(), v2.end(), expression_eq)) {
         return;

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -185,7 +185,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, sstring_view query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
+        cql_test_env& env, sstring_view query, std::unique_ptr<cql3::query_options>&& qo, const std::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get0();
@@ -202,7 +202,7 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
 void require_rows(cql_test_env& e,
                   sstring_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const std::experimental::source_location& loc) {
+                  const std::source_location& loc) {
     try {
         assert_that(cquery_nofail(e, qstr, nullptr, loc)).is_rows().with_rows_ignore_order(expected);
     }
@@ -213,7 +213,7 @@ void require_rows(cql_test_env& e,
 }
 
 void eventually_require_rows(cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
-                             const std::experimental::source_location& loc) {
+                             const std::source_location& loc) {
     try {
         eventually([&] {
             assert_that(cquery_nofail(e, qstr, nullptr, loc)).is_rows().with_rows_ignore_order(expected);
@@ -228,7 +228,7 @@ void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
                   const std::vector<cql3::raw_value>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const std::experimental::source_location& loc) {
+                  const std::source_location& loc) {
     try {
         assert_that(e.execute_prepared(id, values).get0()).is_rows().with_rows_ignore_order(expected);
     } catch (const std::exception& e) {

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -12,7 +12,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "transport/messages/result_message_base.hh"
 #include "bytes.hh"
-#include <experimental/source_location>
+#include <source_location>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/future.hh>
 
@@ -75,22 +75,22 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
         sstring_view query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const std::experimental::source_location& loc = std::experimental::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Asserts that cquery_nofail(e, qstr) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   sstring_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const std::experimental::source_location& loc = std::experimental::source_location::current());
+                  const std::source_location& loc = std::source_location::current());
 
 /// Like require_rows, but wraps assertions in \c eventually.
 void eventually_require_rows(
         cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
-        const std::experimental::source_location& loc = std::experimental::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
                   const std::vector<cql3::raw_value>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const std::experimental::source_location& loc = std::experimental::source_location::current());
+                  const std::source_location& loc = std::source_location::current());

--- a/test/lib/exception_utils.cc
+++ b/test/lib/exception_utils.cc
@@ -25,7 +25,7 @@ std::function<bool(const std::exception&)> exception_predicate::make(
 
 std::function<bool(const std::exception&)> exception_predicate::message_contains(
         const sstring& fragment,
-        const std::experimental::source_location& loc) {
+        const std::source_location& loc) {
     return make([=] (const std::exception& e) { return sstring(e.what()).find(fragment) != sstring::npos; },
                 [=] (const std::exception& e) {
                     return fmt::format("Message '{}' doesn't contain '{}'\n{}:{}: invoked here",
@@ -35,7 +35,7 @@ std::function<bool(const std::exception&)> exception_predicate::message_contains
 
 std::function<bool(const std::exception&)> exception_predicate::message_equals(
         const sstring& text,
-        const std::experimental::source_location& loc) {
+        const std::source_location& loc) {
     return make([=] (const std::exception& e) { return text == e.what(); },
                 [=] (const std::exception& e) {
                     return fmt::format("Message '{}' doesn't equal '{}'\n{}:{}: invoked here",
@@ -45,7 +45,7 @@ std::function<bool(const std::exception&)> exception_predicate::message_equals(
 
 std::function<bool(const std::exception&)> exception_predicate::message_matches(
         const std::string& regex,
-        const std::experimental::source_location& loc) {
+        const std::source_location& loc) {
     // Use boost::regex since std::regex (with libstdc++ 12) uses too much stack
     return make([=] (const std::exception& e) { return boost::regex_search(e.what(), boost::regex(regex)); },
                 [=] (const std::exception& e) {

--- a/test/lib/exception_utils.hh
+++ b/test/lib/exception_utils.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <experimental/source_location>
+#include <source_location>
 #include <functional>
 #include <seastar/core/sstring.hh>
 
@@ -25,16 +25,16 @@ extern std::function<bool(const std::exception&)> make(
 /// Returns a predicate that will check if the exception message contains the given fragment.
 extern std::function<bool(const std::exception&)> message_contains(
         const sstring& fragment,
-        const std::experimental::source_location& loc = std::experimental::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Returns a predicate that will check if the exception message equals the given text.
 extern std::function<bool(const std::exception&)> message_equals(
         const sstring& text,
-        const std::experimental::source_location& loc = std::experimental::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Returns a predicate that will check if the exception message matches the given regular expression.
 extern std::function<bool(const std::exception&)> message_matches(
         const std::string& regex,
-        const std::experimental::source_location& loc = std::experimental::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 } // namespace exception_predicate

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -19,13 +19,13 @@ namespace tests {
 
 namespace {
 
-std::string format_msg(std::string_view test_function_name, bool ok, std::experimental::source_location sl, std::string_view msg) {
+std::string format_msg(std::string_view test_function_name, bool ok, std::source_location sl, std::string_view msg) {
     return fmt::format("{}(): {} @ {}() {}:{:d}{}{}", test_function_name, ok ? "OK" : "FAIL", sl.function_name(), sl.file_name(), sl.line(), msg.empty() ? "" : ": ", msg);
 }
 
 }
 
-bool do_check(bool condition, std::experimental::source_location sl, std::string_view msg) {
+bool do_check(bool condition, std::source_location sl, std::string_view msg) {
     if (condition) {
         testlog.trace("{}", format_msg(__FUNCTION__, condition, sl, msg));
     } else {
@@ -34,7 +34,7 @@ bool do_check(bool condition, std::experimental::source_location sl, std::string
     return condition;
 }
 
-void do_require(bool condition, std::experimental::source_location sl, std::string_view msg) {
+void do_require(bool condition, std::source_location sl, std::string_view msg) {
     if (condition) {
         testlog.trace("{}", format_msg(__FUNCTION__, condition, sl, msg));
     } else {
@@ -45,7 +45,7 @@ void do_require(bool condition, std::experimental::source_location sl, std::stri
 
 }
 
-void fail(std::string_view msg, std::experimental::source_location sl) {
+void fail(std::string_view msg, std::source_location sl) {
     throw_with_backtrace<std::runtime_error>(format_msg(__FUNCTION__, false, sl, msg));
 }
 

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <experimental/source_location>
+#include <source_location>
 #include <string>
 
 #include <fmt/format.h>
@@ -20,30 +20,30 @@
 
 namespace tests {
 
-[[nodiscard]] bool do_check(bool condition, std::experimental::source_location sl, std::string_view msg);
+[[nodiscard]] bool do_check(bool condition, std::source_location sl, std::string_view msg);
 
-[[nodiscard]] inline bool check(bool condition, std::experimental::source_location sl = std::experimental::source_location::current()) {
+[[nodiscard]] inline bool check(bool condition, std::source_location sl = std::source_location::current()) {
     return do_check(condition, sl, {});
 }
 
 template <typename LHS, typename RHS>
-[[nodiscard]] bool check_equal(const LHS& lhs, const RHS& rhs, std::experimental::source_location sl = std::experimental::source_location::current()) {
+[[nodiscard]] bool check_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     const auto condition = (lhs == rhs);
     return do_check(condition, sl, fmt::format("{} {}= {}", lhs, condition ? "=" : "!", rhs));
 }
 
-void do_require(bool condition, std::experimental::source_location sl, std::string_view msg);
+void do_require(bool condition, std::source_location sl, std::string_view msg);
 
-inline void require(bool condition, std::experimental::source_location sl = std::experimental::source_location::current()) {
+inline void require(bool condition, std::source_location sl = std::source_location::current()) {
     do_require(condition, sl, {});
 }
 
 template <typename LHS, typename RHS>
-void require_equal(const LHS& lhs, const RHS& rhs, std::experimental::source_location sl = std::experimental::source_location::current()) {
+void require_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     const auto condition = (lhs == rhs);
     do_require(condition, sl, fmt::format("{} {}= {}", lhs, condition ? "=" : "!", rhs));
 }
 
-void fail(std::string_view msg, std::experimental::source_location sl = std::experimental::source_location::current());
+void fail(std::string_view msg, std::source_location sl = std::source_location::current());
 
 }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -9,7 +9,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <filesystem>
-#include <experimental/source_location>
+#include <source_location>
 #include <fmt/chrono.h>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/coroutine.hh>
@@ -2071,10 +2071,10 @@ class json_mutation_stream_parser {
             }
             return true;
         }
-        bool unexpected(std::experimental::source_location sl = std::experimental::source_location::current()) {
+        bool unexpected(std::source_location sl = std::source_location::current()) {
             return error("unexpected json event {} in state {}", sl.function_name(), stack_to_string());
         }
-        bool unexpected(std::string_view key, std::experimental::source_location sl = std::experimental::source_location::current()) {
+        bool unexpected(std::string_view key, std::source_location sl = std::source_location::current()) {
             return error("unexpected json event {}({}) in state {}", sl.function_name(), key, stack_to_string());
         }
     public:


### PR DESCRIPTION
Now that we use libstdc++ 12, we can use the standardized source_location.