### PR TITLE
Use topology nodes for repair and node operations

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1101,7 +1101,7 @@
                   },
                   {
                      "name":"ignore_nodes",
-                     "description":"Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas.",
+                     "description":"Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas. Use the same method for all nodes to ignore: either Host IDs or ip addresses.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/endpoint_snitch.cc
+++ b/api/endpoint_snitch.cc
@@ -28,7 +28,7 @@ void set_endpoint_snitch(http_context& ctx, routes& r, sharded<locator::snitch_p
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return sstring(locator::production_snitch_base::default_dc);
+            return locator::endpoint_dc_rack::default_location.dc;
         }
         return topology.get_datacenter(ep);
     });
@@ -39,7 +39,7 @@ void set_endpoint_snitch(http_context& ctx, routes& r, sharded<locator::snitch_p
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return sstring(locator::production_snitch_base::default_rack);
+            return locator::endpoint_dc_rack::default_location.rack;
         }
         return topology.get_rack(ep);
     });

--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -19,7 +19,6 @@ using namespace netw;
 namespace api {
 
 using shard_info = messaging_service::shard_info;
-using msg_addr = messaging_service::msg_addr;
 
 static const int32_t num_verb = static_cast<int32_t>(messaging_verb::LAST);
 
@@ -45,7 +44,7 @@ future_json_function get_client_getter(sharded<netw::messaging_service>& ms, std
         using map_type = std::unordered_map<gms::inet_address, uint64_t>;
         auto get_shard_map = [f](messaging_service& ms) {
             std::unordered_map<gms::inet_address, unsigned long> map;
-            ms.foreach_client([&map, f] (const msg_addr& id, const shard_info& info) {
+            ms.foreach_client([&map, f] (const netw::msg_addr& id, const shard_info& info) {
                 map[id.addr] = f(info);
             });
             return map;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -79,7 +79,7 @@ sstring validate_keyspace(http_context& ctx, const parameters& param) {
 
 locator::host_id validate_host_id(const sstring& param) {
     auto hoep = locator::host_id_or_endpoint(param, locator::host_id_or_endpoint::param_type::host_id);
-    return hoep.id;
+    return hoep.id();
 }
 
 // splits a request parameter assumed to hold a comma-separated list of table names

--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -32,8 +32,10 @@ bool host_filter::can_hint_for(const locator::topology& topo, gms::inet_address 
     switch (_enabled_kind) {
     case enabled_kind::enabled_for_all:
         return true;
-    case enabled_kind::enabled_selectively:
-        return topo.has_endpoint(ep) && _dcs.contains(topo.get_datacenter(ep));
+    case enabled_kind::enabled_selectively: {
+        auto node = topo.find_node(ep);
+        return node && _dcs.contains(node->dc_rack().dc);
+    }
     case enabled_kind::disabled_for_all:
         return false;
     }

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -121,6 +121,7 @@ std::set<std::string_view> feature_service::supported_feature_set() {
         "UNBOUNDED_RANGE_TOMBSTONES"sv,
         "MC_SSTABLE_FORMAT"sv,
         "LARGE_COLLECTION_DETECTION"sv,
+        "NODE_OPS_CMD_V2"
     };
 
     for (auto& [name, f_ref] : _registered_features) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -113,6 +113,8 @@ public:
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
     gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
+    // node_ops_cmd v2 extension, identifying nodes by their host_id.
+    gms::feature node_ops_cmd_v2 { *this, "NODE_OPS_CMD_V2"sv };
 
 public:
 

--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -14,6 +14,7 @@
 #include "idl/frozen_mutation.idl.hh"
 #include "idl/token.idl.hh"
 #include "repair/id.hh"
+#include "locator/token_metadata.hh"
 
 class repair_hash {
     uint64_t hash;
@@ -100,11 +101,21 @@ class node_ops_id final {
     utils::UUID uuid();
 };
 
+namespace locator {
+
+struct host_id_and_endpoint final {
+    locator::host_id host_id;
+    gms::inet_address endpoint;
+};
+
+} // namespace locator
+
 struct node_ops_cmd_request {
     // Mandatory field, set by all cmds
     node_ops_cmd cmd;
     // Mandatory field, set by all cmds
     node_ops_id ops_uuid;
+
     // Optional field, list nodes to ignore, set by all cmds
     std::list<gms::inet_address> ignore_nodes;
     // Optional field, list leaving nodes, set by decommission and removenode cmd
@@ -115,6 +126,11 @@ struct node_ops_cmd_request {
     std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<table_id> repair_tables;
+
+    // v2:
+    // Optional field, maps node index to (host_id, inet_address)
+    // gms:inet_address values above will contain the node index as a raw ipv4 address
+    std::unordered_map<locator::node::idx_type, locator::host_id_and_endpoint> nodes_dict;
 };
 
 struct node_ops_cmd_response {

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -28,10 +28,6 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-bool operator==(const endpoint_dc_rack& d1, const endpoint_dc_rack& d2) {
-    return std::tie(d1.dc, d1.rack) == std::tie(d2.dc, d2.rack);
-}
-
 network_topology_strategy::network_topology_strategy(
     const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options,

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -477,9 +477,7 @@ future<> token_metadata_impl::update_normal_tokens(std::unordered_set<token> tok
 
 size_t token_metadata_impl::first_token_index(const token& start) const {
     if (_sorted_tokens.empty()) {
-        auto msg = format("sorted_tokens is empty in first_token_index!");
-        tlogger.error("{}", msg);
-        throw std::runtime_error(msg);
+        log_error_and_throw<std::runtime_error>(tlogger, "sorted_tokens is empty in first_token_index!");
     }
     auto it = std::lower_bound(_sorted_tokens.begin(), _sorted_tokens.end(), start);
     if (it == _sorted_tokens.end()) {
@@ -644,9 +642,7 @@ token token_metadata_impl::get_predecessor(token t) const {
     auto& tokens = sorted_tokens();
     auto it = std::lower_bound(tokens.begin(), tokens.end(), t);
     if (it == tokens.end() || *it != t) {
-        auto msg = format("token error in get_predecessor!");
-        tlogger.error("{}", msg);
-        throw std::runtime_error(msg);
+        log_error_and_throw<std::runtime_error>(tlogger, "token error in get_predecessor!");
     }
     if (it == tokens.begin()) {
         // If the token is the first element, its preprocessor is the last element

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -521,6 +521,7 @@ void token_metadata_impl::debug_show() const {
 }
 
 void token_metadata_impl::update_host_id(const host_id& host_id, inet_address endpoint) {
+    _topology.update_endpoint(endpoint, host_id);
     _endpoint_to_host_id_map[endpoint] = host_id;
 }
 
@@ -1261,7 +1262,7 @@ future<> shared_token_metadata::mutate_on_all_shards(sharded<shared_token_metada
     auto lk = co_await stm.local().get_lock();
 
     std::vector<mutable_token_metadata_ptr> pending_token_metadata_ptr;
-    pending_token_metadata_ptr.reserve(smp::count);
+    pending_token_metadata_ptr.resize(smp::count);
     auto tmptr = make_token_metadata_ptr(co_await stm.local().get()->clone_async());
     auto& tm = *tmptr;
     // bump the token_metadata ring_version

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -102,8 +102,8 @@ public:
         return _bootstrap_tokens;
     }
 
-    void update_topology(inet_address ep, endpoint_dc_rack dr) {
-        _topology.update_endpoint(ep, std::move(dr));
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
+        _topology.update_endpoint(ep, std::move(dr), std::move(opt_st));
     }
 
     /**
@@ -852,7 +852,7 @@ void token_metadata_impl::calculate_pending_ranges_for_bootstrap(
     for (auto& x : tmp) {
         auto& endpoint = x.first;
         auto& tokens = x.second;
-        all_left_metadata->update_topology(endpoint, get_dc_rack(endpoint));
+        all_left_metadata->update_topology(endpoint, get_dc_rack(endpoint), node::state::joining);
         all_left_metadata->update_normal_tokens(tokens, endpoint).get();
         auto address_ranges = strategy.get_ranges(endpoint, *all_left_metadata).get0();
         for (const dht::token_range& x : address_ranges) {
@@ -1025,8 +1025,8 @@ token_metadata::get_bootstrap_tokens() const {
 }
 
 void
-token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr) {
-    _impl->update_topology(ep, std::move(dr));
+token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
+    _impl->update_topology(ep, std::move(dr), std::move(opt_st));
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>
@@ -1046,6 +1046,11 @@ token_metadata::get_topology() {
 
 const topology&
 token_metadata::get_topology() const {
+    return _impl->get_topology();
+}
+
+topology&
+token_metadata::get_mutable_topology() const {
     return _impl->get_topology();
 }
 

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -153,9 +153,9 @@ public:
 
     void add_bootstrap_token(token t, inet_address endpoint);
 
-    void add_bootstrap_tokens(std::unordered_set<token> tokens, inet_address endpoint);
+    void add_bootstrap_tokens(const std::unordered_set<token>& tokens, inet_address endpoint);
 
-    void remove_bootstrap_tokens(std::unordered_set<token> tokens);
+    void remove_bootstrap_tokens(const std::unordered_set<token>& tokens);
 
     void add_leaving_endpoint(inet_address endpoint);
     void del_leaving_endpoint(inet_address endpoint);
@@ -583,7 +583,7 @@ token_metadata_impl::ring_range(const std::optional<dht::partition_range::bound>
     return r;
 }
 
-void token_metadata_impl::add_bootstrap_tokens(std::unordered_set<token> tokens, inet_address endpoint) {
+void token_metadata_impl::add_bootstrap_tokens(const std::unordered_set<token>& tokens, inet_address endpoint) {
     for (auto t : tokens) {
         auto old_endpoint = _bootstrap_tokens.find(t);
         if (old_endpoint != _bootstrap_tokens.end() && (*old_endpoint).second != endpoint) {
@@ -600,12 +600,12 @@ void token_metadata_impl::add_bootstrap_tokens(std::unordered_set<token> tokens,
 
     std::erase_if(_bootstrap_tokens, [endpoint] (const std::pair<token, inet_address>& n) { return n.second == endpoint; });
 
-    for (auto t : tokens) {
+    for (const auto& t : tokens) {
         _bootstrap_tokens[t] = endpoint;
     }
 }
 
-void token_metadata_impl::remove_bootstrap_tokens(std::unordered_set<token> tokens) {
+void token_metadata_impl::remove_bootstrap_tokens(const std::unordered_set<token>& tokens) {
     if (tokens.empty()) {
         tlogger.warn("tokens is empty in remove_bootstrap_tokens!");
         return;
@@ -1092,13 +1092,13 @@ token_metadata::add_bootstrap_token(token t, inet_address endpoint) {
 }
 
 void
-token_metadata::add_bootstrap_tokens(std::unordered_set<token> tokens, inet_address endpoint) {
-    _impl->add_bootstrap_tokens(std::move(tokens), endpoint);
+token_metadata::add_bootstrap_tokens(const std::unordered_set<token>& tokens, inet_address endpoint) {
+    _impl->add_bootstrap_tokens(tokens, endpoint);
 }
 
 void
-token_metadata::remove_bootstrap_tokens(std::unordered_set<token> tokens) {
-    _impl->remove_bootstrap_tokens(std::move(tokens));
+token_metadata::remove_bootstrap_tokens(const std::unordered_set<token>& tokens) {
+    _impl->remove_bootstrap_tokens(tokens);
 }
 
 void

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -117,6 +117,10 @@ public:
     const std::unordered_map<token, inet_address>& get_token_to_endpoint() const;
     const std::unordered_set<inet_address>& get_leaving_endpoints() const;
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
+
+    /**
+     * Update or add endpoint given its inet_address and endpoint_dc_rack.
+     */
     void update_topology(inet_address ep, endpoint_dc_rack dr);
     /**
      * Creates an iterable range of the sorted tokens starting at the token next

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -73,6 +73,11 @@ struct host_id_or_endpoint {
     node_ptr resolve(const topology& topo);
 };
 
+struct host_id_and_endpoint {
+    locator::host_id host_id;
+    gms::inet_address endpoint;
+};
+
 class token_metadata_impl;
 
 class token_metadata final {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -121,7 +121,7 @@ public:
     /**
      * Update or add endpoint given its inet_address and endpoint_dc_rack.
      */
-    void update_topology(inet_address ep, endpoint_dc_rack dr);
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st = std::nullopt);
     /**
      * Creates an iterable range of the sorted tokens starting at the token next
      * after the given one.
@@ -136,6 +136,7 @@ public:
 
     topology& get_topology();
     const topology& get_topology() const;
+    topology& get_mutable_topology() const;
     void debug_show() const;
 
     /**

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -178,9 +178,9 @@ public:
 
     void add_bootstrap_token(token t, inet_address endpoint);
 
-    void add_bootstrap_tokens(std::unordered_set<token> tokens, inet_address endpoint);
+    void add_bootstrap_tokens(const std::unordered_set<token>& tokens, inet_address endpoint);
 
-    void remove_bootstrap_tokens(std::unordered_set<token> tokens);
+    void remove_bootstrap_tokens(const std::unordered_set<token>& tokens);
 
     void add_leaving_endpoint(inet_address endpoint);
     void del_leaving_endpoint(inet_address endpoint);

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -20,6 +20,11 @@ namespace locator {
 
 static logging::logger tlogger("topology");
 
+thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
+    .dc = locator::production_snitch_base::default_dc,
+    .rack = locator::production_snitch_base::default_rack,
+};
+
 future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_dc_endpoints);
     co_await utils::clear_gently(_dc_racks);
@@ -128,13 +133,8 @@ const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with
     // on_internal_error()
-    static thread_local endpoint_dc_rack default_location = {
-        .dc = locator::production_snitch_base::default_dc,
-        .rack = locator::production_snitch_base::default_rack,
-    };
-
     tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
-    return default_location;
+    return endpoint_dc_rack::default_location;
 }
 
 // FIXME -- both methods below should rather return data from the

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -25,81 +25,264 @@ thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
     .rack = locator::production_snitch_base::default_rack,
 };
 
+node::node(::locator::host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, local is_local)
+    : _host_id(id)
+    , _endpoint(endpoint)
+    , _dc_rack(std::move(dc_rack))
+    , _is_local(is_local)
+{}
+
 future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_dc_endpoints);
     co_await utils::clear_gently(_dc_racks);
-    co_await utils::clear_gently(_current_locations);
     _datacenters.clear();
-    co_return;
+    _dc_rack_nodes.clear();
+    _dc_nodes.clear();
+    _nodes_by_endpoint.clear();
+    _nodes_by_host_id.clear();
+    _local_node = {};
+    co_await utils::clear_gently(_all_nodes);
+}
+
+topology::topology() noexcept
+        : _shard(this_shard_id())
+{
+    tlogger.trace("topology[{}]: default-constructed", fmt::ptr(this));
 }
 
 topology::topology(config cfg)
-        : _sort_by_proximity(!cfg.disable_proximity_sorting)
+        : _shard(this_shard_id())
+        , _sort_by_proximity(!cfg.disable_proximity_sorting)
 {
-    update_endpoint(utils::fb_utilities::get_broadcast_address(), cfg.local_dc_rack);
+    tlogger.trace("topology[{}]: constructing using config: host_id={} endpoint={} dc={} rack={}", fmt::ptr(this),
+            cfg.local_host_id, cfg.local_endpoint, cfg.local_dc_rack.dc, cfg.local_dc_rack.rack);
+    if (cfg.local_host_id || cfg.local_endpoint != inet_address{}) {
+        add_node(make_lw_shared<node>(cfg.local_host_id, cfg.local_endpoint, cfg.local_dc_rack, node::local::yes));
+    }
+}
+
+topology::topology(topology&& o) noexcept
+    : _shard(o._shard)
+    , _all_nodes(std::move(o._all_nodes))
+    , _local_node(std::move(o._local_node))
+    , _nodes_by_host_id(std::move(o._nodes_by_host_id))
+    , _nodes_by_endpoint(std::move(o._nodes_by_endpoint))
+    , _dc_nodes(std::move(o._dc_nodes))
+    , _dc_rack_nodes(std::move(o._dc_rack_nodes))
+    , _dc_endpoints(std::move(o._dc_endpoints))
+    , _dc_racks(std::move(o._dc_racks))
+    , _sort_by_proximity(o._sort_by_proximity)
+    , _datacenters(std::move(o._datacenters))
+{
+    assert(_shard == this_shard_id());
+    tlogger.trace("topology[{}]: move from [{}]", fmt::ptr(this), fmt::ptr(&o));
 }
 
 future<topology> topology::clone_gently() const {
     topology ret;
-    ret._dc_endpoints.reserve(_dc_endpoints.size());
-    for (const auto& p : _dc_endpoints) {
-        ret._dc_endpoints.emplace(p);
-    }
-    co_await coroutine::maybe_yield();
-    ret._dc_racks.reserve(_dc_racks.size());
-    for (const auto& [dc, rack_endpoints] : _dc_racks) {
-        ret._dc_racks[dc].reserve(rack_endpoints.size());
-        for (const auto& p : rack_endpoints) {
-            ret._dc_racks[dc].emplace(p);
+    if (this_shard_id() == _shard) {
+        tlogger.debug("topology[{}]: clone_gently to {} on same shard", fmt::ptr(this), fmt::ptr(&ret));
+        ret._all_nodes = _all_nodes;
+        co_await coroutine::maybe_yield();
+        ret._local_node = _local_node;
+        ret._nodes_by_host_id = _nodes_by_host_id;
+        ret._nodes_by_endpoint = _nodes_by_endpoint;
+        ret._dc_nodes = _dc_nodes;
+        ret._dc_rack_nodes = _dc_rack_nodes;
+        ret._dc_endpoints = _dc_endpoints;
+        ret._dc_racks = _dc_racks;
+        ret._datacenters = _datacenters;
+    } else {
+        tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);
+        for (const auto& n : _all_nodes) {
+            ret.add_node(make_lw_shared<node>(*n));
+            co_await coroutine::maybe_yield();
+        }
+        // local node may be detached for _all_nodes
+        // if it was decommissioned.
+        if (!ret._local_node && _local_node) {
+            ret.add_node(make_lw_shared<node>(*_local_node));
         }
     }
     co_await coroutine::maybe_yield();
-    ret._current_locations.reserve(_current_locations.size());
-    for (const auto& p : _current_locations) {
-        ret._current_locations.emplace(p);
-    }
-    co_await coroutine::maybe_yield();
-    ret._datacenters = _datacenters;
     ret._sort_by_proximity = _sort_by_proximity;
     co_return ret;
 }
 
-void topology::update_endpoint(const inet_address& ep, endpoint_dc_rack dr)
-{
-    auto current = _current_locations.find(ep);
-
-    if (current != _current_locations.end()) {
-        if (current->second.dc == dr.dc && current->second.rack == dr.rack) {
-            return;
-        }
-        remove_endpoint(ep);
+node_ptr topology::add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr) {
+    if (dr.dc.empty() || dr.rack.empty()) {
+        on_internal_error(tlogger, "Node must have valid dc and rack");
     }
-
-    tlogger.debug("update_endpoint: {} {}/{}", ep, dr.dc, dr.rack);
-    _dc_endpoints[dr.dc].insert(ep);
-    _dc_racks[dr.dc][dr.rack].insert(ep);
-    _datacenters.insert(dr.dc);
-    _current_locations[ep] = std::move(dr);
+    auto is_local = node::local(ep == utils::fb_utilities::get_broadcast_address());
+    if (is_local && _local_node) {
+        if (_local_node->host_id() == id) {
+            on_internal_error_noexcept(tlogger, format("Local node already set: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={} endpoint={}",
+                    id, ep, dr.dc, dr.rack,
+                    _local_node->host_id(), _local_node->endpoint()));
+            return _local_node;
+        }
+        // Replacing node with the same ip address
+        is_local = node::local::no;
+    }
+    return add_node(make_lw_shared<node>(id, ep, dr, is_local));
 }
 
-void topology::remove_endpoint(inet_address ep)
-{
-    auto cur_dc_rack = _current_locations.find(ep);
+node_ptr topology::add_node(mutable_node_ptr node) {
+    tlogger.debug("topology[{}]: add_node: node={} host_id={} endpoint={} dc={} rack={} local={}, at {}", fmt::ptr(this), fmt::ptr(node.get()),
+            node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack, node->is_local(), current_backtrace());
+    if (node->is_local() && _local_node && _local_node != node) {
+        on_internal_error(tlogger, format("Local node already set: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={} endpoint={}",
+                node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack,
+                _local_node->host_id(), _local_node->endpoint()));
+    }
+    if (_all_nodes.contains(node)) {
+        return node;
+    }
+    try {
+        // FIXME: for now we allow adding nodes with null host_id
+        if (node->host_id()) {
+            auto [nit, inserted_host_id] = _nodes_by_host_id.emplace(node->host_id(), node.get());
+            if (!inserted_host_id) {
+                on_internal_error(tlogger, format("Node already exists: host_id={} endpoint={} dc={} rack={}",
+                        node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack));
+            }
+        }
+        if (node->endpoint() != inet_address{}) {
+            auto [eit, inserted_endpoint] = _nodes_by_endpoint.emplace(node->endpoint(), node.get());
+            if (!inserted_endpoint) {
+                if (node->host_id()) {
+                    _nodes_by_host_id.erase(node->host_id());
+                }
+                on_internal_error(tlogger, format("Node endpoint already mapped: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={}",
+                        node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack,
+                        eit->second->host_id()));
+            }
+        }
 
-    if (cur_dc_rack == _current_locations.end()) {
-        return;
+        const auto& dc = node->dc_rack().dc;
+        const auto& rack = node->dc_rack().rack;
+        const auto& endpoint = node->endpoint();
+        _dc_nodes[dc].emplace(node.get());
+        _dc_rack_nodes[dc][rack].emplace(node.get());
+        _dc_endpoints[dc].insert(endpoint);
+        _dc_racks[dc][rack].insert(endpoint);
+        _datacenters.insert(dc);
+
+        if (node->is_local()) {
+            _local_node = node;
+        }
+        _all_nodes.emplace(node);
+    } catch (...) {
+        do_remove_node(node);
+        throw;
+    }
+    return node;
+}
+
+topology::mutable_node_ptr topology::make_mutable(const node_ptr& nptr) {
+    return const_cast<class node*>(nptr.get())->shared_from_this();
+}
+
+node_ptr topology::update_node(node_ptr node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr) {
+    tlogger.debug("topology[{}]: update_node: node={} host_id={} endpoint={} dc={} rack={}, at {}", fmt::ptr(this), fmt::ptr(node.get()),
+            opt_id.value_or(host_id::create_null_id()), opt_ep.value_or(inet_address{}), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack,
+            current_backtrace());
+    bool changed = false;
+    if (opt_id) {
+        if (*opt_id != node->host_id()) {
+            // FIXME: allow updating host_id for replace node.
+            // if (node->host_id()) {
+            //    on_internal_error(tlogger, format("Updating non-null node host_id is disallowed: host_id={} endpoint={}: new host_id={}",
+            //            node->host_id(), node->endpoint(), *opt_id));
+            // }
+            if (!*opt_id) {
+                on_internal_error(tlogger, format("Updating node host_id to null is disallowed: host_id={} endpoint={}: new host_id={}",
+                        node->host_id(), node->endpoint(), *opt_id));
+            }
+            if (_nodes_by_host_id.contains(*opt_id)) {
+                on_internal_error(tlogger, format("Cannot update node host_id: new host_id={} already exists: endpoint={}: ",
+                        *opt_id, node->endpoint()));
+            }
+            changed = true;
+        } else {
+            opt_id.reset();
+        }
+    }
+    if (opt_ep) {
+        if (*opt_ep != node->endpoint()) {
+            if (*opt_ep == inet_address{}) {
+                on_internal_error(tlogger, format("Updating node endpoint to null is disallowed: host_id={} endpoint={}: new endpoint={}",
+                        node->host_id(), node->endpoint(), *opt_ep));
+            }
+            changed = true;
+        } else {
+            opt_ep.reset();
+        }
+    }
+    if (opt_dr) {
+        if (opt_dr->dc.empty() || opt_dr->dc == production_snitch_base::default_dc) {
+            opt_dr->dc = node->dc_rack().dc;
+        }
+        if (opt_dr->rack.empty() || opt_dr->rack == production_snitch_base::default_rack) {
+            opt_dr->rack = node->dc_rack().rack;
+        }
+        if (*opt_dr != node->dc_rack()) {
+            changed = true;
+        } else {
+            opt_dr.reset();
+        }
     }
 
-    const auto& dc = cur_dc_rack->second.dc;
-    const auto& rack = cur_dc_rack->second.rack;
-    tlogger.debug("remove_endpoint: {} {}/{}", ep, dc, rack);
+    if (!changed) {
+        return node;
+    }
+
+    auto mutable_node = make_mutable(node);
+    do_remove_node(mutable_node);
+    if (opt_id) {
+        mutable_node->_host_id = *opt_id;
+    }
+    if (opt_ep) {
+        mutable_node->_endpoint = *opt_ep;
+    }
+    if (opt_dr) {
+        mutable_node->_dc_rack = std::move(*opt_dr);
+    }
+    return add_node(mutable_node);
+}
+
+void topology::remove_node(host_id id, must_exist require_exist) {
+    if (id == _local_node->host_id()) {
+        on_internal_error(tlogger, format("Cannot remove the local node: host_id={} endpoint={}",
+                _local_node->host_id(), _local_node->endpoint()));
+    }
+    tlogger.trace("topology[{}]: remove_node: host_id={}", fmt::ptr(this), id);
+    auto it = _nodes_by_host_id.find(id);
+    if (it != _nodes_by_host_id.end()) {
+        do_remove_node(make_mutable(it->second->shared_from_this()));
+    } else if (require_exist) {
+        on_internal_error(tlogger, format("Node not found: host_id={}", id));
+    }
+}
+
+void topology::remove_node(node_ptr node) {
+    if (node) {
+        do_remove_node(make_mutable(node));
+    }
+}
+
+void topology::do_remove_node(mutable_node_ptr node) {
+    tlogger.debug("remove_node: node={} host_id={} endpoint={}, at {}", fmt::ptr(node.get()), node->host_id(), node->endpoint(), current_backtrace());
+ 
+    const auto& dc = node->dc_rack().dc;
+    const auto& rack = node->dc_rack().rack;
     if (auto dit = _dc_endpoints.find(dc); dit != _dc_endpoints.end()) {
+        const auto& ep = node->endpoint();
         auto& eps = dit->second;
         eps.erase(ep);
         if (eps.empty()) {
-            _dc_endpoints.erase(dit);
-            _datacenters.erase(dc);
             _dc_racks.erase(dc);
+            _dc_endpoints.erase(dit);
         } else {
             auto& racks = _dc_racks[dc];
             if (auto rit = racks.find(rack); rit != racks.end()) {
@@ -111,51 +294,105 @@ void topology::remove_endpoint(inet_address ep)
             }
         }
     }
-
-    // Keep the local endpoint around
-    // Just unlist it from _dc_endpoints and _dc_racks
-    // This is needed after it is decommissioned
-    if (ep != utils::fb_utilities::get_broadcast_address()) {
-        _current_locations.erase(cur_dc_rack);
+    if (auto dit = _dc_nodes.find(dc); dit != _dc_nodes.end()) {
+        auto& nodes = dit->second;
+        nodes.erase(node.get());
+        if (nodes.empty()) {
+            _dc_rack_nodes.erase(dc);
+            _datacenters.erase(dc);
+            _dc_nodes.erase(dit);
+        } else {
+            auto& racks = _dc_rack_nodes[dc];
+            if (auto rit = racks.find(rack); rit != racks.end()) {
+                nodes = rit->second;
+                nodes.erase(node.get());
+                if (nodes.empty()) {
+                    racks.erase(rit);
+                }
+            }
+        }
     }
+    _nodes_by_host_id.erase(node->host_id());
+    _nodes_by_endpoint.erase(node->endpoint());
+    _all_nodes.erase(node);
+}
+
+// Finds a node by its host_id
+// Returns nullptr if not found
+node_ptr topology::find_node(host_id id, must_exist must_exist) const noexcept {
+    auto it = _nodes_by_host_id.find(id);
+    if (it != _nodes_by_host_id.end()) {
+        return it->second->shared_from_this();
+    }
+    if (must_exist) {
+        on_internal_error(tlogger, format("Could not find node: host_id={}", id));
+    }
+    return nullptr;
+}
+
+// Finds a node by its endpoint
+// Returns nullptr if not found
+node_ptr topology::find_node(const inet_address& ep, must_exist must_exist) const noexcept {
+    auto it = _nodes_by_endpoint.find(ep);
+    if (it != _nodes_by_endpoint.end()) {
+        return it->second->shared_from_this();
+    }
+    if (must_exist) {
+        on_internal_error(tlogger, format("Could not find node: endpoint={}", ep));
+    }
+    return nullptr;
+}
+
+node_ptr topology::update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr)
+{
+    tlogger.trace("topology[{}]: update_endpoint: ep={} host_id={} dc={} rack={}, at {}", fmt::ptr(this),
+            ep, opt_id.value_or(host_id::create_null_id()), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack,
+            current_backtrace());
+    node_ptr n = find_node(ep);
+    if (n) {
+        return update_node(make_mutable(n), opt_id, std::nullopt, std::move(opt_dr));
+    } else if (opt_id && (n = find_node(*opt_id))) {
+        return update_node(make_mutable(n), std::nullopt, ep, std::move(opt_dr));
+    } else {
+        return add_node(opt_id.value_or(host_id::create_null_id()), ep, opt_dr.value_or(endpoint_dc_rack::default_location));
+    }
+}
+
+void topology::remove_endpoint(inet_address ep)
+{
+    tlogger.trace("topology[{}]: remove_endpoint: endpoint={}", fmt::ptr(this), ep);
+    remove_node(find_node(ep));
+}
+
+bool topology::has_node(host_id id) const noexcept {
+    auto node = find_node(id);
+    tlogger.trace("topology[{}]: has_node: host_id={}: node={}", fmt::ptr(this), id, fmt::ptr(node.get()));
+    return bool(node);
+}
+
+bool topology::has_node(inet_address ep) const noexcept {
+    auto node = find_node(ep);
+    tlogger.trace("topology[{}]: has_node: endpoint={}: node={}", fmt::ptr(this), ep, fmt::ptr(node.get()));
+    return bool(node);
 }
 
 bool topology::has_endpoint(inet_address ep) const
 {
-    return _current_locations.contains(ep);
+    return has_node(ep);
 }
 
 const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
-    if (_current_locations.contains(ep)) {
-        return _current_locations.at(ep);
+    if (ep == utils::fb_utilities::get_broadcast_address()) {
+        return get_location();
     }
-
+    if (auto node = find_node(ep, must_exist::no)) {
+        return node->dc_rack();
+    }
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with
     // on_internal_error()
     tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
     return endpoint_dc_rack::default_location;
-}
-
-// FIXME -- both methods below should rather return data from the
-// get_location() result, but to make it work two things are to be fixed:
-// - topology should be aware of internal-ip conversions
-// - topology should be pre-populated with data loaded from system ks
-
-sstring topology::get_rack() const {
-    return get_rack(utils::fb_utilities::get_broadcast_address());
-}
-
-sstring topology::get_rack(inet_address ep) const {
-    return get_location(ep).rack;
-}
-
-sstring topology::get_datacenter() const {
-    return get_datacenter(utils::fb_utilities::get_broadcast_address());
-}
-
-sstring topology::get_datacenter(inet_address ep) const {
-    return get_location(ep).dc;
 }
 
 void topology::sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const {

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -47,6 +47,24 @@ sstring node::to_sstring(node::state s) {
     __builtin_unreachable();
 }
 
+bool contains_endpoint(const node_set& nodes, gms::inet_address endpoint) {
+    for (const auto& node : nodes) {
+        if (node->endpoint() == endpoint) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool contains_host_id(const node_set& nodes, host_id id) {
+    for (const auto& node : nodes) {
+        if (node->host_id() == id) {
+            return true;
+        }
+    }
+    return false;
+}
+
 future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_dc_endpoints);
     co_await utils::clear_gently(_dc_racks);

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -453,3 +453,11 @@ int topology::compare_endpoints(const inet_address& address, const inet_address&
 }
 
 } // namespace locator
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const locator::node_ptr& node) {
+    return out << node->host_id() << '/' << node->endpoint();
+}
+
+} // namespace std

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -79,6 +79,10 @@ public:
     idx_type idx() const noexcept { return _idx; }
 
     static sstring to_sstring(state);
+
+    netw::msg_addr msg_addr() const noexcept {
+        return netw::msg_addr(_endpoint, 0, _host_id);
+    }
 };
 
 using node_ptr = lw_shared_ptr<const node>;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -20,6 +20,7 @@
 
 #include "locator/types.hh"
 #include "inet_address_vectors.hh"
+#include "message/msg_addr.hh"
 
 using namespace seastar;
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -290,6 +290,9 @@ private:
     static mutable_node_ptr make_mutable(const node_ptr& node);
 };
 
+bool contains_endpoint(const node_set& nodes, gms::inet_address endpoint);
+bool contains_host_id(const node_set& nodes, host_id id);
+
 } // namespace locator
 
 namespace std {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -24,24 +24,113 @@ using namespace seastar;
 
 namespace locator {
 
+class topology;
+
+class node : public enable_lw_shared_from_this<node> {
+public:
+    using local = bool_class<struct local_tag>;
+
+private:
+    host_id _host_id;
+    inet_address _endpoint;
+    endpoint_dc_rack _dc_rack;
+
+    // Private state of this instance.
+    // May change across topology generations
+    local _is_local;
+
+    friend class topology;
+public:
+    node(host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, local is_local);
+
+    node(const node&) = default;
+    node(node&&) = delete;
+
+    const host_id& host_id() const noexcept {
+        return _host_id;
+    }
+
+    const inet_address& endpoint() const noexcept {
+        return _endpoint;
+    }
+
+    const endpoint_dc_rack& dc_rack() const noexcept {
+        return _dc_rack;
+    }
+
+    local is_local() const noexcept { return _is_local; }
+};
+
+using node_ptr = lw_shared_ptr<const node>;
+using node_set = std::unordered_set<node_ptr>;
+
 class topology {
 public:
     struct config {
+        host_id local_host_id;
+        inet_address local_endpoint;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;
     };
     topology(config cfg);
-    topology(topology&&) = default;
+    topology(topology&&) noexcept;
 
     topology& operator=(topology&&) = default;
 
     future<topology> clone_gently() const;
     future<> clear_gently() noexcept;
 
+public:
+    const node_ptr& local_node() const noexcept {
+        return _local_node;
+    }
+
+    // Adds a node with given host_id, endpoint, and DC/rack.
+    node_ptr add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr);
+
+    // Optionally updates node's current host_id, endpoint, or DC/rack.
+    node_ptr update_node(node_ptr node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr);
+
+    using must_exist = bool_class<struct must_exist_tag>;
+
+    // Removes a node using its host_id
+    //
+    // If host_id is not found and must_exist is true:
+    //   the function throws internal error.
+    void remove_node(host_id id, must_exist must_exist = must_exist::no);
+
+    // Finds a node by its host_id
+    //
+    // If host_id is not found:
+    //   the function throws internal error if must_exist is true,
+    //   or returns nullptr otherwise.
+    node_ptr find_node(host_id id, must_exist must_exist = must_exist::no) const noexcept;
+
+    // Finds a node by its endpoint
+    //
+    // If endpoint is not found,
+    //   the function throws internal error if must_exist is true,
+    //   or returns nullptr otherwise.
+    node_ptr find_node(const inet_address& ep, must_exist must_exist = must_exist::no) const noexcept;
+
+    // Returns true if a node with given host_id is found
+    bool has_node(host_id id) const noexcept;
+    bool has_node(inet_address id) const noexcept;
+
     /**
      * Stores current DC/rack assignment for ep
+     *
+     * Adds or updates a node with given endpoint
      */
-    void update_endpoint(const inet_address& ep, endpoint_dc_rack dr);
+    node_ptr update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr);
+
+    // Legacy entry point from token_metadata::update_topology
+    node_ptr update_endpoint(inet_address ep, endpoint_dc_rack dr) {
+        return update_endpoint(ep, std::nullopt, std::move(dr));
+    }
+    node_ptr update_endpoint(inet_address ep, host_id id) {
+        return update_endpoint(ep, id, std::nullopt);
+    }
 
     /**
      * Removes current DC/rack assignment for ep
@@ -70,11 +159,42 @@ public:
         return _datacenters;
     }
 
+    // Get dc/rack location of the local node
+    const endpoint_dc_rack& get_location() const noexcept{
+        return _local_node->dc_rack();
+    }
+    // Get dc/rack location of a node identified by host_id
+    const endpoint_dc_rack& get_location(host_id id) const {
+        return find_node(id, must_exist::yes)->dc_rack();
+    }
+    // Get dc/rack location of a node identified by endpoint
     const endpoint_dc_rack& get_location(const inet_address& ep) const;
-    sstring get_rack() const;
-    sstring get_rack(inet_address ep) const;
-    sstring get_datacenter() const;
-    sstring get_datacenter(inet_address ep) const;
+
+    // Get rack of the local node
+    const sstring& get_rack() const noexcept {
+        return get_location().rack;
+    }
+    // Get rack of a node identified by host_id
+    const sstring& get_rack(host_id id) const {
+        return get_location(id).rack;
+    }
+    // Get rack of a node identified by endpoint
+    const sstring& get_rack(inet_address ep) const {
+        return get_location(ep).rack;
+    }
+
+    // Get datacenter of the local node
+    const sstring& get_datacenter() const noexcept {
+        return get_location().dc;
+    }
+    // Get datacenter of a node identified by host_id
+    const sstring& get_datacenter(host_id id) const {
+        return get_location(id).dc;
+    }
+    // Get datacenter of a node identified by endpoint
+    const sstring& get_datacenter(inet_address ep) const {
+        return get_location(ep).dc;
+    }
 
     auto get_local_dc_filter() const noexcept {
         return [ this, local_dc = get_datacenter() ] (inet_address ep) {
@@ -94,14 +214,29 @@ public:
     void sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const;
 
 private:
+    using mutable_node_ptr = lw_shared_ptr<node>;
+
     // default constructor for cloning purposes
-    topology() = default;
+    topology() noexcept;
+
+    node_ptr add_node(mutable_node_ptr node);
+    void remove_node(node_ptr node);
+    void do_remove_node(mutable_node_ptr node);
 
     /**
      * compares two endpoints in relation to the target endpoint, returning as
      * Comparator.compare would
      */
     int compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
+
+    unsigned _shard;
+    std::unordered_set<mutable_node_ptr> _all_nodes;
+    node_ptr _local_node;
+    std::unordered_map<host_id, const node*> _nodes_by_host_id;
+    std::unordered_map<inet_address, const node*> _nodes_by_endpoint;
+
+    std::unordered_map<sstring, std::unordered_set<const node*>> _dc_nodes;
+    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<const node*>>> _dc_rack_nodes;
 
     /** multi-map: DC -> endpoints in that DC */
     std::unordered_map<sstring,
@@ -114,15 +249,13 @@ private:
                                           std::unordered_set<inet_address>>>
         _dc_racks;
 
-    /** reverse-lookup map: endpoint -> current known dc/rack assignment */
-    std::unordered_map<inet_address, endpoint_dc_rack> _current_locations;
-
     bool _sort_by_proximity = true;
 
     // pre-calculated
     std::unordered_set<sstring> _datacenters;
 
     void calculate_datacenters();
+    static mutable_node_ptr make_mutable(const node_ptr& node);
 };
 
 } // namespace locator

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -12,6 +12,7 @@
 
 #include <unordered_set>
 #include <unordered_map>
+#include <iostream>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -259,3 +260,9 @@ private:
 };
 
 } // namespace locator
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const locator::node_ptr& node);
+
+} // namespace std

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -25,6 +25,9 @@ using inet_address = gms::inet_address;
 struct endpoint_dc_rack {
     sstring dc;
     sstring rack;
+
+    bool operator==(const endpoint_dc_rack&) const = default;
+    bool operator!=(const endpoint_dc_rack&) const = default;
 };
 
 using dc_rack_fn = seastar::noncopyable_function<endpoint_dc_rack(inet_address)>;

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -26,6 +26,8 @@ struct endpoint_dc_rack {
     sstring dc;
     sstring rack;
 
+    static thread_local const endpoint_dc_rack default_location;
+
     bool operator==(const endpoint_dc_rack&) const = default;
     bool operator!=(const endpoint_dc_rack&) const = default;
 };

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -10,7 +10,12 @@
 
 #pragma once
 
+#include <unordered_set>
+
+#include <boost/intrusive/list.hpp>
+
 #include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
 
 #include "gms/inet_address.hh"
 #include "locator/host_id.hh"
@@ -20,6 +25,8 @@ using namespace seastar;
 namespace locator {
 
 using inet_address = gms::inet_address;
+
+class shared_token_metadata;
 
 // Endpoint Data Center and Rack names
 struct endpoint_dc_rack {

--- a/log.hh
+++ b/log.hh
@@ -34,3 +34,20 @@ using seastar::pretty_type_name;
 using seastar::level_name;
 
 }
+
+template <typename ExceptionType, typename... Args>
+void log_and_throw(seastar::logger& logger, seastar::log_level log_level, const char* fmt, Args... args) {
+    auto msg = format(fmt, std::forward<Args>(args)...);
+    logger.log(log_level, "{}", msg);
+    throw ExceptionType(msg);
+}
+
+template <typename ExceptionType, typename... Args>
+void log_warning_and_throw(seastar::logger& logger, const char* fmt, Args... args) {
+    log_and_throw<ExceptionType>(logger, seastar::log_level::warn, fmt, std::forward<Args>(args)...);
+}
+
+template <typename ExceptionType, typename... Args>
+void log_error_and_throw(seastar::logger& logger, const char* fmt, Args... args) {
+    log_and_throw<ExceptionType>(logger, seastar::log_level::error, fmt, std::forward<Args>(args)...);
+}

--- a/main.cc
+++ b/main.cc
@@ -751,6 +751,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting tokens manager");
             locator::token_metadata::config tm_cfg;
+            // The local node's host_id is updated after loading from system.local
+            // or making a random one for a new node
+            tm_cfg.topo_cfg.local_host_id = host_id::create_null_id();
+            tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             if (snitch.local()->get_name() == "org.apache.cassandra.locator.SimpleSnitch") {
                 //
@@ -1164,6 +1168,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return sys_ks.start(snitch.local());
             }).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+            shared_token_metadata::mutate_on_all_shards(token_metadata, [hostid = cfg->host_id, endpoint = utils::fb_utilities::get_broadcast_address()] (locator::token_metadata& tm) {
+                tm.get_topology().update_endpoint(endpoint, hostid);
+                return make_ready_future<>();
+            }).get();
 
             if (raft_gr.local().is_enabled()) {
                 auto my_raft_id = raft::server_id{cfg->host_id.uuid()};

--- a/main.cc
+++ b/main.cc
@@ -1168,6 +1168,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return sys_ks.start(snitch.local());
             }).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+            utils::fb_utilities::set_host_id(cfg->host_id);
             shared_token_metadata::mutate_on_all_shards(token_metadata, [hostid = cfg->host_id, endpoint = utils::fb_utilities::get_broadcast_address()] (locator::token_metadata& tm) {
                 tm.get_topology().update_endpoint(endpoint, hostid);
                 return make_ready_future<>();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -113,6 +113,7 @@
 #include "idl/partition_checksum.dist.impl.hh"
 #include "idl/forward_request.dist.hh"
 #include "idl/forward_request.dist.impl.hh"
+#include "utils/UUID_gen.hh"
 
 namespace netw {
 
@@ -147,7 +148,7 @@ const size_t PER_TENANT_CONNECTION_COUNT = 3;
 
 bool operator==(const netw::msg_addr& x, const netw::msg_addr& y) noexcept {
     // Ignore cpu id for now since we do not really support shard to shard connections
-    return x.addr == y.addr;
+    return x.addr == y.addr && (x.host_id == y.host_id || !x.host_id || !y.host_id);
 }
 
 bool operator<(const netw::msg_addr& x, const netw::msg_addr& y) noexcept {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -215,9 +215,8 @@ public:
     struct rpc_protocol_server_wrapper;
     struct shard_info;
 
-    using msg_addr = netw::msg_addr;
     using inet_address = gms::inet_address;
-    using clients_map = std::unordered_map<msg_addr, shard_info, msg_addr::hash>;
+    using clients_map = std::unordered_map<netw::msg_addr, shard_info>;
 
     // This should change only if serialization format changes
     static constexpr int32_t current_version = 0;
@@ -229,7 +228,7 @@ public:
         rpc::stats get_stats() const;
     };
 
-    void foreach_client(std::function<void(const msg_addr& id, const shard_info& info)> f) const;
+    void foreach_client(std::function<void(const netw::msg_addr& id, const shard_info& info)> f) const;
 
     void increment_dropped_messages(messaging_verb verb);
 
@@ -341,13 +340,13 @@ public:
     // Wrapper for PREPARE_MESSAGE verb
     void register_prepare_message(std::function<future<streaming::prepare_message> (const rpc::client_info& cinfo,
             streaming::prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func);
-    future<streaming::prepare_message> send_prepare_message(msg_addr id, streaming::prepare_message msg, streaming::plan_id plan_id,
+    future<streaming::prepare_message> send_prepare_message(netw::msg_addr id, streaming::prepare_message msg, streaming::plan_id plan_id,
             sstring description, streaming::stream_reason);
     future<> unregister_prepare_message();
 
     // Wrapper for PREPARE_DONE_MESSAGE verb
     void register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id)>&& func);
-    future<> send_prepare_done_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id);
+    future<> send_prepare_done_message(netw::msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id);
     future<> unregister_prepare_done_message();
 
     // Wrapper for STREAM_MUTATION_FRAGMENTS
@@ -355,154 +354,154 @@ public:
     void register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func);
     future<> unregister_stream_mutation_fragments();
     rpc::sink<int32_t> make_sink_for_stream_mutation_fragments(rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>>& source);
-    future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>> make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, streaming::plan_id plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id);
+    future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>> make_sink_and_source_for_stream_mutation_fragments(table_schema_version schema_id, streaming::plan_id plan_id, table_id cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, netw::msg_addr id);
 
     // Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM
-    future<std::tuple<rpc::sink<repair_hash_with_cmd>, rpc::source<repair_row_on_wire_with_cmd>>> make_sink_and_source_for_repair_get_row_diff_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
+    future<std::tuple<rpc::sink<repair_hash_with_cmd>, rpc::source<repair_row_on_wire_with_cmd>>> make_sink_and_source_for_repair_get_row_diff_with_rpc_stream(uint32_t repair_meta_id, netw::msg_addr id);
     rpc::sink<repair_row_on_wire_with_cmd> make_sink_for_repair_get_row_diff_with_rpc_stream(rpc::source<repair_hash_with_cmd>& source);
     void register_repair_get_row_diff_with_rpc_stream(std::function<future<rpc::sink<repair_row_on_wire_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_hash_with_cmd> source)>&& func);
     future<> unregister_repair_get_row_diff_with_rpc_stream();
 
     // Wrapper for REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM
-    future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd>, rpc::source<repair_stream_cmd>>> make_sink_and_source_for_repair_put_row_diff_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
+    future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd>, rpc::source<repair_stream_cmd>>> make_sink_and_source_for_repair_put_row_diff_with_rpc_stream(uint32_t repair_meta_id, netw::msg_addr id);
     rpc::sink<repair_stream_cmd> make_sink_for_repair_put_row_diff_with_rpc_stream(rpc::source<repair_row_on_wire_with_cmd>& source);
     void register_repair_put_row_diff_with_rpc_stream(std::function<future<rpc::sink<repair_stream_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd> source)>&& func);
     future<> unregister_repair_put_row_diff_with_rpc_stream();
 
     // Wrapper for REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM
-    future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd>>> make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
+    future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd>>> make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream(uint32_t repair_meta_id, netw::msg_addr id);
     rpc::sink<repair_hash_with_cmd> make_sink_for_repair_get_full_row_hashes_with_rpc_stream(rpc::source<repair_stream_cmd>& source);
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
 
     void register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id)>&& func);
-    future<> send_stream_mutation_done(msg_addr id, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id);
+    future<> send_stream_mutation_done(netw::msg_addr id, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id);
     future<> unregister_stream_mutation_done();
 
     void register_complete_message(std::function<future<> (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func);
-    future<> send_complete_message(msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id, bool failed = false);
+    future<> send_complete_message(netw::msg_addr id, streaming::plan_id plan_id, unsigned dst_cpu_id, bool failed = false);
     future<> unregister_complete_message();
 
     // Wrapper for REPAIR_GET_FULL_ROW_HASHES
     void register_repair_get_full_row_hashes(std::function<future<repair_hash_set> (const rpc::client_info& cinfo, uint32_t repair_meta_id)>&& func);
     future<> unregister_repair_get_full_row_hashes();
-    future<repair_hash_set> send_repair_get_full_row_hashes(msg_addr id, uint32_t repair_meta_id);
+    future<repair_hash_set> send_repair_get_full_row_hashes(netw::msg_addr id, uint32_t repair_meta_id);
 
     // Wrapper for REPAIR_GET_COMBINED_ROW_HASH
     void register_repair_get_combined_row_hash(std::function<future<get_combined_row_hash_response> (const rpc::client_info& cinfo, uint32_t repair_meta_id, std::optional<repair_sync_boundary> common_sync_boundary)>&& func);
     future<> unregister_repair_get_combined_row_hash();
-    future<get_combined_row_hash_response> send_repair_get_combined_row_hash(msg_addr id, uint32_t repair_meta_id, std::optional<repair_sync_boundary> common_sync_boundary);
+    future<get_combined_row_hash_response> send_repair_get_combined_row_hash(netw::msg_addr id, uint32_t repair_meta_id, std::optional<repair_sync_boundary> common_sync_boundary);
 
     // Wrapper for REPAIR_GET_SYNC_BOUNDARY
     void register_repair_get_sync_boundary(std::function<future<get_sync_boundary_response> (const rpc::client_info& cinfo, uint32_t repair_meta_id, std::optional<repair_sync_boundary> skipped_sync_boundary)>&& func);
     future<> unregister_repair_get_sync_boundary();
-    future<get_sync_boundary_response> send_repair_get_sync_boundary(msg_addr id, uint32_t repair_meta_id, std::optional<repair_sync_boundary> skipped_sync_boundary);
+    future<get_sync_boundary_response> send_repair_get_sync_boundary(netw::msg_addr id, uint32_t repair_meta_id, std::optional<repair_sync_boundary> skipped_sync_boundary);
 
     // Wrapper for REPAIR_GET_ROW_DIFF
     void register_repair_get_row_diff(std::function<future<repair_rows_on_wire> (const rpc::client_info& cinfo, uint32_t repair_meta_id, repair_hash_set set_diff, bool needs_all_rows)>&& func);
     future<> unregister_repair_get_row_diff();
-    future<repair_rows_on_wire> send_repair_get_row_diff(msg_addr id, uint32_t repair_meta_id, repair_hash_set set_diff, bool needs_all_rows);
+    future<repair_rows_on_wire> send_repair_get_row_diff(netw::msg_addr id, uint32_t repair_meta_id, repair_hash_set set_diff, bool needs_all_rows);
 
     // Wrapper for REPAIR_PUT_ROW_DIFF
     void register_repair_put_row_diff(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, repair_rows_on_wire row_diff)>&& func);
     future<> unregister_repair_put_row_diff();
-    future<> send_repair_put_row_diff(msg_addr id, uint32_t repair_meta_id, repair_rows_on_wire row_diff);
+    future<> send_repair_put_row_diff(netw::msg_addr id, uint32_t repair_meta_id, repair_rows_on_wire row_diff);
 
     // Wrapper for REPAIR_ROW_LEVEL_START
     void register_repair_row_level_start(std::function<future<repair_row_level_start_response> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, rpc::optional<streaming::stream_reason> reason)>&& func);
     future<> unregister_repair_row_level_start();
-    future<rpc::optional<repair_row_level_start_response>> send_repair_row_level_start(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason);
+    future<rpc::optional<repair_row_level_start_response>> send_repair_row_level_start(netw::msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason);
 
     // Wrapper for REPAIR_ROW_LEVEL_STOP
     void register_repair_row_level_stop(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range)>&& func);
     future<> unregister_repair_row_level_stop();
-    future<> send_repair_row_level_stop(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range);
+    future<> send_repair_row_level_stop(netw::msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range);
 
     // Wrapper for REPAIR_GET_ESTIMATED_PARTITIONS
     void register_repair_get_estimated_partitions(std::function<future<uint64_t> (const rpc::client_info& cinfo, uint32_t repair_meta_id)>&& func);
     future<> unregister_repair_get_estimated_partitions();
-    future<uint64_t> send_repair_get_estimated_partitions(msg_addr id, uint32_t repair_meta_id);
+    future<uint64_t> send_repair_get_estimated_partitions(netw::msg_addr id, uint32_t repair_meta_id);
 
     // Wrapper for REPAIR_SET_ESTIMATED_PARTITIONS
     void register_repair_set_estimated_partitions(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, uint64_t estimated_partitions)>&& func);
     future<> unregister_repair_set_estimated_partitions();
