### PR TITLE
Report a warning when a server's IP cannot be found in ping.

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -406,6 +406,10 @@ raft_group_registry::~raft_group_registry() = default;
 future<bool> direct_fd_pinger::ping(direct_failure_detector::pinger::endpoint_id id, abort_source& as) {
     auto addr = _address_map.find(raft::server_id{id});
     if (!addr) {
+        auto [it, _] = _rate_limits.try_emplace(id, std::chrono::minutes(5));
+        auto& rate_limit = it->second;
+
+        rslog.log(log_level::warn, rate_limit, "Raft server id {} cannot be translated to an IP address.", id);
         co_return false;
     }
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -132,6 +132,9 @@ class direct_fd_pinger : public seastar::peering_sharded_service<direct_fd_pinge
     gms::echo_pinger& _echo_pinger;
     raft_address_map& _address_map;
 
+    using rate_limits = std::unordered_map<direct_failure_detector::pinger::endpoint_id, logger::rate_limit>;
+    rate_limits _rate_limits;
+
 public:
     direct_fd_pinger(gms::echo_pinger& pinger, raft_address_map& address_map)
             : _echo_pinger(pinger), _address_map(address_map) {}


### PR DESCRIPTION
issue: https://github.com/scylladb/scylladb/issues/12156

Add warning log record with rate_limit every 5 min.