### PR TITLE
prevent populating cache with expired rows from sstables

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1470,7 +1470,7 @@ table::sstables_as_snapshot_source() {
             return make_compacting_reader(
                 std::move(reader),
                 gc_clock::now(),
-                [](const dht::decorated_key&) { return api::min_timestamp; },
+                [](const dht::decorated_key&) { return api::max_timestamp; },
                 _compaction_manager.get_tombstone_gc_state(),
                 fwd);
         }, [this, sst_set] {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3391,9 +3391,11 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         cf->start();
         cf->set_compaction_strategy(sstables::compaction_strategy_type::null);
 
+        // since we use compacting_reader expired tombstones shouldn't be read from sstables
+        // so we just check there are no live (resurrected for this test) rows in partition
         auto is_partition_dead = [&s, &cf, &env] (partition_key& pkey) {
             replica::column_family::const_mutation_partition_ptr mp = cf->find_partition_slow(s, env.make_reader_permit(), pkey).get0();
-            return mp && bool(mp->partition_tombstone());
+            return mp && mp->live_row_count(*s, gc_clock::time_point::max()) == 0;
         };
 
         cf->add_sstable_and_update_cache(non_expired_sst).get();


### PR DESCRIPTION
change row purge condition for compacting_reader to remove all expired
rows to avoid read perfomance problems when there are many expired
tombstones in row cache

Refs #2252