-    future<> send_repair_set_estimated_partitions(msg_addr id, uint32_t repair_meta_id, uint64_t estimated_partitions);
+    future<> send_repair_set_estimated_partitions(netw::msg_addr id, uint32_t repair_meta_id, uint64_t estimated_partitions);
 
     // Wrapper for REPAIR_GET_DIFF_ALGORITHMS
     void register_repair_get_diff_algorithms(std::function<future<std::vector<row_level_diff_detect_algorithm>> (const rpc::client_info& cinfo)>&& func);
     future<> unregister_repair_get_diff_algorithms();
-    future<std::vector<row_level_diff_detect_algorithm>> send_repair_get_diff_algorithms(msg_addr id);
+    future<std::vector<row_level_diff_detect_algorithm>> send_repair_get_diff_algorithms(netw::msg_addr id);
 
     // Wrapper for NODE_OPS_CMD
     void register_node_ops_cmd(std::function<future<node_ops_cmd_response> (const rpc::client_info& cinfo, node_ops_cmd_request)>&& func);
     future<> unregister_node_ops_cmd();
-    future<node_ops_cmd_response> send_node_ops_cmd(msg_addr id, node_ops_cmd_request);
+    future<node_ops_cmd_response> send_node_ops_cmd(netw::msg_addr id, node_ops_cmd_request);
 
     // Wrapper for GOSSIP_ECHO verb
     void register_gossip_echo(std::function<future<> (const rpc::client_info& cinfo, rpc::optional<int64_t> generation_number)>&& func);
     future<> unregister_gossip_echo();
