### PR TITLE
doc: extend the information about the recommended RF on the Tracing page

### DIFF
--- a/docs/using-scylla/tracing.rst
+++ b/docs/using-scylla/tracing.rst
@@ -11,10 +11,10 @@ Tracing is a ScyllaDB tool meant to help debugging and analyzing internal flows 
 
 .. note:: If you're planning to use either **probabilistic tracing** or **slow query logging** (see below), it's advisable to change the ``replication_factor`` of the  ``system_traces`` keyspace to ``ALL``:
           
-          If you use ``NetworkTopologyStrategy``, the replication factor set for each datacenter should equal the number 
-          of nodes in that datacenter. Alternatively, you can use ``EverywhereReplicationStrategy``. 
-          
-          See :doc:`How to Safely Increase the Replication Factor </kb/rf-increase>` for details on changing the RF.
+          If you use ``NetworkTopologyStrategy``, we recommend using a replication factor for each datacenter equal to the number 
+          of nodes in that datacenter. Alternatively, you can use ``EverywhereReplicationStrategy``. See :doc:`How to Safely Increase the Replication Factor </kb/rf-increase>` for details on changing the RF.
+
+          Such configuration will speed up reads and writes (if combined with a reasonable consistency level, such as ONE or LOCAL_ONE).
 
 User Defined CQL Query Tracing 
 ..............................

--- a/docs/using-scylla/tracing.rst
+++ b/docs/using-scylla/tracing.rst
@@ -9,8 +9,12 @@ Tracing is a ScyllaDB tool meant to help debugging and analyzing internal flows 
 * **Probalistic Tracing** randomly chooses a request to be traced with some defined probability.
 * **Slow Query Logging** - records queries with handling time above the specified threshold.
 
-.. note:: If you're planning to use either **probabilistic tracing** or **slow query logging** (see below), it's advisable to change the ``replication_factor`` of the  ``system_traces`` keyspace to ``ALL``. 
-
+.. note:: If you're planning to use either **probabilistic tracing** or **slow query logging** (see below), it's advisable to change the ``replication_factor`` of the  ``system_traces`` keyspace to ``ALL``:
+          
+          If you use ``NetworkTopologyStrategy``, the replication factor set for each datacenter should equal the number 
+          of nodes in that datacenter. Alternatively, you can use ``EverywhereReplicationStrategy``. 
+          
+          See :doc:`How to Safely Increase the Replication Factor </kb/rf-increase>` for details on changing the RF.
 
 User Defined CQL Query Tracing 
 ..............................


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-doc-issues/issues/823.
This PR extends the note on the Tracing page to explain what is meant by setting the RF to ALL and adds a link for reference.
