### PR TITLE
doc: add the general upgrade policy

### DIFF
--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -25,11 +25,10 @@ successive X.Y version. For example, to upgrade from version 4.4 to 5.0, you sho
    <div class="panel callout radius animated">
             <div class="row">
               <div class="medium-3 columns">
-                <h5 id="getting-started">Upgrade Scylla</h5>
+                <h5 id="getting-started">Procedures for upgrading ScyllaDB</h5>
               </div>
               <div class="medium-9 columns">
 
-Procedures for upgrading Scylla.
 
 * :doc:`Upgrade ScyllaDB Enterprise <upgrade-enterprise/index>`
 

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -11,6 +11,14 @@ Upgrade ScyllaDB
    ScyllaDB Open Source to ScyllaDB Enterprise <upgrade-to-enterprise/index>
    ScyllaDB AMI <ami-upgrade>
 
+
+ScyllaDB upgrade is a rolling procedure - it does not require a full cluster shutdown and is performed without any 
+downtime or disruption of service.
+
+To ensure a successful upgrade and avoid breaking anything, you should perform your upgrades consecutively - to each 
+successive X.Y version. For example, to upgrade from version 4.4 to 5.0, you should first upgrade ScyllaDB to version 
+4.5, next from 4.5 to 4.6, and finally, from 4.6 to 5.0, **without skipping any major version**.
+
 .. raw:: html
 
 


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-docs/issues/3968

This PR adds the information that an upgrade to each successive major version is required to upgrade from an old ScyllaDB version.