### PR TITLE
Remove legacy half reverse

### DIFF
--- a/docs/dev/reverse-reads.md
+++ b/docs/dev/reverse-reads.md
@@ -26,8 +26,7 @@ order is considered reverse.
 ## Legacy format
 
 The legacy format is how scylla handled reverse queries internally. We
-are in the process of migrating to the native reverse format, but for
-now coordinator-side code still uses the legacy format.
+are in the process of migrating to the native reverse format.
 
 ### Request
 

--- a/mutation.hh
+++ b/mutation.hh
@@ -146,8 +146,6 @@ public:
     // * consume_in_reverse::yes - consume in reverse order, as if the schema
     //   had the opposite clustering order. This effectively reverses the
     //   mutation's content, according to the native reverse order[1].
-    // * consume_in_reverse::legacy_half_reverse - consume rows and range
-    //   tombstones in legacy reverse order[2].
     //
     // For definition of [1] and [2] see docs/dev/reverse-reads.md.
     //
@@ -198,10 +196,10 @@ namespace {
 
 template<consume_in_reverse reverse, FlattenedConsumerV2 Consumer>
 std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutation_partition& partition, Consumer& consumer, mutation_consume_cookie& cookie, is_preemptible preempt = is_preemptible::no) {
-    constexpr bool crs_in_reverse = reverse == consume_in_reverse::legacy_half_reverse || reverse == consume_in_reverse::yes;
+    constexpr bool crs_in_reverse = reverse == consume_in_reverse::yes;
     // We can read the range_tombstone_list in reverse order in consume_in_reverse::yes mode
     // since we deoverlap range_tombstones on insertion.
-    constexpr bool rts_in_reverse = reverse == consume_in_reverse::legacy_half_reverse || reverse == consume_in_reverse::yes;
+    constexpr bool rts_in_reverse = reverse == consume_in_reverse::yes;
 
     using crs_type = mutation_partition::rows_type;
     using crs_iterator_type = std::conditional_t<crs_in_reverse, std::reverse_iterator<crs_type::iterator>, crs_type::iterator>;
@@ -267,11 +265,7 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
             }
             if (crs_it != crs_end) {
                 const auto cmp_res = cmp(rts_it->position(), crs_it->position());
-                if constexpr (reverse == consume_in_reverse::legacy_half_reverse) {
-                    emit_rt = cmp_res > 0;
-                } else {
-                    emit_rt = cmp_res < 0;
-                }
+                emit_rt = cmp_res < 0;
             }
         }
         if (emit_rt) {
@@ -341,8 +335,6 @@ auto mutation::consume(Consumer& consumer, consume_in_reverse reverse, mutation_
 
     if (reverse == consume_in_reverse::yes) {
         stop = *consume_clustering_fragments<consume_in_reverse::yes>(_ptr->_schema, partition, consumer, cookie);
-    } else if (reverse == consume_in_reverse::legacy_half_reverse) {
-        stop = *consume_clustering_fragments<consume_in_reverse::legacy_half_reverse>(_ptr->_schema, partition, consumer, cookie);
     } else {
         stop = *consume_clustering_fragments<consume_in_reverse::no>(_ptr->_schema, partition, consumer, cookie);
     }
@@ -380,10 +372,6 @@ auto mutation::consume_gently(Consumer& consumer, consume_in_reverse reverse, mu
     std::optional<stop_iteration> stop_opt;
     if (reverse == consume_in_reverse::yes) {
         while (!(stop_opt = consume_clustering_fragments<consume_in_reverse::yes>(_ptr->_schema, partition, consumer, cookie, is_preemptible::yes))) {
-            co_await yield();
-        }
-    } else if (reverse == consume_in_reverse::legacy_half_reverse) {
-        while (!(stop_opt = consume_clustering_fragments<consume_in_reverse::legacy_half_reverse>(_ptr->_schema, partition, consumer, cookie, is_preemptible::yes))) {
             co_await yield();
         }
     } else {

--- a/mutation.hh
+++ b/mutation.hh
@@ -16,7 +16,7 @@
 #include "dht/i_partitioner.hh"
 #include "hashing.hh"
 #include "mutation_fragment_v2.hh"
-#include "mutation_consumer_concepts.hh"
+#include "mutation_consumer.hh"
 #include "range_tombstone_change_generator.hh"
 #include "utils/preempt.hh"
 
@@ -58,12 +58,6 @@ template<>
 struct mutation_consume_result<void> {
     stop_iteration stop;
     mutation_consume_cookie cookie;
-};
-
-enum class consume_in_reverse {
-    no = 0,
-    yes,
-    legacy_half_reverse,
 };
 
 class mutation final {

--- a/mutation_consumer.hh
+++ b/mutation_consumer.hh
@@ -13,5 +13,4 @@
 enum class consume_in_reverse {
     no = 0,
     yes,
-    legacy_half_reverse,
 };

--- a/mutation_consumer.hh
+++ b/mutation_consumer.hh
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "mutation_consumer_concepts.hh"
+
+enum class consume_in_reverse {
+    no = 0,
+    yes,
+    legacy_half_reverse,
+};

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2209,7 +2209,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
+    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
 
     // FIXME: frozen_mutation::consume supports only forward consumers
     if (reverse == consume_in_reverse::no) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2241,7 +2241,7 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
+    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
     std::move(m).consume(consumer, reverse);
     return builder.build(compaction_state->current_full_position());
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2560,14 +2560,6 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume) {
             assert_that(std::move(rebuilt_mut)).is_equal_to(mut);
         }
     }
-    testlog.info("Legacy half reverse");
-    {
-        for (const auto& mut : muts) {
-            mutation_rebuilder_v2 rebuilder(forward_schema);
-            auto rebuilt_mut = *mutation(mut).consume(rebuilder, consume_in_reverse::legacy_half_reverse).result;
-            assert_that(std::move(rebuilt_mut)).is_equal_to(mut);
-        }
-    }
     testlog.info("Reverse");
     {
         for (const auto& mut : muts) {


### PR DESCRIPTION
This commit removes consume_in_reverse::legacy_half_reverse, an option
once used to indicate that the given key ranges are sorted descending,
based on the clustering key of the start of the range, and that the
range tombstones inside partition would be sorted (descending, as all
the mutation fragments would) according to their end (but range
tombstone would still be stored according to their start bound).

As it turns out, mutation::consume, when called with legacy_half_reverse
option produces invalid fragment stream, one where all the row
tombstone changes come after all the clustering rows. This was not an
issue, since when constructing results from the query, Scylla would not
pass the tombstones to the client, but instead compact data beforehand.

In this commit, the consume_in_reverse::legacy_half_reverse is removed,
along with all the uses.

As for the swap out in mutation_partition.cc in query_mutation and
to_data_query_result:
    
The downstream was not prepared to deal with legacy_half_reverse.
mutation::consume contains
    
```
     if (reverse == consume_in_reverse::yes) {
         while (!(stop_opt = consume_clustering_fragments<consume_in_reverse::yes>(_ptr->_schema, partition, consumer, cookie, is_preemptible::yes))) {
             co_await yield();
        }
     } else {
         while (!(stop_opt = consume_clustering_fragments<consume_in_reverse::no>(_ptr->_schema, partition, consumer, cookie, is_preemptible::yes))) {
             co_await yield();
         }
     }
```
    
So why did it work at all? to_data_query_result deals with a single slice.
The used consumer (compact_for_query_v2) compacts-away the range tombstone
changes, and thus the only difference between the consume_in_reverse::no
and consume_in_reverse::yes was that one was ordered increasing wrt. ckeys
and the second one was ordered decreasing. This property is maintained if
we swap out for the consume_in_reverse::yes format.


Refs: #12353