### PR TITLE
Allow entire test suite to run with multiple compaction groups

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -113,4 +113,7 @@ public:
     compaction::table_state& as_table_state() const noexcept;
 };
 
+// Used by the tests to increase the default number of compaction groups by increasing the minimum to X.
+void set_minimum_x_log2_compaction_groups(unsigned x_log2_compaction_groups);
+
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1440,6 +1440,16 @@ void compaction_group::clear_sstables() {
     _maintenance_sstables = _t.make_maintenance_sstable_set();
 }
 
+static std::atomic<unsigned> minimum_x_log2_compaction_groups{0};
+
+void set_minimum_x_log2_compaction_groups(unsigned x_log2_compaction_groups) {
+    minimum_x_log2_compaction_groups.store(x_log2_compaction_groups, std::memory_order_relaxed);
+}
+
+static inline unsigned get_x_log2_compaction_groups(unsigned x_log2_compaction_groups) {
+    return std::max(x_log2_compaction_groups, minimum_x_log2_compaction_groups.load(std::memory_order_relaxed));
+}
+
 table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_manager& compaction_manager,
         sstables::sstables_manager& sst_manager, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker)
     : _schema(std::move(schema))
@@ -1448,7 +1458,7 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
                          keyspace_label(_schema->ks_name()),
                          column_family_label(_schema->cf_name())
                         )
