### PR TITLE
alternator-test: xfail a flaky test exposing a known bug

### DIFF
--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -102,7 +102,7 @@ def test_too_large_request(dynamodb, test_table):
 #    Content-Length header or chunked encoding (reproduces issue #8196).
 # 2. The client should be able to recognize this error as a 413 error, not
 #     some I/O error like broken pipe (reproduces issue #8195).
-@pytest.mark.xfail(reason="issue #8196")
+@pytest.mark.xfail(reason="issue #8196, #12166")
 def test_too_large_request_chunked(dynamodb, test_table):
     if Version(urllib3.__version__) < Version('1.26'):
         pytest.skip("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")
@@ -118,6 +118,7 @@ def test_too_large_request_chunked(dynamodb, test_table):
     # request succeeded, and the status_code was 200 instead of 413.
     assert response.status_code == 413
 
+@pytest.mark.xfail(reason="issue #12166. Note that only fails very rairly, will usually xpass")
 def test_too_large_request_content_length(dynamodb, test_table):
     if Version(urllib3.__version__) < Version('1.26'):
         pytest.skip("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")


### PR DESCRIPTION
In a recent commit 757d2a4, we removed the "xfail" mark from the test test_manual_requests.py::test_too_large_request_content_length because it started to pass on more modern versions of Python, with a urllib3 bug fixed.

Unfortunately, the celebration was premature: It turns out that although the test now *usually* passes, it sometimes fails. This is caused by a Seastar bug scylladb/seastar#1325, which I opened #12166 to track in this project. So unfortunately we need to add the "xfail" mark back to this test.

Note that although the test will now be marked "xfail", it will actually pass most of the time, so will appear as "xpass" to people run it. I put a note in the xfail reason string as a reminder why this is happening.

Fixes #12143
Refs #12166
Refs scylladb/seastar#1325

Signed-off-by: Nadav Har'El <nyh@scylladb.com>