### PR TITLE
Cleanup sstables::test_env's manager usage

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -809,7 +809,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , prometheus_address(this, "prometheus_address", value_status::Used, {/* listen_address */}, "Prometheus listening address, defaulting to listen_address if not explicitly set")
     , prometheus_prefix(this, "prometheus_prefix", value_status::Used, "scylla", "Set the prefix of the exported Prometheus metrics. Changing this will break Scylla's dashboard compatibility, do not change unless you know what you are doing.")
     , abort_on_lsa_bad_alloc(this, "abort_on_lsa_bad_alloc", value_status::Used, false, "Abort when allocation in LSA region fails")
-    , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, 12, "Number of most siginificant token bits to ignore in murmur3 partitioner; increase for very large clusters")
+    , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, default_murmur3_partitioner_ignore_msb_bits, "Number of most siginificant token bits to ignore in murmur3 partitioner; increase for very large clusters")
     , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit")
     , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default) "
         "bytes written to data file. Value must be between 0 and 1.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -99,6 +99,7 @@ struct tri_mode_restriction_t {
 };
 using tri_mode_restriction = enum_option<tri_mode_restriction_t>;
 
+constexpr unsigned default_murmur3_partitioner_ignore_msb_bits = 12;
 
 class config : public utils::config_file {
 public:

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -29,7 +29,7 @@ feature_config::feature_config() {
 feature_service::feature_service(feature_config cfg) : _config(cfg)
 {}
 
-feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
+feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled) {
     feature_config fcfg;
 
     fcfg._disabled_features = std::move(disabled);

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -32,10 +32,10 @@ private:
     feature_config();
 
     friend class feature_service;
-    friend feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled);
+    friend feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled);
 };
 
-feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled = {});
+feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
 
 using namespace std::literals;
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -997,28 +997,6 @@ SEASTAR_TEST_CASE(reader_selector_fast_forwarding_test) {
     });
 }
 
-sstables::shared_sstable create_sstable(sstables::test_env& env, simple_schema& sschema, const sstring& path) {
-    std::vector<mutation> mutations;
-    mutations.reserve(1 << 14);
-
-    for (std::size_t p = 0; p < (1 << 10); ++p) {
-        mutation m(sschema.schema(), sschema.make_pkey(p));
-        sschema.add_static_row(m, format("{:d}_static_val", p));
-
-        for (std::size_t c = 0; c < (1 << 4); ++c) {
-            sschema.add_row(m, sschema.make_ckey(c), format("val_{:d}", c));
-        }
-
-        mutations.emplace_back(std::move(m));
-        thread::yield();
-    }
-
-    return make_sstable_containing([&] {
-            return env.make_sstable(sschema.schema(), path, 0);
-        }
-        , mutations);
-}
-
 static
 sstables::shared_sstable create_sstable(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations) {
     static thread_local auto tmp = tmpdir();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5195,19 +5195,17 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
+        test_db_config.host_id = locator::host_id::create_random_id();
+        tmpdir dir;
+        auto sst = env.manager().make_sstable(
+                s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
 
-    test_db_config.host_id = locator::host_id::create_random_id();
-    tmpdir dir;
-    auto sst = env.manager().make_sstable(
-            s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
-
-    // The test provides thresholds values for the large row handler. Whether the handler gets
-    // trigger depends on the size of rows after they are written in the MC format and that size
-    // depends on the encoding statistics (because of variable-length encoding). The original values
-    // were chosen with the default-constructed encoding_stats, so let's keep it that way.
-    sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
-    BOOST_REQUIRE_EQUAL(i, expected.size());
-
+        // The test provides thresholds values for the large row handler. Whether the handler gets
+        // trigger depends on the size of rows after they are written in the MC format and that size
+        // depends on the encoding statistics (because of variable-length encoding). The original values
+        // were chosen with the default-constructed encoding_stats, so let's keep it that way.
+        sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
+        BOOST_REQUIRE_EQUAL(i, expected.size());
     }, { &handler }).get();
 }
 
