### PR TITLE
api: gossiper: get alive nodes after reaching current shard 0 version

### DIFF
--- a/api/api-doc/gossiper.json
+++ b/api/api-doc/gossiper.json
@@ -46,6 +46,25 @@
          ]
       },
       {
+         "path":"/gossiper/endpoint/live_synchronized/",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Get the addreses of live endpoints",
+               "type":"array",
+               "items":{
+                  "type":"string"
+               },
+               "nickname":"get_live_endpoint_synchronized",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            }
+         ]
+      },
+      {
          "path":"/gossiper/downtime/{addr}",
          "operations":[
             {

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -24,6 +24,11 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
         return container_to_vec(res);
     });
 
+    httpd::gossiper_json::get_live_endpoint_synchronized.set(r, [&g] (const_req req) {
+        auto res = g.get_live_members_synchronized(1s).get0();
+        return container_to_vec(res);
+    });
+
     httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (const_req req) {
         gms::inet_address ep(req.param["addr"]);
         return g.get_endpoint_downtime(ep);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -202,6 +202,7 @@ private:
     /* live member set */
     utils::chunked_vector<inet_address> _live_endpoints;
     uint64_t _live_endpoints_version = 0;
+    condition_variable _live_endpoints_version_condvar;
 
     /* nodes are being marked as alive */
     std::unordered_set<inet_address> _pending_mark_alive_endpoints;
@@ -434,6 +435,9 @@ public:
     bool is_dead_state(const endpoint_state& eps) const;
     // Wait for nodes to be alive on all shards
     future<> wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout);
+
+    // Wait for nodes to have gossiper version equal or greater than current version on shard 0
+    future<std::set<inet_address>> get_live_members_synchronized(std::chrono::milliseconds timeout);
 
     future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
 


### PR DESCRIPTION

Add an API call to wait for all shards to reach the current shard 0 gossiper version. Throws when timeout is reached.