### PR TITLE
test/python: increase CQL connection timeout for test_ssl

### DIFF
--- a/test/cql-pytest/test_ssl.py
+++ b/test/cql-pytest/test_ssl.py
@@ -55,7 +55,14 @@ def try_connect(orig_cluster, ssl_version):
         port=orig_cluster.port,
         protocol_version=orig_cluster.protocol_version,
         auth_provider=orig_cluster.auth_provider,
-        ssl_context=ssl_context)
+        ssl_context=ssl_context,
+        # The default timeout for new connections is 5 seconds, and for
+        # requests made by the control connection is 2 seconds. These should
+        # have been more than enough, but in some extreme cases with a very
+        # slow debug build running on a very busy machine, they may not be.
+        # so let's increase them to 60 seconds. See issue #11289.
+        connect_timeout = 60,
+        control_connection_timeout = 60)
     cluster.connect()
     cluster.shutdown()
 


### PR DESCRIPTION
In very slow debug builds the default driver timeouts are too low and tests might fail. Bump up the values to a more reasonable time.
