### PR TITLE
test.py: improve logging

### DIFF
--- a/test.py
+++ b/test.py
@@ -877,7 +877,7 @@ class TopologyTest(PythonTest):
         self._prepare_pytest_params(options)
 
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
-        async with get_cluster_manager(self.uname, self.suite.clusters, test_path) as manager:
+        async with get_cluster_manager(self.mode + '/' + self.uname, self.suite.clusters, test_path) as manager:
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:

--- a/test/broadcast_tables/pytest.ini
+++ b/test/broadcast_tables/pytest.ini
@@ -2,3 +2,5 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -5,7 +5,14 @@
 #
 import time
 import asyncio
+import logging
 from typing import Callable, Awaitable, Optional, TypeVar, Generic
+
+
+class LogPrefixAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        return '[%s] %s' % (self.extra['prefix'], msg), kwargs
+
 
 unique_name_prefix = 'test_'
 T = TypeVar('T')

--- a/test/topology/pytest.ini
+++ b/test/topology/pytest.ini
@@ -2,8 +2,8 @@
 asyncio_mode = auto
 
 log_cli = true
-log_format = %(asctime)s %(levelname)s %(message)s
-log_date_format = %Y-%m-%d %H:%M:%S
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S
 
 markers =
     slow: tests that take more than 30 seconds to run

--- a/test/topology_raft_disabled/pytest.ini
+++ b/test/topology_raft_disabled/pytest.ini
@@ -5,5 +5,5 @@
 asyncio_mode = auto
 
 log_cli = true
-log_format = %(asctime)s %(levelname)s %(message)s
-log_date_format = %Y-%m-%d %H:%M:%S
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S


### PR DESCRIPTION
Make it easy to see which clusters are operated on by which tests in which build modes and so on.
Add some additional logs.

These improvements would have saved me a lot of debugging time if I had them last week and we would have https://github.com/scylladb/scylladb/pull/12482 much faster.