### PR TITLE
docs: move documentation of tools online

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -24,9 +24,6 @@ Currently, SStableDump_ works better on production systems as it automatically l
 Usage
 ------
 
-Syntax
-^^^^^^
-
 The command syntax is as follows:
 
 .. code-block:: console
@@ -37,7 +34,7 @@ The command syntax is as follows:
 You can specify more than one SStable.
 
 Schema
-^^^^^^
+------
 All operations need a schema to interpret the SStables with.
 Currently, there are two ways to obtain the schema:
 
@@ -75,7 +72,7 @@ Note:
 * The schema file doesn't have to be called ``schema.cql``, this is just the default name. Any file name is supported (with any extension).
 
 Dropped columns
-***************
+^^^^^^^^^^^^^^^
 
 The examined sstable might have columns which were dropped from the schema definition. In this case providing the up-do-date schema will not be enough, the tool will fail when attempting to process a cell for the dropped column.
 Dropped columns can be provided to the tool in the form of insert statements into the ``system_schema.dropped_columns`` system table, in the schema definition file. Example:
@@ -99,7 +96,7 @@ Dropped columns can be provided to the tool in the form of insert statements int
     CREATE TABLE ks.cf (pk int PRIMARY KEY, v2 int);
 
 System tables
-*************
+^^^^^^^^^^^^^
 
 If the examined table is a system table -- it belongs to one of the system keyspaces (``system``, ``system_schema``, ``system_distributed`` or ``system_distributed_everywhere``) -- you can just tell the tool to use the known built-in definition of said table. This is possible with the ``--system-schema`` flag. Example:
 
@@ -108,7 +105,7 @@ If the examined table is a system table -- it belongs to one of the system keysp
     scylla sstable dump-data --system-schema system.local ./path/to/md-123456-big-Data.db
 
 Supported Operations
-^^^^^^^^^^^^^^^^^^^^^^^
+--------------------
 The ``dump-*`` operations output JSON. For ``dump-data``, you can specify another output format.
 
 * ``dump-data`` - Dumps the content of the SStable. You can use it with additional parameters:
@@ -132,7 +129,7 @@ The ``dump-*`` operations output JSON. For ``dump-data``, you can specify anothe
 * ``decompress`` - Decompresses the data component of the SStable (the ``*-Data.db`` file) if compressed. The decompressed data is written to a ``*-Data.decompressed`` file.
 
 Examples
-^^^^^^^^
+--------
 Dumping the content of the SStable:
 
 .. code-block:: console

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -135,27 +135,487 @@ The stream is strictly ordered:
 
 Supported Operations
 --------------------
-The ``dump-*`` operations output JSON. For ``dump-data``, you can specify another output format.
 
-* ``dump-data`` - Dumps the content of the SStable. You can use it with additional parameters:
+dump-data
+^^^^^^^^^
 
-   * ``--merge`` - Allows you to process multiple SStables as a unified stream (if not specified, multiple SStables are processed one by one). 
-   * ``--partition={{<partition key>}}`` or ``partitions-file={{<partition key>}}`` - Allows you to narrow down the scope of the operation to specified partitions. To specify the partition(s) you want to be processed, provide partition keys in the hexdump format used by ScyllaDB (the hex representation of the raw buffer).
-   * ``--output-format=<format>`` - Allows you to specify the output format: ``json`` or ``text``.
+Dumps the content of the data component (the component that contains the data-proper
+of the SStable). This operation might produce a huge amount of output. In general, the
+human-readable output will be larger than the binary file.
 
-* ``dump-index`` - Dumps the content of the SStable index.
-* ``dump-compression-info`` - Dumps the SStable compression information, including compression parameters and mappings between 
-  compressed and uncompressed data.
-* ``dump-summary`` - Dumps the summary of the SStable index.
-* ``dump-statistics`` - Dumps the statistics of the SStable, including metadata about the data component.
-* ``dump-scylla-metadata`` - Dumps the SStable's scylla-specific metadata.
-* ``writetime-histogram`` - Generates a histogram of all the timestamps in the SStable. You can use it with a parameter:
+It is possible to filter the data to print via the ``--partitions`` or
+``--partitions-file`` options. Both expect partition key values in the hexdump
+format.
 
-   * ``--bucket=<unit>`` - Allows you to specify the unit of time to be used as bucket (years, months, weeks, days, or hours).
+Supports both a text and JSON output. The text output uses the built-in Scylla
+printers, which are also used when logging mutation-related data structures.
 
