### PR TITLE
test/pylib: increase timeout when waiting for cluster before test

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -77,7 +77,7 @@ class ManagerClient():
         if dirty:
             self.driver_close()  # Close driver connection to old cluster
         try:
-            cluster_str = await self.client.get_text(f"/cluster/before-test/{test_case_name}")
+            cluster_str = await self.client.get_text(f"/cluster/before-test/{test_case_name}", timeout=600)
             logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
         except aiohttp.ClientError as exc:
             raise RuntimeError(f"Failed before test check {exc}") from exc


### PR DESCRIPTION
Increase the timeout from default 5 minutes to 10 minutes.
Sent as a workaround for https://github.com/scylladb/scylladb/issues/12546 to unblock next promotions.