### PR TITLE
schema: operator<<: print also tombstone_gc_options

### DIFF
--- a/schema.cc
+++ b/schema.cc
@@ -656,6 +656,7 @@ std::ostream& operator<<(std::ostream& os, const schema& s) {
     os << ",comment=" << s._raw._comment;
     os << ",readRepairChance=" << s._raw._read_repair_chance;
     os << ",dcLocalReadRepairChance=" << s._raw._dc_local_read_repair_chance;
+    os << ",tombstoneGcOptions=" << s.tombstone_gc_options().to_sstring();
     os << ",gcGraceSeconds=" << s._raw._gc_grace_seconds;
     os << ",keyValidator=" << s.thrift_key_validator();
     os << ",minCompactionThreshold=" << s._raw._min_compaction_threshold;


### PR DESCRIPTION
They are currently missing from the printout
when the a table is created, but they are determinal to understanding the mode with which tombstones are to be garbage-collected in the table.  gcGraceSeconds alone is no longer enough since the introduction of
tombstone_gc_option in a8ad385ecd3e2b372db3c354492dbe57d9d91760.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>