### PR TITLE
open-coredump.sh: handle dev versions

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -235,8 +235,13 @@ else
 fi
 
 COMMIT_HASH=$(cut -f3 -d. <<< $RELEASE)
-BASE_VERSION=$(grep -o "^[0-9]\+\.[0-9]\+" <<< $VERSION)
-BRANCH=branch-${BASE_VERSION}
+if [ "$(grep -o ~dev <<< $VERSION)" == "~dev" ]
+then
+    BRANCH=master
+else
+    BASE_VERSION=$(grep -o "^[0-9]\+\.[0-9]\+" <<< $VERSION)
+    BRANCH=branch-${BASE_VERSION}
+fi
 
 if ! [[ -d ${SCYLLA_REPO_PATH} ]]
 then


### PR DESCRIPTION
Like: 5.2.0~dev, which really means master. Don't try to checkout branch-5.2 in this case, it doesn't exist yet, checkout master instead.