### PR TITLE
Backport nodeops abort thread use-after-free patches

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1122,7 +1122,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // ATTN -- sharded repair reference already sits on storage_service and if
             // it calls repair.local() before this place it'll crash (now it doesn't do
             // both)
-            supervisor::notify("starting messaging service");
+            supervisor::notify("starting repair service");
             auto max_memory_repair = memory::stats().total_memory() * 0.1;
             repair.start(std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(bm), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(mm), max_memory_repair).get();
             auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -63,11 +63,25 @@ void node_ops_info::check_abort() {
 }
 
 future<> node_ops_info::start() {
-    co_return;  // for now
+    if (as) {
+        co_await _sas.start();
+        _abort_subscription = as->subscribe([this] () noexcept {
+            _abort_done = _sas.invoke_on_all([] (abort_source& as) noexcept {
+                as.request_abort();
+            });
+        });
+    }
 }
 
 future<> node_ops_info::stop() noexcept {
-    co_return;  // for now
+    if (as) {
+        co_await std::exchange(_abort_done, make_ready_future<>());
+        co_await _sas.stop();
+    }
+}
+
+abort_source* node_ops_info::local_abort_source() {
+    return as ? &_sas.local() : nullptr;
 }
 
 node_ops_metrics::node_ops_metrics(tracker& tracker)
@@ -538,7 +552,7 @@ repair_info::repair_info(repair_service& repair,
     const std::vector<sstring>& hosts_,
     const std::unordered_set<gms::inet_address>& ignore_nodes_,
     streaming::stream_reason reason_,
-    shared_ptr<abort_source> as,
+    abort_source* as,
     bool hints_batchlog_flushed)
     : rs(repair)
     , db(repair.get_db())
@@ -1297,9 +1311,10 @@ future<> repair_service::do_sync_data_using_repair(
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
                 bool hints_batchlog_flushed = false;
+                abort_source* asp = ops_info ? ops_info->local_abort_source() : nullptr;
                 auto ri = make_lw_shared<repair_info>(local_repair,
                         std::move(keyspace), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, ops_info ? ops_info->as : nullptr, hints_batchlog_flushed);
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, asp, hints_batchlog_flushed);
                 ri->neighbors = std::move(neighbors);
                 return repair_ranges(ri);
             });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -49,7 +49,7 @@
 logging::logger rlogger("repair");
 
 void node_ops_info::check_abort() {
-    if (abort) {
+    if (as && as->abort_requested()) {
         auto msg = format("Node operation with ops_uuid={} is aborted", ops_uuid);
         rlogger.warn("{}", msg);
         throw std::runtime_error(msg);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -48,6 +48,12 @@
 
 logging::logger rlogger("repair");
 
+node_ops_info::node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept
+    : ops_uuid(ops_uuid_)
+    , as(std::move(as_))
+    , ignore_nodes(std::move(ignore_nodes_))
+{}
+
 void node_ops_info::check_abort() {
     if (as && as->abort_requested()) {
         auto msg = format("Node operation with ops_uuid={} is aborted", ops_uuid);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -524,7 +524,6 @@ repair_info::repair_info(repair_service& repair,
     const std::vector<sstring>& hosts_,
     const std::unordered_set<gms::inet_address>& ignore_nodes_,
     streaming::stream_reason reason_,
-    std::optional<utils::UUID> ops_uuid,
     shared_ptr<abort_source> as,
     bool hints_batchlog_flushed)
     : rs(repair)
@@ -547,7 +546,6 @@ repair_info::repair_info(repair_service& repair,
     , reason(reason_)
     , total_rf(db.local().find_keyspace(keyspace).get_effective_replication_map()->get_replication_factor())
     , nr_ranges_total(ranges.size())
-    , _ops_uuid(std::move(ops_uuid))
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed)) {
     if (as != nullptr) {
         _abort_subscription = as->subscribe([this] () noexcept { abort(); });
@@ -1184,7 +1182,7 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
                 auto ri = make_lw_shared<repair_info>(local_repair,
                         std::move(keyspace), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, id.uuid, nullptr, hints_batchlog_flushed);
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, nullptr, hints_batchlog_flushed);
                 return repair_ranges(ri);
             });
             repair_results.push_back(std::move(f));
@@ -1287,7 +1285,7 @@ future<> repair_service::do_sync_data_using_repair(
                 bool hints_batchlog_flushed = false;
                 auto ri = make_lw_shared<repair_info>(local_repair,
                         std::move(keyspace), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, ops_info ? std::make_optional<utils::UUID>(ops_info->ops_uuid) : std::nullopt, ops_info ? ops_info->as : nullptr, hints_batchlog_flushed);
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, ops_info ? ops_info->as : nullptr, hints_batchlog_flushed);
                 ri->neighbors = std::move(neighbors);
                 return repair_ranges(ri);
             });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -62,6 +62,14 @@ void node_ops_info::check_abort() {
     }
 }
 
