### PR TITLE
doc: update the 5.1 upgrade guide with the mode-related information

### DIFF
--- a/docs/kb/perftune-modes-sync.rst
+++ b/docs/kb/perftune-modes-sync.rst
@@ -2,7 +2,7 @@
 Updating the Mode in perftune.yaml After a ScyllaDB Upgrade
 ==============================================================
 
-In version 2022.1, we improved ScyllaDB's performance by `removing the rx_queues_count from the mode 
+In versions 5.1 (ScyllaDB Open Source) and 2022.2 (ScyllaDB Enterprise), we improved ScyllaDB's performance by `removing the rx_queues_count from the mode 
 condition <https://github.com/scylladb/seastar/pull/949>`_. As a result, ScyllaDB operates in 
 the ``sq_split`` mode instead of the ``mq`` mode (see :doc:`Seastar Perftune </operating-scylla/admin-tools/perftune>` for information about the modes).
 If you upgrade from an earlier version of ScyllaDB, your cluster's existing nodes may use the ``mq`` mode, 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
@@ -225,6 +225,14 @@ Once you are sure the node upgrade was successful, move to the next node in the 
 
 See |Scylla_METRICS|_ for more information..
 
+Update the Mode in perftune.yaml
+------------------------------------
+Due to performance improvements in version 5.1, your cluster's existing nodes may use a different mode than 
+the nodes created after the upgrade. Using different modes across one cluster is not recommended, so you 
+should ensure that the same mode is used on all nodes. See 
+:doc:`Updating the Mode in perftune.yaml After a ScyllaDB Upgrade</kb/perftune-modes-sync>` for instructions.
+
+
 Rollback Procedure
 ==================
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/upgrade-guide-from-5.0-to-5.1-generic.rst
@@ -28,8 +28,8 @@
 .. |ROLLBACK| replace:: rollback
 .. _ROLLBACK: ./#rollback-procedure
 
-.. |SCYLLA_METRICS| replace:: Scylla Metrics Update - Scylla 5.0 to 5.1
-.. _SCYLLA_METRICS: ../metric-update-5.0-to-5.1
+.. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - ScyllaDB 5.0 to 5.1
+.. _SCYLLA_METRICS: /upgrade/upgrade-opensource/upgrade-guide-from-5.0-to-5.1/metric-update-5.0-to-5.1
 
 =============================================================================
 Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION|
@@ -223,7 +223,7 @@ Validate
 
 Once you are sure the node upgrade was successful, move to the next node in the cluster.
 
-See |Scylla_METRICS|_ for more information..
+See |Scylla_METRICS|_ for more information.
 
 Update the Mode in perftune.yaml
 ------------------------------------


### PR DESCRIPTION
This PR adds the link to the KB article about updating the mode after the upgrade to the 5.1 upgrade guide.
In addition, I have:
- updated the KB article to include the versions affected by that change.
- fixed the broken link to the page about metric updates (it is not related to the KB article, but I fixed it in the same PR to limit the number of PRs that need to be backported).

Related: https://github.com/scylladb/scylladb/pull/11122

@roydahan Could you review it so that it can be merged and backported to 5.1?