### PR TITLE
Drop support for cql binary protocols versions 1 and 2

### DIFF
--- a/alternator/auth.cc
+++ b/alternator/auth.cc
@@ -141,7 +141,7 @@ future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::strin
     service::storage_proxy::coordinator_query_result qr = co_await proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
             service::storage_proxy::coordinator_query_options(executor::default_timeout(), empty_service_permit(), client_state));
 
-    cql3::selection::result_set_builder builder(*selection, gc_clock::now(), cql_serialization_format::latest());
+    cql3::selection::result_set_builder builder(*selection, gc_clock::now());
     query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
 
     auto result_set = builder.build();

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2305,7 +2305,7 @@ void executor::describe_single_item(const cql3::selection::selection& selection,
                 rjson::add_with_string_name(field, type_to_string((*column_it)->type), json_key_column_value(*cell, **column_it));
             }
         } else if (cell) {
-            auto deserialized = attrs_type()->deserialize(*cell, cql_serialization_format::latest());
+            auto deserialized = attrs_type()->deserialize(*cell);
             auto keys_and_values = value_cast<map_type_impl::native_type>(deserialized);
             for (auto entry : keys_and_values) {
                 std::string attr_name = value_cast<sstring>(entry.first);
@@ -2340,7 +2340,7 @@ std::optional<rjson::value> executor::describe_single_item(schema_ptr schema,
         const std::optional<attrs_to_get>& attrs_to_get) {
     rjson::value item = rjson::empty_object();
 
-    cql3::selection::result_set_builder builder(selection, gc_clock::now(), cql_serialization_format::latest());
+    cql3::selection::result_set_builder builder(selection, gc_clock::now());
     query::result_view::consume(query_result, slice, cql3::selection::result_set_builder::visitor(builder, *schema, selection));
 
     auto result_set = builder.build();
@@ -2363,7 +2363,7 @@ std::vector<rjson::value> executor::describe_multi_item(schema_ptr schema,
         const cql3::selection::selection& selection,
         const query::result& query_result,
         const std::optional<attrs_to_get>& attrs_to_get) {
-    cql3::selection::result_set_builder builder(selection, gc_clock::now(), cql_serialization_format::latest());
+    cql3::selection::result_set_builder builder(selection, gc_clock::now());
     query::result_view::consume(query_result, slice, cql3::selection::result_set_builder::visitor(builder, *schema, selection));
     auto result_set = builder.build();
     std::vector<rjson::value> ret;
@@ -3511,7 +3511,7 @@ public:
                     rjson::add_with_string_name(field, type_to_string((*_column_it)->type), json_key_column_value(bv, **_column_it));
                 }
             } else {
-                auto deserialized = attrs_type()->deserialize(bv, cql_serialization_format::latest());
+                auto deserialized = attrs_type()->deserialize(bv);
                 auto keys_and_values = value_cast<map_type_impl::native_type>(deserialized);
                 for (auto entry : keys_and_values) {
                     std::string attr_name = value_cast<sstring>(entry.first);

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -73,7 +73,7 @@ struct from_json_visitor {
     }
     // default
     void operator()(const abstract_type& t) const {
-        bo.write(from_json_object(t, v, cql_serialization_format::internal()));
+        bo.write(from_json_object(t, v));
     }
 };
 

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -883,7 +883,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     return _proxy.query(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state)).then(
             [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), start_time = std::move(start_time), limit, key_names = std::move(key_names), attr_names = std::move(attr_names), type, iter, high_ts] (service::storage_proxy::coordinator_query_result qr) mutable {       
-        cql3::selection::result_set_builder builder(*selection, gc_clock::now(), cql_serialization_format::latest());
+        cql3::selection::result_set_builder builder(*selection, gc_clock::now());
         query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
 
         auto result_set = builder.build();

--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -21,8 +21,6 @@ class row_tombstone;
 
 class collection_mutation;
 
-class cql_serialization_format;
-
 // An auxiliary struct used to (de)construct collection_mutations.
 // Unlike collection_mutation which is a serialized blob, this struct allows to inspect logical units of information
 // (tombstone and cells) inside the mutation easily.
@@ -131,4 +129,4 @@ collection_mutation merge(const abstract_type&, collection_mutation_view, collec
 collection_mutation difference(const abstract_type&, collection_mutation_view, collection_mutation_view);
 
 // Serializes the given collection of cells to a sequence of bytes ready to be sent over the CQL protocol.
-bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view, cql_serialization_format);
+bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view);

--- a/compound.hh
+++ b/compound.hh
@@ -16,7 +16,6 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include "utils/serialization.hh"
 #include <seastar/util/backtrace.hh>
-#include "cql_serialization_format.hh"
 
 enum class allow_prefixes { no, yes };
 
@@ -280,7 +279,7 @@ public:
         }
         for (size_t i = 0; i != values.size(); ++i) {
             //FIXME: is it safe to assume internal serialization-format format?
-            _types[i]->validate(values[i], cql_serialization_format::internal());
+            _types[i]->validate(values[i]);
         }
     }
     bool equal(managed_bytes_view v1, managed_bytes_view v2) const {

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -50,7 +50,7 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
         return now;
     }
     try {
-        return tval.view().validate_and_deserialize<int64_t>(*long_type, cql_serialization_format::internal());
+        return tval.view().validate_and_deserialize<int64_t>(*long_type);
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid timestamp value");
     }
