### PR TITLE
docs/dev: Add backport instructions for contributors

### DIFF
--- a/docs/dev/backport.md
+++ b/docs/dev/backport.md
@@ -64,6 +64,7 @@ Before the changes end up on `branch-5.0`, they are first added to the `next-5.0
 git fetch origin branch-5.0
 git checkout -t origin/branch-5.0
 git submodule sync
+git pull origin branch-5.0
 git submodule update --recursive
 ```
 2. Create a branch with the fix

--- a/docs/dev/backport.md
+++ b/docs/dev/backport.md
@@ -37,9 +37,13 @@ keep the label
 5.6. Ask someone else (from QA, or the patch author, or anyone relevant)
 for assistance in selecting among the options
 
-## How to backport a patch
+## Contributor instructions
+When backporting the maintainer will try to cherry-pick the changes onto the branch with older version of Scylla,
+but sometimes additional changes are needed to make the change work with old code.
 
-Here are the instructions on how to backport some changes to an older version of Scylla.  
+In such case the maintainer can ask the contributor to prepare a change to work with this particular version.
+Here are the instructions for a contributor on how to properly prepare these changes.
+
 It's the easiest to show it by an example, so let's look at PR [#12031](https://github.com/scylladb/scylladb/pull/12031), which fixed issue [#12014](https://github.com/scylladb/scylladb/issues/12014).
 
 ### Wait for the original change to get merged

--- a/docs/dev/backport.md
+++ b/docs/dev/backport.md
@@ -71,7 +71,8 @@ git submodule update --recursive
 git checkout -b my_fix_branch_5.0
 ```
 
-3. Copy the changes to the branch, use the merge commit from `master`
+3. Copy the changes to the branch, use the merge commit from `master`.  
+This command will copy all commits to the branch at once, which might result in a lot conflicts to resolve. It's also possible to cherry-pick the commits individually in order to tackle the conflicts one at a time. Please use the `-x` option on cherry-pick so that's it's possible to tell where the commit came from.
 ```bash
 git cherry-pick -m1 -x 2d2034ea28b8615a130146ad9780010d29d2fcc9
 ```

--- a/docs/dev/backport.md
+++ b/docs/dev/backport.md
@@ -50,13 +50,13 @@ It's the easiest to show it by an example, so let's look at PR [#12031](https://
 First the original PR should get merged.
 In the example the author wanted to merge the branch `cvybhu:filter_multi_bug` into `scylladb:master`.
 Each PR is submitted on its own branch, which the PR author wants to merge into the `master` branch.
-Before the changes end up on `master`, they are first added to the `next` branch to run some additional tests. Later the `next` branch becomes `master` and the PR is officialy merged.
+Before the changes end up on `master`, they are first added to the `next` branch to run some additional tests. Later the `next` branch is merged into `master` and the PR is officialy merged.
 
 ### A backport PR
 Released versions of `Scylla` live on their own branches - `branch-5.0`, `branch-4.6` etc.
 To backport the change we will have to put it on its own branch and merge it into the branch with the desired version.
 In the example, the PR with the backport [#12086](https://github.com/scylladb/scylladb/pull/12086) wants to merge `cvybhu:filter_multi_bug_5.0` into `scylladb:branch-5.0`.
-Before the changes end up on `branch-5.0`, they are first added to the `next-5.0` branch to run some additional tests. Later the `next-5.0` branch becomes `branch-5.0` and the PR is officially backported.
+Before the changes end up on `branch-5.0`, they are first added to the `next-5.0` branch to run some additional tests. Later the `next-5.0` branch is merged into `branch-5.0` and the PR is officially backported.
 
 ### Preparing the backport PR
 1. Go to the branch with the target backport version


### PR DESCRIPTION
Add instructions on how to backport a feature to on older version of Scylla.

It contains a detailed step-by-step instruction so that people unfamiliar with intricacies of Scylla's repository organization can easily get the hang of it.

This is the guide I wish I had when I had to do my first backport.

I put it in backport.md because that looks like the file responsible for this sort of information.
For a moment I thought about `CONTRIBUTING.md`, but this is a really short file with general information, so it doesn't really fit there. Maybe in the future there will be some sort of unification (see #12126)