### PR TITLE
gdbinit: add ignore clause for SIG35

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -1,6 +1,7 @@
 # Recommended .gdbinit for debugging scylla
 # See docs/dev/debugging.md for more information
 handle SIG34 pass noprint
+handle SIG35 pass noprint
 handle SIGUSR1 pass noprint
 set print pretty
 set python print-stack full


### PR DESCRIPTION
Another real-time even often raised in scylla, making debugging a live process annoying.