-    , _x_log2_compaction_groups(_config.x_log2_compaction_groups)
+    , _x_log2_compaction_groups(get_x_log2_compaction_groups(_config.x_log2_compaction_groups))
     , _compaction_manager(compaction_manager)
     , _compaction_strategy(make_compaction_strategy(_schema->compaction_strategy(), _schema->compaction_strategy_options()))
     , _compaction_groups(make_compaction_groups())

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -500,7 +500,9 @@ void table::enable_off_strategy_trigger() {
 
 std::vector<std::unique_ptr<compaction_group>> table::make_compaction_groups() {
     std::vector<std::unique_ptr<compaction_group>> ret;
-    for (auto&& range : dht::split_token_range_msb(_x_log2_compaction_groups)) {
+    auto&& ranges = dht::split_token_range_msb(_x_log2_compaction_groups);
+    tlogger.debug("Created {} compaction groups for {}.{}", ranges.size(), _schema->ks_name(), _schema->cf_name());
+    for (auto&& range : ranges) {
         ret.emplace_back(std::make_unique<compaction_group>(*this, std::move(range)));
     }
     return ret;

--- a/test/boost/aggregate_fcts_test.cc
+++ b/test/boost/aggregate_fcts_test.cc
@@ -15,7 +15,7 @@
 
 #include "utils/big_decimal.hh"
 #include "exceptions/exceptions.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -17,7 +17,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/exception_utils.hh"

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -13,7 +13,7 @@
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/btree_test.cc
+++ b/test/boost/btree_test.cc
@@ -9,7 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <fmt/core.h>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/unit/tree_test_key.hh"
 #include "utils/intrusive_btree.hh"

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/thread.hh>
 #include "schema_builder.hh"
 #include "keys.hh"

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/range/irange.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/when_all.hh>

--- a/test/boost/canonical_mutation_test.cc
+++ b/test/boost/canonical_mutation_test.cc
@@ -13,7 +13,7 @@
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/mutation_assertions.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include <seastar/core/thread.hh>
 

--- a/test/boost/castas_fcts_test.cc
+++ b/test/boost/castas_fcts_test.cc
@@ -15,7 +15,7 @@
 
 #include "utils/big_decimal.hh"
 #include "exceptions/exceptions.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/exception_utils.hh"

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <seastar/util/defer.hh>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <string>
 #include <boost/range/adaptor/map.hpp>
 

--- a/test/boost/cell_locker_test.cc
+++ b/test/boost/cell_locker_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include <seastar/core/thread.hh>
 

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include <deque>
 #include <random>

--- a/test/boost/clustering_ranges_walker_test.cc
+++ b/test/boost/clustering_ranges_walker_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "test/lib/simple_schema.hh"
 #include "clustering_ranges_walker.hh"

--- a/test/boost/column_mapping_test.cc
+++ b/test/boost/column_mapping_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -17,7 +17,7 @@
 #include <set>
 #include <deque>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>

--- a/test/boost/compound_test.cc
+++ b/test/boost/compound_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/random_utils.hh"
 

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <iostream>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/future-util.hh>
 #include "db/config.hh"

--- a/test/boost/continuous_data_consumer_test.cc
+++ b/test/boost/continuous_data_consumer_test.cc
@@ -19,7 +19,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <random>
 

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -15,7 +15,7 @@
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/random_shuffle.hpp>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/random_utils.hh"
 #include "schema_builder.hh"
 #include "keys.hh"

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -12,7 +12,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/defer.hh>
 
 #include "auth/authenticated_user.hh"

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -15,7 +15,7 @@
 
 #include <seastar/net/inet_address.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -16,7 +16,7 @@
 
 #include <seastar/net/inet_address.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -14,7 +14,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <source_location>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -14,7 +14,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <source_location>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -17,7 +17,7 @@
 
 #include <seastar/net/inet_address.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/log.hh"

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -12,7 +12,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/file.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -21,7 +21,7 @@
 #include <seastar/core/thread_cputime_clock.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 #include <deque>

--- a/test/boost/double_decker_test.cc
+++ b/test/boost/double_decker_test.cc
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
 #include <seastar/core/print.hh>

--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -8,7 +8,7 @@
 
 #include "test/lib/cql_test_env.hh"
 #include <seastar/core/manual_clock.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/rpc/rpc_types.hh>
 #include "utils/error_injection.hh"
 #include "db/timeout_clock.hh"

--- a/test/boost/exception_container_test.cc
+++ b/test/boost/exception_container_test.cc
@@ -9,7 +9,7 @@
 #include <stdexcept>
 #include "utils/exception_container.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/sstring.hh>
 
 using namespace seastar;

--- a/test/boost/extensions_test.cc
+++ b/test/boost/extensions_test.cc
@@ -12,7 +12,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sleep.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -15,7 +15,7 @@
 
 #include <seastar/net/inet_address.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/flush_queue_test.cc
+++ b/test/boost/flush_queue_test.cc
@@ -16,7 +16,7 @@
 #include <seastar/core/thread.hh>
 
 #include "seastarx.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/print.hh>
 #include "utils/flush_queue.hh"
 #include "log.hh"

--- a/test/boost/fragmented_temporary_buffer_test.cc
+++ b/test/boost/fragmented_temporary_buffer_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <seastar/core/thread.hh>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "utils/fragmented_temporary_buffer.hh"
 

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -9,7 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -10,7 +10,7 @@
 #include <boost/test/unit_test.hpp>
 #include "locator/gossiping_property_file_snitch.hh"
 #include "utils/fb_utilities.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/reactor.hh>
 #include <vector>

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/coroutine.hh>
 
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/hash_test.cc
+++ b/test/boost/hash_test.cc
@@ -11,7 +11,7 @@
 #include <seastar/core/future.hh>
 
 #include "seastarx.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "utils/hash.hh"
 
 SEASTAR_TEST_CASE(test_pair_hash){

--- a/test/boost/hashers_test.cc
+++ b/test/boost/hashers_test.cc
@@ -9,7 +9,7 @@
 #include "db/timeout_clock.hh"
 
 #include <seastar/util/closeable.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "hashers.hh"
 #include "xx_hasher.hh"

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/smp.hh>
 
 #include "db/hints/sync_point.hh"

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "cql3/untyped_result_set.hh"

--- a/test/boost/intrusive_array_test.cc
+++ b/test/boost/intrusive_array_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <fmt/core.h>
 
 #include "utils/intrusive-array.hh"

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -15,7 +15,7 @@
 
 #include <seastar/net/inet_address.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/large_paging_state_test.cc
+++ b/test/boost/large_paging_state_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "test/lib/cql_test_env.hh"
 #include "transport/messages/result_message.hh"

--- a/test/boost/limiting_data_source_test.cc
+++ b/test/boost/limiting_data_source_test.cc
@@ -9,7 +9,7 @@
 #include "utils/limiting_data_source.hh"
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/test/boost/lister_test.cc
+++ b/test/boost/lister_test.cc
@@ -13,7 +13,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/file.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
 #include "test/lib/tmpdir.hh"

--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -20,7 +20,7 @@
 
 #include "seastarx.hh"
 #include "test/lib/eventually.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/tmpdir.hh"
 #include "test/lib/log.hh"

--- a/test/boost/logalloc_standard_allocator_segment_pool_backend_test.cc
+++ b/test/boost/logalloc_standard_allocator_segment_pool_backend_test.cc
@@ -1,7 +1,7 @@
 #ifdef SEASTAR_DEFAULT_ALLOCATOR
 
 #include "utils/logalloc.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 using namespace logalloc;
 

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -21,7 +21,7 @@
 #include <seastar/core/thread_cputime_clock.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 #include <deque>

--- a/test/boost/managed_vector_test.cc
+++ b/test/boost/managed_vector_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "utils/managed_vector.hh"
 #include "utils/logalloc.hh"

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -11,7 +11,7 @@
 #include "replica/database.hh"
 #include "db/config.hh"
 #include "utils/UUID_gen.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "schema_builder.hh"
 #include <seastar/util/closeable.hh>

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -989,11 +989,10 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         utils::get_local_injector().enable("table_seal_active_memtable_try_flush", true /* oneshot */);
         utils::get_local_injector().enable("table_seal_active_memtable_reacquire_write_permit");
 
+        // Trigger flush
+        auto f = t.flush();
+
         BOOST_ASSERT(eventually_true([&] {
-            // Trigger flush
-            for (auto m : memtables) {
-                m->get_dirty_memory_manager().notify_soft_pressure();
-            }
             return db.cf_stats()->failed_memtables_flushes_count - failed_memtables_flushes_count >= 4;
         }));
 
@@ -1006,6 +1005,8 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
             // seal_active_memtable retry loop should eventually succeed
             return t.min_memtable_timestamp() == api::max_timestamp;
         }));
+
+        std::move(f).get();
     });
 #endif
 }

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -14,7 +14,7 @@
 
 #include <seastar/core/thread.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/test_services.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -21,7 +21,7 @@
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
 
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include <source_location>
 

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -9,7 +9,7 @@
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/on_internal_error.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -15,7 +15,7 @@
 #include "query-result-set.hh"
 #include "query-result-writer.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/result_set_assertions.hh"

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -17,7 +17,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/closeable.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -32,7 +32,7 @@
 #include "test/lib/tmpdir.hh"
 #include "compaction/compaction_manager.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/result_set_assertions.hh"

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/closeable.hh>

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -19,7 +19,7 @@
 #include "partition_snapshot_reader.hh"
 #include "clustering_interval_set.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/simple_schema.hh"

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -11,7 +11,7 @@
 #include "utils/fb_utilities.hh"
 #include "utils/sequenced_set.hh"
 #include "locator/network_topology_strategy.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/sstring.hh>
 #include "log.hh"

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -8,7 +8,7 @@
 
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/combine.hpp>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"

