### PR TITLE
test/lib: Remove sstable_utils.hh from simple_schema.hh

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -27,6 +27,7 @@
 #include "schema_registry.hh"
 #include "service/migration_manager.hh"
 #include "sstables/sstables.hh"
+#include "sstables/generation_type.hh"
 #include "db/config.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/commitlog/commitlog.hh"
@@ -37,6 +38,7 @@
 #include "db/snapshot-ctl.hh"
 
 using namespace std::chrono_literals;
+using namespace sstables;
 
 class database_test {
     replica::database& _db;

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -18,6 +18,7 @@
 #include "mutation_partition_view.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/reader_concurrency_semaphore.hh"
 
 #include <seastar/core/thread.hh>
 #include <seastar/core/coroutine.hh>

--- a/test/boost/hashers_test.cc
+++ b/test/boost/hashers_test.cc
@@ -8,12 +8,14 @@
 
 #include "db/timeout_clock.hh"
 
+#include <seastar/util/closeable.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include "hashers.hh"
 #include "xx_hasher.hh"
 #include "gc_clock.hh"
 #include "test/lib/simple_schema.hh"
+#include "reader_concurrency_semaphore.hh"
 
 bytes text_part1("sanity");
 bytes text_part2("check");

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -35,6 +35,8 @@
 #include "db/commitlog/commitlog.hh"
 #include "test/lib/make_random_string.hh"
 
+using namespace std::literals::chrono_literals;
+
 static api::timestamp_type next_timestamp() {
     static thread_local api::timestamp_type next_timestamp = 1;
     return next_timestamp++;

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -22,6 +22,7 @@
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 
+#include "querier.hh"
 #include "mutation_query.hh"
 #include <seastar/core/do_with.hh>
 #include <seastar/core/thread.hh>
@@ -29,6 +30,8 @@
 #include "partition_slice_builder.hh"
 #include "readers/from_mutations_v2.hh"
 #include "mutation_rebuilder.hh"
+#include "readers/mutation_source.hh"
+#include "service/priority_manager.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -16,6 +16,7 @@
 #include "mutation_fragment.hh"
 #include "mutation_rebuilder.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/reader_concurrency_semaphore.hh"
 #include "readers/from_mutations_v2.hh"
 #include "mutation_writer/multishard_writer.hh"
 #include "mutation_writer/timestamp_based_splitting_writer.hh"

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -24,6 +24,7 @@
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/failure_injecting_allocation_strategy.hh"
 #include "test/lib/log.hh"
 #include "test/boost/range_tombstone_list_assertions.hh"

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -6,7 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/util/closeable.hh>
+#include <seastar/core/file.hh>
 #include "reader_concurrency_semaphore.hh"
+#include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/eventually.hh"
 #include "test/lib/random_utils.hh"
@@ -17,6 +20,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <boost/test/unit_test.hpp>
 #include "readers/empty_v2.hh"
+#include "replica/database.hh" // new_reader_base_cost is there :(
 
 SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_clear_inactive_reads) {
     simple_schema s;

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "replica/memtable.hh"
 #include "readers/from_fragments_v2.hh"
 #include "readers/upgrading_consumer.hh"
 #include "repair/hash.hh"

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -11,6 +11,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include "data_dictionary/user_types_metadata.hh"
 #include "schema_registry.hh"
 #include "schema_builder.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -10,10 +10,14 @@
 #include <seastar/testing/test_case.hh>
 
 #include "sstables/sstable_set_impl.hh"
+#include "sstables/shared_sstable.hh"
 #include "sstables/sstable_set.hh"
 #include "sstables/sstables.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/sstable_utils.hh"
 #include "readers/from_mutations_v2.hh"
+
+using namespace sstables;
 
 static sstables::sstable_set make_sstable_set(schema_ptr schema, lw_shared_ptr<sstable_list> all = {}, bool use_level_metadata = true) {
     auto ret = sstables::sstable_set(std::make_unique<partitioned_sstable_set>(schema, use_level_metadata), schema);

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/util/closeable.hh>
 #include "db/virtual_table.hh"
 #include "db/system_keyspace.hh"
 #include "schema.hh"

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -12,6 +12,7 @@
 #include "partition_slice_builder.hh"
 #include "schema_builder.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "readers/mutation_source.hh"
 #include "counters.hh"
 #include "mutation_rebuilder.hh"
 #include "test/lib/simple_schema.hh"

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include "test/lib/sstable_utils.hh"
+#include "readers/flat_mutation_reader_fwd.hh"
+#include "test/lib/simple_schema.hh"
 
 using populate_fn = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&)>;
 using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&, gc_clock::time_point)>;

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -18,10 +18,38 @@
 #include "mutation_fragment.hh"
 #include "mutation.hh"
 #include "schema_builder.hh"
-#include "sstable_utils.hh"
 #include "reader_permit.hh"
 #include "types/map.hh"
 #include "atomic_cell_or_collection.hh"
+
+struct local_shard_only_tag { };
+using local_shard_only = bool_class<local_shard_only_tag>;
+
+//
+// Make set of keys sorted by token for current or remote shard.
+//
+std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, std::optional<shard_id> shard);
+std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1, local_shard_only lso = local_shard_only::yes);
+
+inline std::vector<sstring> make_keys_for_shard(shard_id shard, unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
+    return do_make_keys(n, s, min_key_size, shard);
+}
+
+inline sstring make_key_for_shard(shard_id shard, const schema_ptr& s, size_t min_key_size = 1) {
+    return do_make_keys(1, s, min_key_size, shard).front();
+}
+
+inline std::vector<sstring> make_local_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
+    return do_make_keys(n, s, min_key_size, local_shard_only::yes);
+}
+
+inline sstring make_local_key(const schema_ptr& s, size_t min_key_size = 1) {
+    return do_make_keys(1, s, min_key_size, local_shard_only::yes).front();
+}
+
+inline std::vector<sstring> make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
+    return do_make_keys(n, s, min_key_size, local_shard_only::no);
+}
 
 // Helper for working with the following table:
 //

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -13,9 +13,7 @@
 #include "dht/i_partitioner.hh"
 #include "dht/murmur3_partitioner.hh"
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/algorithm/sort.hpp>
 #include "sstables/version.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
