### PR TITLE
docs: remove auto_bootstrap option from the documentation

### DIFF
--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -186,17 +186,6 @@ On RHEL and CentOS, the Automatic Bug Reporting Tool (`ABRT <https://docs.fedora
 
 Scylla places any core dumps in :code:`var/lib/scylla/coredump`. They are not visible with the :code:`coredumpctl` command. See the :doc:`System Configuration Guide </getting-started/system-configuration/>` for details on core dump configuration scripts. Check with Scylla support before sharing any core dump, as they may contain sensitive data.
 
-
-Manual bootstrapping
-====================
-It’s possible to skip the bootstrapping process entirely and join the ring straight away by setting the hidden parameter ``auto_bootstrap: false``. 
-A manual bootstrap node will skip the data stream phase and immediately join the cluster in a *UN* (Up Normal) state and start serving queries, even though it has no data.
-**It is firmly advised not to use Manual bootstrapping.**
-
-Note that starting a node as a seed, by including itself in the seeds list, has a similar effect of and it is similarly dangerous.
-
-See :doc:`Node Joined With No Data </troubleshooting/node-joined-without-any-data>` for troubleshooting a manually bootstrap node.
-
 Schedule fstrim
 ===============
 

--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -117,7 +117,6 @@ Add New DC
    * **cluster_name** - Set the selected cluster_name.
    * **seeds** - IP address of an existing node (or nodes).
    * **listen_address** - IP address that Scylla used to connect to the other Scylla nodes in the cluster.
-   * **auto_bootstrap** - By default, this parameter is set to true, it allows new nodes to migrate data to themselves automatically.
    * **endpoint_snitch** - Set the selected snitch.
    * **rpc_address** - Address for client connections (Thrift, CQL).
 

--- a/docs/operating-scylla/procedures/cluster-management/create-cluster-multidc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/create-cluster-multidc.rst
@@ -68,7 +68,6 @@ the file can be found under ``/etc/scylla/``
 - **cluster_name** - Set the selected cluster_name
 - **seeds** - Specify the IP of the first node and **only the first node**. New nodes will use the IP of this seed node to connect to the cluster and learn the cluster topology and state.
 - **listen_address** - IP address that the Scylla use to connect to other Scylla nodes in the cluster
-- **auto_bootstrap** - By default, this parameter is set to true, it allows new nodes to migrate data to themselves automatically
 - **endpoint_snitch** - Set the selected snitch
 - **rpc_address** - Address for client connection (Thrift, CQLSH)
 

--- a/docs/operating-scylla/procedures/cluster-management/create-cluster.rst
+++ b/docs/operating-scylla/procedures/cluster-management/create-cluster.rst
@@ -24,7 +24,6 @@ The file can be found under ``/etc/scylla/``
 - **cluster_name** - Set the selected cluster_name
 - **seeds** - Specify the IP of the first node and **only the first node**. New nodes will use the IP of this seed node to connect to the cluster and learn the cluster topology and state.
 - **listen_address** - IP address that Scylla used to connect to other Scylla nodes in the cluster
-- **auto_bootstrap** - By default, this parameter is set to **true**, it allows new nodes to migrate data to themselves automatically.
 - **endpoint_snitch** - Set the selected snitch
 - **rpc_address** - Address for client connection (Thrift, CQL)
 

--- a/docs/operating-scylla/procedures/cluster-management/ec2-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/ec2-dc.rst
@@ -59,7 +59,6 @@ Perform the following steps for each node in the new cluster:
      * **cluster_name** - Set the selected cluster_name.
      * **seeds** - IP address of the first node in the cluster. See :doc:`Scylla Seed Nodes </kb/seed-nodes/>` for details.
      * **listen_address** - IP address that Scylla used to connect to other Scylla nodes in the cluster.
-     * **auto_bootstrap** - By default, this parameter is set to **true**. It allows new nodes to migrate data to themselves automatically. If using Scylla AMI add ``--bootstrap`` to the user settings when creating a node.
      * **endpoint_snitch** - Set the selected snitch.
      * **rpc_address** - Address for client connection (Thrift, CQL).
      * **broadcast_address** - The IP address a node tells other nodes in the cluster to contact it by.

--- a/docs/operating-scylla/procedures/cluster-management/rebuild-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/rebuild-node.rst
@@ -10,14 +10,9 @@ This is also why it's highly recommended to use a replication factor of at least
 
 To recover the data and rebuild the node, follow this procedure:
 
-#. If ``auto_bootstrap`` disabled, enable it by setting the value to ``true`` in the scylla.yaml.
-   Auto-bootstrap is enabled by default. To disable it, a setting is normally added to the scylla.yaml.
-   The Scylla configuration file is located in ``/etc/scylla/scylla.yaml``.
-   Look for ``auto_bootstrap: false``. If this setting is in the file, change it to true.
+#. Open the ``/etc/scylla/scylla.yaml`` file.
 
-   .. note:: If the ``auto_bootstrap`` parameter is missing from ``/etc/scylla/scylla.yaml``, default setting ``true`` is applied.
-
-#. With the yaml file still open, add, if not present,else edit, the ``replace_address_first_boot`` parameter and change it to the
+#. Add, if not present,else edit, the ``replace_address_first_boot`` parameter and change it to the
    IP of the node before it restarted it might be the same IP after restart.
 #. Stop Scylla Server
 
@@ -28,6 +23,6 @@ To recover the data and rebuild the node, follow this procedure:
 
    .. include:: /rst_include/scylla-commands-start-index.rst
 
-#. Revert the ``auto_bootstrap`` and ``replace_address_first_boot`` settings to what they were before you ran this procedure.
+#. Revert the ``replace_address_first_boot`` setting to what they were before you ran this procedure.
    For ease of use, you can comment out the ``replace_address_first_boot`` parameter.
 

--- a/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/replace-dead-node.rst
@@ -62,8 +62,6 @@ Procedure
 
     - **seeds** - Set the seed nodes
 
-    - **auto_bootstrap** - By default, this parameter is set to true, it allows new nodes to migrate data to themselves automatically
-
     - **endpoint_snitch** - Set the selected snitch
 
     - **rpc_address** - Address for client connection (Thrift, CQL)
@@ -182,12 +180,6 @@ In this case, the node's data will be cleaned after restart. To remedy this, you
    .. code-block:: none
 
       sudo sed -e '/.*scylla/s/^/#/g' -i /etc/fstab
-
-#. Run the following command to enable auto_bootstrap after restart to sync the data:
-
-   .. code-block:: none
-
-      sudo sed -e '/auto_bootstrap:.*/s/False/True/g' -i /etc/scylla/scylla.yaml
 
 #. Run the following command, replacing 172.30.0.186 with the listen_address / rpc_address of the node that you are restarting:
 

--- a/docs/troubleshooting/node-joined-without-any-data.rst
+++ b/docs/troubleshooting/node-joined-without-any-data.rst
@@ -11,12 +11,10 @@ Use the procedure that follows to correct situations where a node joins a cluste
 The Problem
 ^^^^^^^^^^^
 
-There are two possible causes for a new node not acquiring data from its peers:
+A new node may not acquire data from its peers if the ``seeds`` parameter in the new node's ``scylla.yaml`` file 
+does not specify the IP of an existing node in the cluster (for example, it specifies its own IP).
 
-* The ``seeds`` parameter in the new node's ``scylla.yaml`` file does not specify the IP of an existing node in the cluster (for example, it specifies its own IP).
-* The node was added with the ``auto_bootstrap`` flag set to *False*
-
-Both scenarios constitute user errors and are the incorrect way of adding new nodes to the cluster. See :doc:`Adding New Node </operating-scylla/procedures/cluster-management/add-node-to-cluster/>` for more details. This article explains how to restore a cluster safely in such a case.
+The scenario constitutes a user error and is the incorrect way of adding new nodes to the cluster. See :doc:`Adding New Node </operating-scylla/procedures/cluster-management/add-node-to-cluster/>` for more details. This article explains how to restore a cluster safely in such a case.
 
 .. warning:: You mustn't run nodetool cleanup in any other nodes in the cluster until this is fixed, as it will delete data that is not yet available from the new node.
 
@@ -32,7 +30,7 @@ Steps to fix:
 
    Actual directories might be different than above, check your ``scylla.yaml`` to validate.   
    
-#. Once all the new nodes are decommissioned, add them again with the :doc:`correct procedure </operating-scylla/procedures/cluster-management/add-node-to-cluster/>`. Do not add the nodes with the ``auto_bootstrap`` flag set to *False*.
+#. Once all the new nodes are decommissioned, add them again with the :doc:`correct procedure </operating-scylla/procedures/cluster-management/add-node-to-cluster/>`.
 
 
 Other important considerations:


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12318

This PR removes all occurrences of the `auto_bootstrap` option in the docs. 
In most cases, I've simply removed the option name and its definition, but sometimes additional changes were necessary:
- In node-joined-without-any-data.rst, I removed the `auto_bootstrap `option as one of the causes of the problem.
- In rebuild-node.rst, I removed the first step in the procedure (enabling the `auto_bootstrap `option).
- In admin. rst, I removed the section about manual bootstrapping - it's based on setting `auto_bootstrap` to false, which is not possible now.