### PR TITLE
remove expired rows from cache on read

### DIFF
--- a/read_context.hh
+++ b/read_context.hh
@@ -127,6 +127,7 @@ class read_context final : public enable_lw_shared_from_this<read_context> {
     tracing::trace_state_ptr _trace_state;
     mutation_reader::forwarding _fwd_mr;
     bool _range_query;
+    const tombstone_gc_state* _tombstone_gc_state;
     // When reader enters a partition, it must be set up for reading that
     // partition from the underlying mutation source (_underlying) in one of two ways:
     //
@@ -149,6 +150,7 @@ public:
             reader_permit permit,
             const dht::partition_range& range,
             const query::partition_slice& slice,
+            const tombstone_gc_state* gc_state,
             const io_priority_class& pc,
             tracing::trace_state_ptr trace_state,
             mutation_reader::forwarding fwd_mr)
@@ -161,6 +163,7 @@ public:
         , _trace_state(std::move(trace_state))
         , _fwd_mr(fwd_mr)
         , _range_query(!query::is_single_partition(range))
+        , _tombstone_gc_state(gc_state)
         , _underlying(_cache, *this)
     {
         if (_slice.options.contains(query::partition_slice::option::reversed)) {
@@ -199,6 +202,7 @@ public:
     bool partition_exists() const { return _partition_exists; }
     void on_underlying_created() { ++_underlying_created; }
     bool digest_requested() const { return _slice.options.contains<query::partition_slice::option::with_digest>(); }
+    const tombstone_gc_state* tombstone_gc_state() const { return _tombstone_gc_state; }
 public:
     future<> ensure_underlying() {
         if (_underlying_snapshot) {

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -726,13 +726,14 @@ row_cache::make_reader_opt(schema_ptr s,
                        reader_permit permit,
                        const dht::partition_range& range,
                        const query::partition_slice& slice,
+                       const tombstone_gc_state* gc_state,
                        const io_priority_class& pc,
                        tracing::trace_state_ptr trace_state,
                        streamed_mutation::forwarding fwd,
                        mutation_reader::forwarding fwd_mr)
 {
     auto make_context = [&] {
-        return std::make_unique<read_context>(*this, s, std::move(permit), range, slice, pc, trace_state, fwd_mr);
+        return std::make_unique<read_context>(*this, s, std::move(permit), range, slice, gc_state, pc, trace_state, fwd_mr);
     };
 
     if (query::is_single_partition(range) && !fwd_mr) {


### PR DESCRIPTION
- check and remove expired tombstones on read from row cache
- prevent populating cache with expired rows from sstables (compact on read) - maybe we should apply this in separate patch?

there are few questions in code comments

Refs #2252
Fixes #6033