### PR TITLE
Configure sstable_test_env with tempdir

### DIFF
--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,6 +47,7 @@ struct test_env_config {
 
 class test_env {
     struct impl {
+        tmpdir dir;
         std::unique_ptr<db::config> db_config;
         directory_semaphore dir_sem;
         cache_tracker cache_tracker;
@@ -96,6 +97,7 @@ public:
     test_env_sstables_manager& manager() { return _impl->mgr; }
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
     db::config& db_config() { return *_impl->db_config; }
+    tmpdir& tempdir() noexcept { return _impl->dir; }
 
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
         return _impl->semaphore.make_tracking_only_permit(s, n, timeout);

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,7 +47,7 @@ struct test_env_config {
 
 class test_env {
     struct impl {
-        db::config db_config;
+        std::unique_ptr<db::config> db_config;
         directory_semaphore dir_sem;
         cache_tracker cache_tracker;
         gms::feature_service feature_service;
@@ -95,7 +95,7 @@ public:
 
     test_env_sstables_manager& manager() { return _impl->mgr; }
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
-    db::config& db_config() { return _impl->db_config; }
+    db::config& db_config() { return *_impl->db_config; }
 
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
         return _impl->semaphore.make_tracking_only_permit(s, n, timeout);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -148,10 +148,16 @@ future<> table_for_tests::stop() {
 
 namespace sstables {
 
+std::unique_ptr<db::config> make_db_config() {
+    auto cfg = std::make_unique<db::config>();
+    return cfg;
+}
+
 test_env::impl::impl(test_env_config cfg)
-    : dir_sem(1)
-    , feature_service(gms::feature_config_from_db_config(db_config))
-    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
+    : db_config(make_db_config())
+    , dir_sem(1)
+    , feature_service(gms::feature_config_from_db_config(*db_config))
+    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -148,13 +148,15 @@ future<> table_for_tests::stop() {
 
 namespace sstables {
 
-std::unique_ptr<db::config> make_db_config() {
+std::unique_ptr<db::config> make_db_config(sstring temp_dir) {
     auto cfg = std::make_unique<db::config>();
+    cfg->data_file_directories.set({ temp_dir });
     return cfg;
 }
 
 test_env::impl::impl(test_env_config cfg)
-    : db_config(make_db_config())
+    : dir()
+    , db_config(make_db_config(dir.path().native()))
     , dir_sem(1)
     , feature_service(gms::feature_config_from_db_config(*db_config))
     , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)


### PR DESCRIPTION
Today's sstable_test_env starts with a default-configured db::config and, thus, sstables_manager. Test cases that run in this env always create a tempdir to store sstable files in on their own. Next patching makes sstable-manager and friends fully control the data-dir path in order to support object storage for sstables in a nice way, and this behavior of tests upsets this ongoing work.

Said that, this PR configures sstable_test_env with a tempdir and pins down the cases using it to stick to that directory, rather than to the custom one.