@@ -5254,19 +5252,17 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
+        test_db_config.host_id = locator::host_id::create_random_id();
+        tmpdir dir;
+        auto sst = env.manager().make_sstable(
+                s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
 
-    test_db_config.host_id = locator::host_id::create_random_id();
-    tmpdir dir;
-    auto sst = env.manager().make_sstable(
-            s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
-
-    // The test provides thresholds values for the large row handler. Whether the handler gets
-    // trigger depends on the size of rows after they are written in the MC format and that size
-    // depends on the encoding statistics (because of variable-length encoding). The original values
-    // were chosen with the default-constructed encoding_stats, so let's keep it that way.
-    sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
-    BOOST_REQUIRE_EQUAL(i, expected.size());
-
+        // The test provides thresholds values for the large row handler. Whether the handler gets
+        // trigger depends on the size of rows after they are written in the MC format and that size
+        // depends on the encoding statistics (because of variable-length encoding). The original values
+        // were chosen with the default-constructed encoding_stats, so let's keep it that way.
+        sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
+        BOOST_REQUIRE_EQUAL(i, expected.size());
     }, { &handler }).get();
 }
 
@@ -5317,14 +5313,12 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
+        test_db_config.host_id = locator::host_id::create_random_id();
+        tmpdir dir;
+        auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
-    test_db_config.host_id = locator::host_id::create_random_id();
-    tmpdir dir;
-    auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
-    sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
-
-    BOOST_REQUIRE_EQUAL(logged, expected);
-
+        BOOST_REQUIRE_EQUAL(logged, expected);
     }, { &handler }).get();
 }
 
@@ -5372,14 +5366,12 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
+        test_db_config.host_id = locator::host_id::create_random_id();
+        tmpdir dir;
+        auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
-    test_db_config.host_id = locator::host_id::create_random_id();
-    tmpdir dir;
-    auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
-    sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
-
-    BOOST_REQUIRE_EQUAL(logged, expected);
-
+        BOOST_REQUIRE_EQUAL(logged, expected);
     }, { &handler }).get();
 }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5195,7 +5195,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        test_db_config.host_id = locator::host_id::create_random_id();
+        env.db_config().host_id = locator::host_id::create_random_id();
         tmpdir dir;
         auto sst = env.make_sstable(s, dir.path().string(), 1, version, sstables::sstable::format_types::big);
 
@@ -5251,7 +5251,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        test_db_config.host_id = locator::host_id::create_random_id();
+        env.db_config().host_id = locator::host_id::create_random_id();
         tmpdir dir;
         auto sst = env.make_sstable(s, dir.path().string(), 1, version, sstables::sstable::format_types::big);
 
@@ -5311,7 +5311,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        test_db_config.host_id = locator::host_id::create_random_id();
+        env.db_config().host_id = locator::host_id::create_random_id();
         tmpdir dir;
         auto sst = env.make_sstable(sc, dir.path().string(), 1, version, sstables::sstable::format_types::big);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
