### PR TITLE
db: commitlog: remove unused max_active_writes()

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1354,11 +1354,6 @@ db::commitlog::segment_manager::segment_manager(config c)
             cfg.commit_log_location = "/var/lib/scylla/commitlog";
         }
 
-        if (cfg.max_active_writes == 0) {
-            cfg.max_active_writes = // TODO: call someone to get an idea...
-                            25 * smp::count;
-        }
-        cfg.max_active_writes = std::max(uint64_t(1), cfg.max_active_writes / smp::count);
         if (cfg.max_active_flushes == 0) {
             cfg.max_active_flushes = // TODO: call someone to get an idea...
                             5 * smp::count;
@@ -2527,10 +2522,6 @@ future<> db::commitlog::release() {
 
 size_t db::commitlog::max_record_size() const {
     return _segment_manager->max_mutation_size - segment::entry_overhead_size;
-}
-
-uint64_t db::commitlog::max_active_writes() const {
-    return _segment_manager->cfg.max_active_writes;
 }
 
 uint64_t db::commitlog::max_active_flushes() const {

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -98,9 +98,8 @@ public:
         // Max number of segments to keep in pre-alloc reserve.
         // Not (yet) configurable from scylla.conf.
         uint64_t max_reserve_segments = 12;
-        // Max active writes/flushes. Default value
+        // Max active flushes. Default value
         // zero means try to figure it out ourselves
-        uint64_t max_active_writes = 0;
         uint64_t max_active_flushes = 0;
 
         sync_mode mode = sync_mode::PERIODIC;
@@ -307,10 +306,6 @@ public:
      */
     size_t max_record_size() const;
 
-    /**
-     * Return max allowed pending writes (per this shard)
-     */
-    uint64_t max_active_writes() const;
     /**
      * Return max allowed pending flushes (per this shard)
      */


### PR DESCRIPTION
Dead and misleading code.