--- a/test/boost/per_partition_rate_limit_test.cc
+++ b/test/boost/per_partition_rate_limit_test.cc
@@ -1,7 +1,7 @@
 #include <chrono>
 #include <cstdint>
 #include <seastar/core/coroutine.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -15,7 +15,7 @@
 
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/closeable.hh>
 
 #include <boost/range/algorithm/sort.hpp>

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -14,7 +14,7 @@
 #include <iterator>
 #include <stdint.h>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/radix_tree_test.cc
+++ b/test/boost/radix_tree_test.cc
@@ -8,7 +8,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <fmt/core.h>
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -21,7 +21,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <boost/test/unit_test.hpp>
 #include "readers/empty_v2.hh"

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -16,7 +16,7 @@
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
 
 // Helper mutation_fragment_queue that stores the received stream of

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -9,7 +9,7 @@
 #include <boost/range/adaptors.hpp>
 #include <source_location>
 #include <fmt/format.h>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "cql3/cql_config.hh"
 #include "cql3/values.hh"

--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -14,7 +14,7 @@
 #include "utils/result_loop.hh"
 #include "utils/result_try.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/sstring.hh>
 #include <seastar/core/map_reduce.hh>
 #include <seastar/util/later.hh>

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -8,7 +8,7 @@
 
 #include "auth/standard_role_manager.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "service/migration_manager.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -14,7 +14,7 @@
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <seastar/util/closeable.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -9,7 +9,7 @@
 
 #include <iostream>
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/defer.hh>
 
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/thread.hh>
 #include "sstables/sstables.hh"

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "tools/schema_loader.hh"
 

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -9,7 +9,7 @@
 
 #include <seastar/core/thread.hh>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "data_dictionary/user_types_metadata.hh"
 #include "schema_registry.hh"

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "transport/messages/result_message.hh"

--- a/test/boost/serialized_action_test.cc
+++ b/test/boost/serialized_action_test.cc
@@ -10,7 +10,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/semaphore.hh>
 #include "utils/serialized_action.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "utils/phased_barrier.hh"
 #include <seastar/core/timer.hh>

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -12,7 +12,7 @@
 #include <iostream>
 
 #include "seastarx.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/future-util.hh>
 #include <algorithm>

--- a/test/boost/snitch_reset_test.cc
+++ b/test/boost/snitch_reset_test.cc
@@ -10,7 +10,7 @@
 #include <boost/test/unit_test.hpp>
 #include "locator/gossiping_property_file_snitch.hh"
 #include "utils/fb_utilities.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/std-compat.hh>
 #include <vector>
 #include <string>

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -14,7 +14,7 @@
 
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -17,7 +17,7 @@
 #include "sstables/key.hh"
 #include "sstables/compress.hh"
 #include "compaction/compaction.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "schema.hh"
 #include "schema_builder.hh"

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2207,44 +2207,43 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
 
             table->add_sstable_and_update_cache(sst).get();
 
