### PR TITLE
code: Redice fanout of sstables(_manager)?.hh over headers

### DIFF
--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "sstables/sstables.hh"
 #include "size_tiered_compaction_strategy.hh"
 
 #include <boost/range/adaptor/transformed.hpp>

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -10,7 +10,7 @@
 
 #include "compaction_strategy_impl.hh"
 #include "compaction.hh"
-#include "sstables/sstables.hh"
+#include "sstables/shared_sstable.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 
 class size_tiered_backlog_tracker;

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -10,15 +10,15 @@
 #pragma once
 
 #include "schema_fwd.hh"
-#include "sstables/sstable_set.hh"
-#include "sstables/sstables_manager.hh"
 #include "compaction_descriptor.hh"
 
 class reader_permit;
 class compaction_backlog_tracker;
 
 namespace sstables {
+class sstable_set;
 class compaction_strategy;
+class sstables_manager;
 struct sstable_writer_config;
 }
 

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -15,7 +15,7 @@
 #include "size_tiered_compaction_strategy.hh"
 #include "timestamp.hh"
 #include "exceptions/exceptions.hh"
-#include "sstables/sstables.hh"
+#include "sstables/shared_sstable.hh"
 #include "service/priority_manager.hh"
 
 namespace sstables {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -64,6 +64,7 @@
 #include "db/operation_type.hh"
 #include "utils/serialized_action.hh"
 #include "compaction/compaction_manager.hh"
+#include "utils/disk-error-handler.hh"
 
 class cell_locker;
 class cell_locker_stats;

--- a/sstables/mx/partition_reversing_data_source.hh
+++ b/sstables/mx/partition_reversing_data_source.hh
@@ -13,7 +13,6 @@
 #include "reader_permit.hh"
 #include "sstables/index_reader.hh"
 #include "sstables/shared_sstable.hh"
-#include "sstables/sstables.hh"
 #include "tracing/trace_state.hh"
 
 namespace sstables {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string.hpp>
 #include "sstables/sstable_directory.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
 #include "compaction/compaction_manager.hh"
 #include "log.hh"
 #include "sstable_directory.hh"

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #include "mutation.hh"
-#include "sstables.hh"
 #include "types.hh"
 #include <seastar/core/future-util.hh>
 #include <seastar/core/coroutine.hh>

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -13,6 +13,8 @@
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/sort.hpp>
 
+#include "sstables.hh"
+
 #include "compatible_ring_position.hh"
 #include "compaction/compaction_strategy_impl.hh"
 #include "compaction/leveled_compaction_strategy.hh"

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -17,7 +17,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/shareable_components.hh"
 #include "sstables/shared_sstable.hh"
-#include "sstables/sstables.hh"
 #include "sstables/version.hh"
 #include "sstables/component_type.hh"
 #include "sstables/sstable_directory.hh"

--- a/sstables/writer_impl.hh
+++ b/sstables/writer_impl.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "sstables.hh"
 #include "sstable_writer.hh"
 #include "sstables_manager.hh"
 #include "schema_fwd.hh"

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -16,7 +16,7 @@
 #include "db/config.hh"
 #include "db/large_data_handler.hh"
 #include "gms/feature_service.hh"
-#include "sstables/sstables.hh"
+#include "sstables/version.hh"
 #include "sstables/sstable_directory.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/test_services.hh"


### PR DESCRIPTION
This change removes sstables.hh from some other headers replacing it with version.hh and shared_sstable.hh. Also this drops sstables_manager.hh from some more headers, because this header propagates sstables.hh via self. That change is pretty straightforward, but has a recochet in database.hh that needs disk-error-handler.hh.

Without the patch touch sstables/sstable.hh results in 409 targets recompillation, with the patch -- 299 targets.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>