+future<> node_ops_info::start() {
+    co_return;  // for now
+}
+
+future<> node_ops_info::stop() noexcept {
+    co_return;  // for now
+}
+
 node_ops_metrics::node_ops_metrics(tracker& tracker)
     : _tracker(tracker)
 {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -436,16 +436,6 @@ void tracker::abort_all_repairs() {
     rlogger.info0("Aborted {} repair job(s)", count);
 }
 
-void tracker::abort_repair_node_ops(utils::UUID ops_uuid) {
-    for (auto& x : _repairs) {
-        auto& ri = x.second;
-        if (ri->ops_uuid() && ri->ops_uuid().value() == ops_uuid) {
-            rlogger.info0("Aborted repair jobs for ops_uuid={}", ops_uuid);
-            ri->abort();
-        }
-    }
-}
-
 float tracker::report_progress(streaming::stream_reason reason) {
     uint64_t nr_ranges_finished = 0;
     uint64_t nr_ranges_total = 0;
@@ -1715,12 +1705,6 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
                 table->trigger_offstrategy_compaction();
             }
         });
-    });
-}
-
-future<> repair_service::abort_repair_node_ops(utils::UUID ops_uuid) {
-    return container().invoke_on_all([ops_uuid] (repair_service& rs) {
-        rs.repair_tracker().abort_repair_node_ops(ops_uuid);
     });
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -575,7 +575,7 @@ void repair_info::check_failed_ranges() {
     }
 }
 