-          // FIXME: indentation.
-          bool found_sstable = false;
-          foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
-            auto sstables = in_strategy_sstables(ts);
-            if (sstables.empty()) {
-                return;
-            }
-            BOOST_REQUIRE(sstables.size() == 1);
-            BOOST_REQUIRE(sstables.front() == sst);
-            found_sstable = true;
-
-            auto verify_fragments = [&](sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
-                auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
-                for (const auto& mf : mfs) {
-                   testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
-                   r.produces(*schema, mf);
+            bool found_sstable = false;
+            foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
+                auto sstables = in_strategy_sstables(ts);
+                if (sstables.empty()) {
+                    return;
                 }
-                r.produces_end_of_stream();
-            };
+                BOOST_REQUIRE(sstables.size() == 1);
+                BOOST_REQUIRE(sstables.front() == sst);
+                found_sstable = true;
 
-            testlog.info("Verifying written data...");
+                auto verify_fragments = [&](sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
+                    auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
+                    for (const auto& mf : mfs) {
+                       testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
+                       r.produces(*schema, mf);
+                    }
+                    r.produces_end_of_stream();
+                };
 
-            // Make sure we wrote what we though we wrote.
-            verify_fragments(sst, corrupt_fragments);
+                testlog.info("Verifying written data...");
 
-            testlog.info("Validate");
+                // Make sure we wrote what we though we wrote.
+                verify_fragments(sst, corrupt_fragments);
 
-            // No way to really test validation besides observing the log messages.
-            sstables::compaction_type_options::scrub opts = {
-                .operation_mode = sstables::compaction_type_options::scrub::mode::validate,
-            };
-            table.get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+                testlog.info("Validate");
 
-            BOOST_REQUIRE(sst->is_quarantined());
-            BOOST_REQUIRE(in_strategy_sstables(ts).empty());
-            verify_fragments(sst, corrupt_fragments);
-          }).get();
-          assert(found_sstable);
+                // No way to really test validation besides observing the log messages.
+                sstables::compaction_type_options::scrub opts = {
+                    .operation_mode = sstables::compaction_type_options::scrub::mode::validate,
+                };
+                table.get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+
+                BOOST_REQUIRE(sst->is_quarantined());
+                BOOST_REQUIRE(in_strategy_sstables(ts).empty());
+                verify_fragments(sst, corrupt_fragments);
+            }).get();
+            assert(found_sstable);
         });
     }, test_cfg);
 }
@@ -2406,52 +2405,51 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
 
             table->add_sstable_and_update_cache(sst).get();
 
-          // FIXME: indentation.
-          bool found_sstable = false;
-          foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
-            auto sstables = in_strategy_sstables(ts);
-            if (sstables.empty()) {
-                return;
-            }
-            BOOST_REQUIRE(sstables.size() == 1);
-            BOOST_REQUIRE(sstables.front() == sst);
-            found_sstable = true;
-
-            auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
-                auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, permit));
-                for (const auto& mf : mfs) {
-                   testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
-                   r.produces(*schema, mf);
+            bool found_sstable = false;
+            foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
+                auto sstables = in_strategy_sstables(ts);
+                if (sstables.empty()) {
+                    return;
                 }
-                r.produces_end_of_stream();
-            };
+                BOOST_REQUIRE(sstables.size() == 1);
+                BOOST_REQUIRE(sstables.front() == sst);
+                found_sstable = true;
 
-            testlog.info("Verifying written data...");
+                auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
+                    auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, permit));
+                    for (const auto& mf : mfs) {
+                       testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
+                       r.produces(*schema, mf);
+                    }
+                    r.produces_end_of_stream();
+                };
 
-            // Make sure we wrote what we though we wrote.
-            verify_fragments(sst, corrupt_fragments);
+                testlog.info("Verifying written data...");
 
-            testlog.info("Scrub in abort mode");
+                // Make sure we wrote what we though we wrote.
+                verify_fragments(sst, corrupt_fragments);
 
-            // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
-            sstables::compaction_type_options::scrub opts = {};
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(ts, opts).get(), sstables::compaction_aborted_exception);
+                testlog.info("Scrub in abort mode");
 
-            BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
-            verify_fragments(sst, corrupt_fragments);
+                // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
+                sstables::compaction_type_options::scrub opts = {};
+                opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
+                BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(ts, opts).get(), sstables::compaction_aborted_exception);
 
-            testlog.info("Scrub in skip mode");
+                BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
+                verify_fragments(sst, corrupt_fragments);
 
-            // We expect the scrub with mode=srub::mode::skip to get rid of all invalid data.
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::skip;
-            compaction_manager.perform_sstable_scrub(ts, opts).get();
+                testlog.info("Scrub in skip mode");
 
-            BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
-            BOOST_REQUIRE(in_strategy_sstables(ts).front() != sst);
-            verify_fragments(in_strategy_sstables(ts).front(), scrubbed_fragments);
-          }).get();
-          assert(found_sstable);
+                // We expect the scrub with mode=srub::mode::skip to get rid of all invalid data.
+                opts.operation_mode = sstables::compaction_type_options::scrub::mode::skip;
+                compaction_manager.perform_sstable_scrub(ts, opts).get();
+
+                BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
+                BOOST_REQUIRE(in_strategy_sstables(ts).front() != sst);
+                verify_fragments(in_strategy_sstables(ts).front(), scrubbed_fragments);
+            }).get();
+            assert(found_sstable);
         });
     }, test_cfg);
 }
