### PR TITLE
Label basic metrics

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -48,6 +48,7 @@
 #include "dht/sharder.hh"
 #include "db/config.hh"
 #include "db/tags/utils.hh"
+#include "utils/labels.hh"
 
 #include "ttl.hh"
 
@@ -850,13 +851,13 @@ future<> expiration_service::stop() {
 expiration_service::stats::stats() {
     _metrics.add_group("expiration", {
         seastar::metrics::make_total_operations("scan_passes", scan_passes,
-            seastar::metrics::description("number of passes over the database")),
+            seastar::metrics::description("number of passes over the database"))(alternator_label).set_skip_when_empty(),
         seastar::metrics::make_total_operations("scan_table", scan_table,
-            seastar::metrics::description("number of table scans (counting each scan of each table that enabled expiration)")),
+            seastar::metrics::description("number of table scans (counting each scan of each table that enabled expiration)"))(alternator_label).set_skip_when_empty(),
         seastar::metrics::make_total_operations("items_deleted", items_deleted,
-            seastar::metrics::description("number of items deleted after expiration")),
+            seastar::metrics::description("number of items deleted after expiration"))(basic_level)(alternator_label).set_skip_when_empty(),
         seastar::metrics::make_total_operations("secondary_ranges_scanned", secondary_ranges_scanned,
-            seastar::metrics::description("number of token ranges scanned by this node while their primary owner was down")),
+            seastar::metrics::description("number of token ranges scanned by this node while their primary owner was down"))(alternator_label).set_skip_when_empty(),
     });
 }
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -40,6 +40,7 @@
 #include "types/listlike_partial_deserializing_iterator.hh"
 #include "tracing/trace_state.hh"
 #include "stats.hh"
+#include "utils/labels.hh"
 
 namespace std {
 
@@ -67,7 +68,7 @@ void cdc::stats::parts_touched_stats::register_metrics(seastar::metrics::metric_
         metrics.add_group(cdc_group_name, {
                 sm::make_total_operations(seastar::format("operations_on_{}_performed_{}", part_name, suffix), count[(size_t)part],
                         sm::description(seastar::format("number of {} CDC operations that processed a {}", suffix, part_name)),
-                        {})
+                        {cdc_label}).set_skip_when_empty()
             });
     };
 
@@ -90,23 +91,23 @@ cdc::stats::stats() {
         _metrics.add_group(cdc_group_name, {
                 sm::make_total_operations("operations_" + kind, counters.unsplit_count,
                         sm::description(format("number of {} CDC operations", kind)),
-                        {split_label(false)}),
+                        {split_label(false), basic_level, cdc_label}).set_skip_when_empty(),
 
                 sm::make_total_operations("operations_" + kind, counters.split_count,
                         sm::description(format("number of {} CDC operations", kind)),
-                        {split_label(true)}),
+                        {split_label(true), basic_level, cdc_label}).set_skip_when_empty(),
 
                 sm::make_total_operations("preimage_selects_" + kind, counters.preimage_selects,
                         sm::description(format("number of {} preimage queries performed", kind)),
-                        {}),
+                        {cdc_label}).set_skip_when_empty(),
 
                 sm::make_total_operations("operations_with_preimage_" + kind, counters.with_preimage_count,
                         sm::description(format("number of {} operations that included preimage", kind)),
-                        {}),
+                        {cdc_label}).set_skip_when_empty(),
 
                 sm::make_total_operations("operations_with_postimage_" + kind, counters.with_postimage_count,
                         sm::description(format("number of {} operations that included postimage", kind)),
-                        {})
+                        {cdc_label}).set_skip_when_empty()
             });
 
         counters.touches.register_metrics(_metrics, kind);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -29,6 +29,7 @@
 #include "db/system_keyspace.hh"
 #include "tombstone_gc-internals.hh"
 #include <cmath>
+#include "utils/labels.hh"
 
 static logging::logger cmlog("compaction_manager");
 using namespace std::chrono_literals;
