### PR TITLE
snitch: Use set_my_dc_and_rack() on all shards

### DIFF
--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -46,11 +46,11 @@ future<> azure_snitch::load_config() {
     logger().info("AzureSnitch using region: {}, zone: {}.", azure_region, azure_zone);
 
     // Zoneless regions return empty zone
-    _my_rack = (azure_zone != "" ? azure_zone : azure_region);
-    _my_dc = azure_region;
+    sstring my_rack = (azure_zone != "" ? azure_zone : azure_region);
+    sstring my_dc = azure_region;
 
-    co_return co_await container().invoke_on_others([this] (snitch_ptr& local_s) {
-        local_s->set_my_dc_and_rack(_my_dc, _my_rack);
+    co_return co_await container().invoke_on_all([my_dc, my_rack] (snitch_ptr& local_s) {
+        local_s->set_my_dc_and_rack(my_dc, my_rack);
     });
 }
 

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -169,16 +169,10 @@ future<> gossiping_property_file_snitch::reload_configuration() {
         }
     }
 
-    if (_state == snitch_state::initializing || _my_dc != new_dc ||
-        _my_rack != new_rack || _prefer_local != new_prefer_local) {
-
-        _my_dc = new_dc;
-        _my_rack = new_rack;
-        _prefer_local = new_prefer_local;
-
-        return container().invoke_on_others([this] (snitch_ptr& local_s) {
-            local_s->set_my_dc_and_rack(_my_dc, _my_rack);
-            local_s->set_prefer_local(_prefer_local);
+    if (_state == snitch_state::initializing || _my_dc != new_dc || _my_rack != new_rack || _prefer_local != new_prefer_local) {
+        return container().invoke_on_all([new_dc, new_rack, new_prefer_local] (snitch_ptr& local_s) {
+            local_s->set_my_dc_and_rack(new_dc, new_rack);
+            local_s->set_prefer_local(new_prefer_local);
         }).then([this] {
             return seastar::async([this] {
                 _reconfigured();


### PR DESCRIPTION
Most of snitch drivers set _my_dc and _my_rack with direct assignment thus skipping the sanity checks for dc/rack being empty. On other shards they call set_my_dc_and_rack() helper which warns the empty value and replaces it with some defaults.

It's better to use the helper on all shards in order to have the same dc/rack values everywhere.

refs: #12185

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>