### PR TITLE
sstables: Drop set_generation() method

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -192,8 +192,6 @@ public:
     // Call as the last method before the object is destroyed.
     // No other uses of the object can happen at this point.
     future<> destroy();
-
-    future<> set_generation(generation_type generation);
     future<> move_to_new_dir(sstring new_dir, generation_type generation, bool do_sync_dirs = true);
 
     // Move the sstable to the quarantine_dir

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2100,13 +2100,9 @@ SEASTAR_TEST_CASE(test_unknown_component) {
         BOOST_REQUIRE(file_exists(tmp.path().string() + "/la-1-big-UNKNOWN.txt").get0());
 
         sstp = env.reusable_sst(uncompressed_schema(), tmp.path().string(), 1).get0();
-        sstp->set_generation(generation_from_value(2)).get();
-        BOOST_REQUIRE(!file_exists(tmp.path().string() +  "/la-1-big-UNKNOWN.txt").get0());
-        BOOST_REQUIRE(file_exists(tmp.path().string() + "/la-2-big-UNKNOWN.txt").get0());
-
         sstables::sstable_directory::delete_atomically({sstp}).get();
         // assure unknown component is deleted
-        BOOST_REQUIRE(!file_exists(tmp.path().string() + "/la-2-big-UNKNOWN.txt").get0());
+        BOOST_REQUIRE(!file_exists(tmp.path().string() + "/la-1-big-UNKNOWN.txt").get0());
     });
 }
 


### PR DESCRIPTION
The method became unused since 70e5252a (table: no longer accept online loading of SSTable files in the main directory) and the whole concept of reshuffling sstables was dropped later by 7351db7c (Reshape upload files and reshard+reshape at boot).

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>