### PR TITLE
boost/mvcc_test: use failure_injecting_allocation_strategy where it is meant to

### DIFF
--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -1358,7 +1358,7 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
         logalloc::region r;
         mutation_cleaner cleaner(r, no_cache_tracker, app_stats_for_tests);
         failure_injecting_allocation_strategy alloc(r.allocator());
-        with_allocator(r.allocator(), [&] {
+        with_allocator(alloc, [&] {
             auto target = gen();
             auto second = gen();
             target.partition().make_fully_continuous();


### PR DESCRIPTION
In test_apply_is_atomic, a basic form of exception testing is used. There is failure_injecting_allocation_strategy, which however is not used for any allocation, since for some reason,
`with_allocator(r.allocator()` is used instead of
`with_allocator(alloc`. Fix that. 

Ref #9419