### PR TITLE
dht: incremental_owned_ranges_checker: belongs_to_current_node: mark as const

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1176,7 +1176,7 @@ private:
 
 class cleanup_compaction final : public regular_compaction {
     owned_ranges_ptr _owned_ranges;
-    mutable dht::incremental_owned_ranges_checker _owned_ranges_checker;
+    dht::incremental_owned_ranges_checker _owned_ranges_checker;
 private:
     // Called in a seastar thread
     dht::partition_range_vector

--- a/dht/partition_filter.hh
+++ b/dht/partition_filter.hh
@@ -24,7 +24,7 @@ public:
     }
 
     // Must be called with increasing token values.
-    bool belongs_to_current_node(const dht::token& t) {
+    bool belongs_to_current_node(const dht::token& t) const noexcept {
         // While token T is after a range Rn, advance the iterator.
         // iterator will be stopped at a range which either overlaps with T (if T belongs to node),
         // or at a range which is after T (if T doesn't belong to this node).


### PR DESCRIPTION
Its _it member keeps state about the current range. Although it's modified by the method, this is an implementation detail that irrelevant to the caller, hence mark the belongs_to_current_node method as const (and noexcept while at it).

This allows the caller, cleanup_compaction, to use it from inside a const method, without having to mark
its respective member as mutable too.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>