### PR TITLE
Make regexes in types.cc static and remove unnecessary tolower transform

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -352,14 +352,12 @@ static uint32_t serialize(const std::string& input, int64_t days) {
     return static_cast<uint32_t>(days);
 }
 uint32_t simple_date_type_impl::from_sstring(sstring_view s) {
-    std::string str;
-    str.resize(s.size());
-    std::transform(s.begin(), s.end(), str.begin(), ::tolower);
     char* end;
     auto v = std::strtoll(s.begin(), &end, 10);
     if (end == s.begin() + s.size()) {
         return v;
     }
+    auto str = std::string(s); // FIXME: this copy probably can be avoided
     static const std::regex date_re("^(-?\\d+)-(\\d+)-(\\d+)");
     std::smatch dsm;
     if (!std::regex_match(str, dsm, date_re)) {

--- a/types.cc
+++ b/types.cc
@@ -298,7 +298,7 @@ int64_t timestamp_from_string(sstring_view s) {
             return v;
         }
 
-        std::regex date_re("^(\\d{4})-(\\d+)-(\\d+)([ tT](\\d+):(\\d+)(:(\\d+)(\\.(\\d+))?)?)?");
+        static const std::regex date_re("^(\\d{4})-(\\d+)-(\\d+)([ tT](\\d+):(\\d+)(:(\\d+)(\\.(\\d+))?)?)?");
         std::smatch dsm;
         if (!std::regex_search(str, dsm, date_re)) {
             throw marshal_exception(format("Unable to parse timestamp from '{}'", str));
@@ -306,7 +306,7 @@ int64_t timestamp_from_string(sstring_view s) {
         auto t = get_time(dsm);
 
         auto tz = dsm.suffix().str();
-        std::regex tz_re("([\\+-]\\d{2}:?(\\d{2})?)");
+        static const std::regex tz_re("([\\+-]\\d{2}:?(\\d{2})?)");
         std::smatch tsm;
         if (std::regex_match(tz, tsm, tz_re)) {
             t -= get_utc_offset(tsm.str());
@@ -360,7 +360,7 @@ uint32_t simple_date_type_impl::from_sstring(sstring_view s) {
     if (end == s.begin() + s.size()) {
         return v;
     }
-    static std::regex date_re("^(-?\\d+)-(\\d+)-(\\d+)");
+    static const std::regex date_re("^(-?\\d+)-(\\d+)-(\\d+)");
     std::smatch dsm;
     if (!std::regex_match(str, dsm, date_re)) {
         throw marshal_exception(format("Unable to coerce '{}' to a formatted date (long)", str));


### PR DESCRIPTION
- makes all regexes static

If making regex compilation static
for uuid_type_impl and timeuuid_type_impl helps then it should
also help for timestamp_type and simple_date_type.

-  remove unnecessary tolower transform in simple_date_type_impl::from_sstring

Following function uses only decimal and '-' characters (see date_re). They are not
affected by tolower call in any way.

Aditionally std::strtoll supports "0x" prefixes but also accepts
upper case version "0X" so it's also not affected by tolower call.

get_simple_date_time only casts strings to integer types using
boost:lexical_cast so also not affected by tolower.

Finally, serialize only uses str to include it in an exception text
so tolower doesn't affect it in a positive way. It's even better
that input is displayed to the user as it was, not converted to lower
case.
