### PR TITLE
row_cache: Destroy coroutine under region's allocator

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -952,6 +952,11 @@ future<> row_cache::do_update(external_updater eu, replica::memtable& m, Updater
             _prev_snapshot = {};
         });
         utils::coroutine update; // Destroy before cleanup to release snapshots before invalidating.
+        auto destroy_update = defer([&] {
+            with_allocator(_tracker.allocator(), [&] {
+                update = {};
+            });
+        });
         partition_presence_checker is_present = _prev_snapshot->make_partition_presence_checker();
         while (!m.partitions.empty()) {
             with_allocator(_tracker.allocator(), [&] () {


### PR DESCRIPTION
The reason is alloc-dealloc mismatch of position_in_partition objects allocated by cursors inside coroutine object stored in the update variable in row_cache::do_update()

It is allocated under cache region, but in case of exception it will be destroyed under the standard allocator. If update is successful, it will be cleared under region allocator, so there is not problem in the normal case.

Fixes #12068