### PR TITLE
table: compaction_group_for_token: use signed arithmetic

### DIFF
--- a/dht/token.cc
+++ b/dht/token.cc
@@ -271,4 +271,21 @@ dht::token find_first_token_for_shard(
     }
 }
 
+size_t
+compaction_group_of(unsigned most_significant_bits, const token& t) {
+    if (!most_significant_bits) {
+        return 0;
+    }
+    switch (t._kind) {
+        case token::kind::before_all_keys:
+            return 0;
+        case token::kind::after_all_keys:
+            return (1 << most_significant_bits) - 1;
+        case token::kind::key:
+            uint64_t adjusted = unbias(t);
+            return adjusted >> (64 - most_significant_bits);
+    }
+    __builtin_unreachable();
+}
+
 } // namespace dht

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -218,4 +218,6 @@ inline bool operator<=(const token& t1, const token& t2) { return std::rel_ops::
 inline bool operator>=(const token& t1, const token& t2) { return std::rel_ops::operator>=(t1, t2); }
 std::ostream& operator<<(std::ostream& out, const token& t);
 
+size_t compaction_group_of(unsigned most_significant_bits, const token& t);
+
 } // namespace dht

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -521,14 +521,10 @@ compaction_group* table::single_compaction_group_if_available() const noexcept {
 }
 
 compaction_group& table::compaction_group_for_token(dht::token token) const noexcept {
-    unsigned idx = 0;
-    // avoids shift by 64.
-    if (_x_log2_compaction_groups) {
-        auto value = dht::token::to_int64(token);
-        auto mask = (1 << _x_log2_compaction_groups) - 1;
-        idx = (value >> (64 - _x_log2_compaction_groups)) & mask;
+    auto idx = dht::compaction_group_of(_x_log2_compaction_groups, token);
+    if (idx >= _compaction_groups.size()) {
+        on_fatal_internal_error(tlogger, format("compaction_group_for_token: index out of range: idx={} size_log2={} size={} token={}", idx, _x_log2_compaction_groups, _compaction_groups.size(), token));
     }
-    assert(idx < _compaction_groups.size());
     return *_compaction_groups[idx];
 }
 


### PR DESCRIPTION
Add and use dht::compaction_group_of that computes the compaction_group index by unbiasing the token,
similar to dht::shard_of.

This way, all tokens in `_compaction_groups[i]` are ordered before `_compaction_groups[j]` iff i < j.

Fixes #12595

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>