### PR TITLE
doc: improve the general upgrade policy

### DIFF
--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -15,9 +15,18 @@ Upgrade ScyllaDB
 ScyllaDB upgrade is a rolling procedure - it does not require a full cluster shutdown and is performed without any 
 downtime or disruption of service.
 
-To ensure a successful upgrade and avoid breaking anything, you should perform your upgrades consecutively - to each 
-successive X.Y version. For example, to upgrade from version 4.4 to 5.0, you should first upgrade ScyllaDB to version 
-4.5, next from 4.5 to 4.6, and finally, from 4.6 to 5.0, **without skipping any major version**.
+To ensure a successful upgrade, follow the documented upgrade procedures tested by ScyllaDB. This means that:
+
+* You should perform the upgrades consecutively - to each successive X.Y version, **without skipping any major version**.
+* Before you upgrade to the next version, the whole cluster (each node) must be upgraded to the previous version.
+
+**Example**
+
+The following example shows the upgrade path for a 3-node cluster from version 4.3 to version 4.6: 
+
+#. Upgrade all three nodes to version 4.4.
+#. Upgrade all three nodes to version 4.5.
+#. Upgrade all three nodes to version 4.6.
 
 .. raw:: html
 

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -31,6 +31,11 @@ The following example shows the upgrade path for a 3-node cluster from version 4
 #. Upgrade all three nodes to version 4.5.
 #. Upgrade all three nodes to version 4.6.
 
+
+Upgrading to each patch version by following the :doc:`Scylla Maintenance Release Upgrade Guide </upgrade/upgrade-opensource/upgrade-guide-from-4.x.y-to-4.x.z/index>` 
+is optional. However, we recommend upgrading to the latest patch release for your version before upgrading to a new version. 
+For example, upgrade to patch 4.4.8 before upgrading to version 4.5.
+
 .. _upgrade-upgrade-procedures:
 
 Procedures for Upgrading ScyllaDB

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -19,7 +19,7 @@ downtime or disruption of service.
 
 To ensure a successful upgrade, follow the :ref:`documented upgrade procedures <upgrade-upgrade-procedures>` tested by ScyllaDB. This means that:
 
-* You should perform the upgrades consecutively - to each successive X.Y version, **without skipping any major version**.
+* You should perform the upgrades consecutively - to each successive X.Y version, **without skipping any major or minor version**.
 * Before you upgrade to the next version, the whole cluster (each node) must be upgraded to the previous version.
 
 Example

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -11,16 +11,19 @@ Upgrade ScyllaDB
    ScyllaDB Open Source to ScyllaDB Enterprise <upgrade-to-enterprise/index>
    ScyllaDB AMI <ami-upgrade>
 
+Overview
+---------
 
 ScyllaDB upgrade is a rolling procedure - it does not require a full cluster shutdown and is performed without any 
 downtime or disruption of service.
 
-To ensure a successful upgrade, follow the documented upgrade procedures tested by ScyllaDB. This means that:
+To ensure a successful upgrade, follow the :ref:`documented upgrade procedures <upgrade-upgrade-procedures>` tested by ScyllaDB. This means that:
 
 * You should perform the upgrades consecutively - to each successive X.Y version, **without skipping any major version**.
 * Before you upgrade to the next version, the whole cluster (each node) must be upgraded to the previous version.
 
-**Example**
+Example
+========
 
 The following example shows the upgrade path for a 3-node cluster from version 4.3 to version 4.6: 
 
@@ -28,16 +31,10 @@ The following example shows the upgrade path for a 3-node cluster from version 4
 #. Upgrade all three nodes to version 4.5.
 #. Upgrade all three nodes to version 4.6.
 
-.. raw:: html
+.. _upgrade-upgrade-procedures:
 
-
-   <div class="panel callout radius animated">
-            <div class="row">
-              <div class="medium-3 columns">
-                <h5 id="getting-started">Procedures for upgrading ScyllaDB</h5>
-              </div>
-              <div class="medium-9 columns">
-
+Procedures for Upgrading ScyllaDB
+-----------------------------------
 
 * :doc:`Upgrade ScyllaDB Enterprise <upgrade-enterprise/index>`
 
@@ -48,10 +45,6 @@ The following example shows the upgrade path for a 3-node cluster from version 4
 * :doc:`Upgrade ScyllaDB AMI <ami-upgrade>`
 
 
-.. raw:: html
 
-   </div>
-   </div>
-   </div>
 
 


### PR DESCRIPTION
Related: https://github.com/scylladb/scylladb/pull/12586

This PR improves the upgrade policy added with https://github.com/scylladb/scylladb/pull/12586, according to the feedback from:

@tzach
> Upgrading from 4.6 to 5.0 is not clear; better to use 4.x to 4.y versions as an example.

and @bhalevy
> It is not completely clear that when upgrading through several versions, the whole cluster needs to be upgraded to each consecutive version, not just the rolling node.

In addition, the content is organized into sections for the sake of readability. 