-* ``validate`` - Validates the content of the SStable with the mutation fragment stream validator.
-* ``validate-checksums`` - Validates SStable checksums (full checksum and per-chunk checksum) against the SStable data.
-* ``decompress`` - Decompresses the data component of the SStable (the ``*-Data.db`` file) if compressed. The decompressed data is written to a ``*-Data.decompressed`` file.
+The schema of the JSON output is the following:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := $NON_MERGED_ROOT | $MERGED_ROOT
+
+    $NON_MERGED_ROOT := { "$sstable_path": $SSTABLE, ... } // without --merge
+
+    $MERGED_ROOT := { "anonymous": $SSTABLE } // with --merge
+
+    $SSTABLE := [$PARTITION, ...]
+
+    $PARTITION := {
+        "key": {
+            "token": String,
+            "raw": String, // hexadecimal representation of the raw binary
+            "value": String
+        },
+        "tombstone: $TOMBSTONE, // optional
+        "static_row": $COLUMNS, // optional
+        "clustering_elements": [
+            $CLUSTERING_ROW | $RANGE_TOMBSTONE_CHANGE,
+            ...
+        ]
+    }
+
+    $TOMBSTONE := {
+        "timestamp": Int64,
+        "deletion_time": String // YYYY-MM-DD HH:MM:SS
+    }
+
+    $COLUMNS := {
+        "$column_name": $REGULAR_CELL | $COUNTER_SHARDS_CELL | $COUNTER_UPDATE_CELL | $FROZEN_COLLECTION | $COLLECTION,
+        ...
+    }
+
+    $REGULAR_CELL := {
+        "is_live": Bool, // is the cell live or not
+        "type": "regular",
+        "timestamp": Int64,
+        "ttl": String, // gc_clock::duration - optional
+        "expiry": String, // YYYY-MM-DD HH:MM:SS - optional
+        "value": String // only if is_live == true
+    }
+
+    $COUNTER_SHARDS_CELL := {
+        "is_live": true,
+        "type": "counter-shards",
+        "timestamp": Int64,
+        "value": [$COUNTER_SHARD, ...]
+    }
+
+    $COUNTER_SHARD := {
+        "id": String, // UUID
+        "value": Int64,
+        "clock": Int64
+    }
+
+    $COUNTER_UPDATE_CELL := {
+        "is_live": true,
+        "type": "counter-update",
+        "timestamp": Int64,
+        "value": Int64
+    }
+
+    $FROZEN_COLLECTION is the same as a $REGULAR_CELL, with type = "frozen-collection".
+
+    $COLLECTION := {
+        "type": "collection",
+        "tombstone": $TOMBSTONE, // optional
+        "cells": [
+            {
+                "key": String,
+                "value": $REGULAR_CELL
+            },
+            ...
+        ]
+    }
+
+    $CLUSTERING_ROW := {
+        "type": "clustering-row",
+        "key": {
+            "raw": String, // hexadecimal representation of the raw binary
+            "value": String
+        },
+        "tombstone": $TOMBSTONE, // optional
+        "shadowable_tombstone": $TOMBSTONE, // optional
+        "marker": { // optional
+            "timestamp": Int64,
+            "ttl": String, // gc_clock::duration
+            "expiry": String // YYYY-MM-DD HH:MM:SS
+        },
+        "columns": $COLUMNS
+    }
+
+    $RANGE_TOMBSTONE_CHANGE := {
+        "type": "range-tombstone-change",
+        "key": { // optional
+            "raw": String, // hexadecimal representation of the raw binary
+            "value": String
+        },
+        "weight": Int, // -1 or 1
+        "tombstone": $TOMBSTONE
+    }
+
+dump-index
+^^^^^^^^^^
+
+Dumps the content of the index component. It the partition-index of the data
+component, which is effectively a list of all the partitions in the SStable, with
+their starting position in the data component and, optionally, a promoted index.
+The promoted index contains a sampled index of the clustering rows in the partition.
+Positions (both that of partition and that of rows) are valid for uncompressed
+data.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := [$INDEX_ENTRY, ...]
+
+    $INDEX_ENTRY := {
+        "key": {
+            "raw": String, // hexadecimal representation of the raw binary
+            "value": String
+        },
+        "pos": Uint64
+    }
+    )",
+                dump_index_operation},
+    /* dump-compression-info */
+        {"dump-compression-info",
+                "Dump content of sstable compression info(s)",
+    R"(
+    Dumps the content of the compression-info component. Contains compression
+    parameters and maps positions into the uncompressed data to that into compressed
+    data. Note that compression happens over chunks with configurable size, so to
+    get data at a position in the middle of a compressed chunk, the entire chunk has
+    to be decompressed.
+    For more information about the sstable components and the format itself, visit
+    https://docs.scylladb.com/architecture/sstable/.
+
+    The content is dumped in JSON, using the following schema:
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := {
+        "name": String,
+        "options": {
+            "$option_name": String,
+            ...
+        },
+        "chunk_len": Uint,
+        "data_len": Uint64,
+        "offsets": [Uint64, ...]
+    }
+
+dump-compression-info
+^^^^^^^^^^^^^^^^^^^^^
+
+Dumps the content of the compression-info component. It contains compression
+parameters and maps positions into the uncompressed data to that into compressed
+data. Note that compression happens over chunks with configurable size, so to
+get data at a position in the middle of a compressed chunk, the entire chunk has
+to be decompressed.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := {
+        "name": String,
+        "options": {
+            "$option_name": String,
+            ...
+        },
+        "chunk_len": Uint,
+        "data_len": Uint64,
+        "offsets": [Uint64, ...]
+    }
+
+dump-summary
+^^^^^^^^^^^^
+
+Dumps the content of the summary component. The summary is a sampled index of the
+content of the index-component (an index of the index). The sampling rate is chosen
+such that this file is small enough to be kept in memory even for very large
+SStables.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := {
+        "header": {
+            "min_index_interval": Uint64,
+            "size": Uint64,
+            "memory_size": Uint64,
+            "sampling_level": Uint64,
+            "size_at_full_sampling": Uint64
+        },
+        "positions": [Uint64, ...],
+        "entries": [$SUMMARY_ENTRY, ...],
+        "first_key": $KEY,
+        "last_key": $KEY
+    }
+
+    $SUMMARY_ENTRY := {
+        "key": $DECORATED_KEY,
+        "position": Uint64
+    }
+
+    $DECORATED_KEY := {
+        "token": String,
+        "raw": String, // hexadecimal representation of the raw binary
+        "value": String
+    }
+
+    $KEY := {
+        "raw": String, // hexadecimal representation of the raw binary
+        "value": String
+    }
+
+dump-statistics
+^^^^^^^^^^^^^^^
+
+Dumps the content of the statistics component. It contains various metadata about the
+data component. In the SStable 3 format, this component is critical for parsing
+the data component.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := {
+        "offsets": {
+            "$metadata": Uint,
+            ...
+        },
+        "validation": $VALIDATION_METADATA,
+        "compaction": $COMPACTION_METADATA,
+        "stats": $STATS_METADATA,
+        "serialization_header": $SERIALIZATION_HEADER // >= MC only
+    }
+
+    $VALIDATION_METADATA := {
+        "partitioner": String,
+        "filter_chance": Double
+    }
+
+    $COMPACTION_METADATA := {
+        "ancestors": [Uint, ...], // < MC only
+        "cardinality": [Uint, ...]
+    }
+
+    $STATS_METADATA := {
+        "estimated_partition_size": $ESTIMATED_HISTOGRAM,
+        "estimated_cells_count": $ESTIMATED_HISTOGRAM,
+        "position": $REPLAY_POSITION,
+        "min_timestamp": Int64,
+        "max_timestamp": Int64,
+        "min_local_deletion_time": Int64, // >= MC only
+        "max_local_deletion_time": Int64,
+        "min_ttl": Int64, // >= MC only
+        "max_ttl": Int64, // >= MC only
+        "compression_ratio": Double,
+        "estimated_tombstone_drop_time": $STREAMING_HISTOGRAM,
+        "sstable_level": Uint,
+        "repaired_at": Uint64,
+        "min_column_names": [Uint, ...],
+        "max_column_names": [Uint, ...],
+        "has_legacy_counter_shards": Bool,
+        "columns_count": Int64, // >= MC only
+        "rows_count": Int64, // >= MC only
+        "commitlog_lower_bound": $REPLAY_POSITION, // >= MC only
+        "commitlog_intervals": [$COMMITLOG_INTERVAL, ...] // >= MC only
+    }
+
+    $ESTIMATED_HISTOGRAM := [$ESTIMATED_HISTOGRAM_BUCKET, ...]
+
+    $ESTIMATED_HISTOGRAM_BUCKET := {
+        "offset": Int64,
+        "value": Int64
+    }
+
+    $STREAMING_HISTOGRAM := {
+        "$key": Uint64,
+        ...
+    }
+
+    $REPLAY_POSITION := {
+        "id": Uint64,
+        "pos": Uint
+    }
+
+    $COMMITLOG_INTERVAL := {
+        "start": $REPLAY_POSITION,
+        "end": $REPLAY_POSITION
+    }
+
+    $SERIALIZATION_HEADER_METADATA := {
+        "min_timestamp_base": Uint64,
+        "min_local_deletion_time_base": Uint64,
+        "min_ttl_base": Uint64",
+        "pk_type_name": String,
+        "clustering_key_types_names": [String, ...],
+        "static_columns": [$COLUMN_DESC, ...],
+        "regular_columns": [$COLUMN_DESC, ...],
+    }
+
+    $COLUMN_DESC := {
+        "name": String,
+        "type_name": String
+    }
+
+dump-scylla-metadata
+^^^^^^^^^^^^^^^^^^^^
+
+Dumps the content of the scylla-metadata component. Contains Scylla-specific
+metadata about the data component. This component won't be present in SStables
+produced by Apache Cassandra.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $SSTABLE, ... }
+
+    $SSTABLE := {
+        "sharding": [$SHARDING_METADATA, ...],
+        "features": $FEATURES_METADATA,
+        "extension_attributes": { "$key": String, ...}
+        "run_identifier": String, // UUID
+        "large_data_stats": {"$key": $LARGE_DATA_STATS_METADATA, ...}
+        "sstable_origin": String
+    }
+
+    $SHARDING_METADATA := {
+        "left": {
+            "exclusive": Bool,
+            "token": String
+        },
+        "right": {
+            "exclusive": Bool,
+            "token": String
+        }
+    }
+
+    $FEATURES_METADATA := {
+        "mask": Uint64,
+        "features": [String, ...]
+    }
+
+    $LARGE_DATA_STATS_METADATA := {
+        "max_value": Uint64,
+        "threshold": Uint64,
+        "above_threshold": Uint
+    }
+
+validate
+^^^^^^^^
+
+Validates the content of the sstable on the mutation-fragment level, see `sstable content <scylla-sstable-sstable-content_>`_ for more details.
+Any parsing errors will also be detected, but after successful parsing the validation will happen on the fragment level.
+The following things are validated:
+
+* Partitions are ordered in strictly monotonic ascending order.
+* Fragments are correctly ordered.
+* Clustering elements are ordered according in a strictly increasing clustering order as defined by the schema.
+* All range deletions are properly terminated with a corresponding end bound.
+* The stream ends with a partition-end fragment.
+
+Any errors found will be logged with error level to ``stderr``.
+
+validate-checksums
+^^^^^^^^^^^^^^^^^^
+
+There are two kinds of checksums for SStable data files:
+* The digest (full checksum), stored in the ``Digest.crc32`` file. It is calculated over the entire content of ``Data.db``.
+* The per-chunk checksum. For uncompressed SStables, it is stored in ``CRC.db``; for compressed SStables, it is stored inline after each compressed chunk in ``Data.db``.
+
+During normal reads, ScyllaDB validates the per-chunk checksum for compressed SStables.
+The digest and the per-chunk checksum of uncompressed SStables are currently not checked on any code paths.
+
+This operation reads the entire ``Data.db`` and validates both kinds of checksums against the data.
+Errors found are logged to stderr. The output contains a bool for each SStable that is true if the SStable matches all checksums.
+
+The content is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": Bool, ... }
+
+decompress
+^^^^^^^^^^
+
+Decompress Data.db if compressed (no-op if not compressed). The decompressed data is written to Data.db.decompressed.
+For example, for the SStable:
+
+.. code-block:: console
+    :class: hide-copy-button
+
+    md-12311-big-Data.db
+
+the output will be:
+
+.. code-block:: console
+    :class: hide-copy-button
+
+    md-12311-big-Data.db.decompressed
+
+write
+^^^^^
+
+Writes an SStable based on a JSON representation of the content.
+The JSON representation has to have the same schema as that of a single SStable from the output of the `dump-data operation <dump-data_>`_ (corresponding to the ``$SSTABLE`` symbol).
+The easiest way to get started with writing your own SStable is to dump an existing SStable, modify the JSON then invoke this operation with the result.
+You can feed the output of dump-data to write by filtering the output of the former with ``jq .sstables[]``:
+
+.. code-block:: console
+
+    scylla sstable dump-data --system-schema system_schema.columns /path/to/me-14-big-Data.db | jq .sstables[] > input.json
+    scylla sstable write --system-schema system_schema.columns --input-file ./input.json --generation 0
+    scylla sstable dump-data --system-schema system_schema.columns ./me-0-big-Data.db | jq .sstables[] > dump.json
+
+At the end of the above, ``input.json`` and ``dump.json`` will have the same content.
+
+Note that `write` doesn't yet support all the features of the ScyllaDB storage engine. The following are not supported:
+
+* Counters.
+* Non-strictly atomic cells, including frozen multi-cell types like collections, tuples, and UDTs.
+
+Parsing uses a streaming JSON parser, it is safe to pass in input files of any size.
+
+The output SStable will use the BIG format, the highest supported SStable format, and the specified generation (``--generation``).
+By default, it is placed in the local directory, which can be changed with ``--output-dir``.
+If the output SStable clashes with an existing SStable, the write will fail.
+
+The output is validated before being written to the disk.
+The validation done here is similar to that done by the `validate operation <validate_>`_.
+The level of validation can be changed with the ``--validation-level`` flag.
+Possible validation-levels are:
+
+* ``partition_region`` - Only checks fragment types, e.g., that a partition-end is followed by partition-start or EOS.
+* ``token`` - In addition, checks the token order of partitions.
+* ``partition_key`` - Full check on partition ordering.
+* ``clustering_key`` - In addition, checks clustering element ordering.
+
+Note that levels are cumulative - each contains all the checks of the previous levels, too.
+By default, the strictest level is used.
+This can be relaxed, for example, if you want to produce intentionally corrupt SStables for tests.
 
 Examples
 --------

