### PR TITLE
sstables: harden close(index_bound&)

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -748,7 +748,9 @@ private:
         if (b.context) {
             close_context = b.context->close();
         }
-        return seastar::when_all_succeed(std::move(close_context), reset_clustered_cursor(b)).discard_result();
+        return seastar::when_all_succeed(std::move(close_context), reset_clustered_cursor(b)).discard_result().then([&b] {
+            b.current_list = {};
+        });
     }
 public:
     index_reader(shared_sstable sst, reader_permit permit, const io_priority_class& pc, tracing::trace_state_ptr trace_state,


### PR DESCRIPTION
This mini-series hardens `close(index_bound&)` in 2 ways:
1. reset unique_ptr:s that are being closed on the sync path, before close returns to allow closing both _lower_bound and *_upper_bound safely if they happen to be the same.
2. reset the index_bound.current_list to free up the reference it holds, so the respective page could be evicted gently when the index_reader uses a _local_index_cache.

Ref #12271