### PR TITLE
view: row_locker: fix leak of operations_currently_waiting_for_lock stat on failure

### DIFF
--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -30,6 +30,7 @@
 #include "dht/i_partitioner.hh"
 #include "query-request.hh"
 #include "utils/estimated_histogram.hh"
+#include "utils/latency.hh"
 
 class row_locker {
 public:
@@ -43,6 +44,15 @@ public:
         single_lock_stats shared_row;
         single_lock_stats exclusive_partition;
         single_lock_stats shared_partition;
+    };
+    struct latency_stats_tracker {
+        single_lock_stats& lock_stats;
+        utils::latency_counter waiting_latency;
+
+        latency_stats_tracker(single_lock_stats& stats);
+        ~latency_stats_tracker();
+
+        void lock_acquired();
     };
     // row_locker's locking functions lock_pk(), lock_ck() return a
     // "lock_holder" object. When the caller destroys the object it received,


### PR DESCRIPTION
Currently, operations_currently_waiting_for_lock is incremented unconditionally
but decremented only on the success path.

This mini-series introduces and RAII struct latency_stats_tracker
that makes sure that the stats are updated properly on both good and bad execution paths.

While at it, count lock_acquisitions only on success.
    
Decrement operations_currently_waiting_for_lock in the destructor
so it's always balanced with the uncoditional increment in the ctor.

As for updating estimated_waiting_for_lock, it is always
updated in the dtor, both on success and failure since
the wait for the lock happened, whether waiting
timed out or not.

Fixes #12190
