### PR TITLE
docs: fix the option name from compaction to compression

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -631,7 +631,7 @@ A table supports the following options:
      - map
      - see below
      - :ref:`Compaction options <cql-compaction-options>`
-   * - ``compaction``
+   * - ``compression``
      - map
      - see below
      - :ref:`Compression options <cql-compression-options>`


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12334

Fixes the option name in the "Other table options" table on the Data Definition page.