### PR TITLE
repair: finish repair immediately on local keyspaces

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -988,6 +988,11 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
     auto id = _repair_module->new_repair_uniq_id();
     rlogger.info("repair[{}]: starting user-requested repair for keyspace {}, repair id {}, options {}", id.uuid(), keyspace, id.id, options_map);
 
+    if (erm.get_replication_strategy().get_type() == locator::replication_strategy_type::local) {
+        rlogger.info("repair[{}]: completed successfully: nothing to repair for keyspace {} with local replication strategy", id.uuid(), keyspace);
+        co_return id.id;
+    }
+
     if (!_gossiper.local().is_normal(utils::fb_utilities::get_broadcast_address())) {
         throw std::runtime_error("Node is not in NORMAL status yet!");
     }


### PR DESCRIPTION
System keyspace is a keyspace with local replication strategy and thus
it does not need to be repaired. It is possible to invoke repair
of this keyspace through the api, which leads to runtime error since
peer_events and scylla_table_schema_history have different sharding logic.

For keyspaces with local replication strategy repair_service::do_repair_start
returns immediately.