### PR TITLE
docs: update the "nodetool rebuild" command

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -193,7 +193,7 @@ Add New DC
 
    For example:
 
-   ``nodetool rebuild -- <existing_data_center_name>``
+   ``nodetool rebuild <existing_data_center_name>``
 
    The rebuild ensures that the new nodes that were just added to the cluster will recognize the existing datacenters in the cluster.
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-doc-issues/issues/870
Removes `-- `from the command to ensure consistency across the docs.