### PR TITLE
Consume in reverese frozen mutations

### DIFF
--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -16,6 +16,7 @@
 #include "mutation_consumer.hh"
 #include "range_tombstone_change_generator.hh"
 #include "schema.hh"
+#include <exception>
 
 class mutation;
 class flat_mutation_reader_v2;
@@ -294,7 +295,7 @@ auto frozen_mutation::consume(schema_ptr s, frozen_mutation_consumer_adaptor<Con
         return adaptor.on_end_of_partition();
     } catch (...) {
         std::throw_with_nested(std::runtime_error(format(
-                "frozen_mutation::consume(): failed consuming mutation {} of {}.{}", key(), s->ks_name(), s->cf_name())));
+                "frozen_mutation::consume(): failed consuming mutation {} of {}.{}: {}", key(), s->ks_name(), s->cf_name(), std::current_exception())));
     }
 }
 
@@ -314,7 +315,7 @@ auto frozen_mutation::consume_gently(schema_ptr s, frozen_mutation_consumer_adap
         co_return adaptor.on_end_of_partition();
     } catch (...) {
         std::throw_with_nested(std::runtime_error(format(
-                "frozen_mutation::consume_gently(): failed consuming mutation {} of {}.{}", key(), s->ks_name(), s->cf_name())));
+                "frozen_mutation::consume_gently(): failed consuming mutation {} of {}.{}: {}", key(), s->ks_name(), s->cf_name(), std::current_exception())));
     }
 }
 

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -301,7 +301,8 @@ auto frozen_mutation::consume(schema_ptr s, frozen_mutation_consumer_adaptor<Con
 
 template<FlattenedConsumerV2 Consumer>
 auto frozen_mutation::consume(schema_ptr s, Consumer& consumer, consume_in_reverse reverse) const -> frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())> {
-    frozen_mutation_consumer_adaptor adaptor(s, consumer);
+    schema_ptr ss = reverse == consume_in_reverse::yes ? s->make_reversed() : s;
+    frozen_mutation_consumer_adaptor adaptor(ss, consumer);
     return consume(s, adaptor, reverse);
 }
 
