### PR TITLE
Use Host ID as Raft ID

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3197,17 +3197,8 @@ future<utils::UUID> system_keyspace::get_raft_group0_id() {
     co_return opt.value_or<utils::UUID>({});
 }
 
-future<utils::UUID> system_keyspace::get_raft_server_id() {
-    auto opt = co_await get_scylla_local_param_as<utils::UUID>("raft_server_id");
-    co_return opt.value_or<utils::UUID>({});
-}
-
 future<> system_keyspace::set_raft_group0_id(utils::UUID uuid) {
     return set_scylla_local_param_as<utils::UUID>("raft_group0_id", uuid);
-}
-
-future<> system_keyspace::set_raft_server_id(utils::UUID uuid) {
-    return set_scylla_local_param_as<utils::UUID>("raft_server_id", uuid);
 }
 
 static constexpr auto GROUP0_HISTORY_KEY = "history";

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -431,15 +431,8 @@ public:
     // Load Raft Group 0 id from scylla.local
     static future<utils::UUID> get_raft_group0_id();
 
-    // Load this server id from scylla.local
-    future<utils::UUID> get_raft_server_id();
-
     // Persist Raft Group 0 id. Should be a TIMEUUID.
     static future<> set_raft_group0_id(utils::UUID id);
-
-    // Called once at fresh server startup to make sure every server
-    // has a Raft ID
-    future<> set_raft_server_id(utils::UUID id);
 
     // Save advertised gossip feature set to system.local
     static future<> save_local_supported_features(const std::set<std::string_view>& feats);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -347,10 +347,6 @@ public:
      */
     future<std::unordered_map<gms::inet_address, locator::host_id>> load_host_ids();
 
