### PR TITLE
tools/schema_loader: data_dictionary_impl:try_find_table(): also check ks name

### DIFF
--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -113,7 +113,7 @@ private:
     }
     virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db, std::string_view ks, std::string_view tab) const override {
         auto& tables = unwrap(db).tables;
-        auto it = std::find_if(tables.begin(), tables.end(), [tab] (const table& tbl) { return tbl.schema->cf_name() == tab; });
+        auto it = std::find_if(tables.begin(), tables.end(), [ks, tab] (const table& tbl) { return tbl.schema->ks_name() == ks && tbl.schema->cf_name() == tab; });
         if (it == tables.end()) {
             return {};
         }


### PR DESCRIPTION
Although the number of keyspaces should mostly be 1 here, and thus the chance of two tables from different keyspaces colliding is miniscule, it is not zero. Better be safe than sorry, so match the keyspace name too when looking up a table.