### PR TITLE
build: don't force-disable io_uring in Seastar

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1605,7 +1605,6 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
-        '-DSeastar_IO_URING=OFF', # Fedora 34's liburing is too old
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:


### PR DESCRIPTION
The reasons for force-disabling are doubly wrong: we now use liburing from Fedora 37, which is sufficiently recent, and the auto-detection code will disable io_uring if a sufficiently recent version isn't present.