### PR TITLE
Reduce the number of table::make_sstable() overloads

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -485,6 +485,8 @@ private:
     db_clock::time_point _truncated_at = db_clock::time_point::min();
 
     bool _is_bootstrap_or_replace = false;
+    sstables::shared_sstable make_sstable(sstring dir);
+
 public:
     data_dictionary::table as_data_dictionary() const;
 
@@ -492,10 +494,6 @@ public:
                                           sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> add_sstables_and_update_cache(const std::vector<sstables::shared_sstable>& ssts);
     future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);
-    sstables::shared_sstable make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
-            io_error_handler_gen error_handler_gen);
-    sstables::shared_sstable make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f);
-    sstables::shared_sstable make_sstable(sstring dir);
     sstables::shared_sstable make_sstable();
     void cache_truncation_record(db_clock::time_point truncated_at) {
         _truncated_at = truncated_at;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -387,19 +387,9 @@ static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {
     return shards.size() != size_t(belongs_to_current_shard(shards));
 }
 
-sstables::shared_sstable table::make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
-        io_error_handler_gen error_handler_gen) {
-    return get_sstables_manager().make_sstable(_schema, dir, generation, v, f, gc_clock::now(), error_handler_gen);
-}
-
-sstables::shared_sstable table::make_sstable(sstring dir, sstables::generation_type generation,
-        sstables::sstable_version_types v, sstables::sstable_format_types f) {
-    return get_sstables_manager().make_sstable(_schema, dir, generation, v, f);
-}
-
 sstables::shared_sstable table::make_sstable(sstring dir) {
-    return make_sstable(dir, calculate_generation_for_new_table(),
-                        get_sstables_manager().get_highest_supported_format(), sstables::sstable::format_types::big);
+    auto& sstm = get_sstables_manager();
+    return sstm.make_sstable(_schema, dir, calculate_generation_for_new_table(), sstm.get_highest_supported_format(), sstables::sstable::format_types::big);
 }
 
 sstables::shared_sstable table::make_sstable() {

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -87,7 +87,7 @@ make_sstable_for_all_shards(replica::database& db, replica::table& table, fs::pa
         m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
         mt->apply(std::move(m));
     }
-    auto sst = table.make_sstable(sstdir.native(), generation_from_value(generation++),
+    auto sst = table.get_sstables_manager().make_sstable(s, sstdir.native(), generation_from_value(generation++),
             sstables::get_highest_sstable_version(), sstables::sstable::format_types::big);
     write_memtable_to_sstable(*mt, sst, table.get_sstables_manager().configure_writer("test")).get();
     mt->clear_gently().get();
@@ -504,7 +504,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.make_sstable(upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
         }).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
       });
@@ -546,7 +546,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.make_sstable(upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
         }).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
       });
@@ -588,7 +588,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.make_sstable(upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), upload_path.native(), generation_from_value(generation), sstables::sstable::version_types::mc, sstables::sstable::format_types::big);
         }).get();
         verify_that_all_sstables_are_local(sstdir, 2 * smp::count * smp::count).get();
       });


### PR DESCRIPTION
There are several helpers to make an sstable for the table and two with most of the arguments are only used by tests. This PR leaves table with just one arg-less call thus making it easier to patch further.