### PR TITLE
alterator::streams: Sort tables in list_streams to ensure no duplicates

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -140,7 +140,7 @@ namespace alternator {
 future<alternator::executor::request_return_type> alternator::executor::list_streams(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.list_streams++;
 
-    auto limit = rjson::get_opt<int>(request, "Limit").value_or(std::numeric_limits<int>::max());
+    auto limit = rjson::get_opt<int>(request, "Limit").value_or(100);
     auto streams_start = rjson::get_opt<stream_arn>(request, "ExclusiveStartStreamArn");
     auto table = find_table(_proxy, request);
     auto db = _proxy.data_dictionary();

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -154,9 +154,11 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     // generate duplicates in a paged listing here. Can obviously miss things if they 
     // are added between paged calls and end up with a "smaller" UUID/ARN, but that 
     // is to be expected.
-    std::sort(cfs.begin(), cfs.end(), [](const data_dictionary::table& t1, const data_dictionary::table& t2) {
-        return t1.schema()->id().uuid() < t2.schema()->id().uuid();
-    });
+    if ((limit < cfs.size() && !table) || streams_start) {
+        std::sort(cfs.begin(), cfs.end(), [](const data_dictionary::table& t1, const data_dictionary::table& t2) {
+            return t1.schema()->id().uuid() < t2.schema()->id().uuid();
+        });
+    }
 
     auto i = cfs.begin();
     auto e = cfs.end();

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -34,6 +34,7 @@
 
 #include "executor.hh"
 #include "rmw_operation.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 /**
  * Base template type to implement  rapidjson::internal::TypeHelper<...>:s
@@ -144,17 +145,29 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     auto streams_start = rjson::get_opt<stream_arn>(request, "ExclusiveStartStreamArn");
     auto table = find_table(_proxy, request);
     auto db = _proxy.data_dictionary();
-    auto cfs = db.get_tables();
 
     if (limit < 1) {
         throw api_error::validation("Limit must be 1 or more");
+    }
+
+    std::vector<data_dictionary::table> cfs;
+
+    if (table) {
+        auto log_name = cdc::log_name(table->cf_name());
+        try {
+            cfs.emplace_back(db.find_table(table->ks_name(), log_name));
+        } catch (data_dictionary::no_such_column_family&) {
+            cfs.clear();
+        }
+    } else {
+        cfs = db.get_tables();
     }
 
     // # 12601 (maybe?) - sort the set of tables on ID. This should ensure we never
     // generate duplicates in a paged listing here. Can obviously miss things if they 
     // are added between paged calls and end up with a "smaller" UUID/ARN, but that 
     // is to be expected.
-    if ((limit < cfs.size() && !table) || streams_start) {
+    if (limit < cfs.size() || streams_start) {
         std::sort(cfs.begin(), cfs.end(), [](const data_dictionary::table& t1, const data_dictionary::table& t2) {
             return t1.schema()->id().uuid() < t2.schema()->id().uuid();
         });
@@ -188,14 +201,7 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
         if (!is_alternator_keyspace(ks_name)) {
             continue;
         }
-        if (table && ks_name != table->ks_name()) {
-            continue;
-        }
         if (cdc::is_log_for_some_table(db.real_database(), ks_name, cf_name)) {
-            if (table && table != cdc::get_base_table(db.real_database(), *s)) {
-                continue;
-            }
-
             rjson::value new_entry = rjson::empty_object();
 
             last = i->schema()->id();

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -145,19 +145,24 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     auto table = find_table(_proxy, request);
     auto db = _proxy.data_dictionary();
     auto cfs = db.get_tables();
-    auto i = cfs.begin();
-    auto e = cfs.end();
 
     if (limit < 1) {
         throw api_error::validation("Limit must be 1 or more");
     }
 
-    // TODO: the unordered_map here is not really well suited for partial
-    // querying - we're sorting on local hash order, and creating a table
-    // between queries may or may not miss info. But that should be rare,
-    // and we can probably expect this to be a single call.
+    // # 12601 (maybe?) - sort the set of tables on ID. This should ensure we never
+    // generate duplicates in a paged listing here. Can obviously miss things if they 
+    // are added between paged calls and end up with a "smaller" UUID/ARN, but that 
+    // is to be expected.
+    std::sort(cfs.begin(), cfs.end(), [](const data_dictionary::table& t1, const data_dictionary::table& t2) {
+        return t1.schema()->id().uuid() < t2.schema()->id().uuid();
+    });
+
+    auto i = cfs.begin();
+    auto e = cfs.end();
+
     if (streams_start) {
-        i = std::find_if(i, e, [&](data_dictionary::table t) {
+        i = std::find_if(i, e, [&](const data_dictionary::table& t) {
             return t.schema()->id().uuid() == streams_start
                 && cdc::get_base_table(db.real_database(), *t.schema())
                 && is_alternator_keyspace(t.schema()->ks_name())


### PR DESCRIPTION
Fixes #12601 (maybe?)

Sort the set of tables on ID. This should ensure we never generate duplicates in a paged listing here. Can obviously miss things if they are added between paged calls and end up with a "smaller" UUID/ARN, but that is to be expected.