### PR TITLE
Mark sstable::<directory accessing methods> private

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -275,7 +275,7 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
     co_await dir.do_for_each_sstable([&table, datadir = std::move(datadir), &new_sstables] (sstables::shared_sstable sst) -> future<> {
         auto gen = table.calculate_generation_for_new_table();
         dblog.trace("Loading {} into {}, new generation {}", sst->get_filename(), datadir.native(), gen);
-        co_await sst->move_to_new_dir(datadir.native(), gen, true);
+        co_await sst->move_to_new_dir(datadir.native(), gen);
             // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
             sst->set_sstable_level(0);
             new_sstables.push_back(std::move(sst));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2782,20 +2782,6 @@ static inline sstring parent_path(const sstring& fname) {
     return fs::canonical(fs::path(fname)).parent_path().string();
 }
 
-// Must be called on a directory.
-future<>
-fsync_directory(const io_error_handler& error_handler, sstring dirname) {
-    return ::sstable_io_check(error_handler, [&] {
-        return open_checked_directory(error_handler, dirname).then([] (file f) {
-            return do_with(std::move(f), [] (file& f) {
-                return f.flush().then([&f] {
-                    return f.close();
-                });
-            });
-        });
-    });
-}
-
 future<> remove_by_toc_name(sstring sstable_toc_name) {
     sstring prefix = sstable_toc_name.substr(0, sstable_toc_name.size() - sstable_version_constants::TOC_SUFFIX.size());
     sstring new_toc_name = prefix + sstable_version_constants::TEMPORARY_TOC_SUFFIX;
@@ -2804,7 +2790,7 @@ future<> remove_by_toc_name(sstring sstable_toc_name) {
     if (co_await sstable_io_check(sstable_write_error_handler, file_exists, sstable_toc_name)) {
         // If new_toc_name exists it will be atomically replaced.  See rename(2)
         co_await sstable_io_check(sstable_write_error_handler, rename_file, sstable_toc_name, new_toc_name);
-        co_await fsync_directory(sstable_write_error_handler, parent_path(new_toc_name));
+        co_await sstable_io_check(sstable_write_error_handler, sync_directory, parent_path(new_toc_name));
     } else {
         if (!co_await sstable_io_check(sstable_write_error_handler, file_exists, new_toc_name)) {
             sstlog.warn("Unable to delete {} because it doesn't exist.", sstable_toc_name);
@@ -2846,7 +2832,7 @@ future<> remove_by_toc_name(sstring sstable_toc_name) {
             sstlog.debug("Forgiving ENOENT when deleting file {}", fname);
         }
     });
-    co_await fsync_directory(sstable_write_error_handler, parent_path(new_toc_name));
+    co_await sstable_io_check(sstable_write_error_handler, sync_directory, parent_path(new_toc_name));
     co_await sstable_io_check(sstable_write_error_handler, remove_file, new_toc_name);
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -189,10 +189,17 @@ public:
     future<> open_data() noexcept;
     future<> update_info_for_opened_data();
 
+    class delayed_commit_changes {
+        std::unordered_set<sstring> _dirs;
+        friend class sstable;
+    public:
+        future<> commit();
+    };
+
     // Call as the last method before the object is destroyed.
     // No other uses of the object can happen at this point.
     future<> destroy();
-    future<> move_to_new_dir(sstring new_dir, generation_type generation, bool do_sync_dirs = true);
+    future<> move_to_new_dir(sstring new_dir, generation_type generation, delayed_commit_changes* delay = nullptr);
 
     // Move the sstable to the quarantine_dir
     //
@@ -202,7 +209,7 @@ public:
     //
     // Note: moving a sstable in any other dir to quarantine
     // will move it into a quarantine_dir subdirectory of its current directory.
-    future<> move_to_quarantine(bool do_sync_dirs = true);
+    future<> move_to_quarantine(delayed_commit_changes* delay = nullptr);
 
     generation_type generation() const {
         return _generation;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -50,6 +50,7 @@ class large_data_handler;
 
 namespace sstables {
 
+class sstable_directory;
 extern thread_local utils::updateable_value<bool> global_cache_index_pages;
 
 namespace mc {
@@ -350,10 +351,6 @@ public:
         return component_basename(_schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 
-    sstring filename(const sstring& dir, component_type f) const {
-        return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
-    }
-
     sstring filename(component_type f) const {
         return filename(get_dir(), f);
     }
@@ -390,14 +387,6 @@ public:
     static bool is_pending_delete_dir(const fs::path& dirpath)
     {
         return dirpath.filename().string() == pending_delete_dir_basename().c_str();
-    }
-
-    const sstring& get_dir() const {
-        return _dir;
-    }
-
-    const sstring get_temp_dir() const {
-        return temp_sst_dir(_dir, _generation);
     }
 
     bool requires_view_building() const;
@@ -485,6 +474,19 @@ public:
         return _last_partition_last_position;
     }
 private:
+    sstring filename(const sstring& dir, component_type f) const {
+        return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
+    }
+
+    friend class sstable_directory;
+    const sstring& get_dir() const {
+        return _dir;
+    }
+
+    const sstring get_temp_dir() const {
+        return temp_sst_dir(_dir, _generation);
+    }
+
     size_t sstable_buffer_size;
 
     static std::unordered_map<version_types, sstring, enum_hash<version_types>> _version_string;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1114,9 +1114,7 @@ SEASTAR_TEST_CASE(populate_from_quarantine_works) {
                 auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
                 testlog.debug("Moving sstable #{} out of {} to quarantine", idx, sstables.size());
                 auto sst = sstables[idx];
-                auto quarantine_dir = sst->get_dir() + "/" + sstables::quarantine_dir;
-                co_await touch_directory(quarantine_dir);
-                co_await sst->move_to_new_dir(quarantine_dir, sst->generation());
+                co_await sst->move_to_quarantine();
                 co_return true;
             });
         }
@@ -1167,10 +1165,7 @@ SEASTAR_TEST_CASE(snapshot_with_quarantine_works) {
                 }
                 auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
                 auto sst = sstables[idx];
-                auto quarantine_dir = sst->get_dir() + "/" + sstables::quarantine_dir;
-                co_await touch_directory(quarantine_dir);
-                testlog.debug("Moving sstable #{} out of {}: {} to quarantine", idx, sstables.size(), sst->get_filename());
-                co_await sst->move_to_new_dir(quarantine_dir, sst->generation());
+                co_await sst->move_to_quarantine();
             });
         }
         BOOST_REQUIRE(found);

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -282,7 +282,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
     auto dir = tmpdir();
 
     auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env.local()), dir.path(), 1));
