### PR TITLE
tools: toolchain: drop s390x from prepare script architecture list

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -22,7 +22,7 @@ if (( ! ok )); then
     exit 1
 fi
 
-archs=(amd64 arm64 s390x)
+archs=(amd64 arm64)
 
 # docker arch has a diffrent spelling than uname arch
 declare -A arch_unames=(


### PR DESCRIPTION
It's been a long while since we built ScyllaDB for s390x, and in fact the last time I checked it was broken on the ragel parser generator generating bad source files for the HTTP parser. So just drop it from the list.

I kept s390x in the architecture mapping table since it's still valid.