--- a/docs/operating-scylla/admin-tools/scylla-types.rst
+++ b/docs/operating-scylla/admin-tools/scylla-types.rst
@@ -13,9 +13,6 @@ Run ``scylla types --help`` for additional information about the tool and the op
 Usage
 ------
 
-Syntax
-^^^^^^
-
 The command syntax is as follows:
 
 .. code-block:: console
@@ -31,7 +28,7 @@ The command syntax is as follows:
 .. _scylla-types-type:
 
 Specifying the Value Type
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
 You must specify the type of the value(s) you want to examine by adding the ``-t [type name]`` option to the operation. 
 Specify the type by providing its Cassandra class name (the prefix can be omitted, for example, you can provide ``Int32Type`` 
@@ -63,7 +60,7 @@ of the types on the command line must be the same as the order in the compound).
 .. _scylla-types-operations:
 
 Supported Operations
-^^^^^^^^^^^^^^^^^^^^^^^
+--------------------
 * ``serialize`` - Serialize the value and prints it in a hex encoded form. Required arguments: 1 value in human-readable form. To avoid problems around special symbols, separate values with ``--`` from the rest of the arguments.
 * ``deserialize`` - Deserializes and prints the provided value in a human-readable form. Required arguments: 1 or more serialized values.
 * ``compare`` - Compares two values and prints the result. Required arguments: 2 serialized values.