@@ -25,35 +23,6 @@
 
 using namespace sstables;
 using namespace std::chrono_literals;
-
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, std::optional<shard_id> shard) {
-    std::vector<std::pair<sstring, dht::decorated_key>> p;
-    p.reserve(n);
-
-    auto key_id = 0U;
-    auto generated = 0U;
-    while (generated < n) {
-        auto raw_key = sstring(std::max(min_key_size, sizeof(key_id)), int8_t(0));
-        std::copy_n(reinterpret_cast<int8_t*>(&key_id), sizeof(key_id), raw_key.begin());
-        auto dk = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes(raw_key)));
-        key_id++;
-        if (shard) {
-            if (*shard != shard_of(*s, dk.token())) {
-                continue;
-            }
-        }
-        generated++;
-        p.emplace_back(std::move(raw_key), std::move(dk));
-    }
-    boost::sort(p, [&] (auto& p1, auto& p2) {
-        return p1.second.less_compare(*s, p2.second);
-    });
-    return boost::copy_range<std::vector<sstring>>(p | boost::adaptors::map_keys);
-}
-
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, local_shard_only lso) {
-    return do_make_keys(n, s, min_key_size, lso ? std::optional(this_shard_id()) : std::nullopt);
-}
 
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts) {
     tests::reader_concurrency_semaphore_wrapper semaphore;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -25,39 +25,10 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
-struct local_shard_only_tag { };
-using local_shard_only = bool_class<local_shard_only_tag>;
-
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts);
 
 inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstables::shared_sstable sst) {
     return write_memtable_to_sstable(mt, sst, sst->manager().configure_writer("memtable"));
-}
-
-//
-// Make set of keys sorted by token for current or remote shard.
-//
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, std::optional<shard_id> shard);
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1, local_shard_only lso = local_shard_only::yes);
-
-inline std::vector<sstring> make_keys_for_shard(shard_id shard, unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, shard);
-}
-
-inline sstring make_key_for_shard(shard_id shard, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(1, s, min_key_size, shard).front();
-}
-
-inline std::vector<sstring> make_local_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, local_shard_only::yes);
-}
-
-inline sstring make_local_key(const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(1, s, min_key_size, local_shard_only::yes).front();
-}
-
-inline std::vector<sstring> make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, local_shard_only::no);
 }
 
 shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -14,6 +14,7 @@
 #include "compaction/compaction_manager.hh"
 #include "compaction/time_window_compaction_strategy.hh"
 #include "cell_locking.hh"
+#include "test/lib/simple_schema.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/test_services.hh"
 #include "test/lib/random_utils.hh"


### PR DESCRIPTION
The latter is pretty popular test/lib header that disseminates the former one over whole lot of unit tests. The former, in turn, naturally includes sstables.hh thus making tons of unrelated tests depend on sstables class unused by them.

However, simple removal doesn't work, becase of local_shard_only bool class definition in sstable_utils.hh used in simple_schema.hh. This thing, in turn, is used in keys making helpers that don't belong to sstable utils, so these are moved into simple_schema as well.

When done, this affects the mutation_source_test.hh, which needs the local_shard_only bool class (and helps spreading the sstables.hh throughout more unrelated tests) and a bunch of .cc test sources that used sstable_utils.hh to indirectly include various headers of their demand.

After patching, sstables.hh touches 2x times less tests. As a side effect the sstables_manager.hh also becomes 2x times less dependent on by tests.

Continuation of 9bdea110a61b270d2f586aa253e0587e66c50caa

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>