### PR TITLE
rust: use depfile and Cargo.lock to avoid building rust when unnecessary

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1828,7 +1828,8 @@ with open(buildfile, 'w') as f:
               pool = console
               description = TEST {mode}
             rule rust_lib.{mode}
-              command = cargo build --manifest-path=rust/Cargo.toml --target-dir=build/{mode} --profile=rust-{mode}
+              command = CARGO_BUILD_DEP_INFO_BASEDIR='.' cargo build --locked --manifest-path=rust/Cargo.toml --target-dir=$builddir/{mode} --profile=rust-{mode} $
+                        && touch $out
               description = RUST_LIB $out
             ''').format(mode=mode, antlr3_exec=antlr3_exec, fmt_lib=fmt_lib, test_repeat=test_repeat, test_timeout=test_timeout, **modeval))
         f.write(
@@ -1990,8 +1991,8 @@ with open(buildfile, 'w') as f:
             obj = cc.replace('.cc', '.o')
             f.write('build {}: cxx.{} {}\n'.format(obj, mode, cc))
         f.write('build {}: cxxbridge_header\n'.format('$builddir/{}/gen/rust/cxx.h'.format(mode)))
-        librust = '$builddir/{}/rust-{}/librust_combined.a'.format(mode, mode)
-        f.write('build {}: rust_lib.{} | always\n'.format(librust, mode))
+        librust = '$builddir/{}/rust-{}/librust_combined'.format(mode, mode)
+        f.write('build {}.a: rust_lib.{} rust/Cargo.lock\n  depfile={}.d\n'.format(librust, mode, librust))
         for thrift in thrifts:
             outs = ' '.join(thrift.generated('$builddir/{}/gen'.format(mode)))
             f.write('build {}: thrift.{} {}\n'.format(outs, mode, thrift.source))

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -37,7 +37,7 @@ versions used in the last successful build. Dependency modification may include:
  * adding a new dependency to a package
 
 After each such modification, a new Cargo.lock file should be submitted. Cargo.lock can be generated
-by the `cargo update` command. It will also update after each build that modifies the dependencies.
+by the `cargo update` command.
 
 ## Rust interoperability implementation
 


### PR DESCRIPTION
Currently, we call cargo build every time we build scylla, even when no rust files have been changed.
This is avoided by adding a depfile to the ninja rule for the rust library.
The rust file is generated by default during cargo build, but it uses the full paths of all depenencies that it includes, and we use relative paths. This is fixed by specifying CARGO_BUILD_DEP_INFO_BASEDIR='.', which makes it so the current path is subtracted from all generated paths.
Instead of using 'always' when specifying when to run the cargo build, a dependency on Cargo.lock is added additionally to the depfile. As a result, the rust files are recompiled not only when the source files included in the depfile are modified, but also when some rust dependency is updated.

Cargo may put an old cached file as a result of the build even when the Cargo.lock was recently updated. Because of that, the the build result may be older than the Cargo.lock file even if the build was just performed. This may cause ninja to rebuilt the file every following time. To avoid this, we 'touch' the build result, so that its last modification time is up to date. Because the dependency on Cargo.lock was added, the new command for the build does not modify it. Instead, the developer must update it when modifying the dependencies - the docs are updated to reflect that.