### PR TITLE
compaction_manager: Delete compaction_state's move constructor

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1582,7 +1582,7 @@ compaction_manager::compaction_state::compaction_state(table_state& t)
 }
 
 void compaction_manager::add(compaction::table_state& t) {
-    auto [_, inserted] = _compaction_state.insert({&t, compaction_state(t)});
+    auto [_, inserted] = _compaction_state.try_emplace(&t, t);
     if (!inserted) {
         auto s = t.schema();
         on_internal_error(cmlog, format("compaction_state for table {}.{} [{}] already exists", s->ks_name(), s->cf_name(), fmt::ptr(&t)));

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -86,7 +86,7 @@ private:
         compaction_backlog_tracker backlog_tracker;
 
         explicit compaction_state(table_state& t);
-        compaction_state(compaction_state&&) = default;
+        compaction_state(compaction_state&&) = delete;
         ~compaction_state();
 
         bool compaction_disabled() const noexcept {


### PR DESCRIPTION
compaction_state shouldn't be moved once emplaced. moving it could theoretically cause task's gate holder to have a dangling pointer to compaction_state's gate, but turns out gate's move ctor will actually fail under this assertion:
assert(!_count && "gate reassigned with outstanding requests");

Cannot happen today, but let's make it more future proof.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>