@@ -2503,61 +2501,60 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
 
             table->add_sstable_and_update_cache(sst).get();
 
-          // FIXME: indentation.
-          bool found_sstable = false;
-          foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
-            auto sstables = in_strategy_sstables(ts);
-            if (sstables.empty()) {
-                return;
-            }
-            BOOST_REQUIRE(sstables.size() == 1);
-            BOOST_REQUIRE(sstables.front() == sst);
-            found_sstable = true;
-
-            auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
-                auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
-                for (const auto& mf : mfs) {
-                   testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
-                   r.produces(*schema, mf);
+            bool found_sstable = false;
+            foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
+                auto sstables = in_strategy_sstables(ts);
+                if (sstables.empty()) {
+                    return;
                 }
-                r.produces_end_of_stream();
-            };
+                BOOST_REQUIRE(sstables.size() == 1);
+                BOOST_REQUIRE(sstables.front() == sst);
+                found_sstable = true;
 
-            testlog.info("Verifying written data...");
+                auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
+                    auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
+                    for (const auto& mf : mfs) {
+                       testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
+                       r.produces(*schema, mf);
+                    }
+                    r.produces_end_of_stream();
+                };
 
-            // Make sure we wrote what we though we wrote.
-            verify_fragments(sst, corrupt_fragments);
+                testlog.info("Verifying written data...");
 
-            testlog.info("Scrub in abort mode");
+                // Make sure we wrote what we though we wrote.
+                verify_fragments(sst, corrupt_fragments);
 
-            // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
-            sstables::compaction_type_options::scrub opts = {};
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-            BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(ts, opts).get(), sstables::compaction_aborted_exception);
+                testlog.info("Scrub in abort mode");
 
-            BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
-            verify_fragments(sst, corrupt_fragments);
+                // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
+                sstables::compaction_type_options::scrub opts = {};
+                opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
+                BOOST_REQUIRE_THROW(compaction_manager.perform_sstable_scrub(ts, opts).get(), sstables::compaction_aborted_exception);
 
-            testlog.info("Scrub in segregate mode");
+                BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
+                verify_fragments(sst, corrupt_fragments);
 
-            // We expect the scrub with mode=srub::mode::segregate to fix all out-of-order data.
-            opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
-            compaction_manager.perform_sstable_scrub(ts, opts).get();
+                testlog.info("Scrub in segregate mode");
 
-            testlog.info("Scrub resulted in {} sstables", in_strategy_sstables(ts).size());
-            BOOST_REQUIRE(in_strategy_sstables(ts).size() > 1);
-            {
-                auto sst_reader = assert_that(table->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
-                auto mt_reader = scrubbed_mt->as_data_source().make_reader_v2(schema, env.make_reader_permit());
-                auto mt_reader_close = deferred_close(mt_reader);
-                while (auto mf_opt = mt_reader().get()) {
-                   testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, *mf_opt));
-                   sst_reader.produces(*schema, *mf_opt);
+                // We expect the scrub with mode=srub::mode::segregate to fix all out-of-order data.
+                opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
+                compaction_manager.perform_sstable_scrub(ts, opts).get();
+
+                testlog.info("Scrub resulted in {} sstables", in_strategy_sstables(ts).size());
+                BOOST_REQUIRE(in_strategy_sstables(ts).size() > 1);
+                {
+                    auto sst_reader = assert_that(table->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
+                    auto mt_reader = scrubbed_mt->as_data_source().make_reader_v2(schema, env.make_reader_permit());
+                    auto mt_reader_close = deferred_close(mt_reader);
+                    while (auto mf_opt = mt_reader().get()) {
+                       testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, *mf_opt));
+                       sst_reader.produces(*schema, *mf_opt);
+                    }
+                    sst_reader.produces_end_of_stream();
                 }
-                sst_reader.produces_end_of_stream();
-            }
-          }).get();
-          assert(found_sstable);
+            }).get();
+            assert(found_sstable);
         });
     }, test_cfg);
 }
@@ -2615,75 +2612,74 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
 
                 table->add_sstable_and_update_cache(sst).get();
 
