### PR TITLE
test_raft_upgrade: wait until alive nodes are marked as such before remove_nod

### DIFF
--- a/api/api-doc/gossiper.json
+++ b/api/api-doc/gossiper.json
@@ -22,6 +22,14 @@
                   "application/json"
                ],
                "parameters":[
+                  {
+                     "name":"shard",
+                     "description": "The shard to query",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
                ]
             }
          ]
@@ -41,6 +49,14 @@
                   "application/json"
                ],
                "parameters":[
+                  {
+                     "name":"shard",
+                     "description": "The shard to query",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
                ]
             }
          ]

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -13,15 +13,41 @@
 namespace api {
 using namespace json;
 
+static unsigned parse_shard_number(const std::string& str) {
+    try {
+        long s = std::stol(str);
+        if (s < 0 || s >= smp::count) {
+            throw std::runtime_error{format(
+                "Shard number {} outside valid shard range [0, {})", s, smp::count)};
+        }
+        return s;
+    } catch (...) {
+        throw std::runtime_error{format(
+            "Invalid shard number \"{}\": {}", str, std::current_exception())};
+    }
+}
+
 void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
-    httpd::gossiper_json::get_down_endpoint.set(r, [&g] (const_req req) {
-        auto res = g.get_unreachable_members();
-        return container_to_vec(res);
+    httpd::gossiper_json::get_down_endpoint.set(r, [&g] (std::unique_ptr<request> req) {
+        std::string shard_str = req->get_query_param("shard");
+        unsigned shard = shard_str.empty() ? 0 : parse_shard_number(shard_str);
+
+        return g.container().invoke_on(shard, [] (gms::gossiper& g) {
+            return g.get_unreachable_members();
+        }).then([] (std::set<gms::inet_address> s) {
+            return make_ready_future<json::json_return_type>(container_to_vec(s));
+        });
     });
 
-    httpd::gossiper_json::get_live_endpoint.set(r, [&g] (const_req req) {
-        auto res = g.get_live_members();
-        return container_to_vec(res);
+    httpd::gossiper_json::get_live_endpoint.set(r, [&g] (std::unique_ptr<request> req) {
+        std::string shard_str = req->get_query_param("shard");
+        unsigned shard = shard_str.empty() ? 0 : parse_shard_number(shard_str);
+
+        return g.container().invoke_on(shard, [] (gms::gossiper& g) {
+            return g.get_live_members();
+        }).then([] (std::set<gms::inet_address> s) {
+            return make_ready_future<json::json_return_type>(container_to_vec(s));
+        });
     });
 
     httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (const_req req) {

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -149,12 +149,12 @@ class ScyllaRESTAPIClient():
         assert(type(result) == list)
         return result
 
-    async def get_down_endpoints(self, dst_server_id: str) -> list:
+    async def get_down_endpoints(self, node_ip: IPAddress, shard: int = 0) -> list:
         """Retrieve down endpoints from gossiper's point of view """
-        response = await self.client.get("/gossiper/endpoint/down/", dst_server_id)
-        result = await response.json()
-        assert(type(result) == list)
-        return result
+        data = await self.client.get_json("/gossiper/endpoint/down/",
+                                          host=node_ip, params = {"shard": str(shard)})
+        assert(type(data) == list)
+        return data
 
     async def remove_node(self, initiator_ip: IPAddress, host_id: HostID,
                           ignore_dead: list[IPAddress]) -> None:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -40,6 +40,10 @@ from cassandra.cluster import EXEC_PROFILE_DEFAULT  # pylint: disable=no-name-in
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 
 
+# Number of shards on each node
+NUM_SHARDS = 2
+
+
 class ReplaceConfig(NamedTuple):
     replaced_id: ServerNum
     reuse_ip_addr: bool
@@ -100,7 +104,7 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
 # it easier to restart. Sic: if you make a typo on the command line,
 # Scylla refuses to boot.
 SCYLLA_CMDLINE_OPTIONS = [
-    '--smp', '2',
+    '--smp', str(NUM_SHARDS),
     '-m', '1G',
     '--collectd', '0',
     '--overprovisioned',


### PR DESCRIPTION
In test_raft_upgrade_with_node_remove we restart 2 out of 3 nodes,
then remove the third node. This worked with non-RBNO removenode.
RBNO removenode fails because it requires other nodes to participate and
checks whether they are alive - but the test called the removenode
operation immediately, before gossiper managed to mark the other node
alive on each of the restarted node.

Fix this by waiting until the nodes mark each other as alive so they
only consider the dead node as dead. We must do this on every shard
because liveness information is not replicated instantaneously between
shards.

The fix required extending one of the gossiper endpoints (for returning dead or
alive endpoints, I extended both) so they allow querying a specific shard.

Ref: https://github.com/scylladb/scylladb/pull/12173