-    // Load the list of raft server ids and their ips known to
-    // gossip.
-    future<std::optional<utils::UUID>> get_peer_raft_id_if_known(gms::inet_address ip_addr);
-
     future<std::vector<gms::inet_address>> load_peers();
 
     /*

--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -25,7 +25,6 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::REMOVAL_COORDINATOR,    "REMOVAL_COORDINATOR"},
     {application_state::INTERNAL_IP,            "INTERNAL_IP"},
     {application_state::RPC_ADDRESS,            "RPC_ADDRESS"},
-    {application_state::RAFT_SERVER_ID,         "RAFT_SERVER_ID"},
     {application_state::SEVERITY,               "SEVERITY"},
     {application_state::NET_VERSION,            "NET_VERSION"},
     {application_state::HOST_ID,                "HOST_ID"},

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -38,11 +38,6 @@ enum class application_state {
     IGNORE_MSB_BITS,
     CDC_GENERATION_ID,
     SNITCH_NAME,
-    // RAFT ID is a server identifier which is maintained
-    // and gossiped in addition to HOST_ID because it's truly
-    // unique: any new node gets a new RAFT ID, while may keep
-    // its existing HOST ID, e.g. if it's replacing an existing node.
-    RAFT_SERVER_ID,
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1895,8 +1895,7 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) 
             gms::application_state::DC,
             gms::application_state::RACK,
             gms::application_state::SUPPORTED_FEATURES,
-            gms::application_state::SNITCH_NAME,
-            gms::application_state::RAFT_SERVER_ID}};
+            gms::application_state::SNITCH_NAME}};
         logger.info("Gossip shadow round started with nodes={}", nodes);
         std::unordered_set<gms::inet_address> nodes_talked;
         size_t nodes_down = 0;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2003,10 +2003,6 @@ future<> gossiper::add_saved_endpoint(inet_address ep) {
     if (host_id) {
         ep_state.add_application_state(gms::application_state::HOST_ID, versioned_value::host_id(host_id.value()));
     }
-    auto raft_id = co_await _sys_ks.local().get_peer_raft_id_if_known(ep);
-    if (raft_id) {
-        ep_state.add_application_state(gms::application_state::RAFT_SERVER_ID, versioned_value::raft_server_id(raft_id.value()));
-    }
     ep_state.mark_dead();
     _endpoint_state_map[ep] = ep_state;
     co_await replicate(ep, ep_state);

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -151,10 +151,6 @@ public:
         return versioned_value(host_id.to_sstring());
     }
 
-    static versioned_value raft_server_id(const utils::UUID& id) {
-        return versioned_value(id.to_sstring());
-    }
-
     static versioned_value tokens(const std::unordered_set<dht::token>& tokens) {
         return versioned_value(make_full_token_string(tokens));
     }

--- a/main.cc
+++ b/main.cc
@@ -1151,7 +1151,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
 
             if (raft_gr.local().is_enabled()) {
-                auto my_raft_id = service::load_or_create_my_raft_id(sys_ks.local()).get();
+                auto my_raft_id = raft::server_id{cfg->host_id.uuid()};
                 raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {
                     return raft_gr.start(my_raft_id);
                 }).get();

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -279,17 +279,6 @@ public:
         }
         return entry._addr;
     }
-    // Linear search for id based on inet address. Used when
-    // removing a node which id is unknown. Do not return self
-    // - we need to remove id of the node self is replacing.
-    std::optional<raft::server_id> find_replace_id(gms::inet_address addr, raft::server_id self) const {
-        for (auto& [id, entry] : _map) {
-            if (entry._addr.has_value() && entry._addr.value() == addr && id != self) {
-                return id;
-            }
-        }
-        return {};
-    }
 
     // Convert an expiring entry to a non-expiring one, or
     // insert a new non-expiring entry if the entry is missing.

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -647,13 +647,13 @@ future<> raft_group0::persist_initial_raft_address_map() {
 
 void raft_group0::load_initial_raft_address_map() {
     for (auto& [ip_addr, state] : _gossiper.get_endpoint_states()) {
-        auto* value = state.get_application_state_ptr(gms::application_state::RAFT_SERVER_ID);
+        auto* value = state.get_application_state_ptr(gms::application_state::HOST_ID);
         if (value == nullptr) {
             continue;
         }
         auto server_id = utils::UUID(value->value);
         if (server_id == utils::UUID{}) {
-            upgrade_log.error("empty raft server id for host {} ", ip_addr);
+            upgrade_log.error("empty Host ID for host {} ", ip_addr);
             continue;
         }
         // The failure detector needs the IPs on all shards. We

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -591,51 +591,6 @@ future<> raft_group0::setup_group0(
     co_await _client.set_group0_upgrade_state(group0_upgrade_state::use_post_raft_procedures);
 }
 
-future<> raft_group0::persist_initial_raft_address_map() {
-    static constexpr auto max_concurrency = 10;
-    std::vector<gms::inet_address> endpoints;
-    const auto& states = _gossiper.get_endpoint_states();
-    endpoints.reserve(states.size());
-    std::transform(states.begin(), states.end(), std::back_inserter(endpoints), [](const auto& it) { return it.first; });
-    //
-    // Gossiper only persists node state when it switches to
-    // NORMAL. When persisting a node state, Raft ID is only
-    // persisted if the cluster supports raft.  Some nodes switch
-    // to NORMAL before the whole cluster enables raft. For these
-    // nodes we may never persist their Raft ID unless, here, as
-    // soon as we discover that the entire cluster supports Raft,
-    // we go over these nodes and explicitly persist their RAFT
-    // IDs.
-
-    co_await max_concurrent_for_each(endpoints, max_concurrency, [this] (const gms::inet_address& ip_addr) -> future<> {
-        auto* state = _gossiper.get_endpoint_state_for_endpoint_ptr(ip_addr);
-        if (state == nullptr) {
-            co_return;
-        }
-        if (!state->is_normal()) {
-            // Handle only NORMAL states, others should not be
-            // persisted to avoid garbage in the peers table if
-            // bootstrap fails.
-            co_return;
-        }
-        auto* value = state->get_application_state_ptr(gms::application_state::RAFT_SERVER_ID);
-        if (value == nullptr) {
-            co_return;
-        }
-        auto server_id = utils::UUID(value->value);
-        if (server_id == utils::UUID{}) {
-            upgrade_log.error("empty raft server id for host {} ", ip_addr);
-            co_return;
-        }
-        try {
-            co_await _sys_ks.update_peer_info(ip_addr, "raft_server_id", server_id);
-        } catch (...) {
-            upgrade_log.error("failed to persist raft_server_id for {}: {}",
-                    ip_addr, std::current_exception());
-        }
-    });
-}
-
 void raft_group0::load_initial_raft_address_map() {
     for (auto& [ip_addr, state] : _gossiper.get_endpoint_states()) {
         auto* value = state.get_application_state_ptr(gms::application_state::HOST_ID);
@@ -1476,7 +1431,6 @@ future<> raft_group0::upgrade_to_group0() {
             break;
         case group0_upgrade_state::use_pre_raft_procedures:
             upgrade_log.info("starting in `use_pre_raft_procedures` state.");
-            co_await persist_initial_raft_address_map();
             break;
     }
 

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -250,10 +250,6 @@ private:
     // Remove the node from raft config, retries raft::commit_status_unknown.
     future<> remove_from_raft_config(raft::server_id id);
 
-    // Persist the initial Raft <-> IP address map as seen by
-    // the gossiper.
-    future<> persist_initial_raft_address_map();
-
     // Load the initial Raft <-> IP address map as seen by
     // the gossiper.
     void load_initial_raft_address_map();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -98,9 +98,7 @@ public:
     // Passed to `setup_group0` when replacing a node.
     struct replace_info {
         gms::inet_address ip_addr;
-        // Optional because it might be missing when Raft is disabled or in RECOVERY mode.
-        // `setup_group0` will verify that it's present when it's required.
-        std::optional<raft::server_id> raft_id;
+        raft::server_id raft_id;
     };
 
     // Assumes that the provided services are fully started.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -164,10 +164,7 @@ public:
     // 2. or we're currently bootstrapping and replacing an existing node.
     //
     // In both cases, `setup_group0()` must have finished earlier.
-    //
-    // The provided address may be our own - if we're replacing a node that had the same address as ours.
-    // We'll look for the other node's Raft ID in the Raft address map.
-    future<> remove_from_group0(gms::inet_address host);
+    future<> remove_from_group0(raft::server_id);
 
     // Assumes that this node's Raft server ID is already initialized and returns it.
     // It's a fatal error if the id is missing.

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -135,16 +135,6 @@ public:
 
 // }}} gossiper_state_change_subscriber_proxy
 
-future<raft::server_id> load_or_create_my_raft_id(db::system_keyspace& sys_ks) {
-    assert(this_shard_id() == 0);
-    auto id = raft::server_id{co_await sys_ks.get_raft_server_id()};
-    if (id == raft::server_id{}) {
-        id = raft::server_id::create_random_id();
-        co_await sys_ks.set_raft_server_id(id.id);
-    }
-    co_return id;
-}
-
 raft_group_registry::raft_group_registry(bool is_enabled, raft_address_map& address_map,
         netw::messaging_service& ms, gms::gossiper& gossiper, direct_failure_detector::failure_detector& fd)
     : _is_enabled(is_enabled)

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -75,7 +75,7 @@ class gossiper_state_change_subscriber_proxy: public gms::i_endpoint_state_chang
 
     future<>
     on_endpoint_change(gms::inet_address endpoint, gms::endpoint_state ep_state) {
-        auto app_state_ptr = ep_state.get_application_state_ptr(gms::application_state::RAFT_SERVER_ID);
+        auto app_state_ptr = ep_state.get_application_state_ptr(gms::application_state::HOST_ID);
         if (app_state_ptr) {
             raft::server_id id(utils::UUID(app_state_ptr->value));
             rslog.debug("gossiper_state_change_subscriber_proxy::on_endpoint_change() {} {}", endpoint, id);

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -52,8 +52,6 @@ class direct_fd_pinger;
 class direct_fd_proxy;
 class gossiper_state_change_subscriber_proxy;
 
-future<raft::server_id> load_or_create_my_raft_id(db::system_keyspace&);
-
 // This class is responsible for creating, storing and accessing raft servers.
 // It also manages the raft rpc verbs initialization.
 //

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -314,6 +314,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
 
     bool replacing_a_node_with_same_ip = false;
     bool replacing_a_node_with_diff_ip = false;
+    std::optional<locator::host_id> replaced_host_id;
     std::optional<raft_group0::replace_info> raft_replace_info;
     auto tmlock = std::make_unique<token_metadata_lock>(co_await get_token_metadata_lock());
     auto tmptr = co_await get_mutable_token_metadata_ptr();
@@ -332,6 +333,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
             get_broadcast_address(), *replace_address);
         tmptr->update_topology(*replace_address, std::move(ri.dc_rack));
         co_await tmptr->update_normal_tokens(bootstrap_tokens, *replace_address);
+        replaced_host_id = ri.host_id;
         raft_replace_info = raft_group0::replace_info {
             .ip_addr = *replace_address,
             .raft_id = raft::server_id{ri.host_id.uuid()},
@@ -527,7 +529,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         co_await sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
         co_await mark_existing_views_as_built(sys_dist_ks);
         co_await _sys_ks.local().update_tokens(bootstrap_tokens);
-        co_await bootstrap(cdc_gen_service, bootstrap_tokens, cdc_gen_id);
+        co_await bootstrap(cdc_gen_service, bootstrap_tokens, cdc_gen_id, replaced_host_id);
     } else {
         supervisor::notify("starting system distributed keyspace");
         co_await sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
@@ -649,8 +651,8 @@ std::list<gms::inet_address> storage_service::get_ignore_dead_nodes_for_replace(
 }
 
 // Runs inside seastar::async context
-future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id) {
-    return seastar::async([this, &bootstrap_tokens, &cdc_gen_id, &cdc_gen_service] {
+future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id, const std::optional<locator::host_id>& replaced_host_id) {
+    return seastar::async([this, &bootstrap_tokens, &cdc_gen_id, &cdc_gen_service, &replaced_host_id] {
         auto bootstrap_rbno = is_repair_based_node_ops_enabled(streaming::stream_reason::bootstrap);
 
         set_mode(mode::BOOTSTRAP);
@@ -737,9 +739,11 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
             slogger.debug("Removing replaced endpoint {} from system.peers", *replace_addr);
             _sys_ks.local().remove_endpoint(*replace_addr).get();
 
-            slogger.info("Replace: removing {} from group 0...", *replace_addr);
+            assert(replaced_host_id);
+            auto raft_id = raft::server_id{replaced_host_id->uuid()};
+            slogger.info("Replace: removing {}/{} from group 0...", *replace_addr, raft_id);
             assert(_group0);
-            _group0->remove_from_group0(*replace_addr).get();
+            _group0->remove_from_group0(raft_id).get();
 
             slogger.info("Starting to bootstrap...");
             run_replace_ops(bootstrap_tokens);
@@ -2450,9 +2454,10 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
                     });
                 }).get();
 
-                slogger.info("removenode[{}]: removing node {} from group 0", uuid, endpoint);
+                auto raft_id = raft::server_id{host_id.uuid()};
+                slogger.info("removenode[{}]: removing node {}/{} from group 0", uuid, endpoint, raft_id);
                 assert(ss._group0);
-                ss._group0->remove_from_group0(endpoint).get();
+                ss._group0->remove_from_group0(raft_id).get();
 
                 slogger.info("removenode[{}]: Finished removenode operation, removing node={}, sync_nodes={}, ignore_nodes={}", uuid, endpoint, nodes, ignore_nodes);
             } catch (...) {
@@ -3373,7 +3378,7 @@ future<> storage_service::force_remove_completion() {
 
                     slogger.info("force_remove_completion: removing endpoint {} from group 0", endpoint);
                     assert(ss._group0);
-                    co_await ss._group0->remove_from_group0(endpoint);
+                    co_await ss._group0->remove_from_group0(raft::server_id{host_id.uuid()});
                 }
             } else {
                 slogger.warn("No tokens to force removal on, call 'removenode' first");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -414,10 +414,6 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     app_states.emplace(gms::application_state::NET_VERSION, versioned_value::network_version());
     app_states.emplace(gms::application_state::HOST_ID, versioned_value::host_id(local_host_id));
     app_states.emplace(gms::application_state::RPC_ADDRESS, versioned_value::rpcaddress(broadcast_rpc_address));
-    if (_group0->is_raft_enabled()) {
-        auto my_id = _group0->load_my_id();
-        app_states.emplace(gms::application_state::RAFT_SERVER_ID, versioned_value::raft_server_id(my_id.id));
-    }
     app_states.emplace(gms::application_state::RELEASE_VERSION, versioned_value::release_version());
     app_states.emplace(gms::application_state::SUPPORTED_FEATURES, versioned_value::supported_features(features));
     app_states.emplace(gms::application_state::CACHE_HITRATES, versioned_value::cache_hitrates(""));
@@ -1327,13 +1323,6 @@ future<> storage_service::do_update_system_peers_table(gms::inet_address endpoin
         co_await update_table(endpoint, "schema_version", utils::UUID(value.value));
     } else if (state == application_state::HOST_ID) {
         co_await update_table(endpoint, "host_id", utils::UUID(value.value));
-    } else if (state == application_state::RAFT_SERVER_ID && _feature_service.supports_raft_cluster_mgmt) {
-        auto server_id = utils::UUID(value.value);
-        if (server_id == utils::UUID{}) {
-            slogger.error("empty raft server id in application state for host {} ", endpoint);
-        } else {
-            co_await update_table(endpoint, "raft_server_id", server_id);
-        }
     } else if (state == application_state::SUPPORTED_FEATURES) {
         co_await update_table(endpoint, "supported_features", value.value);
     }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -368,7 +368,7 @@ private:
     // Stream data for which we become a new replica.
     // Before that, if we're not replacing another node, inform other nodes about our chosen tokens
     // and wait for RING_DELAY ms so that we receive new writes from coordinators during streaming.
-    future<> bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id);
+    future<> bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id, const std::optional<locator::host_id>& replaced_host_id);
 
 public:
     /**

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -293,8 +293,7 @@ private:
     struct replacement_info {
         std::unordered_set<token> tokens;
         locator::endpoint_dc_rack dc_rack;
-        // Present only if Raft is enabled.
-        std::optional<raft::server_id> raft_id;
+        locator::host_id host_id;
     };
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -786,7 +786,7 @@ public:
             }).get();
 
             if (raft_gr.local().is_enabled()) {
-                auto my_raft_id = service::load_or_create_my_raft_id(sys_ks.local()).get();
+                auto my_raft_id = raft::server_id{cfg->host_id.uuid()};
                 raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {
                     return raft_gr.start(my_raft_id);
                 }).get();


### PR DESCRIPTION
Thanks to #12250, Host IDs uniquely identify nodes. We can use them as Raft IDs which simplifies the code and makes reasoning about it easier, because Host IDs are always guaranteed to be present (while Raft IDs may be missing during upgrade).

Fixes: https://github.com/scylladb/scylladb/issues/12204