### PR TITLE
doc: mark the in-memory tables feature as deprecated

### DIFF
--- a/docs/using-scylla/in-memory.rst
+++ b/docs/using-scylla/in-memory.rst
@@ -5,6 +5,7 @@ Scylla in-memory tables
 :label-tip:`ScyllaDB Enterprise`
 
 .. versionadded:: 2018.1.7
+.. deprecated:: 2022.2.0
 
 Overview
 ========


### PR DESCRIPTION
Related: https://github.com/scylladb/scylla-enterprise/issues/2507