-    future<> send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout);
-    future<> send_gossip_echo(msg_addr id, int64_t generation_number, abort_source&);
+    future<> send_gossip_echo(netw::msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout);
+    future<> send_gossip_echo(netw::msg_addr id, int64_t generation_number, abort_source&);
 
     // Wrapper for GOSSIP_SHUTDOWN
     void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func);
     future<> unregister_gossip_shutdown();
-    future<> send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number);
+    future<> send_gossip_shutdown(netw::msg_addr id, inet_address from, int64_t generation_number);
 
     // Wrapper for GOSSIP_DIGEST_SYN
     void register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_syn)>&& func);
     future<> unregister_gossip_digest_syn();
-    future<> send_gossip_digest_syn(msg_addr id, gms::gossip_digest_syn msg);
+    future<> send_gossip_digest_syn(netw::msg_addr id, gms::gossip_digest_syn msg);
 
     // Wrapper for GOSSIP_DIGEST_ACK
     void register_gossip_digest_ack(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack)>&& func);
     future<> unregister_gossip_digest_ack();
-    future<> send_gossip_digest_ack(msg_addr id, gms::gossip_digest_ack msg);
+    future<> send_gossip_digest_ack(netw::msg_addr id, gms::gossip_digest_ack msg);
 
     // Wrapper for GOSSIP_DIGEST_ACK2
     void register_gossip_digest_ack2(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_ack2)>&& func);
     future<> unregister_gossip_digest_ack2();
