### PR TITLE
replica/database: fix read related metrics

### DIFF
--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -419,6 +419,10 @@ public:
         return _resources;
     }
 
+    const resources consumed_resources() const {
+        return _initial_resources - _resources;
+    }
+
     void consume(resources r) {
         _resources -= r;
     }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -440,4 +440,8 @@ public:
     void set_max_queue_length(size_t size) {
         _max_queue_length = size;
     }
+
+    uint64_t active_reads() const noexcept {
+        return _stats.current_permits - _stats.inactive_reads - waiters();
+    }
 };

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -83,6 +83,10 @@ public:
         uint64_t used_permits = 0;
         // Current number of blocked permits.
         uint64_t blocked_permits = 0;
+        // Current number of reads reading from the disk.
+        uint64_t disk_reads = 0;
+        // The number of sstables read currently.
+        uint64_t sstables_read = 0;
     };
 
     using permit_list_type = bi::list<

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -157,6 +157,9 @@ public:
 
     query::max_result_size max_result_size() const;
     void set_max_result_size(query::max_result_size);
+
+    void on_start_sstable_read() noexcept;
+    void on_finish_sstable_read() noexcept;
 };
 
 using reader_permit_opt = optimized_optional<reader_permit>;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -607,6 +607,14 @@ database::setup_metrics() {
                                        " When the queue is full, excessive reads are shed to avoid overload."),
                        {user_label_instance}),
 
