### PR TITLE
raft: improve group 0 reconfiguration failure handling

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -238,10 +238,9 @@ schema_ptr system_keyspace::raft_snapshot_config() {
         auto id = generate_legacy_id(system_keyspace::NAME, RAFT_SNAPSHOT_CONFIG);
         return schema_builder(system_keyspace::NAME, RAFT_SNAPSHOT_CONFIG, std::optional(id))
             .with_column("group_id", timeuuid_type, column_kind::partition_key)
-            .with_column("server_id", uuid_type, column_kind::clustering_key)
             .with_column("disposition", ascii_type, column_kind::clustering_key) // can be 'CURRENT` or `PREVIOUS'
+            .with_column("server_id", uuid_type, column_kind::clustering_key)
             .with_column("can_vote", boolean_type)
-            .with_column("ip_addr", inet_addr_type)
 
             .set_comment("RAFT configuration for the latest snapshot descriptor")
             .with_version(generate_schema_version(id))

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -56,6 +56,7 @@
 #include "service/storage_service.hh"
 #include "gms/gossiper.hh"
 #include "service/paxos/paxos_state.hh"
+#include "service/raft/raft_group_registry.hh"
 #include "utils/build_id.hh"
 #include "query-result-set.hh"
 #include "idl/frozen_mutation.dist.hh"
@@ -2647,10 +2648,123 @@ public:
     }
 };
 
+// Shows the current state of each Raft group.
+// Currently it shows only the configuration.
+// In the future we plan to add additional columns with more information.
+class raft_state_table : public streaming_virtual_table {
+private:
+    sharded<service::raft_group_registry>& _raft_gr;
+
+public:
+    raft_state_table(sharded<service::raft_group_registry>& raft_gr)
+        : streaming_virtual_table(build_schema())
+        , _raft_gr(raft_gr) {
+    }
+
+    future<> execute(reader_permit permit, result_collector& result, const query_restrictions& qr) override {
+        struct decorated_gid {
+            raft::group_id gid;
+            dht::decorated_key key;
+            unsigned shard;
+        };
+
+        auto groups_and_shards = co_await _raft_gr.map([] (service::raft_group_registry& raft_gr) {
+            return std::pair{raft_gr.all_groups(), this_shard_id()};
+        });
+
+        std::vector<decorated_gid> decorated_gids;
+        for (auto& [groups, shard]: groups_and_shards) {
+            for (auto& gid: groups) {
+                decorated_gids.push_back(decorated_gid{gid, make_partition_key(gid), shard});
+            }
+        }
+
+        // Must return partitions in token order.
+        std::sort(decorated_gids.begin(), decorated_gids.end(), [less = dht::ring_position_less_comparator(*_s)]
+                (const decorated_gid& l, const decorated_gid& r) { return less(l.key, r.key); });
+
+        for (auto& [gid, dk, shard]: decorated_gids) {
+            if (!contains_key(qr.partition_range(), dk)) {
+                continue;
+            }
+
+            auto cfg_opt = co_await _raft_gr.invoke_on(shard,
+                    [gid=gid] (service::raft_group_registry& raft_gr) -> std::optional<raft::configuration> {
+                // Be ready for a group to disappear while we're querying.
+                auto* srv = raft_gr.find_server(gid);
+                if (!srv) {
+                    return std::nullopt;
+                }
+                // FIXME: the configuration returned here is obtained from raft::fsm, it may not be
+                // persisted yet, so this is not 100% correct. It may happen that we crash after
+                // a config entry is appended in-memory in fsm but before it's persisted. It would be
+                // incorrect to return the configuration observed during this window - after restart
+                // the configuration would revert to the previous one.  Perhaps this is unlikely to
+                // happen in practice, but for correctness we should add a way of querying the
+                // latest persisted configuration.
+                return srv->get_configuration();
+            });
+
+            if (!cfg_opt) {
+                continue;
+            }
+
+            co_await result.emit_partition_start(dk);
+
+            // List current config first, because 'C' < 'P' and the disposition
+            // (ascii_type, 'CURRENT' vs 'PREVIOUS') is the first column in the clustering key.
+            co_await emit_member_set(result, "CURRENT", cfg_opt->current);
+            co_await emit_member_set(result, "PREVIOUS", cfg_opt->previous);
+
+            co_await result.emit_partition_end();
+        }
+    }
+
+private:
+    static schema_ptr build_schema() {
+        auto id = generate_legacy_id(system_keyspace::NAME, "raft_state");
+        return schema_builder(system_keyspace::NAME, "raft_state", std::make_optional(id))
+            .with_column("group_id", timeuuid_type, column_kind::partition_key)
+            .with_column("disposition", ascii_type, column_kind::clustering_key) // can be 'CURRENT` or `PREVIOUS'
+            .with_column("server_id", uuid_type, column_kind::clustering_key)
+            .with_column("can_vote", boolean_type)
+            .set_comment("Currently operating RAFT configuration")
+            .with_version(system_keyspace::generate_schema_version(id))
+            .build();
+    }
+
+    dht::decorated_key make_partition_key(raft::group_id gid) {
+        // Make sure to use timeuuid_native_type so comparisons are done correctly
+        // (we must emit partitions in the correct token order).
+        return dht::decorate_key(*_s, partition_key::from_single_value(
+                *_s, data_value(timeuuid_native_type{gid.uuid()}).serialize_nonnull()));
+    }
+
+    clustering_key make_clustering_key(std::string_view disposition, raft::server_id id) {
+        return clustering_key::from_exploded(*_s, {
+            data_value(disposition).serialize_nonnull(),
+            data_value(id.uuid()).serialize_nonnull()
+        });
+    }
+
+    future<> emit_member_set(result_collector& result, std::string_view disposition,
+                             const raft::config_member_set& set) {
+        // Must sort servers in clustering order (i.e. according to their IDs).
+        // This is how `config_member::operator<` works so no need for custom comparator.
+        std::vector<raft::config_member> members{set.begin(), set.end()};
+        std::sort(members.begin(), members.end());
+        for (auto& member: members) {
+            clustering_row cr{make_clustering_key(disposition, member.addr.id)};
+            set_cell(cr.cells(), "can_vote", member.can_vote);
+            co_await result.emit_row(std::move(cr));
+        }
+    }
+};
+
 // Map from table's schema ID to table itself. Helps avoiding accidental duplication.
 static thread_local std::map<table_id, std::unique_ptr<virtual_table>> virtual_tables;
 
