### PR TITLE
Fix handling of non-full clustering keys in the read path

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -907,7 +907,7 @@ void compacted_fragments_writer::split_large_partition() {
     // will result in current fragment storing an inclusive end bound for last pos, and the
     // next fragment storing an exclusive start bound for last pos. This is very important
     // for not losing information on the range tombstone.
-    auto after_last_pos = position_in_partition::after_key(_current_partition.last_pos.key());
+    auto after_last_pos = position_in_partition::after_key(*_c.schema(), _current_partition.last_pos.key());
     if (_current_partition.current_emitted_tombstone) {
         auto rtc = range_tombstone_change(after_last_pos, tombstone{});
         _c.log_debug("Closing active tombstone {} with {} for partition {}", _current_partition.current_emitted_tombstone, rtc, *_current_partition.dk);

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -446,7 +446,7 @@ public:
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration consume_end_of_partition(Consumer& consumer, GCConsumer& gc_consumer) {
         if (_effective_tombstone) {
-            auto rtc = range_tombstone_change(position_in_partition::after_key(_last_pos), tombstone{});
+            auto rtc = range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), tombstone{});
             // do_consume() overwrites _effective_tombstone with {}, so save and restore it.
             auto prev_tombstone = _effective_tombstone;
             do_consume(std::move(rtc), consumer, gc_consumer);
@@ -539,7 +539,7 @@ public:
             consume(*std::exchange(_last_static_row, {}), consumer, nc);
         }
         if (_effective_tombstone) {
-            auto rtc = range_tombstone_change(position_in_partition_view::after_key(_last_pos), _effective_tombstone);
+            auto rtc = range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), _effective_tombstone);
             do_consume(std::move(rtc), consumer, nc);
         }
     }
@@ -574,7 +574,7 @@ public:
         partition_start ps(std::move(_last_dk), _partition_tombstone);
         if (_effective_tombstone) {
             return detached_compaction_state{std::move(ps), std::move(_last_static_row),
-                    range_tombstone_change(position_in_partition_view::after_key(_last_pos), _effective_tombstone)};
+                    range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), _effective_tombstone)};
         } else {
             return detached_compaction_state{std::move(ps), std::move(_last_static_row), std::optional<range_tombstone_change>{}};
         }

--- a/mutation_fragment.cc
+++ b/mutation_fragment.cc
@@ -258,12 +258,12 @@ position_in_partition_view mutation_fragment::position() const
     return visit([] (auto& mf) -> position_in_partition_view { return mf.position(); });
 }
 
