### PR TITLE
test.py: regression for remove from group0 after remove node

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -730,6 +730,9 @@ future<> raft_group0::leave_group0() {
 future<> raft_group0::remove_from_group0(gms::inet_address node) {
     assert(this_shard_id() == 0);
 
+    utils::get_local_injector().inject("removenode_group0_after_finish",
+        [] { throw std::runtime_error("error injection after finish, before remove from group 0"); });
+
     if (!_raft_gr.is_enabled()) {
         group0_log.info("remove_from_group0({}): local RAFT feature disabled, skipping.", node);
         co_return;

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -892,7 +892,7 @@ class ScyllaClusterManager:
         # initate remove
         try:
             await self.cluster.api.remove_node(initiator.ip_addr, to_remove.host_id, ignore_dead)
-        except RuntimeError as exc:
+        except HTTPError as exc:
             logging.error("_cluster_remove_node failed initiator %s server %s ignore_dead %s, check log at %s",
                           initiator, to_remove, ignore_dead, initiator.log_filename)
             return aiohttp.web.Response(status=500,


### PR DESCRIPTION
Failure of `remove_from_group0` in `storage_service::removenode` is not handled correctly after node is removed.
    
To test this bug, add an error injection at `group0` and create a regression test.