### PR TITLE
broadcast_tables: Forward-declare storage_proxy in lang.hh

### DIFF
--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -19,7 +19,7 @@
 #include "partition_slice_builder.hh"
 #include "query-request.hh"
 #include "cache_temperature.hh"
-
+#include "service/storage_proxy.hh"
 
 namespace service::broadcast_tables {
 

--- a/service/broadcast_tables/experimental/lang.hh
+++ b/service/broadcast_tables/experimental/lang.hh
@@ -13,8 +13,8 @@
 #include <seastar/core/future.hh>
 
 #include "bytes.hh"
+#include "utils/UUID.hh"
 #include "exceptions/exceptions.hh"
-#include "service/storage_proxy.hh"
 #include "service/broadcast_tables/experimental/query_result.hh"
 
 
@@ -22,6 +22,7 @@ namespace service {
 
 class raft_group0_client;
 class group0_command;
+class storage_proxy;
 
 }
 


### PR DESCRIPTION
Currently the header includes storage_proxy.hh and spreads this over the code via raft_group0_client.hh -> group0_state_machine.hh -> lang.hh

Forward declaring proxy class it eliminates ~100 indirect dependencies on storage_proxy.hh via this chain.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>