### PR TITLE
reader_concurrency_semaphore_test: leak test: relax iteration limit

### DIFF
--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1266,7 +1266,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_leaks
     auto stop_sem = deferred_stop(semaphore);
 
     const size_t reader_count_target = 6;
-    const size_t iteration_limit = 100;
+    const size_t iteration_limit = 1000;
 
     std::list<allocating_reader> readers;
 


### PR DESCRIPTION
This test creates random dummy reads and simulates a query with them. The test works in terms of iteration (tick), advancing each simulating read in each iteration. To prevent infinite runtime an iteration limit of 100 was added to detect a non-converging test and kill it. This limit proved too strict however and in this patch we bump it to 1000 to prevent some unlucky seed making this test fail, as seen recently in CI.