-    future<> send_gossip_digest_ack2(msg_addr id, gms::gossip_digest_ack2 msg);
+    future<> send_gossip_digest_ack2(netw::msg_addr id, gms::gossip_digest_ack2 msg);
 
     // Wrapper for GOSSIP_GET_ENDPOINT_STATES
     void register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request)>&& func);
     future<> unregister_gossip_get_endpoint_states();
-    future<gms::gossip_get_endpoint_states_response> send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request);
+    future<gms::gossip_get_endpoint_states_response> send_gossip_get_endpoint_states(netw::msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request);
 
     // Wrapper for DEFINITIONS_UPDATE
     void register_definitions_update(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm,
                 rpc::optional<std::vector<canonical_mutation>> cm)>&& func);
     future<> unregister_definitions_update();
-    future<> send_definitions_update(msg_addr id, std::vector<frozen_mutation> fm, std::vector<canonical_mutation> cm);
+    future<> send_definitions_update(netw::msg_addr id, std::vector<frozen_mutation> fm, std::vector<canonical_mutation> cm);
 
     // Wrapper for MIGRATION_REQUEST
     void register_migration_request(std::function<future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> (
                 const rpc::client_info&, rpc::optional<schema_pull_options>)>&& func);
     future<> unregister_migration_request();
