### PR TITLE
tasks: add virtual destructor to task_manager::module

### DIFF
--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -154,6 +154,7 @@ public:
         uint64_t _sequence_number = 0;
     public:
         module(task_manager& tm, std::string name) noexcept;
+        virtual ~module() = default;
 
         uint64_t new_sequence_number() noexcept;
         task_manager& get_task_manager() noexcept;


### PR DESCRIPTION
When an object of a class inheriting from task_manager::module
is destroyed, destructor of the derived class should be called.