### PR TITLE
cql3/expr: make it possible to prepare binary_operator

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -692,7 +692,7 @@ std::optional<expression> try_prepare_expression(const expression& expr, data_di
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.
-extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, schema_ptr schema);
+extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema);
 
 
 /**

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1229,7 +1229,7 @@ static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column
 }
 
 binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema) {
-    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, "", &table_schema, {});
+    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, table_schema.ks_name(), &table_schema, {});
     if (!prepared_lhs_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", binop.lhs));
     }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1228,16 +1228,16 @@ static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column
     }
 }
 
-binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, schema_ptr schema) {
-    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, "", schema.get(), {});
+binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema) {
+    std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, "", &table_schema, {});
     if (!prepared_lhs_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", binop.lhs));
     }
     auto& prepared_lhs = *prepared_lhs_opt;
-    lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, *schema);
+    lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, table_schema);
 
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
-    expression prepared_rhs = prepare_expression(binop.rhs, db, schema->ks_name(), schema.get(), rhs_receiver);
+    expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
     return binary_operator(std::move(prepared_lhs), binop.op, std::move(prepared_rhs), binop.order);
 }

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -201,7 +201,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
     preliminary_binop_vaidation_checks(restriction);
 
     // Prepare the restriction
-    binary_operator prepared_binop = prepare_binary_operator(restriction, db, schema);
+    binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema);
 
     // Fill prepare context
     const column_value* lhs_pk_col_search_res = find_in_expression<column_value>(prepared_binop.lhs,

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1235,7 +1235,7 @@ BOOST_AUTO_TEST_CASE(prepare_subscript_list) {
 
     expression sub =
         subscript{.val = unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)},
-                  .sub = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"}};
+                  .sub = make_int_untyped("123")};
 
     expression prepared = prepare_expression(sub, db, "test_ks", table_schema.get(), nullptr);
 
@@ -1256,7 +1256,7 @@ BOOST_AUTO_TEST_CASE(prepare_subscript_map) {
 
     expression sub =
         subscript{.val = unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)},
-                  .sub = untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"}};
+                  .sub = make_bool_untyped("true")};
 
     expression prepared = prepare_expression(sub, db, "test_ks", table_schema.get(), nullptr);
 
@@ -1276,7 +1276,7 @@ BOOST_AUTO_TEST_CASE(prepare_subscript_set) {
 
     expression sub =
         subscript{.val = unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)},
-                  .sub = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"}};
+                  .sub = make_int_untyped("123")};
 
     BOOST_REQUIRE_THROW(prepare_expression(sub, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -1292,7 +1292,7 @@ BOOST_AUTO_TEST_CASE(prepare_subscript_list_checks_type) {
 
     expression sub =
         subscript{.val = unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)},
-                  .sub = untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"}};
+                  .sub = make_bool_untyped("true")};
 
     BOOST_REQUIRE_THROW(prepare_expression(sub, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -1308,7 +1308,7 @@ BOOST_AUTO_TEST_CASE(prepare_subscript_map_checks_type) {
 
     expression sub =
         subscript{.val = unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("r", true)},
-                  .sub = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"}};
+                  .sub = make_int_untyped("123")};
 
     BOOST_REQUIRE_THROW(prepare_expression(sub, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -1357,7 +1357,7 @@ BOOST_AUTO_TEST_CASE(prepare_cast_int_int) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression cast_expr =
-        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+        cast{.arg = make_int_untyped("123"),
              .type = cql3_type::raw::from(int32_type)};
 
     ::lw_shared_ptr<column_specification> receiver = make_receiver(int32_type);
@@ -1373,7 +1373,7 @@ BOOST_AUTO_TEST_CASE(prepare_cast_int_short) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression cast_expr =
-        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+        cast{.arg = make_int_untyped("123"),
              .type = cql3_type::raw::from(short_type)};
 
     ::lw_shared_ptr<column_specification> receiver = make_receiver(short_type);
@@ -1389,7 +1389,7 @@ BOOST_AUTO_TEST_CASE(prepare_cast_text_int) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression cast_expr =
-        cast{.arg = untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "123"},
+        cast{.arg = make_string_untyped("123"),
              .type = cql3_type::raw::from(short_type)};
 
     ::lw_shared_ptr<column_specification> receiver = make_receiver(short_type);
@@ -1451,7 +1451,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_no_receiver) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337"};
+    expression untyped = make_int_untyped("1337");
 
     // Can't infer type
     BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr),
@@ -1462,7 +1462,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bool) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"};
+    expression untyped = make_bool_untyped("true");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(boolean_type));
     expression expected = make_bool_const(true);
@@ -1474,7 +1474,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int8) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "13"};
+    expression untyped = make_int_untyped("13");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(byte_type));
     expression expected = make_tinyint_const(13);
@@ -1486,7 +1486,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int16) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression untyped = untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337"};
+    expression untyped = make_int_untyped("1337");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(short_type));
     expression expected = make_smallint_const(1337);
@@ -1499,7 +1499,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int32) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression untyped =
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "13377331"};
+        make_int_untyped("13377331");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(int32_type));
     expression expected = make_int_const(13377331);
@@ -1512,7 +1512,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_int64) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression untyped =
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1337733113377331"};
+        make_int_untyped("1337733113377331");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(long_type));
     expression expected = make_bigint_const(1337733113377331);
@@ -1525,7 +1525,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_text) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression untyped =
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "scylla_is_the_best"};
+        make_string_untyped("scylla_is_the_best");
 
     expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(utf8_type));
     expression expected = make_text_const("scylla_is_the_best");
@@ -1538,7 +1538,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bad_int) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression untyped =
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "not_integer_text"};
+        make_int_untyped("not_integer_text");
 
     BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), make_receiver(int32_type)),
                         exceptions::invalid_request_exception);
@@ -1551,9 +1551,9 @@ BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver_fails) {
     expression tup = tuple_constructor{
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
-                untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "some text"},
+                make_int_untyped("123"),
+                make_int_untyped("456"),
+                make_string_untyped("some text"),
             },
         .type = nullptr};
 
@@ -1568,9 +1568,9 @@ BOOST_AUTO_TEST_CASE(prepare_tuple_constructor) {
     expression tup = tuple_constructor{
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
-                untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "some text"},
+                make_int_untyped("123"),
+                make_int_untyped("456"),
+                make_string_untyped("some text"),
             },
         .type = nullptr};
 
@@ -1622,9 +1622,9 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor) {
         .style = collection_constructor::style_type::list,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                make_int_untyped("123"),
+                make_int_untyped("456"),
+                make_int_untyped("789"),
             },
         .type = nullptr};
 
@@ -1676,9 +1676,9 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_no_receiver) {
         .style = collection_constructor::style_type::list,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                make_int_untyped("123"),
+                make_int_untyped("456"),
+                make_int_untyped("789"),
             },
         .type = nullptr};
 
@@ -1696,9 +1696,9 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_bind_var) {
         .style = collection_constructor::style_type::list,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+                make_int_untyped("123"),
                 bind_variable{.bind_index = 1, .receiver = nullptr},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                make_int_untyped("789"),
             },
         .type = nullptr};
 
@@ -1734,8 +1734,8 @@ BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_null) {
 
     expression constructor = collection_constructor{
         .style = collection_constructor::style_type::list,
-        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+        .elements = {make_int_untyped("123"),
+                     make_int_untyped("456"),
                      make_untyped_null()},
         .type = nullptr};
 
@@ -1753,9 +1753,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor) {
         .style = collection_constructor::style_type::set,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+                make_int_untyped("789"),
+                make_int_untyped("123"),
+                make_int_untyped("456"),
             },
         .type = nullptr};
 
@@ -1807,9 +1807,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_no_receiver) {
         .style = collection_constructor::style_type::set,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+                make_int_untyped("789"),
+                make_int_untyped("123"),
+                make_int_untyped("456"),
             },
         .type = nullptr};
 
@@ -1825,9 +1825,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_bind_var) {
         .style = collection_constructor::style_type::set,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                make_int_untyped("789"),
                 bind_variable{.bind_index = 1, .receiver = nullptr},
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"},
+                make_int_untyped("123"),
             },
         .type = nullptr};
 
@@ -1864,9 +1864,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_null) {
         .style = collection_constructor::style_type::set,
         .elements =
             {
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "789"},
+                make_int_untyped("789"),
                 make_untyped_null(),
-                untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "456"},
+                make_int_untyped("456"),
             },
         .type = nullptr};
 
@@ -1887,20 +1887,16 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor) {
                 {
                     tuple_constructor{
                         .elements =
-                            {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "3"},
-                             untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "30"}},
+                            {make_int_untyped("3"),
+                             make_int_untyped("30")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "2"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "-20"}},
+                        .elements = {make_int_untyped("2"),
+                                     make_int_untyped("-20")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "1"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "10"}},
+                        .elements = {make_int_untyped("1"),
+                                     make_int_untyped("10")},
                         .type = nullptr},
                 },
             .type = nullptr};
@@ -1959,20 +1955,16 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_no_receiver) {
                 {
                     tuple_constructor{
                         .elements =
-                            {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "3"},
-                             untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "30"}},
+                            {make_int_untyped("3"),
+                             make_int_untyped("30")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "2"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "-20"}},
+                        .elements = {make_int_untyped("2"),
+                                     make_int_untyped("-20")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "1"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "10"}},
+                        .elements = {make_int_untyped("1"),
+                                     make_int_untyped("10")},
                         .type = nullptr},
                 },
             .type = nullptr};
@@ -1992,19 +1984,16 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_with_bind_var_key) {
                 {
                     tuple_constructor{
                         .elements =
-                            {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "3"},
-                             untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "30"}},
+                            {make_int_untyped("3"),
+                             make_int_untyped("30")},
                         .type = nullptr},
                     tuple_constructor{
                         .elements = {bind_variable{.bind_index = 1, .receiver = nullptr},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "-20"}},
+                                     make_int_untyped("-20")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "1"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "10"}},
+                        .elements = {make_int_untyped("1"),
+                                     make_int_untyped("10")},
                         .type = nullptr},
                 },
             .type = nullptr};
@@ -2054,19 +2043,14 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_with_bind_var_value) {
         .style = collection_constructor::style_type::map,
         .elements =
             {
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "3"},
-                                               untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "30"}},
+                tuple_constructor{.elements = {make_int_untyped("3"),
+                                               make_int_untyped("30")},
                                   .type = nullptr},
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "2"},
+                tuple_constructor{.elements = {make_int_untyped("2"),
                                                bind_variable{.bind_index = 1, .receiver = nullptr}},
                                   .type = nullptr},
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "1"},
-                                               untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "10"}},
+                tuple_constructor{.elements = {make_int_untyped("1"),
+                                               make_int_untyped("10")},
                                   .type = nullptr},
             },
         .type = nullptr};
@@ -2119,19 +2103,16 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_null_key) {
                 {
                     tuple_constructor{
                         .elements =
-                            {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "3"},
-                             untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "30"}},
+                            {make_int_untyped("3"),
+                             make_int_untyped("30")},
                         .type = nullptr},
                     tuple_constructor{
                         .elements = {make_untyped_null(),
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                              .raw_text = "-20"}},
+                                     make_int_untyped("-20")},
                         .type = nullptr},
                     tuple_constructor{
-                        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "1"},
-                                     untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                      .raw_text = "10"}},
+                        .elements = {make_int_untyped("1"),
+                                     make_int_untyped("10")},
                         .type = nullptr},
                 },
             .type = nullptr};
@@ -2150,19 +2131,14 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_null_value) {
         .style = collection_constructor::style_type::map,
         .elements =
             {
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "3"},
-                                               untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "30"}},
+                tuple_constructor{.elements = {make_int_untyped("3"),
+                                               make_int_untyped("30")},
                                   .type = nullptr},
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "2"},
+                tuple_constructor{.elements = {make_int_untyped("2"),
                                                make_untyped_null()},
                                   .type = nullptr},
-                tuple_constructor{.elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "1"},
-                                               untyped_constant{.partial_type = untyped_constant::type_class::integer,
-                                                                .raw_text = "10"}},
+                tuple_constructor{.elements = {make_int_untyped("1"),
+                                               make_int_untyped("10")},
                                   .type = nullptr},
             },
         .type = nullptr};
@@ -2181,7 +2157,7 @@ BOOST_AUTO_TEST_CASE(prepare_collection_constructor_checks_style_type) {
 
     expression set_constructor = collection_constructor{
         .style = collection_constructor::style_type::set,
-        .elements = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "123"}},
+        .elements = {make_int_untyped("123")},
         .type = nullptr};
 
     data_type set_type = set_type_impl::get_instance(int32_type, true);
@@ -2203,13 +2179,13 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor) {
     usertype_constructor::elements_map_type constructor_elements;
     constructor_elements.emplace(
         column_identifier("field1", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
+        make_int_untyped("152"));
     constructor_elements.emplace(
         column_identifier("field2", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "987"});
+        make_int_untyped("987"));
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2231,11 +2207,11 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_null) {
     usertype_constructor::elements_map_type constructor_elements;
     constructor_elements.emplace(
         column_identifier("field1", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
+        make_int_untyped("152"));
     constructor_elements.emplace(column_identifier("field2", true), make_untyped_null());
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2258,10 +2234,10 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_missing_field) {
     usertype_constructor::elements_map_type constructor_elements;
     constructor_elements.emplace(
         column_identifier("field1", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
+        make_int_untyped("152"));
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2283,13 +2259,13 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_no_receiver) {
     usertype_constructor::elements_map_type constructor_elements;
     constructor_elements.emplace(
         column_identifier("field1", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
+        make_int_untyped("152"));
     constructor_elements.emplace(
         column_identifier("field2", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "987"});
+        make_int_untyped("987"));
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2304,12 +2280,12 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_bind_variable) {
     usertype_constructor::elements_map_type constructor_elements;
     constructor_elements.emplace(
         column_identifier("field1", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "152"});
+        make_int_untyped("152"));
     constructor_elements.emplace(column_identifier("field2", true),
                                  bind_variable{.bind_index = 2, .receiver = nullptr});
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2354,7 +2330,7 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_bind_variable_and_missing
                                  bind_variable{.bind_index = 2, .receiver = nullptr});
     constructor_elements.emplace(
         column_identifier("field3", true),
-        untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = "ututu"});
+        make_string_untyped("ututu"));
 
     expression constructor = usertype_constructor{.elements = constructor_elements, .type = nullptr};
 
@@ -2990,7 +2966,7 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_false) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj_one = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "false"}}};
+        .children = {make_bool_untyped("false")}};
 
     expression expected = make_bool_const(false);
 
@@ -3005,7 +2981,7 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_true) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj_one = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"}}};
+        .children = {make_bool_untyped("true")}};
 
     expression expected = make_bool_const(true);
 
@@ -3020,7 +2996,7 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_null) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj_one = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::null, .raw_text = "null"}}};
+        .children = {make_null_untyped()}};
 
     expression expected = constant::make_null(boolean_type);
 
@@ -3036,7 +3012,7 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_int_untyped_const_0) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj_one = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "0"}}};
+        .children = {make_int_untyped("0")}};
 
     BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -3050,10 +3026,10 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_bools_and_one_int_untyped_const_0) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"}}};
+        .children = {make_bool_untyped("true"),
+                     make_bool_untyped("true"),
+                     make_int_untyped("1"),
+                     make_bool_untyped("true")}};
 
     BOOST_REQUIRE_THROW(prepare_expression(conj, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -3067,8 +3043,8 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_and_of_ints_is_invalid) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression conj_one = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "0"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1"}}};
+        .children = {make_int_untyped("0"),
+                     make_int_untyped("1")}};
 
     BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -3088,12 +3064,12 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_many_elements) {
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
     expression sub_conj = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "false"},
+        .children = {make_bool_untyped("false"),
                      unresolved_identifier{::make_shared<column_identifier_raw>("b2", false)}}};
 
     expression conj_many = conjunction{
-        .children = {untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "true"},
-                     untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = "false"},
+        .children = {make_bool_untyped("true"),
+                     make_bool_untyped("false"),
                      unresolved_identifier{
                          unresolved_identifier{::make_shared<column_identifier_raw>("b1", false)},
                      },

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -3492,3 +3492,266 @@ BOOST_AUTO_TEST_CASE(prepare_binary_operator_eq_neq_lt_lte_gt_gte_multi_column) 
         }
     }
 }
+
+
+// `float_col IN ()`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_float_col_in_empty_list) {
+    schema_ptr table_schema = schema_builder("test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(
+            unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)}, oper_t::IN,
+            collection_constructor{.style = collection_constructor::style_type::list, .elements = {}}, comp_order);
+
+        expression expected =
+            binary_operator(column_value(table_schema->get_column_definition("float_col")), oper_t::IN,
+                            constant(make_list_raw({}), list_type_impl::get_instance(float_type, false)), comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_in_list, db, table_schema);
+    }
+}
+
+// `float_col IN (1, 2.3)`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_float_col_in_1_2_dot_3) {
+    schema_ptr table_schema = schema_builder("test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(
+            unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)}, oper_t::IN,
+            collection_constructor{.style = collection_constructor::style_type::list,
+                                   .elements = {make_int_untyped("1"), make_float_untyped("2.3")}},
+            comp_order);
+
+        expression expected =
+            binary_operator(column_value(table_schema->get_column_definition("float_col")), oper_t::IN,
+                            constant(make_list_raw({make_float_raw(1), make_float_raw(2.3)}),
+                                     list_type_impl::get_instance(float_type, false)),
+                            comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_in_list, db, table_schema);
+    }
+}
+
+// `float_col IN (1, 2, 3, 4)`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_float_col_in_1_2_3_4) {
+    schema_ptr table_schema = schema_builder("test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(
+            unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)}, oper_t::IN,
+            collection_constructor{.style = collection_constructor::style_type::list,
+                                   .elements =
+                                       {
+                                           make_int_untyped("1"),
+                                           make_int_untyped("2"),
+                                           make_int_untyped("3"),
+                                           make_int_untyped("4"),
+                                       }},
+            comp_order);
+
+        expression expected = binary_operator(
+            column_value(table_schema->get_column_definition("float_col")), oper_t::IN,
+            constant(make_list_raw({make_float_raw(1), make_float_raw(2), make_float_raw(3), make_float_raw(4)}),
+                     list_type_impl::get_instance(float_type, false)),
+            comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_in_list, db, table_schema);
+    }
+}
+
+// reverse_float_col IN ()
+BOOST_AUTO_TEST_CASE(prepare_binary_operato_reverse_float_col_in_empty_list) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("reverse_float_col", reversed_type_impl::get_instance(float_type), column_kind::regular_column)
+            .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(
+            unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("reverse_float_col", false)},
+            oper_t::IN, collection_constructor{.style = collection_constructor::style_type::list, .elements = {}},
+            comp_order);
+
+        expression expected =
+            binary_operator(column_value(table_schema->get_column_definition("reverse_float_col")), oper_t::IN,
+                            constant(make_list_raw({}), list_type_impl::get_instance(float_type, false)), comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_in_list, db, table_schema);
+    }
+}
+
+// `reverse_float_col IN (1.2, 2.3)`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_float_col_in_1_dot_2_2_dot_3) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("reverse_float_col", reversed_type_impl::get_instance(float_type), column_kind::regular_column)
+            .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(
+            unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("reverse_float_col", false)},
+            oper_t::IN,
+            collection_constructor{.style = collection_constructor::style_type::list,
+                                   .elements = {make_float_untyped("1.2"), make_float_untyped("2.3")}},
+            comp_order);
+
+        expression expected =
+            binary_operator(column_value(table_schema->get_column_definition("reverse_float_col")), oper_t::IN,
+                            constant(make_list_raw({make_float_raw(1.2), make_float_raw(2.3)}),
+                                     list_type_impl::get_instance(float_type, false)),
+                            comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_in_list, db, table_schema);
+    }
+}
+
+// `(float_col, int_col, text_col, reverse_double_col) IN ()`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_multi_col_in_empty_list) {
+    schema_ptr table_schema = schema_builder("test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::clustering_key)
+                                  .with_column("int_col", int32_type, column_kind::clustering_key)
+                                  .with_column("text_col", utf8_type, column_kind::clustering_key)
+                                  .with_column("reverse_double_col", reversed_type_impl::get_instance(double_type))
+                                  .build();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression unprepared_lhs = tuple_constructor{
+        .elements =
+            {
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("int_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("text_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("reverse_double_col", false)},
+            },
+        .type = nullptr};
+
+    data_type tuple_type = tuple_type_impl::get_instance(
+        {float_type, int32_type, utf8_type, reversed_type_impl::get_instance(double_type)});
+
+    expression prepared_lhs =
+        tuple_constructor{.elements = {column_value(table_schema->get_column_definition("float_col")),
+                                       column_value(table_schema->get_column_definition("int_col")),
+                                       column_value(table_schema->get_column_definition("text_col")),
+                                       column_value(table_schema->get_column_definition("reverse_double_col"))},
+                          .type = tuple_type};
+
+    expression unprepared_rhs =
+        collection_constructor{.style = collection_constructor::style_type::list, .elements = {}};
+
+    // reversed is removed!
+    expression prepared_rhs = constant(
+        make_list_raw({}), list_type_impl::get_instance(
+                               tuple_type_impl::get_instance({float_type, int32_type, utf8_type, double_type}), false));
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(unprepared_lhs, oper_t::IN, unprepared_rhs, comp_order);
+
+        expression expected = binary_operator(prepared_lhs, oper_t::IN, prepared_rhs, comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::multi_column_tuple_in_list, db,
+                                                        table_schema);
+    }
+}
+
+// `(float_col, int_col, text_col, reverse_double_col) IN ((1.2, 3, 'four', 8.9), (5, 6, 'seven', 10.11))`
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_multi_col_in_values) {
+    schema_ptr table_schema = schema_builder("test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::clustering_key)
+                                  .with_column("int_col", int32_type, column_kind::clustering_key)
+                                  .with_column("text_col", utf8_type, column_kind::clustering_key)
+                                  .with_column("reverse_double_col", reversed_type_impl::get_instance(double_type))
+                                  .build();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression unprepared_lhs = tuple_constructor{
+        .elements =
+            {
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("int_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("text_col", false)},
+                unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("reverse_double_col", false)},
+            },
+        .type = nullptr};
+
+    data_type tuple_type = tuple_type_impl::get_instance(
+        {float_type, int32_type, utf8_type, reversed_type_impl::get_instance(double_type)});
+
+    expression prepared_lhs =
+        tuple_constructor{.elements = {column_value(table_schema->get_column_definition("float_col")),
+                                       column_value(table_schema->get_column_definition("int_col")),
+                                       column_value(table_schema->get_column_definition("text_col")),
+                                       column_value(table_schema->get_column_definition("reverse_double_col"))},
+                          .type = tuple_type};
+
+    expression unprepared_rhs =
+        collection_constructor{.style = collection_constructor::style_type::list,
+                               .elements = {tuple_constructor{.elements =
+                                                                  {
+                                                                      make_float_untyped("1.2"),
+                                                                      make_int_untyped("3"),
+                                                                      make_string_untyped("four"),
+                                                                      make_float_untyped("8.9"),
+                                                                  }},
+                                            tuple_constructor{.elements = {
+                                                                  make_int_untyped("5"),
+                                                                  make_int_untyped("6"),
+                                                                  make_string_untyped("seven"),
+                                                                  make_float_untyped("10.11"),
+                                                              }}}};
+
+    raw_value prepared_rhs_raw = make_list_raw(
+        {make_tuple_raw({make_float_raw(1.2), make_int_raw(3), make_text_raw("four"), make_double_raw(8.9)}),
+         make_tuple_raw({make_float_raw(5), make_int_raw(6), make_text_raw("seven"), make_double_raw(10.11)})});
+
+    // reversed is removed!
+    data_type prepared_rhs_type = list_type_impl::get_instance(
+        tuple_type_impl::get_instance({float_type, int32_type, utf8_type, double_type}), false);
+
+    expression prepared_rhs = constant(prepared_rhs_raw, prepared_rhs_type);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare = binary_operator(unprepared_lhs, oper_t::IN, unprepared_rhs, comp_order);
+
+        expression expected = binary_operator(prepared_lhs, oper_t::IN, prepared_rhs, comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::multi_column_tuple_in_list, db,
+                                                        table_schema);
+    }
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -3755,3 +3755,51 @@ BOOST_AUTO_TEST_CASE(prepare_binary_operator_multi_col_in_values) {
                                                         table_schema);
     }
 }
+
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_contains) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("float_list", list_type_impl::get_instance(float_type, true), column_kind::regular_column)
+            .with_column("frozen_float_list", list_type_impl::get_instance(float_type, false),
+                         column_kind::regular_column)
+            .with_column("float_set", set_type_impl::get_instance(float_type, true), column_kind::regular_column)
+            .with_column("frozen_float_set", set_type_impl::get_instance(float_type, false),
+                         column_kind::regular_column)
+            .with_column("double_float_map", map_type_impl::get_instance(double_type, float_type, true),
+                         column_kind::regular_column)
+            .with_column("frozen_double_float_map", map_type_impl::get_instance(double_type, float_type, false),
+                         column_kind::regular_column)
+            .build();
+
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    std::vector<const char*> possible_lhs_col_names = {"float_list",       "frozen_float_list",
+                                                       "float_set",        "frozen_float_set",
+                                                       "double_float_map", "frozen_double_float_map"};
+
+    std::vector<std::pair<untyped_constant, constant>> possible_rhs_vals = {
+        {make_int_untyped("123"), make_float_const(123)},
+        {
+            make_float_untyped("123.45"),
+            make_float_const(123.45),
+        }};
+
+    for (const char* lhs_col_name : possible_lhs_col_names) {
+        for (auto& [unprepared_rhs, prepared_rhs] : possible_rhs_vals) {
+            for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+                expression to_prepare = binary_operator(
+                    unresolved_identifier{.ident = ::make_shared<column_identifier_raw>(lhs_col_name, false)},
+                    oper_t::CONTAINS, unprepared_rhs, comp_order);
+
+                expression expected = binary_operator(column_value(table_schema->get_column_definition(lhs_col_name)),
+                                                      oper_t::CONTAINS, prepared_rhs, comp_order);
+
+                test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+                test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::float_type, db,
+                                                                table_schema);
+            }
+        }
+    }
+}

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -46,6 +46,14 @@ raw_value make_text_raw(const sstring_view& text) {
     return raw_value::make_value(utf8_type->decompose(text));
 }
 
+raw_value make_float_raw(float val) {
+    return make_raw(val);
+}
+
+raw_value make_double_raw(double val) {
+    return make_raw(val);
+}
+
 template <class T>
 constant make_const(T t) {
     data_type val_type = data_type_for<T>();
@@ -78,6 +86,14 @@ constant make_bigint_const(int64_t val) {
 
 constant make_text_const(const sstring_view& text) {
     return constant(make_text_raw(text), utf8_type);
+}
+
+constant make_float_const(float val) {
+    return make_const(val);
+}
+
+constant make_double_const(double val) {
+    return make_const(val);
 }
 
 // This function implements custom serialization of collection values.

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -96,6 +96,38 @@ constant make_double_const(double val) {
     return make_const(val);
 }
 
+untyped_constant make_int_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = raw_text};
+}
+
+untyped_constant make_float_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::floating_point, .raw_text = raw_text};
+}
+
+untyped_constant make_string_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::string, .raw_text = raw_text};
+}
+
+untyped_constant make_bool_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::boolean, .raw_text = raw_text};
+}
+
+untyped_constant make_duration_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::duration, .raw_text = raw_text};
+}
+
+untyped_constant make_uuid_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::uuid, .raw_text = raw_text};
+}
+
+untyped_constant make_hex_untyped(const char* raw_text) {
+    return untyped_constant{.partial_type = untyped_constant::type_class::hex, .raw_text = raw_text};
+}
+
+untyped_constant make_null_untyped() {
+    return untyped_constant{.partial_type = untyped_constant::type_class::null, .raw_text = "null"};
+}
+
 // This function implements custom serialization of collection values.
 // Some tests require the collection to contain an empty value,
 // which is impossible to express using the existing code.

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -30,6 +30,8 @@ raw_value make_smallint_raw(int16_t val);
 raw_value make_int_raw(int32_t val);
 raw_value make_bigint_raw(int64_t val);
 raw_value make_text_raw(const sstring_view& text);
+raw_value make_float_raw(float val);
+raw_value make_double_raw(double val);
 
 constant make_empty_const(data_type type);
 constant make_bool_const(bool val);
@@ -38,6 +40,8 @@ constant make_smallint_const(int16_t val);
 constant make_int_const(int32_t val);
 constant make_bigint_const(int64_t val);
 constant make_text_const(const sstring_view& text);
+constant make_float_const(float val);
+constant make_double_const(double val);
 
 // This function implements custom serialization of collection values.
 // Some tests require the collection to contain unset_value or an empty value,

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -43,6 +43,15 @@ constant make_text_const(const sstring_view& text);
 constant make_float_const(float val);
 constant make_double_const(double val);
 
+untyped_constant make_int_untyped(const char* raw_text);
+untyped_constant make_float_untyped(const char* raw_text);
+untyped_constant make_string_untyped(const char* raw_text);
+untyped_constant make_bool_untyped(const char* raw_text);
+untyped_constant make_duration_untyped(const char* raw_text);
+untyped_constant make_uuid_untyped(const char* raw_text);
+untyped_constant make_hex_untyped(const char* raw_text);
+untyped_constant make_null_untyped();
+
 // This function implements custom serialization of collection values.
 // Some tests require the collection to contain unset_value or an empty value,
 // which is impossible to express using the existing code.


### PR DESCRIPTION
`prepare_expression` takes an unprepared CQL expression straight from the parser output and prepares it. Preparation consists of various type checks that are needed to ensure that the expression is correct and to reason about it.

While `prepare_expression` supports a number of different types of expressions, until now it was impossible to prepare a `binary_operator`. Eventually we would like to be able to prepare all kinds of expressions, so this PR adds the missing support for `binary_operator`.