-    future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>> send_migration_request(msg_addr id,
+    future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>> send_migration_request(netw::msg_addr id,
             schema_pull_options options);
 
     // Wrapper for GET_SCHEMA_VERSION
     void register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func);
     future<> unregister_get_schema_version();
-    future<frozen_schema> send_get_schema_version(msg_addr, table_schema_version);
+    future<frozen_schema> send_get_schema_version(netw::msg_addr, table_schema_version);
 
     // Wrapper for SCHEMA_CHECK
     void register_schema_check(std::function<future<table_schema_version>()>&& func);
     future<> unregister_schema_check();
-    future<table_schema_version> send_schema_check(msg_addr);
-    future<table_schema_version> send_schema_check(msg_addr, abort_source&);
+    future<table_schema_version> send_schema_check(netw::msg_addr);
+    future<table_schema_version> send_schema_check(netw::msg_addr, abort_source&);
 
     // Wrapper for REPLICATION_FINISHED verb
     void register_replication_finished(std::function<future<> (inet_address from)>&& func);
     future<> unregister_replication_finished();
-    future<> send_replication_finished(msg_addr id, inet_address from);
+    future<> send_replication_finished(netw::msg_addr id, inet_address from);
 
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 private:
     template <typename Fn>
     requires std::is_invocable_r_v<bool, Fn, const shard_info&>
-    void find_and_remove_client(clients_map& clients, msg_addr id, Fn&& filter);
+    void find_and_remove_client(clients_map& clients, netw::msg_addr id, Fn&& filter);
     void do_start_listen();
 
     bool topology_known_for(inet_address) const;
@@ -511,15 +510,15 @@ private:
 
 public:
     // Return rpc::protocol::client for a shard which is a ip + cpuid pair.
-    shared_ptr<rpc_protocol_client_wrapper> get_rpc_client(messaging_verb verb, msg_addr id);
-    void remove_error_rpc_client(messaging_verb verb, msg_addr id);
-    void remove_rpc_client_with_ignored_topology(msg_addr id);
-    void remove_rpc_client(msg_addr id);
+    shared_ptr<rpc_protocol_client_wrapper> get_rpc_client(messaging_verb verb, netw::msg_addr id);
+    void remove_error_rpc_client(messaging_verb verb, netw::msg_addr id);
+    void remove_rpc_client_with_ignored_topology(netw::msg_addr id);
+    void remove_rpc_client(netw::msg_addr id);
     connection_drop_registration_t when_connection_drops(connection_drop_slot_t& slot) {
         return _connection_dropped.connect(slot);
     }
     std::unique_ptr<rpc_protocol_wrapper>& rpc();
-    static msg_addr get_source(const rpc::client_info& client);
+    static netw::msg_addr get_source(const rpc::client_info& client);
     scheduling_group scheduling_group_for_verb(messaging_verb verb) const;
     scheduling_group scheduling_group_for_isolation_cookie(const sstring& isolation_cookie) const;
     std::vector<messaging_service::scheduling_info_for_connection_index> initial_scheduling_info() const;

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -10,16 +10,21 @@
 
 #include "gms/inet_address.hh"
 #include <cstdint>
+#include "locator/host_id.hh"
 
 namespace netw {
 
 struct msg_addr {
     gms::inet_address addr;
     uint32_t cpu_id;
+    locator::host_id host_id;
     friend bool operator==(const msg_addr& x, const msg_addr& y) noexcept;
     friend bool operator<(const msg_addr& x, const msg_addr& y) noexcept;
-    explicit msg_addr(gms::inet_address ip) noexcept : addr(ip), cpu_id(0) { }
-    msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
+    msg_addr(gms::inet_address ip, uint32_t cpu = 0, std::optional<locator::host_id> opt_id = std::nullopt) noexcept
+        : addr(ip)
+        , cpu_id(cpu)
+        , host_id(opt_id.value_or(locator::host_id::create_null_id()))
+    { }
 };
 
 } // namespace netw
@@ -34,7 +39,7 @@ struct hash<netw::msg_addr> {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const netw::msg_addr& id) {
-    return os << id.addr << ':' << id.cpu_id;
+    return os << id.host_id << '/' << id.addr << ':' << id.cpu_id;
 }
 
 } // namespace std

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -18,12 +18,23 @@ struct msg_addr {
     uint32_t cpu_id;
     friend bool operator==(const msg_addr& x, const msg_addr& y) noexcept;
     friend bool operator<(const msg_addr& x, const msg_addr& y) noexcept;
-    friend std::ostream& operator<<(std::ostream& os, const msg_addr& x);
-    struct hash {
-        size_t operator()(const msg_addr& id) const noexcept;
-    };
     explicit msg_addr(gms::inet_address ip) noexcept : addr(ip), cpu_id(0) { }
     msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
 };
 
+} // namespace netw
+
+namespace std {
+
+template<>
+struct hash<netw::msg_addr> {
+    size_t operator()(const netw::msg_addr& id) const noexcept {
+        return std::hash<bytes_view>()(id.addr.bytes());
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const netw::msg_addr& id) {
+    return os << id.addr << ':' << id.cpu_id;
 }
+
+} // namespace std

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -21,6 +21,7 @@
 #include <boost/range/adaptor/reversed.hpp>
 
 #include <fmt/ostream.h>
+#include "log.hh"
 
 logging::logger mmq_log("multishard_mutation_query");
 
@@ -309,11 +310,9 @@ flat_mutation_reader_v2 read_context::create_reader(
     auto& rm = _readers[shard];
 
     if (rm.state != reader_state::used && rm.state != reader_state::successful_lookup && rm.state != reader_state::inexistent) {
-        auto msg = format("Unexpected request to create reader for shard {}."
+        log_warning_and_throw<std::logic_error>(mmq_log, "Unexpected request to create reader for shard {}."
                 " The reader is expected to be in either `used`, `successful_lookup` or `inexistent` state,"
                 " but is in `{}` state instead.", shard, reader_state_to_string(rm.state));
-        mmq_log.warn(msg.c_str());
-        throw std::logic_error(msg.c_str());
     }
 
     // The reader is either in inexistent or successful lookup state.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -53,7 +53,7 @@
 
 logging::logger rlogger("repair");
 
-node_ops_info::node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept
+node_ops_info::node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_, locator::node_set&& ignore_nodes_) noexcept
     : ops_uuid(ops_uuid_)
     , as(std::move(as_))
     , ignore_nodes(std::move(ignore_nodes_))
@@ -1748,7 +1748,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                 // Remove nodes in ignore_nodes
                 if (ops) {
                     for (const auto& node : ops->ignore_nodes) {
-                        neighbors_set.erase(node);
+                        neighbors_set.erase(node->endpoint());
                     }
                 }
                 auto neighbors = boost::copy_range<std::vector<gms::inet_address>>(neighbors_set |

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1370,7 +1370,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
 
             //Pending ranges
-            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack());
+            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
             metadata_clone.update_normal_tokens(tokens, myip).get();
             auto pending_range_addresses = strat.get_range_addresses(metadata_clone).get0();
             metadata_clone.clear_gently().get();
@@ -1825,7 +1825,7 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     // update a cloned version of tmptr
     // no need to set the original version
     auto cloned_tmptr = make_token_metadata_ptr(std::move(cloned_tm));
-    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack());
+    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::joining);
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, utils::fb_utilities::get_broadcast_address());
     co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1811,7 +1811,7 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
     });
 }
 
-future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes) {
+future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, locator::node_set ignore_nodes) {
     assert(this_shard_id() == 0);
     return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto& db = get_db().local();
@@ -1862,7 +1862,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
                         if (node == myip) {
                             return false;
                         }
-                        if (std::find(ignore_nodes.begin(), ignore_nodes.end(), node) != ignore_nodes.end()) {
+                        if (std::find_if(ignore_nodes.begin(), ignore_nodes.end(), [node] (const locator::node_ptr& n) { return n->endpoint() == node; }) != ignore_nodes.end()) {
                             return false;
                         }
                         return source_dc.empty() ? true : topology.get_datacenter(node) == source_dc;
@@ -1911,7 +1911,7 @@ future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, 
     });
 }
 
