### PR TITLE
cross-tree: allow std::source_location in clang 14

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <functional>
 #include <source_location>
+#include "utils/source_location-compat.hh"
 #include <boost/container/deque.hpp>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/future.hh>

--- a/test/lib/exception_utils.hh
+++ b/test/lib/exception_utils.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <source_location>
+#include "utils/source_location-compat.hh"
 #include <functional>
 #include <seastar/core/sstring.hh>
 

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <source_location>
+#include "utils/source_location-compat.hh"
 #include <string>
 
 #include <fmt/format.h>

--- a/utils/source_location-compat.hh
+++ b/utils/source_location-compat.hh
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// Define std::source_location, introduced in clang 15, even in clang 14
+// where it was called std::experimental::source_location.
+//
+// When we don't need to support clang 14 any more, this file and all
+// its inclusions can be removed.
+
+#pragma once
+
+#if defined(__clang_major__) && __clang_major__ <= 14
+
+#include <experimental/source_location>
+
+namespace std {
+    using source_location = std::experimental::source_location;
+}
+#endif


### PR DESCRIPTION
We recently (commit 6a5d9ff2610ecc9e5e2094fcf438acaf472ba386) started to use std::source_location instead of std::experimental::source_location. However, this does not work on clang 14, because libc++ 12's <source_location> only works if __builtin_source_location, and that is not available on clang 14.

clang 15 is just three months old, and several relatively-recent distributions still carry clang 14 so it would be nice to support it as well.

So this patch adds a trivial compatibility header file, which, when included and compiled with clang 14, it aliases the functional std::experimental::source_location to std::source_location.

It turns out it's enough to include the new header file from one place that included <source_location>, raft.hh - I guess all other uses of source_location depend on that header file directly or indirectly. We may later need to include the compatibility header file in additional places, bug for now we don't.

Refs #12259

Signed-off-by: Nadav Har'El <nyh@scylladb.com>