### PR TITLE
task_manager: task: impl: add virtual destructor

### DIFF
--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -101,6 +101,7 @@ public:
             abort_source _as;
         public:
             impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string type, std::string entity, task_id parent_id) noexcept;
+            virtual ~impl() = default;
 
             virtual future<task_manager::task::progress> get_progress() const;
             virtual tasks::is_abortable is_abortable() const noexcept;


### PR DESCRIPTION
The generic task holds and destroyes a task::impl
but we want the derived class's destructor to be called when the task is destroyed otherwise, for example, member like abort_source subscription will not be destroyed (and auto-unlinked).

Fixes #12183

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>