### PR TITLE
Add compaction module to task manager

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -380,14 +380,13 @@ private:
 
     // This constructor is suposed to only be used for testing so lets be more explicit
     // about invoking it. Ref #10146
-    compaction_manager();
+    compaction_manager(tasks::task_manager& tm);
 public:
     compaction_manager(config cfg, abort_source& as, tasks::task_manager& tm);
-    compaction_manager(config cfg, abort_source& as);
     ~compaction_manager();
     class for_testing_tag{};
     // An inline constructor for testing
-    compaction_manager(for_testing_tag) : compaction_manager() {}
+    compaction_manager(tasks::task_manager& tm, for_testing_tag) : compaction_manager(tm) {}
 
     const scheduling_group& compaction_sg() const noexcept {
         return _cfg.compaction_sched_group;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -32,6 +32,7 @@
 #include "compaction.hh"
 #include "compaction_weight_registration.hh"
 #include "compaction_backlog_manager.hh"
+#include "compaction/task_manager_module.hh"
 #include "strategy_control.hh"
 #include "backlog_controller.hh"
 #include "seastarx.hh"
@@ -244,6 +245,7 @@ public:
     class compaction_manager_test_task;
 
 private:
+    shared_ptr<compaction::task_manager_module> _task_manager_module;
     // compaction manager may have N fibers to allow parallel compaction per shard.
     std::list<shared_ptr<task>> _tasks;
 
@@ -380,6 +382,7 @@ private:
     // about invoking it. Ref #10146
     compaction_manager();
 public:
+    compaction_manager(config cfg, abort_source& as, tasks::task_manager& tm);
     compaction_manager(config cfg, abort_source& as);
     ~compaction_manager();
     class for_testing_tag{};

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "tasks/task_manager.hh"
+
+namespace compaction {
+
+class task_manager_module : public tasks::task_manager::module {
+public:
+    task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}
+};
+
+}

--- a/main.cc
+++ b/main.cc
@@ -1037,7 +1037,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
                 };
             });
-            cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source())).get();
+            cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source()), std::ref(task_manager)).get();
             auto stop_cm = deferred_stop(cm);
 
             supervisor::notify("starting database");

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -278,10 +278,18 @@ future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_p
 
 task_manager::task_manager(config cfg, class abort_source& as) noexcept
     : _cfg(std::move(cfg))
-    , _as(as)
     , _update_task_ttl_action([this] { return update_task_ttl(); })
     , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
     , _task_ttl(_cfg.task_ttl.get())
+{
+    _abort_subscription = as.subscribe([this] () noexcept {
+        _as.request_abort();
+    });
+}
+
+task_manager::task_manager() noexcept
+    : _update_task_ttl_action([this] { return update_task_ttl(); })
+    , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
 {}
 
 task_manager::modules& task_manager::get_modules() noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -47,7 +47,8 @@ private:
     task_map _all_tasks;
     modules _modules;
     config _cfg;
-    seastar::abort_source& _as;
+    seastar::abort_source _as;
+    optimized_optional<abort_source::subscription> _abort_subscription;
     serialized_action _update_task_ttl_action;
     utils::observer<uint32_t> _task_ttl_observer;
     uint32_t _task_ttl;
@@ -190,6 +191,7 @@ public:
     };
 public:
     task_manager(config cfg, abort_source& as) noexcept;
+    task_manager() noexcept;
 
     modules& get_modules() noexcept;
     const modules& get_modules() const noexcept;

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -99,7 +99,8 @@ with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::s
         auto dir = tmpdir();
         cfg.datadir = dir.path().string();
         cfg.x_log2_compaction_groups = x_log2_compaction_groups;
