### PR TITLE
code: Use http::re(quest|ply) instead of httpd:: ones

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -23,7 +23,7 @@ namespace alternator {
 // api_error into a JSON object, and that is returned to the user.
 class api_error final : public std::exception {
 public:
-    using status_type = httpd::reply::status_type;
+    using status_type = http::reply::status_type;
     status_type _http_code;
     std::string _type;
     std::string _msg;
@@ -77,7 +77,7 @@ public:
         return api_error("TableNotFoundException", std::move(msg));
     }
     static api_error internal(std::string msg) {
-        return api_error("InternalServerError", std::move(msg), reply::status_type::internal_server_error);
+        return api_error("InternalServerError", std::move(msg), http::reply::status_type::internal_server_error);
     }
 
     // Provide the "std::exception" interface, to make it easier to print this

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -28,6 +28,8 @@
 static logging::logger slogger("alternator-server");
 
 using namespace httpd;
+using request = http::request;
+using reply = http::reply;
 
 namespace alternator {
 

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -27,7 +27,7 @@ using chunked_content = rjson::chunked_content;
 class server {
     static constexpr size_t content_length_limit = 16*MB;
     using alternator_callback = std::function<future<executor::request_return_type>(executor&, executor::client_state&,
-            tracing::trace_state_ptr, service_permit, rjson::value, std::unique_ptr<request>)>;
+            tracing::trace_state_ptr, service_permit, rjson::value, std::unique_ptr<http::request>)>;
     using alternator_callbacks_map = std::unordered_map<std::string_view, alternator_callback>;
 
     http_server _http_server;
@@ -76,8 +76,8 @@ public:
 private:
     void set_routes(seastar::httpd::routes& r);
     // If verification succeeds, returns the authenticated user's username
-    future<std::string> verify_signature(const seastar::httpd::request&, const chunked_content&);
-    future<executor::request_return_type> handle_api_request(std::unique_ptr<request> req);
+    future<std::string> verify_signature(const seastar::http::request&, const chunked_content&);
+    future<executor::request_return_type> handle_api_request(std::unique_ptr<http::request> req);
 };
 
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -14,6 +14,9 @@
 #include "tasks/task_manager.hh"
 #include "seastarx.hh"
 
+using request = http::request;
+using reply = http::reply;
+
 namespace service {
 
 class load_meter;

--- a/test/manual/gce_snitch_test.cc
+++ b/test/manual/gce_snitch_test.cc
@@ -34,16 +34,16 @@ static constexpr const char* DUMMY_META_SERVER_IP = "DUMMY_META_SERVER_IP";
 static constexpr const char* USE_GCE_META_SERVER = "USE_GCE_META_SERVER";
 
 class gce_meta_get_handler : public seastar::httpd::handler_base {
-    virtual future<std::unique_ptr<seastar::httpd::reply>> handle(const sstring& path, std::unique_ptr<seastar::httpd::request> req, std::unique_ptr<seastar::httpd::reply> rep) override {
+    virtual future<std::unique_ptr<seastar::http::reply>> handle(const sstring& path, std::unique_ptr<seastar::http::request> req, std::unique_ptr<seastar::http::reply> rep) override {
         using namespace seastar::httpd;
 
         if (path == locator::gce_snitch::ZONE_NAME_QUERY_REQ) {
             rep->write_body(sstring("txt"), sstring("projects/431729375847/zones/us-central1-a"));
         } else {
-            rep->set_status(reply::status_type::bad_request);
+            rep->set_status(http::reply::status_type::bad_request);
         }
 
-        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 };
 


### PR DESCRIPTION
Recent seastar update deprecated those from httpd namespace.

fixes: #12142

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>