### PR TITLE
docs: extend the warning on using "nodetool removenode"

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/remove-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/remove-node.rst
@@ -61,7 +61,9 @@ command providing the Host ID of the node you are removing. See :doc:`nodetool r
 
 .. warning::
     * Using ``nodetool removenode`` is a fallback procedure that should only be used when a node is permanently down and cannot
-      be recovered. 
+      be recovered.
+    * It’s essential to ensure the removed node will **never** come back to the cluster, which **might lead to data loss**. To prevent 
+      the removed node from rejoining the cluster, remove that node from the cluster network or VPC.
     * You must never use ``nodetool removenode`` to remove a running node that can be reached by other nodes in the cluster.
 
 **Example:**

--- a/docs/operating-scylla/procedures/cluster-management/remove-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/remove-node.rst
@@ -56,7 +56,7 @@ Removing an Unavailable Node
 If the node status is **Down Normal (DN)**, you should try to restore it. Once the node is up, use the ``nodetool decommission``
 command (see `Removing a Running Node`_) to remove it.
 
-If all attempts to restore the node have failed and the node is down, you can remove the node by running the ``nodetool removenode``
+If all attempts to restore the node have failed and the node is **permanently down**, you can remove the node by running the ``nodetool removenode``
 command providing the Host ID of the node you are removing. See :doc:`nodetool removenode </operating-scylla/nodetool-commands/removenode>` for details.
 
 .. warning::

--- a/docs/operating-scylla/procedures/cluster-management/remove-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/remove-node.rst
@@ -62,9 +62,14 @@ command providing the Host ID of the node you are removing. See :doc:`nodetool r
 .. warning::
     * Using ``nodetool removenode`` is a fallback procedure that should only be used when a node is permanently down and cannot
       be recovered.
-    * It’s essential to ensure the removed node will **never** come back to the cluster, which **might lead to data loss**. To prevent 
-      the removed node from rejoining the cluster, remove that node from the cluster network or VPC.
+    * It’s essential to ensure the removed node will **never** come back to the cluster, which **might adversely affect your data** 
+      (data resurrection/loss). To prevent the removed node from rejoining the cluster, remove that node from the cluster 
+      network or VPC.
     * You must never use ``nodetool removenode`` to remove a running node that can be reached by other nodes in the cluster.
+
+.. REMOVE IN FUTURE VERSIONS - The problem listed as the second bullet in the warning above is solved by Raft.
+.. Update the warning to suggest enabling Raft when Raft topology changes are implemented.
+.. Remove the bullet when Raft topology changes are mandatory.
 
 **Example:**
 


### PR DESCRIPTION
This PR extends the description of using `nodetool removenode `to remove an unavailable node, as requested in https://github.com/scylladb/scylla-enterprise/issues/2338.