-              // FIXME: indentation.
-              bool found_sstable = false;
-              foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
-                auto sstables = in_strategy_sstables(ts);
-                if (sstables.empty()) {
-                    return;
-                }
-                BOOST_REQUIRE(sstables.size() == 1);
-                BOOST_REQUIRE(sstables.front() == sst);
-                found_sstable = true;
-
-                auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
-                    auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
-                    for (const auto& mf : mfs) {
-                    testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
-                    r.produces(*schema, mf);
+                bool found_sstable = false;
+                foreach_table_state_with_thread(table, [&] (compaction::table_state& ts) {
+                    auto sstables = in_strategy_sstables(ts);
+                    if (sstables.empty()) {
+                        return;
                     }
-                    r.produces_end_of_stream();
-                };
+                    BOOST_REQUIRE(sstables.size() == 1);
+                    BOOST_REQUIRE(sstables.front() == sst);
+                    found_sstable = true;
 
-                testlog.info("Verifying written data...");
-
-                // Make sure we wrote what we though we wrote.
-                verify_fragments(sst, corrupt_fragments);
-
-                testlog.info("Scrub in validate mode");
-
-                // We expect the scrub with mode=scrub::mode::validate to quarantine the sstable.
-                sstables::compaction_type_options::scrub opts = {};
-                opts.operation_mode = sstables::compaction_type_options::scrub::mode::validate;
-                compaction_manager.perform_sstable_scrub(ts, opts).get();
-
-                BOOST_REQUIRE(in_strategy_sstables(ts).empty());
-                BOOST_REQUIRE(sst->is_quarantined());
-                verify_fragments(sst, corrupt_fragments);
-
-                testlog.info("Scrub in segregate mode with quarantine_mode {}", qmode);
-
-                // We expect the scrub with mode=scrub::mode::segregate to fix all out-of-order data.
-                opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
-                opts.quarantine_operation_mode = qmode;
-                compaction_manager.perform_sstable_scrub(ts, opts).get();
-
-                switch (qmode) {
-                case sstables::compaction_type_options::scrub::quarantine_mode::include:
-                case sstables::compaction_type_options::scrub::quarantine_mode::only:
-                    // The sstable should be found and scrubbed when scrub::quarantine_mode is scrub::quarantine_mode::{include,only}
-                    testlog.info("Scrub resulted in {} sstables", in_strategy_sstables(ts).size());
-                    BOOST_REQUIRE(in_strategy_sstables(ts).size() > 1);
-                    {
-                        auto sst_reader = assert_that(table->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
-                        auto mt_reader = scrubbed_mt->as_data_source().make_reader_v2(schema, env.make_reader_permit());
-                        auto mt_reader_close = deferred_close(mt_reader);
-                        while (auto mf_opt = mt_reader().get()) {
-                            testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, *mf_opt));
-                            sst_reader.produces(*schema, *mf_opt);
+                    auto verify_fragments = [&] (sstables::shared_sstable sst, const std::vector<mutation_fragment_v2>& mfs) {
+                        auto r = assert_that(sst->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
+                        for (const auto& mf : mfs) {
+                        testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, mf));
+                        r.produces(*schema, mf);
                         }
-                        sst_reader.produces_end_of_stream();
-                    }
-                    break;
-                case sstables::compaction_type_options::scrub::quarantine_mode::exclude:
-                    // The sstable should not be found when scrub::quarantine_mode is scrub::quarantine_mode::exclude
+                        r.produces_end_of_stream();
+                    };
+
+                    testlog.info("Verifying written data...");
+
+                    // Make sure we wrote what we though we wrote.
+                    verify_fragments(sst, corrupt_fragments);
+
+                    testlog.info("Scrub in validate mode");
+
+                    // We expect the scrub with mode=scrub::mode::validate to quarantine the sstable.
+                    sstables::compaction_type_options::scrub opts = {};
+                    opts.operation_mode = sstables::compaction_type_options::scrub::mode::validate;
+                    compaction_manager.perform_sstable_scrub(ts, opts).get();
+
                     BOOST_REQUIRE(in_strategy_sstables(ts).empty());
                     BOOST_REQUIRE(sst->is_quarantined());
                     verify_fragments(sst, corrupt_fragments);
-                    break;
-                }
-              }).get();
-              assert(found_sstable);
+
+                    testlog.info("Scrub in segregate mode with quarantine_mode {}", qmode);
+
+                    // We expect the scrub with mode=scrub::mode::segregate to fix all out-of-order data.
+                    opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
+                    opts.quarantine_operation_mode = qmode;
+                    compaction_manager.perform_sstable_scrub(ts, opts).get();
+
+                    switch (qmode) {
+                    case sstables::compaction_type_options::scrub::quarantine_mode::include:
+                    case sstables::compaction_type_options::scrub::quarantine_mode::only:
+                        // The sstable should be found and scrubbed when scrub::quarantine_mode is scrub::quarantine_mode::{include,only}
+                        testlog.info("Scrub resulted in {} sstables", in_strategy_sstables(ts).size());
+                        BOOST_REQUIRE(in_strategy_sstables(ts).size() > 1);
+                        {
+                            auto sst_reader = assert_that(table->as_mutation_source().make_reader_v2(schema, env.make_reader_permit()));
+                            auto mt_reader = scrubbed_mt->as_data_source().make_reader_v2(schema, env.make_reader_permit());
+                            auto mt_reader_close = deferred_close(mt_reader);
+                            while (auto mf_opt = mt_reader().get()) {
+                                testlog.trace("Expecting {}", mutation_fragment_v2::printer(*schema, *mf_opt));
+                                sst_reader.produces(*schema, *mf_opt);
+                            }
+                            sst_reader.produces_end_of_stream();
+                        }
+                        break;
+                    case sstables::compaction_type_options::scrub::quarantine_mode::exclude:
+                        // The sstable should not be found when scrub::quarantine_mode is scrub::quarantine_mode::exclude
+                        BOOST_REQUIRE(in_strategy_sstables(ts).empty());
+                        BOOST_REQUIRE(sst->is_quarantined());
+                        verify_fragments(sst, corrupt_fragments);
+                        break;
+                    }
+                }).get();
+                assert(found_sstable);
             });
         }, test_cfg);
     }

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/boost/sstable_test.hh"
 #include <seastar/core/thread.hh>

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -15,7 +15,7 @@
 #include "sstables/sstables.hh"
 #include "sstables/key.hh"
 #include "sstables/compress.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "schema.hh"
 #include "schema_builder.hh"

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -7,8 +7,7 @@
  */
 
 
