### PR TITLE
Static compaction groups

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -539,13 +539,13 @@ void set_column_family(http_context& ctx, routes& r) {
 
     cf::get_pending_compactions.set(r, [&ctx] (std::unique_ptr<request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
-            return cf.get_compaction_strategy().estimated_pending_compactions(cf.as_table_state());
+            return cf.estimate_pending_compactions();
         }, std::plus<int64_t>());
     });
 
     cf::get_all_pending_compactions.set(r, [&ctx] (std::unique_ptr<request> req) {
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
-            return cf.get_compaction_strategy().estimated_pending_compactions(cf.as_table_state());
+            return cf.estimate_pending_compactions();
         }, std::plus<int64_t>());
     });
 

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -118,7 +118,9 @@ void set_compaction_manager(http_context& ctx, routes& r) {
             auto& cm = db.get_compaction_manager();
             return parallel_for_each(table_names, [&db, &cm, &ks_name, type] (sstring& table_name) {
                 auto& t = db.find_column_family(ks_name, table_name);
-                return cm.stop_compaction(type, &t.as_table_state());
+                return t.parallel_foreach_table_state([&] (compaction::table_state& ts) {
+                    return cm.stop_compaction(type, &ts);
+                });
             });
         });
         co_return json_void();

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -67,9 +67,9 @@ void set_compaction_manager(http_context& ctx, routes& r) {
     cm::get_pending_tasks_by_table.set(r, [&ctx] (std::unique_ptr<request> req) {
         return ctx.db.map_reduce0([&ctx](replica::database& db) {
             return do_with(std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>(), [&ctx, &db](std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>& tasks) {
-                return do_for_each(db.get_column_families(), [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) {
+                return do_for_each(db.get_column_families(), [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) -> future<> {
                     replica::table& cf = *i.second.get();
-                    tasks[std::make_pair(cf.schema()->ks_name(), cf.schema()->cf_name())] = cf.get_compaction_strategy().estimated_pending_compactions(cf.as_table_state());
+                    tasks[std::make_pair(cf.schema()->ks_name(), cf.schema()->cf_name())] = cf.estimate_pending_compactions();
                     return make_ready_future<>();
                 }).then([&tasks] {
                     return std::move(tasks);
@@ -126,7 +126,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
 
     cm::get_pending_tasks.set(r, [&ctx] (std::unique_ptr<request> req) {
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
-            return cf.get_compaction_strategy().estimated_pending_compactions(cf.as_table_state());
+            return cf.estimate_pending_compactions();
         }, std::plus<int64_t>());
     });
 

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -41,7 +41,6 @@ static std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_ha
     return std::move(a);
 }
 
-
 void set_compaction_manager(http_context& ctx, routes& r) {
     cm::get_compactions.set(r, [&ctx] (std::unique_ptr<request> req) {
         return ctx.db.map_reduce0([](replica::database& db) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -909,6 +909,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 10, "Time for which information about finished task stays in memory.")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, false,
         "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions.")
+    , x_log2_compaction_groups(this, "x_log2_compaction_groups", value_status::Used, 0, "Controls static number of compaction groups per table per shard. For X groups, set the option to log (base 2) of X. Example: Value of 3 implies 8 groups.")
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)
     , log_to_stdout(this, "log_to_stdout", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -389,6 +389,8 @@ public:
 
     named_value<bool> cache_index_pages;
 
+    named_value<unsigned> x_log2_compaction_groups;
+
     seastar::logging_settings logging_settings(const log_cli::options&) const;
 
     const db::extensions& extensions() const;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -98,6 +98,8 @@ public:
     lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
 
     const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept;
+    // Triggers regular compaction.
+    void trigger_compaction();
 
     compaction_backlog_tracker& get_backlog_tracker();
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -70,6 +70,7 @@ public:
     future<> flush();
     bool can_flush() const;
     lw_shared_ptr<memtable_list>& memtables() noexcept;
+    size_t memtable_count() const noexcept;
     // Returns minimum timestamp from memtable list
     api::timestamp_type min_memtable_timestamp() const;
     // Add sstable to main set

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1238,6 +1238,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.view_update_concurrency_semaphore = _config.view_update_concurrency_semaphore;
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
+    cfg.x_log2_compaction_groups = db_config.x_log2_compaction_groups();
 
     return cfg;
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -407,11 +407,14 @@ private:
     lw_shared_ptr<memtable_list> make_memory_only_memtable_list();
     lw_shared_ptr<memtable_list> make_memtable_list(compaction_group& cg);
 
+    // TODO: will be later made a config option.
+    // The value of the parameter controls the number of compaction groups in this table.
+    // 0 (default) means 1 compaction group. 3 means 8 compaction groups.
+    static constexpr unsigned _x_log2_compaction_groups = 0;
+
     compaction_manager& _compaction_manager;
     sstables::compaction_strategy _compaction_strategy;
     std::vector<std::unique_ptr<compaction_group>> _compaction_groups;
-    // FIXME: will be removed once the last ref to single compaction group is gone.
-    compaction_group* _compaction_group;
     // Compound SSTable set for all the compaction groups, which is useful for operations spanning all of them.
     lw_shared_ptr<sstables::sstable_set> _sstables;
     // Control background fibers waiting for sstables to be deleted

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -608,7 +608,6 @@ private:
     snapshot_source sstables_as_snapshot_source();
     partition_presence_checker make_partition_presence_checker(lw_shared_ptr<sstables::sstable_set>);
     std::chrono::steady_clock::time_point _sstable_writes_disabled_at;
-    void do_trigger_compaction();
 
     dirty_memory_manager_logalloc::region_group& dirty_memory_region_group() const {
         return _config.dirty_memory_manager->region_group();
@@ -902,7 +901,7 @@ public:
 
     void start_compaction();
     void trigger_compaction();
-    void try_trigger_compaction() noexcept;
+    void try_trigger_compaction(compaction_group& cg) noexcept;
     // Triggers offstrategy compaction, if needed, in the background.
     void trigger_offstrategy_compaction();
     // Performs offstrategy compaction, if needed, returning

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -612,6 +612,7 @@ private:
         return _config.dirty_memory_manager->region_group();
     }
 
+    // reserve_fn will be called before any element is added to readers
     void add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& readers,
              const schema_ptr& s,
              const reader_permit& permit,
@@ -620,7 +621,8 @@ private:
              const io_priority_class& pc,
              const tracing::trace_state_ptr& trace_state,
              streamed_mutation::forwarding fwd,
-             mutation_reader::forwarding fwd_mr) const;
+             mutation_reader::forwarding fwd_mr,
+             std::function<void(size_t)> reserve_fn) const;
 public:
     sstring dir() const {
         return _config.datadir;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -535,6 +535,8 @@ private:
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const noexcept;
     // Select a compaction group from a given sstable based on its token range.
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) noexcept;
+    // Returns a list of all compaction groups.
+    const std::vector<std::unique_ptr<compaction_group>>& compaction_groups() const noexcept;
 
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -612,6 +612,15 @@ private:
         return _config.dirty_memory_manager->region_group();
     }
 
+    void add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& readers,
+             const schema_ptr& s,
+             const reader_permit& permit,
+             const dht::partition_range& range,
+             const query::partition_slice& slice,
+             const io_priority_class& pc,
+             const tracing::trace_state_ptr& trace_state,
+             streamed_mutation::forwarding fwd,
+             mutation_reader::forwarding fwd_mr) const;
 public:
     sstring dir() const {
         return _config.datadir;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -526,6 +526,7 @@ public:
                        const std::vector<sstables::shared_sstable>& old_sstables);
     };
 private:
+    using compaction_group_ptr = std::unique_ptr<compaction_group>;
     std::vector<std::unique_ptr<compaction_group>> make_compaction_groups();
     // Return compaction group if table owns a single one. Otherwise, null is returned.
     compaction_group* single_compaction_group_if_available() const noexcept;
@@ -713,9 +714,9 @@ public:
     // FIXME: in case a query is satisfied from a single memtable, avoid a copy
     using const_mutation_partition_ptr = std::unique_ptr<const mutation_partition>;
     using const_row_ptr = std::unique_ptr<const row>;
-    // FIXME: for supporting multiple compaction groups, this interface will need to return
-    // as many active sstables as there are groups.
-    memtable& active_memtable();
+    // Return all active memtables, where there will be one per compaction group
+    // TODO: expose stats, whatever, instead of exposing active memtables themselves.
+    std::vector<memtable*> active_memtables();
     api::timestamp_type min_memtable_timestamp() const;
     const row_cache& get_row_cache() const {
         return _cache;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -409,9 +409,9 @@ private:
 
     compaction_manager& _compaction_manager;
     sstables::compaction_strategy _compaction_strategy;
-    // TODO: Still holds a single compaction group, meaning all sstables are eligible to be compacted with one another. Soon, a table
-    //  will be able to hold more than one group.
-    std::unique_ptr<compaction_group> _compaction_group;
+    std::vector<std::unique_ptr<compaction_group>> _compaction_groups;
+    // FIXME: will be removed once the last ref to single compaction group is gone.
+    compaction_group* _compaction_group;
     // Compound SSTable set for all the compaction groups, which is useful for operations spanning all of them.
     lw_shared_ptr<sstables::sstable_set> _sstables;
     // Control background fibers waiting for sstables to be deleted
@@ -526,6 +526,7 @@ public:
                        const std::vector<sstables::shared_sstable>& old_sstables);
     };
 private:
+    std::vector<std::unique_ptr<compaction_group>> make_compaction_groups();
     // Return compaction group if table owns a single one. Otherwise, null is returned.
     compaction_group* single_compaction_group_if_available() const noexcept;
     // Select a compaction group from a given token.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -381,6 +381,7 @@ public:
         // Can be updated by a schema change:
         bool enable_optimized_twcs_queries{true};
         uint32_t tombstone_warn_threshold{0};
+        unsigned x_log2_compaction_groups{0};
     };
     struct no_commitlog {};
 
@@ -407,10 +408,9 @@ private:
     lw_shared_ptr<memtable_list> make_memory_only_memtable_list();
     lw_shared_ptr<memtable_list> make_memtable_list(compaction_group& cg);
 
-    // TODO: will be later made a config option.
     // The value of the parameter controls the number of compaction groups in this table.
     // 0 (default) means 1 compaction group. 3 means 8 compaction groups.
-    static constexpr unsigned _x_log2_compaction_groups = 0;
+    const unsigned _x_log2_compaction_groups = 0;
 
     compaction_manager& _compaction_manager;
     sstables::compaction_strategy _compaction_strategy;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -538,6 +538,8 @@ private:
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) noexcept;
     // Returns a list of all compaction groups.
     const std::vector<std::unique_ptr<compaction_group>>& compaction_groups() const noexcept;
+    // Safely iterate through compaction groups, while performing async operations on them.
+    future<> parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action);
 
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -909,6 +909,7 @@ public:
     // The future value is true iff offstrategy compaction was required.
     future<bool> perform_offstrategy_compaction();
     future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges);
