### PR TITLE
version: Reverse version increase

### DIFF
--- a/version.hh
+++ b/version.hh
@@ -24,7 +24,7 @@ public:
     }
 
     static version current() {
-        static version v(4, 0, 0);
+        static version v(3, 0, 8);
         return v;
     }
 


### PR DESCRIPTION
Revert version change made by PR #11106, which increased it to `4.0.0` to enable server-side describe on latest cqlsh.

Turns out that our tooling some way depends on it (eg. `sstableloader`) and it breaks dtests.
Reverting only the version allows to leave the describe code unchanged and it fixes the dtests.

Our tools have to be updated along with the version increase.

cqlsh 6.0.0 will return a warning when running `DESC ...` commands.