-#include <seastar/testing/thread_test_case.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/sstring.hh>
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstable_directory.hh"

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <filesystem>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
 #include "utils/lister.hh"

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -9,7 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/net/inet_address.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/sstable_partition_index_cache_test.cc
+++ b/test/boost/sstable_partition_index_cache_test.cc
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
 #include "sstables/partition_index_cache.hh"

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -2,14 +2,13 @@
 #include <memory>
 #include <utility>
 
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/distributed.hh>
 #include "types/map.hh"
 #include "sstables/sstables.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "schema.hh"
 #include "replica/database.hh"
 #include "dht/murmur3_partitioner.hh"

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -7,7 +7,7 @@
  */
 
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "sstables/sstable_set_impl.hh"
 #include "sstables/shared_sstable.hh"

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -19,7 +19,7 @@
 #include "sstables/key.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "schema.hh"
 #include "compress.hh"
 #include "replica/database.hh"

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -49,12 +49,6 @@ public:
     static uint64_t calculate_generation_for_new_table(replica::column_family& cf) {
         return generation_value(cf.calculate_generation_for_new_table());
     }
-
-    auto try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
-        auto cg = _cf->single_compaction_group_if_available();
-        assert(cg);
-        return _cf->try_flush_memtable_to_sstable(*cg, mt, replica::sstable_write_permit::unconditional());
-    }
 };
 
 namespace sstables {

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "utils/stall_free.hh"
 #include "utils/small_vector.hh"
 #include "utils/chunked_vector.hh"

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -7,7 +7,7 @@
  */
 
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include <vector>
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -8,7 +8,7 @@
 
 
 #include <seastar/core/thread.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "query-result-writer.hh"
 
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -16,6 +16,11 @@ no_parallel_cases:
     - logalloc_test
     - logalloc_standard_allocator_segment_pool_backend_test
     - memtable_test
+# Enable compaction groups on tests except on a few, listed below
+all_can_run_compaction_groups_except:
+    - exceptions_optimized_test
+    - rate_limiter_test
+    - exceptions_fallback_test
 # Custom command line arguments for some of the tests
 custom_args:
     mutation_reader_test:

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "tracing/tracing.hh"
 #include "tracing/trace_state.hh"

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 #include "transport/request.hh"
 #include "transport/response.hh"

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <string_view>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/net/inet_address.hh>
 #include "utils/UUID_gen.hh"
 #include <boost/asio/ip/address_v4.hpp>

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -16,7 +16,7 @@
 #include "db/config.hh"
 #include "cql3/query_options.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
 

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -13,7 +13,7 @@
 #include "db/view/view_builder.hh"
 #include "compaction/compaction_manager.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 

--- a/test/boost/view_schema_ckey_test.cc
+++ b/test/boost/view_schema_ckey_test.cc
@@ -14,7 +14,7 @@
 #include "types/user.hh"
 #include "db/view/view_builder.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -14,7 +14,7 @@
 #include "types/user.hh"
 #include "db/view/view_builder.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -15,7 +15,7 @@
 #include "db/view/node_view_update_backlog.hh"
 #include "db/view/view_builder.hh"
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/test_services.hh"

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -13,7 +13,7 @@
 
 #include "test/lib/mutation_source_test.hh"
 
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 
 class memtable_filling_test_vt : public db::memtable_filling_virtual_table {
     std::vector<mutation> _mutations;

--- a/test/boost/virtual_table_test.cc
+++ b/test/boost/virtual_table_test.cc
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/test_services.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/wasm_alloc_test.cc
+++ b/test/boost/wasm_alloc_test.cc
@@ -10,7 +10,7 @@
 #include "lang/wasm_instance_cache.hh"
 #include "rust/wasmtime_bindings.hh"
 #include "seastar/core/reactor.hh"
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/coroutine.hh>
 
 // This test file can contain only a single test case which uses the wasmtime

--- a/test/boost/wasm_test.cc
+++ b/test/boost/wasm_test.cc
@@ -12,7 +12,7 @@
 #include "seastar/coroutine/maybe_yield.hh"
 #include <chrono>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/coroutine.hh>
 
 SEASTAR_TEST_CASE(test_long_udf_yields) {

--- a/test/lib/scylla_test_case.hh
+++ b/test/lib/scylla_test_case.hh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+/* That's to define a new entry point that process scylla tests specific options */
+#undef SEASTAR_TESTING_MAIN
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/testing/entry_point.hh>
+#include "test/lib/scylla_tests_cmdline_options.hh"
+
+int main(int argc, char** argv) {
+    scylla_tests_cmdline_options_processor processor;
+    auto [new_argc, new_argv] = processor.process_cmdline_options(argc, argv);
+    return seastar::testing::entry_point(new_argc, new_argv);
+}

--- a/test/lib/scylla_tests_cmdline_options.hh
+++ b/test/lib/scylla_tests_cmdline_options.hh
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <utility>
+
+class scylla_tests_cmdline_options_processor {
+private:
+    int _new_argc = 0;
+    char** _new_argv = nullptr;
+public:
+    scylla_tests_cmdline_options_processor() = default;
+    ~scylla_tests_cmdline_options_processor();
+    // Returns new argv if compaction group option was processed.
+    std::pair<int, char**> process_cmdline_options(int argc, char** argv);
+};

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "test/lib/scylla_tests_cmdline_options.hh"
 #include "test/lib/test_services.hh"
 #include "test/lib/sstable_test_env.hh"
 #include "db/config.hh"
@@ -13,6 +14,9 @@
 #include "dht/i_partitioner.hh"
 #include "gms/feature_service.hh"
 #include "repair/row_level.hh"
+#include <boost/program_options.hpp>
+#include <iostream>
+#include <seastar/util/defer.hh>
 
 dht::token create_token_from_key(const dht::i_partitioner& partitioner, sstring key) {
     sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
@@ -163,4 +167,70 @@ test_env::impl::impl(test_env_config cfg)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 
+}
+
+static std::pair<int, char**> rebuild_arg_list_without(int argc, char** argv, const char* filter_out, bool exclude_positional_arg = false) {
+    int new_argc = 0;
+    char** new_argv = (char**) malloc(argc * sizeof(char*));
+    std::memset(new_argv, 0, argc * sizeof(char*));
+    bool exclude_next_arg = false;
+    for (auto i = 0; i < argc; i++) {
+        if (std::exchange(exclude_next_arg, false)) {
+            continue;
+        }
+        if (strcmp(argv[i], filter_out) == 0) {
+            // if arg filtered out has positional arg, that has to be excluded too.
+            exclude_next_arg = exclude_positional_arg;
+            continue;
+        }
+        new_argv[new_argc] = (char*) malloc(strlen(argv[i]) + 1);
+        std::strcpy(new_argv[new_argc], argv[i]);
+        new_argc++;
+    }
+    return std::make_pair(new_argc, new_argv);
+}
+
+static void free_arg_list(int argc, char** argv) {
+    for (auto i = 0; i < argc; i++) {
+        if (argv[i]) {
+            free(argv[i]);
+        }
+    }
+    free(argv);
+}
+
+scylla_tests_cmdline_options_processor::~scylla_tests_cmdline_options_processor() {
+    if (_new_argv) {
+        free_arg_list(_new_argc, _new_argv);
+    }
+}
+
+std::pair<int, char**> scylla_tests_cmdline_options_processor::process_cmdline_options(int argc, char** argv) {
+    namespace po = boost::program_options;
+
+    // Removes -- (intended to separate boost suite args from seastar ones) which confuses boost::program_options.
+    auto [new_argc, new_argv] = rebuild_arg_list_without(argc, argv, "--");
+    auto _ = defer([argc = new_argc, argv = new_argv] {
+        free_arg_list(argc, argv);
+    });
+
+    po::options_description desc("Scylla tests additional options");
+    desc.add_options()
+            ("help", "Produces help message");
+    po::variables_map vm;
+
+    po::parsed_options parsed = po::command_line_parser(new_argc, new_argv).
+            options(desc).
+            allow_unregistered().
+            run();
+
+    po::store(parsed, vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return std::make_pair(argc, argv);
+    }
+
+    return std::make_pair(argc, argv);
 }


### PR DESCRIPTION
New test/lib/scylla_test_case.hh, introduced in "tests: Add command line options for Scylla unit tests",
allows extension of the command line options provided by Seastar testing framework.
It allows all boost tests to process additional options without changing a single line of code.

Patch "test: Add x-log2-compaction-groups to Scylla test command line options" builds on that, allowing
all test cases to run with N compaction groups. Again, without changing a line of code in the tests.

Now all you have to do is:
./build/dev/test/boost/sstable_compaction_test -- --smp 1 --x-log2-compaction-groups 1
./test.py --mode=dev --x-log2-compaction-groups 1 --verbose

And it will run the test cases with as many groups as you wish.

./test.py passes successfully with parameter --x-log2-compaction-groups 1.