+    unsigned estimate_pending_compactions() const;
 
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);
     const sstables::compaction_strategy& get_compaction_strategy() const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1110,7 +1110,10 @@ public:
     void update_off_strategy_trigger();
     void enable_off_strategy_trigger();
 
+    // FIXME: get rid of it once no users.
     compaction::table_state& as_table_state() const noexcept;
+    // Safely iterate through table states, while performing async operations on them.
+    future<> parallel_foreach_table_state(std::function<future<>(compaction::table_state&)> action);
 
     friend class compaction_group;
 };

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -530,6 +530,13 @@ const std::vector<std::unique_ptr<compaction_group>>& table::compaction_groups()
     return _compaction_groups;
 }
 
+future<> table::parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action) {
+    // TODO: place a barrier here when we allow dynamic groups.
+    co_await coroutine::parallel_for_each(compaction_groups(), [&] (const compaction_group_ptr& cg) {
+        return action(*cg);
+    });
+}
+
 future<>
 table::do_add_sstable_and_update_cache(sstables::shared_sstable sst, sstables::offstrategy offstrategy) {
     auto permit = co_await seastar::get_units(_sstable_set_mutation_sem, 1);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1709,30 +1709,30 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
 
     struct pruner {
         column_family& cf;
-        compaction_group& cg;
         db::replay_position rp;
         struct removed_sstable {
+            compaction_group& cg;
             sstables::shared_sstable sst;
             replica::enable_backlog_tracker enable_backlog_tracker;
         };
         std::vector<removed_sstable> remove;
 
-        pruner(column_family& cf, compaction_group& cg)
-            : cf(cf), cg(cg) {}
+        pruner(column_family& cf)
+            : cf(cf) {}
 
-        void prune(db_clock::time_point truncated_at) {
+        void prune(compaction_group& cg, db_clock::time_point truncated_at) {
             auto gc_trunc = to_gc_clock(truncated_at);
 
             auto pruned = make_lw_shared<sstables::sstable_set>(cf._compaction_strategy.make_sstable_set(cf._schema));
             auto maintenance_pruned = cf.make_maintenance_sstable_set();
 
-            auto prune = [this, &gc_trunc] (lw_shared_ptr<sstables::sstable_set>& pruned,
+            auto prune = [this, &cg, &gc_trunc] (lw_shared_ptr<sstables::sstable_set>& pruned,
                                             const lw_shared_ptr<sstables::sstable_set>& pruning,
                                             replica::enable_backlog_tracker enable_backlog_tracker) mutable {
                 pruning->for_each_sstable([&] (const sstables::shared_sstable& p) mutable {
                     if (p->max_data_age() <= gc_trunc) {
                         rp = std::max(p->get_stats_metadata().position, rp);
-                        remove.emplace_back(removed_sstable{p, enable_backlog_tracker});
+                        remove.emplace_back(removed_sstable{cg, p, enable_backlog_tracker});
                         return;
                     }
                     pruned->insert(p);
@@ -1743,18 +1743,20 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
 
             cg.set_main_sstables(std::move(pruned));
             cg.set_maintenance_sstables(std::move(maintenance_pruned));
-            cf.refresh_compound_sstable_set();
         }
     };
-    auto p = make_lw_shared<pruner>(*this, *_compaction_group);
-    co_await _cache.invalidate(row_cache::external_updater([p, truncated_at] {
-        p->prune(truncated_at);
+    auto p = make_lw_shared<pruner>(*this);
+    co_await _cache.invalidate(row_cache::external_updater([this, p, truncated_at] {
+        for (const compaction_group_ptr& cg : compaction_groups()) {
+            p->prune(*cg, truncated_at);
+        }
+        refresh_compound_sstable_set();
         tlogger.debug("cleaning out row cache");
     }));
     rebuild_statistics();
     co_await coroutine::parallel_for_each(p->remove, [this, p] (pruner::removed_sstable& r) {
         if (r.enable_backlog_tracker) {
-            remove_sstable_from_backlog_tracker(p->cg.get_backlog_tracker(), r.sst);
+            remove_sstable_from_backlog_tracker(r.cg.get_backlog_tracker(), r.sst);
         }
         return sstables::sstable_directory::delete_atomically({r.sst});
     });

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2409,7 +2409,9 @@ table::disable_auto_compaction() {
     //   for new submissions
     _compaction_disabled_by_user = true;
     return with_gate(_async_gate, [this] {
-        return _compaction_manager.stop_ongoing_compactions("disable auto-compaction", &as_table_state(), sstables::compaction_type::Compaction);
+        return parallel_foreach_compaction_group([this] (compaction_group& cg) {
+            return _compaction_manager.stop_ongoing_compactions("disable auto-compaction", &cg.as_table_state(), sstables::compaction_type::Compaction);
+        });
     });
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2674,6 +2674,12 @@ compaction::table_state& table::as_table_state() const noexcept {
     return _compaction_group->as_table_state();
 }
 
+future<> table::parallel_foreach_table_state(std::function<future<>(table_state&)> action) {
+    return parallel_foreach_compaction_group([action = std::move(action)] (compaction_group& cg) -> future<> {
+       return action(cg.as_table_state());
+    });
+}
+
 data_dictionary::table
 table::as_data_dictionary() const {
     static constinit data_dictionary_impl _impl;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -993,8 +993,10 @@ void table::rebuild_statistics() {
     _sstables->for_each_sstable([this] (const sstables::shared_sstable& tab) {
         update_stats_for_new_sstable(tab->bytes_on_disk());
     });
-    for (auto& tab : as_table_state().compacted_undeleted_sstables()) {
-        update_stats_for_new_sstable(tab->bytes_on_disk());
+    for (const compaction_group_ptr& cg : compaction_groups()) {
+        for (auto& tab: cg->compacted_undeleted_sstables()) {
+            update_stats_for_new_sstable(tab->bytes_on_disk());
+        }
     }
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1155,7 +1155,9 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 future<>
 table::compact_all_sstables() {
     co_await flush();
-    co_await _compaction_manager.perform_major_compaction(as_table_state());
+    co_await parallel_foreach_compaction_group([this] (compaction_group& cg) {
+        return _compaction_manager.perform_major_compaction(cg.as_table_state());
+    });
 }
 
 void table::start_compaction() {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -335,7 +335,7 @@ api::timestamp_type compaction_group::min_memtable_timestamp() const {
 }
 
 api::timestamp_type table::min_memtable_timestamp() const {
-    return _compaction_group->min_memtable_timestamp();
+    return *boost::range::min_element(compaction_groups() | boost::adaptors::transformed(std::mem_fn(&compaction_group::min_memtable_timestamp)));
 }
 
 // Not performance critical. Currently used for testing only.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1414,6 +1414,7 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
                          keyspace_label(_schema->ks_name()),
                          column_family_label(_schema->cf_name())
                         )
+    , _x_log2_compaction_groups(_config.x_log2_compaction_groups)
     , _compaction_manager(compaction_manager)
     , _compaction_strategy(make_compaction_strategy(_schema->compaction_strategy(), _schema->compaction_strategy_options()))
     , _compaction_groups(make_compaction_groups())

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1217,6 +1217,12 @@ future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_o
     });
 }
 
+unsigned table::estimate_pending_compactions() const {
+    return boost::accumulate(compaction_groups() | boost::adaptors::transformed([this] (const compaction_group_ptr& cg) {
+        return _compaction_strategy.estimated_pending_compactions(cg->as_table_state());
+    }), unsigned(0));
+}
+
 void table::set_compaction_strategy(sstables::compaction_strategy_type strategy) {
     tlogger.debug("Setting compaction strategy of {}.{} to {}", _schema->ks_name(), _schema->cf_name(), sstables::compaction_strategy::name(strategy));
     auto new_cs = make_compaction_strategy(strategy, _schema->compaction_strategy_options());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1406,8 +1406,10 @@ table::~table() {
 
 logalloc::occupancy_stats table::occupancy() const {
     logalloc::occupancy_stats res;
-    for (auto m : *_compaction_group->memtables()) {
-        res += m->region().occupancy();
+    for (const compaction_group_ptr& cg : compaction_groups()) {
+        for (auto& m : *cg->memtables()) {
+            res += m->region().occupancy();
+        }
     }
     return res;
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1721,7 +1721,9 @@ future<> table::clear() {
 // NOTE: does not need to be futurized, but might eventually, depending on
 // if we implement notifications, whatnot.
 future<db::replay_position> table::discard_sstables(db_clock::time_point truncated_at) {
-    assert(_compaction_manager.compaction_disabled(as_table_state()));
+    assert(std::ranges::all_of(compaction_groups(), [this] (const compaction_group_ptr& cg) {
+        return _compaction_manager.compaction_disabled(cg->as_table_state());
+    }));
 
     struct pruner {
         column_family& cf;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -472,6 +472,12 @@ void table::enable_off_strategy_trigger() {
     do_update_off_strategy_trigger();
 }
 
+std::vector<std::unique_ptr<compaction_group>> table::make_compaction_groups() {
+    std::vector<std::unique_ptr<compaction_group>> ret;
+    ret.emplace_back(std::make_unique<compaction_group>(*this));
+    return ret;
+}
+
 compaction_group* table::single_compaction_group_if_available() const noexcept {
     return &*_compaction_group;
 }
@@ -1324,7 +1330,8 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
                         )
     , _compaction_manager(compaction_manager)
     , _compaction_strategy(make_compaction_strategy(_schema->compaction_strategy(), _schema->compaction_strategy_options()))
-    , _compaction_group(std::make_unique<compaction_group>(*this))
+    , _compaction_groups(make_compaction_groups())
+    , _compaction_group(_compaction_groups.front().get())
     , _sstables(make_compound_sstable_set())
     , _cache(_schema, sstables_as_snapshot_source(), row_cache_tracker, is_continuous::yes)
     , _commitlog(cl)

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1665,7 +1665,7 @@ future<> table::flush(std::optional<db::replay_position> pos) {
 }
 
 bool table::can_flush() const {
-    return _compaction_group->can_flush();
+    return std::ranges::any_of(compaction_groups(), std::mem_fn(&compaction_group::can_flush));
 }
 
 future<> compaction_group::clear_memtables() {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -97,7 +97,14 @@ lw_shared_ptr<sstables::sstable_set> compaction_group::make_compound_sstable_set
 }
 
 lw_shared_ptr<sstables::sstable_set> table::make_compound_sstable_set() {
-    return _compaction_group->make_compound_sstable_set();
+    if (auto cg = single_compaction_group_if_available()) {
+        return cg->make_compound_sstable_set();
+    }
+    // TODO: switch to a specialized set for groups which assumes disjointness across compound sets and incrementally read from them.
+    // FIXME: avoid recreation of compound_set for groups which had no change. usually, only one group will be changed at a time.
+    auto sstable_sets = boost::copy_range<std::vector<lw_shared_ptr<sstables::sstable_set>>>(compaction_groups()
+        | boost::adaptors::transformed(std::mem_fn(&compaction_group::make_compound_sstable_set)));
+    return make_lw_shared(sstables::make_compound_sstable_set(schema(), std::move(sstable_sets)));
 }
 
 lw_shared_ptr<sstables::sstable_set> table::make_maintenance_sstable_set() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1745,8 +1745,10 @@ void table::set_schema(schema_ptr s) {
     tlogger.debug("Changing schema version of {}.{} ({}) from {} to {}",
                 _schema->ks_name(), _schema->cf_name(), _schema->id(), _schema->version(), s->version());
 
-    for (auto& m : *_compaction_group->memtables()) {
-        m->set_schema(s);
+    for (const compaction_group_ptr& cg : compaction_groups()) {
+        for (auto& m: *cg->memtables()) {
+            m->set_schema(s);
+        }
     }
 
     _cache.set_schema(s);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -290,8 +290,10 @@ future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db
     return _counter_cell_locks->lock_cells(m.decorated_key(), partition_cells_range(m.partition()), timeout);
 }
 
-memtable& table::active_memtable() {
-    return _compaction_group->memtables()->active_memtable();
+std::vector<memtable*> table::active_memtables() {
+    return boost::copy_range<std::vector<memtable*>>(compaction_groups() | boost::adaptors::transformed([] (const compaction_group_ptr& cg) {
+        return &cg->memtables()->active_memtable();
+    }));
 }
 
 api::timestamp_type compaction_group::min_memtable_timestamp() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -147,6 +147,23 @@ table::find_row(schema_ptr s, reader_permit permit, const dht::decorated_key& pa
     });
 }
 
+void
+table::add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& readers,
+        const schema_ptr& s,
+        const reader_permit& permit,
+        const dht::partition_range& range,
+        const query::partition_slice& slice,
+        const io_priority_class& pc,
+        const tracing::trace_state_ptr& trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr) const {
+    for (auto&& mt : *_compaction_group->memtables()) {
+        if (auto reader_opt = mt->make_flat_reader_opt(s, permit, range, slice, pc, trace_state, fwd, fwd_mr)) {
+            readers.emplace_back(std::move(*reader_opt));
+        }
+    }
+}
+
 flat_mutation_reader_v2
 table::make_reader_v2(schema_ptr s,
                            reader_permit permit,
@@ -193,11 +210,7 @@ table::make_reader_v2(schema_ptr s,
     // https://github.com/scylladb/scylla/issues/309
     // https://github.com/scylladb/scylla/issues/185
 
-    for (auto&& mt : *_compaction_group->memtables()) {
-        if (auto reader_opt = mt->make_flat_reader_opt(s, permit, range, slice, pc, trace_state, fwd, fwd_mr)) {
-            readers.emplace_back(std::move(*reader_opt));
-        }
-    }
+    add_memtables_to_reader_list(readers, s, permit, range, slice, pc, trace_state, fwd, fwd_mr);
 
     const auto bypass_cache = slice.options.contains(query::partition_slice::option::bypass_cache);
     if (cache_enabled() && !bypass_cache && !(reversed && _config.reversed_reads_auto_bypass_cache())) {
@@ -245,11 +258,7 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
                                       const io_priority_class& pc, tracing::trace_state_ptr trace_state, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         std::vector<flat_mutation_reader_v2> readers;
         readers.reserve(_compaction_group->memtables()->size() + 1);
-        for (auto&& mt : *_compaction_group->memtables()) {
-            if (auto reader_opt = mt->make_flat_reader_opt(s, permit, range, slice, pc, trace_state, fwd, fwd_mr)) {
-                readers.emplace_back(std::move(*reader_opt));
-            }
-        }
+        add_memtables_to_reader_list(readers, s, permit, range, slice, pc, trace_state, fwd, fwd_mr);
         readers.emplace_back(make_sstable_reader(s, permit, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
         return make_combined_reader(s, std::move(permit), std::move(readers), fwd, fwd_mr);
     });
@@ -265,11 +274,7 @@ flat_mutation_reader_v2 table::make_streaming_reader(schema_ptr schema, reader_p
 
     std::vector<flat_mutation_reader_v2> readers;
     readers.reserve(_compaction_group->memtables()->size() + 1);
-    for (auto&& mt : *_compaction_group->memtables()) {
-        if (auto reader_opt = mt->make_flat_reader_opt(schema, permit, range, slice, pc, trace_state, fwd, fwd_mr)) {
-            readers.emplace_back(std::move(*reader_opt));
-        }
-    }
+    add_memtables_to_reader_list(readers, schema, permit, range, slice, pc, trace_state, fwd, fwd_mr);
     readers.emplace_back(make_sstable_reader(schema, permit, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
     return make_combined_reader(std::move(schema), std::move(permit), std::move(readers), fwd, fwd_mr);
 }
@@ -2356,11 +2361,7 @@ table::make_reader_v2_excluding_sstables(schema_ptr s,
     std::vector<flat_mutation_reader_v2> readers;
     readers.reserve(_compaction_group->memtables()->size() + 1);
 
-    for (auto&& mt : *_compaction_group->memtables()) {
-        if (auto reader_opt = mt->make_flat_reader_opt(s, permit, range, slice, pc, trace_state, fwd, fwd_mr)) {
-            readers.emplace_back(std::move(*reader_opt));
-        }
-    }
+    add_memtables_to_reader_list(readers, s, permit, range, slice, pc, trace_state, fwd, fwd_mr);
 
     auto excluded_ssts = boost::copy_range<std::unordered_set<sstables::shared_sstable>>(excluded);
     auto effective_sstables = make_lw_shared(_compaction_strategy.make_sstable_set(_schema));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1203,7 +1203,9 @@ future<bool> table::perform_offstrategy_compaction() {
 
 future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges) {
     co_await flush();
-    co_await get_compaction_manager().perform_cleanup(std::move(sorted_owned_ranges), as_table_state());
+    co_await parallel_foreach_compaction_group([this, sorted_owned_ranges = std::move(sorted_owned_ranges)] (compaction_group& cg) {
+        return get_compaction_manager().perform_cleanup(sorted_owned_ranges, cg.as_table_state());
+    });
 }
 
 void table::set_compaction_strategy(sstables::compaction_strategy_type strategy) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1683,7 +1683,7 @@ future<> compaction_group::clear_memtables() {
 future<> table::clear() {
     auto permits = co_await _config.dirty_memory_manager->get_all_flush_permits();
 
-    co_await _compaction_group->clear_memtables();
+    co_await parallel_foreach_compaction_group(std::mem_fn(&compaction_group::clear_memtables));
 
     co_await _cache.invalidate(row_cache::external_updater([] { /* There is no underlying mutation source */ }));
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1660,7 +1660,7 @@ future<> table::flush(std::optional<db::replay_position> pos) {
     }
     auto op = _pending_flushes_phaser.start();
     auto fp = _highest_rp;
-    co_await _compaction_group->flush();
+    co_await parallel_foreach_compaction_group(std::mem_fn(&compaction_group::flush));
     _flush_rp = std::max(_flush_rp, fp);
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1628,6 +1628,10 @@ lw_shared_ptr<memtable_list>& compaction_group::memtables() noexcept {
     return _memtables;
 }
 
+size_t compaction_group::memtable_count() const noexcept {
+    return _memtables->size();
+}
+
 future<> table::flush(std::optional<db::replay_position> pos) {
     if (pos && *pos < _flush_rp) {
         co_return;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -499,6 +499,10 @@ compaction_group& table::compaction_group_for_sstable(const sstables::shared_sst
     return *_compaction_group;
 }
 
+const std::vector<std::unique_ptr<compaction_group>>& table::compaction_groups() const noexcept {
+    return _compaction_groups;
+}
+
 future<>
 table::do_add_sstable_and_update_cache(sstables::shared_sstable sst, sstables::offstrategy offstrategy) {
     auto permit = co_await seastar::get_units(_sstable_set_mutation_sem, 1);

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4209,9 +4209,13 @@ class scylla_memtables(gdb.Command):
         for table in all_tables(db):
             gdb.write('table %s:\n' % schema_ptr(table['_schema']).table_name())
             try:
-                scylla_memtables.dump_compaction_group_memtables(std_unique_ptr(table["_compaction_group"]).get())
+                for cg_ptr in std_vector(table["_compaction_groups"]):
+                    scylla_memtables.dump_compaction_group_memtables(std_unique_ptr(cg_ptr).get())
             except gdb.error:
-                scylla_memtables.dump_memtable_list(seastar_lw_shared_ptr(table['_memtables']).get()) # Scylla 5.1 compatibility
+                try:
+                    scylla_memtables.dump_compaction_group_memtables(std_unique_ptr(table["_compaction_group"]).get())
+                except gdb.error:
+                    scylla_memtables.dump_memtable_list(seastar_lw_shared_ptr(table['_memtables']).get()) # Scylla 5.1 compatibility
 
 def escape_html(s):
     return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4192,18 +4192,26 @@ class scylla_memtables(gdb.Command):
     def __init__(self):
         gdb.Command.__init__(self, 'scylla memtables', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
 
+    @staticmethod
+    def dump_memtable_list(memtable_list):
+        region_ptr_type = gdb.lookup_type('logalloc::region').pointer()
+        for mt_ptr in std_vector(memtable_list['_memtables']):
+            mt = seastar_lw_shared_ptr(mt_ptr).get()
+            reg = lsa_region(mt.cast(region_ptr_type))
+            gdb.write('  (memtable*) 0x%x: total=%d, used=%d, free=%d, flushed=%d\n' % (mt, reg.total(), reg.used(), reg.free(), mt['_flushed_memory']))
+
+    @staticmethod
+    def dump_compaction_group_memtables(compaction_group):
+        scylla_memtables.dump_memtable_list(seastar_lw_shared_ptr(compaction_group['_memtables']).get())
+
     def invoke(self, arg, from_tty):
         db = find_db()
-        region_ptr_type = gdb.lookup_type('logalloc::region').pointer()
         for table in all_tables(db):
             gdb.write('table %s:\n' % schema_ptr(table['_schema']).table_name())
-            compaction_group = std_unique_ptr(table["_compaction_group"]).get()
-            memtable_list = seastar_lw_shared_ptr(compaction_group['_memtables']).get()
-            for mt_ptr in std_vector(memtable_list['_memtables']):
-                mt = seastar_lw_shared_ptr(mt_ptr).get()
-                reg = lsa_region(mt.cast(region_ptr_type))
-                gdb.write('  (memtable*) 0x%x: total=%d, used=%d, free=%d, flushed=%d\n' % (mt, reg.total(), reg.used(), reg.free(), mt['_flushed_memory']))
-
+            try:
+                scylla_memtables.dump_compaction_group_memtables(std_unique_ptr(table["_compaction_group"]).get())
+            except gdb.error:
+                scylla_memtables.dump_memtable_list(seastar_lw_shared_ptr(table['_memtables']).get()) # Scylla 5.1 compatibility
 
 def escape_html(s):
     return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/util/file.hh>
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -67,10 +68,23 @@ static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id 
     });
 }
 
+future<> do_with_cql_env_and_compaction_groups(std::function<void(cql_test_env&)> func, cql_test_config cfg = {}, thread_attributes thread_attr = {}) {
+    std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 1 /* 2 CGs */, 8 /* 256 CGs */ };
+    for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
+        // clean the dir before running
+        if (cfg.db_config->data_file_directories.is_set()) {
+            co_await recursive_remove_directory(fs::path(cfg.db_config->data_file_directories()[0]));
+            co_await recursive_touch_directory(cfg.db_config->data_file_directories()[0]);
+        }
+        cfg.db_config->x_log2_compaction_groups(x_log2_compaction_groups);
+        co_await do_with_cql_env_thread(func, cfg, thread_attr);
+    }
+}
+
 SEASTAR_TEST_CASE(test_safety_after_truncate) {
     auto cfg = make_shared<db::config>();
     cfg->auto_snapshot.set(false);
-    return do_with_cql_env_thread([](cql_test_env& e) {
+    return do_with_cql_env_and_compaction_groups([](cql_test_env& e) {
         e.execute_cql("create table ks.cf (k text, v int, primary key (k));").get();
         auto& db = e.local_db();
         sstring ks_name = "ks";
@@ -130,7 +144,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
 SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
     auto cfg = make_shared<db::config>();
     cfg->auto_snapshot.set(false);
-    return do_with_cql_env_thread([] (cql_test_env& e) {
+    return do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         sstring ks_name = "ks";
         sstring cf_name = "cf";
         e.execute_cql(fmt::format("create table {}.{} (k text, v int, primary key (k));", ks_name, cf_name)).get();
@@ -165,8 +179,8 @@ SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
 }
 
 SEASTAR_TEST_CASE(test_querying_with_limits) {
-    return do_with_cql_env([](cql_test_env& e) {
-        return seastar::async([&] {
+    return do_with_cql_env_and_compaction_groups([](cql_test_env& e) {
+            // FIXME: restore indent.
             e.execute_cql("create table ks.cf (k text, v int, primary key (k));").get();
             auto& db = e.local_db();
             auto s = db.find_schema("ks", "cf");
@@ -229,12 +243,11 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
                     assert_that(query::result_set::from_raw_result(s, cmd.slice, *result)).has_size(expected_size);
                 }).get();
             }
-        });
     });
 }
 
 static void test_database(void (*run_tests)(populate_fn_ex, bool)) {
-    do_with_cql_env_thread([run_tests] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([run_tests] (cql_test_env& e) {
         run_tests([&] (schema_ptr s, const std::vector<mutation>& partitions, gc_clock::time_point) -> mutation_source {
             auto& mm = e.migration_manager().local();
             try {
@@ -321,7 +334,7 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
     temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
-    do_with_cql_env_thread([&sst_dir, &ks, &cf, &require_exist, &temp_sst_dir_2, &temp_sst_dir_3] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([&sst_dir, &ks, &cf, &require_exist, &temp_sst_dir_2, &temp_sst_dir_3] (cql_test_env& e) {
         require_exist(temp_sst_dir_2, false);
         require_exist(temp_sst_dir_3, false);
 
@@ -420,7 +433,7 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
                component_basename(7, component_type::TOC) + "\n" +
                component_basename(8, component_type::TOC) + "\n");
 
-    do_with_cql_env_thread([&] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([&] (cql_test_env& e) {
         // Empty log file
         require_exist(pending_delete_dir + "/sstables-0-0.log", false);
 
@@ -459,7 +472,7 @@ future<> do_with_some_data(std::vector<sstring> cf_names, std::function<future<>
             db_cfg_ptr = make_shared<db::config>();
             db_cfg_ptr->data_file_directories(std::vector<sstring>({ tmpdir_for_data->path().string() }));
         }
-        do_with_cql_env_thread([cf_names = std::move(cf_names), func = std::move(func)] (cql_test_env& e) {
+        do_with_cql_env_and_compaction_groups([cf_names = std::move(cf_names), func = std::move(func)] (cql_test_env& e) {
             for (const auto& cf_name : cf_names) {
                 e.create_table([&cf_name] (std::string_view ks_name) {
                     return *schema_builder(ks_name, cf_name)
@@ -818,7 +831,7 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_true_snapshots_size) {
 
 // toppartitions_query caused a lw_shared_ptr to cross shards when moving results, #5104
 SEASTAR_TEST_CASE(toppartitions_cross_shard_schema_ptr) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
+    return do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE ks.tab (id int PRIMARY KEY)").get();
         db::toppartitions_query tq(e.db(), {{"ks", "tab"}}, {}, 1s, 100, 100);
         tq.scatter().get();
@@ -833,7 +846,7 @@ SEASTAR_TEST_CASE(toppartitions_cross_shard_schema_ptr) {
 }
 
 SEASTAR_THREAD_TEST_CASE(read_max_size) {
-    do_with_cql_env_thread([] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk text, ck int, v text, PRIMARY KEY (pk, ck));").get();
         auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get0();
 
@@ -923,7 +936,7 @@ SEASTAR_THREAD_TEST_CASE(unpaged_mutation_read_global_limit) {
     // configured based on the available memory, so give a small amount to
     // the "node", so we don't have to work with large amount of data.
     cfg.dbcfg->available_memory = 2 * 1024 * 1024;
-    do_with_cql_env_thread([] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk text, ck int, v text, PRIMARY KEY (pk, ck));").get();
         auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get0();
 
@@ -1008,7 +1021,7 @@ SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_selection_test) {
     scheduling_group_and_expected_semaphore.emplace_back(sched_groups.gossip_scheduling_group, system_semaphore);
     scheduling_group_and_expected_semaphore.emplace_back(unknown_scheduling_group, user_semaphore);
 
-    do_with_cql_env_thread([&scheduling_group_and_expected_semaphore] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([&scheduling_group_and_expected_semaphore] (cql_test_env& e) {
         auto& db = e.local_db();
         database_test tdb(db);
         for (const auto& [sched_group, expected_sem_getter] : scheduling_group_and_expected_semaphore) {
@@ -1053,7 +1066,7 @@ SEASTAR_THREAD_TEST_CASE(max_result_size_for_unlimited_query_selection_test) {
     scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.gossip_scheduling_group, system_max_result_size);
     scheduling_group_and_expected_max_result_size.emplace_back(unknown_scheduling_group, user_max_result_size);
 
-    do_with_cql_env_thread([&scheduling_group_and_expected_max_result_size] (cql_test_env& e) {
+    do_with_cql_env_and_compaction_groups([&scheduling_group_and_expected_max_result_size] (cql_test_env& e) {
         auto& db = e.local_db();
         database_test tdb(db);
         for (const auto& [sched_group, expected_max_size] : scheduling_group_and_expected_max_result_size) {
@@ -1075,7 +1088,7 @@ SEASTAR_THREAD_TEST_CASE(max_result_size_for_unlimited_query_selection_test) {
 // Test `upgrade_sstables` on all keyspaces (including the system keyspace).
 // Refs: #9494 (https://github.com/scylladb/scylla/issues/9494)
 SEASTAR_TEST_CASE(upgrade_sstables) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
+    return do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         e.db().invoke_on_all([&e] (replica::database& db) -> future<> {
             auto& cm = db.get_compaction_manager();
             for (auto& [ks_name, ks] : db.get_keyspaces()) {
@@ -1206,7 +1219,7 @@ SEASTAR_TEST_CASE(snapshot_with_quarantine_works) {
 }
 
 SEASTAR_TEST_CASE(database_drop_column_family_clears_querier_cache) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
+    return do_with_cql_env_and_compaction_groups([] (cql_test_env& e) {
         e.execute_cql("create table ks.cf (k text, v int, primary key (k));").get();
         auto& db = e.local_db();
         const auto ts = db_clock::now();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -591,11 +591,11 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
                 assert_that_scanner3.produces(mutations[i]);
             }
 
-            replica::memtable& m = cf.active_memtable(); // held by scanners
+            auto ms = cf.active_memtables(); // held by scanners
 
             auto flushed = cf.flush();
 
-            while (!m.is_flushed()) {
+            while (!std::ranges::all_of(ms, std::mem_fn(&replica::memtable::is_flushed))) {
                 sleep(10ms).get();
             }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -93,16 +93,19 @@ static mutation_partition get_partition(reader_permit permit, replica::memtable&
 
 future<>
 with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::sstables_manager& sm, noncopyable_function<future<> (replica::column_family&)> func) {
-    auto tracker = make_lw_shared<cache_tracker>();
-    auto dir = tmpdir();
-    cfg.datadir = dir.path().string();
-    auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
-    auto cl_stats = make_lw_shared<cell_locker_stats>();
-    auto cf = make_lw_shared<replica::column_family>(s, cfg, replica::column_family::no_commitlog(), *cm, sm, *cl_stats, *tracker);
-    cf->mark_ready_for_writes();
-    return func(*cf).then([cf, cm] {
-        return cf->stop();
-    }).finally([cf, cm, dir = std::move(dir), cl_stats, tracker] () mutable { cf = { }; });
+    std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 3 /* 8 CGs */ };
+    for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
+        auto tracker = make_lw_shared<cache_tracker>();
+        auto dir = tmpdir();
+        cfg.datadir = dir.path().string();
+        cfg.x_log2_compaction_groups = x_log2_compaction_groups;
+        auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+        auto cl_stats = make_lw_shared<cell_locker_stats>();
+        auto cf = make_lw_shared<replica::column_family>(s, cfg, replica::column_family::no_commitlog(), *cm, sm, *cl_stats, *tracker);
+        cf->mark_ready_for_writes();
+        co_await func(*cf);
+        co_await cf->stop();
+    }
 }
 
 SEASTAR_TEST_CASE(test_mutation_is_applied) {
@@ -496,7 +499,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
     cfg.enable_incremental_backups = false;
     cfg.cf_stats = &*cf_stats;
 
-    with_column_family(s, cfg, env.manager(), [s, &env] (replica::column_family& cf) {
+    with_column_family(s, cfg, env.manager(), [s, &env] (replica::column_family& cf) -> future<> {
         const column_definition& r1_col = *s->get_column_definition("r1");
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
 
@@ -507,14 +510,14 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
             cf.apply(std::move(m));
             return cf.flush();
         };
-        insert_row(1001, 2001).get();
-        insert_row(1002, 2002).get();
-        insert_row(1003, 2003).get();
+        co_await insert_row(1001, 2001);
+        co_await insert_row(1002, 2002);
+        co_await insert_row(1003, 2003);
         {
-            auto verify_row = [&] (int32_t c1, int32_t r1) {
+            auto verify_row = [&] (int32_t c1, int32_t r1) -> future<> {
                 auto c_key = clustering_key::from_exploded(*s, {int32_type->decompose(c1)});
                 auto p_key = dht::decorate_key(*s, key);
-                auto r = cf.find_row(cf.schema(), env.make_reader_permit(), p_key, c_key).get0();
+                auto r = co_await cf.find_row(cf.schema(), env.make_reader_permit(), p_key, c_key);
                 {
                     BOOST_REQUIRE(r);
                     auto i = r->find_cell(r1_col.id);
@@ -524,11 +527,10 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
                     BOOST_REQUIRE(int32_type->equal(cell.value().linearize(), int32_type->decompose(r1)));
                 }
             };
-            verify_row(1001, 2001);
-            verify_row(1002, 2002);
-            verify_row(1003, 2003);
+            co_await verify_row(1001, 2001);
+            co_await verify_row(1002, 2002);
+            co_await verify_row(1003, 2003);
         }
-        return make_ready_future<>();
     }).get();
     });
 }

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -55,8 +55,9 @@ public:
     }
 
     auto try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
-        // FIXME: for multiple groups, rewrite this without directly referencing replica::table::_compaction_group.
-        return _cf->try_flush_memtable_to_sstable(*_cf->_compaction_group, mt, replica::sstable_write_permit::unconditional());
+        auto cg = _cf->single_compaction_group_if_available();
+        assert(cg);
+        return _cf->try_flush_memtable_to_sstable(*cg, mt, replica::sstable_write_permit::unconditional());
     }
 };
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1769,8 +1769,9 @@ void populate(const std::vector<dataset*>& datasets, cql_test_env& env, const ta
                 auto gen = ds.make_generator(s, cfg);
                 while (auto mopt = gen()) {
                     ++fragments;
-                    cf.active_memtable().apply(*mopt);
-                    if (cf.active_memtable().region().occupancy().used_space() > flush_threshold) {
+                    replica::memtable& active_memtable = *cf.active_memtables().front();
+                    active_memtable.apply(*mopt);
+                    if (active_memtable.region().occupancy().used_space() > flush_threshold) {
                         metrics_snapshot before;
                         cf.flush().get();
                         auto r = test_result(std::move(before), std::exchange(fragments, 0));


### PR DESCRIPTION
Allows static configuration of number of compaction groups per table per shard.

To bootstrap the project, config option x_log2_compaction_groups was added which controls both number of groups and partitioning within a shard.

With a value of 0 (default), it means 1 compaction group, therefore all tokens go there.
With a value of 3, it means 8 compaction groups, and 3 most-significant-bits of tokens being used to decide which group owns the token.
And so on.

It's still missing:
- integration with repair / streaming
- integration with reshard / reshape.

perf/perf_simple_query --smp 1 --memory 1G

BEFORE
-----
median 61358.55 tps ( 71.1 allocs/op,  12.2 tasks/op,   56375 insns/op,        0 errors)
median 61322.80 tps ( 71.1 allocs/op,  12.2 tasks/op,   56391 insns/op,        0 errors)
median 61058.58 tps ( 71.1 allocs/op,  12.2 tasks/op,   56386 insns/op,        0 errors)
median 61040.94 tps ( 71.1 allocs/op,  12.2 tasks/op,   56381 insns/op,        0 errors)
median 61118.40 tps ( 71.1 allocs/op,  12.2 tasks/op,   56379 insns/op,        0 errors)

AFTER
-----
median 61656.12 tps ( 71.1 allocs/op,  12.2 tasks/op,   56486 insns/op,        0 errors)
median 61483.29 tps ( 71.1 allocs/op,  12.2 tasks/op,   56495 insns/op,        0 errors)
median 61638.05 tps ( 71.1 allocs/op,  12.2 tasks/op,   56494 insns/op,        0 errors)
median 61726.09 tps ( 71.1 allocs/op,  12.2 tasks/op,   56509 insns/op,        0 errors)
median 61537.55 tps ( 71.1 allocs/op,  12.2 tasks/op,   56491 insns/op,        0 errors)