### PR TITLE
cql3/functions: Fix reactor stalls when aggregating query results

### DIFF
--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -42,6 +42,9 @@ bytes_opt user_function::execute(cql_serialization_format sf, const std::vector<
     if (!seastar::thread::running_in_thread()) {
         on_internal_error(log, "User function cannot be executed in this context");
     }
+    // Possibly yield between each function execution, to avoid reactor stalls
+    // when aggregating a large input.
+    seastar::thread::maybe_yield();
     for (auto& param : parameters) {
         if (!param && !_called_on_null_input) {
             return std::nullopt;


### PR DESCRIPTION
All the rows fetched by query pager are feeded into the aggregator, without a yielding point.
See result_view::consume(), which consumes all rows in the result without yielding. Each aggregation step is not cheap, as it involves function execution, processing the result, etc.
\> 100ms stalls were observed. To avoid them, let's maybe yield after
each function execution, giving reactor a chance to breath.

Refs #12465.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>