### PR TITLE
test.py: handle parsing failure for empty xml files

### DIFF
--- a/test.py
+++ b/test.py
@@ -1313,7 +1313,12 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
         for test in suite.tests:
             if test.mode != mode:
                 continue
-            test_xml = test.get_junit_etree()
+            try:
+                test_xml = test.get_junit_etree()
+            except ET.ParseError as e:
+                print(
+                    palette.warn(f'Failed to parse XML for {test.uname} with error: {e}')
+                )
             if test_xml is not None:
                 xml.extend(test_xml.getroot().findall('.//TestSuite'))
     et = ET.ElementTree(xml)


### PR DESCRIPTION
In case xunit file is empty, the `write_consolidated_boost_junit_xml` func
is failing on parsing the xml file and causes us to lose some of the XML
files as described in detailed on https://github.com/scylladb/scylla-pkg/issues/3196#issuecomment-1348683357

Fix https://github.com/scylladb/scylla-pkg/issues/3196