### PR TITLE
doc: remove duplicatiom of the ScyllaDB ports (table)

### DIFF
--- a/docs/operating-scylla/_common/networking-ports.rst
+++ b/docs/operating-scylla/_common/networking-ports.rst
@@ -27,4 +27,4 @@ Port    Description                                   Protocol
 19142   Native shard-aware transport port  (ssl)         TCP
 ======  ============================================  ========
 
-.. note:: For ScyllaDB Manager ports, see `Scylla Manager <https://manager.docs.scylladb.com/>`.
+.. note:: For ScyllaDB Manager ports, see the `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_ documentation.

--- a/docs/operating-scylla/_common/networking-ports.rst
+++ b/docs/operating-scylla/_common/networking-ports.rst
@@ -1,5 +1,5 @@
 
-Scylla uses the following ports:
+ScyllaDB uses the following ports:
 
 ======  ============================================  ========
 Port    Description                                   Protocol
@@ -27,4 +27,4 @@ Port    Description                                   Protocol
 19142   Native shard-aware transport port  (ssl)         TCP
 ======  ============================================  ========
 
-.. note:: For Scylla Manager ports, see `Scylla Manager <https://manager.docs.scylladb.com/>`.
+.. note:: For ScyllaDB Manager ports, see `Scylla Manager <https://manager.docs.scylladb.com/>`.

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -133,7 +133,7 @@ Scylla versions 1.1 and greater support encryption between nodes and between cli
 Networking
 ----------
 
-The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com/>`_.
+The ScyllaDB ports are detailed in the table below. For ScyllaDB Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com/>`_.
 
 .. image:: /operating-scylla/security/Scylla-Ports2.png
 

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -133,11 +133,9 @@ Scylla versions 1.1 and greater support encryption between nodes and between cli
 Networking
 ----------
 
-.. include:: /operating-scylla/_common/networking-ports.rst
+The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com/>`_.
 
 .. image:: /operating-scylla/security/Scylla-Ports2.png
-
-The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com/>`_.
 
 .. include:: /operating-scylla/_common/networking-ports.rst
 


### PR DESCRIPTION
Fix https://github.com/scylladb/scylladb/issues/12605#event-8328930604

This PR removes the duplicated content (the file with the table was included twice) and reorganizes the content in the Networking section.