### PR TITLE
docs,alternator: link to issue about missing ACL feature

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -133,8 +133,9 @@ supports fine-grain access controls via "IAM policies" - which give each
 authenticated user access to a different subset of the tables, different
 allowed operations, and even different permissions for individual items.
 All of this is not yet implemented in Alternator.
+See <https://github.com/scylladb/scylla/issues/5047>.
 
-### Metrics
+## Metrics
 
 Scylla has an advanced and extensive monitoring framework for inspecting
 and graphing hundreds of different metrics of Scylla's usage and performance.


### PR DESCRIPTION
The alternator compatibility.md document mentions the missing ACL (access control) feature, but unlike other missing features we forgot to link to the open issue about this missing feature. So let's add that link.

Refs #5047.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>