### PR TITLE
cql3: batch_statement: coroutinize get_mutations()

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -161,16 +161,16 @@ future<std::vector<mutation>> batch_statement::get_mutations(query_processor& qp
         db::timeout_clock::time_point timeout, bool local, api::timestamp_type now, service::query_state& query_state) const {
     // Do not process in parallel because operations like list append/prepend depend on execution order.
     using mutation_set_type = std::unordered_set<mutation, mutation_hash_by_key, mutation_equals_by_key>;
-    return do_with(mutation_set_type(), [this, &qp, &options, timeout, now, local, &query_state] (auto& result) mutable {
+    mutation_set_type result;
+    {
         result.reserve(_statements.size());
-        return do_for_each(boost::make_counting_iterator<size_t>(0),
-                           boost::make_counting_iterator<size_t>(_statements.size()),
-                           [this, &qp, &options, now, local, &result, timeout, &query_state] (size_t i) {
+        for (size_t i = 0; i != _statements.size(); ++i) {
             auto&& statement = _statements[i].statement;
             statement->inc_cql_stats(query_state.get_client_state().is_internal());
             auto&& statement_options = options.for_statement(i);
             auto timestamp = _attrs->get_timestamp(now, statement_options);
-            return statement->get_mutations(qp, statement_options, timeout, local, timestamp, query_state).then([&result] (auto&& more) {
+            auto more = co_await statement->get_mutations(qp, statement_options, timeout, local, timestamp, query_state);
+            {
                 for (auto&& m : more) {
                     // We want unordered_set::try_emplace(), but we don't have it
                     auto pos = result.find(m);
@@ -180,17 +180,18 @@ future<std::vector<mutation>> batch_statement::get_mutations(query_processor& qp
                         const_cast<mutation&>(*pos).apply(std::move(m)); // Won't change key
                     }
                 }
-            });
-        }).then([&result] {
+            }
+        }
+        {
             // can't use range adaptors, because we want to move
             auto vresult = std::vector<mutation>();
             vresult.reserve(result.size());
             for (auto&& m : result) {
                 vresult.push_back(std::move(m));
             }
-            return vresult;
-        });
-    });
+            co_return vresult;
+        }
+    }
 }
 
 void batch_statement::verify_batch_size(query_processor& qp, const std::vector<mutation>& mutations) {


### PR DESCRIPTION
As it has a do_with(), coroutinizing it is an automatic win.