### PR TITLE
tools: toolchain: dbuild: pass NOFILE limit from host to container

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -192,6 +192,7 @@ docker_common_args+=(
        --security-opt label=disable \
        --network host \
        --cap-add SYS_PTRACE \
+       --ulimit nofile=$(ulimit -Sn):$(ulimit -Hn) \
        -v "$PWD:$PWD" \
        -v "$tmpdir:/tmp" \
        -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO" \


### PR DESCRIPTION
The leak sanitizer has a bug [1] where, if it detects a leak, it forks something, and before that, it closes all files (instead of using close_range like a good citizen).

Docker tends to create containers with the NOFILE limit (number of open files) set to 1 billion.

The resulting 1 billion close() system calls is incredibly slow.

Work around that problem by passing the host NOFILE limit.

[1] https://github.com/llvm/llvm-project/issues/59112