### PR TITLE
scylla-gdb.py: introduce `scylla get-config-value`

### DIFF
--- a/test/scylla-gdb/run
+++ b/test/scylla-gdb/run
@@ -47,6 +47,7 @@ def run_pytest_in_gdb(pytest_dir, additional_parameters):
         sys.stdout.flush()
         os.execvp('gdb', ['gdb',
             '-batch', '-n', '-se', run.scylla,
+            '-ex', 'set python print-stack full',
             '-ex', 'python ' + pytest_cmd,
             ])
         exit(1)

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -159,4 +159,7 @@ def test_sstable_summary(gdb, sstable):
 def test_read_stats(gdb, sstable):
     scylla(gdb, f'read-stats')
 
+def test_get_config_value(gdb):
+    scylla(gdb, f'get-config-value compaction_static_shares')
+
 # FIXME: need a simple test for lsa-segment


### PR DESCRIPTION
Retrieves the configuration item with the given name and prints its
value as well as its metadata.
Example:

    (gdb) scylla get-config-value compaction_static_shares
    value: 100, type: "float", source: SettingsFile, status: Used, live: MustRestart