### PR TITLE
cache: Fix undefined behavior when populating with non-full keys

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2728,6 +2728,22 @@ SEASTAR_THREAD_TEST_CASE(test_position_in_partition_order_with_prefix_keys) {
     clustering_key::make_full(*s, full_a);
     auto full_a_a = make_ck("a", "a");
 
+    auto holder = pipv::after_key(*s, prefix_a);
+    BOOST_REQUIRE(holder.holder);
+    {
+        auto holder2 = std::move(holder);
+        BOOST_REQUIRE(cmp(pip::after_key(*s, prefix_a), holder2.view) == 0);
+        BOOST_REQUIRE(holder2.holder);
+    }
+
+    holder = pipv::after_key(*s, full_a_a);
+    BOOST_REQUIRE(!holder.holder);
+    {
+        auto holder2 = std::move(holder);
+        BOOST_REQUIRE(cmp(pip::after_key(*s, full_a_a), holder2.view) == 0);
+        BOOST_REQUIRE(!holder2.holder);
+    }
+
     BOOST_REQUIRE(cmp(pip::before_key(prefix_a), prefix_a) < 0);
     BOOST_REQUIRE(cmp(pip::after_key(*s, prefix_a), prefix_a) > 0);
 


### PR DESCRIPTION
Regression introduced in 23e4c8315.

view_and_holder position_in_partiton::after_key() triggers undefined behavior when the key was not full because the holder is moved, which invalidates the view.

Fixes #12367