### PR TITLE
Invalidate cache on compaction when exceed number of expired tombstones

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -564,7 +564,9 @@ protected:
 
     virtual compaction_completion_desc
     get_compaction_completion_desc(std::vector<shared_sstable> input_sstables, std::vector<shared_sstable> output_sstables) {
-        return compaction_completion_desc{std::move(input_sstables), std::move(output_sstables)};
+        auto partitions_to_invalidate = _table_s.get_cached_partitions_where_tombstones_exceed_limit(gc_clock::now());
+
+        return compaction_completion_desc{std::move(input_sstables), std::move(output_sstables), std::move(partitions_to_invalidate)};
     }
 
     // Tombstone expiration is enabled based on the presence of sstable set.

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -45,6 +45,7 @@ public:
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
+    virtual dht::partition_range_vector get_cached_partitions_where_tombstones_exceed_limit(gc_clock::time_point query_time) const = 0;
 };
 
 }

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -376,6 +376,7 @@ commitlog_total_space_in_mb: -1
 # using the StorageService mbean.
 # tombstone_warn_threshold: 1000
 # tombstone_failure_threshold: 100000
+# tombstone_clear_cache_threshold: 0
 
 # Granularity of the collation index of rows within a partition.
 # Increase if your rows are large, or if you have a very large

--- a/db/config.cc
+++ b/db/config.cc
@@ -561,6 +561,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Related information: Cassandra anti-patterns: Queues and queue-like datasets */
     , tombstone_warn_threshold(this, "tombstone_warn_threshold", value_status::Used, 1000,
         "The maximum number of tombstones a query can scan before warning.")
+    , tombstone_clear_cache_threshold(this, "tombstone_clear_cache_threshold", value_status::Used, 0,
+        "The maximum number of partition tombstones in cache before partition cache will be invalidated")
     , tombstone_failure_threshold(this, "tombstone_failure_threshold", value_status::Unused, 100000,
         "The maximum number of tombstones a query can scan before aborting.")
     , query_tombstone_page_limit(this, "query_tombstone_page_limit", liveness::LiveUpdate, value_status::Used, 10000,

--- a/db/config.hh
+++ b/db/config.hh
@@ -227,6 +227,7 @@ public:
     named_value<uint32_t> counter_cache_save_period;
     named_value<uint32_t> counter_cache_keys_to_save;
     named_value<uint32_t> tombstone_warn_threshold;
+    named_value<uint32_t> tombstone_clear_cache_threshold;
     named_value<uint32_t> tombstone_failure_threshold;
     named_value<uint64_t> query_tombstone_page_limit;
     named_value<uint32_t> range_request_timeout_in_ms;

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1545,6 +1545,23 @@ mutation_partition::live_row_count(const schema& s, gc_clock::time_point query_t
 }
 
 uint64_t
+mutation_partition::expired_row_count(const schema& s, gc_clock::time_point gc_before, gc_clock::time_point query_time) const {
+    check_schema(s);
+    uint64_t count = 0;
+
+    for (const rows_entry& e : non_dummy_rows()) {
+        tombstone base_tombstone = range_tombstone_for_row(s, e.key());
+        if (!e.row().is_live(s, column_kind::regular_column, base_tombstone, query_time)) {
+            if (e.row().deleted_at().max_deletion_time() < gc_before) {
+                ++count;
+            }
+        }
+    }
+
+    return count;
+}
+
+uint64_t
 mutation_partition::row_count() const {
     return _rows.calculate_size();
 }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1426,6 +1426,10 @@ public:
     uint64_t live_row_count(const schema&,
         gc_clock::time_point query_time = gc_clock::time_point::min()) const;
 
+    uint64_t expired_row_count(const schema&,
+        gc_clock::time_point gc_before,
+        gc_clock::time_point query_time = gc_clock::time_point::min()) const;
+
     bool is_static_row_live(const schema&,
         gc_clock::time_point query_time = gc_clock::time_point::min()) const;
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1235,6 +1235,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
     cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
+    cfg.tombstone_clear_cache_threshold = db_config.tombstone_clear_cache_threshold();
     cfg.view_update_concurrency_semaphore = _config.view_update_concurrency_semaphore;
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -381,6 +381,7 @@ public:
         // Can be updated by a schema change:
         bool enable_optimized_twcs_queries{true};
         uint32_t tombstone_warn_threshold{0};
+        uint32_t tombstone_clear_cache_threshold{0};
         unsigned x_log2_compaction_groups{0};
     };
     struct no_commitlog {};

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2680,6 +2680,10 @@ public:
     compaction_backlog_tracker& get_backlog_tracker() override {
         return _t._compaction_manager.get_backlog_tracker(*this);
     }
+    dht::partition_range_vector get_cached_partitions_where_tombstones_exceed_limit(gc_clock::time_point query_time) const override {
+        return _t.get_row_cache().get_partitions_where_tombstones_exceed_limit(
+            _t.get_config().tombstone_clear_cache_threshold, get_tombstone_gc_state(), query_time);
+    }
 };
 
 compaction_backlog_tracker& compaction_group::get_backlog_tracker() {

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -425,6 +425,9 @@ public:
     // that they are not evicted by memory reclaimer.
     void unlink_from_lru(const dht::decorated_key&);
 
+    dht::partition_range_vector get_partitions_where_tombstones_exceed_limit(int tombstone_clear_cache_threshold,
+        const tombstone_gc_state& gc_state, gc_clock::time_point query_time);
+
     // Synchronizes cache with the underlying mutation source
     // by invalidating ranges which were modified. This will force
     // them to be re-read from the underlying mutation source

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -118,6 +118,10 @@ public:
     compaction_backlog_tracker& get_backlog_tracker() override {
         return _backlog_tracker;
     }
+    dht::partition_range_vector get_cached_partitions_where_tombstones_exceed_limit(gc_clock::time_point query_time) const override {
+        return table().get_row_cache().get_partitions_where_tombstones_exceed_limit(
+            table().get_config().tombstone_clear_cache_threshold, get_tombstone_gc_state(), query_time);
+    }
 };
 
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)


### PR DESCRIPTION
The situation when expired tombstones are kept in cache indefinitely is described in #6033 issue and discussion here:
https://groups.google.com/g/scylladb-users/c/SI4F_BX_vys

There is a solution: to use **tombstone_clear_cache_threshold** parameter in yaml to set limit of expired row tombstones for partition. At the end of compaction procedure check table's row cache state and if number of expired row tombstones in each cached partition exceeds the limit - invalidate this partition's cache. It's expected that compaction removes all expired tombstones and row cache will reflect current sstables state.
If parameter's isn't defined of it's value is 0 do not perform any checks.

Fixes #6033