@@ -81,7 +78,7 @@ You can learn more about each operation by invoking its help:
 .. _scylla-types-options:
 
 Additional Options
-^^^^^^^^^^^^^^^^^^^
+------------------
 
 You can run ``scylla types [operation] --help`` for additional information on a given operation.
 
@@ -94,7 +91,7 @@ You can run ``scylla types [operation] --help`` for additional information on a 
 * ``--value arg`` - Specifies the value to process (if not provided as a positional argument).
 
 Examples
-^^^^^^^^
+--------
 * Serializing a value of type Int32Type:
 
     .. code-block:: console

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2537,8 +2537,6 @@ R"(
 Dump the content of the data component. This component contains the data-proper
 of the sstable. This might produce a huge amount of output. In general the
 human-readable output will be larger than the binary file.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
 It is possible to filter the data to print via the --partitions or
 --partitions-file options. Both expect partition key values in the hexdump
@@ -2547,108 +2545,8 @@ format.
 Supports both a text and JSON output. The text output uses the built-in scylla
 printers, which are also used when logging mutation-related data structures.
 
-The schema of the JSON output is the following:
-
-$ROOT := $NON_MERGED_ROOT | $MERGED_ROOT
-
-$NON_MERGED_ROOT := { "$sstable_path": $SSTABLE, ... } // without --merge
-
-$MERGED_ROOT := { "anonymous": $SSTABLE } // with --merge
-
-$SSTABLE := [$PARTITION, ...]
-
-$PARTITION := {
-    "key": {
-        "token": String,
-        "raw": String, // hexadecimal representation of the raw binary
-        "value": String
-    },
-    "tombstone: $TOMBSTONE, // optional
-    "static_row": $COLUMNS, // optional
-    "clustering_elements": [
-        $CLUSTERING_ROW | $RANGE_TOMBSTONE_CHANGE,
-        ...
-    ]
-}
-
-$TOMBSTONE := {
-    "timestamp": Int64,
-    "deletion_time": String // YYYY-MM-DD HH:MM:SS
-}
-
-$COLUMNS := {
-    "$column_name": $REGULAR_CELL | $COUNTER_SHARDS_CELL | $COUNTER_UPDATE_CELL | $FROZEN_COLLECTION | $COLLECTION,
-    ...
-}
-
-$REGULAR_CELL := {
-    "is_live": Bool, // is the cell live or not
-    "type": "regular",
-    "timestamp": Int64,
-    "ttl": String, // gc_clock::duration - optional
-    "expiry": String, // YYYY-MM-DD HH:MM:SS - optional
-    "value": String // only if is_live == true
-}
-
-$COUNTER_SHARDS_CELL := {
-    "is_live": true,
-    "type": "counter-shards",
-    "timestamp": Int64,
-    "value": [$COUNTER_SHARD, ...]
-}
-
-$COUNTER_SHARD := {
-    "id": String, // UUID
-    "value": Int64,
-    "clock": Int64
-}
-
-$COUNTER_UPDATE_CELL := {
-    "is_live": true,
-    "type": "counter-update",
-    "timestamp": Int64,
-    "value": Int64
-}
-
-$FROZEN_COLLECTION is the same as a $REGULAR_CELL, with type = "frozen-collection".
-
-$COLLECTION := {
-    "type": "collection",
-    "tombstone": $TOMBSTONE, // optional
-    "cells": [
-        {
-            "key": String,
-            "value": $REGULAR_CELL
-        },
-        ...
-    ]
-}
-
-$CLUSTERING_ROW := {
-    "type": "clustering-row",
-    "key": {
-        "raw": String, // hexadecimal representation of the raw binary
-        "value": String
-    },
-    "tombstone": $TOMBSTONE, // optional
-    "shadowable_tombstone": $TOMBSTONE, // optional
-    "marker": { // optional
-        "timestamp": Int64,
-        "ttl": String, // gc_clock::duration
-        "expiry": String // YYYY-MM-DD HH:MM:SS
-    },
-    "columns": $COLUMNS
-}
-
-$RANGE_TOMBSTONE_CHANGE := {
-    "type": "range-tombstone-change",
-    "key": { // optional
-        "raw": String, // hexadecimal representation of the raw binary
-        "value": String
-    },
-    "weight": Int, // -1 or 1
-    "tombstone": $TOMBSTONE
-}
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-data
+for more information on this operation, including the schema of the JSON output.
 )",
             {"partition", "partitions-file", "merge", "no-skips", "output-format"},
             sstable_consumer_operation<dumping_consumer>},
