### PR TITLE
test.py: manual cluster pool handling for Python suite

### DIFF
--- a/test.py
+++ b/test.py
@@ -859,7 +859,10 @@ class PythonTest(Test):
                 if self.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))
-                    # Don't try to continue if the cluster is broken
+                    logger.info(f"Discarding cluster after failed start for test %s...", self.name)
+                    await self.suite.clusters.steal()
+                    await cluster.stop()
+                    await cluster.release_ips()
                     cm.discard()
                 elif self.is_after_test_ok is False:
                     print("Test {} post-check failed: {}".format(self.name, str(e)))

--- a/test.py
+++ b/test.py
@@ -861,7 +861,7 @@ class PythonTest(Test):
                     print("Server log of the first server:\n{}".format(self.server_log))
                     # Don't try to continue if the cluster is broken
                     cm.discard()
-                if self.is_after_test_ok is False:
+                elif self.is_after_test_ok is False:
                     print("Test {} post-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))
                     logger.info(f"Discarding cluster after failed test %s...", self.name)

--- a/test/pylib/pool.py
+++ b/test/pylib/pool.py
@@ -91,18 +91,14 @@ class Pool(Generic[T]):
         class Instance:
             def __init__(self, pool):
                 self.pool = pool
-                self._discard = False
 
             async def __aenter__(self):
                 self.obj = await self.pool.get(*args, **kwargs)
                 return self.obj
 
             async def __aexit__(self, exc_type, exc, obj):
-                if not self._discard and self.obj:
+                if self.obj:
                     await self.pool.put(self.obj)
                     self.obj = None
-
-            def discard(self):
-                self._discard = True
 
         return Instance(self)


### PR DESCRIPTION
From reviews of https://github.com/scylladb/scylladb/pull/12569, avoid using `async with` and access the `Pool` of clusters with `get()`/`put()`.