-    auto tempstr = sst->filename(dir.path().native(), component_type::TemporaryStatistics);
+    auto tempstr = sst->filename(component_type::TemporaryStatistics);
     auto f = open_file_dma(tempstr, open_flags::rw | open_flags::create | open_flags::truncate).get0();
     f.close().get();
     auto tempstat = fs::canonical(fs::path(tempstr));

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
         auto cur_dir = sst->get_dir();
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
-        sst->move_to_new_dir(new_dir, generation_from_value(gen), true).get();
+        sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
         // the source directory must be empty now
         remove_file(cur_dir).get();
     }
@@ -98,7 +98,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
         done = partial_create_links(sst, fs::path(new_dir), gen, count++);
-        sst->move_to_new_dir(new_dir, generation_from_value(gen), true).get();
+        sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
         remove_file(cur_dir).get();
     } while (!done);
 }
@@ -115,5 +115,5 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     auto cur_dir = src_sst->get_dir();
     auto new_dir = dst_sst->get_dir();
     dst_sst->close_files().get();
-    BOOST_REQUIRE_THROW(src_sst->move_to_new_dir(new_dir, generation_from_value(gen), true).get(), malformed_sstable_exception);
+    BOOST_REQUIRE_THROW(src_sst->move_to_new_dir(new_dir, generation_from_value(gen)).get(), malformed_sstable_exception);
 }

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -27,7 +27,7 @@ static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schem
         auto src_path = fs::path(sst->filename(p.first));
         copy_file(src_path, dst_path / src_path.filename());
     }
-    return env.reusable_sst(schema_ptr, dst_path.native(), gen).get0();
+    return std::make_pair(env.reusable_sst(schema_ptr, dst_path.native(), gen).get0(), dst_path.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
@@ -36,22 +36,21 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;
-    auto sst = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
+    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
 
     for (auto i = 0; i < 2; i++) {
         ++gen;
-        auto cur_dir = sst->get_dir();
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
         sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
         // the source directory must be empty now
         remove_file(cur_dir).get();
+        cur_dir = new_dir;
     }
 
     // close  the sst and make we can load it from the new directory.
-    auto new_dir = sst->get_dir();
     sst->close_files().get();
-    sst = env.reusable_sst(uncompressed_schema(), new_dir, gen).get0();
+    sst = env.reusable_sst(uncompressed_schema(), cur_dir, gen).get0();
 }
 
 // Simulate a crashed create_links.
@@ -88,18 +87,18 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;
-    auto sst = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
+    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
 
     bool done;
     int count = 0;
     do {
         ++gen;
-        auto cur_dir = sst->get_dir();
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
         done = partial_create_links(sst, fs::path(new_dir), gen, count++);
         sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
         remove_file(cur_dir).get();
+        cur_dir = new_dir;
     } while (!done);
 }
 
@@ -109,11 +108,9 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     auto stop_env = defer([&env] { env.stop().get(); });
 
     int64_t gen = 1;
-    auto src_sst = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
-    auto dst_sst = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), ++gen);
+    auto [ src_sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
+    auto [ dst_sst, new_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), ++gen);
 
-    auto cur_dir = src_sst->get_dir();
-    auto new_dir = dst_sst->get_dir();
     dst_sst->close_files().get();
     BOOST_REQUIRE_THROW(src_sst->move_to_new_dir(new_dir, generation_from_value(gen)).get(), malformed_sstable_exception);
 }


### PR DESCRIPTION
One of the prerequisites to make sstables reside on object-storage is not to let the rest of the code "know" the filesystem path they are located on (because sometimes they will not be on any filesystem path). This patch makes the methods that can reveal this path back private so that later they can be abstracted out.