### PR TITLE
cql3: select_statement: split and coroutinize process_results()

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -804,7 +804,14 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
             ::make_shared<metadata>(*_selection->get_result_metadata()))
         ));
     }
+    return process_results_complex(std::move(results), std::move(cmd), options, now);
+}
 
+future<shared_ptr<cql_transport::messages::result_message>>
+select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
+                                  lw_shared_ptr<query::read_command> cmd,
+                                  const query_options& options,
+                                  gc_clock::time_point now) const {
     cql3::selection::result_set_builder builder(*_selection, now,
             options.get_cql_serialization_format());
     return do_with(std::move(builder), [this, cmd, results = std::move(results), options] (cql3::selection::result_set_builder& builder) mutable {

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -79,6 +79,9 @@ protected:
     bool _range_scan = false;
     bool _range_scan_no_bypass_cache = false;
     std::unique_ptr<cql3::attributes> _attrs;
+private:
+    future<shared_ptr<cql_transport::messages::result_message>> process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
+        lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now) const;
 protected :
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,
         service::query_state& state, const query_options& options) const;


### PR DESCRIPTION
Split the simple (and common) case from the complex case,
and coroutinize the latter. Hopefully this generates better
code for the simple case, and it makes the complex case a
little nicer.