@@ -2662,22 +2560,9 @@ their starting position in the data component and optionally a promoted index,
 which contains a sampled index of the clustering rows in the partition.
 Positions (both that of partition and that of rows) is valid for uncompressed
 data.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
-The content is dumped in JSON, using the following schema:
-
-$ROOT := { "$sstable_path": $SSTABLE, ... }
-
-$SSTABLE := [$INDEX_ENTRY, ...]
-
-$INDEX_ENTRY := {
-    "key": {
-        "raw": String, // hexadecimal representation of the raw binary
-        "value": String
-    },
-    "pos": Uint64
-}
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-index
+for more information on this operation, including the schema of the JSON output.
 )",
             dump_index_operation},
 /* dump-compression-info */
@@ -2689,23 +2574,9 @@ parameters and maps positions into the uncompressed data to that into compressed
 data. Note that compression happens over chunks with configurable size, so to
 get data at a position in the middle of a compressed chunk, the entire chunk has
 to be decompressed.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
-The content is dumped in JSON, using the following schema:
-
-$ROOT := { "$sstable_path": $SSTABLE, ... }
-
-$SSTABLE := {
-    "name": String,
-    "options": {
-        "$option_name": String,
-        ...
-    },
-    "chunk_len": Uint,
-    "data_len": Uint64,
-    "offsets": [Uint64, ...]
-}
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-compression-info
+for more information on this operation, including the schema of the JSON output.
 )",
             dump_compression_info_operation},
 /* dump-summary */
