### PR TITLE
sstables: index_reader: always evict the local cache gently

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -1087,10 +1087,9 @@ public:
 
     future<> close() noexcept {
         // index_bound::close must not fail
-        return close(_lower_bound).then([this] {
-            if (_upper_bound) {
-                return close(*_upper_bound);
-            }
+        auto close_lb = close(_lower_bound);
+        auto close_ub = _upper_bound ? close(*_upper_bound) : make_ready_future<>();
+        return when_all(std::move(close_lb), std::move(close_ub)).discard_result().finally([this] {
             if (_local_index_cache) {
                 return _local_index_cache->evict_gently();
             }


### PR DESCRIPTION
Due to an oversight, the local index cache isn't evicted gently when _upper_bound existed. This is a source of reactor stalls. Fix that.

Fixes #12271