### PR TITLE
utils: small_vector: mark throw_out_of_range() const

### DIFF
--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -107,7 +107,7 @@ private:
     }
 
     [[noreturn]] [[gnu::cold]] [[gnu::noinline]]
-    void throw_out_of_range() {
+    void throw_out_of_range() const {
         throw std::out_of_range("out of range small vector access");
     }
 


### PR DESCRIPTION
It can be called from the const version of small_vector::at.