### PR TITLE
Encapsulate filesystem access by sstable into filesystem_storage subsclass

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1501,7 +1501,7 @@ future<table::snapshot_file_set> table::take_snapshot(database& db, sstring json
         table_names->insert(sstable->component_basename(sstables::component_type::Data));
         return with_semaphore(db.get_sharded_sst_dir_semaphore().local()._sem, 1, [&jsondir, sstable] {
             return io_check([sstable, &dir = jsondir] {
-                return sstable->create_links(dir);
+                return sstable->snapshot(dir);
             });
         });
     });

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -157,10 +157,10 @@ private:
 public:
     void verify_end_state() const {
         if (this->_remain > 0) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), _sst.filename(component_type::Index));
+            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), _sst.index_filename());
         }
         if (_state != state::KEY_SIZE && _state != state::START) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), _sst.filename(component_type::Index));
+            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), _sst.index_filename());
         }
     }
 
@@ -308,7 +308,7 @@ inline file make_tracked_index_file(sstable& sst, reader_permit permit, tracing:
     if (!trace_state) {
         return f;
     }
-    return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.filename(component_type::Index)));
+    return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.index_filename()));
 }
 
 inline
@@ -541,7 +541,7 @@ private:
             bound.current_index_idx = 0;
             bound.current_pi_idx = 0;
             if (bound.current_list->empty()) {
-                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->filename(component_type::Index));
+                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->index_filename());
             }
             bound.data_file_position = bound.current_list->_entries[0]->position();
             bound.element = indexable_element::partition;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -787,8 +787,7 @@ public:
         // exactly what callers used to do anyway.
         estimated_partitions = std::max(uint64_t(1), estimated_partitions);
 
