### PR TITLE
test: cql-pytest: test_describe: test_table_options_quoting: USE test_keyspace

### DIFF
--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -620,7 +620,7 @@ def test_table_options_quoting(cql, test_keyspace):
     comment = "table''s comment test!\"; DESC TABLES --quoting test"
     comment_plain = "table's comment test!\"; DESC TABLES --quoting test" #without doubling "'" inside comment
 
-    cql.execute(f"CREATE TYPE \"{type_name}\" (a int)")
+    cql.execute(f"CREATE TYPE {test_keyspace}.\"{type_name}\" (a int)")
     try:
         with new_test_table(cql, test_keyspace, f"a int primary key, b list<frozen<\"{type_name}\">>, \"{column_name}\" int", 
             f"with comment = '{comment}'") as tbl:
@@ -636,7 +636,7 @@ def test_table_options_quoting(cql, test_keyspace):
             assert f"comment = {comment}" not in desc
             assert f"comment = '{comment_plain}'" not in desc
     finally:
-        cql.execute(f"DROP TYPE \"{type_name}\"")
+        cql.execute(f"DROP TYPE {test_keyspace}.\"{type_name}\"")
 
 
 ### =========================== UTILITY FUNCTIONS =============================


### PR DESCRIPTION
Without that, I often (but not always) get the following error:
```
__________________________ test_table_options_quoting __________________________

cql = <cassandra.cluster.Session object at 0x7f1aafb10650>
test_keyspace = 'cql_test_1671103335055'

    def test_table_options_quoting(cql, test_keyspace):
        type_name = f"some_udt; DROP KEYSPACE {test_keyspace}"
        column_name = "col''umn -- @quoting test!!"
        comment = "table''s comment test!\"; DESC TABLES --quoting test"
        comment_plain = "table's comment test!\"; DESC TABLES --quoting test" #without doubling "'" inside comment

>       cql.execute(f"CREATE TYPE \"{type_name}\" (a int)")

test/cql-pytest/test_describe.py:623:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cassandra/cluster.py:2699: in cassandra.cluster.Session.execute
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="No keyspace has been specified. USE a keyspace, or explicitly specify keyspace.tablename"
```

CQL driver in use ise the scylla driver version 3.25.10.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>