### PR TITLE
row_locker: don't use rwlock holders

### DIFF
--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -206,9 +206,8 @@ row_locker::unlock(const dht::decorated_key* pk, bool partition_exclusive,
                 }
             }
             if (row_locks.empty()) {
-            // FIXME: indentation
-            mylog.debug("Erasing lock object for partition {}", *pk);
-            _two_level_locks.erase(pli);
+                mylog.debug("Erasing lock object for partition {}", *pk);
+                _two_level_locks.erase(pli);
             }
         }
      }

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -78,33 +78,20 @@ row_locker::lock_pk(const dht::decorated_key& pk, bool exclusive, db::timeout_cl
 
 future<row_locker::lock_holder>
 row_locker::lock_ck(const dht::decorated_key& pk, const clustering_key_prefix& cpk, bool exclusive, db::timeout_clock::time_point timeout, stats& stats) {
+    try {
+    // FIXME: indentation
     mylog.debug("taking shared lock on partition {}, and {} lock on row {} in it", pk, (exclusive ? "exclusive" : "shared"), cpk);
     auto i = _two_level_locks.try_emplace(pk, this).first;
-    future<lock_type::holder> lock_partition = i->second._partition_lock.hold_read_lock(timeout);
     auto j = i->second._row_locks.find(cpk);
     if (j == i->second._row_locks.end()) {
         // Not yet locked, need to create the lock. This makes a copy of cpk.
-        try {
             j = i->second._row_locks.emplace(cpk, lock_type()).first;
-        } catch(...) {
-            // If this emplace() failed, e.g., out of memory, we fail. We
-            // could do nothing - the partition lock we already started
-            // taking will be unlocked automatically after being locked.
-            // But it's better form to wait for the work we started, and it
-            // will also allow us to remove the hash-table row we added.
-            return lock_partition.then([ex = std::current_exception()] (auto lock) {
-                // The lock is automatically released when "lock" goes out of scope.
-                // TODO: unlock (lock = {}) now, search for the partition in the
-                // hash table (we know it's still there, because we held the lock until
-                // now) and remove the unused lock from the hash table if still unused.
-                return make_exception_future<row_locker::lock_holder>(std::current_exception());
-            });
-        }
     }
     single_lock_stats &single_lock_stats = exclusive ? stats.exclusive_row : stats.shared_row;
     single_lock_stats.operations_currently_waiting_for_lock++;
     utils::latency_counter waiting_latency;
     waiting_latency.start();
+    future<lock_type::holder> lock_partition = i->second._partition_lock.hold_read_lock(timeout);
     future<lock_type::holder> lock_row = exclusive ? j->second.hold_write_lock(timeout) : j->second.hold_read_lock(timeout);
     return when_all_succeed(std::move(lock_partition), std::move(lock_row))
     .then_unpack([this, pk = &i->first, cpk = &j->first, exclusive, &single_lock_stats, waiting_latency = std::move(waiting_latency)] (auto lock1, auto lock2) mutable {
@@ -116,6 +103,9 @@ row_locker::lock_ck(const dht::decorated_key& pk, const clustering_key_prefix& c
         single_lock_stats.operations_currently_waiting_for_lock--;
         return lock_holder(this, pk, cpk, exclusive ? lock_state::exclusive : lock_state::shared);
     });
+    } catch (...) {
+        return make_exception_future<row_locker::lock_holder>(std::current_exception());
+    }
 }
 
 row_locker::lock_holder::lock_holder(row_locker::lock_holder&& old) noexcept

--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -71,6 +71,8 @@ public:
         // Allow move (noexcept) but disallow copy
         lock_holder(lock_holder&&) noexcept;
         lock_holder& operator=(lock_holder&&) noexcept;
+
+        friend class row_locker;
     };
 private:
     schema_ptr _schema;

--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -33,6 +33,7 @@
 
 class row_locker {
 public:
+    using lock_type = basic_rwlock<db::timeout_clock>;
     struct single_lock_stats {
         uint64_t lock_acquisitions = 0;
         uint64_t operations_currently_waiting_for_lock = 0;
@@ -72,11 +73,11 @@ public:
         lock_holder(lock_holder&&) noexcept;
         lock_holder& operator=(lock_holder&&) noexcept;
 
-        friend class row_locker;
+        future<> lock_partition(lock_type& partition_lock, bool exclusive) noexcept;
+        future<> lock_row(lock_type& row_lock, bool exclusive) noexcept;
     };
 private:
     schema_ptr _schema;
-    using lock_type = basic_rwlock<db::timeout_clock>;
     struct two_level_lock {
         lock_type _partition_lock;
         struct clustering_key_prefix_less {


### PR DESCRIPTION
This series cleans up and simplifies db/view row locking by extending
the lock holder to keep a tri-state for the partition and row locks to
state if they are unlocked, exclusive, or shared locked.

This is used when the lock_holder is destroyed to perform the
respective unlocking in row_locker::unlock.

This mechanism allows us to replace the use of rwlock holders
that proved to be quite tricky as #12168 shows by more straight-forward
`(read|write)_lock` and `(read|write)_unlock` calls, that change
the respective lock_holder lock_state when successful.

Note: depends on #12184