### PR TITLE
rjson: make all from_string funcs visible to avoid unnecessary type conversions

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -470,7 +470,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     auto ttl = std::chrono::seconds(opts.ttl());
     
-    rjson::add(stream_desc, "StreamStatus", rjson::from_string(status));
+    rjson::add(stream_desc, "StreamStatus", rjson::from_string(std::string_view(status)));
 
     stream_view_type type = cdc_options_to_steam_view_type(opts);
 

--- a/schema.cc
+++ b/schema.cc
@@ -1760,7 +1760,7 @@ column_computation_ptr column_computation::deserialize(bytes_view raw) {
 
 bytes legacy_token_column_computation::serialize() const {
     rjson::value serialized = rjson::empty_object();
-    rjson::add(serialized, "type", rjson::from_string("token"));
+    rjson::add(serialized, "type", rjson::from_string(std::string_view("token")));
     return to_bytes(rjson::print(serialized));
 }
 
@@ -1770,7 +1770,7 @@ bytes legacy_token_column_computation::compute_value(const schema& schema, const
 
 bytes token_column_computation::serialize() const {
     rjson::value serialized = rjson::empty_object();
-    rjson::add(serialized, "type", rjson::from_string("token_v2"));
+    rjson::add(serialized, "type", rjson::from_string(std::string_view("token_v2")));
     return to_bytes(rjson::print(serialized));
 }
 
@@ -1793,7 +1793,7 @@ bytes collection_column_computation::serialize() const {
             type = "collection_entries";
             break;
     }
-    rjson::add(serialized, "type", rjson::from_string(type));
+    rjson::add(serialized, "type", rjson::from_string(std::string_view(type)));
     rjson::add(serialized, "collection_name", rjson::from_string(sstring(_collection_name.begin(), _collection_name.end())));
     return to_bytes(rjson::print(serialized));
 }

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -192,6 +192,8 @@ rjson::value parse_yieldable(chunked_content&&, size_t max_nested_level = defaul
 // Creates a JSON value (of JSON string type) out of internal string representations.
 // The string value is copied, so str's liveness does not need to be persisted.
 rjson::value from_string(const char* str, size_t size);
+rjson::value from_string(const std::string& str);
+rjson::value from_string(const sstring& str);
 rjson::value from_string(std::string_view view);
 
 // Returns a pointer to JSON member if it exists, nullptr otherwise


### PR DESCRIPTION
Looks like most usages are sstring and string so adding those definitions avoids going through string_view conversion.

Notable case occured in from_string_map where we do this for every map element.

__IN PROGRESS__