### PR TITLE
test/alternator: enable tests for long strings of consecutive tombstones

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -216,7 +216,9 @@ def run_scylla_cmd(pid, dir):
         '--skip-wait-for-gossip-to-settle', '0',
         '--logger-log-level', 'compaction=warn',
         '--logger-log-level', 'migration_manager=warn',
+        # Use lower settings for some parameters to allow faster testing
         '--num-tokens', '16',
+        '--query-tombstone-page-limit', '1000',
         # Significantly increase default timeouts to allow running tests
         # on a very slow setup (but without network losses). Note that these
         # are server-side timeouts: The client should also avoid timing out


### PR DESCRIPTION
In the past we had issue #7933 where very long strings of consecutive tombstones caused Alternator's paging to take an unbounded amount of time and/or memory for a single page. This issue was fixed (by commit e9cbc9ee85c25deb5ba9ee67ffa6e3ca9f904660) but the two tests we had reproducing that issue were left with the "xfail" mark. They were also marked "veryslow" - each taking about 100 seconds - so they didn't run by default so nobody noticed they started to pass.

In this patch I make these tests much faster (taking less than a second together), confirm that they pass - and remove the "xfail" mark and improve their descriptions.

The trick to making these tests faster is to not create a million tombstones like we used to: We now know that after string of just 10,000 tombstones ('query_tombstone_page_limit') the page should end, so we can check specifically this number. The story is more complicated for partition tombstones, but there too it should be a multiple of query_tombstone_page_limit. To make the tests even faster, we change run.py to lower the query_tombstone_page_limit from the default 10,000 to 1000. The tests work correctly even without this change, but they are ten times faster with it.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>