@@ -997,7 +998,7 @@ void compaction_manager::register_metrics() {
 
     _metrics.add_group("compaction_manager", {
         sm::make_gauge("compactions", [this] { return _stats.active_tasks; },
-                       sm::description("Holds the number of currently active compactions.")),
+                       sm::description("Holds the number of currently active compactions."))(basic_level),
         sm::make_gauge("pending_compactions", [this] { return _stats.pending_tasks; },
                        sm::description("Holds the number of compaction tasks waiting for an opportunity to run.")),
         sm::make_counter("completed_compactions", [this] { return _stats.completed_tasks; },

--- a/configure.py
+++ b/configure.py
@@ -815,6 +815,7 @@ scylla_core = (['message/messaging_service.cc',
                 'utils/on_internal_error.cc',
                 'utils/pretty_printers.cc',
                 'utils/stream_compressor.cc',
+                'utils/labels.cc',
                 'converting_mutation_partition_applier.cc',
                 'readers/combined.cc',
                 'readers/multishard.cc',
@@ -1550,13 +1551,14 @@ deps['test/boost/bytes_ostream_test'] = [
     "bytes.cc",
     "utils/managed_bytes.cc",
     "utils/logalloc.cc",
+    "utils/labels.cc",
     "utils/dynamic_bitset.cc",
     "test/lib/log.cc",
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
 deps['test/boost/UUID_test'] = ['clocks-impl.cc', 'utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc', 'utils/on_internal_error.cc']
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
-deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
+deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc', 'utils/labels.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']
 deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/summary_test'] = ['test/boost/summary_test.cc']

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -55,6 +55,7 @@
 
 #include "checked-file-impl.hh"
 #include "utils/disk-error-handler.hh"
+#include "utils/labels.hh"
 
 static logging::logger clogger("commitlog");
 
@@ -2063,15 +2064,15 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
 
     _metrics.add_group(metrics_category_name, {
         sm::make_gauge("segments", [this] { return _segments.size(); },
-                       sm::description("Holds the current number of segments.")),
+                       sm::description("Holds the current number of segments."))(basic_level),
 
         sm::make_gauge("allocating_segments", [this] { return std::count_if(_segments.begin(), _segments.end(), [] (const sseg_ptr & s) { return s->is_still_allocating(); }); },
                        sm::description("Holds the number of not closed segments that still have some free space. "
-                                       "This value should not get too high.")),
+                                       "This value should not get too high."))(basic_level),
 
         sm::make_gauge("unused_segments", [this] { return std::count_if(_segments.begin(), _segments.end(), [] (const sseg_ptr & s) { return s->is_unused(); }); },
                        sm::description("Holds the current number of unused segments. "
-                                       "A non-zero value indicates that the disk write path became temporary slow.")),
+                                       "A non-zero value indicates that the disk write path became temporary slow."))(basic_level),
 
         sm::make_counter("alloc", totals.allocation_count,
                        sm::description("Counts number of times a new mutation has been added to a segment. "
@@ -2081,7 +2082,7 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
                        sm::description("Counts number of commitlog write cycles - when the data is written from the internal memory buffer to the disk.")),
 
         sm::make_counter("flush", totals.flush_count,
-                       sm::description("Counts number of times the flush() method was called for a file.")),
+                       sm::description("Counts number of times the flush() method was called for a file."))(basic_level),
 
         sm::make_counter("bytes_written", totals.bytes_written,
                        sm::description("Counts number of bytes written to the disk. "
@@ -2101,25 +2102,25 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
 
         sm::make_gauge("pending_allocations", [this] { return pending_allocations(); },
                        sm::description("Holds number of currently pending allocations. "
-                                       "A non-zero value indicates that we have a bottleneck in the disk write flow.")),
+                                       "A non-zero value indicates that we have a bottleneck in the disk write flow."))(basic_level),
 
         sm::make_counter("requests_blocked_memory", totals.requests_blocked_memory,
                        sm::description("Counts number of requests blocked due to memory pressure. "
-                                       "A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests.")),
+                                       "A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests."))(basic_level),
 
         sm::make_counter("flush_limit_exceeded", totals.flush_limit_exceeded,
                        sm::description(
                            seastar::format("Counts number of times a flush limit was exceeded. "
                                            "A non-zero value indicates that there are too many pending flush operations (see pending_flushes) and some of "
-                                           "them will be blocked till the total amount of pending flush operations drops below {}.", cfg.max_active_flushes))),
+                                           "them will be blocked till the total amount of pending flush operations drops below {}.", cfg.max_active_flushes)))(basic_level),
 
         sm::make_gauge("disk_total_bytes", totals.total_size_on_disk,
                        sm::description("Holds size of disk space in bytes reserved for data so far. "
-                                       "A too high value indicates that we have some bottleneck in the writing to sstables path.")),
+                                       "A too high value indicates that we have some bottleneck in the writing to sstables path."))(basic_level),
 
         sm::make_gauge("disk_active_bytes", totals.active_size_on_disk,
                        sm::description("Holds size of disk space in bytes used for data so far. "
-                                       "A too high value indicates that we have some bottleneck in the writing to sstables path.")),
+                                       "A too high value indicates that we have some bottleneck in the writing to sstables path."))(basic_level),
 
         sm::make_gauge("disk_slack_end_bytes", totals.wasted_size_on_disk,
                        sm::description("Holds size of disk space in bytes unused because of segment switching (end slack). "

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -60,6 +60,7 @@
 #include "types/map.hh"
 #include "utils/error_injection.hh"
 #include "utils/exponential_backoff_retry.hh"
+#include "utils/labels.hh"
 #include "query-result-writer.hh"
 #include "readers/from_fragments_v2.hh"
 #include "readers/evictable.hh"
@@ -2247,7 +2248,7 @@ void view_builder::setup_metrics() {
 
         sm::make_gauge("builds_in_progress",
                 sm::description("Number of currently active view builds."),
-                [this] { return _base_to_build_step.size(); })
+                [this] { return _base_to_build_step.size(); })(basic_level)
     });
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -47,6 +47,7 @@
 #include "idl/gossip.dist.hh"
 #include <csignal>
 #include "build_mode.hh"
