### PR TITLE
readers/multishard: shard_reader::close() silence read-ahead timeouts

### DIFF
--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -763,7 +763,10 @@ future<> shard_reader_v2::close() noexcept {
         try {
             co_await *std::exchange(_read_ahead, std::nullopt);
         } catch (...) {
-            mrlog.warn("shard_reader::close(): read_ahead on shard {} failed: {}", _shard, std::current_exception());
+            auto ex = std::current_exception();
+            if (!is_timeout_exception(ex)) {
+                mrlog.warn("shard_reader::close(): read_ahead on shard {} failed: {}", _shard, ex);
+            }
         }
     }
 


### PR DESCRIPTION
Timouts are benign, especially on a read-ahead that turned out to be not needed at all. They just introduce noise in the logs, so silence them.

Fixes: #12435