-        _sst.generate_toc(_schema.get_compressor_params().get_compressor(), _schema.bloom_filter_fp_chance());
-        _sst.write_toc(_pc);
+        _sst.open_sstable(_pc);
         _sst.create_data().get();
         _compression_enabled = !_sst.has_component(component_type::CRC);
         init_file_writers();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -488,11 +488,11 @@ future<> sstable_directory::delete_atomically(std::vector<shared_sstable> ssts) 
             gen_tracker.update(sst->generation());
 
             if (sstdir.empty()) {
-                sstdir = sst->get_dir();
+                sstdir = sst->_storage.prefix();
             } else {
                 // All sstables are assumed to be in the same column_family, hence
                 // sharing their base directory.
-                assert (sstdir == sst->get_dir());
+                assert (sstdir == sst->_storage.prefix());
             }
         }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -143,7 +143,8 @@ future<> sstable::rename_new_sstable_component_file(sstring from_name, sstring t
 future<file> sstable::filesystem_storage::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {
     auto create_flags = open_flags::create | open_flags::exclusive;
     auto readonly = (flags & create_flags) != create_flags;
-    auto name = !readonly && temp_dir ? sst.temp_filename(type) : sst.filename(type);
+    auto tgt_dir = !readonly && temp_dir ? dir + "/" + sstable::sst_dir_basename(sst._generation) : dir;
+    auto name = sst.filename(tgt_dir, type);
 
     auto f = open_sstable_component_file_non_checked(name, flags, options, check_integrity);
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2160,7 +2160,7 @@ future<> sstable::check_create_links_replay(const sstring& dst_dir, generation_t
 /// \param dir - the destination directory.
 /// \param generation - the generation of the destination sstable
 /// \param mark_for_removal - mark the sstable for removal after linking it to the destination dir
-future<> sstable::create_links_common(const sstring& dir, generation_type generation, bool mark_for_removal) const {
+future<> sstable::create_links_common(const sstring& dir, generation_type generation, mark_for_removal mark_for_removal) const {
     sstlog.trace("create_links: {} -> {} generation={} mark_for_removal={}", get_filename(), dir, generation, mark_for_removal);
     return do_with(dir, all_components(), [this, generation, mark_for_removal] (const sstring& dir, auto& comps) {
         return check_create_links_replay(dir, generation, comps).then([this, &dir, generation, &comps, mark_for_removal] {
@@ -2200,11 +2200,11 @@ future<> sstable::create_links_common(const sstring& dir, generation_type genera
 }
 
 future<> sstable::create_links(const sstring& dir, generation_type generation) const {
-    return create_links_common(dir, generation, false /* mark_for_removal */);
+    return create_links_common(dir, generation, mark_for_removal::no);
 }
 
 future<> sstable::create_links_and_mark_for_removal(const sstring& dir, generation_type generation) const {
-    return create_links_common(dir, generation, true /* mark_for_removal */);
+    return create_links_common(dir, generation, mark_for_removal::yes);
 }
 
 future<> sstable::snapshot(const sstring& dir) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -171,8 +171,8 @@ future<file> sstable::new_sstable_component_file(const io_error_handler& error_h
         return make_checked_file(error_handler, std::move(f));
     });
 
-    return f.handle_exception([name] (auto ep) {
-        sstlog.error("Could not create SSTable component {}. Found exception: {}", name, ep);
+    return f.handle_exception([this, type] (auto ep) {
+        sstlog.error("Could not create SSTable component {}. Found exception: {}", filename(type), ep);
         return make_exception_future<file>(ep);
     });
   } catch (...) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2190,8 +2190,8 @@ future<> sstable::create_links_common(sstring dst_dir, generation_type generatio
     sstlog.trace("create_links: {} -> {} generation={}: done", get_filename(), dst_dir, generation);
 }
 
-future<> sstable::create_links(const sstring& dir, generation_type generation) const {
-    return create_links_common(dir, generation, mark_for_removal::no);
+future<> sstable::create_links(const sstring& dir) const {
+    return create_links_common(dir, _generation, mark_for_removal::no);
 }
 
 future<> sstable::snapshot(const sstring& dir) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2163,31 +2163,31 @@ future<> sstable::check_create_links_replay(const sstring& dst_dir, generation_t
 future<> sstable::create_links_common(sstring dst_dir, generation_type generation, mark_for_removal mark_for_removal) const {
     sstlog.trace("create_links: {} -> {} generation={} mark_for_removal={}", get_filename(), dst_dir, generation, mark_for_removal);
     auto comps = all_components();
-        co_await check_create_links_replay(dst_dir, generation, comps);
-            // TemporaryTOC is always first, TOC is always last
-            auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
-            co_await sstable_write_io_check(idempotent_link_file, filename(component_type::TOC), std::move(dst));
-                co_await sstable_write_io_check(sync_directory, dst_dir);
-                co_await parallel_for_each(comps, [this, &dst_dir, generation] (auto p) {
-                    auto src = sstable::filename(_storage.dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, p.second);
-                    auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, p.second);
-                    return sstable_write_io_check(idempotent_link_file, std::move(src), std::move(dst));
-                });
-                co_await sstable_write_io_check(sync_directory, dst_dir);
-            auto dst_temp_toc = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
-            if (mark_for_removal) {
-                // Now that the source sstable is linked to new_dir, mark the source links for
-                // deletion by leaving a TemporaryTOC file in the source directory.
-                auto src_temp_toc = sstable::filename(_storage.dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, component_type::TemporaryTOC);
-                co_await sstable_write_io_check(rename_file, std::move(dst_temp_toc), std::move(src_temp_toc));
-                    co_await sstable_write_io_check(sync_directory, _storage.dir);
-            } else {
-                // Now that the source sstable is linked to dir, remove
-                // the TemporaryTOC file at the destination.
-                co_await sstable_write_io_check(remove_file, std::move(dst_temp_toc));
-            }
-            co_await sstable_write_io_check(sync_directory, dst_dir);
-            sstlog.trace("create_links: {} -> {} generation={}: done", get_filename(), dst_dir, generation);
+    co_await check_create_links_replay(dst_dir, generation, comps);
+    // TemporaryTOC is always first, TOC is always last
+    auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
+    co_await sstable_write_io_check(idempotent_link_file, filename(component_type::TOC), std::move(dst));
+    co_await sstable_write_io_check(sync_directory, dst_dir);
+    co_await parallel_for_each(comps, [this, &dst_dir, generation] (auto p) {
+        auto src = sstable::filename(_storage.dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, p.second);
+        auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, p.second);
+        return sstable_write_io_check(idempotent_link_file, std::move(src), std::move(dst));
+    });
+    co_await sstable_write_io_check(sync_directory, dst_dir);
+    auto dst_temp_toc = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
+    if (mark_for_removal) {
+        // Now that the source sstable is linked to new_dir, mark the source links for
+        // deletion by leaving a TemporaryTOC file in the source directory.
+        auto src_temp_toc = sstable::filename(_storage.dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, component_type::TemporaryTOC);
+        co_await sstable_write_io_check(rename_file, std::move(dst_temp_toc), std::move(src_temp_toc));
+        co_await sstable_write_io_check(sync_directory, _storage.dir);
+    } else {
+        // Now that the source sstable is linked to dir, remove
+        // the TemporaryTOC file at the destination.
+        co_await sstable_write_io_check(remove_file, std::move(dst_temp_toc));
+    }
+    co_await sstable_write_io_check(sync_directory, dst_dir);
+    sstlog.trace("create_links: {} -> {} generation={}: done", get_filename(), dst_dir, generation);
 }
 
 future<> sstable::create_links(const sstring& dir, generation_type generation) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -133,7 +133,7 @@ static future<file> open_sstable_component_file_non_checked(std::string_view nam
     return open_file_dma(name, flags, options);
 }
 
-future<> sstable::rename_new_sstable_component_file(sstring from_name, sstring to_name) {
+future<> sstable::rename_new_sstable_component_file(sstring from_name, sstring to_name) const {
     return sstable_write_io_check(rename_file, from_name, to_name).handle_exception([from_name, to_name] (std::exception_ptr ep) {
         sstlog.error("Could not rename SSTable component {} to {}. Found exception: {}", from_name, to_name, ep);
         return make_exception_future<>(ep);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2005,15 +2005,15 @@ std::vector<sstring> sstable::component_filenames() const {
 }
 
 bool sstable::requires_view_building() const {
-    return boost::algorithm::ends_with(_storage.dir, staging_dir);
+    return boost::algorithm::ends_with(_storage.prefix(), staging_dir);
 }
 
 bool sstable::is_quarantined() const noexcept {
-    return boost::algorithm::ends_with(_storage.dir, quarantine_dir);
+    return boost::algorithm::ends_with(_storage.prefix(), quarantine_dir);
 }
 
 bool sstable::is_uploaded() const noexcept {
-    return boost::algorithm::ends_with(_storage.dir, upload_dir);
+    return boost::algorithm::ends_with(_storage.prefix(), upload_dir);
 }
 
 sstring sstable::component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2157,28 +2157,28 @@ future<> sstable::check_create_links_replay(const sstring& dst_dir, generation_t
 /// are used.  These versions handle EEXIST errors that may happen
 /// when the respective operations are replayed.
 ///
-/// \param dir - the destination directory.
+/// \param dst_dir - the destination directory.
 /// \param generation - the generation of the destination sstable
-/// \param mark_for_removal - mark the sstable for removal after linking it to the destination dir
-future<> sstable::create_links_common(const sstring& dir, generation_type generation, mark_for_removal mark_for_removal) const {
-    sstlog.trace("create_links: {} -> {} generation={} mark_for_removal={}", get_filename(), dir, generation, mark_for_removal);
-    return do_with(dir, all_components(), [this, generation, mark_for_removal] (const sstring& dir, auto& comps) {
-        return check_create_links_replay(dir, generation, comps).then([this, &dir, generation, &comps, mark_for_removal] {
+/// \param mark_for_removal - mark the sstable for removal after linking it to the destination dst_dir
+future<> sstable::create_links_common(const sstring& dst_dir, generation_type generation, mark_for_removal mark_for_removal) const {
+    sstlog.trace("create_links: {} -> {} generation={} mark_for_removal={}", get_filename(), dst_dir, generation, mark_for_removal);
+    return do_with(dst_dir, all_components(), [this, generation, mark_for_removal] (const sstring& dst_dir, auto& comps) {
+        return check_create_links_replay(dst_dir, generation, comps).then([this, &dst_dir, generation, &comps, mark_for_removal] {
             // TemporaryTOC is always first, TOC is always last
-            auto dst = sstable::filename(dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
-            return sstable_write_io_check(idempotent_link_file, filename(component_type::TOC), std::move(dst)).then([this, &dir] {
-                return sstable_write_io_check(sync_directory, dir);
-            }).then([this, &dir, generation, &comps] {
-                return parallel_for_each(comps, [this, &dir, generation] (auto p) {
+            auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
+            return sstable_write_io_check(idempotent_link_file, filename(component_type::TOC), std::move(dst)).then([this, &dst_dir] {
+                return sstable_write_io_check(sync_directory, dst_dir);
+            }).then([this, &dst_dir, generation, &comps] {
+                return parallel_for_each(comps, [this, &dst_dir, generation] (auto p) {
                     auto src = sstable::filename(_storage.dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, p.second);
-                    auto dst = sstable::filename(dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, p.second);
+                    auto dst = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, p.second);
                     return sstable_write_io_check(idempotent_link_file, std::move(src), std::move(dst));
                 });
-            }).then([this, &dir] {
-                return sstable_write_io_check(sync_directory, dir);
+            }).then([this, &dst_dir] {
+                return sstable_write_io_check(sync_directory, dst_dir);
             });
-        }).then([this, &dir, generation, mark_for_removal] {
-            auto dst_temp_toc = sstable::filename(dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
+        }).then([this, &dst_dir, generation, mark_for_removal] {
+            auto dst_temp_toc = sstable::filename(dst_dir, _schema->ks_name(), _schema->cf_name(), _version, generation, _format, component_type::TemporaryTOC);
             if (mark_for_removal) {
                 // Now that the source sstable is linked to new_dir, mark the source links for
                 // deletion by leaving a TemporaryTOC file in the source directory.
@@ -2191,10 +2191,10 @@ future<> sstable::create_links_common(const sstring& dir, generation_type genera
                 // the TemporaryTOC file at the destination.
                 return sstable_write_io_check(remove_file, std::move(dst_temp_toc));
             }
-        }).then([this, &dir] {
-            return sstable_write_io_check(sync_directory, dir);
-        }).then([this, &dir, generation] {
-            sstlog.trace("create_links: {} -> {} generation={}: done", get_filename(), dir, generation);
+        }).then([this, &dst_dir] {
+            return sstable_write_io_check(sync_directory, dst_dir);
+        }).then([this, &dst_dir, generation] {
+            sstlog.trace("create_links: {} -> {} generation={}: done", get_filename(), dst_dir, generation);
         });
     });
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2207,6 +2207,10 @@ future<> sstable::create_links_and_mark_for_removal(const sstring& dir, generati
     return create_links_common(dir, generation, true /* mark_for_removal */);
 }
 
+future<> sstable::snapshot(const sstring& dir) const {
+    return create_links(dir);
+}
+
 future<> sstable::move_to_new_dir(sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {
     sstring old_dir = get_dir();
     sstlog.debug("Moving {} old_generation={} to {} new_generation={} do_sync_dirs={}",

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2194,10 +2194,6 @@ future<> sstable::create_links(const sstring& dir, generation_type generation) c
     return create_links_common(dir, generation, mark_for_removal::no);
 }
 
-future<> sstable::create_links_and_mark_for_removal(const sstring& dir, generation_type generation) const {
-    return create_links_common(dir, generation, mark_for_removal::yes);
-}
-
 future<> sstable::snapshot(const sstring& dir) const {
     return create_links(dir);
 }
@@ -2206,7 +2202,7 @@ future<> sstable::move_to_new_dir(sstring new_dir, generation_type new_generatio
     sstring old_dir = get_dir();
     sstlog.debug("Moving {} old_generation={} to {} new_generation={} do_sync_dirs={}",
             get_filename(), _generation, new_dir, new_generation, delay_commit == nullptr);
-    co_await create_links_and_mark_for_removal(new_dir, new_generation);
+    co_await create_links_common(new_dir, new_generation, mark_for_removal::yes);
     _storage.dir = new_dir;
     generation_type old_generation = std::exchange(_generation, new_generation);
     co_await coroutine::parallel_for_each(all_components(), [this, old_generation, old_dir] (auto p) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -961,11 +961,7 @@ void sstable::write_toc(const io_priority_class& pc) {
 
     // Flushing parent directory to guarantee that temporary TOC file reached
     // the disk.
-    file dir_f = open_checked_directory(_write_error_handler, _dir).get0();
-    sstable_write_io_check([&] {
-        dir_f.flush().get();
-        dir_f.close().get();
-    });
+    sstable_write_io_check(sync_directory, _dir).get();
 }
 
 future<> sstable::seal_sstable() {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -709,7 +709,8 @@ private:
     future<> open_or_create_data(open_flags oflags, file_open_options options = {}) noexcept;
 
     future<> check_create_links_replay(const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
-    future<> create_links_common(const sstring& dst_dir, generation_type dst_gen, bool mark_for_removal) const;
+    using mark_for_removal = bool_class<class mark_for_removal_tag>;
+    future<> create_links_common(const sstring& dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
     future<> create_links_and_mark_for_removal(const sstring& dst_dir, generation_type dst_gen) const;
 public:
     future<> read_toc() noexcept;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -355,10 +355,6 @@ public:
         return filename(get_dir(), f);
     }
 
-    sstring temp_filename(component_type f) const {
-        return filename(get_temp_dir(), f);
-    }
-
     sstring get_filename() const {
         return filename(component_type::Data);
     }
@@ -505,8 +501,8 @@ private:
         return _storage.dir;
     }
 
-    const sstring get_temp_dir() const {
-        return temp_sst_dir(_storage.dir, _generation);
+    sstring temp_filename(component_type f) const {
+        return filename(temp_sst_dir(_storage.dir, _generation), f);
     }
 
     size_t sstable_buffer_size;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -485,13 +485,14 @@ public:
         future<> remove_temp_dir();
         future<> create_links(const sstable& sst, const sstring& dir) const;
         future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
+        future<> touch_temp_dir(const sstable& sst);
 
     public:
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, const sstring& dir) const;
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
-
-        future<> touch_temp_dir(const sstable& sst);
+        // runs in async context
+        void open(sstable& sst, const io_priority_class& pc);
     };
 
 private:
@@ -605,7 +606,6 @@ private:
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
     void generate_toc();
-    void write_toc(const io_priority_class& pc);
     void open_sstable(const io_priority_class& pc);
 
     future<> read_compression(const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -480,8 +480,9 @@ public:
         future<> touch_temp_dir(const sstable& sst);
 
     public:
+        using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
         future<> seal(const sstable& sst);
-        future<> snapshot(const sstable& sst, const sstring& dir) const;
+        future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -912,6 +912,9 @@ public:
     friend void lw_shared_ptr_deleter<sstables::sstable>::dispose(sstable* s);
     gc_clock::time_point get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const;
     gc_clock::time_point get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state) const;
+
+    future<uint32_t> read_digest(io_priority_class pc);
+    future<checksum> read_checksum(io_priority_class pc);
 };
 
 // Validate checksums

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -604,8 +604,9 @@ private:
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
-    void generate_toc(compressor_ptr c, double filter_fp_chance);
+    void generate_toc();
     void write_toc(const io_priority_class& pc);
+    void open_sstable(const io_priority_class& pc);
 
     future<> read_compression(const io_priority_class& pc);
     void write_compression(const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -466,11 +466,8 @@ public:
 
     class filesystem_storage {
         friend class test;
-    public:
         sstring dir;
         std::optional<sstring> temp_dir; // Valid while the sstable is being created, until sealed
-
-        explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
 
     private:
         future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
@@ -480,6 +477,8 @@ public:
         future<> touch_temp_dir(const sstable& sst);
 
     public:
+        explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
+
         using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -367,10 +367,6 @@ public:
         return fmt::format("{}.sstable", gen);
     }
 
-    static sstring temp_sst_dir(const sstring& dir, generation_type gen) {
-        return dir + "/" + sst_dir_basename(gen);
-    }
-
     static bool is_temp_dir(const fs::path& dirpath)
     {
         return dirpath.extension().string() == ".sstable";
@@ -505,10 +501,6 @@ private:
     friend class sstable_directory;
     const sstring& get_dir() const {
         return _storage.dir;
-    }
-
-    sstring temp_filename(component_type f) const {
-        return filename(temp_sst_dir(_storage.dir, _generation), f);
     }
 
     size_t sstable_buffer_size;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -486,6 +486,7 @@ public:
 
     public:
         future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
+        future<> remove_temp_dir();
     };
 
 private:
@@ -599,7 +600,6 @@ private:
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
     future<> touch_temp_dir();
-    future<> remove_temp_dir();
 
     void generate_toc(compressor_ptr c, double filter_fp_chance);
     void write_toc(const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -473,6 +473,15 @@ public:
     const position_in_partition& last_partition_last_position() const noexcept {
         return _last_partition_last_position;
     }
+
+    class filesystem_storage {
+    public:
+        sstring dir;
+        std::optional<sstring> temp_dir; // Valid while the sstable is being created, until sealed
+
+        explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
+    };
+
 private:
     sstring filename(const sstring& dir, component_type f) const {
         return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
@@ -480,11 +489,11 @@ private:
 
     friend class sstable_directory;
     const sstring& get_dir() const {
-        return _dir;
+        return _storage.dir;
     }
 
     const sstring get_temp_dir() const {
-        return temp_sst_dir(_dir, _generation);
+        return temp_sst_dir(_storage.dir, _generation);
     }
 
     size_t sstable_buffer_size;
@@ -523,9 +532,9 @@ private:
     lw_shared_ptr<file_input_stream_history> _index_history = make_lw_shared<file_input_stream_history>();
 
     schema_ptr _schema;
-    sstring _dir;
-    std::optional<sstring> _temp_dir; // Valid while the sstable is being created, until sealed
     generation_type _generation{0};
+
+    filesystem_storage _storage;
 
     version_types _version;
     format_types _format;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -363,6 +363,10 @@ public:
         return filename(component_type::TOC);
     }
 
+    sstring index_filename() const {
+        return filename(component_type::Index);
+    }
+
     static sstring sst_dir_basename(generation_type gen) {
         return fmt::format("{}.sstable", gen);
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -398,7 +398,6 @@ public:
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
     future<> unlink() noexcept;
-    future<> wipe_storage(const sstring& name) noexcept;
 
     db::large_data_handler& get_large_data_handler() {
         return _large_data_handler;
@@ -490,6 +489,7 @@ public:
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);
+        future<> wipe(const sstable& sst) noexcept;
     };
 
 private:

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -710,7 +710,7 @@ private:
 
     future<> check_create_links_replay(const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
     using mark_for_removal = bool_class<class mark_for_removal_tag>;
-    future<> create_links_common(const sstring& dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
+    future<> create_links_common(sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
     future<> create_links_and_mark_for_removal(const sstring& dst_dir, generation_type dst_gen) const;
 public:
     future<> read_toc() noexcept;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -483,10 +483,11 @@ public:
 
     private:
         future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
+        future<> remove_temp_dir();
 
     public:
         future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
-        future<> remove_temp_dir();
+        future<> seal(const sstable& sst);
     };
 
 private:
@@ -603,7 +604,6 @@ private:
 
     void generate_toc(compressor_ptr c, double filter_fp_chance);
     void write_toc(const io_priority_class& pc);
-    future<> seal_sstable();
 
     future<> read_compression(const io_priority_class& pc);
     void write_compression(const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -397,11 +397,7 @@ public:
 
     std::vector<std::pair<component_type, sstring>> all_components() const;
 
-    future<> create_links(const sstring& dir, generation_type generation) const;
-
-    future<> create_links(const sstring& dir) const {
-        return create_links(dir, _generation);
-    }
+    future<> create_links(const sstring& dir) const;
 
     future<> snapshot(const sstring& dir) const;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -351,10 +351,6 @@ public:
         return component_basename(_schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 
-    sstring filename(component_type f) const {
-        return filename(get_dir(), f);
-    }
-
     sstring get_filename() const {
         return filename(component_type::Data);
     }
@@ -497,6 +493,10 @@ public:
     };
 
 private:
+    sstring filename(component_type f) const {
+        return filename(get_dir(), f);
+    }
+
     sstring filename(const sstring& dir, component_type f) const {
         return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -490,6 +490,8 @@ public:
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, const sstring& dir) const;
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
+
+        future<> touch_temp_dir(const sstable& sst);
     };
 
 private:
@@ -601,8 +603,6 @@ private:
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
-
-    future<> touch_temp_dir();
 
     void generate_toc(compressor_ptr c, double filter_fp_chance);
     void write_toc(const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -600,7 +600,7 @@ private:
     void write_crc(const checksum& c);
     void write_digest(uint32_t full_checksum);
 
-    future<> rename_new_sstable_component_file(sstring from_file, sstring to_file);
+    future<> rename_new_sstable_component_file(sstring from_file, sstring to_file) const;
     future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {}) noexcept;
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -484,11 +484,12 @@ public:
         future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
         future<> remove_temp_dir();
         future<> create_links(const sstable& sst, const sstring& dir) const;
+        future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
 
     public:
-        future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, const sstring& dir) const;
+        future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
     };
 
 private:

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -711,7 +711,6 @@ private:
     future<> check_create_links_replay(const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
     using mark_for_removal = bool_class<class mark_for_removal_tag>;
     future<> create_links_common(sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
-    future<> create_links_and_mark_for_removal(const sstring& dst_dir, generation_type dst_gen) const;
 public:
     future<> read_toc() noexcept;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -490,6 +490,7 @@ public:
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);
         future<> wipe(const sstable& sst) noexcept;
+        future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity);
     };
 
 private:

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -472,6 +472,8 @@ public:
         return _last_partition_last_position;
     }
 
+    using mark_for_removal = bool_class<class mark_for_removal_tag>;
+
     class filesystem_storage {
     public:
         sstring dir;
@@ -479,7 +481,11 @@ public:
 
         explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
 
+    private:
         future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
+
+    public:
+        future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
     };
 
 private:
@@ -705,9 +711,6 @@ private:
     }
 
     future<> open_or_create_data(open_flags oflags, file_open_options options = {}) noexcept;
-
-    using mark_for_removal = bool_class<class mark_for_removal_tag>;
-    future<> create_links_common(sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
 public:
     future<> read_toc() noexcept;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -478,6 +478,8 @@ public:
         std::optional<sstring> temp_dir; // Valid while the sstable is being created, until sealed
 
         explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
+
+        future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
     };
 
 private:
@@ -704,7 +706,6 @@ private:
 
     future<> open_or_create_data(open_flags oflags, file_open_options options = {}) noexcept;
 
-    future<> check_create_links_replay(const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
     using mark_for_removal = bool_class<class mark_for_removal_tag>;
     future<> create_links_common(sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
 public:

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -489,11 +489,13 @@ public:
         void open(sstable& sst, const io_priority_class& pc);
         future<> wipe(const sstable& sst) noexcept;
         future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity);
+
+        sstring prefix() const { return dir; }
     };
 
 private:
     sstring filename(component_type f) const {
-        return filename(get_dir(), f);
+        return filename(_storage.prefix(), f);
     }
 
     sstring filename(const sstring& dir, component_type f) const {
@@ -501,9 +503,6 @@ private:
     }
 
     friend class sstable_directory;
-    const sstring& get_dir() const {
-        return _storage.dir;
-    }
 
     size_t sstable_buffer_size;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -397,8 +397,6 @@ public:
 
     std::vector<std::pair<component_type, sstring>> all_components() const;
 
-    future<> create_links(const sstring& dir) const;
-
     future<> snapshot(const sstring& dir) const;
 
     // Delete the sstable by unlinking all sstable files
@@ -475,6 +473,7 @@ public:
     using mark_for_removal = bool_class<class mark_for_removal_tag>;
 
     class filesystem_storage {
+        friend class test;
     public:
         sstring dir;
         std::optional<sstring> temp_dir; // Valid while the sstable is being created, until sealed
@@ -484,10 +483,12 @@ public:
     private:
         future<> check_create_links_replay(const sstable& sst, const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
         future<> remove_temp_dir();
+        future<> create_links(const sstable& sst, const sstring& dir) const;
 
     public:
         future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
         future<> seal(const sstable& sst);
+        future<> snapshot(const sstable& sst, const sstring& dir) const;
     };
 
 private:

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -403,6 +403,8 @@ public:
         return create_links(dir, _generation);
     }
 
+    future<> snapshot(const sstring& dir) const;
+
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
     future<> unlink() noexcept;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -483,6 +483,7 @@ public:
         using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;
+        future<> quarantine(const sstable& sst, delayed_commit_changes* delay);
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -398,6 +398,7 @@ public:
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
     future<> unlink() noexcept;
+    future<> wipe_storage(const sstring& name) noexcept;
 
     db::large_data_handler& get_large_data_handler() {
         return _large_data_handler;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1160,7 +1160,7 @@ SEASTAR_TEST_CASE(snapshot_with_quarantine_works) {
                 }
                 // collect all expected sstable data files
                 for (auto sst : sstables) {
-                    expected.insert(fs::path(sst->get_filename()).filename().native());
+                    expected.insert(sst->component_basename(sstables::component_type::Data));
                 }
                 if (std::exchange(found, true)) {
                     co_return;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -307,12 +307,13 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
         require_exist(file_name, true);
     };
 
-    auto temp_sst_dir = sst::temp_sst_dir(sst_dir, generation_from_value(2));
-    touch_dir(temp_sst_dir);
+    auto temp_sst_dir_2 = sst_dir + "/" + sst::sst_dir_basename(generation_from_value(2));
+    touch_dir(temp_sst_dir_2);
 
-    temp_sst_dir = sst::temp_sst_dir(sst_dir, generation_from_value(3));
-    touch_dir(temp_sst_dir);
-    auto temp_file_name = sst::filename(temp_sst_dir, ks, cf, sst::version_types::mc, generation_from_value(3), sst::format_types::big, component_type::TemporaryTOC);
+    auto temp_sst_dir_3 = sst_dir + "/" + sst::sst_dir_basename(generation_from_value(3));
+    touch_dir(temp_sst_dir_3);
+
+    auto temp_file_name = sst::filename(temp_sst_dir_3, ks, cf, sst::version_types::mc, generation_from_value(3), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
 
     temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC);
@@ -320,9 +321,9 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
     temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
-    do_with_cql_env_thread([&sst_dir, &ks, &cf, &require_exist] (cql_test_env& e) {
-        require_exist(sst::temp_sst_dir(sst_dir, generation_from_value(2)), false);
-        require_exist(sst::temp_sst_dir(sst_dir, generation_from_value(3)), false);
+    do_with_cql_env_thread([&sst_dir, &ks, &cf, &require_exist, &temp_sst_dir_2, &temp_sst_dir_3] (cql_test_env& e) {
+        require_exist(temp_sst_dir_2, false);
+        require_exist(temp_sst_dir_3, false);
 
         require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
         require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data), false);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3143,7 +3143,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 valid = sstables::validate_checksums(sst, permit, default_priority_class()).get();
                 BOOST_REQUIRE(valid);
 
-                auto sst_file = open_file_dma(sst->get_filename(), open_flags::wo).get();
+                auto sst_file = open_file_dma(test::filename(*sst, sstables::component_type::Data).native(), open_flags::wo).get();
                 auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
 
                 testlog.info("Validating corrupted {}", sst->get_filename());
@@ -3188,7 +3188,7 @@ SEASTAR_TEST_CASE(partial_sstable_deletion_test) {
         auto sst = make_sstable_containing(sst_gen, {std::move(mut1)});
 
         // Rename TOC into TMP toc, to stress deletion path for partial files
-        rename_file(sst->toc_filename(), sst->filename(sstables::component_type::TemporaryTOC)).get();
+        rename_file(test::filename(*sst, sstables::component_type::TOC).native(), test::filename(*sst, sstables::component_type::TemporaryTOC).native()).get();
 
         sst->unlink().get();
     });

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2095,7 +2095,7 @@ SEASTAR_TEST_CASE(test_unknown_component) {
         auto tmp = tmpdir();
         copy_directory("test/resource/sstables/unknown_component", std::string(tmp.path().string()) + "/unknown_component");
         auto sstp = env.reusable_sst(uncompressed_schema(), tmp.path().string() + "/unknown_component", 1).get0();
-        sstp->create_links(tmp.path().string()).get();
+        test::create_links(*sstp, tmp.path().string()).get();
         // check that create_links() moved unknown component to new dir
         BOOST_REQUIRE(file_exists(tmp.path().string() + "/la-1-big-UNKNOWN.txt").get0());
 

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -24,7 +24,7 @@ static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schem
     auto dst_path = tmp_path / src_path.filename() / format("gen-{}", gen);
     recursive_touch_directory(dst_path.native()).get();
     for (auto p : sst->all_components()) {
-        auto src_path = fs::path(sst->filename(p.first));
+        auto src_path = test::filename(*sst, p.first);
         copy_file(src_path, dst_path / src_path.filename());
     }
     return std::make_pair(env.reusable_sst(schema_ptr, dst_path.native(), gen).get0(), dst_path.native());
@@ -64,14 +64,14 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
 static bool partial_create_links(sstable_ptr sst, fs::path dst_path, int64_t gen, int count) {
     auto schema = sst->get_schema();
     auto tmp_toc = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), generation_from_value(gen), sstable_format_types::big, component_type::TemporaryTOC);
-    link_file(sst->filename(component_type::TOC), tmp_toc).get();
+    link_file(test::filename(*sst, component_type::TOC).native(), tmp_toc).get();
     for (auto& [c, s] : sst->all_components()) {
         if (count-- <= 0) {
             return false;
         }
-        auto src = sst->filename(c);
+        auto src = test::filename(*sst, c);
         auto dst = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), generation_from_value(gen), sstable_format_types::big, c);
-        link_file(src, dst).get();
+        link_file(src.native(), dst).get();
     }
     if (count-- <= 0) {
         return false;

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -483,7 +483,7 @@ test_sstable_exists(sstring dir, unsigned long generation, bool exists) {
 SEASTAR_TEST_CASE(statistics_rewrite) {
     return test_setup::do_with_cloned_tmp_directory(uncompressed_dir(), [] (test_env& env, sstring uncompressed_dir, sstring generation_dir) {
         return env.reusable_sst(uncompressed_schema(), uncompressed_dir, 1).then([generation_dir] (auto sstp) {
-            return sstp->create_links(generation_dir).then([sstp] {});
+            return test::create_links(*sstp, generation_dir).then([sstp] {});
         }).then([generation_dir] {
             return test_sstable_exists(generation_dir, 1, true);
         }).then([&env, generation_dir] {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -201,7 +201,7 @@ public:
     void rewrite_toc_without_scylla_component() {
         _sst->_recognized_components.erase(component_type::Scylla);
         remove_file(_sst->filename(component_type::TOC)).get();
-        _sst->write_toc(default_priority_class());
+        _sst->_storage.open(*_sst, default_priority_class());
         _sst->seal_sstable(false).get();
     }
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -220,6 +220,10 @@ public:
     static future<> create_links(const sstable& sst, const sstring& dir) {
         return sst._storage.create_links(sst, dir);
     }
+
+    static fs::path filename(const sstable& sst, component_type c) {
+        return fs::path(sst.filename(c));
+    }
 };
 
 inline auto replacer_fn_no_op() {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -158,7 +158,7 @@ public:
         _sst->_recognized_components.erase(component_type::Index);
         _sst->_recognized_components.erase(component_type::Data);
         return seastar::async([sst = _sst] {
-            sst->write_toc(default_priority_class());
+            sst->open_sstable(default_priority_class());
             sst->write_statistics(default_priority_class());
             sst->write_compression(default_priority_class());
             sst->write_filter(default_priority_class());

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -216,6 +216,10 @@ public:
     void set_shards(std::vector<unsigned> shards) {
         _sst->_shards = std::move(shards);
     }
+
+    static future<> create_links(const sstable& sst, const sstring& dir) {
+        return sst._storage.create_links(sst, dir);
+    }
 };
 
 inline auto replacer_fn_no_op() {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -139,7 +139,7 @@ public:
     }
 
     void change_dir(sstring dir) {
-        _sst->_dir = dir;
+        _sst->_storage.dir = dir;
     }
 
     void set_data_file_size(uint64_t size) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -163,7 +163,7 @@ public:
             sst->write_compression(default_priority_class());
             sst->write_filter(default_priority_class());
             sst->write_summary(default_priority_class());
-            sst->seal_sstable().get();
+            sst->seal_sstable(false).get();
         });
     }
 
@@ -202,7 +202,7 @@ public:
         _sst->_recognized_components.erase(component_type::Scylla);
         remove_file(_sst->filename(component_type::TOC)).get();
         _sst->write_toc(default_priority_class());
-        _sst->seal_sstable().get();
+        _sst->seal_sstable(false).get();
     }
 
     future<> remove_component(component_type c) {


### PR DESCRIPTION
This is to define the API sstable needs from underlying storage. When implementing object-storage backend it will need to implement those. The API looks like

        future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;
        future<> quarantine(const sstable& sst, delayed_commit_changes* delay);
        future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
        void open(sstable& sst, const io_priority_class& pc); // runs in async context
        future<> wipe(const sstable& sst) noexcept;

        future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity);

It doesn't have "list" or alike, because it's not a method of an individual sstable, but rather the one from sstables_manager. It will come as separate PR.