+#include "utils/labels.hh"
 
 namespace gms {
 
@@ -113,15 +114,15 @@ gossiper::gossiper(abort_source& as, const locator::shared_token_metadata& stm, 
                 } else {
                     return 0;
                 }
-            }, sm::description("Heartbeat of the current Node.")),
+            }, sm::description("Heartbeat of the current Node."))(basic_level),
         sm::make_gauge("live",
             [this] {
                 return _live_endpoints.size();
-            }, sm::description("How many live nodes the current node sees")),
+            }, sm::description("How many live nodes the current node sees"))(basic_level),
         sm::make_gauge("unreachable",
             [this] {
                 return _unreachable_endpoints.size();
-            }, sm::description("How many unreachable nodes the current node sees")),
+            }, sm::description("How many unreachable nodes the current node sees"))(basic_level),
     });
 
     // Add myself to the map on start

--- a/main.cc
+++ b/main.cc
@@ -114,6 +114,7 @@
 #include "utils/shared_dict.hh"
 #include "message/dictionary_service.hh"
 #include "utils/disk_space_monitor.hh"
+#include "utils/labels.hh"
 
 
 #define P11_KIT_FUTURE_UNSTABLE_API
@@ -122,6 +123,8 @@ extern "C" {
 }
 
 namespace fs = std::filesystem;
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/relabel_config.hh>
 
 seastar::metrics::metric_groups app_metrics;
 
@@ -782,7 +785,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
         namespace sm = seastar::metrics;
         app_metrics.add_group("scylladb", {
-            sm::make_gauge("current_version", sm::description("Current ScyllaDB version."), { sm::label_instance("version", scylla_version()), sm::shard_label("") }, [] { return 0; })
+            sm::make_gauge("current_version", sm::description("Current ScyllaDB version."), { sm::label_instance("version", scylla_version()), sm::shard_label(""), basic_level}, [] { return 0; })
         });
 
         for (auto& opt: deprecated_options.options()) {
@@ -810,13 +813,21 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                   // calling update_relabel_config_from_file can cause an exception that would stop startup
                   // that's on purpose, it means the configuration is broken and needs to be fixed
                   utils::update_relabel_config_from_file(opts["relabel-config-file"].as<sstring>()).get();
+              } else {
+                  smp::invoke_on_all([] {
+                          std::vector<metrics::relabel_config> rl(1);
+                          rl[0].source_labels = {"__name__"};
+                          rl[0].target_label = "__level";
+                          rl[0].replacement = "basic";
+                          rl[0].expr = ".*reactor_utilization";
+                          return metrics::set_relabel_configs(rl).then([](metrics::metric_relabeling_result) {});
+                  }).get();
               }
             // disable reactor stall detection during startup
             auto blocked_reactor_notify_ms = engine().get_blocked_reactor_notify_ms();
             smp::invoke_on_all([] {
                 engine().update_blocked_reactor_notify_ms(10000h);
             }).get();