+        sm::make_gauge("disk_reads", [this] { return _read_concurrency_sem.get_stats().disk_reads; },
+                       sm::description("Holds the number of currently active disk read operations. "),
+                       {user_label_instance}),
+
+        sm::make_gauge("sstables_read", [this] { return _read_concurrency_sem.get_stats().sstables_read; },
+                       sm::description("Holds the number of currently read sstables. "),
+                       {user_label_instance}),
+
         sm::make_gauge("active_reads", [this] { return _streaming_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
@@ -634,6 +642,14 @@ database::setup_metrics() {
                                        " When the queue is full, excessive reads are shed to avoid overload."),
                        {streaming_label_instance}),
 
+        sm::make_gauge("disk_reads", [this] { return _streaming_concurrency_sem.get_stats().disk_reads; },
+                       sm::description("Holds the number of currently active disk read operations. "),
+                       {streaming_label_instance}),
+
+        sm::make_gauge("sstables_read", [this] { return _streaming_concurrency_sem.get_stats().sstables_read; },
+                       sm::description("Holds the number of currently read sstables. "),
+                       {streaming_label_instance}),
+
         sm::make_gauge("active_reads", [this] { return _system_read_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
@@ -659,6 +675,14 @@ database::setup_metrics() {
         sm::make_counter("reads_shed_due_to_overload", _system_read_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
                        sm::description("The number of reads shed because the admission queue reached its max capacity."
                                        " When the queue is full, excessive reads are shed to avoid overload."),
+                       {system_label_instance}),
+
+        sm::make_gauge("disk_reads", [this] { return _system_read_concurrency_sem.get_stats().disk_reads; },
+                       sm::description("Holds the number of currently active disk read operations. "),
+                       {system_label_instance}),
+
+        sm::make_gauge("sstables_read", [this] { return _system_read_concurrency_sem.get_stats().sstables_read; },
+                       sm::description("Holds the number of currently read sstables. "),
                        {system_label_instance}),
 
         sm::make_gauge("total_result_bytes", [this] { return get_result_memory_limiter().total_used_memory(); },

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -580,15 +580,12 @@ database::setup_metrics() {
         sm::make_gauge("active_reads", [this] { return _read_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations. "),
                        {user_label_instance}),
-
     });
 
     // Registering all the metrics with a single call causes the stack size to blow up.
     _metrics.add_group("database", {
-        sm::make_gauge("active_reads_memory_consumption", [this] { return max_memory_concurrent_reads() - _read_concurrency_sem.available_resources().memory; },
-                       sm::description(seastar::format("Holds the amount of memory consumed by currently active read operations. "
-                                                       "If this value gets close to {} we are likely to start dropping new read requests. "
-                                                       "In that case sstable_read_queue_overloads is going to get a non-zero value.", max_memory_concurrent_reads())),
+        sm::make_gauge("reads_memory_consumption", [this] { return _read_concurrency_sem.consumed_resources().memory; },
+                       sm::description("Holds the amount of memory consumed by current read operations. "),
                        {user_label_instance}),
 
         sm::make_gauge("queued_reads", [this] { return _read_concurrency_sem.waiters(); },
@@ -614,11 +611,8 @@ database::setup_metrics() {
                        sm::description("Holds the number of currently active read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
 
-
-        sm::make_gauge("active_reads_memory_consumption", [this] { return max_memory_streaming_concurrent_reads() - _streaming_concurrency_sem.available_resources().memory; },
-                       sm::description(seastar::format("Holds the amount of memory consumed by currently active read operations issued on behalf of streaming "
-                                                       "If this value gets close to {} we are likely to start dropping new read requests. "
-                                                       "In that case sstable_read_queue_overloads is going to get a non-zero value.", max_memory_streaming_concurrent_reads())),
+        sm::make_gauge("reads_memory_consumption", [this] { return _streaming_concurrency_sem.consumed_resources().memory; },
+                       sm::description("Holds the amount of memory consumed by current read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
 
         sm::make_gauge("queued_reads", [this] { return _streaming_concurrency_sem.waiters(); },
@@ -644,10 +638,8 @@ database::setup_metrics() {
                        sm::description("Holds the number of currently active read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
 
-        sm::make_gauge("active_reads_memory_consumption", [this] { return max_memory_system_concurrent_reads() - _system_read_concurrency_sem.available_resources().memory; },
-                       sm::description(seastar::format("Holds the amount of memory consumed by currently active read operations from \"system\" keyspace tables. "
-                                                       "If this value gets close to {} we are likely to start dropping new read requests. "
-                                                       "In that case sstable_read_queue_overloads is going to get a non-zero value.", max_memory_system_concurrent_reads())),
+        sm::make_gauge("reads_memory_consumption", [this] { return max_memory_system_concurrent_reads() - _system_read_concurrency_sem.consumed_resources().memory; },
+                       sm::description("Holds the amount of memory consumed by all read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
 
         sm::make_gauge("queued_reads", [this] { return _system_read_concurrency_sem.waiters(); },

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -577,7 +577,7 @@ database::setup_metrics() {
                        sm::description("Counts the number of times the sstable read queue was overloaded. "
                                        "A non-zero value indicates that we have to drop read requests because they arrive faster than we can serve them.")),
 
-        sm::make_gauge("active_reads", [this] { return max_count_concurrent_reads - _read_concurrency_sem.available_resources().count; },
+        sm::make_gauge("active_reads", [this] { return _read_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations. "),
                        {user_label_instance}),
 
@@ -610,7 +610,7 @@ database::setup_metrics() {
                                        " When the queue is full, excessive reads are shed to avoid overload."),
                        {user_label_instance}),
 
-        sm::make_gauge("active_reads", [this] { return max_count_streaming_concurrent_reads - _streaming_concurrency_sem.available_resources().count; },
+        sm::make_gauge("active_reads", [this] { return _streaming_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
 
@@ -640,7 +640,7 @@ database::setup_metrics() {
                                        " When the queue is full, excessive reads are shed to avoid overload."),
                        {streaming_label_instance}),
 
-        sm::make_gauge("active_reads", [this] { return max_count_system_concurrent_reads - _system_read_concurrency_sem.available_resources().count; },
+        sm::make_gauge("active_reads", [this] { return _system_read_concurrency_sem.active_reads(); },
                        sm::description("Holds the number of currently active read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
 

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -33,7 +33,12 @@ public:
         : mp_row_consumer_reader_base(std::move(sst))
         , impl(std::move(s), std::move(permit))
         , _rtc_gen(*_schema)
-    {}
+    {
+        _permit.on_start_sstable_read();
+    }
+    virtual ~mp_row_consumer_reader_k_l() {
+        _permit.on_finish_sstable_read();
+    }
 
     void on_next_partition(dht::decorated_key key, tombstone tomb) {
         _partition_finished = false;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -22,7 +22,12 @@ public:
     mp_row_consumer_reader_mx(schema_ptr s, reader_permit permit, shared_sstable sst)
         : mp_row_consumer_reader_base(std::move(sst))
         , impl(std::move(s), std::move(permit))
-    { }
+    {
+        _permit.on_start_sstable_read();
+    }
+    virtual ~mp_row_consumer_reader_mx() {
+        _permit.on_finish_sstable_read();
+    }
 
     void on_next_partition(dht::decorated_key, tombstone);
 };


### PR DESCRIPTION
Sstable read related metrics are broken for a long time now. First, the introduction of inactive reads (https://github.com/scylladb/scylladb/issues/1865) diluted this metric, as it now also contained inactive reads (contrary to the metric's name). Then, after moving the semaphore in front of the cache (3d816b7c1) this metric became completely broken as this metric now contains all kinds of reads: disk, in-memory and inactive ones too.
This series aims to remedy this:
* `scylla_database_active_reads` is fixed to only include active reads.
* `scylla_database_active_reads_memory_consumption` is renamed to `scylla_database_reads_memory_consumption` and its description is brought up-to-date.
* `scylla_database_disk_reads` is added to track current reads that are gone to disk.
* `scylla_database_sstables_read` is added to track the number of sstables read currently.

Fixes: https://github.com/scylladb/scylladb/issues/10065