@@ -70,7 +70,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
 
     int32_t ttl;
     try {
-        ttl = tval.view().validate_and_deserialize<int32_t>(*int32_type, cql_serialization_format::internal());
+        ttl = tval.view().validate_and_deserialize<int32_t>(*int32_type);
     }
     catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid TTL value");

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -365,7 +365,6 @@ untyped_constant make_untyped_null();
 // Represents a constant value with known value and type
 // For null and unset the type can sometimes be set to empty_type
 struct constant {
-    // A value serialized using the internal (latest) cql_serialization_format
     cql3::raw_value value;
 
     // Never nullptr, for NULL and UNSET might be empty_type

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -18,7 +18,6 @@
 
 #include "bytes_ostream.hh"
 #include "types.hh"
-#include "cql_serialization_format.hh"
 
 #include <boost/algorithm/cxx11/any_of.hpp>
 
@@ -47,7 +46,7 @@ public:
 
     virtual bool requires_thread() const override;
 
-    virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
         bytes_ostream encoded_row;
         encoded_row.write("{", 1);
         for (size_t i = 0; i < _selector_names.size(); ++i) {

--- a/cql3/functions/bytes_conversion_fcts.hh
+++ b/cql3/functions/bytes_conversion_fcts.hh
@@ -14,7 +14,6 @@
 #include "exceptions/exceptions.hh"
 #include <seastar/core/print.hh>
 #include "cql3/cql3_type.hh"
-#include "cql_serialization_format.hh"
 
 namespace cql3 {
 
@@ -28,7 +27,7 @@ shared_ptr<function>
 make_to_blob_function(data_type from_type) {
     auto name = from_type->as_cql3_type().to_string() + "asblob";
     return make_native_scalar_function<true>(name, bytes_type, { from_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& parameters) {
+            [] (const std::vector<bytes_opt>& parameters) {
         return parameters[0];
     });
 }
@@ -38,13 +37,13 @@ shared_ptr<function>
 make_from_blob_function(data_type to_type) {
     sstring name = sstring("blobas") + to_type->as_cql3_type().to_string();
     return make_native_scalar_function<true>(name, to_type, { bytes_type },
-            [name, to_type] (cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [name, to_type] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
         auto&& val = parameters[0];
         if (!val) {
             return val;
         }
         try {
-            to_type->validate(*val, sf);
+            to_type->validate(*val);
             return val;
         } catch (marshal_exception& e) {
             using namespace exceptions;
@@ -58,7 +57,7 @@ inline
 shared_ptr<function>
 make_varchar_as_blob_fct() {
     return make_native_scalar_function<true>("varcharasblob", bytes_type, { utf8_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
         return parameters[0];
     });
 }
@@ -67,7 +66,7 @@ inline
 shared_ptr<function>
 make_blob_as_varchar_fct() {
     return make_native_scalar_function<true>("blobasvarchar", utf8_type, { bytes_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
         return parameters[0];
     });
 }

--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -35,7 +35,7 @@ public:
     virtual void print(std::ostream& os) const override {
         os << "cast(" << _arg_types[0]->name() << " as " << _return_type->name() << ")";
     }
-    virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
         auto from_type = arg_types()[0];
         auto to_type = return_type();
 

--- a/cql3/functions/error_injection_fcts.cc
+++ b/cql3/functions/error_injection_fcts.cc
@@ -40,8 +40,8 @@ public:
         return Pure;
     }
 
-    bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
-        return _func(sf, parameters);
+    bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+        return _func(parameters);
     }
 };
 
@@ -61,7 +61,7 @@ make_failure_injection_function(sstring name,
 
 shared_ptr<function> make_enable_injection_function() {
     return make_failure_injection_function<false>("enable_injection", empty_type, { ascii_type, ascii_type },
-            [] (cql_serialization_format, const std::vector<bytes_opt>& parameters) {
+            [] (const std::vector<bytes_opt>& parameters) {
         sstring injection_name = ascii_type->get_string(parameters[0].value());
         const bool one_shot = ascii_type->get_string(parameters[1].value()) == "true";
         smp::invoke_on_all([injection_name, one_shot] () mutable {
@@ -73,7 +73,7 @@ shared_ptr<function> make_enable_injection_function() {
 
 shared_ptr<function> make_disable_injection_function() {
     return make_failure_injection_function<false>("disable_injection", empty_type, { ascii_type },
-            [] (cql_serialization_format, const std::vector<bytes_opt>& parameters) {
+            [] (const std::vector<bytes_opt>& parameters) {
         sstring injection_name = ascii_type->get_string(parameters[0].value());
         smp::invoke_on_all([injection_name] () mutable {
             utils::get_local_injector().disable(injection_name);
@@ -85,7 +85,7 @@ shared_ptr<function> make_disable_injection_function() {
 shared_ptr<function> make_enabled_injections_function() {
     const auto list_type_inst = list_type_impl::get_instance(ascii_type, false);
     return make_failure_injection_function<true>("enabled_injections", list_type_inst, {},
-        [list_type_inst] (cql_serialization_format, const std::vector<bytes_opt>&) -> bytes {
+        [list_type_inst] (const std::vector<bytes_opt>&) -> bytes {
             return seastar::map_reduce(smp::all_cpus(), [] (unsigned) {
                 return make_ready_future<std::vector<sstring>>(utils::get_local_injector().enabled_injections());
             }, std::vector<data_value>(),

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -174,7 +174,7 @@ inline
 shared_ptr<function>
 make_to_json_function(data_type t) {
     return make_native_scalar_function<true>("tojson", utf8_type, {t},
-            [t](cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
         return utf8_type->decompose(to_json_string(*t, parameters[0]));
     });
 }
@@ -183,12 +183,12 @@ inline
 shared_ptr<function>
 make_from_json_function(data_dictionary::database db, const sstring& keyspace, data_type t) {
     return make_native_scalar_function<true>("fromjson", t, {utf8_type},
-            [&db, keyspace, t](cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [&db, keyspace, t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
         try {
             rjson::value json_value = rjson::parse(utf8_type->to_string(parameters[0].value()));
             bytes_opt parsed_json_value;
             if (!json_value.IsNull()) {
-                parsed_json_value.emplace(from_json_object(*t, json_value, sf));
+                parsed_json_value.emplace(from_json_object(*t, json_value));
             }
             return parsed_json_value;
         } catch(rjson::error& e) {

--- a/cql3/functions/native_scalar_function.hh
+++ b/cql3/functions/native_scalar_function.hh
@@ -12,7 +12,6 @@
 
 #include "native_function.hh"
 #include "scalar_function.hh"
-#include "cql_serialization_format.hh"
 #include "log.hh"
 #include <seastar/core/shared_ptr.hh>
 
@@ -48,9 +47,9 @@ public:
     virtual bool is_pure() const override {
         return Pure;
     }
-    virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
         try {
-            return _func(sf, parameters);
+            return _func(parameters);
         } catch(exceptions::cassandra_exception&) {
             // If the function's code took the time to produce an official
             // cassandra_exception, pass it through. Otherwise, below we will

--- a/cql3/functions/scalar_function.hh
+++ b/cql3/functions/scalar_function.hh
@@ -23,12 +23,11 @@ public:
     /**
      * Applies this function to the specified parameter.
      *
-     * @param protocolVersion protocol version used for parameters and return value
      * @param parameters the input parameters
      * @return the result of applying this function to the parameter
      * @throws InvalidRequestException if this function cannot not be applied to the parameter
      */
-    virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) = 0;
+    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) = 0;
 };
 
 

--- a/cql3/functions/time_uuid_fcts.hh
+++ b/cql3/functions/time_uuid_fcts.hh
@@ -24,7 +24,7 @@ inline
 shared_ptr<function>
 make_now_fct() {
     return make_native_scalar_function<false>("now", timeuuid_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         return {to_bytes(utils::UUID_gen::get_time_UUID())};
     });
 }
@@ -42,7 +42,7 @@ inline
 shared_ptr<function>
 make_min_timeuuid_fct() {
     return make_native_scalar_function<true>("mintimeuuid", timeuuid_type, { timestamp_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         auto& bb = values[0];
         if (!bb) {
             return {};
@@ -60,7 +60,7 @@ inline
 shared_ptr<function>
 make_max_timeuuid_fct() {
     return make_native_scalar_function<true>("maxtimeuuid", timeuuid_type, { timestamp_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         auto& bb = values[0];
         if (!bb) {
             return {};
@@ -89,7 +89,7 @@ inline
 shared_ptr<function>
 make_date_of_fct() {
     return make_native_scalar_function<true>("dateof", timestamp_type, { timeuuid_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -104,7 +104,7 @@ inline
 shared_ptr<function>
 make_unix_timestamp_of_fct() {
     return make_native_scalar_function<true>("unixtimestampof", long_type, { timeuuid_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -117,7 +117,7 @@ make_unix_timestamp_of_fct() {
 inline shared_ptr<function>
 make_currenttimestamp_fct() {
     return make_native_scalar_function<false>("currenttimestamp", timestamp_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         return {timestamp_type->decompose(db_clock::now())};
     });
 }
@@ -125,7 +125,7 @@ make_currenttimestamp_fct() {
 inline shared_ptr<function>
 make_currenttime_fct() {
     return make_native_scalar_function<false>("currenttime", time_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         constexpr int64_t milliseconds_in_day = 3600 * 24 * 1000;
         int64_t milliseconds_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(db_clock::now().time_since_epoch()).count();
         int64_t nanoseconds_today = (milliseconds_since_epoch % milliseconds_in_day) * 1000 * 1000;
@@ -136,7 +136,7 @@ make_currenttime_fct() {
 inline shared_ptr<function>
 make_currentdate_fct() {
     return make_native_scalar_function<false>("currentdate", simple_date_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         auto to_simple_date = get_castas_fctn(simple_date_type, timestamp_type);
         return {simple_date_type->decompose(to_simple_date(db_clock::now()))};
     });
@@ -146,7 +146,7 @@ inline
 shared_ptr<function>
 make_currenttimeuuid_fct() {
     return make_native_scalar_function<false>("currenttimeuuid", timeuuid_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         return {timeuuid_type->decompose(timeuuid_native_type{utils::UUID_gen::get_time_UUID()})};
     });
 }
@@ -155,7 +155,7 @@ inline
 shared_ptr<function>
 make_timeuuidtodate_fct() {
     return make_native_scalar_function<true>("todate", simple_date_type, { timeuuid_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -171,7 +171,7 @@ inline
 shared_ptr<function>
 make_timestamptodate_fct() {
     return make_native_scalar_function<true>("todate", simple_date_type, { timestamp_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -190,7 +190,7 @@ inline
 shared_ptr<function>
 make_timeuuidtotimestamp_fct() {
     return make_native_scalar_function<true>("totimestamp", timestamp_type, { timeuuid_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -205,7 +205,7 @@ inline
 shared_ptr<function>
 make_datetotimestamp_fct() {
     return make_native_scalar_function<true>("totimestamp", timestamp_type, { simple_date_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -224,7 +224,7 @@ inline
 shared_ptr<function>
 make_timeuuidtounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { timeuuid_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -242,7 +242,7 @@ inline
 shared_ptr<function>
 make_timestamptounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { timestamp_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -260,7 +260,7 @@ inline
 shared_ptr<function>
 make_datetounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { simple_date_type },
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {

--- a/cql3/functions/token_fct.hh
+++ b/cql3/functions/token_fct.hh
@@ -31,7 +31,7 @@ public:
                     , _schema(s) {
     }
 
-    bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
+    bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
         if (std::any_of(parameters.cbegin(), parameters.cend(), [](const auto& param){ return !param; })) {
             return std::nullopt;
         }

--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -9,7 +9,6 @@
 #include "user_function.hh"
 #include "cql3/util.hh"
 #include "log.hh"
-#include "cql_serialization_format.hh"
 #include "lang/wasm.hh"
 
 #include <seastar/core/thread.hh>
@@ -33,7 +32,7 @@ bool user_function::is_aggregate() const { return false; }
 
 bool user_function::requires_thread() const { return true; }
 
-bytes_opt user_function::execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) {
+bytes_opt user_function::execute(const std::vector<bytes_opt>& parameters) {
     const auto& types = arg_types();
     if (parameters.size() != types.size()) {
         throw std::logic_error("Wrong number of parameters");

--- a/cql3/functions/user_function.hh
+++ b/cql3/functions/user_function.hh
@@ -26,7 +26,7 @@ public:
         sstring bitcode;
         // FIXME: We should not need a copy in each function. It is here
         // because user_function::execute is only passed the
-        // cql_serialization_format and the runtime arguments.  We could
+        // the runtime arguments.  We could
         // avoid it by having a runtime->execute(user_function) instead,
         // but that is a large refactoring. We could also store a
         // lua_runtime in a thread_local variable, but that is one extra
@@ -59,7 +59,7 @@ public:
     virtual bool is_native() const override;
     virtual bool is_aggregate() const override;
     virtual bool requires_thread() const override;
-    virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override;
+    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override;
 
     virtual sstring keypace_name() const override { return name().keyspace; }
     virtual sstring element_name() const override { return name().name; }

--- a/cql3/functions/uuid_fcts.hh
+++ b/cql3/functions/uuid_fcts.hh
@@ -22,7 +22,7 @@ inline
 shared_ptr<function>
 make_uuid_fct() {
     return make_native_scalar_function<false>("uuid", uuid_type, {},
-            [] (cql_serialization_format sf, const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
         return {uuid_type->decompose(utils::make_random_uuid())};
     });
 }

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -23,7 +23,7 @@ thread_local const query_options::specific_options query_options::specific_optio
 
 thread_local query_options query_options::DEFAULT{default_cql_config,
     db::consistency_level::ONE, std::nullopt,
-    std::vector<cql3::raw_value_view>(), false, query_options::specific_options::DEFAULT, cql_serialization_format::latest()};
+    std::vector<cql3::raw_value_view>(), false, query_options::specific_options::DEFAULT};
 
 query_options::query_options(const cql_config& cfg,
                            db::consistency_level consistency,
@@ -31,8 +31,8 @@ query_options::query_options(const cql_config& cfg,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
                            bool skip_metadata,
-                           specific_options options,
-                           cql_serialization_format sf)
+                           specific_options options
+                           )
    : _cql_config(cfg)
    , _consistency(consistency)
    , _names(std::move(names))
@@ -40,7 +40,6 @@ query_options::query_options(const cql_config& cfg,
    , _value_views(value_views)
    , _skip_metadata(skip_metadata)
    , _options(std::move(options))
-   , _cql_serialization_format(sf)
 {
 }
 
@@ -49,8 +48,8 @@ query_options::query_options(const cql_config& cfg,
                              std::optional<std::vector<sstring_view>> names,
                              std::vector<cql3::raw_value> values,
                              bool skip_metadata,
-                             specific_options options,
-                             cql_serialization_format sf)
+                             specific_options options
+                             )
     : _cql_config(cfg)
     , _consistency(consistency)
     , _names(std::move(names))
@@ -58,7 +57,6 @@ query_options::query_options(const cql_config& cfg,
     , _value_views()
     , _skip_metadata(skip_metadata)
     , _options(std::move(options))
-    , _cql_serialization_format(sf)
 {
     fill_value_views();
 }
@@ -68,8 +66,8 @@ query_options::query_options(const cql_config& cfg,
                              std::optional<std::vector<sstring_view>> names,
                              std::vector<cql3::raw_value_view> value_views,
                              bool skip_metadata,
-                             specific_options options,
-                             cql_serialization_format sf)
+                             specific_options options
+                             )
     : _cql_config(cfg)
     , _consistency(consistency)
     , _names(std::move(names))
@@ -77,7 +75,6 @@ query_options::query_options(const cql_config& cfg,
     , _value_views(std::move(value_views))
     , _skip_metadata(skip_metadata)
     , _options(std::move(options))
-    , _cql_serialization_format(sf)
 {
 }
 
@@ -89,8 +86,7 @@ query_options::query_options(db::consistency_level cl, std::vector<cql3::raw_val
           {},
           std::move(values),
           false,
-          std::move(options),
-          cql_serialization_format::latest()
+          std::move(options)
       )
 {
 }
@@ -102,8 +98,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_values),
         std::move(qo->_value_views),
         qo->_skip_metadata,
-        query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
-        qo->_cql_serialization_format) {
+        query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
 }
 
@@ -114,8 +109,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_values),
         std::move(qo->_value_views),
         qo->_skip_metadata,
-        query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
-        qo->_cql_serialization_format) {
+        query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
 }
 

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -17,7 +17,6 @@
 #include "service/query_state.hh"
 #include "service/pager/paging_state.hh"
 #include "cql3/values.hh"
-#include "cql_serialization_format.hh"
 
 namespace cql3 {
 
@@ -50,7 +49,6 @@ private:
     std::vector<cql3::raw_value_view> _value_views;
     const bool _skip_metadata;
     const specific_options _options;
-    cql_serialization_format _cql_serialization_format;
     std::optional<std::vector<query_options>> _batch_options;
     // We must use the same microsecond-precision timestamp for
     // all cells created by an LWT statement or when a statement
@@ -110,23 +108,23 @@ public:
                            std::optional<std::vector<sstring_view>> names,
                            std::vector<cql3::raw_value> values,
                            bool skip_metadata,
-                           specific_options options,
-                           cql_serialization_format sf);
+                           specific_options options
+                           );
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<sstring_view>> names,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
                            bool skip_metadata,
-                           specific_options options,
-                           cql_serialization_format sf);
+                           specific_options options
+                           );
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<sstring_view>> names,
                            std::vector<cql3::raw_value_view> value_views,
                            bool skip_metadata,
-                           specific_options options,
-                           cql_serialization_format sf);
+                           specific_options options
+                           );
 
     /**
      * @brief Batch query_options factory.
@@ -193,10 +191,6 @@ public:
     api::timestamp_type get_timestamp(service::query_state& state) const {
         auto tstamp = get_specific_options().timestamp;
         return tstamp != api::missing_timestamp ? tstamp : state.get_timestamp();
-    }
-
-    cql_serialization_format get_cql_serialization_format() const {
-        return _cql_serialization_format;
     }
 
     const query_options::specific_options& get_specific_options() const {
@@ -282,7 +276,7 @@ query_options::query_options(query_options&& o, std::vector<OneMutationDataRange
     std::vector<query_options> tmp;
     tmp.reserve(values_ranges.size());
     std::transform(values_ranges.begin(), values_ranges.end(), std::back_inserter(tmp), [this](auto& values_range) {
-        return query_options(_cql_config, _consistency, {}, std::move(values_range), _skip_metadata, _options, _cql_serialization_format);
+        return query_options(_cql_config, _consistency, {}, std::move(values_range), _skip_metadata, _options);
     });
     _batch_options = std::move(tmp);
 }

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -195,14 +195,6 @@ public:
         return tstamp != api::missing_timestamp ? tstamp : state.get_timestamp();
     }
 
-    /**
-     * The protocol version for the query. Will be 3 if the object don't come from
-     * a native protocol request (i.e. it's been allocated locally or by CQL-over-thrift).
-     */
-    int get_protocol_version() const {
-        return _cql_serialization_format.protocol_version();
-    }
-
     cql_serialization_format get_cql_serialization_format() const {
         return _cql_serialization_format;
     }

--- a/cql3/selection/aggregate_function_selector.hh
+++ b/cql3/selection/aggregate_function_selector.hh
@@ -9,7 +9,6 @@
 
 #include "abstract_function_selector.hh"
 #include "cql3/functions/aggregate_function.hh"
-#include "cql_serialization_format.hh"
 
 #pragma once
 
@@ -24,20 +23,20 @@ public:
         return true;
     }
 
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) override {
+    virtual void add_input(result_set_builder& rs) override {
         // Aggregation of aggregation is not supported
         size_t m = _arg_selectors.size();
         for (size_t i = 0; i < m; ++i) {
             auto&& s = _arg_selectors[i];
-            s->add_input(sf, rs);
-            _args[i] = s->get_output(sf);
+            s->add_input(rs);
+            _args[i] = s->get_output();
             s->reset();
         }
-        _aggregate->add_input(sf, _args);
+        _aggregate->add_input(_args);
     }
 
-    virtual bytes_opt get_output(cql_serialization_format sf) override {
-        return _aggregate->compute(sf);
+    virtual bytes_opt get_output() override {
+        return _aggregate->compute();
     }
 
     virtual void reset() override {

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -13,7 +13,6 @@
 #include "selector.hh"
 #include "types.hh"
 #include "types/user.hh"
-#include "cql_serialization_format.hh"
 
 namespace cql3 {
 
@@ -59,12 +58,12 @@ public:
         return false;
     }
 
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) override {
-        _selected->add_input(sf, rs);
+    virtual void add_input(result_set_builder& rs) override {
+        _selected->add_input(rs);
     }
 
-    virtual bytes_opt get_output(cql_serialization_format sf) override {
-        auto&& value = _selected->get_output(sf);
+    virtual bytes_opt get_output() override {
+        auto&& value = _selected->get_output();
         if (!value) {
             return std::nullopt;
         }

--- a/cql3/selection/scalar_function_selector.hh
+++ b/cql3/selection/scalar_function_selector.hh
@@ -11,7 +11,6 @@
 
 #include "abstract_function_selector.hh"
 #include "cql3/functions/scalar_function.hh"
-#include "cql_serialization_format.hh"
 
 namespace cql3 {
 
@@ -28,25 +27,25 @@ public:
         return _arg_selectors[0]->is_aggregate();
     }
 
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) override {
+    virtual void add_input(result_set_builder& rs) override {
         size_t m = _arg_selectors.size();
         for (size_t i = 0; i < m; ++i) {
             auto&& s = _arg_selectors[i];
-            s->add_input(sf, rs);
+            s->add_input(rs);
         }
     }
 
     virtual void reset() override {
     }
 
-    virtual bytes_opt get_output(cql_serialization_format sf) override {
+    virtual bytes_opt get_output() override {
         size_t m = _arg_selectors.size();
         for (size_t i = 0; i < m; ++i) {
             auto&& s = _arg_selectors[i];
-            _args[i] = s->get_output(sf);
+            _args[i] = s->get_output();
             s->reset();
         }
-        return fun()->execute(sf, _args);
+        return fun()->execute(_args);
     }
 
     virtual bool requires_thread() const override;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -49,9 +49,9 @@ public:
     * @param rs the <code>ResultSetBuilder</code>
     * @throws InvalidRequestException
     */
-    virtual void add_input_row(cql_serialization_format sf, result_set_builder& rs) = 0;
+    virtual void add_input_row(result_set_builder& rs) = 0;
 
-    virtual std::vector<bytes_opt> get_output_row(cql_serialization_format sf) = 0;
+    virtual std::vector<bytes_opt> get_output_row() = 0;
 
     virtual void reset() = 0;
 };
@@ -192,7 +192,6 @@ private:
     std::vector<api::timestamp_type> _timestamps;
     std::vector<int32_t> _ttls;
     const gc_clock::time_point _now;
-    cql_serialization_format _cql_serialization_format;
 public:
     template<typename Func>
     auto with_thread_if_needed(Func&& func) {
@@ -246,7 +245,7 @@ public:
         bool do_filter(const selection& selection, const std::vector<bytes>& pk, const std::vector<bytes>& ck, const query::result_row_view& static_row, const query::result_row_view* row) const;
     };
 
-    result_set_builder(const selection& s, gc_clock::time_point now, cql_serialization_format sf,
+    result_set_builder(const selection& s, gc_clock::time_point now,
                        std::vector<size_t> group_by_cell_indices = {});
     void add_empty();
     void add(bytes_opt value);

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -38,20 +38,18 @@ public:
     /**
      * Add the current value from the specified <code>result_set_builder</code>.
      *
-     * @param protocol_version protocol version used for serialization
      * @param rs the <code>result_set_builder</code>
      * @throws InvalidRequestException if a problem occurs while add the input value
      */
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) = 0;
+    virtual void add_input(result_set_builder& rs) = 0;
 
     /**
      * Returns the selector output.
      *
-     * @param protocol_version protocol version used for serialization
      * @return the selector output
      * @throws InvalidRequestException if a problem occurs while computing the output value
      */
-    virtual bytes_opt get_output(cql_serialization_format sf) = 0;
+    virtual bytes_opt get_output() = 0;
 
     /**
      * Returns the <code>selector</code> output type.

--- a/cql3/selection/simple_selector.hh
+++ b/cql3/selection/simple_selector.hh
@@ -63,7 +63,7 @@ public:
         , _first(true)
     { }
 
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) override {
+    virtual void add_input(result_set_builder& rs) override {
         // GROUP BY calls add_input() repeatedly without reset() in between, and it expects the
         // output to be the first value encountered:
         // https://cassandra.apache.org/doc/latest/cql/dml.html#grouping-results
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    virtual bytes_opt get_output(cql_serialization_format sf) override {
+    virtual bytes_opt get_output() override {
         return std::move(_current);
     }
 

--- a/cql3/selection/writetime_or_ttl_selector.hh
+++ b/cql3/selection/writetime_or_ttl_selector.hh
@@ -56,7 +56,7 @@ public:
         return ::make_shared<wtots_factory>(std::move(column_name), idx, is_writetime);
     }
 
-    virtual void add_input(cql_serialization_format sf, result_set_builder& rs) override {
+    virtual void add_input(result_set_builder& rs) override {
         if (_is_writetime) {
             int64_t ts = rs.timestamp_of(_idx);
             if (ts != api::missing_timestamp) {
@@ -78,7 +78,7 @@ public:
         }
     }
 
-    virtual bytes_opt get_output(cql_serialization_format sf) override {
+    virtual bytes_opt get_output() override {
         return _current;
     }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -252,10 +252,6 @@ modification_statement::execute_without_checking_exception_message(query_process
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
-    if (has_conditions() && options.get_protocol_version() == 1) {
-        throw exceptions::invalid_request_exception("Conditional updates are not supported by the protocol version in use. You need to upgrade to a driver using the native protocol v2.");
-    }
-
     tracing::add_table_name(qs.get_trace_state(), keyspace(), column_family());
 
     inc_cql_stats(qs.get_client_state().is_internal());

--- a/cql3/statements/prune_materialized_view_statement.cc
+++ b/cql3/statements/prune_materialized_view_statement.cc
@@ -46,7 +46,7 @@ static future<> delete_ghost_rows(dht::partition_range_vector partition_ranges, 
     while (!p->is_exhausted()) {
         tracing::trace(state.get_trace_state(), "Fetching a page for ghost row deletion");
         auto timeout = db::timeout_clock::now() + timeout_duration;
-        cql3::selection::result_set_builder builder(*selection, now, options.get_cql_serialization_format());
+        cql3::selection::result_set_builder builder(*selection, now);
         co_await p->fetch_page(builder, page_size, now, timeout);
     }
 }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -51,7 +51,7 @@ static std::unordered_map<sstring, rjson::value> handle_case_sensitivity(rjson::
 }
 
 std::unordered_map<sstring, bytes_opt>
-parse(const sstring& json_string, const std::vector<column_definition>& expected_receivers, cql_serialization_format sf) {
+parse(const sstring& json_string, const std::vector<column_definition>& expected_receivers) {
     std::unordered_map<sstring, bytes_opt> json_map;
     auto prepared_map = handle_case_sensitivity(rjson::parse(json_string));
     for (const auto& def : expected_receivers) {
@@ -63,7 +63,7 @@ parse(const sstring& json_string, const std::vector<column_definition>& expected
             json_map.emplace(std::move(cql_name), bytes_opt{});
             prepared_map.erase(value_it);
         } else {
-            json_map.emplace(std::move(cql_name), from_json_object(*def.type, std::move(value_it->second), sf));
+            json_map.emplace(std::move(cql_name), from_json_object(*def.type, std::move(value_it->second)));
             prepared_map.erase(value_it);
         }
     }
@@ -155,7 +155,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
 modification_statement::json_cache_opt insert_prepared_json_statement::maybe_prepare_json_cache(const query_options& options) const {
     cql3::raw_value c = expr::evaluate(_value, options);
     sstring json_string = utf8_type->to_string(to_bytes(c.view()));
-    return json_helpers::parse(std::move(json_string), s->all_columns(), cql_serialization_format::internal());
+    return json_helpers::parse(std::move(json_string), s->all_columns());
 }
 
 void

--- a/cql3/type_json.hh
+++ b/cql3/type_json.hh
@@ -11,7 +11,7 @@
 #include "types.hh"
 #include "utils/rjson.hh"
 
-bytes from_json_object(const abstract_type &t, const rjson::value& value, cql_serialization_format sf);
+bytes from_json_object(const abstract_type &t, const rjson::value& value);
 sstring to_json_string(const abstract_type &t, bytes_view bv);
 sstring to_json_string(const abstract_type &t, const managed_bytes_view& bv);
 

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -129,26 +129,26 @@ public:
     }
 
     template <typename ValueType>
-    ValueType deserialize(const collection_type_impl& t, cql_serialization_format sf) const {
-        return value_cast<ValueType>(with_value([&] (const FragmentedView auto& v) { return t.deserialize(v, sf); }));
+    ValueType deserialize(const collection_type_impl& t) const {
+        return value_cast<ValueType>(with_value([&] (const FragmentedView auto& v) { return t.deserialize(v); }));
     }
 
-    void validate(const abstract_type& t, cql_serialization_format sf) const {
-        return with_value([&] (const FragmentedView auto& v) { return t.validate(v, sf); });
+    void validate(const abstract_type& t) const {
+        return with_value([&] (const FragmentedView auto& v) { return t.validate(v); });
     }
 
     template <typename ValueType>
-    ValueType validate_and_deserialize(const collection_type_impl& t, cql_serialization_format sf) const {
+    ValueType validate_and_deserialize(const collection_type_impl& t) const {
         return with_value([&] (const FragmentedView auto& v) {
-            t.validate(v, sf);
-            return value_cast<ValueType>(t.deserialize(v, sf));
+            t.validate(v);
+            return value_cast<ValueType>(t.deserialize(v));
         });
     }
 
     template <typename ValueType>
-    ValueType validate_and_deserialize(const abstract_type& t, cql_serialization_format sf) const {
+    ValueType validate_and_deserialize(const abstract_type& t) const {
         return with_value([&] (const FragmentedView auto& v) {
-            t.validate(v, sf);
+            t.validate(v);
             return value_cast<ValueType>(t.deserialize(v));
         });
     }

--- a/cql_serialization_format.hh
+++ b/cql_serialization_format.hh
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <cstdint>
+#include <exception>
 
 using cql_protocol_version_type = uint8_t;
 
@@ -26,15 +27,10 @@ public:
     static constexpr cql_protocol_version_type latest_version = 4;
     explicit cql_serialization_format(cql_protocol_version_type version) : _version(version) {}
     static cql_serialization_format latest() { return cql_serialization_format{latest_version}; }
-    static cql_serialization_format internal() { return latest(); }
-    bool using_32_bits_for_collections() const { return _version >= 3; }
-    bool operator==(cql_serialization_format x) const { return _version == x._version; }
-    bool operator!=(cql_serialization_format x) const { return !operator==(x); }
     cql_protocol_version_type protocol_version() const { return _version; }
-    friend std::ostream& operator<<(std::ostream& out, const cql_serialization_format& sf) {
-        return out << static_cast<int>(sf._version);
-    }
-    bool collection_format_unchanged(cql_serialization_format other = cql_serialization_format::latest()) const {
-        return using_32_bits_for_collections() == other.using_32_bits_for_collections();
+    void ensure_supported() const {
+        if (_version < 3) {
+            throw std::runtime_error("cql protocol version must be 3 or later");
+        }
     }
 };

--- a/db/functions/aggregate_function.hh
+++ b/db/functions/aggregate_function.hh
@@ -63,24 +63,22 @@ public:
         /**
          * Adds the specified input to this aggregate.
          *
-         * @param protocol_version native protocol version
          * @param values the values to add to the aggregate.
          */
-        virtual void add_input(cql_serialization_format sf, const std::vector<opt_bytes>& values) = 0;
+        virtual void add_input(const std::vector<opt_bytes>& values) = 0;
 
         /**
          * Computes and returns the aggregate current value.
          *
-         * @param protocol_version native protocol version
          * @return the aggregate current value.
          */
-        virtual opt_bytes compute(cql_serialization_format sf) = 0;
+        virtual opt_bytes compute() = 0;
 
         virtual void set_accumulator(const opt_bytes& acc) = 0;
 
         virtual opt_bytes get_accumulator() const = 0;
 
-        virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) = 0;
+        virtual void reduce(const opt_bytes& acc) = 0;
 
         /**
          * Reset this aggregate.

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -346,7 +346,7 @@ public:
                         return column_name_type->from_string(name);
                     } catch (marshal_exception&) {
                         // #2597: Scylla < 2.0 writes names in serialized form, try to recover
-                        column_name_type->validate(to_bytes_view(name), cql_serialization_format::latest());
+                        column_name_type->validate(to_bytes_view(name));
                         return to_bytes(name);
                     }
                 }();

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1266,7 +1266,7 @@ future<> system_keyspace::setup_version(sharded<netw::messaging_service>& ms) {
                             version::release(),
                             cql3::query_processor::CQL_VERSION,
                             ::cassandra::thrift_version,
-                            to_sstring(cql_serialization_format::latest_version),
+                            to_sstring(unsigned(cql_serialization_format::latest().protocol_version())),
                             local_dc_rack().dc,
                             local_dc_rack().rack,
                             sstring(cfg.partitioner()),

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -822,7 +822,7 @@ void write_cell(RowWriter& w, const query::partition_slice& slice, data_type typ
 
     w.add().write().skip_timestamp()
         .skip_expiry()
-        .write_fragmented_value(serialize_for_cql(*type, std::move(v), slice.cql_format()))
+        .write_fragmented_value(serialize_for_cql(*type, std::move(v)))
         .skip_ttl()
         .end_qr_cell();
 }

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -62,7 +62,6 @@ partition_slice_builder::build() {
         std::move(regular_columns),
         std::move(_options),
         std::move(_specific_ranges),
-        cql_serialization_format::internal(),
         _partition_row_limit,
     };
 }

--- a/query-request.hh
+++ b/query-request.hh
@@ -25,6 +25,7 @@
 #include "db/per_partition_rate_limit_info.hh"
 #include "utils/UUID.hh"
 #include "bytes.hh"
+#include "cql_serialization_format.hh"
 
 class position_in_partition_view;
 class position_in_partition;
@@ -193,7 +194,6 @@ public:
     option_set options;
 private:
     std::unique_ptr<specific_ranges> _specific_ranges;
-    cql_serialization_format _cql_format;
     uint32_t _partition_row_limit_low_bits;
     uint32_t _partition_row_limit_high_bits;
 public:
@@ -206,7 +206,6 @@ public:
     partition_slice(clustering_row_ranges row_ranges, column_id_vector static_columns,
         column_id_vector regular_columns, option_set options,
         std::unique_ptr<specific_ranges> specific_ranges = nullptr,
-        cql_serialization_format = cql_serialization_format::internal(),
         uint64_t partition_row_limit = partition_max_rows);
     partition_slice(clustering_row_ranges ranges, const schema& schema, const column_set& mask, option_set options);
     partition_slice(const partition_slice&);
@@ -230,8 +229,8 @@ public:
     const std::unique_ptr<specific_ranges>& get_specific_ranges() const {
         return _specific_ranges;
     }
-    const cql_serialization_format& cql_format() const {
-        return _cql_format;
+    const cql_serialization_format cql_format() const {
+        return cql_serialization_format(4); // For IDL compatibility
     }
     const uint32_t partition_row_limit_low_bits() const {
         return _partition_row_limit_low_bits;

--- a/query-result-set.cc
+++ b/query-result-set.cc
@@ -185,7 +185,7 @@ result_set_builder::deserialize(const result_row_view& row, bool is_static)
                             ctype = map_type_impl::get_instance(ctype->name_comparator(), ctype->value_comparator(), true);
                         }
 
-                        cells.emplace(col.name_as_text(), ctype->deserialize_value(*cell, _slice.cql_format()));
+                        cells.emplace(col.name_as_text(), ctype->deserialize_value(*cell));
                     } else {
                         cells.emplace(col.name_as_text(), col.type->deserialize_value(*cell));
                     }

--- a/query.cc
+++ b/query.cc
@@ -49,7 +49,6 @@ std::ostream& operator<<(std::ostream& out, const partition_slice& ps) {
         out << ", specific=[" << *ps._specific_ranges << "]";
     }
     out << ", options=" << format("{:x}", ps.options.mask()); // FIXME: pretty print options
-    out << ", cql_format=" << ps.cql_format();
     out << ", partition_row_limit=" << ps.partition_row_limit();
     return out << "}";
 }
@@ -207,20 +206,20 @@ partition_slice::partition_slice(clustering_row_ranges row_ranges,
     , regular_columns(std::move(regular_columns))
     , options(options)
     , _specific_ranges(std::move(specific_ranges))
-    , _cql_format(std::move(cql_format))
     , _partition_row_limit_low_bits(partition_row_limit_low_bits)
     , _partition_row_limit_high_bits(partition_row_limit_high_bits)
-{}
+{
+    cql_format.ensure_supported();
+}
 
 partition_slice::partition_slice(clustering_row_ranges row_ranges,
     query::column_id_vector static_columns,
     query::column_id_vector regular_columns,
     option_set options,
     std::unique_ptr<specific_ranges> specific_ranges,
-    cql_serialization_format cql_format,
     uint64_t partition_row_limit)
     : partition_slice(std::move(row_ranges), std::move(static_columns), std::move(regular_columns), options,
-            std::move(specific_ranges), std::move(cql_format), static_cast<uint32_t>(partition_row_limit),
+            std::move(specific_ranges), cql_serialization_format::latest(), static_cast<uint32_t>(partition_row_limit),
             static_cast<uint32_t>(partition_row_limit >> 32))
 {}
 
@@ -250,7 +249,6 @@ partition_slice::partition_slice(const partition_slice& s)
     , regular_columns(s.regular_columns)
     , options(s.options)
     , _specific_ranges(s._specific_ranges ? std::make_unique<specific_ranges>(*s._specific_ranges) : nullptr)
-    , _cql_format(s._cql_format)
     , _partition_row_limit_low_bits(s._partition_row_limit_low_bits)
     , _partition_row_limit_high_bits(s._partition_row_limit_high_bits)
 {}

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1678,7 +1678,7 @@ future<mutation> database::do_apply_counter_update(column_family& cf, const froz
                           regular_columns.end());
 
     auto slice = query::partition_slice(std::move(cr_ranges), std::move(static_columns),
-        std::move(regular_columns), { }, { }, cql_serialization_format::internal(), query::max_rows);
+        std::move(regular_columns), { }, { }, query::max_rows);
 
     return do_with(std::move(slice), std::move(m), std::vector<locked_cell>(),
                    [this, &cf, timeout, trace_state = std::move(trace_state), op = cf.write_in_progress()] (const query::partition_slice& slice, mutation& m, std::vector<locked_cell>& locks) mutable {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2558,7 +2558,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
     opts.set(query::partition_slice::option::send_ttl);
     opts.add(custom_opts);
     auto slice = query::partition_slice(
-            std::move(cr_ranges), std::move(static_columns), std::move(regular_columns), std::move(opts), { }, cql_serialization_format::internal(), query::max_rows);
+            std::move(cr_ranges), std::move(static_columns), std::move(regular_columns), std::move(opts), { }, query::max_rows);
     // Take the shard-local lock on the base-table row or partition as needed.
     // We'll return this lock to the caller, which will release it after
     // writing the base-table update.

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -212,8 +212,7 @@ future<std::unique_ptr<cql3::result_set>> query_pager::fetch_page(uint32_t page_
 future<result<std::unique_ptr<cql3::result_set>>> query_pager::fetch_page_result(uint32_t page_size,
         gc_clock::time_point now, db::timeout_clock::time_point timeout) {
     return do_with(
-            cql3::selection::result_set_builder(*_selection, now,
-                    _options.get_cql_serialization_format()),
+            cql3::selection::result_set_builder(*_selection, now),
             [this, page_size, now, timeout](auto& builder) {
                 return this->fetch_page_result(builder, page_size, now, timeout).then(utils::result_wrap([&builder] {
                     return builder.with_thread_if_needed([&builder] () -> result<std::unique_ptr<cql3::result_set>> {

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -250,8 +250,8 @@ future<> raft_sys_table_storage::do_store_log_entries(const std::vector<raft::lo
             std::nullopt,
             std::vector<cql3::raw_value>{},
             false,
-            cql3::query_options::specific_options::DEFAULT,
-            cql_serialization_format::latest()),
+            cql3::query_options::specific_options::DEFAULT
+            ),
         std::move(stmt_value_views));
 
     cql3::statements::batch_statement batch(

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -160,15 +160,6 @@ SEASTAR_TEST_CASE(test_insert_large_collection_values) {
                             { make_map_value(map_type, map_type_impl::native_type({{sstring("key"), long_value}})).serialize() }
                     });
             BOOST_REQUIRE_THROW(e.execute_cql(format("INSERT INTO tbl (pk, m) VALUES ('Golding', {{'{}': 'value'}});", long_value)).get(), std::exception);
-
-            auto make_query_options = [] (cql_protocol_version_type version) {
-                    return std::make_unique<cql3::query_options>(cql3::default_cql_config, db::consistency_level::ONE, std::nullopt,
-                            std::vector<cql3::raw_value_view>(), false,
-                            cql3::query_options::specific_options::DEFAULT, cql_serialization_format{version});
-            };
-
-            BOOST_REQUIRE_THROW(e.execute_cql("SELECT l FROM tbl WHERE pk = 'Zamyatin';", make_query_options(2)).get(), std::exception);
-            BOOST_REQUIRE_THROW(e.execute_cql("SELECT m FROM tbl WHERE pk = 'Haksli';", make_query_options(2)).get(), std::exception);
         });
     });
 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5431,12 +5431,10 @@ SEASTAR_TEST_CASE(test_not_parallelized_select_uda) {
 }
 
 cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vector<cql3::raw_value>& elements_to_write) {
-    cql_serialization_format sf = cql_serialization_format::latest();
-
     size_t serialized_len = 0;
-    serialized_len += collection_size_len(sf);
+    serialized_len += collection_size_len();
     for (const cql3::raw_value& val : elements_to_write) {
-        serialized_len += collection_value_len(sf);
+        serialized_len += collection_value_len();
         if (val.is_value()) {
             serialized_len += val.view().with_value([](const FragmentedView auto& view) {
                 return view.size_bytes();
@@ -5447,7 +5445,7 @@ cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vecto
     bytes b(bytes::initialized_later(), serialized_len);
     bytes::iterator out = b.begin();
 
-    write_collection_size(out, size_to_write, sf);
+    write_collection_size(out, size_to_write);
     for (const cql3::raw_value& val : elements_to_write) {
         if (val.is_null()) {
                 write_int32(out, -1);
@@ -5455,7 +5453,7 @@ cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vecto
                 write_int32(out, -2);
         } else {
             val.view().with_value([&](const FragmentedView auto& val_view) {
-                write_collection_value(out, sf, linearized(val_view));
+                write_collection_value(out, linearized(val_view));
             });
         }
     }
@@ -5525,7 +5523,6 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
             return cql3::raw_value::make_value(int32_type->decompose(val));
         };
 
-        cql_serialization_format sf = cql_serialization_format::latest();
         cql3::raw_value list_with_null = make_collection_raw_value(3, {make_int(1), null_value, make_int(2)});
         cql3::raw_value set_with_null = make_collection_raw_value(3, {make_int(1), null_value, make_int(2)});
 

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -35,7 +35,7 @@ std::unique_ptr<cql3::query_options> to_options(
     return std::make_unique<cql3::query_options>(
             cfg,
             d.get_consistency(), std::move(names), std::move(values), d.skip_metadata(),
-            d.get_specific_options(), d.get_cql_serialization_format());
+            d.get_specific_options());
 }
 
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -575,7 +575,7 @@ BOOST_AUTO_TEST_CASE(test_tuple) {
 void test_validation_fails(const shared_ptr<const abstract_type>& type, bytes_view v)
 {
     try {
-        type->validate(v, cql_serialization_format::latest());
+        type->validate(v);
         BOOST_FAIL("Validation should have failed");
     } catch (const marshal_exception& e) {
         // expected
@@ -583,28 +583,28 @@ void test_validation_fails(const shared_ptr<const abstract_type>& type, bytes_vi
 }
 
 BOOST_AUTO_TEST_CASE(test_ascii_type_validation) {
-    ascii_type->validate(bytes(), cql_serialization_format::latest());
-    ascii_type->validate(bytes("foo"), cql_serialization_format::latest());
+    ascii_type->validate(bytes());
+    ascii_type->validate(bytes("foo"));
     test_validation_fails(ascii_type, bytes("fóo"));
 }
 
 BOOST_AUTO_TEST_CASE(test_utf8_type_validation) {
-    utf8_type->validate(bytes(), cql_serialization_format::latest());
-    utf8_type->validate(bytes("foo"), cql_serialization_format::latest());
-    utf8_type->validate(bytes("fóo"), cql_serialization_format::latest());
+    utf8_type->validate(bytes());
+    utf8_type->validate(bytes("foo"));
+    utf8_type->validate(bytes("fóo"));
     test_validation_fails(utf8_type, bytes("test") + from_hex("fe"));
 }
 
 BOOST_AUTO_TEST_CASE(test_int32_type_validation) {
-    int32_type->validate(bytes(), cql_serialization_format::latest());
-    int32_type->validate(from_hex("deadbeef"), cql_serialization_format::latest());
+    int32_type->validate(bytes());
+    int32_type->validate(from_hex("deadbeef"));
     test_validation_fails(int32_type, from_hex("00"));
     test_validation_fails(int32_type, from_hex("0000000000"));
 }
 
 BOOST_AUTO_TEST_CASE(test_long_type_validation) {
-    long_type->validate(bytes(), cql_serialization_format::latest());
-    long_type->validate(from_hex("deadbeefdeadbeef"), cql_serialization_format::latest());
+    long_type->validate(bytes());
+    long_type->validate(from_hex("deadbeefdeadbeef"));
     test_validation_fails(long_type, from_hex("00"));
     test_validation_fails(long_type, from_hex("00000000"));
     test_validation_fails(long_type, from_hex("000000000000000000"));
@@ -612,7 +612,7 @@ BOOST_AUTO_TEST_CASE(test_long_type_validation) {
 
 BOOST_AUTO_TEST_CASE(test_timeuuid_type_validation) {
     auto now = utils::UUID_gen::get_time_UUID();
-    timeuuid_type->validate(now.serialize(), cql_serialization_format::latest());
+    timeuuid_type->validate(now.serialize());
     auto random = utils::make_random_uuid();
     test_validation_fails(timeuuid_type, random.serialize());
     test_validation_fails(timeuuid_type, from_hex("00"));
@@ -620,27 +620,27 @@ BOOST_AUTO_TEST_CASE(test_timeuuid_type_validation) {
 
 BOOST_AUTO_TEST_CASE(test_uuid_type_validation) {
     auto now = utils::UUID_gen::get_time_UUID();
-    uuid_type->validate(now.serialize(), cql_serialization_format::latest());
+    uuid_type->validate(now.serialize());
     auto random = utils::make_random_uuid();
-    uuid_type->validate(random.serialize(), cql_serialization_format::latest());
+    uuid_type->validate(random.serialize());
     test_validation_fails(uuid_type, from_hex("00"));
 }
 
 BOOST_AUTO_TEST_CASE(test_duration_type_validation) {
-    duration_type->validate(duration_type->from_string("1m23us"), cql_serialization_format::latest());
+    duration_type->validate(duration_type->from_string("1m23us"));
     using exception_predicate::message_equals;
     BOOST_REQUIRE_EXCEPTION(
-            duration_type->validate(from_hex("ff"), cql_serialization_format::latest()),
+            duration_type->validate(from_hex("ff")),
             marshal_exception,
             message_equals("marshaling error: Expected at least 3 bytes for a duration, got 1"));
 
     BOOST_REQUIRE_EXCEPTION(
-            duration_type->validate(from_hex("fffffffffffffffffe0202"), cql_serialization_format::latest()),
+            duration_type->validate(from_hex("fffffffffffffffffe0202")),
             marshal_exception,
             message_equals("marshaling error: The duration months (9223372036854775807) must be a 32 bit integer"));
 
     BOOST_REQUIRE_EXCEPTION(
-            duration_type->validate(from_hex("010201"), cql_serialization_format::latest()),
+            duration_type->validate(from_hex("010201")),
             marshal_exception,
             message_equals("marshaling error: The duration months, days, and "
                            "nanoseconds must be all of the same sign (-1, 1, -1)"));

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -365,7 +365,7 @@ public:
                 actual = c.value().linearize();
             } else {
                 actual = linearized(serialize_for_cql(*col_def->type,
-                        cell->as_collection_mutation(), cql_serialization_format::internal()));
+                        cell->as_collection_mutation()));
             }
             assert(col_def->type->equal(actual, exp));
           });

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -404,7 +404,7 @@ public:
         }
         clustering_ranges.emplace_back(query::clustering_range::make_open_ended_both_sides());
         auto slice = query::partition_slice(std::move(clustering_ranges), { }, std::move(regular_columns), opts,
-                std::move(specific_ranges), cql_serialization_format::internal());
+                std::move(specific_ranges));
         auto cmd = make_lw_shared<query::read_command>(s.id(), s.version(), std::move(slice), proxy.get_max_result_size(slice),
                 query::tombstone_limit(proxy.get_tombstone_limit()), query::row_limit(row_limit), query::partition_limit(partition_limit));
         cmd->allow_limit = db::allow_per_partition_rate_limit::yes;
@@ -1053,7 +1053,7 @@ public:
             }
             auto& qp = _query_processor.local();
             auto opts = std::make_unique<cql3::query_options>(qp.get_cql_config(), cl_from_thrift(consistency), std::nullopt, std::vector<cql3::raw_value_view>(),
-                            false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+                            false, cql3::query_options::specific_options::DEFAULT);
             auto f = qp.execute_direct(query, _query_state, *opts);
             return f.then([cob = std::move(cob), opts = std::move(opts)](auto&& ret) {
                 cql3_result_visitor visitor;
@@ -1133,7 +1133,7 @@ public:
             });
             auto& qp = _query_processor.local();
             auto opts = std::make_unique<cql3::query_options>(qp.get_cql_config(), cl_from_thrift(consistency), std::nullopt, std::move(bytes_values),
-                            false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+                            false, cql3::query_options::specific_options::DEFAULT);
             auto f = qp.execute_prepared(std::move(prepared), std::move(cache_key), _query_state, *opts, needs_authorization);
             return f.then([cob = std::move(cob), opts = std::move(opts)](auto&& ret) {
                 cql3_result_visitor visitor;
@@ -1348,7 +1348,7 @@ private:
             auto column_name_type = db::marshal::type_parser::parse(to_sstring(cf_def.comparator_type));
             for (const ColumnDef& col_def : cf_def.column_metadata) {
                 auto col_name = to_bytes(col_def.name);
-                column_name_type->validate(col_name, cql_serialization_format::latest());
+                column_name_type->validate(col_name);
                 builder.with_column(std::move(col_name), db::marshal::type_parser::parse(to_sstring(col_def.validation_class)),
                                     column_kind::regular_column);
                 auto index = index_metadata_from_thrift(col_def);
@@ -1613,7 +1613,7 @@ private:
             throw make_exception<InvalidRequestException>("SlicePredicate column_names and slice_range may not both be null");
         }
         auto slice = query::partition_slice(std::move(clustering_ranges), {}, std::move(regular_columns), opts,
-                nullptr, cql_serialization_format::internal(), per_partition_row_limit);
+                nullptr, per_partition_row_limit);
         auto cmd = make_lw_shared<query::read_command>(s.id(), s.version(), std::move(slice), proxy.get_max_result_size(slice),
                 query::tombstone_limit(proxy.get_tombstone_limit()));
         cmd->allow_limit = db::allow_per_partition_rate_limit::yes;

--- a/thrift/thrift_validation.cc
+++ b/thrift/thrift_validation.cc
@@ -86,7 +86,7 @@ void validate_column(const Column& col, const column_definition& def) {
     if (!col.__isset.timestamp) {
         throw make_exception<InvalidRequestException>("Column timestamp is required");
     }
-    def.type->validate(to_bytes_view(col.value), cql_serialization_format::latest());
+    def.type->validate(to_bytes_view(col.value));
 }
 
 }

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -142,7 +142,7 @@ void validate_handler(type_variant type, std::vector<bytes> values, const bpo::v
         bytes_view value;
 
         void operator()(const data_type& type) {
-            type->validate(value, cql_serialization_format::internal());
+            type->validate(value);
         }
         void operator()(const compound_type<allow_prefixes::yes>& type) {
             type.validate(value);

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -280,7 +280,7 @@ cql3::query_options trace_keyspace_helper::make_session_mutation_data(const one_
     };
 
     return cql3::query_options(cql3::default_cql_config,
-            db::consistency_level::ANY, std::move(names), std::move(values), false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+            db::consistency_level::ANY, std::move(names), std::move(values), false, cql3::query_options::specific_options::DEFAULT);
 }
 
 cql3::query_options trace_keyspace_helper::make_session_time_idx_mutation_data(const one_session_records& session_records) {
@@ -298,7 +298,7 @@ cql3::query_options trace_keyspace_helper::make_session_time_idx_mutation_data(c
     };
 
     return cql3::query_options(cql3::default_cql_config,
-            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT);
 }
 
 cql3::query_options trace_keyspace_helper::make_slow_query_mutation_data(const one_session_records& session_records, const utils::UUID& start_time_id) {
@@ -341,7 +341,7 @@ cql3::query_options trace_keyspace_helper::make_slow_query_mutation_data(const o
     });
 
     return cql3::query_options(cql3::default_cql_config,
-            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT);
 }
 
 cql3::query_options trace_keyspace_helper::make_slow_query_time_idx_mutation_data(const one_session_records& session_records, const utils::UUID& start_time_id) {
@@ -362,7 +362,7 @@ cql3::query_options trace_keyspace_helper::make_slow_query_time_idx_mutation_dat
     });
 
     return cql3::query_options(cql3::default_cql_config,
-            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest());
+            db::consistency_level::ANY, std::nullopt, std::move(values), false, cql3::query_options::specific_options::DEFAULT);
 }
 
 std::vector<cql3::raw_value> trace_keyspace_helper::make_event_mutation_data(one_session_records& session_records, const event_record& record) {
@@ -398,7 +398,7 @@ future<> trace_keyspace_helper::apply_events_mutation(cql3::query_processor& qp,
         std::for_each(events_records.begin(), events_records.end(), [&values, all_records = records, this] (event_record& one_event_record) { values.emplace_back(make_event_mutation_data(*all_records, one_event_record)); });
 
         return do_with(
-            cql3::query_options::make_batch_options(cql3::query_options(cql3::default_cql_config, db::consistency_level::ANY, std::nullopt, std::vector<cql3::raw_value>{}, false, cql3::query_options::specific_options::DEFAULT, cql_serialization_format::latest()), std::move(values)),
+            cql3::query_options::make_batch_options(cql3::query_options(cql3::default_cql_config, db::consistency_level::ANY, std::nullopt, std::vector<cql3::raw_value>{}, false, cql3::query_options::specific_options::DEFAULT), std::move(values)),
             cql3::statements::batch_statement(cql3::statements::batch_statement::type::UNLOGGED, std::move(modifications), cql3::attributes::none(), qp.get_cql_stats()),
             [this, &qp] (auto& batch_options, auto& batch) {
                 return batch.execute(qp, _dummy_query_state, batch_options).then([] (shared_ptr<cql_transport::messages::result_message> res) { return now(); });

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -204,11 +204,11 @@ private:
         options_flag::NAMES_FOR_VALUES
     >;
 public:
-    std::unique_ptr<cql3::query_options> read_options(uint8_t version, cql_serialization_format cql_ser_format, const cql3::cql_config& cql_config) {
+    std::unique_ptr<cql3::query_options> read_options(uint8_t version, const cql3::cql_config& cql_config) {
         auto consistency = read_consistency();
         if (version == 1) {
             return std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt, std::vector<cql3::raw_value_view>{},
-                false, cql3::query_options::specific_options::DEFAULT, cql_ser_format);
+                false, cql3::query_options::specific_options::DEFAULT);
         }
 
         assert(version >= 2);
@@ -256,11 +256,10 @@ public:
                 onames = std::move(names);
             }
             options = std::make_unique<cql3::query_options>(cql_config, consistency, std::move(onames), std::move(values), skip_metadata,
-                cql3::query_options::specific_options{page_size, std::move(paging_state), serial_consistency, ts},
-                cql_ser_format);
+                cql3::query_options::specific_options{page_size, std::move(paging_state), serial_consistency, ts});
         } else {
             options = std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt, std::move(values), skip_metadata,
-                cql3::query_options::specific_options::DEFAULT, cql_ser_format);
+                cql3::query_options::specific_options::DEFAULT);
         }
 
         return options;

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -111,11 +111,7 @@ private:
             throw exceptions::protocol_exception(format("Invalid or unsupported protocol version: {:d}", version));
         }
 
-        if (version > 0x02) {
-            return make_frame_one<cql_binary_frame_v3>(version, length);
-        } else {
-            return make_frame_one<cql_binary_frame_v1>(version, length);
-        }
+        return make_frame_one<cql_binary_frame_v3>(version, length);
     }
 };
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -303,7 +303,6 @@ cql_server::connection::read_frame() {
                 return make_ready_future<ret_type>();
             }
             _version = buf[0];
-            init_cql_serialization_format();
             if (_version < 3 || _version > current_version) {
                 auto client_version = _version;
                 _version = current_version;
@@ -830,11 +829,6 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_op
     return make_ready_future<std::unique_ptr<cql_server::response>>(make_supported(stream, std::move(trace_state)));
 }
 
-void
-cql_server::connection::init_cql_serialization_format() {
-    _cql_serialization_format = cql_serialization_format(_version);
-}
-
 std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
         cql_protocol_version_type version, bool skip_metadata = false);
@@ -854,7 +848,7 @@ cql_server::connection::process_on_shard(::shared_ptr<messages::result_message::
                     service::client_state& client_state,
                     cql3::computed_function_values& cached_vals) mutable {
             request_reader in(is, linearization_buffer);
-            return process_fn(client_state, server._query_processor, in, stream, _version, _cql_serialization_format,
+            return process_fn(client_state, server._query_processor, in, stream, _version,
                     /* FIXME */empty_service_permit(), std::move(trace_state), false, std::move(cached_vals)).then([] (auto msg) {
                 // result here has to be foreign ptr
                 return std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
@@ -878,7 +872,7 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
     fragmented_temporary_buffer::istream is = in.get_stream();
 
     return process_fn(client_state, _server._query_processor, in, stream,
-            _version, _cql_serialization_format, permit, trace_state, true, {})
+            _version, permit, trace_state, true, {})
             .then([stream, &client_state, this, is, permit, process_fn, trace_state]
                    (process_fn_return_type msg) mutable {
         auto* bounce_msg = std::get_if<shared_ptr<messages::result_message::bounce_to_shard>>(&msg);
@@ -892,12 +886,12 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
 
 static future<process_fn_return_type>
 process_query_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
-        uint16_t stream, cql_protocol_version_type version, cql_serialization_format serialization_format,
+        uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
     auto query = in.read_long_string_view();
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
-    q_state->options = in.read_options(version, serialization_format, qp.local().get_cql_config());
+    q_state->options = in.read_options(version, qp.local().get_cql_config());
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {
         options.set_cached_pk_function_calls(std::move(cached_pk_fn_calls));
@@ -964,7 +958,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
 
 static future<process_fn_return_type>
 process_execute_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
-        uint16_t stream, cql_protocol_version_type version, cql_serialization_format serialization_format,
+        uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
     cql3::prepared_cache_key_type cache_key(in.read_short_bytes());
     auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
@@ -989,9 +983,9 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
         in.read_value_view_list(version, values);
         auto consistency = in.read_consistency();
         q_state->options = std::make_unique<cql3::query_options>(qp.local().get_cql_config(), consistency, std::nullopt, values, false,
-                                                                 cql3::query_options::specific_options::DEFAULT, serialization_format);
+                                                                 cql3::query_options::specific_options::DEFAULT);
     } else {
-        q_state->options = in.read_options(version, serialization_format, qp.local().get_cql_config());
+        q_state->options = in.read_options(version, qp.local().get_cql_config());
     }
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {
@@ -1048,7 +1042,7 @@ future<cql_server::result_with_foreign_response_ptr> cql_server::connection::pro
 
 static future<process_fn_return_type>
 process_batch_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
-        uint16_t stream, cql_protocol_version_type version, cql_serialization_format serialization_format,
+        uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
     if (version == 1) {
         throw exceptions::protocol_exception("BATCH messages are not support in version 1 of the protocol");
@@ -1137,7 +1131,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
     // #563. CQL v2 encodes query_options in v1 format for batch requests.
-    q_state->options = std::make_unique<cql3::query_options>(cql3::query_options::make_batch_options(std::move(*in.read_options(version < 3 ? 1 : version, serialization_format,
+    q_state->options = std::make_unique<cql3::query_options>(cql3::query_options::make_batch_options(std::move(*in.read_options(version < 3 ? 1 : version,
                                                                      qp.local().get_cql_config())), std::move(values)));
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -176,7 +176,6 @@ private:
         fragmented_temporary_buffer::reader _buffer_reader;
         cql_protocol_version_type _version = 0;
         cql_compression _compression = cql_compression::none;
-        cql_serialization_format _cql_serialization_format = cql_serialization_format::latest();
         service::client_state _client_state;
         timer<lowres_clock> _shedding_timer;
         bool _shed_incoming_requests = false;
@@ -257,8 +256,6 @@ private:
                 service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn);
 
         void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
-
-        void init_cql_serialization_format();
 
         friend event_notifier;
     };

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -77,19 +77,6 @@ enum cql_frame_flags {
     warning     = 0x08,
 };
 
-struct [[gnu::packed]] cql_binary_frame_v1 {
-    uint8_t  version;
-    uint8_t  flags;
-    uint8_t  stream;
-    uint8_t  opcode;
-    net::packed<uint32_t> length;
-
-    template <typename Adjuster>
-    void adjust_endianness(Adjuster a) {
-        return a(length);
-    }
-};
-
 struct [[gnu::packed]] cql_binary_frame_v3 {
     uint8_t  version;
     uint8_t  flags;

--- a/types.hh
+++ b/types.hh
@@ -37,7 +37,6 @@
 
 class tuple_type_impl;
 class big_decimal;
-class cql_serialization_format;
 
 namespace utils {
 
@@ -517,8 +516,8 @@ public:
         return deserialize_impl(single_fragmented_view(v));
     };
     // Explicitly instantiated in .cc
-    template <FragmentedView View> void validate(const View& v, cql_serialization_format sf) const;
-    void validate(bytes_view view, cql_serialization_format sf) const;
+    template <FragmentedView View> void validate(const View& v) const;
+    void validate(bytes_view view) const;
     bool is_compatible_with(const abstract_type& previous) const;
     /*
      * Types which are wrappers over other types return the inner type.
@@ -602,7 +601,7 @@ public:
 
     // Checks whether a bound value of this type has to be reserialized.
     // This can be for example because there is a set inside that needs to be sorted.
-    bool bound_value_needs_to_be_reserialized(const cql_serialization_format& sf) const;
+    bool bound_value_needs_to_be_reserialized() const;
 
     friend class list_type_impl;
 private:
@@ -619,7 +618,7 @@ protected:
     static const void* get_value_ptr(const data_value& v) {
         return v._value;
     }
-    friend void write_collection_value(bytes::iterator& out, cql_serialization_format sf, data_type type, const data_value& value);
+    friend void write_collection_value(bytes::iterator& out, data_type type, const data_value& value);
     friend class tuple_type_impl;
     friend class data_value;
     friend class reversed_type_impl;
@@ -1187,21 +1186,21 @@ inline sstring read_simple_short_string(bytes_view& v) {
     return ret;
 }
 
-size_t collection_size_len(cql_serialization_format sf);
-size_t collection_value_len(cql_serialization_format sf);
-void write_collection_size(bytes::iterator& out, int size, cql_serialization_format sf);
-void write_collection_size(managed_bytes_mutable_view&, int size, cql_serialization_format sf);
-void write_collection_value(bytes::iterator& out, cql_serialization_format sf, bytes_view val_bytes);
-void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, bytes_view val_bytes);
-void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, const managed_bytes_view& val_bytes);
+size_t collection_size_len();
+size_t collection_value_len();
+void write_collection_size(bytes::iterator& out, int size);
+void write_collection_size(managed_bytes_mutable_view&, int size);
+void write_collection_value(bytes::iterator& out, bytes_view val_bytes);
+void write_collection_value(managed_bytes_mutable_view&, bytes_view val_bytes);
+void write_collection_value(managed_bytes_mutable_view&, const managed_bytes_view& val_bytes);
 void write_int32(bytes::iterator& out, int32_t value);
 
 // Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
 // Does not perform validation.
 template <FragmentedView View>
-utils::chunked_vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf);
+utils::chunked_vector<managed_bytes> partially_deserialize_listlike(View in);
 template <FragmentedView View>
-std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in, cql_serialization_format sf);
+std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in);
 
 using user_type = shared_ptr<const user_type_impl>;
 using tuple_type = shared_ptr<const tuple_type_impl>;

--- a/types/list.hh
+++ b/types/list.hh
@@ -16,7 +16,6 @@
 #include "types/collection.hh"
 
 class user_type_impl;
-class cql_serialization_format;
 
 namespace Json {
 class Value;
@@ -35,7 +34,7 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
     using collection_type_impl::deserialize;
-    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
+    template <FragmentedView View> data_value deserialize(View v) const;
 };
 
 data_value make_list_value(data_type type, list_type_impl::native_type value);

--- a/types/map.hh
+++ b/types/map.hh
@@ -17,7 +17,6 @@
 #include "types/collection.hh"
 
 class user_type_impl;
-class cql_serialization_format;
 
 namespace Json {
 class Value;
@@ -43,11 +42,9 @@ public:
                         managed_bytes_view o1, managed_bytes_view o2);
     using abstract_type::deserialize;
     using collection_type_impl::deserialize;
-    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
-    static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,
-            cql_serialization_format sf);
-    static managed_bytes serialize_partially_deserialized_form_fragmented(const std::vector<std::pair<managed_bytes_view, managed_bytes_view>>& v,
-            cql_serialization_format sf);
+    template <FragmentedView View> data_value deserialize(View v) const;
+    static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v);
+    static managed_bytes serialize_partially_deserialized_form_fragmented(const std::vector<std::pair<managed_bytes_view, managed_bytes_view>>& v);
 
     // Serializes a map using the internal cql serialization format
     // Takes a range of pair<const bytes, bytes>
@@ -82,7 +79,7 @@ bytes map_type_impl::serialize_to_bytes(const Range& map_range) {
     bytes result(bytes::initialized_later(), serialized_len);
     bytes::iterator out = result.begin();
 
-    write_collection_size(out, map_size, cql_serialization_format::internal());
+    write_collection_size(out, map_size);
     for (const std::pair<const bytes, bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
@@ -94,8 +91,8 @@ bytes map_type_impl::serialize_to_bytes(const Range& map_range) {
                 fmt::format("Map value size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
         }
 
-        write_collection_value(out, cql_serialization_format::internal(), elem.first);
-        write_collection_value(out, cql_serialization_format::internal(), elem.second);
+        write_collection_value(out, elem.first);
+        write_collection_value(out, elem.second);
     }
 
     return result;
@@ -119,7 +116,7 @@ managed_bytes map_type_impl::serialize_to_managed_bytes(const Range& map_range) 
     managed_bytes result(managed_bytes::initialized_later(), serialized_len);
     managed_bytes_mutable_view out(result);
 
-    write_collection_size(out, map_size, cql_serialization_format::internal());
+    write_collection_size(out, map_size);
     for (const std::pair<const managed_bytes, managed_bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
@@ -131,8 +128,8 @@ managed_bytes map_type_impl::serialize_to_managed_bytes(const Range& map_range) 
                 fmt::format("Map value size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
         }
 
-        write_collection_value(out, cql_serialization_format::internal(), elem.first);
-        write_collection_value(out, cql_serialization_format::internal(), elem.second);
+        write_collection_value(out, elem.first);
+        write_collection_value(out, elem.second);
     }
 
     return result;

--- a/types/set.hh
+++ b/types/set.hh
@@ -16,7 +16,6 @@
 #include "types/collection.hh"
 
 class user_type_impl;
-class cql_serialization_format;
 
 namespace Json {
 class Value;
@@ -35,11 +34,11 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
     using collection_type_impl::deserialize;
-    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
+    template <FragmentedView View> data_value deserialize(View v) const;
     static bytes serialize_partially_deserialized_form(
-            const std::vector<bytes_view>& v, cql_serialization_format sf);
+            const std::vector<bytes_view>& v);
     static managed_bytes serialize_partially_deserialized_form_fragmented(
-            const std::vector<managed_bytes_view>& v, cql_serialization_format sf);
+            const std::vector<managed_bytes_view>& v);
 };
 
 data_value make_set_value(data_type tuple_type, set_type_impl::native_type value);


### PR DESCRIPTION
The CQL binary protocol version 3 was introduced in 2014. All Scylla
version support it, and Cassandra versions 2.1 and newer.

Versions 1 and 2 have 16-bit collection sizes, while protocol 3 and newer
use 32-bit collection sizes.

Unfortunately, we implemented support for multiple serialization formats
very intrusively, by pushing the format everywhere. This avoids the need
to re-serialize (sometimes) but is quite obnoxious. It's also likely to be
broken, since it's almost untested and it's too easy to write
cql_serialization_format::internal() instead of propagating the client
specified value.

Since protocols 1 and 2 are obsolete for 9 years, just drop them. It's
easy to verify that they are no longer in use on a running system by
examining the `system.clients` table before upgrade.

Fixes #10607
