### PR TITLE
view: row_locker: unlock: erase partition lock object only if empty

### DIFF
--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -103,14 +103,13 @@ row_locker::lock_ck(const dht::decorated_key& pk, const clustering_key_prefix& c
     return lock_partition.then([this, pk = &i->first, cpk = &j->first, &row_lock = j->second, exclusive, &single_lock_stats, waiting_latency = std::move(waiting_latency), timeout] (auto lock1) mutable {
         auto lock_row = exclusive ? row_lock.hold_write_lock(timeout) : row_lock.hold_read_lock(timeout);
         return lock_row.then([this, pk, cpk, exclusive, &single_lock_stats, waiting_latency = std::move(waiting_latency), lock1 = std::move(lock1)] (auto lock2) mutable {
-        // FIXME: indentation
-        lock1.release();
-        lock2.release();
-        waiting_latency.stop();
-        single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency());
-        single_lock_stats.lock_acquisitions++;
-        single_lock_stats.operations_currently_waiting_for_lock--;
-        return lock_holder(this, pk, cpk, exclusive);
+            lock1.release();
+            lock2.release();
+            waiting_latency.stop();
+            single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency());
+            single_lock_stats.lock_acquisitions++;
+            single_lock_stats.operations_currently_waiting_for_lock--;
+            return lock_holder(this, pk, cpk, exclusive);
         });
     });
 }

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -73,9 +73,8 @@ row_locker::lock_pk(const dht::decorated_key& pk, bool exclusive, db::timeout_cl
     // become invalid (as long as the item is actually in the hash table),
     // even in the case of rehashing.
     co_await holder.lock_partition(&i->first, i->second._partition_lock, exclusive, timeout);
-        // FIXME: indentation
-        tracker.lock_acquired();
-        co_return holder;
+    tracker.lock_acquired();
+    co_return holder;
 }
 
 future<row_locker::lock_holder>
@@ -99,10 +98,9 @@ row_locker::lock_ck(const dht::decorated_key& pk, const clustering_key_prefix& c
     // the pointers to a clustering key and respectively, its lock, never
     // become invalid (as long as the item is actually in the hash table),
     // even in the case of rehashing.
-        // FIXME: indentation
-        co_await holder.lock_row(&j->first, j->second, exclusive, timeout);
-            tracker.lock_acquired();
-            co_return holder;
+    co_await holder.lock_row(&j->first, j->second, exclusive, timeout);
+    tracker.lock_acquired();
+    co_return holder;
 }
 
 // We need to zero old's _partition and _row, so when destructed

--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -30,6 +30,7 @@
 #include "dht/i_partitioner.hh"
 #include "query-request.hh"
 #include "utils/estimated_histogram.hh"
+#include "utils/latency.hh"
 
 class row_locker {
 public:
@@ -43,6 +44,15 @@ public:
         single_lock_stats shared_row;
         single_lock_stats exclusive_partition;
         single_lock_stats shared_partition;
+    };
+    struct latency_stats_tracker {
+        single_lock_stats& lock_stats;
+        utils::latency_counter waiting_latency;
+
+        latency_stats_tracker(single_lock_stats& stats);
+        ~latency_stats_tracker();
+
+        void lock_acquired();
     };
     // row_locker's locking functions lock_pk(), lock_ck() return a
     // "lock_holder" object. When the caller destroys the object it received,


### PR DESCRIPTION
The problematic scenario this series fixes might happen due to
unfortunate serialization of locks/unlocks between lock_pk and lock_ck,
as follows:
    
        1. lock_pk acquires an exclusive lock on the partition.
        2.a lock_ck attempts to acquire shared lock on the partition
            and any lock on the row. both cases currently use a fiber
            returning a future<rwlock::holder>.
        2.b since the partition is locked, the lock_partition times out
            returning an exceptional future.  lock_row has no such problem
            and succeeds, returning a future holding a rwlock::holder,
            pointing to the row lock.
        3.a the lock_holder previously returned by lock_pk is destroyed,
            calling `row_locker::unlock`
        3.b row_locker::unlock sees that the partition is not locked
            and erases it, including the row locks it contains.
        4.a when_all_succeeds continuation in lock_ck runs.  Since
            the lock_partition future failed, it destroyes both futures.
        4.b the lock_row future is destroyed with the rwlock::holder value.
        4.c ~holder attempts to return the semaphore units to the row rwlock,
            but the latter was already destroyed in 3.b above.
    
Acquiring the partition lock and row lock in parallel
doesn't help anything, but it complicates error handling
as seen above.

This series serializes the locking of partition and row in row_locker::lock_ck
to avoid the race described above making sure the row lock is taken
only under the (shared) partition lock, and also making sure they are
unlocked together via orderly call to row_locker::unlock via the
row_locker::lock_holder destructor.

Fixes #12168

Also the series contains a fix for a statistics leak on failure.

Fixes #12190