### PR TITLE
test.py: handle broken clusters for Python suite

### DIFF
--- a/test/pylib/pool.py
+++ b/test/pylib/pool.py
@@ -91,14 +91,18 @@ class Pool(Generic[T]):
         class Instance:
             def __init__(self, pool):
                 self.pool = pool
+                self._discard = False
 
             async def __aenter__(self):
                 self.obj = await self.pool.get(*args, **kwargs)
                 return self.obj
 
             async def __aexit__(self, exc_type, exc, obj):
-                if self.obj:
+                if not self._discard and self.obj:
                     await self.pool.put(self.obj)
                     self.obj = None
+
+            def discard(self):
+                self._discard = True
 
         return Instance(self)


### PR DESCRIPTION
If the after test check fails (is_after_test_ok is False), discard the cluster and raise exception so context manager (pool) does not recycle it.

Ignore exception re-raised by the context manager.

Fixes #12360