### PR TITLE
alternator: fix hangs related to TTL scanning

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -568,7 +568,7 @@ static future<> scan_table_ranges(
                     std::current_exception());
             }
             // If we didn't break out of this loop, add a minimal sleep
-            co_await seastar::sleep(1s);
+            co_await sleep_abortable(std::chrono::seconds(1), abort_source);
         }
         auto rows = rs->rows();
         auto meta = rs->get_metadata().get_names();


### PR DESCRIPTION
The first patch in this small series fixes a hang during shutdown when the expired-item scanning thread can hang in a retry loop instead of quitting.  These hangs were seen in some test runs (issue #12145).

The second patch is a failsafe against additional bugs like those solved by the first patch: If any bugs causes the same page fetch to repeatedly time out, let's stop the attempts after 10 retries instead of retrying for ever. When we stop the retries, a warning will be printed to the log, Scylla will wait until the next scan period and start a new scan from scratch - from a random position in the database, instead of hanging potentially-forever waiting for the same page.