### PR TITLE
mutation_compactor: only pass consumed range-tombstone-change to validator

### DIFF
--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -177,7 +177,6 @@ private:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration do_consume(range_tombstone_change&& rtc, Consumer& consumer, GCConsumer& gc_consumer) {
-        _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
         stop_iteration gc_consumer_stop = stop_iteration::no;
         stop_iteration consumer_stop = stop_iteration::no;
         if (rtc.tombstone() <= _partition_tombstone) {
@@ -199,6 +198,7 @@ private:
             partition_is_not_empty(consumer);
             _current_emitted_tombstone = rtc.tombstone();
             consumer_stop = consumer.consume(std::move(rtc));
+            _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
         }
         return gc_consumer_stop || consumer_stop;
     }


### PR DESCRIPTION
Currently all consumed range tombstone changes are unconditionally forwarded to the validator. Even if they are shadowed by a higher level tombstone and/or purgable. This can result in a situation where a range tombstone change was seen by the validator but not passed to the consumer. The validator expects the range tombstone change to be closed by end-of-partition but the end fragment won't come as the tombstone was dropped, resulting in a false-positive validation failure. Fix by only passing tombstones to the validator, that are actually passed to the consumer too.

Fixes: #12575