@@ -2716,42 +2587,10 @@ Dump the content of the summary component. The summary is a sampled index of the
 content of the index-component. An index of the index. Sampling rate is chosen
 such that this file is small enough to be kept in memory even for very large
 sstables.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
-The content is dumped in JSON, using the following schema:
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-summary
+for more information on this operation, including the schema of the JSON output.
 
-$ROOT := { "$sstable_path": $SSTABLE, ... }
-
-$SSTABLE := {
-    "header": {
-        "min_index_interval": Uint64,
-        "size": Uint64,
-        "memory_size": Uint64,
-        "sampling_level": Uint64,
-        "size_at_full_sampling": Uint64
-    },
-    "positions": [Uint64, ...],
-    "entries": [$SUMMARY_ENTRY, ...],
-    "first_key": $KEY,
-    "last_key": $KEY
-}
-
-$SUMMARY_ENTRY := {
-    "key": $DECORATED_KEY,
-    "position": Uint64
-}
-
-$DECORATED_KEY := {
-    "token": String,
-    "raw": String, // hexadecimal representation of the raw binary
-    "value": String
-}
-
-$KEY := {
-    "raw": String, // hexadecimal representation of the raw binary
-    "value": String
-}
 )",
             dump_summary_operation},
 /* dump-statistics */
@@ -2761,93 +2600,9 @@ R"(
 Dump the content of the statistics component. Contains various metadata about the
 data component. In the sstable 3 format, this component is critical for parsing
 the data component.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
