### PR TITLE
transport: drop some dead code around v1 and v2 protocols

### DIFF
--- a/transport/request.hh
+++ b/transport/request.hh
@@ -206,13 +206,6 @@ private:
 public:
     std::unique_ptr<cql3::query_options> read_options(uint8_t version, const cql3::cql_config& cql_config) {
         auto consistency = read_consistency();
-        if (version == 1) {
-            return std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt, std::vector<cql3::raw_value_view>{},
-                false, cql3::query_options::specific_options::DEFAULT);
-        }
-
-        assert(version >= 2);
-
         auto flags = enum_set<options_flag_enum>::from_mask(read_byte());
         std::vector<cql3::raw_value_view> values;
         std::vector<sstring_view> names;


### PR DESCRIPTION
In 424dbf43f ("transport: drop cql protocol versions 1 and 2"), we dropped support for protocols 1 and 2, but some code remains that checks for those versions. It is now dead code, so remove it.