### PR TITLE
cql: allow disabling of USING TIMESTAMP sanity checking

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -241,7 +241,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute_without_checking_exception_message(
         query_processor& qp, service::query_state& state, const query_options& options) const {
-    cql3::util::validate_timestamp(options, _attrs);
+    cql3::util::validate_timestamp(qp.db().get_config(), options, _attrs);
     return batch_stage(this, seastar::ref(qp), seastar::ref(state),
                        seastar::cref(options), false, options.get_timestamp(state));
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -246,7 +246,7 @@ modification_statement::execute(query_processor& qp, service::query_state& qs, c
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
-    cql3::util::validate_timestamp(options, attrs);
+    cql3::util::validate_timestamp(qp.db().get_config(), options, attrs);
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -90,7 +90,7 @@ sstring single_quote(const sstring& s);
 
 // Check whether timestamp is not too far in the future as this probably
 // indicates its incorrectness (for example using other units than microseconds).
-void validate_timestamp(const query_options& options, const std::unique_ptr<attributes>& attrs);
+void validate_timestamp(const db::config& config, const query_options& options, const std::unique_ptr<attributes>& attrs);
 
 } // namespace util
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -902,6 +902,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::TRUE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
     , restrict_twcs_without_default_ttl(this, "restrict_twcs_without_default_ttl", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent creating TimeWindowCompactionStrategy tables without a default TTL. Can be true, false, or warn.")
+    , restrict_future_timestamp(this, "restrict_future_timestamp",liveness::LiveUpdate, value_status::Used, true, "Controls whether to detect and forbid unreasonable USING TIMESTAMP, more than 3 days into the future.")
     , ignore_truncation_record(this, "unsafe_ignore_truncation_record", value_status::Used, false,
         "Ignore truncation record stored in system tables as if tables were never truncated.")
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,

--- a/db/config.hh
+++ b/db/config.hh
@@ -381,6 +381,7 @@ public:
     named_value<tri_mode_restriction> restrict_replication_simplestrategy;
     named_value<tri_mode_restriction> restrict_dtcs;
     named_value<tri_mode_restriction> restrict_twcs_without_default_ttl;
+    named_value<bool> restrict_future_timestamp;
 
     named_value<bool> ignore_truncation_record;
     named_value<bool> force_schema_commit_log;


### PR DESCRIPTION
As requested by issue #5619, commit 2150c0f7a2d56b9ea2a5607a4066c4c1c3aba40f added a sanity check for USING TIMESTAMP - the number specified in the timestamp must not be more than 3 days into the future (when viewed as a number of microseconds since the epoch).

This sanity checking helps avoid some annoying client-side bugs and mis-configurations, but some users genuinely want to use arbitrary or futuristic-looking timestamps and are hindered by this sanity check (which Cassandra doesn't have, by the way).

So in this patch we add a new configuration option, restrict_future_timestamp If set to "true", futuristic timestamps (more than 3 days into the future) are forbidden. The "true" setting is the default (as has been the case sinced #5619). Setting this option to "false" will allow using any 64-bit integer as a timestamp, like is allowed Cassanda (and was allowed in Scylla prior to #5619.

The error message in the case where a futuristic timestamp is rejected now mentions the configuration paramter that can be used to disable this check (this, and the option's name "restrict_*", is similar to other so-called "safe mode" options).

This patch also includes a test, which works in Scylla and Cassandra, with either setting of restrict_future_timestamp, checking the right thing in all these cases (the futuristic timestamp can either be written and read, or can't be written). I used this test to manually verify that the new option works, defaults to "true", and when set to "false" Scylla behaves like Cassandra.

Fixes #12527

Signed-off-by: Nadav Har'El <nyh@scylladb.com>