-The content is dumped in JSON, using the following schema:
-
-$ROOT := { "$sstable_path": $SSTABLE, ... }
-
-$SSTABLE := {
-    "offsets": {
-        "$metadata": Uint,
-        ...
-    },
-    "validation": $VALIDATION_METADATA,
-    "compaction": $COMPACTION_METADATA,
-    "stats": $STATS_METADATA,
-    "serialization_header": $SERIALIZATION_HEADER // >= MC only
-}
-
-$VALIDATION_METADATA := {
-    "partitioner": String,
-    "filter_chance": Double
-}
-
-$COMPACTION_METADATA := {
-    "ancestors": [Uint, ...], // < MC only
-    "cardinality": [Uint, ...]
-}
-
-$STATS_METADATA := {
-    "estimated_partition_size": $ESTIMATED_HISTOGRAM,
-    "estimated_cells_count": $ESTIMATED_HISTOGRAM,
-    "position": $REPLAY_POSITION,
-    "min_timestamp": Int64,
-    "max_timestamp": Int64,
-    "min_local_deletion_time": Int64, // >= MC only
-    "max_local_deletion_time": Int64,
-    "min_ttl": Int64, // >= MC only
-    "max_ttl": Int64, // >= MC only
-    "compression_ratio": Double,
-    "estimated_tombstone_drop_time": $STREAMING_HISTOGRAM,
-    "sstable_level": Uint,
-    "repaired_at": Uint64,
-    "min_column_names": [Uint, ...],
-    "max_column_names": [Uint, ...],
-    "has_legacy_counter_shards": Bool,
-    "columns_count": Int64, // >= MC only
-    "rows_count": Int64, // >= MC only
-    "commitlog_lower_bound": $REPLAY_POSITION, // >= MC only
-    "commitlog_intervals": [$COMMITLOG_INTERVAL, ...] // >= MC only
-}
-
-$ESTIMATED_HISTOGRAM := [$ESTIMATED_HISTOGRAM_BUCKET, ...]
-
-$ESTIMATED_HISTOGRAM_BUCKET := {
-    "offset": Int64,
-    "value": Int64
-}
-
-$STREAMING_HISTOGRAM := {
-    "$key": Uint64,
-    ...
-}
-
-$REPLAY_POSITION := {
-    "id": Uint64,
-    "pos": Uint
-}
-
-$COMMITLOG_INTERVAL := {
-    "start": $REPLAY_POSITION,
-    "end": $REPLAY_POSITION
-}
-
-$SERIALIZATION_HEADER_METADATA := {
-    "min_timestamp_base": Uint64,
-    "min_local_deletion_time_base": Uint64,
-    "min_ttl_base": Uint64",
-    "pk_type_name": String,
-    "clustering_key_types_names": [String, ...],
-    "static_columns": [$COLUMN_DESC, ...],
-    "regular_columns": [$COLUMN_DESC, ...],
-}
-
-$COLUMN_DESC := {
-    "name": String,
-    "type_name": String
-}
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-statistics
+for more information on this operation, including the schema of the JSON output.
 )",
             dump_statistics_operation},
 /* dump-scylla-metadata */
@@ -2857,43 +2612,9 @@ R"(
 Dump the content of the scylla-metadata component. Contains scylla-specific
 metadata about the data component. This component won't be present in sstables
 produced by Apache Cassandra.
-For more information about the sstable components and the format itself, visit
-https://docs.scylladb.com/architecture/sstable/.
 
-The content is dumped in JSON, using the following schema:
-
-$ROOT := { "$sstable_path": $SSTABLE, ... }
-
-$SSTABLE := {
-    "sharding": [$SHARDING_METADATA, ...],
-    "features": $FEATURES_METADATA,
-    "extension_attributes": { "$key": String, ...}
-    "run_identifier": String, // UUID
-    "large_data_stats": {"$key": $LARGE_DATA_STATS_METADATA, ...}
-    "sstable_origin": String
-}
-
-$SHARDING_METADATA := {
-    "left": {
-        "exclusive": Bool,
-        "token": String
-    },
-    "right": {
-        "exclusive": Bool,
-        "token": String
-    }
-}
-
-$FEATURES_METADATA := {
-    "mask": Uint64,
-    "features": [String, ...]
-}
-
-$LARGE_DATA_STATS_METADATA := {
-    "max_value": Uint64,
-    "threshold": Uint64,
-    "above_threshold": Uint
-}
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-scylla-metadata
+for more information on this operation, including the schema of the JSON output.
 )",
             dump_scylla_metadata_operation},
 /* writetime-histogram */
