### PR TITLE
test/cql-pytest: tests clarifying issue 5825

### DIFF
--- a/test/cqlpy/test_empty.py
+++ b/test/cqlpy/test_empty.py
@@ -6,7 +6,9 @@
 # Tests for empty values (especially, but not just, empty strings)
 #############################################################################
 
+import struct
 import pytest
+from cassandra.cqltypes import Int32Type, EMPTY
 from cassandra.protocol import InvalidRequest
 from .util import unique_name, unique_key_string, unique_key_int, new_test_table
 
@@ -258,3 +260,64 @@ def test_empty_string_for_nonstring_partition_key2(cql, test_keyspace):
         # a number.
         with pytest.raises(InvalidRequest):
             cql.execute(f"INSERT INTO {table} (p,v) VALUES ('', 3)")
+
+# Tests for empty values in collections. In issue #5825 it was suspected
+# that support for such empty values is broken, but these tests demonstrate
+# that it is working as expected.
+def test_empty_string_in_collection(cql, test_keyspace):
+    schema = 'p int primary key, v list<text>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (p,v) VALUES ({p}, ['hi',''])")
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p={p}")) == [(p, ['hi',''])]
+        # Prepared version of the same test.
+        p = unique_key_int()
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES ({p}, ?)")
+        cql.execute(stmt, [['hello','']])
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p={p}")) == [(p, ['hello',''])]
+
+def test_empty_int_in_collection(cql, test_keyspace):
+    schema = 'p int primary key, v list<int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (p,v) VALUES ({p}, [1, blobAsInt(0x)])")
+        # The support_empty_values flag on Int32Type is normally False,
+        # meaning that both null and empty int values are returned by the
+        # driver as None. We can override it to allow us to distinguish
+        # EMPTY and None, confirming that the server stored an empty int and
+        # not a null.
+        Int32Type.support_empty_values = True
+        try:
+            assert list(cql.execute(f"SELECT * FROM {table} WHERE p={p}")) == [(p, [1, EMPTY])]
+        finally:
+            Int32Type.support_empty_values = False
+
+# Prepared-statement version of test_empty_int_in_collection above.
+# Marked cassandra_bug because Cassandra gets a NullPointerException when it
+# receives an empty-length integer element inside a collection.
+def test_empty_int_in_collection_prepared(cql, test_keyspace, cassandra_bug):
+    schema = 'p int primary key, v list<int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # The Python driver provides no direct way to pass an empty (zero-length)
+        # integer value in a prepared statement, since its Int32Type serializer
+        # requires an actual integer. We can hack the driver to do this anyway:
+        # The trick is to manually craft the raw serialized bytes for the list
+        # and inject them into the bound statement's values list, bypassing the
+        # type serializer entirely.
+        p = unique_key_int()
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES (?, ?)")
+        # Bind only the first parameter ("p"); the second slot gets UNSET_VALUE
+        # and is overwritten below.
+        bound_stmt = stmt.bind([p])
+        # Set the second slot to the integer list [1, empty_int]
+        # by writing the raw serialized bytes into bound_stmt.values[1].
+        # The serialization format is the list's length (2), then the
+        # first integer's length (4) and the value (1), and then the
+        # second integer's length (0) and no value.
+        bound_stmt.values[1] = struct.pack('>iiii', 2, 4, 1, 0)
+        cql.execute(bound_stmt)
+        Int32Type.support_empty_values = True
+        try:
+            assert list(cql.execute(f"SELECT * FROM {table} WHERE p={p}")) == [(p, [1, EMPTY])]
+        finally:
+            Int32Type.support_empty_values = False

--- a/test/cqlpy/test_null.py
+++ b/test/cqlpy/test_null.py
@@ -9,7 +9,9 @@
 import pytest
 import re
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, unique_key_string
+from cassandra.connection import DRIVER_NAME
+from .util import unique_name, unique_key_string, unique_key_int, new_test_table
+from test.pylib.skip_types import skip_env
 
 
 @pytest.fixture(scope="module")
@@ -274,3 +276,46 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
 def test_map_subscript_null(cql, table1, cassandra_bug):
     assert list(cql.execute(f"SELECT p FROM {table1} WHERE m[null] = 3 ALLOW FILTERING")) == []
     assert list(cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE m[?] = 3 ALLOW FILTERING"), [None])) == []
+
+# This fixture skips the test when running with the Datastax Python driver,
+# which has a bug (PYTHON-1355) where None in a collection is sent as an empty
+# value (length 0) instead of null (length -1), making null-in-collection
+# rejection untestable. This was noted in issue #5825 and was fixed in the
+# Scylla driver in https://github.com/scylladb/python-driver/issues/201 but is
+# still open in the Datastax driver in https://datastax-oss.atlassian.net/browse/PYTHON-1355.
+@pytest.fixture(scope="function")
+def scylla_driver_only():
+    if 'Scylla' not in DRIVER_NAME:
+        skip_env('Test requires the Scylla Python driver (Datastax driver has PYTHON-1355)')
+
+# Null values are not allowed inside collections, this test verifies this
+# for both unprepared and prepared statements. See issue #5825.
+# The test is marked "cassandra_bug" because Cassandra 5 fails the prepared-
+# statement case with a NoHostAvailable "java.lang.NullPointerException: Cannot
+# invoke "java.nio.ByteBuffer.remaining()" because "value" is null"
+def test_null_string_in_collection(scylla_driver_only, cql, test_keyspace, cassandra_bug):
+    schema = 'p int primary key, v list<text>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        with pytest.raises(InvalidRequest, match='null|NULL'):
+            cql.execute(f"INSERT INTO {table} (p,v) VALUES ({p}, ['hi', null])")
+        # Prepared-statement version of the same test.
+        p = unique_key_int()
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES ({p}, ?)")
+        with pytest.raises(InvalidRequest, match='null|NULL'):
+            cql.execute(stmt, [['hello',None]])
+
+# Same as the above test_null_string_in_collection, just with a null int
+# instead of null string.
+# Marked cassandra_bug for the same reason as the above test.
+def test_null_int_in_collection(scylla_driver_only, cql, test_keyspace, cassandra_bug):
+    schema = 'p int primary key, v list<int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        with pytest.raises(InvalidRequest, match='null|NULL'):
+            cql.execute(f"INSERT INTO {table} (p,v) VALUES ({p}, [1, null])")
+        # Prepared-statement version of the same test.
+        p = unique_key_int()
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES ({p}, ?)")
+        with pytest.raises(InvalidRequest, match='null|NULL'):
+            cql.execute(stmt, [[2,None]])


### PR DESCRIPTION
This patch addes several tests which clarify issue #5825, which claimed that Scylla may allow in certain cases insertion of null values into a collection - which is supposed to be forbidden.

The tests demonstrates that it is an *empty* value (a value with length 0, not a null with length -1), not a null value, which is what is allowed inside a collection, and Python driver bug is what causes an attempt to write a null value to result in an empty value. The latter is most visible with a list<text> column - where what is written into the list lelement is an empty string, not a null.

Therefore, these tests show that issue #5825 is not a Scylla bug.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>