-void register_virtual_tables(distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, db::config& cfg) {
+void register_virtual_tables(distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, sharded<service::raft_group_registry>& dist_raft_gr, db::config& cfg) {
     auto add_table = [] (std::unique_ptr<virtual_table>&& tbl) {
         virtual_tables[tbl->schema()->id()] = std::move(tbl);
     };
@@ -2668,6 +2782,7 @@ void register_virtual_tables(distributed<replica::database>& dist_db, distribute
     add_table(std::make_unique<versions_table>());
     add_table(std::make_unique<db_config_table>(cfg));
     add_table(std::make_unique<clients_table>(ss));
+    add_table(std::make_unique<raft_state_table>(dist_raft_gr));
 }
 
 std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
@@ -2725,9 +2840,9 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
             || s == system_keyspace::raft();
 }
 
-future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, db::config& cfg, table_selector& tables) {
+future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr, db::config& cfg, table_selector& tables) {
     if (tables.contains_keyspace(system_keyspace::NAME)) {
-        register_virtual_tables(dist_db, dist_ss, dist_gossiper, cfg);
+        register_virtual_tables(dist_db, dist_ss, dist_gossiper, dist_raft_gr, cfg);
     }
 
     auto& db = dist_db.local();
@@ -2763,8 +2878,8 @@ future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::
     }
 }
 
