### PR TITLE
raft_topology: RPC fencing initial implementation

### DIFF
--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -15,10 +15,16 @@ struct no_exception {};
 class rate_limit_exception {
 };
 
+class stale_topology_exception {
+    int64_t caller_version();
+    int64_t callee_version();
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
-            replica::rate_limit_exception
+            replica::rate_limit_exception,
+            replica::stale_topology_exception
     > reason;
 };
 

--- a/idl/storage_proxy.idl.hh
+++ b/idl/storage_proxy.idl.hh
@@ -22,16 +22,23 @@
 #include "idl/keys.idl.hh"
 #include "idl/uuid.idl.hh"
 
-verb [[with_client_info, with_timeout, one_way]] mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]);
+namespace service {
+    struct fencing_token {
+        int64_t topology_version;
+        bool allow_previous;
+    };
+}
+
+verb [[with_client_info, with_timeout, one_way]] mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], std::optional<service::fencing_token> fence [[version 5.2.0]]);
 verb [[with_client_info, one_way]] mutation_done (unsigned shard, uint64_t response_id, db::view::update_backlog backlog [[version 3.1.0]]);
 verb [[with_client_info, one_way]] mutation_failed (unsigned shard, uint64_t response_id, size_t num_failed, db::view::update_backlog backlog [[version 3.1.0]], replica::exception_variant exception [[version 5.1.0]]);
-verb [[with_client_info, with_timeout]] counter_mutation (std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info);
-verb [[with_client_info, with_timeout, one_way]] hint_mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]] /* this verb was mistakenly introduced with optional trace_info */);
-verb [[with_client_info, with_timeout]] read_data (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]) -> query::result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
-verb [[with_client_info, with_timeout]] read_mutation_data (query::read_command cmd, ::compat::wrapping_partition_range pr) -> reconcilable_result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
-verb [[with_client_info, with_timeout]] read_digest (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]) -> query::result_digest, api::timestamp_type [[version 1.2.0]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]], std::optional<full_position> [[version 5.2.0]];
+verb [[with_client_info, with_timeout]] counter_mutation (std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info, service::fencing_token fence [[version 5.2.0]]);
+verb [[with_client_info, with_timeout, one_way]] hint_mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]] /* this verb was mistakenly introduced with optional trace_info */, service::fencing_token fence [[version 5.2.0]]);
+verb [[with_client_info, with_timeout]] read_data (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.2.0]]) -> query::result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
+verb [[with_client_info, with_timeout]] read_mutation_data (query::read_command cmd, ::compat::wrapping_partition_range pr, service::fencing_token fence [[version 5.2.0]]) -> reconcilable_result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
+verb [[with_client_info, with_timeout]] read_digest (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.2.0]]) -> query::result_digest, api::timestamp_type [[version 1.2.0]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]], std::optional<full_position> [[version 5.2.0]];
 verb [[with_timeout]] truncate (sstring, sstring);
 verb [[with_client_info, with_timeout]] paxos_prepare (query::read_command cmd, partition_key key, utils::UUID ballot, bool only_digest, query::digest_algorithm da, std::optional<tracing::trace_info> trace_info) -> service::paxos::prepare_response [[unique_ptr]];
 verb [[with_client_info, with_timeout]] paxos_accept (service::paxos::proposal proposal [[ref]], std::optional<tracing::trace_info> trace_info) -> bool;
-verb [[with_client_info, with_timeout, one_way]] paxos_learn (service::paxos::proposal decision, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info>);
+verb [[with_client_info, with_timeout, one_way]] paxos_learn (service::paxos::proposal decision, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info>, std::optional<service::fencing_token> fence [[version 5.2.0]]);
 verb [[with_client_info, with_timeout, one_way]] paxos_prune (table_schema_version schema_id, partition_key key [[ref]], utils::UUID ballot, std::optional<tracing::trace_info> trace_info);

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -69,6 +69,8 @@ private:
     long _ring_version = 0;
     static thread_local long _static_ring_version;
 
+    int64_t _topology_version = 0;
+
     // Note: if any member is added to this class
     // clone_async() must be updated to copy that member.
 
@@ -304,6 +306,14 @@ public:
         _ring_version = ++_static_ring_version;
     }
 
+    int64_t get_topology_version() const {
+        return _topology_version;
+    }
+
+    void set_topology_version(int64_t version) {
+        _topology_version = version;
+    }
+
     friend class token_metadata;
 };
 
@@ -354,6 +364,7 @@ future<token_metadata_impl> token_metadata_impl::clone_async() const noexcept {
         co_await coroutine::maybe_yield();
     }
     ret._ring_version = _ring_version;
+    ret._topology_version = _topology_version;
     co_return ret;
 }
 
@@ -384,6 +395,7 @@ future<> token_metadata_impl::clear_gently() noexcept {
     co_await utils::clear_gently(_pending_ranges_interval_map);
     co_await utils::clear_gently(_sorted_tokens);
     co_await _topology.clear_gently();
+    _topology_version = 0;
     co_return;
 }
 
