### PR TITLE
test/cql-pytest: translate more Cassandra tests

### DIFF
--- a/test/cql-pytest/cassandra_tests/porting.py
+++ b/test/cql-pytest/cassandra_tests/porting.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from cassandra.protocol import SyntaxException, InvalidRequest
 from cassandra.protocol import ConfigurationException
 from cassandra.util import SortedSet, OrderedMapSerializedKey
+from cassandra.query import UNSET_VALUE
 
 import nodetool
 
@@ -107,6 +108,8 @@ def assert_invalid_throw(cql, table, type, cmd, *args):
     with pytest.raises(type):
         execute(cql, table, cmd, *args)
 
+assertInvalidThrow = assert_invalid_throw
+
 def assert_invalid(cql, table, cmd, *args):
     # In the original Java code, assert_invalid() accepts any exception
     # (it's like passing "Exception" below for the exception type).
@@ -125,6 +128,8 @@ def assert_invalid_message(cql, table, message, cmd, *args):
     with pytest.raises(InvalidRequest, match=re.escape(message)):
         execute(cql, table, cmd, *args)
 
+assertInvalidMessage = assert_invalid_message
+
 def assert_invalid_syntax_message(cql, table, message, cmd, *args):
     with pytest.raises(SyntaxException, match=re.escape(message)):
         execute(cql, table, cmd, *args)
@@ -132,6 +137,8 @@ def assert_invalid_syntax_message(cql, table, message, cmd, *args):
 def assert_invalid_message_re(cql, table, message, cmd, *args):
     with pytest.raises(InvalidRequest, match=message):
         execute(cql, table, cmd, *args)
+
+assertInvalidMessageRE = assert_invalid_message_re
 
 def assert_invalid_throw_message(cql, table, message, typ, cmd, *args):
     with pytest.raises(typ, match=re.escape(message)):
@@ -285,3 +292,9 @@ def user_type(*args):
 # a row(...) used in assertRows can simply be a list
 def row(*args):
     return list(args)
+
+# Java tests use "null" where we need "None"
+null = None
+
+def unset():
+    return UNSET_VALUE

--- a/test/cql-pytest/cassandra_tests/validation/operations/compact_table_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/compact_table_test.py
@@ -1,0 +1,68 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+# ALTER ... DROP COMPACT STORAGE was recently dropped (unless a special
+# flag is used) by Cassandra, and it was never implemented in Scylla, so
+# let's skip its test.
+# See issue #3882
+@pytest.mark.skip
+def testDropCompactStorage(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, PRIMARY KEY(pk)) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, ck) VALUES (1, 1)")
+        execute(cql, table, "ALTER TABLE %s DROP COMPACT STORAGE")
+        assertRows(execute(cql, table,  "SELECT * FROM %s"),
+                   row(1, null, 1, null))
+    with create_table(cql, test_keyspace, "(pk int, ck int, PRIMARY KEY(pk, ck)) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, ck) VALUES (1, 1)")
+        execute(cql, table, "ALTER TABLE %s DROP COMPACT STORAGE")
+        assertRows(execute(cql, table,  "SELECT * FROM %s"),
+                   row(1, 1, null))
+    with create_table(cql, test_keyspace, "(pk int, ck int, v int, PRIMARY KEY(pk, ck)) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (1, 1, 1)")
+        execute(cql, table, "ALTER TABLE %s DROP COMPACT STORAGE")
+        assertRows(execute(cql, table,  "SELECT * FROM %s"),
+                   row(1, 1, 1))
+
+def testCompactStorageSemantics(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, PRIMARY KEY(pk, ck)) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, ck) VALUES (?, ?)", 1, 1)
+        execute(cql, table, "DELETE FROM %s WHERE pk = ? AND ck = ?", 1, 1)
+        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = ?", 1))
+
+    with create_table(cql, test_keyspace, "(pk int, ck1 int, ck2 int, v int, PRIMARY KEY(pk, ck1, ck2)) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, ck1, v) VALUES (?, ?, ?)", 2, 2, 2)
+        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = ?",2),
+                   row(2, 2, null, 2))
+
+def testColumnDeletionWithCompactTableWithMultipleColumns(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, v1 int, v2 int) WITH COMPACT STORAGE") as table:
+        execute(cql, table, "INSERT INTO %s (pk, v1, v2) VALUES (1, 1, 1) USING TIMESTAMP 1000")
+        flush(cql, table)
+        execute(cql, table, "INSERT INTO %s (pk, v1) VALUES (1, 2) USING TIMESTAMP 2000")
+        flush(cql, table)
+        execute(cql, table, "DELETE v1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1")
+        flush(cql, table)
+
+        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk=1"), row(1, null, 1))
+        assertRows(execute(cql, table, "SELECT v1, v2 FROM %s WHERE pk=1"), row(null, 1))
+        assertRows(execute(cql, table, "SELECT v1 FROM %s WHERE pk=1"), row(null))

