### PR TITLE
repair: make shard tasks internal

### DIFF
--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -121,6 +121,9 @@ public:
             streaming::stream_reason reason_,
             abort_source* as,
             bool hints_batchlog_flushed);
+    virtual tasks::is_internal is_internal() const noexcept override {
+        return tasks::is_internal::yes;
+    }
     void check_failed_ranges();
     void abort_repair_info() noexcept;
     void check_in_abort();


### PR DESCRIPTION
Shard tasks should not be visible to users by default, thus they are made internal.