@@ -5364,7 +5364,7 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        test_db_config.host_id = locator::host_id::create_random_id();
+        env.db_config().host_id = locator::host_id::create_random_id();
         tmpdir dir;
         auto sst = env.make_sstable(sc, dir.path().string(), 1, version, sstables::sstable::format_types::big);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5197,8 +5197,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     sstables::test_env::do_with_async([&] (auto& env) {
         test_db_config.host_id = locator::host_id::create_random_id();
         tmpdir dir;
-        auto sst = env.manager().make_sstable(
-                s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        auto sst = env.make_sstable(s, dir.path().string(), 1, version, sstables::sstable::format_types::big);
 
         // The test provides thresholds values for the large row handler. Whether the handler gets
         // trigger depends on the size of rows after they are written in the MC format and that size
@@ -5254,8 +5253,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
     sstables::test_env::do_with_async([&] (auto& env) {
         test_db_config.host_id = locator::host_id::create_random_id();
         tmpdir dir;
-        auto sst = env.manager().make_sstable(
-                s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        auto sst = env.make_sstable(s, dir.path().string(), 1, version, sstables::sstable::format_types::big);
 
         // The test provides thresholds values for the large row handler. Whether the handler gets
         // trigger depends on the size of rows after they are written in the MC format and that size
@@ -5315,7 +5313,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     sstables::test_env::do_with_async([&] (auto& env) {
         test_db_config.host_id = locator::host_id::create_random_id();
         tmpdir dir;
-        auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        auto sst = env.make_sstable(sc, dir.path().string(), 1, version, sstables::sstable::format_types::big);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
         BOOST_REQUIRE_EQUAL(logged, expected);
@@ -5368,7 +5366,7 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
     sstables::test_env::do_with_async([&] (auto& env) {
         test_db_config.host_id = locator::host_id::create_random_id();
         tmpdir dir;
-        auto sst = env.manager().make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
+        auto sst = env.make_sstable(sc, dir.path().string(), 1, version, sstables::sstable::format_types::big);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
         BOOST_REQUIRE_EQUAL(logged, expected);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3595,7 +3595,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
             return (gc_clock::now().time_since_epoch() - duration_cast<microseconds>(step)).count();
         };
 
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_expiring_cell = [&] (std::chrono::hours step) {
             static thread_local int32_t value = 1;
@@ -3716,7 +3716,7 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
             return (gc_clock::now().time_since_epoch() - duration_cast<microseconds>(window)).count();
         };
 
-        auto tokens = token_generation_for_shard(4, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(4, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_sstable = [&] (int sstable_idx) {
             static thread_local int32_t value = 1;
@@ -3838,7 +3838,7 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
             using namespace std::chrono;
             return (gc_clock::now().time_since_epoch() - duration_cast<microseconds>(step)).count();
         };
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_row = [&] (std::chrono::hours step) {
             static thread_local int32_t value = 1;
@@ -3899,7 +3899,7 @@ SEASTAR_TEST_CASE(test_twcs_compaction_across_buckets) {
         auto sst_gen = [&env, s, &tmp, gen = make_lw_shared<unsigned>(1)] () mutable {
             return env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
         };
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
         auto pkey = partition_key::from_exploded(*s, {to_bytes(tokens[0].first)});
 
         auto make_row = [&] (std::chrono::hours step) {
@@ -4013,7 +4013,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
             return (now + duration_cast<seconds>(step)).count();
         };
 
-        auto tokens = token_generation_for_shard(disjoint_sstable_count, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(disjoint_sstable_count, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_row = [&](unsigned token_idx, auto step) {
             static thread_local int32_t value = 1;
@@ -4151,7 +4151,7 @@ SEASTAR_TEST_CASE(stcs_reshape_overlapping_test) {
         std::map<sstring, sstring> opts;
         auto cs = sstables::make_compaction_strategy(sstables::compaction_strategy_type::size_tiered, std::move(opts));
 
-        auto tokens = token_generation_for_shard(disjoint_sstable_count, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(disjoint_sstable_count, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_row = [&](unsigned token_idx) {
             auto key_str = tokens[token_idx].first;
@@ -4291,7 +4291,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
         auto tmp = tmpdir();
         auto cl_stats = make_lw_shared<cell_locker_stats>();
         auto tracker = make_lw_shared<cache_tracker>();
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto next_timestamp = [] (auto step) {
             using namespace std::chrono;
@@ -4531,7 +4531,7 @@ SEASTAR_TEST_CASE(twcs_single_key_reader_through_compound_set_test) {
             using namespace std::chrono;
             return (gc_clock::now().time_since_epoch() + duration_cast<microseconds>(step)).count();
         };
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
         auto make_row = [&](std::chrono::hours step) {
             static thread_local int32_t value = 1;
@@ -4592,7 +4592,7 @@ SEASTAR_TEST_CASE(test_major_does_not_miss_data_in_memtable) {
         auto s = builder.build();
 
         auto tmp = tmpdir();
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
         auto pkey = partition_key::from_exploded(*s, {to_bytes(tokens[0].first)});
 
         table_for_tests cf(env.manager(), s, tmp.path().string());
@@ -4763,7 +4763,7 @@ SEASTAR_TEST_CASE(test_compaction_strategy_cleanup_method) {
             auto s = builder.build();
 
             auto tmp = tmpdir();
-            auto tokens = token_generation_for_shard(all_files, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+            auto tokens = token_generation_for_shard(all_files, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
 
             table_for_tests cf(env.manager(), s, tmp.path().string());
             auto close_cf = deferred_stop(cf);
@@ -4857,7 +4857,7 @@ SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
         auto sst_gen = [&env, s, &tmp, gen = make_lw_shared<unsigned>(1)] () mutable {
             return env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
         };
-        auto tokens = token_generation_for_shard(1, this_shard_id(), test_db_config.murmur3_partitioner_ignore_msb_bits(), smp::count);
+        auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
         auto pkey = partition_key::from_exploded(*s, {to_bytes(tokens[0].first)});
         table_for_tests cf(env.manager(), s);
         auto close_cf = deferred_stop(cf);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -214,9 +214,10 @@ SEASTAR_TEST_CASE(compact) {
     auto s = builder.build();
     table_for_tests cf(env.manager(), s);
     auto close_cf = deferred_stop(cf);
+    tmpdir dir;
+    sstring tmpdir_path = dir.path().string();
 
-    test_setup::do_with_tmp_directory([s, generation, cf] (test_env& env, sstring tmpdir_path) {
-        return open_sstables(env, s, "test/resource/sstables/compaction", {1,2,3}).then([&env, tmpdir_path, s, cf, generation] (auto sstables) mutable {
+        open_sstables(env, s, "test/resource/sstables/compaction", {1,2,3}).then([&env, tmpdir_path, s, cf, generation] (auto sstables) mutable {
             auto new_sstable = [&env, gen = make_lw_shared<unsigned>(generation), s, tmpdir_path] {
                 return env.make_sstable(s, tmpdir_path,
                         (*gen)++, sstables::get_highest_sstable_version(), sstables::sstable::format_types::big);
@@ -287,8 +288,7 @@ SEASTAR_TEST_CASE(compact) {
                     });
                 });
             });
-        });
-    }).get();
+        }).get();
   });
 
     // verify that the compacted sstable look like

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -38,6 +38,7 @@ public:
 };
 
 struct test_env_config {
+    db::large_data_handler* large_data_handler = nullptr;
 };
 
 class test_env {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -13,6 +13,9 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/defer.hh>
 
+#include "db/config.hh"
+#include "db/large_data_handler.hh"
+#include "gms/feature_service.hh"
 #include "sstables/sstables.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/test_services.hh"
@@ -43,7 +46,10 @@ struct test_env_config {
 
 class test_env {
     struct impl {
+        db::config db_config;
         cache_tracker cache_tracker;
+        gms::feature_service feature_service;
+        db::nop_large_data_handler nop_ld_handler;
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
 
@@ -87,7 +93,7 @@ public:
 
     test_env_sstables_manager& manager() { return _impl->mgr; }
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
-    db::config& db_config() { return test_db_config; }
+    db::config& db_config() { return _impl->db_config; }
 
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
         return _impl->semaphore.make_tracking_only_permit(s, n, timeout);

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -87,6 +87,8 @@ public:
 
     test_env_sstables_manager& manager() { return _impl->mgr; }
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
+    db::config& db_config() { return test_db_config; }
+
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
         return _impl->semaphore.make_tracking_only_permit(s, n, timeout);
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -328,11 +328,10 @@ public:
     static future<> do_with_cloned_tmp_directory(sstring src, std::function<future<> (test_env&, sstring srcdir_path, sstring destdir_path)>&& fut) {
         return test_env::do_with_async([fut = std::move(fut), src = std::move(src)] (test_env& env) {
             auto src_dir = tmpdir();
-            auto dest_dir = tmpdir();
             for (const auto& entry : std::filesystem::directory_iterator(src.c_str())) {
                 std::filesystem::copy(entry.path(), src_dir.path() / entry.path().filename());
             }
-            auto dest_path = dest_dir.path() / src.c_str();
+            auto dest_path = src_dir.path() / sstables::staging_dir;
             std::filesystem::create_directories(dest_path);
             fut(env, src_dir.path().string(), dest_path.string()).get();
         });

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -33,10 +33,6 @@ range<dht::token> create_token_range_from_keys(const dht::sharder& sinfo, const 
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
 
-db::nop_large_data_handler nop_lp_handler;
-db::config test_db_config;
-gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
-
 table_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "table_for_tests")
 { }
@@ -153,7 +149,8 @@ future<> table_for_tests::stop() {
 namespace sstables {
 
 test_env::impl::impl(test_env_config cfg)
-    : mgr(cfg.large_data_handler == nullptr ? nop_lp_handler : *cfg.large_data_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
+    : feature_service(gms::feature_config_from_db_config(db_config))
+    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, memory::stats().total_memory())
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -153,7 +153,7 @@ future<> table_for_tests::stop() {
 namespace sstables {
 
 test_env::impl::impl(test_env_config cfg)
-    : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
+    : mgr(cfg.large_data_handler == nullptr ? nop_lp_handler : *cfg.large_data_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -152,7 +152,7 @@ future<> table_for_tests::stop() {
 
 namespace sstables {
 
-test_env::impl::impl()
+test_env::impl::impl(test_env_config cfg)
     : mgr(nop_lp_handler, test_db_config, test_feature_service, cache_tracker, memory::stats().total_memory())
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -34,9 +34,6 @@
 #include "compaction/table_state.hh"
 #include "sstables/sstables_manager.hh"
 
-extern db::config test_db_config;
-extern gms::feature_service test_feature_service;
-
 struct table_for_tests {
     class table_state;
     struct data {


### PR DESCRIPTION
Mainly this PR removes global db::config and feature service that are used by sstables::test_env as dependencies for embedded sstables_manager. Other than that -- drop unused methods, remove nested test_env-s and relax few cases that use two temp dirs at a time for no gain.