### PR TITLE
replica: Kill table::calculate_shard_from_sstable_generation()

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -574,12 +574,6 @@ private:
         // overwrite an existing table.
         return sstables::generation_from_value((*_sstable_generation)++ * smp::count + this_shard_id());
     }
-
-    // inverse of calculate_generation_for_new_table(), used to determine which
-    // shard a sstable should be opened at.
-    static seastar::shard_id calculate_shard_from_sstable_generation(sstables::generation_type sstable_generation) {
-        return sstables::generation_value(sstable_generation) % smp::count;
-    }
 private:
     void rebuild_statistics();
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -50,10 +50,6 @@ public:
         return generation_value(cf.calculate_generation_for_new_table());
     }
 
-    static int64_t calculate_shard_from_sstable_generation(int64_t generation) {
-        return replica::column_family::calculate_shard_from_sstable_generation(generation_from_value(generation));
-    }
-
     auto try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
         auto cg = _cf->single_compaction_group_if_available();
         assert(cg);


### PR DESCRIPTION
Inferring shard from generation is long gone. We still use it in some scripts, but that's no longer needed in Scylla, when loading the SSTables, and it also conflicts with ongoing work of UUID-based generations.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>