### PR TITLE
dist: fix scylla-housekeeping strict umask support

### DIFF
--- a/dist/common/systemd/scylla-housekeeping-daily.service
+++ b/dist/common/systemd/scylla-housekeeping-daily.service
@@ -3,10 +3,12 @@ Description=Scylla Housekeeping daily mode
 After=network.target
 
 [Service]
+PermissionsStartOnly=true
 Type=simple
 User=scylla
 Group=scylla
 EnvironmentFile=/etc/sysconfig/scylla-housekeeping
+ExecStartPre=/bin/bash -c '/usr/bin/chmod 644 $REPO_FILES'
 ExecStart=/opt/scylladb/scripts/scylla-housekeeping --uuid-file $UUID_FILE -q -c $CONFIG_FILE --repo-files $REPO_FILES version --mode d
 Slice=scylla-helper.slice
 

--- a/dist/common/systemd/scylla-housekeeping-restart.service
+++ b/dist/common/systemd/scylla-housekeeping-restart.service
@@ -3,10 +3,12 @@ Description=Scylla Housekeeping restart mode
 After=network.target
 
 [Service]
+PermissionsStartOnly=true
 Type=simple
 User=scylla
 Group=scylla
 EnvironmentFile=/etc/sysconfig/scylla-housekeeping
+ExecStartPre=/bin/bash -c '/usr/bin/chmod 644 $REPO_FILES'
 ExecStart=/opt/scylladb/scripts/scylla-housekeeping --uuid-file $UUID_FILE -q -c $CONFIG_FILE --repo-files $REPO_FILES version --mode r
 
 [Install]


### PR DESCRIPTION
Currently, scylla-housekeeping will cause error if user downloads repo file after scylla_setup executed, on strict umask setting. To fix the issue, we need to run chmod on ExecStartPre of scylla-housekeeping services.

Fixes #12610