### PR TITLE
pytest: start after ungraceful stop

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -102,6 +102,8 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
 
         'reader_concurrency_semaphore_serialize_limit_multiplier': 0,
         'reader_concurrency_semaphore_kill_limit_multiplier': 0,
+
+        'force_schema_commit_log': True,
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line

--- a/test/topology/test_topology.py
+++ b/test/topology/test_topology.py
@@ -372,3 +372,14 @@ async def test_remove_node_with_concurrent_ddl(manager, random_tables):
         stopped = True
         await ddl_task
         logger.debug("ddl fiber done, finished")
+
+
+@pytest.mark.asyncio
+async def test_start_after_sudden_stop(manager: ManagerClient, random_tables) -> None:
+    """Tests a server can rejoin the cluster after being stopped suddenly"""
+    servers = await manager.running_servers()
+    table = await random_tables.add_table(ncolumns=5)
+    await manager.server_stop(servers[0].server_id)
+    await table.add_column()
+    await manager.server_start(servers[0].server_id)
+    await random_tables.verify_schema()


### PR DESCRIPTION
If a server is stopped suddenly (i.e. not graceful), commitlog might be in inconsistent state. Add a test case and enable Scylla configuration options to handle this.

Fixes https://github.com/scylladb/scylladb/issues/12218