-void repair_info::abort() {
+void repair_info::abort() noexcept {
     aborted = true;
 }
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -182,7 +182,7 @@ public:
             std::optional<utils::UUID> ops_uuid,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
-    void abort();
+    void abort() noexcept;
     void check_in_abort();
     void check_in_shutdown();
     repair_neighbors get_repair_neighbors(const dht::token_range& range);

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -69,7 +69,7 @@ std::ostream& operator<<(std::ostream& os, const repair_uniq_id& x);
 
 struct node_ops_info {
     utils::UUID ops_uuid;
-    bool abort = false;
+    shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
     void check_abort();
 };

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -71,6 +71,11 @@ struct node_ops_info {
     utils::UUID ops_uuid;
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
+
+    node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
+    node_ops_info(const node_ops_info&) = delete;
+    node_ops_info(node_ops_info&&) = delete;
+
     void check_abort();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -167,7 +167,6 @@ public:
     int ranges_index = 0;
     repair_stats _stats;
     std::unordered_set<sstring> dropped_tables;
-    std::optional<utils::UUID> _ops_uuid;
     optimized_optional<abort_source::subscription> _abort_subscription;
     bool _hints_batchlog_flushed = false;
 public:
@@ -180,7 +179,6 @@ public:
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
-            std::optional<utils::UUID> ops_uuid,
             shared_ptr<abort_source> as,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
@@ -194,9 +192,6 @@ public:
     const std::vector<sstring>& table_names() {
         return cfs;
     }
-    const std::optional<utils::UUID>& ops_uuid() const {
-        return _ops_uuid;
-    };
 
     bool hints_batchlog_flushed() const {
         return _hints_batchlog_flushed;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -76,6 +76,9 @@ struct node_ops_info {
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
 
+    future<> start();
+    future<> stop() noexcept;
+
     void check_abort();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -67,11 +67,18 @@ struct repair_uniq_id {
 };
 std::ostream& operator<<(std::ostream& os, const repair_uniq_id& x);
 
-struct node_ops_info {
+class node_ops_info {
+public:
     utils::UUID ops_uuid;
     shared_ptr<abort_source> as;
     std::list<gms::inet_address> ignore_nodes;
 
+private:
+    optimized_optional<abort_source::subscription> _abort_subscription;
+    sharded<abort_source> _sas;
+    future<> _abort_done = make_ready_future<>();
+
+public:
     node_ops_info(utils::UUID ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
@@ -80,6 +87,8 @@ struct node_ops_info {
     future<> stop() noexcept;
 
     void check_abort();
+
+    abort_source* local_abort_source();
 };
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
@@ -187,7 +196,7 @@ public:
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
-            shared_ptr<abort_source> as,
+            abort_source* as,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
     void abort() noexcept;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -254,7 +254,6 @@ public:
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
     float report_progress(streaming::stream_reason reason);
-    void abort_repair_node_ops(utils::UUID ops_uuid);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, const sstring& keyspace,

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -168,6 +168,7 @@ public:
     repair_stats _stats;
     std::unordered_set<sstring> dropped_tables;
     std::optional<utils::UUID> _ops_uuid;
+    optimized_optional<abort_source::subscription> _abort_subscription;
     bool _hints_batchlog_flushed = false;
 public:
     repair_info(repair_service& repair,
@@ -180,6 +181,7 @@ public:
             const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
             std::optional<utils::UUID> ops_uuid,
+            shared_ptr<abort_source> as,
             bool hints_batchlog_flushed);
     void check_failed_ranges();
     void abort() noexcept;

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -141,13 +141,13 @@ private:
             dht::token_range_vector ranges,
             std::unordered_map<dht::token_range, repair_neighbors> neighbors,
             streaming::stream_reason reason,
-            std::optional<utils::UUID> ops_uuid);
+            shared_ptr<node_ops_info> ops_info);
 
     future<> do_sync_data_using_repair(sstring keyspace,
             dht::token_range_vector ranges,
             std::unordered_map<dht::token_range, repair_neighbors> neighbors,
             streaming::stream_reason reason,
-            std::optional<utils::UUID> ops_uuid);
+            shared_ptr<node_ops_info> ops_info);
 
     future<repair_update_system_table_response> repair_update_system_table_handler(
             gms::inet_address from,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -193,8 +193,6 @@ public:
     // Abort all the repairs
     future<> abort_all();
 
-    future<> abort_repair_node_ops(utils::UUID ops_uuid);
-
     std::unordered_map<node_repair_meta_id, repair_meta_ptr>& repair_meta_map() noexcept {
         return _repair_metas;
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3561,7 +3561,6 @@ node_ops_meta_data::node_ops_meta_data(
 
 future<> node_ops_meta_data::abort() {
     slogger.debug("node_ops_meta_data: ops_uuid={} abort", _ops_uuid);
-    _aborted = true;
     if (_ops) {
         _ops->abort = true;
     }
@@ -3571,7 +3570,7 @@ future<> node_ops_meta_data::abort() {
 
 void node_ops_meta_data::update_watchdog() {
     slogger.debug("node_ops_meta_data: ops_uuid={} update_watchdog", _ops_uuid);
-    if (_aborted) {
+    if (_abort_source->abort_requested()) {
         return;
     }
     _watchdog.cancel();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3624,6 +3624,24 @@ void storage_service::node_ops_done(utils::UUID ops_uuid) {
 void storage_service::node_ops_abort(utils::UUID ops_uuid) {
     slogger.debug("node_ops_abort: ops_uuid={}", ops_uuid);
     auto permit = seastar::get_units(_node_ops_abort_sem, 1).get0();
+
+    if (!ops_uuid) {
+        for (auto& [uuid, meta] : _node_ops) {
+            meta.abort().get();
+            auto as = meta.get_abort_source();
+            if (as && !as->abort_requested()) {
+                as->request_abort();
+            }
+        }
+
+        for (auto it = _node_ops.begin(); it != _node_ops.end(); it = _node_ops.erase(it)) {
+            node_ops_meta_data& meta = it->second;
+            meta.stop().get();
+        }
+
+        return;
+    }
+
     auto it = _node_ops.find(ops_uuid);
     if (it != _node_ops.end()) {
         node_ops_meta_data& meta = it->second;
@@ -3652,14 +3670,14 @@ future<> storage_service::node_ops_abort_thread() {
             while (!_node_ops_abort_queue.empty()) {
                 auto uuid_opt = _node_ops_abort_queue.front();
                 _node_ops_abort_queue.pop_front();
+                try {
+                    storage_service::node_ops_abort(uuid_opt.value_or(utils::null_uuid()));
+                } catch (...) {
+                    slogger.warn("Failed to abort node operation ops_uuid={}: {}", *uuid_opt, std::current_exception());
+                }
                 if (!uuid_opt) {
                     slogger.info("Stopped node_ops_abort_thread");
                     return;
-                }
-                try {
-                    storage_service::node_ops_abort(*uuid_opt);
-                } catch (...) {
-                    slogger.warn("Failed to abort node operation ops_uuid={}: {}", *uuid_opt, std::current_exception());
                 }
             }
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3564,11 +3564,11 @@ node_ops_meta_data::node_ops_meta_data(
 }
 
 future<> node_ops_meta_data::start() {
-    return make_ready_future<>(); // for now
+    return _ops ? _ops->start() : make_ready_future<>();
 }
 
 future<> node_ops_meta_data::stop() noexcept {
-    return make_ready_future<>(); // for now
+    return _ops ? _ops->stop() : make_ready_future<>();
 }
 
 future<> node_ops_meta_data::abort() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3619,7 +3619,6 @@ void storage_service::node_ops_abort(utils::UUID ops_uuid) {
         if (as && !as->abort_requested()) {
             as->request_abort();
         }
-        _repair.local().abort_repair_node_ops(ops_uuid).get();
         _node_ops.erase(it);
     }
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3653,6 +3653,7 @@ future<> storage_service::node_ops_abort_thread() {
                 auto uuid_opt = _node_ops_abort_queue.front();
                 _node_ops_abort_queue.pop_front();
                 if (!uuid_opt) {
+                    slogger.info("Stopped node_ops_abort_thread");
                     return;
                 }
                 try {
@@ -3662,7 +3663,7 @@ future<> storage_service::node_ops_abort_thread() {
                 }
             }
         }
-        slogger.info("Stopped node_ops_abort_thread");
+        __builtin_unreachable();
     });
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2785,7 +2785,7 @@ future<> storage_service::removenode_with_stream(gms::inet_address leaving_node,
 future<> storage_service::restore_replica_count(inet_address endpoint, inet_address notify_endpoint) {
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::removenode)) {
         auto ops_uuid = utils::make_random_uuid();
-        auto ops = seastar::make_shared<node_ops_info>(node_ops_info{ops_uuid, nullptr, std::list<gms::inet_address>()});
+        auto ops = seastar::make_shared<node_ops_info>(ops_uuid, nullptr, std::list<gms::inet_address>());
         return _repair.local().removenode_with_repair(get_token_metadata_ptr(), endpoint, ops).finally([this, notify_endpoint] () {
             return send_replication_notification(notify_endpoint);
         });
@@ -3554,7 +3554,7 @@ node_ops_meta_data::node_ops_meta_data(
     , _abort(std::move(abort_func))
     , _abort_source(seastar::make_shared<abort_source>())
     , _signal(std::move(signal_func))
-    , _ops(seastar::make_shared<node_ops_info>({_ops_uuid, _abort_source, std::move(ignore_nodes)}))
+    , _ops(seastar::make_shared<node_ops_info>(_ops_uuid, _abort_source, std::move(ignore_nodes)))
     , _watchdog([sig = _signal] { sig(); }) {
     _watchdog.arm(_watchdog_interval);
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -111,6 +111,8 @@ public:
             std::list<gms::inet_address> ignore_nodes,
             std::function<future<> ()> abort_func,
             std::function<void ()> signal_func);
+    future<> start();
+    future<> stop() noexcept;
     shared_ptr<node_ops_info> get_ops_info();
     shared_ptr<abort_source> get_abort_source();
     future<> abort();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -104,7 +104,6 @@ class node_ops_meta_data {
     shared_ptr<node_ops_info> _ops;
     seastar::timer<lowres_clock> _watchdog;
     std::chrono::seconds _watchdog_interval{30};
-    bool _aborted = false;
 public:
     explicit node_ops_meta_data(
             utils::UUID ops_uuid,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -109,7 +109,7 @@ public:
     explicit node_ops_meta_data(
             utils::UUID ops_uuid,
             gms::inet_address coordinator,
-            shared_ptr<node_ops_info> ops,
+            std::list<gms::inet_address> ignore_nodes,
             std::function<future<> ()> abort_func,
             std::function<void ()> signal_func);
     shared_ptr<node_ops_info> get_ops_info();

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -234,3 +234,25 @@ BOOST_AUTO_TEST_CASE(test_negate) {
 
     BOOST_REQUIRE(original_uuid == re_negated_uuid);
 }
+
+BOOST_AUTO_TEST_CASE(test_null_uuid) {
+    // Verify that the default-constructed UUID is null
+    utils::UUID uuid;
+    BOOST_CHECK(uuid.is_null());
+    BOOST_CHECK(!uuid);
+
+    // Verify that the null_uuid is indeed null
+    uuid = utils::null_uuid();
+    BOOST_CHECK(uuid.is_null());
+    BOOST_CHECK(!uuid);
+
+    // Verify that a random uuid is not null
+    uuid = utils::make_random_uuid();
+    BOOST_CHECK(!uuid.is_null());
+    BOOST_CHECK(uuid);
+
+    // Verify that a time uuid is not null
+    uuid = utils::UUID_gen::get_time_UUID();
+    BOOST_CHECK(!uuid.is_null());
+    BOOST_CHECK(uuid);
+}

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -115,7 +115,7 @@ public:
         return !most_sig_bits && !least_sig_bits;
     }
 
-    operator bool() const noexcept {
+    explicit operator bool() const noexcept {
         return !is_null();
     }
 

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -109,6 +109,16 @@ public:
         return !(*this < v);
     }
 
+    // Valid (non-null) UUIDs always have their version
+    // nibble set to a non-zero value
+    bool is_null() const noexcept {
+        return !most_sig_bits && !least_sig_bits;
+    }
+
+    operator bool() const noexcept {
+        return !is_null();
+    }
+
     bytes serialize() const {
         bytes b(bytes::initialized_later(), serialized_size());
         auto i = b.begin();
@@ -126,6 +136,10 @@ public:
         serialize_int64(out, least_sig_bits);
     }
 };
+
+inline UUID null_uuid() noexcept {
+    return UUID();
+}
 
 UUID make_random_uuid();
 


### PR DESCRIPTION
This includes merges 396d9e6a46 and 2c021affd1

Things that got changed here:

1. All the node_ops_... stuff in storage_service was coroutinized after 5.0, so in this merge the changes were de-coroutinized back
2. Had to cherry-pick molding for UUID (69fcc053bbb and 489e50ef3a7)
3. tracker::is_aborted() was added after 5.0, it caused minor context conflict
4. watchdog interval was changed, also caused minor context conflict

refs: #10284