### PR TITLE
[Backport] docs: fix problems with Raft documentation for 5.1

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/index.rst
+++ b/docs/operating-scylla/procedures/cluster-management/index.rst
@@ -102,4 +102,4 @@ Cluster Management Procedures
 
   Procedures for handling failures and practical examples of different scenarios.
 
-  * :ref:`Handling Failures<raft-handliing-failures>`
+  * :ref:`Handling Failures<raft-handling-failures>`


### PR DESCRIPTION
Fix some problems in the 5.1 documentation, e.g. it is not possible to enable Raft in an existing cluster in 5.0, but the documentation claimed that it is.

(cherry picked from commit 1cc68b262ed545f1e52f931f69b90473c2f987b2)

Cherry-pick note: the original commit added a lot of new stuff like describing the Raft upgrade procedure, but also fixed problems with the existing documentation. In this backport we include only the latter.