### PR TITLE
forward_service: fix timeout support in parallel aggregates

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1550,7 +1550,7 @@ parallelized_select_statement::do_execute(
 
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
     auto timeout_duration = get_timeout(state.get_client_state(), options);
-    auto timeout = db::timeout_clock::now() + timeout_duration;
+    auto timeout = lowres_system_clock::now() + timeout_duration;
     auto reductions = _selection->get_reductions();
 
     query::forward_request req = {

--- a/idl/forward_request.idl.hh
+++ b/idl/forward_request.idl.hh
@@ -36,7 +36,7 @@ struct forward_request {
     dht::partition_range_vector pr;
 
     db::consistency_level cl;
-    lowres_clock::time_point timeout;
+    lowres_system_clock::time_point timeout;
 
     std::optional<std::vector<query::forward_request::aggregation_info>> aggregation_infos [[version 5.1]];
 };

--- a/query-request.hh
+++ b/query-request.hh
@@ -402,7 +402,7 @@ struct forward_request {
     dht::partition_range_vector pr;
 
     db::consistency_level cl;
-    lowres_clock::time_point timeout;
+    lowres_system_clock::time_point timeout;
     std::optional<std::vector<aggregation_info>> aggregation_infos;
 };
 

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -365,6 +365,13 @@ future<query::forward_result> forward_service::dispatch_to_shards(
     });
 }
 
+static lowres_clock::time_point compute_timeout(const query::forward_request& req) {
+    lowres_system_clock::duration time_left = req.timeout - lowres_system_clock::now();
+    lowres_clock::time_point timeout_point = lowres_clock::now() + time_left;
+
+    return timeout_point;
+}
+
 // This function executes forward_request on a shard.
 // It retains partition ranges owned by this shard from requested partition
 // ranges vector, so that only owned ones are queried.
@@ -383,7 +390,7 @@ future<query::forward_result> forward_service::execute_on_this_shard(
 
     schema_ptr schema = local_schema_registry().get(req.cmd.schema_version);
 
-    auto timeout = req.timeout;
+    auto timeout = compute_timeout(req);
     auto now = gc_clock::now();
 
     auto selection = mock_selection(req, schema, _db.local());


### PR DESCRIPTION
`forward_request` verb carried information about timeouts using `lowres_clock::time_point` (that came from local steady clock `seastar::lowres_clock`). The time point was produced on one node and later compared against other node `lowres_clock`. That behavior was wrong (`lowres_clock::time_point`s produced with different `lowres_clock`s cannot be compared) and could lead to delayed or premature timeout.

To fix this issue, `lowres_clock::time_point` was replaced with `lowres_system_clock::time_point` in `forward_request` verb. Representation to which both time point types serialize is the same (64-bit integer denoting the count of elapsed nanoseconds), so it was possible to do an in-place switch of those types using the logic suggested by @avikivity:
1. using steady_clock is just broken, so we aren't taking anything from users by breaking it further
2. once all nodes are upgraded, it magically starts to work

Fixes: https://github.com/scylladb/scylladb/issues/12458