### PR TITLE
service/raft: raft_group0: prevent double abort

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -949,7 +949,11 @@ with_timeout(abort_source& as, db::timeout_clock::duration d, F&& fun) {
     // FIXME: using lambda as workaround for clang bug #50345 (miscompiling coroutine templates).
     auto impl = [] (abort_source& as, db::timeout_clock::duration d, F&& fun) -> future_t {
         abort_source timeout_src;
-        auto sub = as.subscribe([&timeout_src] () noexcept { timeout_src.request_abort(); });
+        auto sub = as.subscribe([&timeout_src] () noexcept {
+            if (!timeout_src.abort_requested()) {
+                timeout_src.request_abort();
+            }
+        });
         if (!sub) {
             throw abort_requested_exception{};
         }


### PR DESCRIPTION
There was a small chance that we called `timeout_src.request_abort()` twice in the `with_timeout` function, first by timeout and then by shutdown. `abort_source` fails on an assertion in this case. Fix this.

Fixes: #12512