### PR TITLE
Improve verbosity of task manager api

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -168,6 +168,26 @@
                   "failed"
                 ],
                 "description":"The state of a task"
+             },
+             "type":{
+                "type":"string",
+                "description":"The description of the task"
+             },
+             "keyspace":{
+                "type":"string",
+                "description":"The keyspace the task is working on (if applicable)"
+             },
+             "table":{
+                "type":"string",
+                "description":"The table the task is working on (if applicable)"
+             },
+             "entity":{
+                "type":"string",
+                "description":"Task-specific entity description"
+             },
+             "sequence_number":{
+                "type":"long",
+                "description":"The running sequence number of the task"
              }
            }
        },

--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -264,6 +264,13 @@
             "progress_completed":{
                "type":"double",
                "description":"The number of units completed so far"
+            },
+            "children_ids":{
+               "type":"array",
+                "items":{
+                    "type":"string"
+                },
+               "description":"Task IDs of children of this task"
             }
           }
        }

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -35,6 +35,7 @@ struct full_task_status {
     std::string module;
     tasks::task_id parent_id;
     tasks::is_abortable abortable;
+    std::vector<std::string> children_ids;
 };
 
 struct task_stats {
@@ -81,6 +82,7 @@ tm::task_status make_status(full_task_status status) {
     res.progress_units = status.task_status.progress_units;
     res.progress_total = status.progress.total;
     res.progress_completed = status.progress.completed;
+    res.children_ids = std::move(status.children_ids);
     return res;
 }
 
@@ -97,6 +99,11 @@ future<json::json_return_type> retrieve_status(tasks::task_manager::foreign_task
     s.module = task->get_module_name();
     s.progress.completed = progress.completed;
     s.progress.total = progress.total;
+    std::vector<std::string> ct{task->get_children().size()};
+    boost::transform(task->get_children(), ct.begin(), [] (const auto& child) {
+        return child->id().to_sstring();
+    });
+    s.children_ids = std::move(ct);
     co_return make_status(s);
 }
 

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -38,10 +38,23 @@ struct full_task_status {
 };
 
 struct task_stats {
-    task_stats(tasks::task_manager::task_ptr task) : task_id(task->id().to_sstring()), state(task->get_status().state) {}
+    task_stats(tasks::task_manager::task_ptr task)
+        : task_id(task->id().to_sstring())
+        , state(task->get_status().state)
+        , type(task->type())
+        , keyspace(task->get_status().keyspace)
+        , table(task->get_status().table)
+        , entity(task->get_status().entity)
+        , sequence_number(task->get_status().sequence_number)
+    { }
 
     sstring task_id;
     tasks::task_manager::task_state state;
+    std::string type;
+    std::string keyspace;
+    std::string table;
+    std::string entity;
+    uint64_t sequence_number;
 };
 
 tm::task_status make_status(full_task_status status) {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -193,6 +193,10 @@ void task_manager::task::unregister_task() noexcept {
     _impl->_module->unregister_task(id());
 }
 
+const task_manager::foreign_task_vector& task_manager::task::get_children() const noexcept {
+    return _impl->_children;
+}
+
 task_manager::module::module(task_manager& tm, std::string name) noexcept : _tm(tm), _name(std::move(name)) {}
 
 uint64_t task_manager::module::new_sequence_number() noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -140,6 +140,7 @@ public:
         future<> done() const noexcept;
         void register_task();
         void unregister_task() noexcept;
+        const foreign_task_vector& get_children() const noexcept;
 
         friend class test_task;
         friend class ::repair_module;


### PR DESCRIPTION
The PR introduces changes to task manager api:
- extends tasks' list returned with get_tasks with task type,
   keyspace, table, entity, and sequence number
- extends status returned with get_task_status and wait_task
   with a list of children's ids