### PR TITLE
Backport Alternator TTL tests

### DIFF
--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -279,7 +279,7 @@ def test_ttl_stats(dynamodb, metrics, alternator_ttl_period_in_seconds):
             # to have increased. Add some time to that, to account for
             # extremely overloaded test machines.
             start_time = time.time()
-            while time.time() < start_time + alternator_ttl_period_in_seconds + 60:
+            while time.time() < start_time + alternator_ttl_period_in_seconds + 120:
                 if not 'Item' in table.get_item(Key={'p': p0}):
                     break
                 time.sleep(0.1)

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -348,7 +348,7 @@ def test_ttl_expiration_with_rangekey(dynamodb, waits_for_expiration):
     # Note that unlike test_ttl_expiration, this test doesn't have a fixed
     # duration - it finishes as soon as the item we expect to be expired
     # is expired.
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
@@ -386,7 +386,7 @@ def test_ttl_expiration_with_rangekey(dynamodb, waits_for_expiration):
 # Just like test_ttl_expiration() above, these tests are extremely slow
 # on AWS because DynamoDB delays expiration by around 10 minutes.
 def test_ttl_expiration_hash(dynamodb, waits_for_expiration):
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -418,7 +418,7 @@ def test_ttl_expiration_hash(dynamodb, waits_for_expiration):
         assert check_expired()
 
 def test_ttl_expiration_range(dynamodb, waits_for_expiration):
-    max_duration = 1200 if is_aws(dynamodb) else 120
+    max_duration = 1200 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
@@ -490,7 +490,7 @@ def test_ttl_expiration_gsi_lsi(dynamodb, waits_for_expiration):
     # items are expired with significant delay. Whereas a 10 minute delay
     # for regular tables was typical, in the table we have here we saw
     # a typical delay of 30 minutes before items expired.
-    max_duration = 3600 if is_aws(dynamodb) else 120
+    max_duration = 3600 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[
@@ -576,7 +576,7 @@ def test_ttl_expiration_gsi_lsi(dynamodb, waits_for_expiration):
 def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
     # In my experiments, a 30-minute (1800 seconds) is the typical delay
     # for expiration in this test for DynamoDB
-    max_duration = 3600 if is_aws(dynamodb) else 120
+    max_duration = 3600 if is_aws(dynamodb) else 240
     sleep = 30 if is_aws(dynamodb) else 0.1
     with new_test_table(dynamodb,
         KeySchema=[


### PR DESCRIPTION
This series backports several patches which add or enable tests for  Alternator TTL. The series does not touch the code - just tests.
The goal of backporting more tests is to get the code - which is already in branch 5.1 - tested. It wasn't a good idea to backport code without backporting the tests for it.