### PR TITLE
Eliminate extraneous copies of dht::token_range_vector

### DIFF
--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -53,7 +53,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
             // The keyspace may be dropped in the meantime.
             dht::token_range_vector ranges = co_await strategy.get_pending_address_ranges(_token_metadata_ptr, _tokens, _address, _dr);
             blogger.debug("Will stream keyspace={}, ranges={}", keyspace_name, ranges);
-            co_await streamer->add_ranges(keyspace_name, erm, ranges, gossiper, reason == streaming::stream_reason::replace);
+            co_await streamer->add_ranges(keyspace_name, erm, std::move(ranges), gossiper, reason == streaming::stream_reason::replace);
         }
         _abort_source.check();
         co_await streamer->stream_async();

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -221,8 +221,8 @@ future<> range_streamer::add_ranges(const sstring& keyspace_name, locator::effec
     }
     _nr_rx_added++;
     auto ranges_for_keyspace = !is_replacing && use_strict_sources_for_ranges(keyspace_name, erm)
-        ? get_all_ranges_with_strict_sources_for(keyspace_name, erm, ranges, gossiper)
-        : get_all_ranges_with_sources_for(keyspace_name, erm, ranges);
+        ? get_all_ranges_with_strict_sources_for(keyspace_name, erm, std::move(ranges), gossiper)
+        : get_all_ranges_with_sources_for(keyspace_name, erm, std::move(ranges));
 
     if (logger.is_enabled(logging::log_level::debug)) {
         for (auto& x : ranges_for_keyspace) {

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -287,9 +287,8 @@ future<> range_streamer::stream_async() {
                 };
                 try {
                     dht::token_range_vector ranges_to_stream;
-                    for (auto it = range_vec.begin(); it < range_vec.end();) {
-                        ranges_to_stream.push_back(*it);
-                        it = range_vec.erase(it);
+                    for (const auto& r : range_vec) {
+                        ranges_to_stream.push_back(r);
                         if (ranges_to_stream.size() < nr_ranges_per_stream_plan) {
                             continue;
                         } else {
@@ -299,6 +298,7 @@ future<> range_streamer::stream_async() {
                     if (ranges_to_stream.size() > 0) {
                         do_streaming(std::move(ranges_to_stream));
                     }
+                    range_vec.resize(0);
                 } catch (...) {
                     auto t = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - start_time).count();
                     logger.warn("{} with {} for keyspace={} failed, took {} seconds: {}", description, source, keyspace, t, std::current_exception());

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -286,6 +286,9 @@ future<> range_streamer::stream_async() {
                             _nr_total_ranges - remaining, _nr_total_ranges, _reason, percentage);
                 };
                 try {
+                  if (range_vec.size() <= nr_ranges_per_stream_plan) {
+                    do_streaming(std::move(range_vec));
+                  } else {
                     dht::token_range_vector ranges_to_stream;
                     for (const auto& r : range_vec) {
                         ranges_to_stream.push_back(r);
@@ -299,6 +302,7 @@ future<> range_streamer::stream_async() {
                         do_streaming(std::move(ranges_to_stream));
                     }
                     range_vec.resize(0);
+                  }
                 } catch (...) {
                     auto t = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - start_time).count();
                     logger.warn("{} with {} for keyspace={} failed, took {} seconds: {}", description, source, keyspace, t, std::current_exception());

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -301,9 +301,6 @@ future<> range_streamer::stream_async() {
                         do_streaming();
                     }
                 } catch (...) {
-                    for (auto& range : ranges_to_stream) {
-                        range_vec.push_back(range);
-                    }
                     auto t = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - start_time).count();
                     logger.warn("{} with {} for keyspace={} failed, took {} seconds: {}", description, source, keyspace, t, std::current_exception());
                     throw;

--- a/streaming/stream_plan.cc
+++ b/streaming/stream_plan.cc
@@ -16,11 +16,11 @@ namespace streaming {
 
 extern logging::logger sslog;
 
-stream_plan& stream_plan::request_ranges(inet_address from, sstring keyspace, dht::token_range_vector ranges) {
+stream_plan& stream_plan::request_ranges(inet_address from, sstring keyspace, dht::token_range_vector&& ranges) {
     return request_ranges(from, keyspace, std::move(ranges), {});
 }
 
-stream_plan& stream_plan::request_ranges(inet_address from, sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families) {
+stream_plan& stream_plan::request_ranges(inet_address from, sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families) {
     _range_added = true;
     auto session = _coordinator->get_or_create_session(_mgr, from);
     session->add_stream_request(keyspace, std::move(ranges), std::move(column_families));
@@ -28,11 +28,11 @@ stream_plan& stream_plan::request_ranges(inet_address from, sstring keyspace, dh
     return *this;
 }
 
-stream_plan& stream_plan::transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector ranges) {
+stream_plan& stream_plan::transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector&& ranges) {
     return transfer_ranges(to, keyspace, std::move(ranges), {});
 }
 
-stream_plan& stream_plan::transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families) {
+stream_plan& stream_plan::transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families) {
     _range_added = true;
     auto session = _coordinator->get_or_create_session(_mgr, to);
     session->add_transfer_ranges(keyspace, std::move(ranges), std::move(column_families));

--- a/streaming/stream_plan.hh
+++ b/streaming/stream_plan.hh
@@ -65,7 +65,7 @@ public:
      * @param ranges ranges to fetch
      * @return this object for chaining
      */
-    stream_plan& request_ranges(inet_address from, sstring keyspace, dht::token_range_vector ranges);
+    stream_plan& request_ranges(inet_address from, sstring keyspace, dht::token_range_vector&& ranges);
 
     /**
      * Request data in {@code columnFamilies} under {@code keyspace} and {@code ranges} from specific node.
@@ -77,7 +77,7 @@ public:
      * @param columnFamilies specific column families
      * @return this object for chaining
      */
-    stream_plan& request_ranges(inet_address from, sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families);
+    stream_plan& request_ranges(inet_address from, sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families);
 
     /**
      * Add transfer task to send data of specific keyspace and ranges.
@@ -88,7 +88,7 @@ public:
      * @param ranges ranges to send
      * @return this object for chaining
      */
-    stream_plan& transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector ranges);
+    stream_plan& transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector&& ranges);
 
     /**
      * Add transfer task to send data of specific {@code columnFamilies} under {@code keyspace} and {@code ranges}.
@@ -100,7 +100,7 @@ public:
      * @param columnFamilies specific column families
      * @return this object for chaining
      */
-    stream_plan& transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families);
+    stream_plan& transfer_ranges(inet_address to, sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families);
 
     stream_plan& listeners(std::vector<stream_event_handler*> handlers);
 public:

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -288,7 +288,7 @@ future<prepare_message> stream_session::prepare(std::vector<stream_request> requ
                 throw std::runtime_error(err);
             }
         }
-        add_transfer_ranges(request.keyspace, request.ranges, request.column_families);
+        add_transfer_ranges(request.keyspace, std::move(request.ranges), request.column_families);
     }
     for (auto& summary : summaries) {
         sslog.debug("[Stream #{}] prepare stream_summary={}", plan_id, summary);
@@ -445,13 +445,13 @@ std::vector<replica::column_family*> stream_session::get_column_family_stores(co
     return stores;
 }
 
-void stream_session::add_transfer_ranges(sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families) {
+void stream_session::add_transfer_ranges(sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families) {
     auto cfs = get_column_family_stores(keyspace, column_families);
     for (auto& cf : cfs) {
         auto cf_id = cf->schema()->id();
         auto it = _transfers.find(cf_id);
         if (it == _transfers.end()) {
-            stream_transfer_task task(shared_from_this(), cf_id, ranges);
+            stream_transfer_task task(shared_from_this(), cf_id, std::move(ranges));
             auto inserted = _transfers.emplace(cf_id, std::move(task)).second;
             assert(inserted);
         } else {

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -215,7 +215,7 @@ public:
      * @param ranges Ranges to retrieve data
      * @param columnFamilies ColumnFamily names. Can be empty if requesting all CF under the keyspace.
      */
-    void add_stream_request(sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families) {
+    void add_stream_request(sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families) {
         _requests.emplace_back(std::move(keyspace), std::move(ranges), std::move(column_families));
     }
 
@@ -230,7 +230,7 @@ public:
      * @param flushTables flush tables?
      * @param repairedAt the time the repair started.
      */
-    void add_transfer_ranges(sstring keyspace, dht::token_range_vector ranges, std::vector<sstring> column_families);
+    void add_transfer_ranges(sstring keyspace, dht::token_range_vector&& ranges, std::vector<sstring> column_families);
 
     std::vector<replica::column_family*> get_column_family_stores(const sstring& keyspace, const std::vector<sstring>& column_families);
 

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -36,7 +36,7 @@ namespace streaming {
 
 extern logging::logger sslog;
 
-stream_transfer_task::stream_transfer_task(shared_ptr<stream_session> session, table_id cf_id, dht::token_range_vector ranges, long total_size)
+stream_transfer_task::stream_transfer_task(shared_ptr<stream_session> session, table_id cf_id, dht::token_range_vector&& ranges, long total_size)
     : stream_task(session, cf_id)
     , _ranges(std::move(ranges))
     , _total_size(total_size) {

--- a/streaming/stream_transfer_task.hh
+++ b/streaming/stream_transfer_task.hh
@@ -32,7 +32,7 @@ private:
     bool _mutation_done_sent = false;
 public:
     stream_transfer_task(stream_transfer_task&&) = default;
-    stream_transfer_task(shared_ptr<stream_session> session, table_id cf_id, dht::token_range_vector ranges, long total_size = 0);
+    stream_transfer_task(shared_ptr<stream_session> session, table_id cf_id, dht::token_range_vector&& ranges, long total_size = 0);
     ~stream_transfer_task();
 public:
     virtual void abort() override {


### PR DESCRIPTION
In several places we copy token range vectors where we could move them and eliminate unnecessary memory copies.

Ref #11005