-position_range mutation_fragment::range() const {
+position_range mutation_fragment::range(const schema& s) const {
     switch (_kind) {
     case kind::static_row:
         return position_range::for_static_row();
     case kind::clustering_row:
-        return position_range(position_in_partition(position()), position_in_partition::after_key(key()));
+        return position_range(position_in_partition(position()), position_in_partition::after_key(s, key()));
     case kind::partition_start:
         return position_range(position_in_partition(position()), position_in_partition::for_static_row());
     case kind::partition_end:

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -361,7 +361,7 @@ public:
     position_in_partition_view position() const;
 
     // Returns the range of positions for which this fragment holds relevant information.
-    position_range range() const;
+    position_range range(const schema& s) const;
 
     // Checks if this fragment may be relevant for any range starting at given position.
     bool relevant_for_range(const schema& s, position_in_partition_view pos) const;

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2145,7 +2145,7 @@ stop_iteration reconcilable_result_builder::consume(static_row&& sr, tombstone, 
 
 stop_iteration reconcilable_result_builder::consume(clustering_row&& cr, row_tombstone, bool is_alive) {
     if (_rt_assembler.needs_flush()) {
-        if (auto rt_opt = _rt_assembler.flush(_schema, position_in_partition::after_key(cr.key()))) {
+        if (auto rt_opt = _rt_assembler.flush(_schema, position_in_partition::after_key(_schema, cr.key()))) {
             consume(std::move(*rt_opt));
         }
     }
@@ -2368,10 +2368,10 @@ clustering_interval_set mutation_partition::get_continuity(const schema& s, is_c
         }
         if (i->position().is_clustering_row() && bool(i->dummy()) == !bool(cont)) {
             result.add(s, position_range(position_in_partition(i->position()),
-                position_in_partition::after_key(i->position().key())));
+                position_in_partition::after_key(s, i->position().key())));
         }
         prev_pos = i->position().is_clustering_row()
-            ? position_in_partition::after_key(i->position().key())
+            ? position_in_partition::after_key(s, i->position().key())
             : position_in_partition(i->position());
         ++i;
     }

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -36,7 +36,7 @@ private:
         _mut_builder->consume_new_partition(key);
         _mut_builder->consume(tomb);
         if (_current_tombstone) {
-            _mut_builder->consume(range_tombstone_change(position_in_partition_view::after_key(_last_pos), _current_tombstone));
+            _mut_builder->consume(range_tombstone_change(position_in_partition::after_key(*_schema, _last_pos), _current_tombstone));
         }
     }
 
@@ -49,7 +49,7 @@ private:
         if (_memtable->occupancy().total_space() + _current_mut_size > _max_memory) {
             if (_mut_builder) {
                 if (_current_tombstone) {
-                    _mut_builder->consume(range_tombstone_change(position_in_partition_view::after_key(_last_pos), {}));
+                    _mut_builder->consume(range_tombstone_change(position_in_partition::after_key(*_schema, _last_pos), {}));
                 }
                 auto mut = _mut_builder->consume_end_of_stream();
                 init_current_mut(mut->decorated_key(), mut->partition().partition_tombstone());

--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -275,6 +275,10 @@ public:
         , _ck(*pos._ck) { }
     position_in_partition(before_clustering_row_tag_t, clustering_key_prefix ck)
         : _type(partition_region::clustered), _bound_weight(bound_weight::before_all_prefixed), _ck(std::move(ck)) { }
+    position_in_partition(before_clustering_row_tag_t, position_in_partition_view pos)
+        : _type(partition_region::clustered)
+        , _bound_weight(pos._bound_weight != bound_weight::equal ? pos._bound_weight : bound_weight::before_all_prefixed)
+        , _ck(*pos._ck) { }
     position_in_partition(range_tag_t, bound_view bv)
         : _type(partition_region::clustered), _bound_weight(position_weight(bv.kind())), _ck(bv.prefix()) { }
     position_in_partition(range_tag_t, bound_kind kind, clustering_key_prefix&& prefix)
@@ -306,6 +310,13 @@ public:
 
     static position_in_partition after_all_clustered_rows() {
         return {position_in_partition::range_tag_t(), bound_view::top()};
+    }
+
+    // If given position is a clustering row position, returns a position
+    // right before it. Otherwise, returns it unchanged.
+    // The position "pos" must be a clustering position.
+    static position_in_partition before_key(position_in_partition_view pos) {
+        return {before_clustering_row_tag_t(), pos};
     }
 
     static position_in_partition before_key(clustering_key ck) {

--- a/query-request.hh
+++ b/query-request.hh
@@ -27,6 +27,7 @@
 #include "bytes.hh"
 
 class position_in_partition_view;
+class position_in_partition;
 class partition_slice_builder;
 
 using query_id = utils::tagged_uuid<struct query_id_tag>;
@@ -80,7 +81,7 @@ typedef std::vector<clustering_range> clustering_row_ranges;
 /// partially overlap are trimmed.
 /// Result: each range will overlap fully with [pos, +inf), or (-int, pos] if
 /// reversed is true.
-void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition_view pos, bool reversed = false);
+void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition pos, bool reversed = false);
 
 /// Trim the clustering ranges.
 ///

--- a/query.cc
+++ b/query.cc
@@ -135,14 +135,13 @@ void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& range
 }
 
 void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, const clustering_key& key, bool reversed) {
-    if (key.is_full(s)) {
+    if (key.is_full(s) || reversed) {
         return trim_clustering_row_ranges_to(s, ranges,
                 reversed ? position_in_partition_view::before_key(key) : position_in_partition_view::after_key(key), reversed);
     }
     auto full_key = key;
     clustering_key::make_full(s, full_key);
-    return trim_clustering_row_ranges_to(s, ranges,
-            reversed ? position_in_partition_view::after_key(full_key) : position_in_partition_view::before_key(full_key), reversed);
+    return trim_clustering_row_ranges_to(s, ranges, position_in_partition_view::before_key(full_key), reversed);
 }
 
 

--- a/query.cc
+++ b/query.cc
@@ -107,7 +107,7 @@ std::ostream& operator<<(std::ostream& out, const specific_ranges& s) {
     return out << "{" << s._pk << " : " << join(", ", s._ranges) << "}";
 }
 
-void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition_view pos, bool reversed) {
+void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition pos, bool reversed) {
     auto cmp = [reversed, cmp = position_in_partition::composite_tri_compare(s)] (const auto& a, const auto& b) {
         return reversed ? cmp(b, a) : cmp(a, b);
     };
@@ -135,13 +135,8 @@ void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& range
 }
 
 void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, const clustering_key& key, bool reversed) {
-    if (key.is_full(s) || reversed) {
-        return trim_clustering_row_ranges_to(s, ranges,
-                reversed ? position_in_partition_view::before_key(key) : position_in_partition_view::after_key(key), reversed);
-    }
-    auto full_key = key;
-    clustering_key::make_full(s, full_key);
-    return trim_clustering_row_ranges_to(s, ranges, position_in_partition_view::before_key(full_key), reversed);
+    return trim_clustering_row_ranges_to(s, ranges,
+            reversed ? position_in_partition::before_key(key) : position_in_partition::after_key(s, key), reversed);
 }
 
 

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -325,7 +325,7 @@ void evictable_reader_v2::update_next_position() {
                 push_mutation_fragment(_reader->pop_mutation_fragment());
                 _next_position_in_partition = position_in_partition::for_partition_start();
             } else {
-                _next_position_in_partition = position_in_partition::after_key(last_pos);
+                _next_position_in_partition = position_in_partition::after_key(*_schema, last_pos);
             }
             break;
         case partition_region::partition_end:

