### PR TITLE
Backport 5.0: cleanup compaction: flush memtable

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -637,7 +637,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                 // as a table can be dropped during loop below, let's find it before issuing the cleanup request.
                 for (auto& id : table_ids) {
                     replica::table& t = db.find_column_family(id);
-                    co_await cm.perform_cleanup(db, &t);
+                    co_await t.perform_cleanup_compaction(db);
                 }
                 co_return;
             }).then([]{

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -900,6 +900,8 @@ public:
     // The future value is true iff offstrategy compaction was required.
     future<bool> perform_offstrategy_compaction();
     future<> run_offstrategy_compaction(sstables::compaction_data& info);
+    future<> perform_cleanup_compaction(replica::database& db);
+
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);
     const sstables::compaction_strategy& get_compaction_strategy() const {
         return _compaction_strategy;
@@ -925,7 +927,11 @@ public:
         return _config;
     }
 
-    compaction_manager& get_compaction_manager() const {
+    const compaction_manager& get_compaction_manager() const noexcept {
+        return _compaction_manager;
+    }
+
+    compaction_manager& get_compaction_manager() noexcept {
         return _compaction_manager;
     }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1137,6 +1137,10 @@ future<> table::run_offstrategy_compaction(sstables::compaction_data& info) {
     tlogger.info("Done with off-strategy compaction for {}.{}", _schema->ks_name(), _schema->cf_name());
 }
 
+future<> table::perform_cleanup_compaction(replica::database& db) {
+    co_await get_compaction_manager().perform_cleanup(db, this);
+}
+
 void table::set_compaction_strategy(sstables::compaction_strategy_type strategy) {
     tlogger.debug("Setting compaction strategy of {}.{} to {}", _schema->ks_name(), _schema->cf_name(), sstables::compaction_strategy::name(strategy));
     auto new_cs = make_compaction_strategy(strategy, _schema->compaction_strategy_options());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1138,6 +1138,7 @@ future<> table::run_offstrategy_compaction(sstables::compaction_data& info) {
 }
 
 future<> table::perform_cleanup_compaction(replica::database& db) {
+    co_await flush();
     co_await get_compaction_manager().perform_cleanup(db, this);
 }
 


### PR DESCRIPTION
This a backport of 9fa17838929a3ca8ec6e0568a4c72062d7ed3e73 (#11902) to branch-5.0

Flush the memtable before cleaning up the table so not to leave any disowned tokens in the memtable
as they might be resurrected if left in the memtable.

Refs #1239