### PR TITLE
table: Remove unused column_family_directory() overload

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1275,11 +1275,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
 }
 
 sstring
-keyspace::column_family_directory(const sstring& name, table_id uuid) const {
-    return column_family_directory(_config.datadir, name, uuid);
-}
-
-sstring
 keyspace::column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const {
     auto uuid_sstring = uuid.to_sstring();
     boost::erase_all(uuid_sstring, "-");

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1211,7 +1211,6 @@ public:
     }
 
     sstring column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const;
-    sstring column_family_directory(const sstring& name, table_id uuid) const;
 
     future<> ensure_populated() const;
     void mark_as_populated();


### PR DESCRIPTION
There's another one that accepts explicit basedir first argument and that's used by the rest of the code.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>