### PR TITLE
database_test: Reduce x_log2_compaction_group values to avoid timeout

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -69,7 +69,11 @@ static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id 
 }
 
 future<> do_with_cql_env_and_compaction_groups(std::function<void(cql_test_env&)> func, cql_test_config cfg = {}, thread_attributes thread_attr = {}) {
+#ifdef SEASTAR_DEBUG
+    std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 1 /* 2 CGs */ };
+#else
     std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 1 /* 2 CGs */, 8 /* 256 CGs */ };
+#endif
     for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
         // clean the dir before running
         if (cfg.db_config->data_file_directories.is_set()) {


### PR DESCRIPTION
database_test in timing out because it's having to run the tests calling do_with_cql_env_and_compaction_groups 3x, one for each compaction group setting. reduce it to 2 settings instead of 3 if running in debug mode.

Refs #12396.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>