### PR TITLE
utils/rjson: enable inlining in rapidjson library

### DIFF
--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -55,6 +55,10 @@ public:
 // Fortunately, the default policy can be overridden, and so rapidjson errors will
 // throw an rjson::error exception instead.
 #define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(std::string("JSON error: condition not met: ") + #x); } while (0)
+// This macro is used for functions which are called for every json char making it
+// quite costly if not inlined, by default rapidjson only enables it if NDEBUG
+// is defined which isn't the case for us.
+#define RAPIDJSON_FORCEINLINE __attribute__((always_inline))
 
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>


### PR DESCRIPTION
Due to lack of NDEBUG macro inlining was disabled. It's important for parsing and printing performance.

Testing with perf_simple_query shows that it reduced around 7000 insns/op, thus increasing median tps by 4.2% for the alternator frontend.

Because inlined functions are called for every character in json this scales with request/response size. When default write size is increased by around 7x (from ~180 to ~ 1255 bytes) then the median tps increased by 12%.

Running:
./build/release/test/perf/perf_simple_query_g --smp 1 \
                                --alternator forbid --default-log-level error \
                                --random-seed=1235000092 --duration=60 --write

Results before the patch:

median 46011.50 tps (197.1 allocs/op,  12.1 tasks/op,  170989 insns/op,        0 errors)
median absolute deviation: 296.05
maximum: 46548.07
minimum: 42955.49

Results after the patch:

median 47974.79 tps (197.1 allocs/op,  12.1 tasks/op,  163723 insns/op,        0 errors)
median absolute deviation: 303.06
maximum: 48517.53
minimum: 44083.74

The change affects both json parsing and printing.