### PR TITLE
sstables: track decompressed buffers

### DIFF
--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -47,6 +47,8 @@
 #include "checksum_utils.hh"
 #include "../compress.hh"
 
+class reader_permit;
+
 class compression_parameters;
 class compressor;
 using compressor_ptr = shared_ptr<compressor>;
@@ -371,11 +373,11 @@ compressor_ptr get_sstable_compressor(const compression&);
 // sstable alive, and the compression metadata is only a part of it.
 input_stream<char> make_compressed_file_k_l_format_input_stream(file f,
                 sstables::compression* cm, uint64_t offset, size_t len,
-                class file_input_stream_options options);
+                class file_input_stream_options options, reader_permit permit);
 
 input_stream<char> make_compressed_file_m_format_input_stream(file f,
                 sstables::compression* cm, uint64_t offset, size_t len,
-                class file_input_stream_options options);
+                class file_input_stream_options options, reader_permit permit);
 
 output_stream<char> make_compressed_file_m_format_output_stream(output_stream<char> out,
                 sstables::compression* cm,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2412,7 +2412,7 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len, const io_prior
     options.read_ahead = 4;
     options.dynamic_adjustments = std::move(history);
 
-    file f = make_tracked_file(_data_file, std::move(permit));
+    file f = make_tracked_file(_data_file, permit);
     if (trace_state) {
         f = tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", get_filename()));
     }
@@ -2421,10 +2421,10 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len, const io_prior
     if (_components->compression && raw == raw_stream::no) {
         if (_version >= sstable_version_types::mc) {
              return make_compressed_file_m_format_input_stream(f, &_components->compression,
-                pos, len, std::move(options));
+                pos, len, std::move(options), permit);
         } else {
             return make_compressed_file_k_l_format_input_stream(f, &_components->compression,
-                pos, len, std::move(options));
+                pos, len, std::move(options), permit);
         }
     }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -18,6 +18,7 @@
 #include "compaction/compaction_manager.hh"
 #include "sstables/key.hh"
 #include "test/lib/sstable_utils.hh"
+#include "test/lib/reader_concurrency_semaphore.hh"
 #include <seastar/testing/test_case.hh>
 #include "schema.hh"
 #include "compress.hh"
@@ -731,6 +732,8 @@ SEASTAR_TEST_CASE(sub_partitions_read) {
 
 SEASTAR_TEST_CASE(test_skipping_in_compressed_stream) {
     return seastar::async([] {
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+
         tmpdir tmp;
         auto file_path = (tmp.path() / "test").string();
         file f = open_file_dma(file_path, open_flags::create | open_flags::wo).get0();
@@ -766,7 +769,7 @@ SEASTAR_TEST_CASE(test_skipping_in_compressed_stream) {
 
         auto make_is = [&] {
             f = open_file_dma(file_path, open_flags::ro).get0();
-            return make_compressed_file_m_format_input_stream(f, &c, 0, uncompressed_size, opts);
+            return make_compressed_file_m_format_input_stream(f, &c, 0, uncompressed_size, opts, semaphore.make_permit());
         };
 
         auto expect = [] (input_stream<char>& in, const temporary_buffer<char>& buf) {


### PR DESCRIPTION
Convert decompressed temporary buffers into tracked buffers just before returning them to the upper layer. This ensures these buffers are known to the reader concurrency semaphore and it has an accurate view of the actual memory consumption of reads.

Fixes: #12448