### PR TITLE
test/cql-pytest: test more than one restriction on same clustering co…

### DIFF
--- a/test/cql-pytest/test_restrictions.py
+++ b/test/cql-pytest/test_restrictions.py
@@ -18,6 +18,11 @@ def table1(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "a int, b int, PRIMARY KEY (a)") as table:
         yield table
 
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "a int, b int, PRIMARY KEY (a, b)") as table:
+        yield table
+
 # Cassandra does not allow a WHERE clause restricting the same column with
 # an equality more than once. It complains that that column "cannot be
 # restricted by more than one relation if it includes an Equal".
@@ -33,3 +38,38 @@ def test_multiple_eq_restrictions_on_pk(cql, table1, scylla_only):
     assert [] == list(cql.execute(f'SELECT * FROM {table1} WHERE a = {p} AND a = {p2}'))
     assert [] == list(cql.execute(f'SELECT * FROM {table1} WHERE a = {p2} AND a = {p}'))
     assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table1} WHERE a = {p} AND a = {p}'))
+
+# Cassandra also doesn't allow restricting the same clustering-key column
+# more than once, producing all sorts of different error messages depending
+# if the operator is an equality or comparison and which order (see examples
+# in issue #12472). Scylla allows all these combination, and this test
+# verifies that they are implemented correctly:
+def test_multiple_restrictions_on_ck(cql, table2, scylla_only):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table2} (a, b) VALUES ({p}, 3)')
+    cql.execute(f'INSERT INTO {table2} (a, b) VALUES ({p}, 5)')
+    cql.execute(f'INSERT INTO {table2} (a, b) VALUES ({p}, 0)')
+    # b = ? and b = ?
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b = 4'))
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 4 AND b = 3'))
+    assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b = 3'))
+    # b = ? and b > ?
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b > 4'))
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 4 AND b = 3'))
+    assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b > 2'))
+    assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 2 AND b = 3'))
+    # b = ? and b < ?
+    assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b < 4'))
+    assert [(p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 4 AND b = 3'))
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b = 3 AND b < 2'))
+    assert [] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 2 AND b = 3'))
+    # b > ? and b > ?
+    assert [(p, 3), (p, 5)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 2 AND b > 1'))
+    assert [(p, 5)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 4 AND b > 1'))
+    assert [(p, 5)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 1 AND b > 4'))
+    assert [(p, 5)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b > 3 AND b > 4'))
+    # b < ? and b < ?
+    assert [(p, 0), (p, 3)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 4 AND b < 5'))
+    assert [(p, 0)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 4 AND b < 1'))
+    assert [(p, 0)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 1 AND b < 4'))
+    assert [(p, 0)] == list(cql.execute(f'SELECT * FROM {table2} WHERE a = {p} AND b < 1 AND b < 2'))


### PR DESCRIPTION
…lumn

Cassandra refuses a request with more than one relation to the same clustering column, for example

    DELETE FROM tbl WHERE p = ? and c = ? AND c > ?

complains that

    c cannot be restricted by more than one relation if it includes an Equal

But it produces different error messages for different operators and even order.

Currently, Scylla doesn't consider such requests an error. Whether or not we should be compatible with Cassandra here is discussed in issue #12472. But as long as we do accept these queries, we should be sure we do the right thing: "WHERE c = 1 AND c > 2" should match nothing, "WHERE c = 1 AND c > 0" should match the matches of c = 1, and so on. This patch adds a test for verify that these requests indeed yield correct results. The test is scylla_only because, as explained above, Cassandra doesn't support these requests at all.

Refs #12472

Signed-off-by: Nadav Har'El <nyh@scylladb.com>