-
             ::stop_signal stop_signal; // we can move this earlier to support SIGINT during initialization
             read_config(opts, *cfg).get();
 #ifdef SCYLLA_ENABLE_ERROR_INJECTION

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -51,6 +51,7 @@
 #include "idl/repair.dist.hh"
 #include "idl/node_ops.dist.hh"
 #include "utils/user_provided_param.hh"
+#include "utils/labels.hh"
 
 using namespace std::chrono_literals;
 
@@ -77,17 +78,17 @@ node_ops_metrics::node_ops_metrics(shared_ptr<repair::task_manager_module> modul
     auto ops_label_type = sm::label("ops");
     _metrics.add_group("node_ops", {
         sm::make_gauge("finished_percentage", [this] { return bootstrap_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("bootstrap")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("bootstrap"), basic_level}),
         sm::make_gauge("finished_percentage", [this] { return replace_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace"), basic_level}),
         sm::make_gauge("finished_percentage", [this] { return rebuild_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("rebuild")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("rebuild"), basic_level}),
         sm::make_gauge("finished_percentage", [this] { return decommission_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("decommission")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("decommission"), basic_level}),
         sm::make_gauge("finished_percentage", [this] { return removenode_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("removenode")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("removenode"), basic_level}),
         sm::make_gauge("finished_percentage", [this] { return repair_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("repair")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("repair"), basic_level}),
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -72,6 +72,7 @@
 #include "replica/exceptions.hh"
 #include "readers/multi_range.hh"
 #include "readers/multishard.hh"
+#include "utils/labels.hh"
 
 #include <algorithm>
 
@@ -558,11 +559,11 @@ database::setup_metrics() {
         sm::make_gauge("requests_blocked_memory_current", [this] { return _dirty_memory_manager.region_group().blocked_requests(); },
                        sm::description(
                            seastar::format("Holds the current number of requests blocked due to reaching the memory quota ({}B). "
-                                           "Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the \"database\" component.", _dirty_memory_manager.throttle_threshold()))),
+                                           "Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the \"database\" component.", _dirty_memory_manager.throttle_threshold())))(basic_level),
 
         sm::make_counter("requests_blocked_memory", [this] { return _dirty_memory_manager.region_group().blocked_requests_counter(); },
                        sm::description(seastar::format("Holds the current number of requests blocked due to reaching the memory quota ({}B). "
-                                       "Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the \"database\" component.", _dirty_memory_manager.throttle_threshold()))),
+                                       "Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the \"database\" component.", _dirty_memory_manager.throttle_threshold())))(basic_level),
 
         sm::make_counter("clustering_filter_count", _cf_stats.clustering_filter_count,
                        sm::description("Counts bloom filter invocations.")),
