### PR TITLE
tasks: task_manager: move invoke_on_task<> to .hh

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -323,29 +323,6 @@ future<> task_manager::invoke_on_task(sharded<task_manager>& tm, task_id id, std
     }));
 }
 
-template<typename T>
-future<T> task_manager::invoke_on_task(sharded<task_manager>& tm, task_id id, std::function<future<T> (task_manager::task_ptr)> func) {
-    std::optional<T> res;
-    co_await coroutine::parallel_for_each(boost::irange(0u, smp::count), [&tm, id, &res, &func] (unsigned shard) -> future<> {
-        auto local_res = co_await tm.invoke_on(shard, [id, func] (const task_manager& local_tm) -> future<std::optional<T>> {
-            const auto& all_tasks = local_tm.get_all_tasks();
-            if (auto it = all_tasks.find(id); it != all_tasks.end()) {
-                co_return co_await func(it->second);
-            }
-            co_return std::nullopt;
-        });
-        if (!res) {
-            res = std::move(local_res);
-        } else if (local_res) {
-            on_internal_error(tmlogger, format("task_id {} found on more than one shard", id));
-        }
-    });
-    if (!res) {
-        co_await coroutine::return_exception(task_manager::task_not_found(id));
-    }
-    co_return std::move(res.value());
-}
-
 abort_source& task_manager::abort_source() noexcept {
     return _as;
 }


### PR DESCRIPTION
invoke_on_task is used in translation units where its definition is not visible, yet it has no explicit instantiations. If the compiler always decides to inline the definition, not to instantiate it implicitly, linking invoke_on_task will fail. (It happened to me when I turned up inline-threshold). Fix that.