-future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::list<gms::inet_address> ignore_nodes) {
+future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, locator::node_set ignore_nodes) {
     assert(this_shard_id() == 0);
     auto cloned_tm = co_await tmptr->clone_async();
     auto op = sstring("replace_with_repair");

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -26,6 +26,7 @@
 #include "service/migration_manager.hh"
 #include "partition_range_compat.hh"
 #include "gms/feature_service.hh"
+#include "log.hh"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -60,9 +61,7 @@ node_ops_info::node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_
 
 void node_ops_info::check_abort() {
     if (as && as->abort_requested()) {
-        auto msg = format("Node operation with ops_uuid={} is aborted", ops_uuid);
-        rlogger.warn("{}", msg);
-        throw std::runtime_error(msg);
+        log_warning_and_throw<std::runtime_error>(rlogger, "Node operation with ops_uuid={} is aborted", ops_uuid);
     }
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -104,11 +104,24 @@ node_ops_cmd_request node_ops_cmd_request::make_node_ops_cmd_request(node_ops_cm
     return req;
 }
 
-std::list<gms::inet_address> node_ops_cmd_request::get_ignore_nodes() {
-    std::list<gms::inet_address> ret = std::move(ignore_nodes);
+locator::node_set node_ops_cmd_request::get_ignore_nodes(const locator::topology& topo) {
+    locator::node_set ret;
     if (!nodes_dict.empty()) {
-        for (auto& ep : ret) {
-            ep = nodes_dict.at(ep.raw_addr()).endpoint;
+        for (const auto& x : ignore_nodes) {
+            auto haep = nodes_dict.at(x.raw_addr());
+            auto node = topo.find_node(haep.host_id);
+            if (!node) {
+                log_error_and_throw<std::runtime_error>(rlogger, "Ignore node {}/{} not found in topology", haep.host_id, haep.endpoint);
+            }
+            ret.emplace(std::move(node));
+        }
+    } else {
+        for (const auto& ep : ignore_nodes) {
+            auto node = topo.find_node(ep);
+            if (!node) {
+                log_error_and_throw<std::runtime_error>(rlogger, "Ignore node {} not found in topology", ep);
+            }
+            ret.emplace(std::move(node));
         }
     }
     return ret;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -333,7 +333,7 @@ struct node_ops_cmd_request {
             std::list<table_id> tables = {});
 
     locator::node_set get_ignore_nodes(const locator::topology& topo);
-    std::list<gms::inet_address> get_leaving_nodes();
+    locator::node_set get_leaving_nodes(const locator::topology& topo);
     std::unordered_map<gms::inet_address, gms::inet_address> get_replace_nodes();
     std::unordered_map<gms::inet_address, std::list<dht::token>> get_bootstrap_nodes();
 };

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -290,6 +290,15 @@ struct node_ops_cmd_request {
     std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<table_id> repair_tables;
+
+    node_ops_cmd_request(node_ops_cmd command,
+            node_ops_id uuid,
+            std::list<table_id> tables)
+        : cmd(command)
+        , ops_uuid(std::move(uuid))
+        , repair_tables(std::move(tables)) {
+    }
+
     node_ops_cmd_request(node_ops_cmd command,
             node_ops_id uuid,
             std::list<gms::inet_address> ignore = {},
@@ -305,6 +314,14 @@ struct node_ops_cmd_request {
         , bootstrap_nodes(std::move(bootstrap))
         , repair_tables(std::move(tables)) {
     }
+
+    static node_ops_cmd_request make_node_ops_cmd_request(node_ops_cmd cmd,
+            node_ops_id uuid,
+            locator::node_set ignore_nodes = {},
+            locator::node_ptr leaving_node = nullptr,
+            std::unordered_map<locator::node_ptr, locator::node_ptr> replace_nodes = {},
+            std::unordered_map<locator::node_ptr, std::list<dht::token>> bootstrap_nodes = {},
+            std::list<table_id> tables = {});
 };
 
 struct node_ops_cmd_response {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -291,6 +291,9 @@ struct node_ops_cmd_request {
     // Optional field, list uuids of tables being repaired, set by repair cmd
     std::list<table_id> repair_tables;
 
+    // v2
+    std::unordered_map<locator::node::idx_type, locator::host_id_and_endpoint> nodes_dict;
+
     node_ops_cmd_request(node_ops_cmd command,
             node_ops_id uuid,
             std::list<table_id> tables)
@@ -305,23 +308,34 @@ struct node_ops_cmd_request {
             std::list<gms::inet_address> leaving = {},
             std::unordered_map<gms::inet_address, gms::inet_address> replace = {},
             std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap = {},
-            std::list<table_id> tables = {})
+            std::list<table_id> tables = {},
+            std::unordered_map<locator::node::idx_type, locator::host_id_and_endpoint> dict = {})
         : cmd(command)
         , ops_uuid(std::move(uuid))
         , ignore_nodes(std::move(ignore))
         , leaving_nodes(std::move(leaving))
         , replace_nodes(std::move(replace))
         , bootstrap_nodes(std::move(bootstrap))
-        , repair_tables(std::move(tables)) {
+        , repair_tables(std::move(tables))
+        , nodes_dict(std::move(dict))
+    {
     }
+
+    using enable_v2 = bool_class<struct enable_v2_tag>;
 
     static node_ops_cmd_request make_node_ops_cmd_request(node_ops_cmd cmd,
             node_ops_id uuid,
+            enable_v2 v2,
             locator::node_set ignore_nodes = {},
             locator::node_ptr leaving_node = nullptr,
             std::unordered_map<locator::node_ptr, locator::node_ptr> replace_nodes = {},
             std::unordered_map<locator::node_ptr, std::list<dht::token>> bootstrap_nodes = {},
             std::list<table_id> tables = {});
+
+    std::list<gms::inet_address> get_ignore_nodes();
+    std::list<gms::inet_address> get_leaving_nodes();
+    std::unordered_map<gms::inet_address, gms::inet_address> get_replace_nodes();
+    std::unordered_map<gms::inet_address, std::list<dht::token>> get_bootstrap_nodes();
 };
 
 struct node_ops_cmd_response {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -334,7 +334,9 @@ struct node_ops_cmd_request {
 
     locator::node_set get_ignore_nodes(const locator::topology& topo);
     locator::node_set get_leaving_nodes(const locator::topology& topo);
-    std::unordered_map<gms::inet_address, gms::inet_address> get_replace_nodes();
+    std::unordered_map<locator::node_ptr, locator::node_ptr> get_replace_nodes(const locator::topology& topo);
+    // May update topology for replacing nodes
+    std::unordered_map<locator::node_ptr, locator::node_ptr> get_replace_nodes(locator::topology& topo, const gms::gossiper& gossiper);
     std::unordered_map<gms::inet_address, std::list<dht::token>> get_bootstrap_nodes();
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -332,7 +332,7 @@ struct node_ops_cmd_request {
             std::unordered_map<locator::node_ptr, std::list<dht::token>> bootstrap_nodes = {},
             std::list<table_id> tables = {});
 
-    std::list<gms::inet_address> get_ignore_nodes();
+    locator::node_set get_ignore_nodes(const locator::topology& topo);
     std::list<gms::inet_address> get_leaving_nodes();
     std::unordered_map<gms::inet_address, gms::inet_address> get_replace_nodes();
     std::unordered_map<gms::inet_address, std::list<dht::token>> get_bootstrap_nodes();

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -337,7 +337,8 @@ struct node_ops_cmd_request {
     std::unordered_map<locator::node_ptr, locator::node_ptr> get_replace_nodes(const locator::topology& topo);
     // May update topology for replacing nodes
     std::unordered_map<locator::node_ptr, locator::node_ptr> get_replace_nodes(locator::topology& topo, const gms::gossiper& gossiper);
-    std::unordered_map<gms::inet_address, std::list<dht::token>> get_bootstrap_nodes();
+    // May update topology for bootstrap nodes
+    std::unordered_map<locator::node_ptr, std::unordered_set<dht::token>> get_bootstrap_nodes(locator::topology& topo, const gms::gossiper& gossiper);
 };
 
 struct node_ops_cmd_response {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -87,10 +87,10 @@ class node_ops_info {
 public:
     node_ops_id ops_uuid;
     shared_ptr<abort_source> as;
-    std::list<gms::inet_address> ignore_nodes;
+    locator::node_set ignore_nodes;
 
 public:
-    node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_, std::list<gms::inet_address>&& ignore_nodes_) noexcept;
+    node_ops_info(node_ops_id ops_uuid_, shared_ptr<abort_source> as_, locator::node_set&& ignore_nodes_) noexcept;
     node_ops_info(const node_ops_info&) = delete;
     node_ops_info(node_ops_info&&) = delete;
 

--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -42,9 +42,9 @@ private:
     dht::token_range_vector _ranges;
     std::vector<sstring> _hosts;
     std::vector<sstring> _data_centers;
-    std::unordered_set<gms::inet_address> _ignore_nodes;
+    locator::node_set _ignore_nodes;
 public:
-    user_requested_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, lw_shared_ptr<locator::global_effective_replication_map> germs, std::vector<sstring> cfs, dht::token_range_vector ranges, std::vector<sstring> hosts, std::vector<sstring> data_centers, std::unordered_set<gms::inet_address> ignore_nodes) noexcept
+    user_requested_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, lw_shared_ptr<locator::global_effective_replication_map> germs, std::vector<sstring> cfs, dht::token_range_vector ranges, std::vector<sstring> hosts, std::vector<sstring> data_centers, locator::node_set ignore_nodes) noexcept
         : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), streaming::stream_reason::repair)
         , _germs(germs)
         , _cfs(std::move(cfs))
@@ -107,7 +107,7 @@ public:
     repair_uniq_id id;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
-    std::unordered_set<gms::inet_address> ignore_nodes;
+    locator::node_set ignore_nodes;
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
     size_t total_rf;
     uint64_t nr_ranges_finished = 0;
@@ -129,7 +129,7 @@ public:
             repair_uniq_id parent_id_,
             const std::vector<sstring>& data_centers_,
             const std::vector<sstring>& hosts_,
-            const std::unordered_set<gms::inet_address>& ignore_nodes_,
+            locator::node_set ignore_nodes_,
             streaming::stream_reason reason_,
             bool hints_batchlog_flushed);
     virtual tasks::is_internal is_internal() const noexcept override {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -142,11 +142,11 @@ public:
     // all repair-based node operation entry points must be called on shard 0
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
-    future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
+    future<> removenode_with_repair(locator::token_metadata_ptr tmptr, locator::node_ptr leaving_node, shared_ptr<node_ops_info> ops);
     future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc);
     future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, locator::node_set ignore_nodes);
 private:
-    future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
+    future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, locator::node_ptr leaving_node, shared_ptr<node_ops_info> ops);
     future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, locator::node_set ignore_nodes);
 
     // Must be called on shard 0

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -144,10 +144,10 @@ public:
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
     future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc);
-    future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::list<gms::inet_address> ignore_nodes);
+    future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, locator::node_set ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::list<gms::inet_address> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, locator::node_set ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -59,7 +59,7 @@ class migration_manager : public seastar::async_sharded_service<migration_manage
 private:
     migration_notifier& _notifier;
 
-    std::unordered_map<netw::msg_addr, serialized_action, netw::msg_addr::hash> _schema_pulls;
+    std::unordered_map<netw::msg_addr, serialized_action> _schema_pulls;
     std::vector<gms::feature::listener_registration> _feature_listeners;
     seastar::gate _background_tasks;
     static const std::chrono::milliseconds migration_delay;

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -98,7 +98,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
 
         co_await std::visit(make_visitor(
         [&] (schema_change& chng) -> future<> {
-            return _mm.merge_schema_from(netw::messaging_service::msg_addr(std::move(cmd.creator_addr)), std::move(chng.mutations));
+            return _mm.merge_schema_from(netw::msg_addr(std::move(cmd.creator_addr)), std::move(chng.mutations));
         },
         [&] (broadcast_table_query& query) -> future<> {
             auto result = co_await service::broadcast_tables::execute_broadcast_table_query(_sp, query.query, cmd.new_state_id);
@@ -128,7 +128,7 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
     // machine is idempotent it is not a problem.
 
     slogger.trace("transfer snapshot from {} index {} snp id {}", from, snp.idx, snp.id);
-    netw::messaging_service::msg_addr addr{from, 0};
+    netw::msg_addr addr{from, 0};
     // (Ab)use MIGRATION_REQUEST to also transfer group0 history table mutation besides schema tables mutations.
     auto [_, cm] = co_await _mm._messaging.send_migration_request(addr, netw::schema_pull_options { .group0_snapshot_transfer = true });
     if (!cm) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3739,12 +3739,12 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
     auto local_dc = topology.get_datacenter();
 
     for(auto dest: handler.get_targets()) {
-        sstring dc = topology.get_datacenter(dest);
+        auto node = topology.find_node(dest);
         // read repair writes do not go through coordinator since mutations are per destination
-        if (handler.read_repair_write() || dc == local_dc) {
+        if (handler.read_repair_write() || !node || node->dc_rack().dc == local_dc) {
             local.emplace_back("", inet_address_vector_replica_set({dest}));
         } else {
-            dc_groups[dc].push_back(dest);
+            dc_groups[node->dc_rack().dc].push_back(dest);
         }
     }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -333,7 +333,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         slogger.info("Replacing a node with {} IP address, my address={}, node being replaced={}",
             get_broadcast_address() == *replace_address ? "the same" : "a different",
             get_broadcast_address(), *replace_address);
-        tmptr->update_topology(*replace_address, std::move(ri->dc_rack));
+        tmptr->update_topology(*replace_address, ri->dc_rack, locator::node::state::leaving);
         co_await tmptr->update_normal_tokens(bootstrap_tokens, *replace_address);
         replaced_host_id = ri->host_id;
         raft_replace_info = raft_group0::replace_info {
@@ -375,7 +375,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         // This node must know about its chosen tokens before other nodes do
         // since they may start sending writes to this node after it gossips status = NORMAL.
         // Therefore we update _token_metadata now, before gossip starts.
-        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack());
+        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::normal);
         co_await tmptr->update_normal_tokens(my_tokens, get_broadcast_address());
 
         cdc_gen_id = co_await _sys_ks.local().get_cdc_generation_id();
@@ -552,7 +552,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         // This node must know about its chosen tokens before other nodes do
         // since they may start sending writes to this node after it gossips status = NORMAL.
         // Therefore, in case we haven't updated _token_metadata with our tokens yet, do it now.
-        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack());
+        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::normal);
         return tmptr->update_normal_tokens(bootstrap_tokens, get_broadcast_address());
     });
 
@@ -695,7 +695,7 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
                 slogger.debug("bootstrap: update pending ranges: endpoint={} bootstrap_tokens={}", get_broadcast_address(), bootstrap_tokens);
                 mutate_token_metadata([this, &bootstrap_tokens] (mutable_token_metadata_ptr tmptr) {
                     auto endpoint = get_broadcast_address();
-                    tmptr->update_topology(endpoint, _sys_ks.local().local_dc_rack());
+                    tmptr->update_topology(endpoint, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(bootstrap_tokens, endpoint);
                     return update_pending_ranges(std::move(tmptr), format("bootstrapping node {}", endpoint));
                 }).get();
@@ -824,7 +824,7 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
         tmptr->remove_endpoint(endpoint);
     }
 
-    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::joining);
     tmptr->add_bootstrap_tokens(tokens, endpoint);
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
@@ -959,7 +959,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
             do_notify_joined = true;
         }
 
-        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::normal);
         co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
     }
 
@@ -1010,7 +1010,7 @@ future<> storage_service::handle_state_leaving(inet_address endpoint) {
         // FIXME: this code should probably resolve token collisions too, like handle_state_normal
         slogger.info("Node {} state jump to leaving", endpoint);
 
-        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::leaving);
         co_await tmptr->update_normal_tokens(tokens, endpoint);
     } else {
         auto tokens_ = tmptr->get_tokens(endpoint);
@@ -1425,7 +1425,7 @@ future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,
                     // entry has been mistakenly added, delete it
                     _sys_ks.local().remove_endpoint(ep).get();
                 } else {
-                    tmptr->update_topology(ep, get_dc_rack(ep));
+                    tmptr->update_topology(ep, get_dc_rack(ep), locator::node::state::normal);
                     tmptr->update_normal_tokens(tokens, ep).get();
                     if (loaded_host_ids.contains(ep)) {
                         tmptr->update_host_id(loaded_host_ids.at(ep), ep);
@@ -2757,7 +2757,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     auto existing_node = x.first;
                     auto replacing_node = x.second;
                     slogger.info("replace[{}]: Added replacing_node={} to replace existing_node={}, coordinator={}", req.ops_uuid, replacing_node, existing_node, coordinator);
-                    tmptr->update_topology(replacing_node, get_dc_rack_for(replacing_node));
+                    tmptr->update_topology(replacing_node, get_dc_rack_for(replacing_node), locator::node::state::joining);
                     tmptr->add_replacing_endpoint(existing_node, replacing_node);
                 }
                 return make_ready_future<>();
@@ -2811,7 +2811,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     auto& endpoint = x.first;
                     auto tokens = std::unordered_set<dht::token>(x.second.begin(), x.second.end());
                     slogger.info("bootstrap[{}]: Added node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
-                    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+                    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(tokens, endpoint);
                 }
                 return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1324,8 +1324,8 @@ locator::endpoint_dc_rack storage_service::get_dc_rack_for(inet_address endpoint
     auto* dc = _gossiper.get_application_state_ptr(endpoint, gms::application_state::DC);
     auto* rack = _gossiper.get_application_state_ptr(endpoint, gms::application_state::RACK);
     return locator::endpoint_dc_rack{
-        .dc = dc ? dc->value : locator::production_snitch_base::default_dc,
-        .rack = rack ? rack->value : locator::production_snitch_base::default_rack,
+        .dc = dc ? dc->value : locator::endpoint_dc_rack::default_location.dc,
+        .rack = rack ? rack->value : locator::endpoint_dc_rack::default_location.rack,
     };
 }
 
@@ -1404,10 +1404,7 @@ future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,
                 if (loaded_dc_rack.contains(ep)) {
                     return loaded_dc_rack[ep];
                 } else {
-                    return locator::endpoint_dc_rack {
-                        .dc = locator::production_snitch_base::default_dc,
-                        .rack = locator::production_snitch_base::default_rack,
-                    };
+                    return locator::endpoint_dc_rack::default_location;
                 }
             };
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -306,10 +306,8 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
             slogger.warn("This node was decommissioned, but overriding by operator request.");
             co_await _sys_ks.local().set_bootstrap_state(db::system_keyspace::bootstrap_state::COMPLETED);
         } else {
-            auto msg = sstring("This node was decommissioned and will not rejoin the ring unless override_decommission=true has been set,"
+            log_error_and_throw<std::runtime_error>(slogger, "This node was decommissioned and will not rejoin the ring unless override_decommission=true has been set,"
                                "or all existing data is removed and the node is bootstrapped again");
-            slogger.error("{}", msg);
-            throw std::runtime_error(msg);
         }
     }
 
