### PR TITLE
Remove qctx from system_keyspace::increment_and_get_generation()

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3023,28 +3023,28 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
 future<int> system_keyspace::increment_and_get_generation() {
     auto req = format("SELECT gossip_generation FROM system.{} WHERE key='{}'", LOCAL, LOCAL);
     auto rs = co_await qctx->qp().execute_internal(req, cql3::query_processor::cache_internal::yes);
-        int generation;
-        if (rs->empty() || !rs->one().has("gossip_generation")) {
-            // seconds-since-epoch isn't a foolproof new generation
-            // (where foolproof is "guaranteed to be larger than the last one seen at this ip address"),
-            // but it's as close as sanely possible
-            generation = utils::get_generation_number();
+    int generation;
+    if (rs->empty() || !rs->one().has("gossip_generation")) {
+        // seconds-since-epoch isn't a foolproof new generation
+        // (where foolproof is "guaranteed to be larger than the last one seen at this ip address"),
+        // but it's as close as sanely possible
+        generation = utils::get_generation_number();
+    } else {
+        // Other nodes will ignore gossip messages about a node that have a lower generation than previously seen.
+        int stored_generation = rs->one().template get_as<int>("gossip_generation") + 1;
+        int now = utils::get_generation_number();
+        if (stored_generation >= now) {
+            slogger.warn("Using stored Gossip Generation {} as it is greater than current system time {}."
+                        "See CASSANDRA-3654 if you experience problems", stored_generation, now);
+            generation = stored_generation;
         } else {
-            // Other nodes will ignore gossip messages about a node that have a lower generation than previously seen.
-            int stored_generation = rs->one().template get_as<int>("gossip_generation") + 1;
-            int now = utils::get_generation_number();
-            if (stored_generation >= now) {
-                slogger.warn("Using stored Gossip Generation {} as it is greater than current system time {}."
-                            "See CASSANDRA-3654 if you experience problems", stored_generation, now);
-                generation = stored_generation;
-            } else {
-                generation = now;
-            }
+            generation = now;
         }
-        req = format("INSERT INTO system.{} (key, gossip_generation) VALUES ('{}', ?)", LOCAL, LOCAL);
-        co_await qctx->qp().execute_internal(req, {generation}, cql3::query_processor::cache_internal::yes);
-        co_await force_blocking_flush(LOCAL);
-        co_return generation;
+    }
+    req = format("INSERT INTO system.{} (key, gossip_generation) VALUES ('{}', ?)", LOCAL, LOCAL);
+    co_await qctx->qp().execute_internal(req, {generation}, cql3::query_processor::cache_internal::yes);
+    co_await force_blocking_flush(LOCAL);
+    co_return generation;
 }
 
 mutation system_keyspace::make_size_estimates_mutation(const sstring& ks, std::vector<system_keyspace::range_estimates> estimates) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3022,7 +3022,7 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
 
 future<int> system_keyspace::increment_and_get_generation() {
     auto req = format("SELECT gossip_generation FROM system.{} WHERE key='{}'", LOCAL, LOCAL);
-    auto rs = co_await qctx->qp().execute_internal(req, cql3::query_processor::cache_internal::yes);
+    auto rs = co_await _qp.local().execute_internal(req, cql3::query_processor::cache_internal::yes);
     int generation;
     if (rs->empty() || !rs->one().has("gossip_generation")) {
         // seconds-since-epoch isn't a foolproof new generation
@@ -3042,7 +3042,7 @@ future<int> system_keyspace::increment_and_get_generation() {
         }
     }
     req = format("INSERT INTO system.{} (key, gossip_generation) VALUES ('{}', ?)", LOCAL, LOCAL);
-    co_await qctx->qp().execute_internal(req, {generation}, cql3::query_processor::cache_internal::yes);
+    co_await _qp.local().execute_internal(req, {generation}, cql3::query_processor::cache_internal::yes);
     co_await force_blocking_flush(LOCAL);
     co_return generation;
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -365,7 +365,7 @@ public:
 
     static future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
 
-    static future<int> increment_and_get_generation();
+    future<int> increment_and_get_generation();
     bool bootstrap_needed() const;
     bool bootstrap_complete() const;
     bool bootstrap_in_progress() const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -445,7 +445,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
 
     slogger.info("Starting up server gossip");
 
-    auto generation_number = co_await db::system_keyspace::increment_and_get_generation();
+    auto generation_number = co_await _sys_ks.local().increment_and_get_generation();
     auto advertise = gms::advertise_myself(!replacing_a_node_with_same_ip);
     co_await _gossiper.start_gossiping(generation_number, app_states, advertise);
 


### PR DESCRIPTION
It's a simple helper used during boot-time that can enjoy query-processor from sharded<system_keyspace>