@@ -579,30 +580,29 @@ database::setup_metrics() {
                                        "High value indicates that bloom filter is not very efficient and still have to access a lot of sstables to get data.")),
 
         sm::make_counter("dropped_view_updates", _cf_stats.dropped_view_updates,
-                       sm::description("Counts the number of view updates that have been dropped due to cluster overload. ")),
+                       sm::description("Counts the number of view updates that have been dropped due to cluster overload. "))(basic_level),
 
        sm::make_counter("view_building_paused", _cf_stats.view_building_paused,
                       sm::description("Counts the number of times view building process was paused (e.g. due to node unavailability). ")),
 
         sm::make_counter("total_writes", _stats->total_writes,
-                       sm::description("Counts the total number of successful write operations performed by this shard.")),
+                       sm::description("Counts the total number of successful write operations performed by this shard."))(basic_level),
 
         sm::make_counter("total_writes_failed", _stats->total_writes_failed,
                        sm::description("Counts the total number of failed write operations. "
-                                       "A sum of this value plus total_writes represents a total amount of writes attempted on this shard.")),
+                                       "A sum of this value plus total_writes represents a total amount of writes attempted on this shard."))(basic_level),
 
         sm::make_counter("total_writes_timedout", _stats->total_writes_timedout,
-                       sm::description("Counts write operations failed due to a timeout. A positive value is a sign of storage being overloaded.")),
+                       sm::description("Counts write operations failed due to a timeout. A positive value is a sign of storage being overloaded."))(basic_level),
 
         sm::make_counter("total_writes_rate_limited", _stats->total_writes_rate_limited,
-                       sm::description("Counts write operations which were rejected on the replica side because the per-partition limit was reached.")),
-
+                       sm::description("Counts write operations which were rejected on the replica side because the per-partition limit was reached."))(basic_level),
 
         sm::make_counter("total_reads_rate_limited", _stats->total_reads_rate_limited,
                        sm::description("Counts read operations which were rejected on the replica side because the per-partition limit was reached.")),
 
         sm::make_current_bytes("view_update_backlog", [this] { return get_view_update_backlog().get_current_bytes(); },
-                       sm::description("Holds the current size in bytes of the pending view updates for all tables")),
+                       sm::description("Holds the current size in bytes of the pending view updates for all tables"))(basic_level),
 
         sm::make_counter("querier_cache_lookups", _querier_cache.get_stats().lookups,
                        sm::description("Counts querier cache lookups (paging queries)")),
@@ -662,10 +662,10 @@ database::setup_metrics() {
                 "Large partitions have performance impact and should be avoided, check the documentation for details.")),
 
         sm::make_total_operations("total_view_updates_pushed_local", _cf_stats.total_view_updates_pushed_local,
-                sm::description("Total number of view updates generated for tables and applied locally.")),
+                sm::description("Total number of view updates generated for tables and applied locally."))(basic_level),
 
         sm::make_total_operations("total_view_updates_pushed_remote", _cf_stats.total_view_updates_pushed_remote,
-                sm::description("Total number of view updates generated for tables and sent to remote replicas.")),
+                sm::description("Total number of view updates generated for tables and sent to remote replicas."))(basic_level),
 
         sm::make_total_operations("total_view_updates_failed_local", _cf_stats.total_view_updates_failed_local,
                 sm::description("Total number of view updates generated for tables and failed to be applied locally.")),
@@ -682,7 +682,7 @@ database::setup_metrics() {
     if (this_shard_id() == 0) {
         _metrics.add_group("database", {
                 sm::make_counter("schema_changed", _schema_change_count,
-                        sm::description("The number of times the schema changed")),
+                        sm::description("The number of times the schema changed"))(basic_level),
         });
     }
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -115,6 +115,7 @@
 #include "service/qos/service_level_controller.hh"
 #include "service/qos/standard_service_level_distributed_data_accessor.hh"
 #include <csignal>
+#include "utils/labels.hh"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -284,7 +285,7 @@ void storage_service::register_metrics() {
             sm::make_gauge("operation_mode", sm::description("The operation mode of the current node. UNKNOWN = 0, STARTING = 1, JOINING = 2, NORMAL = 3, "
                     "LEAVING = 4, DECOMMISSIONED = 5, DRAINING = 6, DRAINED = 7, MOVING = 8, MAINTENANCE = 9"), [this] {
                 return static_cast<std::underlying_type_t<node_external_status>>(map_operation_mode(_operation_mode));
-            }),
+            })(basic_level),
     });
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -82,6 +82,7 @@
 
 #include "release.hh"
 #include "utils/build_id.hh"
+#include "utils/labels.hh"
 
 #include <boost/lexical_cast.hpp>
 
