### PR TITLE
cql3: expr: remove reference to temporary in get_rhs_receiver

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1190,7 +1190,7 @@ static lw_shared_ptr<column_specification> get_lhs_receiver(const expression& pr
 // Given type of LHS and the operation finds the expected type of RHS.
 // The type will be the same as LHS for simple operations like =, but it will be different for more complex ones like IN or CONTAINS.
 static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column_specification>& lhs_receiver, oper_t oper) {
-    const data_type& lhs_type = lhs_receiver->type->underlying_type();
+    const data_type lhs_type = lhs_receiver->type->underlying_type();
 
     if (oper == oper_t::IN) {
         data_type rhs_receiver_type = list_type_impl::get_instance(std::move(lhs_type), false);


### PR DESCRIPTION
The function `underlying_type()` returns a `data_type` by value, but the code assigned it to a reference.

At first I was sure this is an error (assigning temporary value to a reference), but it turns out that this is most likely correct due to C++ lifetime extension rules.
    
I think it's better to avoid such unintuitive tricks. Assigning to value makes it clearer that the code is correct and there are no dangling references.