### PR TITLE
gdb: Introduce 'scylla range-tombstones' command

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -906,20 +906,26 @@ class managed_bytes_printer(gdb.printing.PrettyPrinter):
     def __init__(self, val):
         self.val = val
 
-    def bytes(self):
+    def pure_bytes(self):
         inf = gdb.selected_inferior()
-        def to_hex(data, size):
-            return bytes(inf.read_memory(data, size)).hex()
+        def to_bytes(data, size):
+            return bytes(inf.read_memory(data, size))
 
         if self.val['_u']['small']['size'] >= 0:
-            return to_hex(self.val['_u']['small']['data'], int(self.val['_u']['small']['size']))
+            return to_bytes(self.val['_u']['small']['data'], int(self.val['_u']['small']['size']))
         else:
             ref = self.val['_u']['ptr']
             chunks = list()
             while ref['ptr']:
-                chunks.append(to_hex(ref['ptr']['data'], int(ref['ptr']['frag_size'])))
+                chunks.append(to_bytes(ref['ptr']['data'], int(ref['ptr']['frag_size'])))
                 ref = ref['ptr']['next']
-            return ''.join(chunks)
+            return b''.join(chunks)
+
+    def bytes_as_hex(self):
+        return self.pure_bytes().hex()
+
+    def bytes(self):
+        return self.bytes_as_hex()
 
     def to_string(self):
         return str(self.bytes())

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4882,6 +4882,114 @@ class scylla_compaction_tasks(gdb.Command):
         gdb.write('Total: {} instances of compaction_manager::task\n'.format(len(task_list)))
 
 
+class Schema(object):
+    def __init__(self, schema, partition_key_types, clustering_key_types):
+        self.schema = schema
+        self.partition_key_types = partition_key_types
+        self.clustering_key_types = clustering_key_types
+        self.cql_type_deserializers = dict()
+
+    def get_cql_type_deserializer(self, type_name):
+        if type_name in self.cql_type_deserializers:
+            return self.cql_type_deserializers[type_name]
+
+        if type_name == '"org.apache.cassandra.db.marshal.UTF8Type"':
+            d = lambda b: b.decode('utf-8')
+        else:
+            raise Exception(f'Deserializer for {type_name} not implemented')
+
+        self.cql_type_deserializers[type_name] = d
+        return d
+
+    """key must be a reference to an instance of clustering_key.
+    Returns a list of values of key components. 
+    The object sorts the same as the clustering key.
+    """
+    def parse_clustering_key(self, key):
+        b = managed_bytes_printer(key['_bytes']).pure_bytes()
+        return self.parse_clustering_key_bytes(b)
+
+    """key must be a reference to an instance of partition_key.
+    
+    Returns a list of values of key components. 
+    The object sorts the same as the partition key.
+    """
+    def parse_partition_key(self, key):
+        b = managed_bytes_printer(key['_bytes']).pure_bytes()
+        return self.parse_partition_key_bytes(b)
+
+    """b is a bytes object representing a clustering_key in memory"""
+    def parse_clustering_key_bytes(self, b):
+        return self.parse_key_bytes(self.clustering_key_types, b)
+
+    """b is a bytes object representing a partition_key in memory"""
+    def parse_partition_key_bytes(self, b):
+        return self.parse_key_bytes(self.partition_key_types, b)
+
+    def deserialize_cql_value(self, abstract_type, b):
+        return self.get_cql_type_deserializer(str(abstract_type['_name']))(b)
+
+    """b is a byte representation of a compound object"""
+    def parse_key_bytes(self, types, b):
+        offset = 0
+        type_nr = 0
+        components = list()
+        while offset < len(b):
+            component_size = int.from_bytes(b[offset:(offset+2)], byteorder='big')
+            offset += 2
+            components.append(self.deserialize_cql_value(types[type_nr], b[offset:(offset+component_size)]))
+            offset += component_size
+            type_nr += 1
+        return components
+
+
+current_schema = None
+
+
+def get_current_schema():
+    if not current_schema:
+        raise Exception('Current schema not set. Use \"scylla set-schema\" to set it.')
+    return current_schema
+
+
+class scylla_set_schema(gdb.Command):
+    """Sets the current schema to be used by schema-aware commands.
+
+    Setting the schema allows some commands and printers to interpret schema-dependent objects and present them
+    in a more friendly form.
+
+    Some commands require schema to work and will fail otherwise.
+    """
+
+    def __init__(self):
+        gdb.Command.__init__(self, 'scylla set-schema', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
+
+    def get_abstract_types(self, key_type):
+        return [seastar_shared_ptr(key_type).get().dereference() for key_type in std_vector(key_type['_types'])]
+
+    def invoke(self, schema, from_tty):
+        global current_schema
+        if not schema:
+            current_schema = None
+            return
+        schema = gdb.parse_and_eval(schema)
+        typ = schema.type.strip_typedefs()
+        if typ.code == gdb.TYPE_CODE_PTR or typ.code == gdb.TYPE_CODE_REF or typ.code == gdb.TYPE_CODE_RVALUE_REF:
+            schema = schema.referenced_value()
+            typ = schema.type
+        if typ.name.startswith('seastar::lw_shared_ptr<'):
+            schema = seastar_lw_shared_ptr(schema).get().dereference()
+            typ = schema.type
+
+        raw_schema = schema['_raw']
+
+        gdb.write('(schema*) 0x{:x} ks={} cf={} id={} version={}\n'.format(int(schema.address), raw_schema['_ks_name'], raw_schema['_cf_name'], raw_schema['_id'], raw_schema['_version']))
+
+        partition_key_type = self.get_abstract_types(seastar_lw_shared_ptr(schema['_partition_key_type']).get().dereference())
+        clustering_key_type = self.get_abstract_types(seastar_lw_shared_ptr(schema['_clustering_key_type']).get().dereference())
+        current_schema = Schema(schema, partition_key_type, clustering_key_type)
+
+
 class scylla_schema(gdb.Command):
     """Pretty print a schema
 
@@ -5522,6 +5630,7 @@ scylla_features()
 scylla_repairs()
 scylla_small_objects()
 scylla_compaction_tasks()
+scylla_set_schema()
 scylla_schema()
 scylla_read_stats()
 scylla_get_config_value()


### PR DESCRIPTION
Prints and validates range tombstones in a given container.

Currently supported containers:

 - mutation_partition

Example:
```
    (gdb) scylla range-tombstones $mp
    {
      start: ['a', 'b'],
      kind: bound_kind::excl_start,
      end: ['a', 'b'],
      kind: bound_kind::incl_end,
      t: {timestamp = 1672546889091665, deletion_time = {__d = {__r = 1672546889}}}
    }
    {
      start: ['a', 'b'],
      kind: bound_kind::excl_start,
      end: ['a', 'c']
      kind: bound_kind::incl_end,
      t: {timestamp = 1673731764010123, deletion_time = {__d = {__r = 1673731764}}}
    }
```