@@ -3150,18 +3151,18 @@ future<> init_metrics() {
         sm::make_counter("cell_writes", [] { return sstables_stats::get_shard_stats().cell_writes; },
             sm::description("Number of cells written")),
         sm::make_counter("tombstone_writes", [] { return sstables_stats::get_shard_stats().tombstone_writes; },
-            sm::description("Number of tombstones written")),
+            sm::description("Number of tombstones written"))(basic_level),
         sm::make_counter("range_tombstone_writes", [] { return sstables_stats::get_shard_stats().range_tombstone_writes; },
-            sm::description("Number of range tombstones written")),
+            sm::description("Number of range tombstones written"))(basic_level),
         sm::make_counter("pi_auto_scale_events", [] { return sstables_stats::get_shard_stats().promoted_index_auto_scale_events; },
             sm::description("Number of promoted index auto-scaling events")),
 
         sm::make_counter("range_tombstone_reads", [] { return sstables_stats::get_shard_stats().range_tombstone_reads; },
-            sm::description("Number of range tombstones read")),
+            sm::description("Number of range tombstones read"))(basic_level),
         sm::make_counter("row_tombstone_reads", [] { return sstables_stats::get_shard_stats().row_tombstone_reads; },
-            sm::description("Number of row tombstones read")),
+            sm::description("Number of row tombstones read"))(basic_level),
         sm::make_counter("cell_tombstone_writes", [] { return sstables_stats::get_shard_stats().cell_tombstone_writes; },
-            sm::description("Number of cell tombstones written")),
+            sm::description("Number of cell tombstones written"))(basic_level),
         sm::make_counter("single_partition_reads", [] { return sstables_stats::get_shard_stats().single_partition_reads; },
             sm::description("Number of single partition flat mutation reads")),
         sm::make_counter("range_partition_reads", [] { return sstables_stats::get_shard_stats().range_partition_reads; },

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -18,6 +18,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include "db/config.hh"
+#include "utils/labels.hh"
 
 namespace streaming {
 
@@ -60,22 +61,22 @@ stream_manager::stream_manager(db::config& cfg,
                         sm::description("Total number of bytes sent on this shard.")),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::bootstrap]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("bootstrap")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("bootstrap"), basic_level}),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::decommission]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("decommission")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("decommission"), basic_level}),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::removenode]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("removenode")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("removenode"), basic_level}),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::rebuild]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("rebuild")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("rebuild"), basic_level}),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::repair]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("repair")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("repair"), basic_level}),
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::replace]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace")}),
+                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace"), basic_level}),
     });
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -60,6 +60,7 @@
 
 #include "transport/cql_protocol_extension.hh"
 #include "utils/bit_cast.hh"
+#include "utils/labels.hh"
 #include "db/config.hh"
 #include "utils/reusable_buffer.hh"
 
@@ -269,10 +270,10 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
                         sm::description("Counts a number of client connections.")),
 
         sm::make_gauge("current_connections", _stats.connections,
-                        sm::description("Holds a current number of client connections.")),
+                        sm::description("Holds a current number of client connections."))(basic_level),
 
         sm::make_counter("requests_served", _stats.requests_served,
-                        sm::description("Counts a number of served requests.")),
+                        sm::description("Counts a number of served requests."))(basic_level),
 
         sm::make_gauge("requests_serving", _stats.requests_serving,
                         sm::description("Holds a number of requests that are being processed right now.")),
