### PR TITLE
systemd: replace PermissionsStartOnly with '+'

### DIFF
--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -5,7 +5,6 @@ Wants=scylla-housekeeping-restart.timer
 Wants=scylla-housekeeping-daily.timer
 
 [Service]
-PermissionsStartOnly=true
 Type=notify
 LimitCORE=infinity
 LimitMEMLOCK=infinity
@@ -14,9 +13,9 @@ LimitAS=infinity
 LimitNPROC=8096
 EnvironmentFile=/etc/sysconfig/scylla-server
 EnvironmentFile=/etc/scylla.d/*.conf
-ExecStartPre=/opt/scylladb/scripts/scylla_prepare
+ExecStartPre=+/opt/scylladb/scripts/scylla_prepare
 ExecStart=/usr/bin/scylla $SCYLLA_ARGS $SEASTAR_IO $DEV_MODE $CPUSET $MEM_CONF
-ExecStopPost=/opt/scylladb/scripts/scylla_stop
+ExecStopPost=+/opt/scylladb/scripts/scylla_stop
 TimeoutStartSec=1y
 TimeoutStopSec=900
 KillMode=process

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -140,6 +140,7 @@ rm -rf $RPM_BUILD_ROOT
 %ghost /etc/systemd/system/scylla-helper.slice.d/memory.conf
 %ghost /etc/systemd/system/scylla-server.service.d/capabilities.conf
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
+%ghost /etc/systemd/system/scylla-server.service.d/exec_start.conf
 /etc/systemd/system/scylla-server.service.d/dependencies.conf
 %ghost %config /etc/systemd/system/var-lib-systemd-coredump.mount
 %ghost /etc/systemd/system/scylla-cpupower.service


### PR DESCRIPTION
Since PermissionsStartOnly is deperecated, we need to use new format on ExecStartPre / ExecStopPost, a special executable prefix '+'. (which means the command will run in full privilege)

see https://github.com/systemd/systemd/pull/10802
see https://man7.org/linux/man-pages/man5/systemd.service.5.html

Related with scylladb/scylla-enterprise#1067