-        auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+        tasks::task_manager tm;
+        auto cm = make_lw_shared<compaction_manager>(tm, compaction_manager::for_testing_tag{});
         auto cl_stats = make_lw_shared<cell_locker_stats>();
         auto cf = make_lw_shared<replica::column_family>(s, cfg, replica::column_family::no_commitlog(), *cm, sm, *cl_stats, *tracker);
         cf->mark_ready_for_writes();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3022,10 +3022,10 @@ static std::vector<sstables::shared_sstable> open_sstables(test_env& env, schema
 
 static flat_mutation_reader_v2 compacted_sstable_reader(test_env& env, schema_ptr s,
                      sstring table_name, std::vector<unsigned long> generations) {
-    auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+    auto cm = make_lw_shared<compaction_manager_for_testing>(false);
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto tracker = make_lw_shared<cache_tracker>();
-    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
+    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), **cm, env.manager(), *cl_stats, *tracker);
     cf->mark_ready_for_writes();
     lw_shared_ptr<replica::memtable> mt = make_lw_shared<replica::memtable>(s);
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4647,12 +4647,14 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
         const uint64_t all_tables_disk_usage = double(available_disk_size_per_shard) * target_disk_usage;
 
         auto as = abort_source();
+
+        auto task_manager = tasks::task_manager({}, as);
         compaction_manager::config cfg = {
             .compaction_sched_group = { default_scheduling_group(), default_priority_class() },
             .maintenance_sched_group = { default_scheduling_group(), default_priority_class() },
             .available_memory = available_memory,
         };
-        auto manager = compaction_manager(std::move(cfg), as);
+        auto manager = compaction_manager(std::move(cfg), as, task_manager);
 
         auto add_sstable = [&env, &manager, gen = make_lw_shared<unsigned>(1)] (table_for_tests& t, uint64_t data_size, int level) {
             auto sst = env.make_sstable(t.schema(), "", (*gen)++, la, big);
@@ -5006,8 +5008,8 @@ SEASTAR_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
     abort_source as;
 
     auto cfg = compaction_manager::config{ .available_memory = 1 };
-
-    auto cm = compaction_manager(cfg, as);
+    auto task_manager = tasks::task_manager({}, as);
+    auto cm = compaction_manager(cfg, as, task_manager);
     cm.enable();
 
     testlog.info("requesting abort");

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -165,7 +165,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 }
 
 compaction_manager_for_testing::wrapped_compaction_manager::wrapped_compaction_manager(bool enabled)
-        : cm(compaction_manager::for_testing_tag{})
+        : cm(tm, compaction_manager::for_testing_tag{})
 {
     if (enabled) {
         cm.enable();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -322,6 +322,7 @@ public:
 // Must be used in a seastar thread
 class compaction_manager_for_testing {
     struct wrapped_compaction_manager {
+        tasks::task_manager tm;
         compaction_manager cm;
         explicit wrapped_compaction_manager(bool enabled);
         // Must run in a seastar thread

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -43,7 +43,8 @@ struct table_for_tests {
         replica::cf_stats cf_stats{0};
         replica::column_family::config cfg;
         cell_locker_stats cl_stats;
-        compaction_manager cm{compaction_manager::for_testing_tag{}};
+        tasks::task_manager tm;
+        compaction_manager cm{tm, compaction_manager::for_testing_tag{}};
         lw_shared_ptr<replica::column_family> cf;
         std::unique_ptr<table_state> table_s;
         data();

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -170,7 +170,8 @@ public:
 
                 cache_tracker tracker;
                 cell_locker_stats cl_stats;
-                auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
+                tasks::task_manager tm;
+                auto cm = make_lw_shared<compaction_manager>(tm, compaction_manager::for_testing_tag{});
                 auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), replica::column_family::no_commitlog(), *cm, env.manager(), cl_stats, tracker);
 
                 auto start = perf_sstable_test_env::now();


### PR DESCRIPTION
Introduces task manager's compaction module. That's an initial
part of integration of compaction with task manager. 

When fully integrated, task manager will allow user to track compaction 
operations, check status and progress of each individual one. It will help 
with creating an asynchronous version of rest api that forces any compaction.

Currently, users can see with /task_manager/list_modules api call that
compaction is one of the modules accessible through task manager. 
They won't get any additional information though, since compaction 
tasks are not created yet.

A shared_ptr to compaction module is kept in compaction manager.