@@ -2010,10 +2008,8 @@ future<> storage_service::decommission() {
                 }
             }
             if (!gossip_nodes_down.empty()) {
-                auto msg = format("decommission[{}]: Rejected decommission operation, removing node={}, sync_nodes={}, ignore_nodes={}, nodes_down={}",
+                log_warning_and_throw<std::runtime_error>(slogger, "decommission[{}]: Rejected decommission operation, removing node={}, sync_nodes={}, ignore_nodes={}, nodes_down={}",
                         uuid, endpoint, nodes, ignore_nodes, gossip_nodes_down);
-                slogger.warn("{}", msg);
-                throw std::runtime_error(msg);
             }
 
             assert(ss._group0);
@@ -2038,14 +2034,10 @@ future<> storage_service::decommission() {
                     });
                 }).get();
                 if (!nodes_unknown_verb.empty()) {
-                    auto msg = format("decommission[{}]: Nodes={} do not support decommission verb. Please upgrade your cluster and run decommission again.", uuid, nodes_unknown_verb);
-                    slogger.warn("{}", msg);
-                    throw std::runtime_error(msg);
+                    log_warning_and_throw<std::runtime_error>(slogger, "decommission[{}]: Nodes={} do not support decommission verb. Please upgrade your cluster and run decommission again.", uuid, nodes_unknown_verb);
                 }
                 if (!nodes_down.empty()) {
-                    auto msg = format("decommission[{}]: Nodes={} needed for decommission operation are down. It is highly recommended to fix the down nodes and try again.", uuid, nodes_down);
-                    slogger.warn("{}", msg);
-                    throw std::runtime_error(msg);
+                    log_warning_and_throw<std::runtime_error>(slogger, "decommission[{}]: Nodes={} needed for decommission operation are down. It is highly recommended to fix the down nodes and try again.", uuid, nodes_down);
                 }
 
                 // Step 3: Start heartbeat updater
@@ -2231,14 +2223,10 @@ void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tok
             });
         }).get();
         if (!nodes_unknown_verb.empty()) {
-            auto msg = format("bootstrap[{}]: Nodes={} do not support bootstrap verb. Please upgrade your cluster and run bootstrap again.", uuid, nodes_unknown_verb);
-            slogger.warn("{}", msg);
-            throw std::runtime_error(msg);
+            log_warning_and_throw<std::runtime_error>(slogger, "bootstrap[{}]: Nodes={} do not support bootstrap verb. Please upgrade your cluster and run bootstrap again.", uuid, nodes_unknown_verb);
         }
         if (!nodes_down.empty()) {
-            auto msg = format("bootstrap[{}]: Nodes={} needed for bootstrap operation are down. It is highly recommended to fix the down nodes and try again.", uuid, nodes_down);
-            slogger.warn("{}", msg);
-            throw std::runtime_error(msg);
+            log_warning_and_throw<std::runtime_error>(slogger, "bootstrap[{}]: Nodes={} needed for bootstrap operation are down. It is highly recommended to fix the down nodes and try again.", uuid, nodes_down);
         }
 
         // Step 4: Start heartbeat updater
@@ -2329,14 +2317,10 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             });
         }).get();
         if (!nodes_unknown_verb.empty()) {
-            auto msg = format("replace[{}]: Nodes={} do not support replace verb. Please upgrade your cluster and run replace again.", uuid, nodes_unknown_verb);
-            slogger.warn("{}", msg);
-            throw std::runtime_error(msg);
+            log_warning_and_throw<std::runtime_error>(slogger, "replace[{}]: Nodes={} do not support replace verb. Please upgrade your cluster and run replace again.", uuid, nodes_unknown_verb);
         }
         if (!nodes_down.empty()) {
-            auto msg = format("replace[{}]: Nodes={} needed for replace operation are down. It is highly recommended to fix the down nodes and try again. To proceed with best-effort mode which might cause data inconsistency, add --ignore-dead-nodes-for-replace <list_of_dead_nodes>. E.g., scylla --ignore-dead-nodes-for-replace 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e", uuid, nodes_down);
-            slogger.warn("{}", msg);
-            throw std::runtime_error(msg);
+            log_warning_and_throw<std::runtime_error>(slogger, "replace[{}]: Nodes={} needed for replace operation are down. It is highly recommended to fix the down nodes and try again. To proceed with best-effort mode which might cause data inconsistency, add --ignore-dead-nodes-for-replace <list_of_dead_nodes>. E.g., scylla --ignore-dead-nodes-for-replace 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e", uuid, nodes_down);
         }
 
         // Step 3: Start heartbeat updater
@@ -2506,14 +2490,10 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
                         });
                     }).get();
                     if (!nodes_unknown_verb.empty()) {
-                        auto msg = format("removenode[{}]: Nodes={} do not support removenode verb. Please upgrade your cluster and run removenode again.", uuid, nodes_unknown_verb);
-                        slogger.warn("{}", msg);
-                        throw std::runtime_error(msg);
+                        log_warning_and_throw<std::runtime_error>(slogger, "removenode[{}]: Nodes={} do not support removenode verb. Please upgrade your cluster and run removenode again.", uuid, nodes_unknown_verb);
                     }
                     if (!nodes_down.empty()) {
-                        auto msg = format("removenode[{}]: Nodes={} needed for removenode operation are down. It is highly recommended to fix the down nodes and try again. To proceed with best-effort mode which might cause data inconsistency, run nodetool removenode --ignore-dead-nodes <list_of_dead_nodes> <host_id>. E.g., nodetool removenode --ignore-dead-nodes 127.0.0.1,127.0.0.2 817e9515-316f-4fe3-aaab-b00d6f12dddd", uuid, nodes_down);
-                        slogger.warn("{}", msg);
-                        throw std::runtime_error(msg);
+                        log_warning_and_throw<std::runtime_error>(slogger, "removenode[{}]: Nodes={} needed for removenode operation are down. It is highly recommended to fix the down nodes and try again. To proceed with best-effort mode which might cause data inconsistency, run nodetool removenode --ignore-dead-nodes <list_of_dead_nodes> <host_id>. E.g., nodetool removenode --ignore-dead-nodes 127.0.0.1,127.0.0.2 817e9515-316f-4fe3-aaab-b00d6f12dddd", uuid, nodes_down);
                     }
 
                     // Step 4: Start heartbeat updater
@@ -2621,8 +2601,7 @@ void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const no
         }
     }
     if (!msg.empty()) {
-        slogger.warn("{}", msg);
-        throw std::runtime_error(msg);
+        log_warning_and_throw<std::runtime_error>(slogger, "{}", msg);
     }
 }
 
