### PR TITLE
azure_snitch: Handle empty zone returned from IMDS

### DIFF
--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -44,7 +44,8 @@ future<> azure_snitch::load_config() {
 
     logger().info("AzureSnitch using region: {}, zone: {}.", azure_region, azure_zone);
 
-    _my_rack = azure_zone;
+    // Zoneless regions return empty zone
+    _my_rack = (azure_zone != "" ? azure_zone : azure_region);
     _my_dc = azure_region;
 
     co_return co_await container().invoke_on_others([this] (snitch_ptr& local_s) {


### PR DESCRIPTION
Azure metadata API may return empty zone sometimes. If that happens shard-0 gets empty string as its rack, but propagates UNKNOWN_RACK to other shards.

Empty zones response should be handled regardless.

refs: #12185

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>