### PR TITLE
Make restore_replica_count abortable

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2949,7 +2949,7 @@ future<> storage_service::restore_replica_count(inet_address endpoint, inet_addr
     auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, as, get_broadcast_address(), _sys_ks.local().local_dc_rack(), "Restore_replica_count", streaming::stream_reason::removenode);
     removenode_add_ranges(streamer, endpoint).get();
     auto check_status_loop = [this, endpoint, &as] () -> future<> {
-        slogger.info("restore_replica_count: Started status checker for removing node {}", endpoint);
+        slogger.debug("restore_replica_count: Started status checker for removing node {}", endpoint);
         while (!as.abort_requested()) {
             auto status = _gossiper.get_gossip_status(endpoint);
             // If the node to be removed is already in removed status, it has
@@ -2987,7 +2987,7 @@ future<> storage_service::restore_replica_count(inet_address endpoint, inet_addr
         }
     }
     try {
-        slogger.info("restore_replica_count: Started to stop status checker for removing node {}", endpoint);
+        slogger.debug("restore_replica_count: Started to stop status checker for removing node {}", endpoint);
         if (!as.abort_requested()) {
             as.request_abort();
         }
@@ -2998,7 +2998,7 @@ future<> storage_service::restore_replica_count(inet_address endpoint, inet_addr
         slogger.warn("restore_replica_count: Found error in status checker for removing node {}: {}",
                 endpoint, std::current_exception());
     }
-    slogger.info("restore_replica_count: Finished to stop status checker for removing node {}", endpoint);
+    slogger.debug("restore_replica_count: Finished to stop status checker for removing node {}", endpoint);
     if (ex) {
         co_await coroutine::return_exception_ptr(std::move(ex));
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1118,7 +1118,7 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
             // OK to discard future since _async_gate is closed on stop()
             (void)with_gate(_async_gate, [this, endpoint, notify_endpoint] {
               return restore_replica_count(endpoint, notify_endpoint).handle_exception([endpoint, notify_endpoint] (auto ep) {
-                slogger.info("Failed to restore_replica_count for node {}, notify_endpoint={} : {}", endpoint, notify_endpoint, ep);
+                slogger.warn("Failed to restore_replica_count for node {}, notify_endpoint={} : {}", endpoint, notify_endpoint, ep);
               });
             });
         }
@@ -2982,17 +2982,26 @@ future<> storage_service::restore_replica_count(inet_address endpoint, inet_addr
         slogger.info("restore_replica_count: Finished to stop status checker for removing node {}", endpoint);
     });
 
-    streamer->stream_async().then_wrapped([this, streamer, notify_endpoint] (auto&& f) {
-        try {
-            f.get();
-            return this->send_replication_notification(notify_endpoint);
-        } catch (...) {
-            slogger.warn("Streaming to restore replica count failed: {}", std::current_exception());
-            // We still want to send the notification
-            return this->send_replication_notification(notify_endpoint);
+    std::exception_ptr ex;
+    try {
+        streamer->stream_async().get();
+    } catch (...) {
+        ex = std::current_exception();
+        slogger.debug("Streaming to restore replica count failed: {}.", ex);
+        // We still want to send the notification
+    }
+    try {
+        this->send_replication_notification(notify_endpoint).get();
+    } catch (...) {
+        auto ex2 = std::current_exception();
+        slogger.debug("Sending replication notification to {} failed: {}", notify_endpoint, ex2);
+        if (!ex) {
+            ex = std::move(ex2);
         }
-        return make_ready_future<>();
-    }).get();
+    }
+    if (ex) {
+        std::rethrow_exception(std::move(ex));
+    }
   });
 }
 


### PR DESCRIPTION
Similar to the way we allow aborting streaming-based
removenode, subscribe to storage_service::_abort_source
to request abort locally and pass a shared_ptr<abort_source>
to `node_ops_info`, used to abort removenode_with_repair
on shutdown.

Fixes #12429
