### PR TITLE
types: is_tuple(): handle reverse types

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -735,6 +735,7 @@ bool abstract_type::is_collection() const {
 bool abstract_type::is_tuple() const {
     struct visitor {
         bool operator()(const abstract_type&) { return false; }
+        bool operator()(const reversed_type_impl& t) { return t.underlying_type()->is_tuple(); }
         bool operator()(const tuple_type_impl&) { return true; }
     };
     return visit(*this, visitor{});


### PR DESCRIPTION
Currently reverse types match the default case (false), even though they might be wrapping a tuple type. One user-visible effect of this is that a schema, which has a reversed<frozen<UDT>> clustering key component, will have this component incorrectly represented in the schema cql dump: the UDT will loose the frozen attribute. When attempting to recreate this schema based on the dump, it will fail as the only frozen UDTs are allowed in primary key components.

Fixes: #12576