-future<> system_keyspace::make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, table_selector& tables) {
-    return system_keyspace_make(*this, db, ss, g, cfg, tables);
+future<> system_keyspace::make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, distributed<service::raft_group_registry>& raft_gr, db::config& cfg, table_selector& tables) {
+    return system_keyspace_make(*this, db, ss, g, raft_gr, cfg, tables);
 }
 
 future<locator::host_id> system_keyspace::load_local_host_id() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -32,6 +32,7 @@ namespace service {
 
 class storage_proxy;
 class storage_service;
+class raft_group_registry;
 
 namespace paxos {
     class paxos_state;
@@ -256,6 +257,7 @@ public:
     future<> make(distributed<replica::database>& db,
                          distributed<service::storage_service>& ss,
                          sharded<gms::gossiper>& g,
+                         sharded<service::raft_group_registry>& raft_gr,
                          db::config& cfg,
                          table_selector& = table_selector::all());
 

--- a/main.cc
+++ b/main.cc
@@ -1066,7 +1066,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
             auto system_keyspace_sel = db::table_selector::all_in_keyspace(db::system_keyspace::NAME);
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, *system_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, *system_keyspace_sel).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
@@ -1198,7 +1198,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Needs to be before system_keyspace::setup(), which writes to schema tables.
             supervisor::notify("loading system_schema sstables");
             auto schema_keyspace_sel = db::table_selector::all_in_keyspace(db::schema_tables::NAME);
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, *schema_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, *schema_keyspace_sel).get();
 
             // schema migration, if needed, is also done on shard 0
             db::legacy_schema_migrator::migrate(proxy, db, qp.local()).get();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -79,6 +79,7 @@ namespace service {
 class storage_proxy;
 class storage_service;
 class migration_notifier;
+class raft_group_registry;
 }
 
 namespace gms {
@@ -120,7 +121,7 @@ class large_data_handler;
 class system_keyspace;
 class table_selector;
 
-future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
 
 }
 
@@ -1399,7 +1400,7 @@ private:
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -692,12 +692,12 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     });
 }
 