@@ -1235,6 +1247,16 @@ token_metadata::get_ring_version() const {
 void
 token_metadata::invalidate_cached_rings() {
     _impl->invalidate_cached_rings();
+}
+
+int64_t
+token_metadata::get_topology_version() const {
+    return _impl->get_topology_version();
+}
+
+void
+token_metadata::set_topology_version(int64_t version) {
+    _impl->set_topology_version(version);
 }
 
 void shared_token_metadata::set(mutable_token_metadata_ptr tmptr) noexcept {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -275,6 +275,9 @@ public:
     long get_ring_version() const;
     void invalidate_cached_rings();
 
+    int64_t get_topology_version() const;
+    void set_topology_version(int64_t version);
+
     friend class token_metadata_impl;
 };
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -41,6 +41,7 @@
 #include "cache_temperature.hh"
 #include "raft/raft.hh"
 #include "service/raft/group0_fwd.hh"
+#include "service/raft_topology.hh"
 #include "replica/exceptions.hh"
 #include "serializer.hh"
 #include "full_position.hh"

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -20,8 +20,10 @@ namespace replica {
 exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
     try {
         std::rethrow_exception(std::move(eptr));
-    } catch (rate_limit_exception&) {
+    } catch (const rate_limit_exception&) {
         return rate_limit_exception();
+    } catch (const stale_topology_exception& e) {
+        return e;
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -18,6 +18,7 @@
 
 #include "utils/exception_container.hh"
 #include "utils/result.hh"
+#include "seastarx.hh"
 
 namespace replica {
 
@@ -43,10 +44,34 @@ public:
     virtual const char* what() const noexcept override { return "rate limit exceeded"; }
 };
 
+class stale_topology_exception final : public replica_exception {
+    int64_t _caller_version;
+    int64_t _callee_version;
+    sstring _message;
+public:
+    stale_topology_exception(int64_t caller_version, int64_t callee_version)
+        : _caller_version(caller_version)
+        , _callee_version(callee_version)
+        , _message(format("stale topology exception, caller version {}, callee version {}", caller_version, callee_version))
+    {
+    }
+
+    int64_t caller_version() const {
+        return _caller_version;
+    }
+
+    int64_t callee_version() const {
+        return _callee_version;
+    }
+
+    virtual const char* what() const noexcept override { return _message.c_str(); }
+};
+
 struct exception_variant {
     std::variant<unknown_exception,
             no_exception,
-            rate_limit_exception
+            rate_limit_exception,
+            stale_topology_exception
     > reason;
 
     exception_variant()

--- a/service/raft_topology.hh
+++ b/service/raft_topology.hh
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright (C) 2023-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <iostream>
+
+// This a temporary header for raft-topology related declarations,
+// it will be merged into a more appropriate header when the main
+// raft-topology patch is merged.
+
+namespace service {
+
+struct fencing_token {
+    int64_t topology_version;
+    bool allow_previous;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const fencing_token& fencing_token) {
+    return os << "fencing_token(" << fencing_token.topology_version << ',' << fencing_token.allow_previous << ")";
+}
+
+}

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -30,6 +30,7 @@
 #include "db/hints/host_filter.hh"
 #include "utils/small_vector.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
+#include "service/raft_topology.hh"
 #include <seastar/core/circular_buffer.hh>
 #include "exceptions/exceptions.hh"
 #include "exceptions/coordinator_result.hh"


### PR DESCRIPTION
This is the initial implementation of fencing for raft-based topology changes.

The patch introduces the concept of topology version, an int which leaves in `token_metadata` and is incremented when the topology state changes. It's used to catch and block with error the RPCs which were issued based on the old topology version when the cluster is transitioning to the new one.

The patch adds topology version handling to the storage proxy. The main function `try_apply_fence` compares the version from the RPC parameters with the current one. If the version from the parameters is greater than the current version, we wait for the topology update on the current node (`wait_for_next_version`). If the version from the parameters is less than the current version, and the range no longer belongs to the current node, an exception is thrown. At the moment, this exception causes the original request to fail, in the future the code will be improved so that the original request is retried on the new topology.

This patch strives not to change the current behaviour. The `token_metadata::set_topology_version` method is not called anywhere yet, `topology_version` is always zero and should not affect anything. We will add a call to `set_topology_version` later, when the main raft-based topology changes patch is merged.

The patch implies a series of follow-ups. The things that should be handled:
* retries for reads
* retries for writes
* truncate, do we need fencing here? it broadcasts to all nodes, but what if new nodes have been added?
* `handle_counter_mutation`, now we just `throw stale_topology`, in other places (reads, writes) there are explicit containers for exception, maybe here we should do the same?
* hints, `manager::end_point_hints_manager::sender::send_one_mutation` uses `get_natural_endpoints` so it somehow depends on topology changes, not sure should we do something about it
* add topology version handling to raft topology changes state machine
