### PR TITLE
storage_service: unbootstrap: avoid unnecessary copy of ranges_to_stream

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3100,6 +3100,7 @@ storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multim
             dht::token_range r = end_point_entry.first;
             inet_address endpoint = end_point_entry.second;
             ranges_per_endpoint[endpoint].emplace_back(r);
+            co_await coroutine::maybe_yield();
         }
         streamer->add_tx_ranges(keyspace, std::move(ranges_per_endpoint));
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2887,7 +2887,7 @@ future<> storage_service::unbootstrap() {
 
         set_mode(mode::LEAVING);
 
-        auto stream_success = stream_ranges(ranges_to_stream);
+        auto stream_success = stream_ranges(std::move(ranges_to_stream));
 
         // wait for the transfer runnables to signal the latch.
         slogger.debug("waiting for stream acks.");


### PR DESCRIPTION
`ranges_to_stream` is a map of ` std::unordered_multimap<dht::token_range, inet_address>` per keyspace.
On large clusters with a large number of keyspace, copying it may cause reactor stalls as seen in #12332

This series eliminates this copy by using std::move and also
turns `stream_ranges` into a coroutine, adding maybe_yield calls to avoid further stalls down the road.

Fixes #12332