-future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector& tables) {
+future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector& tables) {
     population_started = true;
 
-    return seastar::async([&sys_ks, &db, &ss, &cfg, &g, &tables] {
-        sys_ks.invoke_on_all([&db, &ss, &cfg, &g, &tables] (auto& sys_ks) {
-            return sys_ks.make(db, ss, g, cfg, tables);
+    return seastar::async([&sys_ks, &db, &ss, &cfg, &g, &raft_gr, &tables] {
+        sys_ks.invoke_on_all([&db, &ss, &cfg, &g, &raft_gr, &tables] (auto& sys_ks) {
+            return sys_ks.make(db, ss, g, raft_gr, cfg, tables);
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -48,6 +48,7 @@ namespace service {
 
 class storage_proxy;
 class storage_service;
+class raft_group_registry;
 
 }
 
@@ -81,7 +82,7 @@ class distributed_loader {
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg, db::table_selector&);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -675,9 +675,11 @@ future<> raft_group0::leave_group0() {
 
     auto my_id = load_my_id();
 
+    group0_log.info("leaving group 0 (my id = {})...", my_id);
     // Note: if this gets stuck due to a failure, the DB admin can abort.
     // FIXME: this gets stuck without failures if we're the leader (#10833)
     co_return co_await remove_from_raft_config(my_id);
+    group0_log.info("left group 0.");
 }
 
 future<> raft_group0::remove_from_group0(raft::server_id node) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -776,6 +776,10 @@ future<bool> raft_group0::wait_for_raft() {
             "We're fully upgraded to use Raft but didn't join group 0. Please report a bug.");
     }
 
+    group0_log.info("Performing a group 0 read barrier...");
+    co_await _raft_gr.group0().read_barrier(&_abort_source);
+    group0_log.info("Finished group 0 read barrier.");
+
     co_return true;
 }
 

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -671,6 +671,15 @@ future<> raft_group0::finish_setup_after_join() {
     });
 }
 
+bool raft_group0::is_member(raft::server_id id, bool include_voters_only) {
+    if (!joined_group0()) {
+        on_internal_error(group0_log, "called is_member before we joined group 0");
+    }
+
+    auto cfg = _raft_gr.group0().get_configuration();
+    return cfg.contains(id) && (!include_voters_only || cfg.can_vote(id));
+}
+
 future<> raft_group0::become_nonvoter() {
     if (!(co_await raft_upgrade_complete())) {
         on_internal_error(group0_log, "called become_nonvoter before Raft upgrade finished");

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -158,6 +158,18 @@ public:
     // This is a prerequisite for performing group 0 configuration operations.
     future<bool> wait_for_raft();
 
+    // Become a non-voter in group 0.
+    //
+    // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
+    // `wait_for_raft` must've also been called earlier and returned `true`.
+    future<> become_nonvoter();
+
+    // Make the given server, other than us, a non-voter in group 0.
+    //
+    // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
+    // `wait_for_raft` must've also been called earlier and returned `true`.
+    future<> make_nonvoter(raft::server_id);
+
     // Remove ourselves from group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
@@ -259,6 +271,10 @@ private:
     // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
     // (we could then try restarting the server internally).
     future<> start_server_for_group0(raft::group_id group0_id);
+
+    // Make the given server a non-voter in Raft group 0 configuration.
+    // Retries on raft::commit_status_unknown.
+    future<> make_raft_config_nonvoter(raft::server_id);
 
     // Remove the node from raft config, retries raft::commit_status_unknown.
     future<> remove_from_raft_config(raft::server_id id);

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #pragma once
+
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/discovery.hh"
 #include "service/raft/group0_fwd.hh"
@@ -149,10 +150,19 @@ public:
     // which will start a procedure to create group 0 and switch administrative operations to use it.
     future<> finish_setup_after_join();
 
+    // If Raft is disabled or in RECOVERY mode, returns `false`.
+    // Otherwise:
+    // - waits for the Raft upgrade procedure to finish if it's currently in progress,
+    // - returns `true`.
+    //
+    // This is a prerequisite for performing group 0 configuration operations.
+    future<bool> wait_for_raft();
+
     // Remove ourselves from group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // Assumes to run during decommission, after the node entered LEFT status.
+    // `wait_for_raft` must've also been called earlier and returned `true`.
     //
     // FIXME: make it retryable and do nothing if we're not a member.
     // Currently if we call leave_group0 twice, it will get stuck the second time
@@ -168,6 +178,7 @@ public:
     // 2. or we're currently bootstrapping and replacing an existing node.
     //
     // In both cases, `setup_group0()` must have finished earlier.
+    // `wait_for_raft` must've also been called earlier and returned `true`
     future<> remove_from_group0(raft::server_id);
 
     // Assumes that this node's Raft server ID is already initialized and returns it.
@@ -181,6 +192,7 @@ private:
     static future<> uninit_rpc_verbs(netw::messaging_service& ms);
 
     bool joined_group0() const;
+    future<bool> raft_upgrade_complete() const;
 
     // Handle peer_exchange RPC
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -153,6 +153,7 @@ public:
     // If Raft is disabled or in RECOVERY mode, returns `false`.
     // Otherwise:
     // - waits for the Raft upgrade procedure to finish if it's currently in progress,
+    // - performs a Raft read barrier,
     // - returns `true`.
     //
     // This is a prerequisite for performing group 0 configuration operations.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -159,6 +159,15 @@ public:
     // This is a prerequisite for performing group 0 configuration operations.
     future<bool> wait_for_raft();
 
+    // Check whether the given Raft server is a member of group 0 configuration
+    // according to our current knowledge.
+    //
+    // If `include_voters_only` is `true`, returns `true` only if the server is a voting member.
+    //
+    // Precondition: joined_group0(). In particular, this can be called safely
+    // if wait_for_raft() was called earlier and returned `true`.
+    bool is_member(raft::server_id, bool include_voters_only);
+
     // Become a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -370,6 +370,23 @@ raft::server& raft_group_registry::get_server(raft::group_id gid) {
     return *ptr;
 }
 
+raft::server* raft_group_registry::find_server(raft::group_id gid) {
+    auto it = _servers.find(gid);
+    if (it == _servers.end()) {
+        return nullptr;
+    }
+    return it->second.server.get();
+}
+
+std::vector<raft::group_id> raft_group_registry::all_groups() const {
+    std::vector<raft::group_id> result;
+    result.reserve(_servers.size());
+    for (auto& [gid, _]: _servers) {
+        result.push_back(gid);
+    }
+    return result;
+}
+
 raft::server& raft_group_registry::group0() {
     if (!_group0_id) {
         on_internal_error(rslog, "group0(): _group0_id not present");

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -123,6 +123,13 @@ public:
     // there is no such group.
     raft::server& get_server(raft::group_id gid);
 
+    // Find server for the given group.
+    // Returns `nullptr` if there is no such group.
+    raft::server* find_server(raft::group_id);
+
+    // Returns the list of all Raft groups on this shard by their IDs.
+    std::vector<raft::group_id> all_groups() const;
+
     // Return an instance of group 0. Valid only on shard 0,
     // after boot/upgrade is complete
     raft::server& group0();

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -129,7 +129,7 @@ future<raft::snapshot_descriptor> raft_sys_table_storage::load_snapshot_descript
     // have a single snapshot installed at a time
     const auto& snp_row = snp_rs->one();
     // Fetch current and previous raft configurations for the snapshot
-    static const auto  load_cfg_cql = format("SELECT server_id, disposition, can_vote FROM system.{} WHERE group_id = ?", db::system_keyspace::RAFT_SNAPSHOT_CONFIG);
+    static const auto  load_cfg_cql = format("SELECT disposition, server_id, can_vote FROM system.{} WHERE group_id = ?", db::system_keyspace::RAFT_SNAPSHOT_CONFIG);
     ::shared_ptr<cql3::untyped_result_set> cfg_rs = co_await _qp.execute_internal(load_cfg_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
 
     raft::configuration cfg;
@@ -166,16 +166,16 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
         static const auto delete_raft_cfg_cql = format("DELETE FROM system.{} WHERE group_id = ?", db::system_keyspace::RAFT_SNAPSHOT_CONFIG);
         co_await _qp.execute_internal(delete_raft_cfg_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
         // store current and previous raft configurations
-        static const auto store_raft_cfg_cql = format("INSERT INTO system.{} (group_id, server_id, disposition, can_vote) VALUES (?, ?, ?, ?)",
+        static const auto store_raft_cfg_cql = format("INSERT INTO system.{} (group_id, disposition, server_id, can_vote) VALUES (?, ?, ?, ?)",
             db::system_keyspace::RAFT_SNAPSHOT_CONFIG);
         for (const raft::config_member& srv : snap.config.current) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
-                {_group_id.id, srv.addr.id.id, "CURRENT", srv.can_vote},
+                {_group_id.id, "CURRENT", srv.addr.id.id, srv.can_vote},
                     cql3::query_processor::cache_internal::yes);
         }
         for (const raft::config_member& srv : snap.config.previous) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
-                {_group_id.id, srv.addr.id.id, "PREVIOUS", srv.can_vote},
+                {_group_id.id, "PREVIOUS", srv.addr.id.id, srv.can_vote},
                     cql3::query_processor::cache_internal::yes);
         }
         // Also update the latest snapshot id in `system.raft` table

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2104,6 +2104,9 @@ future<> storage_service::decommission() {
             // --- hence the `left_token_ring` check.
             std::exception_ptr leave_group0_ex;
             try {
+                utils::get_local_injector().inject("decommission_fail_before_leave_group0",
+                    [] { throw std::runtime_error("decommission_fail_before_leave_group0"); });
+
                 if (raft_available && left_token_ring) {
                     slogger.info("decommission[{}]: leaving Raft group 0", uuid);
                     assert(ss._group0);
@@ -2556,6 +2559,9 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
             // If the node was a token ring member but we failed to remove it,
             // don't remove it from group 0 -- hence the `removed_from_token_ring` check.
             try {
+                utils::get_local_injector().inject("removenode_fail_before_remove_from_group0",
+                    [] { throw std::runtime_error("removenode_fail_before_remove_from_group0"); });
+
                 if (is_group0_member && removed_from_token_ring) {
                     slogger.info("removenode[{}]: removing node {} from Raft group 0", uuid, raft_id);
                     ss._group0->remove_from_group0(raft_id).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -769,7 +769,7 @@ public:
                 std::ref(snitch)).get();
             auto stop_storage_service = defer([&ss] { ss.stop().get(); });
 
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, *cfg, db::table_selector::all()).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, db::table_selector::all()).get();
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
             parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -6,8 +6,13 @@
 import time
 import asyncio
 import logging
+
 from typing import Callable, Awaitable, Optional, TypeVar, Generic
 
+from cassandra.cluster import NoHostAvailable, Session  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.pool import Host                         # type: ignore # pylint: disable=no-name-in-module
+
+from test.pylib.internal_types import ServerInfo
 
 class LogPrefixAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
@@ -36,6 +41,40 @@ async def wait_for(
         if res is not None:
             return res
         await asyncio.sleep(period)
+
+
+async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
+    async def cql_ready():
+        try:
+            await cql.run_async("select * from system.local", host=host)
+        except NoHostAvailable:
+            logging.info(f"Driver not connected to {host} yet")
+            return None
+        return True
+    await wait_for(cql_ready, deadline)
+
+
+async def wait_for_cql_and_get_hosts(cql: Session, servers: list[ServerInfo], deadline: float) \
+        -> list[Host]:
+    """Wait until every server in `servers` is available through `cql`
+       and translate `servers` to a list of Cassandra `Host`s.
+    """
+    ip_set = set(str(srv.ip_addr) for srv in servers)
+    async def get_hosts() -> Optional[list[Host]]:
+        hosts = cql.cluster.metadata.all_hosts()
+        remaining = ip_set - {h.address for h in hosts}
+        if not remaining:
+            return hosts
+
+        logging.info(f"Driver hasn't yet learned about hosts: {remaining}")
+        return None
+    hosts = await wait_for(get_hosts, deadline)
+
+    # Take only hosts from `ip_set` (there may be more)
+    hosts = [h for h in hosts if h.address in ip_set]
+    await asyncio.gather(*(wait_for_cql(cql, h, deadline) for h in hosts))
+
+    return hosts
 
 
 unique_name.last_ms = 0

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -17,7 +17,7 @@ from cassandra.pool import Host                         # type: ignore # pylint:
 from test.pylib.manager_client import ManagerClient, IPAddress, ServerInfo
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import ScyllaRESTAPIClient, inject_error
-from test.pylib.util import wait_for
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 
 
 async def reconnect_driver(manager: ManagerClient) -> Session:
@@ -49,40 +49,6 @@ async def enable_raft(manager: ManagerClient, server: ServerInfo) -> None:
 async def enable_raft_and_restart(manager: ManagerClient, server: ServerInfo) -> None:
     await enable_raft(manager, server)
     await restart(manager, server)
-
-
-async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
-    async def cql_ready():
-        try:
-            await cql.run_async("select * from system.local", host=host)
-        except NoHostAvailable:
-            logging.info(f"Driver not connected to {host} yet")
-            return None
-        return True
-    await wait_for(cql_ready, deadline)
-
-
-async def wait_for_cql_and_get_hosts(cql: Session, servers: list[ServerInfo], deadline: float) \
-        -> list[Host]:
-    """Wait until every server in `servers` is available through `cql`
-       and translate `servers` to a list of Cassandra `Host`s.
-    """
-    ip_set = set(str(srv.ip_addr) for srv in servers)
-    async def get_hosts() -> Optional[list[Host]]:
-        hosts = cql.cluster.metadata.all_hosts()
-        remaining = ip_set - {h.address for h in hosts}
-        if not remaining:
-            return hosts
-
-        logging.info(f"Driver hasn't yet learned about hosts: {remaining}")
-        return None
-    hosts = await wait_for(get_hosts, deadline)
-
-    # Take only hosts from `ip_set` (there may be more)
-    hosts = [h for h in hosts if h.address in ip_set]
-    await asyncio.gather(*(wait_for_cql(cql, h, deadline) for h in hosts))
-
-    return hosts
 
 
 async def wait_for_upgrade_state(state: str, cql: Session, host: Host, deadline: float) -> None:


### PR DESCRIPTION
Make it so that failures in `removenode`/`decommission` don't lead to reduced availability, and any leftovers in group 0 can be removed by `removenode`:
- In `removenode`, make the node a non-voter before removing it from the token ring. This removes the possibility of having a group 0 voting member which doesn't correspond to a token ring member. We can still be left with a non-voter, but that's doesn't reduce the availability of group 0.
- As above but for `decommission`.
- Make it possible to remove group 0 members that don't correspond to token ring members from group 0 using `removenode`. 
- Add an API to query the current group 0 configuration.

Fixes #11723.