@@ -2952,60 +2673,25 @@ support soon (don't quote me on that).
     {"validate",
             "Validate the sstable(s), same as scrub in validate mode",
 R"(
-On a conceptual level, the data in sstables is represented by objects called
-mutation fragments. We have the following kinds of fragments:
-* partition-start (1)
-* static-row (0-1)
-* clustering-row (0-N)
-* range-tombstone/range-tombstone-change (0-N)
-* partition-end (1)
+Validates the content of the sstable on the mutation-fragment level, see
+https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#sstable-content
+for more details.
+Any parsing errors will also be detected, but after successful parsing the
+validation will happen on the fragment level.
 
-Data from the sstable is parsed into these fragments. We use these fragments to
-stream data because it allows us to represent as little as part of a partition
-or as many as the entire content of an sstable.
-
-This operation validates data on the mutation-fragment level. Any parsing errors
-will also be detected, but after successful parsing the validation will happen
-on the fragment level. The following things are validated:
-* Partitions are ordered in strictly monotonic ascending order [1].
-* Fragments are correctly ordered. Fragments must follow the order defined in the
-  listing above also respecting the occurrence numbers within a partition. Note
-  that clustering rows and range tombstone [change] fragments can be intermingled.
-* Clustering elements are ordered according in a strictly increasing clustering
-  order as defined by the schema. Range tombstones (but not range tombstone
-  changes) are allowed to have weakly monotonically increasing positions.
-* The stream ends with a partition-end fragment.
-
-[1] Although partitions are said to be unordered, this is only true w.r.t. the
-data type of the key components. Partitions are ordered according to their tokens
-(hashes), so partitions are unordered in the sense that a hash-table is
-unordered: they have a random order as perceived by they user but they have a
-well defined internal order.
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#validate
+for more information on this operation.
 )",
             {"merge"},
             validate_operation},
     {"validate-checksums",
             "Validate the checksums of the sstable(s)",
 R"(
-There are two kinds of checksums for sstable data files:
-* The digest (full checksum), stored in the Digest.crc32 file. This is calculated
-  over the entire content of Data.db.
-* The per-chunk checksum. For uncompressed sstables, this is stored in CRC.db,
-  for compressed sstables it is stored inline after each compressed chunk in
-  Data.db.
+Validate both the whole-file and the per-chunk checksums checksums of the data
+component.
 
-During normal reads Scylla validates the per-chunk checksum for compressed
-sstables. The digest and the per-chunk checksum of uncompressed sstables are not
-checked on any code-paths currently.
-
-This operation reads the entire Data.db and validates both kind of checksums
-against the data. Errors found are logged to stderr. The output just contains a
-bool for each sstable that is true if the sstable matches all checksums.
-
-The content is dumped in JSON, using the following schema:
-
-$ROOT := { "$sstable_path": Bool, ... }
-
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#validate-checksums
+for more information on this operation.
 )",
             validate_checksums_operation},
     {"decompress",
@@ -3027,18 +2713,7 @@ R"(
 Write an sstable based on a JSON representation of the content. The JSON
 representation has to have the same schema as that of a single sstable
 from the output of the dump-data operation (corresponding to the $SSTABLE
-symbol). See the help of dump-data more details on the json schema.
-The easiest way to get started with writing your own sstable is to dump
-an existing sstable, modify the json then invoke this operation with the
-result. You can feed the output of dump-data to write by filtering the
-output of the former with `jq .sstables[]`:
-
-    $ scylla sstable dump-data --system-schema system_schema.columns /path/to/me-14-big-Data.db | jq .sstables[] > input.json
-    $ scylla sstable write --system-schema system_schema.columns --input-file ./input.json --generation 0
-    $ scylla sstable dump-data --system-schema system_schema.columns ./me-0-big-Data.db | jq .sstables[] > dump.json
-
-At the end of the above, `input.json` and `dump.json` will have the same
-content.
+symbol).
 
 Note that "write" doesn't yet support all the features of the scylladb
 storage engine. The following is not supported:
@@ -3054,20 +2729,8 @@ format and the specified generation (--generation). By default it is
 placed in the local directory, can be changed with --output-dir. If the
 output sstable clashes with an existing sstable, the write will fail.
 
-The output is validated before being written to the disk. The validation
-done here is similar to that done by the validate operation. The level
-of validation can be changed with the --validation-level flag.
-Possible validation-levels are:
-* partition_region - only check fragment types, e.g. that a
-  partition-end is followed by partition-start or EOS.
-* token - also check token order of partitions.
-* partition_key - full check on partition-ordering.
-* clustering_key - also check clustering element ordering.
-
-Note that levels are cumulative, each contains all the checks of the
-previous levels too. By default the strictest level is used. This can
-be relaxed if e.g. one wants to produce intentionally corrupt sstables
-for tests.
+See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#write
+for more information on this operation, including the schema of the JSON input.
 )",
             {"input-file", "output-dir", "generation", "validation-level"},
             write_operation},


### PR DESCRIPTION
Currently the scylla tools (`scylla-types` and `scylla-sstable`) have documentation in two places: high level documentation can be found at `docs/operating-scylla/admin-tools/scylla-{types,sstable}.rst`, while low level, more detailed documentation is embedded in the tool itself. This is especially pronounced for `scylla-sstable`, which only has a short description of its operations online, all details being found only in the command-line help.
We want to move away from this model, such that all documentation can be found online, with the command-line help being reserved to documenting how the various switches and flags work, on top of a short description of the operation and a link to the detailed online docs.