### PR TITLE
Range repair tasks

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -622,7 +622,7 @@ repair_neighbors repair::shard_repair_task_impl::get_repair_neighbors(const dht:
         neighbors[range];
 }
 
-size_t repair::shard_repair_task_impl::ranges_size() {
+size_t repair::shard_repair_task_impl::ranges_size() const noexcept {
     return ranges.size() * table_ids.size();
 }
 

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -62,7 +62,8 @@ public:
 protected:
     future<> run() override;
 
-    // TODO: implement progress for user-requested repairs
+    virtual future<std::optional<double>> expected_total_workload() const override;
+    virtual std::optional<double> expected_children_number() const override;
 };
 
 class data_sync_repair_task_impl : public repair_task_impl {
@@ -70,6 +71,7 @@ private:
     dht::token_range_vector _ranges;
     std::unordered_map<dht::token_range, repair_neighbors> _neighbors;
     optimized_optional<abort_source::subscription> _abort_subscription;
+    size_t _cfs_size = 0;
 public:
     data_sync_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, dht::token_range_vector ranges, std::unordered_map<dht::token_range, repair_neighbors> neighbors, streaming::stream_reason reason, shared_ptr<node_ops_info> ops_info)
         : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), reason)
@@ -89,7 +91,8 @@ public:
 protected:
     future<> run() override;
 
-    // TODO: implement progress for data-sync repairs
+    virtual future<std::optional<double>> expected_total_workload() const override;
+    virtual std::optional<double> expected_children_number() const override;
 };
 
 class shard_repair_task_impl : public repair_task_impl {
@@ -164,6 +167,9 @@ public:
 protected:
     future<> do_repair_ranges();
     future<> run() override;
+
+    virtual future<std::optional<double>> expected_total_workload() const override;
+    virtual std::optional<double> expected_children_number() const override;
 
     friend class range_repair_task_impl;
 };

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -160,8 +160,6 @@ public:
         return _hints_batchlog_flushed;
     }
 
-    future<> repair_range(const dht::token_range& range, table_info table);
-
     size_t ranges_size();
 protected:
     future<> do_repair_ranges();
@@ -189,6 +187,8 @@ public:
         , _range(range)
         , _table_id(table.id)
     {}
+
+    future<> repair_range();
 
     table_info get_table_info() const noexcept {
         return table_info{

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -160,7 +160,7 @@ public:
         return _hints_batchlog_flushed;
     }
 
-    future<> repair_range(const dht::token_range& range, table_id);
+    future<> repair_range(const dht::token_range& range, table_info table);
 
     size_t ranges_size();
 protected:

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -160,7 +160,7 @@ public:
         return _hints_batchlog_flushed;
     }
 
-    size_t ranges_size();
+    size_t ranges_size() const noexcept;
 protected:
     future<> do_repair_ranges();
     future<> run() override;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -115,6 +115,9 @@ public:
             optimized_optional<seastar::abort_source::subscription> _shutdown_subscription;
         public:
             impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept;
+            // impl is always created as a smart pointer so it does not need to be moved or copied.
+            impl(const impl&) = delete;
+            impl(impl&&) = delete;
             virtual ~impl() = default;
 
             virtual std::string type() const = 0;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -132,8 +132,8 @@ public:
             void finish() noexcept;
             void finish_failed(std::exception_ptr ex, std::string error) noexcept;
             void finish_failed(std::exception_ptr ex);
-            future<std::optional<double>> expected_total_workload() const;
-            std::optional<double> expected_children_number() const;
+            virtual future<std::optional<double>> expected_total_workload() const;
+            virtual std::optional<double> expected_children_number() const;
             task_manager::task::progress get_binary_progress() const;
 
             friend task;

--- a/test/rest_api/test_repair_task.py
+++ b/test/rest_api/test_repair_task.py
@@ -1,0 +1,53 @@
+import functools
+import requests
+import sys
+
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+from util import new_test_table, new_test_keyspace
+from rest_util import set_tmp_task_ttl
+from task_manager_utils import list_tasks
+
+empty_id = "00000000-0000-0000-0000-000000000000"
+
+def get_status(rest_api, task, sequence_number):
+    task_id = task["task_id"]
+    resp = rest_api.send("GET", f"task_manager/task_status/{task_id}")
+    if resp.status_code == requests.codes.ok:
+        status = resp.json()
+        if status["sequence_number"] == sequence_number:
+            assert status["progress_completed"] == status["progress_total"], "invalid progress"
+            return status
+    return None
+
+def test_repair_task_progress(cql, this_dc, rest_api):
+    long_time = 1000000000
+    with set_tmp_task_ttl(rest_api, long_time):
+        # Insert some data.
+        with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+            schema = 'p int, v text, primary key (p)'
+            with new_test_table(cql, keyspace, schema) as t0:
+                stmt = cql.prepare(f"INSERT INTO {t0} (p, v) VALUES (?, ?)")
+                cql.execute(stmt, [0, 'hello'])
+
+                # Run repair and wait until it is finished.
+                resp = rest_api.send("POST", f"storage_service/repair_async/{keyspace}")
+                resp.raise_for_status()
+                sequence_number = resp.json()
+                resp = rest_api.send("GET", f"storage_service/repair_status", { "id": sequence_number })
+                resp.raise_for_status()
+
+                # Get all repairs.
+                tasks = list_tasks(rest_api, "repair", internal=True)
+
+                statuses = list(filter(lambda s : s is not None, map(lambda s: get_status(rest_api, s, sequence_number), tasks)))
+
+                roots = list(filter(lambda s : s["parent_id"] == empty_id, statuses))
+                assert len(roots) == 1, "incorrect roots number"
+                root = roots[0]
+
+                descendants = list(filter(lambda s : s["parent_id"] == root["parent_id"], statuses))
+                progress_total = functools.reduce(lambda a, b: a + b, map(lambda s : s["progress_total"], descendants))
+                progress_completed = functools.reduce(lambda a, b: a + b, map(lambda s : s["progress_completed"], descendants))
+                assert progress_total == root["progress_total"], "incorrect total progress value"
+                assert progress_completed == root["progress_completed"], "incorrect completed progress value"


### PR DESCRIPTION
Repair tasks spanning over a range are introduced.

The progress of repair tasks is counted basing on the number
of ranges that were processed. Completed ranges in shard 
and top level tasks are gathered recursively from their children. 