@@ -2662,9 +2641,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
         if (req.cmd == node_ops_cmd::removenode_prepare) {
             auto leaving_nodes = req.get_leaving_nodes();
             if (leaving_nodes.size() > 1) {
-                auto msg = format("removenode[{}]: Could not removenode more than one node at a time: leaving_nodes={}", req.ops_uuid, leaving_nodes);
-                slogger.warn("{}", msg);
-                throw std::runtime_error(msg);
+                log_warning_and_throw<std::runtime_error>(slogger, "removenode[{}]: Could not removenode more than one node at a time: leaving_nodes={}", req.ops_uuid, leaving_nodes);
             }
             auto ignore_nodes = req.get_ignore_nodes();
             mutate_token_metadata([coordinator, &req, &leaving_nodes, this] (mutable_token_metadata_ptr tmptr) mutable {
@@ -2714,9 +2691,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 "storage_service_decommission_prepare_handler_sleep", std::chrono::milliseconds{1500}).get();
             auto leaving_nodes = req.get_leaving_nodes();
             if (leaving_nodes.size() > 1) {
-                auto msg = format("decommission[{}]: Could not decommission more than one node at a time: leaving_nodes={}", req.ops_uuid, leaving_nodes);
-                slogger.warn("{}", msg);
-                throw std::runtime_error(msg);
+                log_warning_and_throw<std::runtime_error>(slogger, "decommission[{}]: Could not decommission more than one node at a time: leaving_nodes={}", req.ops_uuid, leaving_nodes);
             }
             auto ignore_nodes = req.get_ignore_nodes();
             mutate_token_metadata([coordinator, &req, &leaving_nodes, this] (mutable_token_metadata_ptr tmptr) mutable {
@@ -2775,9 +2750,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             // Mark the replacing node as replacing
             auto replace_nodes = req.get_replace_nodes();
             if (replace_nodes.size() > 1) {
-                auto msg = format("replace[{}]: Could not replace more than one node at a time: replace_nodes={}", req.ops_uuid, replace_nodes);
-                slogger.warn("{}", msg);
-                throw std::runtime_error(msg);
+                log_warning_and_throw<std::runtime_error>(slogger, "replace[{}]: Could not replace more than one node at a time: replace_nodes={}", req.ops_uuid, replace_nodes);
             }
             mutate_token_metadata([coordinator, &req, &replace_nodes, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: replace_nodes) {
@@ -2833,9 +2806,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             // Mark the bootstrap node as bootstrapping
             auto bootstrap_nodes = req.get_bootstrap_nodes();
             if (bootstrap_nodes.size() > 1) {
-                auto msg = format("bootstrap[{}]: Could not bootstrap more than one node at a time: bootstrap_nodes={}", req.ops_uuid, bootstrap_nodes);
-                slogger.warn("{}", msg);
-                throw std::runtime_error(msg);
+                log_warning_and_throw<std::runtime_error>(slogger, "bootstrap[{}]: Could not bootstrap more than one node at a time: bootstrap_nodes={}", req.ops_uuid, bootstrap_nodes);
             }
             mutate_token_metadata([coordinator, &req, &bootstrap_nodes, this] (mutable_token_metadata_ptr tmptr) mutable {
                 for (auto& x: bootstrap_nodes) {
@@ -2870,9 +2841,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
         } else if (req.cmd == node_ops_cmd::bootstrap_abort) {
             node_ops_abort(ops_uuid).get();
         } else {
-            auto msg = format("node_ops_cmd_handler: ops_uuid={}, unknown cmd={}", req.ops_uuid, req.cmd);
-            slogger.warn("{}", msg);
-            throw std::runtime_error(msg);
+            log_warning_and_throw<std::runtime_error>(slogger, "node_ops_cmd_handler: ops_uuid={}, unknown cmd={}", req.ops_uuid, req.cmd);
         }
         bool ok = true;
         node_ops_cmd_response resp(ok);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2358,9 +2358,7 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
         // Step 7: Sync data for replace
         if (is_repair_based_node_ops_enabled(streaming::stream_reason::replace)) {
             slogger.info("replace[{}]: Using repair based node ops to sync data", uuid);
-            auto ignore_nodes_eps = boost::copy_range<std::list<gms::inet_address>>(ignore_nodes
-                    | boost::adaptors::transformed([] (const locator::node_ptr& node) { return node->endpoint(); }));
-            _repair.local().replace_with_repair(get_token_metadata_ptr(), bootstrap_tokens, ignore_nodes_eps).get();
+            _repair.local().replace_with_repair(get_token_metadata_ptr(), bootstrap_tokens, ignore_nodes).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_broadcast_address(), _sys_ks.local().local_dc_rack(), bootstrap_tokens, get_token_metadata_ptr());

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -301,7 +301,7 @@ private:
     void run_replace_ops(std::unordered_set<token>& bootstrap_tokens, replacement_info replace_info);
     void run_bootstrap_ops(std::unordered_set<token>& bootstrap_tokens);
 
-    std::list<gms::inet_address> get_ignore_dead_nodes_for_replace(const locator::token_metadata& tm);
+    locator::node_set get_ignore_dead_nodes_for_replace(const locator::token_metadata& tm);
     future<> wait_for_ring_to_settle(std::chrono::milliseconds delay);
 
 public:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -104,7 +104,7 @@ public:
     explicit node_ops_meta_data(
             node_ops_id ops_uuid,
             gms::inet_address coordinator,
-            std::list<gms::inet_address> ignore_nodes,
+            locator::node_set ignore_nodes,
             std::function<future<> ()> abort_func,
             std::function<void ()> signal_func);
     shared_ptr<node_ops_info> get_ops_info();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -697,6 +697,7 @@ public:
     future<> removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes);
     future<node_ops_cmd_response> node_ops_cmd_handler(gms::inet_address coordinator, node_ops_cmd_request req);
     void node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req);
+    future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::unordered_set<locator::node_ptr> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
     future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
 
     future<mode> get_operation_mode();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -583,12 +583,12 @@ private:
      *
      * @param endpoint the node that left
      */
-    future<> restore_replica_count(inet_address endpoint, inet_address notify_endpoint);
-    future<> removenode_with_stream(gms::inet_address leaving_node, shared_ptr<abort_source> as_ptr);
-    future<> removenode_add_ranges(lw_shared_ptr<dht::range_streamer> streamer, gms::inet_address leaving_node);
+    future<> restore_replica_count(locator::node_ptr leaving_node, locator::node_ptr notify_node);
+    future<> removenode_with_stream(locator::node_ptr leaving_node, shared_ptr<abort_source> as_ptr);
+    future<> removenode_add_ranges(lw_shared_ptr<dht::range_streamer> streamer, locator::node_ptr leaving_node);
 
     // needs to be modified to accept either a keyspace or ARS.
-    future<std::unordered_multimap<dht::token_range, inet_address>> get_changed_ranges_for_leaving(locator::effective_replication_map_ptr erm, inet_address endpoint);
+    future<std::unordered_multimap<dht::token_range, inet_address>> get_changed_ranges_for_leaving(locator::effective_replication_map_ptr erm, locator::node_ptr leaving_node);
 
     future<> maybe_reconnect_to_preferred_ip(inet_address ep, inet_address local_ip);
 public:

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -173,7 +173,7 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
                     for (auto& node : current_targets) {
                         if (!metas.contains(node)) {
                             auto [sink, source] = co_await ms.make_sink_and_source_for_stream_mutation_fragments(reader.schema()->version(),
-                                    ops_uuid, cf_id, estimated_partitions, reason, netw::messaging_service::msg_addr(node));
+                                    ops_uuid, cf_id, estimated_partitions, reason, netw::msg_addr(node));
                             llog.debug("load_and_stream: ops_uuid={}, make sink and source for node={}", ops_uuid, node);
                             metas.emplace(node, send_meta_data(node, std::move(sink), std::move(source)));
                             metas.at(node).receive();

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -48,7 +48,7 @@ struct send_info {
     netw::messaging_service& ms;
     streaming::plan_id plan_id;
     table_id cf_id;
-    netw::messaging_service::msg_addr id;
+    netw::msg_addr id;
     uint32_t dst_cpu_id;
     stream_reason reason;
     size_t mutations_nr{0};
@@ -60,7 +60,7 @@ struct send_info {
     mutation_fragment_v1_stream reader;
     noncopyable_function<void(size_t)> update;
     send_info(netw::messaging_service& ms_, streaming::plan_id plan_id_, replica::table& tbl_, reader_permit permit_,
-              dht::token_range_vector ranges_, netw::messaging_service::msg_addr id_,
+              dht::token_range_vector ranges_, netw::msg_addr id_,
               uint32_t dst_cpu_id_, stream_reason reason_, noncopyable_function<void(size_t)> update_fn)
         : ms(ms_)
         , plan_id(plan_id_)
@@ -190,7 +190,7 @@ future<> stream_transfer_task::execute() {
     auto plan_id = session->plan_id();
     auto cf_id = this->cf_id;
     auto dst_cpu_id = session->dst_cpu_id;
-    auto id = netw::messaging_service::msg_addr{session->peer, session->dst_cpu_id};
+    auto id = netw::msg_addr{session->peer, session->dst_cpu_id};
     sslog.debug("[Stream #{}] stream_transfer_task: cf_id={}", plan_id, cf_id);
     sort_and_merge_ranges();
     auto reason = session->get_reason();

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -34,6 +34,7 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     engine().set_strict_dma(false);
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -8,6 +8,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include "gms/inet_address.hh"
+#include "locator/types.hh"
+#include "utils/UUID_gen.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/sequenced_set.hh"
 #include "locator/network_topology_strategy.hh"
@@ -35,6 +38,7 @@ using namespace locator;
 struct ring_point {
     double point;
     inet_address host;
+    host_id id = host_id::create_random_id();
 };
 
 void print_natural_endpoints(double point, const inet_address_vector_replica_set v) {
@@ -140,9 +144,9 @@ auto d2t = [](double d) -> int64_t {
 void full_ring_check(const std::vector<ring_point>& ring_points,
                      const std::map<sstring, sstring>& options,
                      abstract_replication_strategy::ptr_type ars_ptr,
-                     locator::token_metadata_ptr tmptr,
-                     const locator::topology& topo) {
+                     locator::token_metadata_ptr tmptr) {
     auto& tm = *tmptr;
+    const auto& topo = tm.get_topology();
     strategy_sanity_check(ars_ptr, tm, options);
 
     auto erm = calculate_effective_replication_map(ars_ptr, tmptr).get0();
@@ -171,18 +175,12 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
     }
 }
 
-std::unique_ptr<locator::topology> generate_topology(const std::vector<ring_point>& pts) {
-    auto topo = std::make_unique<locator::topology>(locator::topology::config{});
-
+locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
     // This resembles rack_inferring_snitch dc/rack generation which is
     // still in use by this test via token_metadata internals
-    for (const auto& p : pts) {
-        auto rack = std::to_string(uint8_t(p.host.bytes()[2]));
-        auto dc = std::to_string(uint8_t(p.host.bytes()[1]));
-        topo->update_endpoint(p.host, { dc, rack });
-    }
-
-    return topo;
+    auto dc = std::to_string(uint8_t(endpoint.bytes()[1]));
+    auto rack = std::to_string(uint8_t(endpoint.bytes()[2]));
+    return locator::endpoint_dc_rack{dc, rack};
 }
 
 // Run in a seastar thread.
@@ -198,7 +196,11 @@ void simple_test() {
     auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
-    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, locator::token_metadata::config{});
+    locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.local_host_id = host_id::create_random_id();
+    tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
+    tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
+    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
 
     std::vector<ring_point> ring_points = {
         { 1.0,  inet_address("192.100.10.1") },
@@ -214,18 +216,14 @@ void simple_test() {
         { 11.0, inet_address("192.102.40.2") }
     };
 
-    auto topo = generate_topology(ring_points);
-
-    std::unordered_map<inet_address, std::unordered_set<token>> endpoint_tokens;
-    for (const auto& [ring_point, endpoint] : ring_points) {
-        endpoint_tokens[endpoint].insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
-    }
-
     // Initialize the token_metadata
-    stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
-        for (auto&& i : endpoint_tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
-            co_await tm.update_normal_tokens(std::move(i.second), i.first);
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        auto& topo = tm.get_topology();
+        for (const auto& [ring_point, endpoint, id] : ring_points) {
+            std::unordered_set<token> tokens;
+            tokens.insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint));
+            co_await tm.update_normal_tokens(std::move(tokens), endpoint);
         }
     }).get();
 
@@ -240,8 +238,7 @@ void simple_test() {
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", options323);
 
-
-    full_ring_check(ring_points, options323, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
     ///////////////
     // Create the replication strategy
@@ -254,7 +251,7 @@ void simple_test() {
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", options320);
 
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
     //
     // Check cache invalidation: invalidate the cache and run a full ring
@@ -266,7 +263,7 @@ void simple_test() {
         tm.invalidate_cached_rings();
         return make_ready_future<>();
     }).get();
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 }
 
 // Run in a seastar thread.
@@ -326,19 +323,18 @@ void heavy_origin_test() {
         }
     }
 
-    auto topo = generate_topology(ring_points);
-
-    stm.mutate_token_metadata([&tokens, &topo] (token_metadata& tm) -> future<> {
-        for (auto&& i : tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
-            co_await tm.update_normal_tokens(std::move(i.second), i.first);
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        auto& topo = tm.get_topology();
+        for (const auto& [ring_point, endpoint, id] : ring_points) {
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint));
+            co_await tm.update_normal_tokens(std::move(tokens[endpoint]), endpoint);
         }
     }).get();
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", config_options);
 
-    full_ring_check(ring_points, config_options, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
 
 
@@ -394,7 +390,7 @@ static bool has_sufficient_replicas(
 
 static locator::endpoint_set calculate_natural_endpoints(
                 const token& search_token, const token_metadata& tm,
-                locator::topology& topo,
+                const locator::topology& topo,
                 const std::unordered_map<sstring, size_t>& datacenters) {
     //
     // We want to preserve insertion order so that the first added endpoint
@@ -432,7 +428,7 @@ static locator::endpoint_set calculate_natural_endpoints(
     // the members of a DC
     //
     const std::unordered_map<sstring,
-                       std::unordered_set<inet_address>>&
+                       std::unordered_set<inet_address>>
         all_endpoints = tp.get_datacenter_endpoints();
     //
     // all racks in a DC so we can check when we have exhausted all racks in a
@@ -440,7 +436,7 @@ static locator::endpoint_set calculate_natural_endpoints(
     //
     const std::unordered_map<sstring,
                        std::unordered_map<sstring,
-                                          std::unordered_set<inet_address>>>&
+                                          std::unordered_set<inet_address>>>
         racks = tp.get_datacenter_racks();
 
     // not aware of any cluster members
@@ -504,7 +500,7 @@ static locator::endpoint_set calculate_natural_endpoints(
 }
 
 // Called in a seastar thread.
-static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<locator::topology> topo, const std::unordered_map<sstring, size_t>& datacenters) {
+static void test_equivalence(const shared_token_metadata& stm, const locator::topology& topo, const std::unordered_map<sstring, size_t>& datacenters) {
     class my_network_topology_strategy : public network_topology_strategy {
     public:
         using network_topology_strategy::network_topology_strategy;
@@ -522,7 +518,7 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {
         auto token = dht::token::get_random_token();
-        auto expected = calculate_natural_endpoints(token, tm, *topo, datacenters);
+        auto expected = calculate_natural_endpoints(token, tm, topo, datacenters);
         auto actual = nts.calculate_natural_endpoints(token, tm).get0();
 
         // Because the old algorithm does not put the nodes in the correct order in the case where more replicas
@@ -537,7 +533,7 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
 }
 
 
-std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
+void generate_topology(topology& topo, const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
     auto& e1 = seastar::testing::local_random_engine;
 
     std::unordered_map<sstring, size_t> racks_per_dc;
@@ -557,16 +553,12 @@ std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<ss
         out = std::fill_n(out, rf, std::cref(dc));
     }
 
-    auto topo = std::make_unique<locator::topology>(locator::topology::config{});
-
     for (auto& node : nodes) {
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo->update_endpoint(node, { dc, to_sstring(r) });
+        topo.add_node(host_id::create_random_id(), node, { dc, to_sstring(r) });
     }
-
-    return topo;
 }
 
 SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
@@ -593,7 +585,6 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
     for (size_t run = 0; run < RUNS; ++run) {
         semaphore sem(1);
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{});
-        auto topo = generate_topology(datacenters, nodes);
 
         std::unordered_set<dht::token> random_tokens;
         while (random_tokens.size() < nodes.size() * VNODES) {
@@ -608,13 +599,13 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
             }
         }
         
-        stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
+        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+            generate_topology(tm.get_topology(), datacenters, nodes);
             for (auto&& i : endpoint_tokens) {
-                tm.update_topology(i.first, topo->get_location(i.first));
                 co_await tm.update_normal_tokens(std::move(i.second), i.first);
             }
         }).get();
-        test_equivalence(stm, std::move(topo), datacenters);
+        test_equivalence(stm, stm.get()->get_topology(), datacenters);
     }
 }
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -56,7 +56,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
                 const auto endpoint = gms::inet_address("10.0.0.1");
                 const auto endpoint_token = ring[2].token();
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(endpoint, {});
+                tmptr->update_topology(endpoint, {"dc1", "rack1"});
                 tmptr->update_normal_tokens({endpoint_token}, endpoint).get();
 
                 const auto next_token = dht::token::from_int64(dht::token::to_int64(endpoint_token) + 1);
@@ -75,7 +75,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
             {
                 // Ring with minimum token
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.1"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({dht::minimum_token()}), gms::inet_address("10.0.0.1")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {
@@ -89,9 +89,9 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
 
             {
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.1"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[2].token()}), gms::inet_address("10.0.0.1")).get();
-                tmptr->update_topology(gms::inet_address("10.0.0.2"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.2"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[5].token()}), gms::inet_address("10.0.0.2")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -519,6 +519,7 @@ public:
             if (!cfg->host_id) {
                 cfg->host_id = locator::host_id::create_random_id();
             }
+            utils::fb_utilities::set_host_id(cfg->host_id);
             create_directories((data_dir_path + "/system").c_str());
             create_directories(cfg->commitlog_directory().c_str());
             create_directories(cfg->hints_directory().c_str());

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -64,6 +64,7 @@
 #include "db/schema_tables.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service/raft/raft_group0.hh"
+#include "utils/fb_utilities.hh"
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -541,6 +542,8 @@ public:
 
             sharded<locator::shared_token_metadata> token_metadata;
             locator::token_metadata::config tm_cfg;
+            tm_cfg.topo_cfg.local_host_id = cfg->host_id;
+            tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg).get();
             auto stop_token_metadata = defer([&token_metadata] { token_metadata.stop().get(); });

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -59,6 +59,7 @@ int main(int ac, char ** av) {
             const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
             utils::fb_utilities::set_broadcast_address(listen);
             utils::fb_utilities::set_broadcast_rpc_address(listen);
+            utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
             auto cfg = std::make_unique<db::config>();
 
             sharded<gms::feature_service> feature_service;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -174,6 +174,7 @@ int main(int ac, char ** av) {
         }
         const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
         utils::fb_utilities::set_broadcast_address(listen);
+        utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
         seastar::sharded<netw::messaging_service> messaging;
         return messaging.start(listen).then([config, api_port, stay_alive, &messaging] () {
             auto testers = new distributed<tester>;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -30,11 +30,10 @@ private:
     uint32_t _cpuid;
 public:
     tester(netw::messaging_service& ms_) : ms(ms_) {}
-    using msg_addr = netw::messaging_service::msg_addr;
     using inet_address = gms::inet_address;
     using endpoint_state = gms::endpoint_state;
-    msg_addr get_msg_addr() {
-        return msg_addr{_server, _cpuid};
+    netw::msg_addr get_msg_addr() {
+        return netw::msg_addr{_server, _cpuid};
     }
     void set_server_ip(sstring ip) {
         _server = inet_address(ip);

--- a/utils/fb_utilities.hh
+++ b/utils/fb_utilities.hh
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include "gms/inet_address.hh"
+#include "locator/host_id.hh"
 
 namespace utils {
 
@@ -29,6 +30,11 @@ private:
 
         return _broadcast_rpc_address;
     }
+    static locator::host_id& host_id() noexcept {
+        static locator::host_id _host_id;
+
+        return _host_id;
+    }
 public:
    static constexpr int32_t MAX_UNSIGNED_SHORT = 0xFFFF;
 
@@ -39,6 +45,10 @@ public:
    static void set_broadcast_rpc_address(inet_address addr) noexcept {
        broadcast_rpc_address() = addr;
    }
+
+    static void set_host_id(const locator::host_id& id) noexcept {
+        host_id() = id;
+    }
 
 
    static const inet_address get_broadcast_address() noexcept {
@@ -51,8 +61,15 @@ public:
        return *broadcast_rpc_address();
    }
 
+    static const locator::host_id& get_host_id() noexcept {
+        return host_id();
+    }
+
     static bool is_me(gms::inet_address addr) noexcept {
         return addr == get_broadcast_address();
+    }
+    static bool is_me(const locator::host_id id) noexcept {
+        return id == get_host_id();
     }
 };
 }


### PR DESCRIPTION
This series depends on #11987 for introducing class node to topology.
It then uses shared node pointers to refer to nodes in node operations instead of using their endpoints,
in particular, to depend on the always-unique node host_id rather than on the endpoint that may change and may not be unique during replace node.