@@ -287,7 +288,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
                                             "The first derivative of this value shows how often we block due to memory exhaustion in the \"CQL transport\" component.", _max_request_size))),
         sm::make_counter("requests_shed", _stats.requests_shed,
                         sm::description("Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). "
-                                            "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component.")),
+                                            "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component."))(basic_level),
         sm::make_gauge("requests_memory_available", [this] { return _memory_available.current(); },
                         sm::description(
                             seastar::format("Holds the amount of available memory for admitting new requests (max is {}B)."
@@ -306,7 +307,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
 
         transport_metrics.emplace_back(
             sm::make_counter("cql_errors_total", sm::description("Counts the total number of returned CQL errors."),
-                        {label_instance},
+                        {label_instance, basic_level},
                         [this, code = e.first] { auto it = _stats.errors.find(code); return it != _stats.errors.end() ? it->second : 0; }).set_skip_when_empty()
         );
     }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(utils
     updateable_value.cc
     utf8.cc
     uuid.cc
+    labels.cc
     aws_sigv4.cc
     stream_compressor.cc
     s3/aws_error.cc

--- a/utils/labels.cc
+++ b/utils/labels.cc
@@ -1,0 +1,10 @@
+// Copyright (C) 2025-present ScyllaDB
+// SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+#include "utils/labels.hh"
+
+seastar::metrics::label level_label("__level");
+seastar::metrics::label_instance basic_level("__level", "basic");
+seastar::metrics::label_instance cdc_label("__cdc", "1");
+seastar::metrics::label_instance cas_label("__cas", "1");
+seastar::metrics::label_instance alternator_label("__alternator", "1");

--- a/utils/labels.hh
+++ b/utils/labels.hh
@@ -1,0 +1,26 @@
+// Copyright (C) 2025-present ScyllaDB
+// SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+#include <seastar/core/metrics.hh>
+
+extern seastar::metrics::label level_label;
+/*!
+ * \brief we use label to allow granularity when reporting metrics
+ */
+
+/*!
+ * \brief Basic level are metrics that are being used by Scylla Monitoring
+ * To scrap only those metrics a user can use __level=basic
+ */
+extern seastar::metrics::label_instance basic_level;
+
+
+/*!
+ * \brief The following labels are used for specific features
+ * It allows user disable a set of metrics that belong to the same
+ * feature in an easy way.
+ */
+extern seastar::metrics::label_instance cdc_label;
+extern seastar::metrics::label_instance cas_label;
+extern seastar::metrics::label_instance lwt_label;
+extern seastar::metrics::label_instance alternator_label;

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -33,6 +33,7 @@
 #include "utils/preempt.hh"
 #include "utils/vle.hh"
 #include "utils/coarse_steady_clock.hh"
+#include "utils/labels.hh"
 
 #include <random>
 #include <chrono>
@@ -2876,7 +2877,7 @@ tracker::impl::impl() : _segment_pool(std::make_unique<logalloc::segment_pool>(*
 
     _metrics.add_group("lsa", {
         sm::make_gauge("total_space_bytes", [this] { return region_occupancy().total_space(); },
-                       sm::description("Holds a current size of allocated memory in bytes.")),
+                       sm::description("Holds a current size of allocated memory in bytes."))(basic_level),
 
         sm::make_gauge("used_space_bytes", [this] { return region_occupancy().used_space(); },
                        sm::description("Holds a current amount of used memory in bytes.")),
@@ -2891,7 +2892,7 @@ tracker::impl::impl() : _segment_pool(std::make_unique<logalloc::segment_pool>(*
                        sm::description("Holds a current size of allocated non-LSA memory.")),
 
         sm::make_gauge("non_lsa_used_space_bytes", [this] { return non_lsa_used_space(); },
-                       sm::description("Holds a current amount of used non-LSA memory.")),
+                       sm::description("Holds a current amount of used non-LSA memory."))(basic_level),
 
         sm::make_gauge("free_space", [this] { return _segment_pool->unreserved_free_segments() * segment_size; },
                        sm::description("Holds a current amount of free memory that is under lsa control.")),


### PR DESCRIPTION
This series is part of the effort to reduce the overall overhead originating from metrics reporting, both on the Scylla side and the metrics collecting server (Prometheus or similar)

The idea in this series is to create an equivalent of levels with a label. 
First, label a subset of the metrics used by the dashboards.
Second, the per-table metrics that are now off by default will be marked with a different label.
The following specific optional features: CDC, CAS, and Alternator have a dedicated label now.
This will allow users to disable all metrics of features that are not in use.

All the rest of the metrics are left unlabeled. 

Without any changes, users would get the same metrics they are getting today.
But you could pass the `__level=1` and get only those metrics the dashboard needs. That reduces between 50% and 70% (many metrics are hidden if not used, so the overall number of metrics varies).

The labels are not reported based on the seastar feature of hiding labels that start with an underscore.