--- a/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
@@ -1,0 +1,206 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testInsertWithUnset(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
+        # insert using nulls
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", "text", 10)
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", null, null)
+        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k = 10"),
+                   row(null, null) # sending null deletes the data
+        )
+        # insert using UNSET
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", "text", 10)
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", unset(), unset())
+        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k=11"),
+                   row("text", 10) # unset columns does not delete the existing data
+        )
+
+        # The Python driver doesn't allow unset() as partition key (needed
+        # for selecting the coordinator), so we can't test this:
+        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "UPDATE %s SET i = 0 WHERE k = ?", unset())
+        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "DELETE FROM %s WHERE k = ?", unset())
+        # Scylla and Cassandra have slightly different messages here. Cassandra
+        # has "Invalid unset value for argument in call to function blobasint"
+        # Scylla has "Invalid null or unset value for argument to
+        # system.blobasint : (blob) -> int"
+        assertInvalidMessageRE(cql, table, "Invalid.*unset value for argument.*blobasint", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset())
+
+# Both Scylla and Cassandra define MAX_TTL or max_ttl with the same formula,
+# 20 years in seconds. In both systems, it is not configurable.
+MAX_TTL = 20 * 365 * 24 * 60 * 60
+
+# Reproduces #12243:
+@pytest.mark.xfail(reason="Issue #12243")
+def testInsertWithTtl(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v int)") as table:
+        # test with unset
+        execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, 1) USING TTL ?", unset()); # treat as 'unlimited'
+        assertRows(execute(cql, table, "SELECT ttl(v) FROM %s"), row(null))
+
+        # test with null
+        # Reproduces #12243:
+        execute(cql, table, "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, null)
+        assertRows(execute(cql, table, "SELECT k, v, TTL(v) FROM %s"), row(1, 1, null))
+
+        # test error handling
+        assertInvalidMessage(cql, table, "TTL must be greater or equal to 0",
+                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, -5)
+
+        assertInvalidMessage(cql, table, "ttl is too large.",
+                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, MAX_TTL + 1)
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsert(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering) VALUES (0, 0)")
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
+        if forceFlush:
+            flush(cql, table)
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(0, 0, null),
+                   row(0, 1, 1))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering, value) VALUES (0, 1)")
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*clustering",
+                             "INSERT INTO %s (partitionKey, value) VALUES (0, 2)")
+
+        # multiple time the same value
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)")
+
+        # multiple time same primary key element in WHERE clause
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)")
+
+        # unknown identifiers
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clusteringx",
+                             "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)")
+
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
+                             "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)")
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsertWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)")
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
+        if forceFlush:
+            flush(cql, table)
+
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(0, 0, 0, null),
+                   row(0, 0, 1, 1))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)")
+        assertInvalidMessageRE(cql, table, "clustering_1",
+                             "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)")
+
+        # multiple time the same value
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)")
+
+        # multiple time same primary key element in WHERE clause
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)")
+
+        # unknown identifiers
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clustering_1x",
+                             "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)")
+
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
+                             "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)")
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsertWithAStaticColumn(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, staticValue) VALUES (0, 0, 0, 'A')")
+        execute(cql, table, "INSERT INTO %s (partitionKey, staticValue) VALUES (1, 'B')")
+        if forceFlush:
+            flush(cql, table)
+
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(1, null, null, "B", null),
+                   row(0, 0, 0, "A", null))
+
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 0)")
+        if forceFlush:
+            flush(cql, table)
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(1, 0, 0, "B", 0),
+                   row(0, 0, 0, "A", null))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering_1, clustering_2, staticValue) VALUES (0, 0, 'A')")
+        assertInvalidMessageRE(cql, table, "clustering_1",
+                             "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')")
+
+# Reproduces #6447 and #12243:
+@pytest.mark.xfail(reason="Issue #6447, #12243")
+def testInsertWithDefaultTtl(cql, test_keyspace):
+    secondsPerMinute = 60
+    with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10*secondsPerMinute}") as table:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 1"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (2, 2) USING TTL ?", (5 * secondsPerMinute))
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 2"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') <= 5 * secondsPerMinute
+
+        # Reproduces #6447:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (3, 3) USING TTL ?", 0)
+        assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 3"), row(null))
+
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (4, 4) USING TTL ?", unset())
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+
+        # Reproduces #12243:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?) USING TTL ?", 4, 4, null)
+        assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"), row(null))
+
+
+TOO_BIG = 1024 * 65
+
+# Reproduces #12247:
+@pytest.mark.xfail(reason="Issue #12247")
+def testPKInsertWithValueOver64K(cql, test_keyspace):
+    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
+        assertInvalidThrow(cql, table, InvalidRequest,
+                           "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
+
+# Reproduces #12247:
+@pytest.mark.xfail(reason="Issue #12247")
+def testCKInsertWithValueOver64K(cql, test_keyspace):
+    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
+        assertInvalidThrow(cql, table, InvalidRequest,
+                           "INSERT INTO %s (a, b) VALUES ('foo', ?)", 'x'*TOO_BIG)


### PR DESCRIPTION
This patch includes a translation of two more test files from Cassandra's CQL unit test directory cql3/validation/operations.

All tests included here pass on Cassandra. Several test fail on Scylla and are marked "xfail". These failures discovered two previously-unknown bugs:

#12243: Setting USING TTL of "null" should be allowed
#12247: Better error reporting for oversized keys during INSERT

And also added reproducers for two previously-known bugs:

#3882: Support "ALTER TABLE DROP COMPACT STORAGE"
#6447: TTL unexpected behavior when setting to 0 on a table with
           default_time_to_live

Signed-off-by: Nadav Har'El <nyh@scylladb.com>