### PR TITLE
SCYLLA-VERSION-GEN: remove unnecessary bashism

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -34,7 +34,7 @@ END
 
 DATE=""
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
 	opt="$1"
 	case $opt in
 		-h|--help)


### PR DESCRIPTION
remove unnecessary bashism, so that this script can be interpreted by a POSIX shell.

/bin/sh is specified in the shebang line. on debian derivatives, /bin/sh is dash, which is POSIX compliant. but this script is written in the bash dialect.

before this change, we could run into following build failure when building the tree on Debian:

[7/904] ./SCYLLA-VERSION-GEN
./SCYLLA-VERSION-GEN: 37: [[: not found

after this change, the build is able to proceed.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>