@@ -321,6 +322,7 @@ auto frozen_mutation::consume_gently(schema_ptr s, frozen_mutation_consumer_adap
 
 template<FlattenedConsumerV2 Consumer>
 auto frozen_mutation::consume_gently(schema_ptr s, Consumer& consumer, consume_in_reverse reverse) const -> future<frozen_mutation_consume_result<decltype(consumer.consume_end_of_stream())>> {
-    frozen_mutation_consumer_adaptor adaptor(s, consumer);
+    schema_ptr ss = reverse == consume_in_reverse::yes ? s->make_reversed() : s;
+    frozen_mutation_consumer_adaptor adaptor(ss, consumer);
     co_return co_await consume_gently(s, adaptor, reverse);
 }

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -14,6 +14,7 @@
 #include "atomic_cell.hh"
 #include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
+#include "mutation_consumer.hh"
 
 namespace ser {
 class mutation_partition_view;
@@ -83,7 +84,7 @@ private:
         accept_ordered_cookie cookie;
     };
 
-    template <bool is_preemptible>
+    template <bool is_preemptible, consume_in_reverse reverse>
     accept_ordered_result do_accept_ordered(const schema& schema, mutation_partition_view_virtual_visitor& mpvvv, accept_ordered_cookie cookie) const;
 
 public:
@@ -96,8 +97,8 @@ public:
     void accept(const column_mapping&, converting_mutation_partition_applier& visitor) const;
     future<> accept_gently(const column_mapping&, converting_mutation_partition_applier& visitor) const;
     void accept(const column_mapping&, mutation_partition_view_virtual_visitor& mpvvv) const;
-    void accept_ordered(const schema& schema, mutation_partition_view_virtual_visitor& mpvvv) const;
-    future<> accept_gently_ordered(const schema&, mutation_partition_view_virtual_visitor& mpvvv) const;
+    void accept_ordered(const schema& schema, mutation_partition_view_virtual_visitor& mpvvv, consume_in_reverse reverse) const;
+    future<> accept_gently_ordered(const schema&, mutation_partition_view_virtual_visitor& mpvvv, consume_in_reverse reverse) const;
 
     std::optional<clustering_key> first_row_key() const;
     std::optional<clustering_key> last_row_key() const;

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -67,6 +67,7 @@ private:
     future<> do_accept_gently(const column_mapping&, Visitor& visitor) const;
 
     struct accept_ordered_cookie {
+        schema_ptr schema;
         bool accepted_partition_tombstone = false;
         bool accepted_static_row = false;
 

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -12,6 +12,7 @@
 #include <boost/range/algorithm_ext/push_back.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include "mutation_consumer.hh"
 #include "query-result-set.hh"
 #include "query-result-writer.hh"
 
@@ -578,6 +579,7 @@ SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer) {
     BOOST_REQUIRE_EQUAL(um, m);
 
     // Rebuild mutation by consuming from the frozen_mutation
+    // consume_in_reverse::no (default)
     mutation_rebuilder_v2 rebuilder(s);
     auto res = fm.consume(s, rebuilder);
     BOOST_REQUIRE(res.result);

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -567,6 +567,70 @@ SEASTAR_THREAD_TEST_CASE(test_result_size_calculation) {
     BOOST_REQUIRE_EQUAL(digest_only_builder.memory_accounter().used_memory(), result_and_digest_builder.memory_accounter().used_memory());
 }
 
+struct mut_consumer_accumulator {
+    const schema& s;
+    tests::reader_concurrency_semaphore_wrapper& rcsw;
+    std::vector<mutation_fragment_v2> mfs;
+
+    std::vector<mutation_fragment_v2> consume_end_of_stream() {
+        return std::move(mfs);
+    }
+    stop_iteration consume(static_row sr) {
+        mfs.emplace_back(s, rcsw.make_permit(), std::move(sr));
+        return stop_iteration::no;
+    }
+    stop_iteration consume(clustering_row cr) {
+        mfs.emplace_back(s, rcsw.make_permit(), std::move(cr));
+        return stop_iteration::no;
+    }
+    stop_iteration consume(range_tombstone_change rtc) {
+        mfs.emplace_back(s, rcsw.make_permit(), std::move(rtc));
+        return stop_iteration::no;
+    }
+    stop_iteration consume(tombstone _tb) {
+        return stop_iteration::no;
+    }
+    stop_iteration consume_new_partition(dht::decorated_key dk) {
+        mfs.emplace_back(s, rcsw.make_permit(), partition_start{dk, {}});
+        return stop_iteration::no;
+    }
+    stop_iteration consume_end_of_partition() {
+        mfs.emplace_back(s, rcsw.make_permit(), partition_end{});
+        return stop_iteration::no;
+    }
+};
+
+
+SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer_compare_mf) {
+    random_mutation_generator gen(random_mutation_generator::generate_counters::no);
+    schema_ptr s = gen.schema();
+    auto rs = s->make_reversed();
+    std::vector<mutation> mutations = gen(1);
+    tests::reader_concurrency_semaphore_wrapper rcsw = "aabbccdd";
+
+    mut_consumer_accumulator mca_frozen{*rs, rcsw};
+    mut_consumer_accumulator mca_unfrozen{*rs, rcsw};
+
+    const mutation& m = mutations[0];
+    mutation nfm = mutations[0];
+    frozen_mutation fm = freeze(m);
+
+    auto res_frozen = fm.consume(s, mca_frozen, consume_in_reverse::yes);
+
+    auto res_unfrozen = std::move(nfm).consume(mca_unfrozen, consume_in_reverse::yes, mutation_consume_cookie{});
+
+    auto equal = [&rs](const mutation_fragment_v2& mf1, const mutation_fragment_v2& mf2) {
+        return mf1.equal(*rs, mf2);
+    };
+
+    BOOST_REQUIRE_EQUAL(res_frozen.result.size(), res_unfrozen.result.size());
+    for (const auto& res : res_frozen.result) {
+        auto i = &res - &res_frozen.result[0];
+        mutation_fragment_v2::printer p_f(*rs, res), p_nf(*rs, res_unfrozen.result[i]);
+        BOOST_REQUIRE_MESSAGE(equal(res, res_unfrozen.result[i]), fmt::format("idx={}\nfrozen={}\n\nnonfrozen={}", i, p_f, p_nf));
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer) {
     random_mutation_generator gen(random_mutation_generator::generate_counters::no);
     schema_ptr s = gen.schema();
@@ -575,7 +639,7 @@ SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer) {
     frozen_mutation fm = freeze(m);
 
     // sanity check unfreeze first
-    mutation um = fm.unfreeze(s);
+    const mutation um = fm.unfreeze(s);
     BOOST_REQUIRE_EQUAL(um, m);
 
     // Rebuild mutation by consuming from the frozen_mutation
@@ -583,6 +647,28 @@ SEASTAR_THREAD_TEST_CASE(test_frozen_mutation_consumer) {
     mutation_rebuilder_v2 rebuilder(s);
     auto res = fm.consume(s, rebuilder);
     BOOST_REQUIRE(res.result);
-    const auto& rebuilt = *res.result;
-    BOOST_REQUIRE_EQUAL(rebuilt, m);
+    BOOST_REQUIRE_EQUAL(*res.result, m);
+    res = fm.consume_gently(s, rebuilder).get0();
+    BOOST_REQUIRE(res.result);
+    BOOST_REQUIRE_EQUAL(*res.result, m);
+
+    // consume_in_reverse::yes
+    auto rs = s->make_reversed();
+
+    // Consume non-frozen for comparison.
+    rebuilder = mutation_rebuilder_v2(rs);
+    auto nonfrozen_consume_result = mutation(um).consume(rebuilder, consume_in_reverse::yes);
+    BOOST_REQUIRE(nonfrozen_consume_result.result);
+
+    // Consume.
+    rebuilder = mutation_rebuilder_v2(rs);
+    auto frozen_consume_result = fm.consume(s, rebuilder, consume_in_reverse::yes);
+    BOOST_REQUIRE(frozen_consume_result.result);
+    BOOST_REQUIRE_EQUAL(*frozen_consume_result.result, *nonfrozen_consume_result.result);
+
+    // Consume gently.
+    rebuilder = mutation_rebuilder_v2(rs);
+    frozen_consume_result = fm.consume_gently(s, rebuilder, consume_in_reverse::yes).get();
+    BOOST_REQUIRE(frozen_consume_result.result);
+    BOOST_REQUIRE_EQUAL(*frozen_consume_result.result, *nonfrozen_consume_result.result);
 }


### PR DESCRIPTION
This series introduces consuming frozen mutations in reverse.  It also strips the `to_data_query_result` from unfrozing the mutation before being consumed in reverse, which is a time-consuming operation. 
Only `consume_in_reverse::yes` is supported, as the `consume_in_reverse::legacy_half_reverse` support is not needed anywhere.

Fixes #11199