--- a/readers/mutation_fragment_v1_stream.hh
+++ b/readers/mutation_fragment_v1_stream.hh
@@ -20,7 +20,7 @@ class mutation_fragment_v1_stream final {
     }
     mutation_fragment_opt consume(clustering_row mf) {
         if (_rt_assembler.needs_flush()) [[unlikely]] {
-            if (auto rt_opt = _rt_assembler.flush(*_schema, position_in_partition::after_key(mf.position()))) [[unlikely]] {
+            if (auto rt_opt = _rt_assembler.flush(*_schema, position_in_partition::after_key(*_schema, mf.position()))) [[unlikely]] {
                 _row = std::move(mf);
                 return wrap(std::move(*rt_opt));
             }

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -150,9 +150,10 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
 
         if (has_ck) {
             query::clustering_row_ranges row_ranges = _cmd->slice.default_row_ranges();
-            position_in_partition_view next_pos = _last_pos;
+            position_in_partition next_pos = _last_pos;
             if (_last_pos.has_key()) {
-                next_pos = reversed ? position_in_partition_view::before_key(_last_pos) : position_in_partition_view::after_key(_last_pos);
+                next_pos = reversed ? position_in_partition::before_key(_last_pos)
+                                    : position_in_partition::after_key(*_schema, _last_pos);
             }
             query::trim_clustering_row_ranges_to(*_schema, row_ranges, next_pos, reversed);
 

--- a/sstables/metadata_collector.cc
+++ b/sstables/metadata_collector.cc
@@ -38,7 +38,7 @@ void metadata_collector::update_min_max_components(position_in_partition_view po
     // This is how callers expect prefixes to be interpreted.
     const auto is_prefix_row = pos.is_clustering_row() && !pos.key().is_full(_schema);
     const auto min_pos = is_prefix_row ? position_in_partition_view::before_key(pos) : pos;
-    const auto max_pos = is_prefix_row ? position_in_partition_view::after_key(pos) : pos;
+    const auto max_pos = is_prefix_row ? position_in_partition_view::after_all_prefixed(pos) : pos;
 
     if (!_min_clustering_pos || cmp(min_pos, *_min_clustering_pos) < 0) {
         mdclogger.trace("{}: setting min_clustering_key={}", _name, position_in_partition_view::printer(_schema, min_pos));

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -503,7 +503,7 @@ struct rt_marker {
         if (kind == bound_kind_m::incl_start || kind == bound_kind_m::excl_end_incl_start) {
             return position_in_partition_view::before_key(clustering);
         }
-        return position_in_partition_view::after_key(clustering);
+        return position_in_partition_view::after_all_prefixed(clustering);
     }
 
     // We need this one to uniformly write rows and RT markers inside write_clustered().

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -262,11 +262,11 @@ void test_single_row(int ck,
 }
 
 static expected_row after_cont(int ck) {
-    return expected_row(position_in_partition::after_key(make_ck(ck)), is_continuous::yes, is_dummy::yes);
+    return expected_row(position_in_partition::after_key(*SCHEMA, make_ck(ck)), is_continuous::yes, is_dummy::yes);
 }
 
 static expected_row after_notc(int ck) {
-    return expected_row(position_in_partition::after_key(make_ck(ck)), is_continuous::no, is_dummy::yes);
+    return expected_row(position_in_partition::after_key(*SCHEMA, make_ck(ck)), is_continuous::no, is_dummy::yes);
 }
 
 static expected_row before_cont(int ck) {
@@ -1289,7 +1289,7 @@ SEASTAR_TEST_CASE(test_single_row_and_tombstone_not_cached_single_row_range1) {
         test_slice_single_version(underlying, cache, slice, {
             expected_fragment(position_in_partition::before_key(make_ck(1)), rt.tomb),
             expected_fragment(1),
-            expected_fragment(position_in_partition::after_key(make_ck(1)), {}),
+            expected_fragment(position_in_partition_view::after_all_prefixed(make_ck(1)), {}),
         }, {
             expected_row(1, is_continuous::no),
             expected_row(expected_row::dummy_tag_t{}, is_continuous::no)
@@ -1336,7 +1336,7 @@ SEASTAR_TEST_CASE(test_single_row_and_tombstone_not_cached_single_row_range3) {
 
         test_slice_single_version(underlying, cache, slice, {
             expected_fragment(position_in_partition_view::before_key(make_ck(0)), rt.tomb),
-            expected_fragment(position_in_partition_view::after_key(make_ck(2)), {}),
+            expected_fragment(position_in_partition_view::after_all_prefixed(make_ck(2)), {}),
             expected_fragment(4)
         }, {
             before_notc(0),

--- a/test/boost/clustering_ranges_walker_test.cc
+++ b/test/boost/clustering_ranges_walker_test.cc
@@ -102,7 +102,7 @@ SEASTAR_TEST_CASE(test_basic_operation_on_various_data_sets) {
             query::clustering_range::make({keys[6], true}, {keys[6], true}),
         });
 
-        auto end_pos = position_in_partition::after_key(keys[6]);
+        auto end_pos = position_in_partition::after_key(*s.schema(), keys[6]);
 
         auto steps = std::vector<step>({
             {position_in_partition_view::for_static_row(),            true},
@@ -125,7 +125,7 @@ SEASTAR_TEST_CASE(test_basic_operation_on_various_data_sets) {
             query::clustering_range::make({keys[1], false}, {keys[2], true}),
         });
 
-        auto end_pos = position_in_partition::after_key(keys[2]);
+        auto end_pos = position_in_partition::after_key(*s.schema(), keys[2]);
 
         auto steps = std::vector<step>({
             {position_in_partition_view::for_static_row(),            true},
@@ -143,7 +143,7 @@ SEASTAR_TEST_CASE(test_basic_operation_on_various_data_sets) {
             query::clustering_range::make({keys[1], false}, {keys[2], true}),
         });
 
-        auto end_pos = position_in_partition::after_key(keys[2]);
+        auto end_pos = position_in_partition::after_key(*s.schema(), keys[2]);
 
         auto steps = std::vector<step>({
             {position_in_partition_view::for_static_row(),            false},
@@ -214,14 +214,14 @@ SEASTAR_TEST_CASE(test_range_overlap) {
 
     BOOST_REQUIRE(!walker.advance_to(
         position_in_partition::for_key(keys[0]),
-        position_in_partition::after_key(keys[0])));
+        position_in_partition::after_key(*s.schema(), keys[0])));
 
     ++lbcc;
     BOOST_REQUIRE(walker.lower_bound_change_counter() == lbcc);
     BOOST_REQUIRE(eq(walker.lower_bound(), position_in_partition::for_range_start(range1)));
 
     BOOST_REQUIRE(walker.advance_to(
-        position_in_partition::after_key(keys[0]),
+        position_in_partition::after_key(*s.schema(), keys[0]),
         position_in_partition::for_key(keys[1])));
 
     BOOST_REQUIRE(walker.lower_bound_change_counter() == lbcc);
@@ -240,7 +240,7 @@ SEASTAR_TEST_CASE(test_range_overlap) {
     BOOST_REQUIRE(eq(walker.lower_bound(), position_in_partition::for_range_start(range2)));
 
     BOOST_REQUIRE(walker.advance_to(
-        position_in_partition::after_key(keys[2]),
+        position_in_partition::after_key(*s.schema(), keys[2]),
         position_in_partition::for_key(keys[4])));
 
     BOOST_REQUIRE(walker.advance_to(

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1595,13 +1595,13 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
     check_reversed(
             { {excl{9, 39}, incl{10}} },
             {10},
-            { {excl{9, 39}, incl{10, null{}}} });
+            { {excl{9, 39}, excl{10}} });
 
     // (13)
     check_reversed(
             { {incl{9, 10}, incl{10, 30}} },
             {10},
-            { {incl{9, 10}, incl{10, null{}}} });
+            { {incl{9, 10}, excl{10}} });
 
     // (14)
     check_reversed(

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -500,8 +500,8 @@ static std::vector<range_tombstone> make_random() {
                     tombstone(dist(gen), gc_now));
         } else {
             rts.emplace_back(
-                    position_in_partition::after_key(key),
-                    position_in_partition::after_key(key),
+                    position_in_partition::after_key(*s, key),
+                    position_in_partition::after_key(*s, key),
                     tombstone(dist(gen), gc_now));
         }
     }

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -2121,7 +2121,7 @@ SEASTAR_TEST_CASE(test_scan_with_partial_partitions_reversed) {
                     .produces_range_tombstone_change(start_change(reversed(rt2)))
                     .produces_range_tombstone_change(range_tombstone_change(reversed(rt2).end_position(), rt1.tomb))
                     .produces_row_with_key(s.make_ckey(2))
-                    .produces_range_tombstone_change(range_tombstone_change(position_in_partition::after_key(s.make_ckey(1)), {}))
+                    .produces_range_tombstone_change(range_tombstone_change(position_in_partition::after_key(*s.schema(), s.make_ckey(1)), {}))
                     .produces_partition_end()
                     .produces_end_of_stream();
         }

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -159,7 +159,7 @@ static std::vector<position_range> random_ranges(const std::vector<clustering_ke
                 positions.emplace_back(position_in_partition::clustering_row_tag_t{}, std::move(ckp));
                 break;
             default:
-                positions.emplace_back(position_in_partition::after_clustering_row_tag_t{}, std::move(ckp));
+                positions.emplace_back(position_in_partition_view::after_all_prefixed(std::move(ckp)));
                 break;
         }
     }

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -703,6 +703,13 @@ BOOST_AUTO_TEST_CASE(test_parse_valid_frozen_set) {
     BOOST_REQUIRE(type->as_cql3_type().to_string() == "frozen<set<int>>");
 }
 
+BOOST_AUTO_TEST_CASE(test_empty_frozen_set_compare) {
+    auto parser = db::marshal::type_parser("org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.Int32Type))");
+    auto type = parser.parse();
+    std::unordered_set<int> set = {1, 2, 3};
+    type->compare(bytes_view(), bytes_view(*data_value(set).serialize()));
+}
+
 BOOST_AUTO_TEST_CASE(test_parse_valid_set_frozen_set) {
     sstring frozen = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.Int32Type))";
     auto parser = db::marshal::type_parser("org.apache.cassandra.db.marshal.SetType(" + frozen + ")");

--- a/types.cc
+++ b/types.cc
@@ -2298,9 +2298,11 @@ struct compare_visitor {
     std::strong_ordering operator()(const listlike_collection_type_impl& l) {
         using llpdi = listlike_partial_deserializing_iterator;
         auto sf = cql_serialization_format::internal();
-        return lexicographical_tri_compare(llpdi::begin(v1, sf), llpdi::end(v1, sf), llpdi::begin(v2, sf),
-                llpdi::end(v2, sf),
-                [&] (const managed_bytes_view& o1, const managed_bytes_view& o2) { return l.get_elements_type()->compare(o1, o2); });
+        return with_empty_checks([&] {
+            return lexicographical_tri_compare(llpdi::begin(v1, sf), llpdi::end(v1, sf), llpdi::begin(v2, sf),
+                    llpdi::end(v2, sf),
+                    [&] (const managed_bytes_view& o1, const managed_bytes_view& o2) { return l.get_elements_type()->compare(o1, o2); });
+        });
     }
     std::strong_ordering operator()(const map_type_impl& m) {
         return map_type_impl::compare_maps(m.get_keys_type(), m.get_values_type(), v1, v2);


### PR DESCRIPTION
This PR fixes several bugs related to handling of non-full
clustering keys.

One is in trim_clustering_row_ranges_to(), which is broken for non-full keys in reverse
mode. It will trim the range to position_in_partition_view::after_key(full_key) instead of
position_in_partition_view::before_key(key), hence it will include the
key in the resulting range rather than exclude it.

Fixes #12180

after_key() was creating a position which is after all keys prefixed
by a non-full key, rather than a position which is right after that
key.

This will issue will be caught by cql_query_test::test_compact_storage
in debug mode when mutation_partition_v2 merging starts inserting
sentinels at position after_key() on preemption.

It probably already causes problems for such keys as after_key() is used 
in various parts in the read path.

Refs #1446
