### PR TITLE
cql3, transport, tests: remove "unset" from value type system

### DIFF
--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cql3/expr/expression.hh"
+#include "cql3/expr/unset.hh"
 #include "db/timeout_clock.hh"
 
 namespace cql3 {
@@ -24,7 +25,9 @@ class prepare_context;
  */
 class attributes final {
 private:
+    expr::unset_bind_variable_guard _timestamp_unset_guard;
     std::optional<cql3::expr::expression> _timestamp;
+    expr::unset_bind_variable_guard _time_to_live_unset_guard;
     std::optional<cql3::expr::expression> _time_to_live;
     std::optional<cql3::expr::expression> _timeout;
 public:

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -139,10 +139,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
 
         cql3::raw_value key_constant = expr::evaluate(*_collection_element, options);
         cql3::raw_value_view key = key_constant.view();
-        if (key.is_unset_value()) {
-            throw exceptions::invalid_request_exception(
-                    format("Invalid 'unset' value in {} element access", cell_type.cql3_type_name()));
-        }
         if (key.is_null()) {
             throw exceptions::invalid_request_exception(
                     format("Invalid null value for {} element access", cell_type.cql3_type_name()));
@@ -196,9 +192,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         // <, >, >=, <=, !=
         cql3::raw_value param = expr::evaluate(*_value, options);
 
-        if (param.is_unset_value()) {
-            throw exceptions::invalid_request_exception("Invalid 'unset' value in condition");
-        }
         if (param.is_null()) {
             if (_op == expr::oper_t::EQ) {
                 return cell_value == nullptr;
@@ -224,9 +217,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
             return (*_matcher)(bytes_view(cell_value->serialize_nonnull()));
         } else {
             auto param = expr::evaluate(*_value, options);  // LIKE pattern
-            if (param.is_unset_value()) {
-                throw exceptions::invalid_request_exception("Invalid 'unset' value in LIKE pattern");
-            }
             if (param.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid NULL value in LIKE pattern");
             }

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -372,7 +372,6 @@ struct constant {
 
     constant(cql3::raw_value value, data_type type);
     static constant make_null(data_type val_type = empty_type);
-    static constant make_unset_value(data_type val_type = empty_type);
     static constant make_bool(bool bool_val);
 
     bool is_null() const;

--- a/cql3/expr/unset.hh
+++ b/cql3/expr/unset.hh
@@ -1,0 +1,30 @@
+// Copyright (C) 2023-present ScyllaDB
+// SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+
+#pragma once
+
+#include <optional>
+#include "expression.hh"
+
+namespace cql3 {
+
+class query_options;
+
+}
+
+namespace cql3::expr {
+
+// Some expression users can behave differently if the expression is a bind variable
+// and if that bind variable is unset. unset_bind_variable_guard encapsulates the two
+// conditions.
+class unset_bind_variable_guard {
+    // Disengaged if the operand is not exactly a single bind variable.
+    std::optional<bind_variable> _var;
+public:
+    explicit unset_bind_variable_guard(const expr::expression& operand);
+    explicit unset_bind_variable_guard(std::nullopt_t) {}
+    explicit unset_bind_variable_guard(const std::optional<expr::expression>& operand);
+    bool is_unset(const query_options& qo) const;
+};
+
+}

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -27,21 +27,21 @@ public:
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification&);
     static lw_shared_ptr<column_specification> uuid_index_spec_of(const column_specification&);
 public:
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_index : public operation {
+    class setter_by_index : public operation_skip_if_unset {
     protected:
         expr::expression _idx;
     public:
         setter_by_index(const column_definition& column, expr::expression idx, expr::expression e)
-            : operation(column, std::move(e)), _idx(std::move(idx)) {
+            : operation_skip_if_unset(column, std::move(e)), _idx(std::move(idx)) {
         }
         virtual bool requires_read() const override;
         virtual void fill_prepare_context(prepare_context& ctx) override;
@@ -57,9 +57,9 @@ public:
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class appender : public operation {
+    class appender : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
@@ -69,25 +69,25 @@ public:
             const column_definition& column,
             const update_parameters& params);
 
-    class prepender : public operation {
+    class prepender : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class discarder : public operation {
+    class discarder : public operation_skip_if_unset {
     public:
         discarder(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual bool requires_read() const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class discarder_by_index : public operation {
+    class discarder_by_index : public operation_skip_if_unset {
     public:
         discarder_by_index(const column_definition& column, expr::expression idx)
-                : operation(column, std::move(idx)) {
+                : operation_skip_if_unset(column, std::move(idx)) {
         }
         virtual bool requires_read() const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -27,30 +27,30 @@ public:
     static lw_shared_ptr<column_specification> key_spec_of(const column_specification& column);
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification& column);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_key : public operation {
+    class setter_by_key : public operation_skip_if_unset {
         expr::expression _k;
     public:
         setter_by_key(const column_definition& column, expr::expression k, expr::expression e)
-            : operation(column, std::move(e)), _k(std::move(k)) {
+            : operation_skip_if_unset(column, std::move(e)), _k(std::move(k)) {
         }
         virtual void fill_prepare_context(prepare_context& ctx) override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class putter : public operation {
+    class putter : public operation_skip_if_unset {
     public:
         putter(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
@@ -58,10 +58,10 @@ public:
     static void do_put(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params,
             const cql3::raw_value& value, const column_definition& column);
 
-    class discarder_by_key : public operation {
+    class discarder_by_key : public operation_no_unset_support {
     public:
         discarder_by_key(const column_definition& column, expr::expression k)
-                : operation(column, std::move(k)) {
+                : operation_no_unset_support(column, std::move(k)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -268,9 +268,9 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
     auto v = prepare_expression(_value, db, keyspace, nullptr, spec);
 
     // Will not be used elsewhere, so make it local.
-    class counter_setter : public operation {
+    class counter_setter : public operation_no_unset_support {
     public:
-        using operation::operation;
+        using operation_no_unset_support::operation_no_unset_support;
 
         bool is_raw_counter_shard_write() const override {
             return true;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1788,7 +1788,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
             oper_t::EQ,
             // TODO: This should be a unique marker whose value we set at execution time.  There is currently no
             // handy mechanism for doing that in query_options.
-            expr::constant::make_unset_value(token_column->type));
+            expr::constant::make_null(token_column->type));
 }
 
 void statement_restrictions::prepare_indexed_local(const schema& idx_tbl_schema) {

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -21,9 +21,6 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 
 void
 sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
-    if (value.is_unset_value()) {
-        return;
-    }
     if (column.type->is_multi_cell()) {
         // Delete all cells first, then add new ones
         collection_mutation_description mut;
@@ -36,9 +33,6 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 void
 sets::adder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     const cql3::raw_value value = expr::evaluate(*_e, params._options);
-    if (value.is_unset_value()) {
-        return;
-    }
     assert(column.type->is_multi_cell()); // "Attempted to add items to a frozen set";
     do_add(m, row_key, params, value, column);
 }
@@ -79,7 +73,7 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
     assert(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
 
     cql3::raw_value svalue = expr::evaluate(*_e, params._options);
-    if (svalue.is_null_or_unset()) {
+    if (svalue.is_null()) {
         return;
     }
 

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -27,19 +27,19 @@ class sets {
 public:
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification& column);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class adder : public operation {
+    class adder : public operation_skip_if_unset {
     public:
         adder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
@@ -47,18 +47,18 @@ public:
     };
 
     // Note that this is reused for Map subtraction too (we subtract a set from a map)
-    class discarder : public operation {
+    class discarder : public operation_skip_if_unset {
     public:
         discarder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 
-    class element_discarder : public operation {
+    class element_discarder : public operation_no_unset_support {
     public:
         element_discarder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) { }
+            : operation_no_unset_support(column, std::move(e)) { }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 };

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -48,6 +48,9 @@ void delete_statement::add_update_for_key(mutation& m, const query::clustering_r
     }
 
     for (auto&& op : _column_operations) {
+        if (op->should_skip_operation(params._options)) {
+            continue;
+        }
         op->execute(m, range.start() ? std::move(range.start()->value()) : clustering_key_prefix::make_empty(), params);
     }
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -171,7 +171,9 @@ select_statement::select_statement(schema_ptr schema,
     , _restrictions_need_filtering(_restrictions->need_filtering())
     , _group_by_cell_indices(group_by_cell_indices)
     , _is_reversed(is_reversed)
+    , _limit_unset_guard(limit)
     , _limit(std::move(limit))
+    , _per_partition_limit_unset_guard(per_partition_limit)
     , _per_partition_limit(std::move(per_partition_limit))
     , _ordering_comparator(std::move(ordering_comparator))
     , _stats(stats)
@@ -268,17 +270,15 @@ select_statement::make_partition_slice(const query_options& options) const
 
 uint64_t select_statement::do_get_limit(const query_options& options,
                                         const std::optional<expr::expression>& limit,
+                                        const expr::unset_bind_variable_guard& limit_unset_guard,
                                         uint64_t default_limit) const {
-    if (!limit.has_value() || _selection->is_aggregate()) {
+    if (!limit.has_value() || limit_unset_guard.is_unset(options) || _selection->is_aggregate()) {
         return default_limit;
     }
 
     auto val = expr::evaluate(*limit, options);
     if (val.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of limit");
-    }
-    if (val.is_unset_value()) {
-        return default_limit;
     }
     try {
         auto l = val.view().validate_and_deserialize<int32_t>(*int32_type);

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cql3/statements/raw/select_statement.hh"
+#include "cql3/expr/unset.hh"
 #include "cql3/cql_statement.hh"
 #include "cql3/stats.hh"
 #include <seastar/core/shared_ptr.hh>
@@ -60,7 +61,9 @@ protected:
     const bool _restrictions_need_filtering;
     ::shared_ptr<std::vector<size_t>> _group_by_cell_indices; ///< Indices in result row of cells holding GROUP BY values.
     bool _is_reversed;
+    expr::unset_bind_variable_guard _limit_unset_guard;
     std::optional<expr::expression> _limit;
+    expr::unset_bind_variable_guard _per_partition_limit_unset_guard;
     std::optional<expr::expression> _per_partition_limit;
 
     template<typename T>
@@ -141,12 +144,12 @@ public:
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 
 protected:
-    uint64_t do_get_limit(const query_options& options, const std::optional<expr::expression>& limit, uint64_t default_limit) const;
+    uint64_t do_get_limit(const query_options& options, const std::optional<expr::expression>& limit, const expr::unset_bind_variable_guard& unset_guard, uint64_t default_limit) const;
     uint64_t get_limit(const query_options& options) const {
-        return do_get_limit(options, _limit, query::max_rows);
+        return do_get_limit(options, _limit, _limit_unset_guard, query::max_rows);
     }
     uint64_t get_per_partition_limit(const query_options& options) const {
-        return do_get_limit(options, _per_partition_limit, query::partition_max_rows);
+        return do_get_limit(options, _per_partition_limit, _per_partition_limit_unset_guard, query::partition_max_rows);
     }
     bool needs_post_query_ordering() const;
     virtual void update_stats_rows_read(int64_t rows_read) const {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -96,6 +96,9 @@ bool update_statement::allow_clustering_key_slices() const {
 
 void update_statement::execute_operations_for_key(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const json_cache_opt& json_cache) const {
     for (auto&& update : _column_operations) {
+        if (update->should_skip_operation(params._options)) {
+            continue;
+        }
         update->execute(m, prefix, params);
     }
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -25,10 +25,6 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
 }
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& ut_value) {
-    if (ut_value.is_unset_value()) {
-        return;
-    }
-
     auto& type = static_cast<const user_type_impl&>(*column.type);
     if (type.is_multi_cell()) {
         // Non-frozen user defined type.
@@ -79,9 +75,6 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
     assert(column.type->is_user_type() && column.type->is_multi_cell());
 
     auto value = expr::evaluate(*_e, params._options);
-    if (value.is_unset_value()) {
-        return;
-    }
 
     auto& type = static_cast<const user_type_impl&>(*column.type);
 

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -26,29 +26,29 @@ class user_types {
 public:
     static lw_shared_ptr<column_specification> field_spec_of(const column_specification& column, size_t field);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_field : public operation {
+    class setter_by_field : public operation_skip_if_unset {
         size_t _field_idx;
     public:
         setter_by_field(const column_definition& column, size_t field_idx, expr::expression e)
-            : operation(column, std::move(e)), _field_idx(field_idx) {
+            : operation_skip_if_unset(column, std::move(e)), _field_idx(field_idx) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 
-    class deleter_by_field : public operation {
+    class deleter_by_field : public operation_no_unset_support {
         size_t _field_idx;
     public:
         deleter_by_field(const column_definition& column, size_t field_idx)
-            : operation(column, std::nullopt), _field_idx(field_idx) {
+            : operation_no_unset_support(column, std::nullopt), _field_idx(field_idx) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -26,16 +26,12 @@ struct null_value {
     friend bool operator==(const null_value&, const null_value) { return true; }
 };
 
-struct unset_value {
-    friend bool operator==(const unset_value&, const unset_value) { return true; }
-};
-
 class raw_value;
 /// \brief View to a raw CQL protocol value.
 ///
 /// \see raw_value
 class raw_value_view {
-    std::variant<fragmented_temporary_buffer::view, managed_bytes_view, null_value, unset_value> _data;
+    std::variant<fragmented_temporary_buffer::view, managed_bytes_view, null_value> _data;
     // Temporary storage is only useful if a raw_value_view needs to be instantiated
     // with a value which lifetime is bounded only to the view itself.
     // This hack is introduced in order to avoid storing temporary storage
@@ -48,9 +44,6 @@ class raw_value_view {
     lw_shared_ptr<managed_bytes> _temporary_storage = nullptr;
 
     raw_value_view(null_value data)
-        : _data{std::move(data)}
-    {}
-    raw_value_view(unset_value data)
         : _data{std::move(data)}
     {}
     raw_value_view(fragmented_temporary_buffer::view data)
@@ -66,9 +59,6 @@ public:
     static raw_value_view make_null() {
         return raw_value_view{null_value{}};
     }
-    static raw_value_view make_unset_value() {
-        return raw_value_view{unset_value{}};
-    }
     static raw_value_view make_value(fragmented_temporary_buffer::view view) {
         return raw_value_view{view};
     }
@@ -82,13 +72,10 @@ public:
     bool is_null() const {
         return std::holds_alternative<null_value>(_data);
     }
-    bool is_unset_value() const {
-        return std::holds_alternative<unset_value>(_data);
-    }
-    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty value is not null, but it has 0 bytes of data.
     // An empty int value can be created in CQL using blobasint(0x).
     bool is_empty_value() const {
-        if (is_null() || is_unset_value()) {
+        if (is_null()) {
             return false;
         }
         return size_bytes() == 0;
@@ -174,15 +161,12 @@ public:
 /// \brief Raw CQL protocol value.
 ///
 /// The `raw_value` type represents an uninterpreted value from the CQL wire
-/// protocol. A raw value can hold either a null value, an unset value, or a byte
+/// protocol. A raw value can hold either a null value, or a byte
 /// blob that represents the value.
 class raw_value {
-    std::variant<bytes, managed_bytes, null_value, unset_value> _data;
+    std::variant<bytes, managed_bytes, null_value> _data;
 
     raw_value(null_value&& data)
-        : _data{std::move(data)}
-    {}
-    raw_value(unset_value&& data)
         : _data{std::move(data)}
     {}
     raw_value(bytes&& data)
@@ -200,9 +184,6 @@ class raw_value {
 public:
     static raw_value make_null() {
         return raw_value{null_value{}};
-    }
-    static raw_value make_unset_value() {
-        return raw_value{unset_value{}};
     }
     static raw_value make_value(const raw_value_view& view);
     static raw_value make_value(managed_bytes&& mb) {
@@ -235,16 +216,10 @@ public:
     bool is_null() const {
         return std::holds_alternative<null_value>(_data);
     }
-    bool is_unset_value() const {
-        return std::holds_alternative<unset_value>(_data);
-    }
-    bool is_null_or_unset() const {
-        return !is_value();
-    }
-    // An empty value is not null or unset, but it has 0 bytes of data.
+    // An empty value is not null, but it has 0 bytes of data.
     // An empty int value can be created in CQL using blobasint(0x).
     bool is_empty_value() const {
-        if (is_null_or_unset()) {
+        if (is_null()) {
             return false;
         }
         return view().size_bytes() == 0;
@@ -262,9 +237,6 @@ public:
             [](null_value&&) -> bytes {
                 throw std::runtime_error("to_bytes() called on raw value that is null");
             },
-            [](unset_value&&) -> bytes {
-                throw std::runtime_error("to_bytes() called on raw value that is unset_value");
-            }
         }, std::move(_data));
     }
     bytes_opt to_bytes_opt() && {
@@ -274,9 +246,6 @@ public:
             [](null_value&&) -> bytes_opt {
                 return std::nullopt;
             },
-            [](unset_value&&) -> bytes_opt {
-                return std::nullopt;
-            }
         }, std::move(_data));
     }
     managed_bytes to_managed_bytes() && {
@@ -286,9 +255,6 @@ public:
             [](null_value&&) -> managed_bytes {
                 throw std::runtime_error("to_managed_bytes() called on raw value that is null");
             },
-            [](unset_value&&) -> managed_bytes {
-                throw std::runtime_error("to_managed_bytes() called on raw value that is unset_value");
-            }
         }, std::move(_data));
     }
     managed_bytes_opt to_managed_bytes_opt() && {
@@ -298,9 +264,6 @@ public:
             [](null_value&&) -> managed_bytes_opt {
                 return std::nullopt;
             },
-            [](unset_value&&) -> managed_bytes_opt {
-                return std::nullopt;
-            }
         }, std::move(_data));
     }
     raw_value_view view() const;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -204,7 +204,7 @@ future<> raft_sys_table_storage::do_store_log_entries(const std::vector<raft::lo
     // fragmented storage for log_entries data
     std::vector<fragmented_temporary_buffer> stmt_data_views;
     // statement value views -- required for `query_options` to consume `fragmented_temporary_buffer::view`
-    std::vector<std::vector<cql3::raw_value_view>> stmt_value_views;
+    std::vector<cql3::raw_value_view_vector_with_unset> stmt_value_views;
     const size_t entries_size = entries.size();
     batch_stmts.reserve(entries_size);
     stmt_values.reserve(entries_size);

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -273,10 +273,10 @@ def testMapWithUnsetValues(cql, test_keyspace):
         # test unset variables in a map update operation, should not delete the contents
         execute(cql, table, "UPDATE %s SET m['k'] = ? WHERE k = 10", UNSET_VALUE)
         assert_rows(execute(cql, table, "SELECT m FROM %s WHERE k = 10"), [m])
-        assert_invalid_message(cql, table, "Invalid unset map key", "UPDATE %s SET m[?] = 'foo' WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset", "UPDATE %s SET m[?] = 'foo' WHERE k = 10", UNSET_VALUE)
 
         # test unset value for map key
-        assert_invalid_message(cql, table, "Invalid unset map key", "DELETE m[?] FROM %s WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset", "DELETE m[?] FROM %s WHERE k = 10", UNSET_VALUE)
 
 def testListWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, l list<text>)") as table:
@@ -294,7 +294,7 @@ def testListWithUnsetValues(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT l FROM %s WHERE k = 10"), [l])
 
         # set in index
-        assert_invalid_message(cql, table, "Invalid unset value for list index", "UPDATE %s SET l[?] = 'foo' WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "UPDATE %s SET l[?] = 'foo' WHERE k = 10", UNSET_VALUE)
 
         # remove element by index
         execute(cql, table, "DELETE l[?] FROM %s WHERE k = 10", UNSET_VALUE)

--- a/test/cql-pytest/cassandra_tests/validation/entities/tuple_type_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/tuple_type_test.py
@@ -92,7 +92,7 @@ def testInvalidQueries(cql, test_keyspace):
 def testTupleWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, t tuple<int, text, double>)") as table:
         # invalid positional field substitution
-        assert_invalid_message(cql, table, "Invalid unset value for tuple field number 1",
+        assert_invalid_message(cql, table, "unset",
                              "INSERT INTO %s (k, t) VALUES(0, (3, ?, 2.1))", UNSET_VALUE)
 
         #FIXME: The Python driver doesn't agree to send such a command to the server,

--- a/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
@@ -159,10 +159,10 @@ def testUDTWithUnsetValues(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(x int, y int)") as myType:
         with create_type(cql, test_keyspace, f"(a frozen<{myType}>)") as myOtherType:
             with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v frozen<{myType}>, z frozen<{myOtherType}>)") as table:
-                assert_invalid_message(cql, table, "Invalid unset value for field 'y' of user defined type ",
+                assert_invalid_message(cql, table, "unset",
                     "INSERT INTO %s (k, v) VALUES (10, {x:?, y:?})", 1, UNSET_VALUE)
                 # Reproduces issue #9671:
-                assert_invalid_message(cql, table, "Invalid unset value for field 'y' of user defined type ",
+                assert_invalid_message(cql, table, "unset",
                     "INSERT INTO %s (k, v, z) VALUES (10, {x:?, y:?}, {a:{x: ?, y: ?}})", 1, 1, 1, UNSET_VALUE)
 
 def testAlteringUserTypeNestedWithinMap(cql, test_keyspace):

--- a/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
@@ -44,7 +44,7 @@ def testInsertWithUnset(cql, test_keyspace):
         # has "Invalid unset value for argument in call to function blobasint"
         # Scylla has "Invalid null or unset value for argument to
         # system.blobasint : (blob) -> int"
-        assertInvalidMessageRE(cql, table, "Invalid.*unset value for argument.*blobasint", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset())
+        assertInvalidMessageRE(cql, table, "unset", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset())
 
 # Both Scylla and Cassandra define MAX_TTL or max_ttl with the same formula,
 # 20 years in seconds. In both systems, it is not configurable.

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -474,9 +474,9 @@ def testFunctionCallWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
         # The error messages in Scylla and Cassandra here are slightly
         # different.
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset",
                              "SELECT * FROM %s WHERE token(k) >= token(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset",
                              "SELECT * FROM %s WHERE k = blobAsInt(?)", UNSET_VALUE)
 
 def testLimitWithUnset(cql, test_keyspace):

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -220,7 +220,7 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # the scan brings up several rows, it may exercise different code
         # paths.
         assert list(cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")) == []
-        with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+        with pytest.raises(InvalidRequest, match='unset'):
             cql.execute(stmt, [UNSET_VALUE])
 
         # check subscripted list filtering

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -241,7 +241,7 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared(
         cql3::prepared_cache_key_type id,
-        std::vector<cql3::raw_value> values,
+        cql3::raw_value_vector_with_unset values,
         db::consistency_level cl = db::consistency_level::ONE) override {
 
         const auto& so = cql3::query_options::specific_options::DEFAULT;

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -113,7 +113,7 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared(
         cql3::prepared_cache_key_type id,
-        std::vector<cql3::raw_value> values,
+        cql3::raw_value_vector_with_unset values,
         db::consistency_level cl = db::consistency_level::ONE) = 0;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared_with_qo(

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -392,7 +392,7 @@ future<> trace_keyspace_helper::apply_events_mutation(cql3::query_processor& qp,
         tlogger.trace("{}: storing {} events records: parent_id {} span_id {}", records->session_id, events_records.size(), records->parent_id, records->my_span_id);
 
         std::vector<cql3::statements::batch_statement::single_statement> modifications(events_records.size(), cql3::statements::batch_statement::single_statement(_events.insert_stmt(), false));
-        std::vector<std::vector<cql3::raw_value>> values;
+        std::vector<cql3::raw_value_vector_with_unset> values;
 
         values.reserve(events_records.size());
         std::for_each(events_records.begin(), events_records.end(), [&values, all_records = records, this] (event_record& one_event_record) { values.emplace_back(make_event_mutation_data(*all_records, one_event_record)); });

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -25,6 +25,7 @@
 namespace cql3{
 class query_options;
 struct raw_value_view;
+struct raw_value_view_vector_with_unset;
 
 namespace statements {
 class prepared_statement;
@@ -319,7 +320,7 @@ private:
      * @param t type object corresponding to the given raw value.
      * @return the string with the representation of the given raw value.
      */
-    sstring raw_value_to_sstring(const cql3::raw_value_view& v, const data_type& t);
+    sstring raw_value_to_sstring(const cql3::raw_value_view& v, bool is_unset, const data_type& t);
 
     /**
      * Stores a page size of a query being traced.
@@ -420,7 +421,7 @@ private:
      */
     void build_parameters_map_for_one_prepared(const prepared_checked_weak_ptr& prepared_ptr,
             std::optional<std::vector<sstring_view>>& names_opt,
-            std::vector<cql3::raw_value_view>& values, const sstring& param_name_prefix);
+            cql3::raw_value_view_vector_with_unset& values, const sstring& param_name_prefix);
 
     /**
      * The actual trace message storing method.

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -15,6 +15,16 @@
 
 namespace cql_transport {
 
+struct unset_tag {};
+
+struct value_view_and_unset {
+    cql3::raw_value_view value;
+    bool unset = false;
+
+    value_view_and_unset(cql3::raw_value_view value) : value(std::move(value)) {}
+    value_view_and_unset(unset_tag) : value(cql3::raw_value_view::make_null()), unset(true) {}
+};
+
 class request_reader {
     fragmented_temporary_buffer::istream _in;
     bytes_ostream* _linearization_buffer;
@@ -123,7 +133,7 @@ public:
         return b;
     }
 
-    cql3::raw_value_view read_value_view(uint8_t version) {
+    value_view_and_unset read_value_view(uint8_t version) {
         auto len = read_int();
         if (len < 0) {
             if (version < 4) {
@@ -132,7 +142,7 @@ public:
             if (len == -1) {
                 return cql3::raw_value_view::make_null();
             } else if (len == -2) {
-                return cql3::raw_value_view::make_unset_value();
+                return value_view_and_unset(unset_tag());
             } else {
                 throw exceptions::protocol_exception(format("invalid value length: {:d}", len));
             }
@@ -140,13 +150,17 @@ public:
         return cql3::raw_value_view::make_value(_in.read_view(len, exception_thrower()));
     }
 
-    void read_name_and_value_list(uint8_t version, std::vector<sstring_view>& names, std::vector<cql3::raw_value_view>& values) {
+    void read_name_and_value_list(uint8_t version, std::vector<sstring_view>& names, std::vector<cql3::raw_value_view>& values,
+            cql3::unset_bind_variable_vector& unset) {
         uint16_t size = read_short();
         names.reserve(size);
+        unset.reserve(size);
         values.reserve(size);
         for (uint16_t i = 0; i < size; i++) {
             names.emplace_back(read_string_view());
-            values.emplace_back(read_value_view(version));
+            auto&& [value, is_unset] = read_value_view(version);
+            values.emplace_back(std::move(value));
+            unset.emplace_back(is_unset);
         }
     }
 
@@ -158,11 +172,14 @@ public:
         }
     }
 
-    void read_value_view_list(uint8_t version, std::vector<cql3::raw_value_view>& values) {
+    void read_value_view_list(uint8_t version, std::vector<cql3::raw_value_view>& values, cql3::unset_bind_variable_vector& unset) {
         uint16_t size = read_short();
         values.reserve(size);
+        unset.reserve(size);
         for (uint16_t i = 0; i < size; i++) {
-            values.emplace_back(read_value_view(version));
+            auto&& [value, is_unset] = read_value_view(version);
+            values.emplace_back(std::move(value));
+            unset.emplace_back(is_unset);
         }
     }
 
@@ -208,13 +225,14 @@ public:
         auto consistency = read_consistency();
         auto flags = enum_set<options_flag_enum>::from_mask(read_byte());
         std::vector<cql3::raw_value_view> values;
+        cql3::unset_bind_variable_vector unset;
         std::vector<sstring_view> names;
 
         if (flags.contains<options_flag::VALUES>()) {
             if (flags.contains<options_flag::NAMES_FOR_VALUES>()) {
-                read_name_and_value_list(version, names, values);
+                read_name_and_value_list(version, names, values, unset);
             } else {
-                read_value_view_list(version, values);
+                read_value_view_list(version, values, unset);
             }
         }
 
@@ -248,10 +266,12 @@ public:
             if (!names.empty()) {
                 onames = std::move(names);
             }
-            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::move(onames), std::move(values), skip_metadata,
+            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::move(onames),
+                cql3::raw_value_view_vector_with_unset(std::move(values), std::move(unset)), skip_metadata,
                 cql3::query_options::specific_options{page_size, std::move(paging_state), serial_consistency, ts});
         } else {
-            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt, std::move(values), skip_metadata,
+            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt,
+                cql3::raw_value_view_vector_with_unset(std::move(values), std::move(unset)), skip_metadata,
                 cql3::query_options::specific_options::DEFAULT);
         }
 


### PR DESCRIPTION
The CQL binary protocol introduced "unset" values in version 4
of the protocol. Unset values can be bound to variables, which
cause certain CQL fragments to be skipped. For example, the
fragment `SET a = :var` will not change the value of `a` if `:var`
is bound to an unset value.

Unsets, however, are very limited in where they can appear. They
can only appear at the top-level of an expression, and any computation
done with them is invalid. For example, `SET list_column = [3, :var]`
is invalid if `:var` is bound to unset.

This causes the code to be littered with checks for unset, and there
are plenty of tests dedicated to catching unsets. However, a simpler
way is possible - prevent the infiltration of unsets at the point of
entry (when evaluating a bind variable expression), and introduce
guards to check for the few cases where unsets are allowed.

This is what this long patch does. It performs the following:

(general)

1. unset is removed from the possible values of cql3::raw_value and
   cql3::raw_value_view.

(external->cql3)

2. query_options is fortified with a vector of booleans,
   unset_bind_variable_vector, where each boolean corresponds to a bind
   variable index and is true when it is unset.
3. To avoid churn, two compatiblity structs are introduced:
   cql3::raw_value{,_view}_vector_with_unset, which can be constructed
   from a std::vector<raw_value{,_view/}>, which is what most callers
   have. They can also be constructed with explicit unset vectors, for
   the few cases they are needed.

(cql3->variables)

4. query_options::get_value_at() now throws if the requested bind variable
   is unset. This replaces all the throwing checks in expression evaluation
   and statement execution, which are removed.
5. A new query_options::is_unset() is added for the users that can tolerate
   unset; though it is not used directly.
6. A new cql3::unset_operation_guard class guards against unsets. It accepts
   an expression, and can be queried whether an unset is present. Two
   conditions are checked: the expression must be a singleton bind
   variable, and at runtime it must be bound to an unset value.
7. The modification_statement operations are split into two, via two
   new subclasses of cql3::operation. cql3::operation_no_unset_support
   ignores unsets completely. cql3::operation_skip_if_unset checks if
   an operand is unset (luckily all operations have at most one operand that
   tolerates unset) and applies unset_operation_guard to it.
8. The various sites that accept expressions or operations are modified
   to check for should_skip_operation(). This are the loops around
   operations in update_statement and delete_statement, and the checks
   for unset in attributes (LIMIT and PER PARTITION LIMIT)

(tests)

9. Many unset tests are removed. It's now impossible to enter an
   unset value into the expression evaluation machinery (there's
   just no unset value), so it's impossible to test for it.
10. Other unset tests now have to be invoked via bind variables,
   since there's no way to create an unset cql3::expr::constant.
11. Many tests have their exception message match strings relaxed.
   Since unsets are now checked very early, we don't know the context
   where they happen. It would be possible to reintroduce it (by adding
   a format string parameter to cql3::unset_operation_guard), but it
   seems not to be worth the effort. Usage of unsets is rare, and it is
   explicit (at least with the Python driver, an unset cannot be
   introduced by ommission).

I tried as an alternative to wrap cql3::raw_value{,_view} (that doesn't
recognize unsets) with cql3::maybe_unset_value (that does), but that
caused huge amounts of churn, so I abandoned that in favor of the
current approach.
