### PR TITLE
Get rid of handle_state_replacing

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
@@ -95,19 +95,9 @@ Procedure
     ``192.168.1.203`` is the dead node.
     
     The replacing node ``192.168.1.204`` will be bootstrapping data.
-    We will not see ``192.168.1.204`` during the bootstrap.
+    We will not see ``192.168.1.204`` in ``nodetool status`` during the bootstrap.
 
-    .. code-block:: shell
-    
-       Datacenter: dc1
-       ===============
-       Status=Up/Down
-       |/ State=Normal/Leaving/Joining/Moving
-       --  Address    Load       Tokens       Owns    Host ID                               Rack
-           UN  192.168.1.201  112.82 KB  256     32.7%             8d5ed9f4-7764-4dbd-bad8-43fddce94b7c   B1
-           UN  192.168.1.202  91.11 KB   256     32.9%             125ed9f4-7777-1dbn-mac8-43fddce9123e   B1
-   
-    Use ``nodetool gossipinfo`` to see ``192.168.1.204`` is in HIBERNATE status.
+    Use ``nodetool gossipinfo`` to see ``192.168.1.204`` is in NORMAL status.
 
     .. code-block:: shell
                              
@@ -115,7 +105,7 @@ Procedure
          generation:1553759984                                                                                            
          heartbeat:104                      
          HOST_ID:655ae64d-e3fb-45cc-9792-2b648b151b67
-         STATUS:hibernate,true
+         STATUS:NORMAL
          RELEASE_VERSION:3.0.8
          X3:3                                        
          X5:                                                                                    
@@ -128,10 +118,10 @@ Procedure
          RACK:B1
          INTERNAL_IP:192.168.1.204
     
-         /192.168.1.203
+       /192.168.1.203
          generation:1553759866
          heartbeat:2147483647
-        HOST_ID:675ed9f4-6564-6dbd-can8-43fddce952gy
+         HOST_ID:675ed9f4-6564-6dbd-can8-43fddce952gy
          STATUS:shutdown,true
          RELEASE_VERSION:3.0.8
          X3:3

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -174,10 +174,6 @@ public:
             sstring(DELIMITER_STR) + host_id.to_sstring());
     }
 
-    static versioned_value hibernate(bool value) {
-        return versioned_value(sstring(HIBERNATE) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
-    }
-
     static versioned_value shutdown(bool value) {
         return versioned_value(sstring(SHUTDOWN) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
     }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -541,13 +541,6 @@ private:
      */
     future<> handle_state_removing(inet_address endpoint, std::vector<sstring> pieces);
 
-    /**
-     * Handle notification that a node is replacing another node.
-     *
-     * @param endpoint node
-     */
-    future<> handle_state_replacing(inet_address endpoint);
-
     future<>
     handle_state_replacing_update_pending_ranges(mutable_token_metadata_ptr tmptr, inet_address replacing_node);
 


### PR DESCRIPTION
Since [repair: Always use run_replace_ops](https://github.com/scylladb/scylladb/compare/2ec1f719de29d98e1be7fc7c171b06986b81af14), nodes no longer publish HIBERNATE state so we don't need to support handling it.

Replace is now always done using node operations (using repair or streaming).
so nodes are never expected to change status to HIBERNATE.

Therefore storage_service:handle_state_replacing is not needed anymore.

This series gets rid of it and updates documentation related to STATUS:HIBERNATE respectively.

Fixes #12330