### PR TITLE
raft: raft_group0, register RPC verbs on all shards

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1441,8 +1441,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             db.local().enable_autocompaction_toggle();
 
             service::raft_group0 group0_service{
-                    stop_signal.as_local_abort_source(), raft_gr.local(), messaging.local(),
+                    stop_signal.as_local_abort_source(), raft_gr.local(), messaging,
                     gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client};
+            group0_service.start().get();
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
                 group0_service.abort().get();
             });

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -351,6 +351,19 @@ struct append_request {
     // Log entries to store (empty vector for heartbeat; may send more
     // than one entry for efficiency).
     std::vector<log_entry_ptr> entries;
+
+    append_request copy() const {
+        append_request result;
+        result.current_term = current_term;
+        result.prev_log_idx = prev_log_idx;
+        result.prev_log_term = prev_log_term;
+        result.leader_commit_idx = leader_commit_idx;
+        result.entries.reserve(entries.size());
+        for (const auto& e: entries) {
+            result.entries.push_back(make_lw_shared(*e));
+        }
+        return result;
+    }
 };
 
 struct append_reply {

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -175,9 +175,12 @@ void raft_group_registry::init_rpc_verbs() {
     });
 
     ser::raft_rpc_verbs::register_raft_append_entries(&_ms, [handle_raft_rpc] (const rpc::client_info& cinfo, rpc::opt_time_point timeout,
-           raft::group_id gid, raft::server_id from, raft::server_id dst, raft::append_request append_request) mutable {
-        return handle_raft_rpc(cinfo, gid, from, dst, [from, append_request = std::move(append_request)] (raft_rpc& rpc) mutable {
-            rpc.append_entries(std::move(from), std::move(append_request));
+        raft::group_id gid, raft::server_id from, raft::server_id dst, raft::append_request append_request) mutable {
+        return handle_raft_rpc(cinfo, gid, from, dst, [from, append_request = std::move(append_request), original_shard_id = this_shard_id()] (raft_rpc& rpc) mutable {
+            // lw_shared_ptr (raft::log_entry_ptr) doesn't support cross-shard ref counting (see debug_shared_ptr_counter_type),
+            // so we are copying entries to this shard if it isn't equal the original one.
+            rpc.append_entries(std::move(from),
+                this_shard_id() == original_shard_id ? std::move(append_request) : append_request.copy());
             return netw::messaging_service::no_wait();
         });
     });

--- a/test.py
+++ b/test.py
@@ -35,7 +35,7 @@ from scripts import coverage    # type: ignore
 from test.pylib.artifact_registry import ArtifactRegistry
 from test.pylib.host_registry import HostRegistry
 from test.pylib.pool import Pool
-from test.pylib.scylla_cluster import ScyllaServer, ScyllaCluster, get_cluster_manager
+from test.pylib.scylla_cluster import ScyllaServer, ScyllaCluster, get_cluster_manager, merge_cmdline_options
 from typing import Dict, List, Callable, Any, Iterable, Optional, Awaitable
 
 output_is_a_tty = sys.stdout.isatty()
@@ -349,6 +349,7 @@ class PythonTestSuite(TestSuite):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])
             if type(cmdline_options) == str:
                 cmdline_options = [cmdline_options]
+            cmdline_options = merge_cmdline_options(cmdline_options, create_cfg.cmdline_from_test)
 
             # There are multiple sources of config options, with increasing priority
             # (if two sources provide the same config option, the higher priority one wins):

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -846,8 +846,9 @@ public:
             });
 
             service::raft_group0 group0_service{
-                    abort_sources.local(), raft_gr.local(), ms.local(),
+                    abort_sources.local(), raft_gr.local(), ms,
                     gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client};
+            group0_service.start().get();
             auto stop_group0_service = defer([&group0_service] {
                 group0_service.abort().get();
             });

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -9,7 +9,7 @@
    Manages driver refresh when cluster is cycled.
 """
 
-from typing import List, Optional, Callable, NamedTuple
+from typing import List, Optional, Callable, NamedTuple, Any
 import logging
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient
 from test.pylib.util import wait_for
@@ -147,10 +147,14 @@ class ManagerClient():
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
-    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None) -> ServerInfo:
+    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None) -> ServerInfo:
         """Add a new server"""
         try:
-            data = {'replace_cfg': replace_cfg._asdict()} if replace_cfg else {}
+            data: dict[str, Any] = {}
+            if replace_cfg:
+                data['replace_cfg'] = replace_cfg._asdict()
+            if cmdline:
+                data['cmdline'] = cmdline
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json")
         except Exception as exc:
             raise Exception("Failed to add server") from exc


### PR DESCRIPTION
raft_group0 used to register RPC verbs only on shard 0. This worked on clusters with the same --smp setting on all nodes, since RPCs in this case are processed on the same shard as the calling code, and raft_group0 methods only run on shard 0.

A new test test_nodes_with_different_smp was added to identify the problem. Since --smp can
only be specified via the command line, a
corresponding parameter was added to the
ManagerClient.server_add method.
It allows to override the default parameters
set by the SCYLLA_CMDLINE_OPTIONS variable
by changing, adding or deleting individual
items.

Fixes: #12252