### PR TITLE
Generalize sstable::move_to_new_dir() method

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1799,7 +1799,7 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
 
     if (validation_errors != 0) {
         for (auto& sst : *sstables->all()) {
-            co_await sst->move_to_quarantine();
+            co_await sst->change_state(sstables::quarantine_dir);
         }
     }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -376,11 +376,7 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
     co_await dir.do_for_each_sstable([&table, needs_view_update, &new_sstables] (sstables::shared_sstable sst) -> future<> {
         auto gen = table.calculate_generation_for_new_table();
         dblog.trace("Loading {} into {}, new generation {}", sst->get_filename(), needs_view_update ? "staging" : "base", gen);
-        fs::path datadir(table.dir());
-        if (needs_view_update) {
-            datadir /= sstables::staging_dir;
-        }
-        co_await sst->move_to_new_dir(datadir.native(), gen);
+        co_await sst->pick_up_from_upload(!needs_view_update ? sstables::normal_dir : sstables::staging_dir, gen);
             // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
             sst->set_sstable_level(0);
             new_sstables.push_back(std::move(sst));

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -74,7 +74,7 @@ class distributed_loader {
     static future<> lock_table(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring cf_name);
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,
-            std::filesystem::path datadir, sstring ks, sstring cf);
+            bool needs_view_update, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
     static future<> cleanup_column_family_temp_sst_dirs(sstring sstdir);
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2543,7 +2543,7 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
             // completed first.
             // The _sstable_deletion_sem prevents list update on off-strategy completion and move_sstables_from_staging()
             // from stepping on each other's toe.
-            co_await sst->move_to_new_dir(dir(), sst->generation(), &delay_commit);
+            co_await sst->change_state(sstables::normal_dir, &delay_commit);
             // If view building finished faster, SSTable with repair origin still exists.
             // It can also happen the SSTable is not going through reshape, so it doesn't have a repair origin.
             // That being said, we'll only add this SSTable to tracker if its origin is other than repair.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2282,6 +2282,11 @@ future<> sstable::change_state(sstring to, delayed_commit_changes* delay_commit)
     co_await _storage.change_state(*this, to, _generation, delay_commit);
 }
 
+future<> sstable::pick_up_from_upload(sstring to, generation_type new_generation) {
+    co_await _storage.change_state(*this, to, new_generation, nullptr);
+    _generation = std::move(new_generation);
+}
+
 future<> sstable::delayed_commit_changes::commit() {
     return parallel_for_each(_dirs, [] (sstring dir) {
         return sync_directory(dir);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2224,11 +2224,6 @@ future<> sstable::filesystem_storage::move(const sstable& sst, sstring new_dir, 
     }
 }
 
-future<> sstable::move_to_new_dir(sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {
-    co_await _storage.move(*this, std::move(new_dir), new_generation, delay_commit);
-    _generation = std::move(new_generation);
-}
-
 future<> sstable::filesystem_storage::quarantine(const sstable& sst, delayed_commit_changes* delay_commit) {
     auto path = fs::path(dir);
     if (path.filename().native() == staging_dir) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2241,12 +2241,45 @@ future<> sstable::filesystem_storage::quarantine(const sstable& sst, delayed_com
     co_await move(sst, std::move(new_dir), sst.generation(), delay_commit);
 }
 
+future<> sstable::filesystem_storage::change_state(const sstable& sst, sstring to, generation_type new_generation, delayed_commit_changes* delay_commit) {
+    auto path = fs::path(dir);
+    auto current = path.filename().native();
+
+    // Moving between states means moving between basedir/state subdirectories.
+    // However, normal state maps to the basedir itself and thus there's no way
+    // to check if current is normal_dir. The best that can be done here is to
+    // check that it's not anything else
+    if (current == staging_dir || current == upload_dir || current == quarantine_dir) {
+        if (to == quarantine_dir && current != staging_dir) {
+            // Legacy exception -- quarantine from anything but staging
+            // moves to the current directory quarantine subdir
+            path = path / to;
+        } else {
+            path = path.parent_path() / to;
+        }
+    } else {
+        current = normal_dir;
+        path = path / to;
+    }
+
+    if (current == to) {
+        co_return; // Already there
+    }
+
+    sstlog.info("Moving sstable {} to {} in {}", sst.get_filename(), to, path);
+    co_await move(sst, path.native(), std::move(new_generation), delay_commit);
+}
+
 future<> sstable::move_to_quarantine(delayed_commit_changes* delay_commit) {
     if (is_quarantined()) {
         return make_ready_future<>();
     }
 
     return _storage.quarantine(*this, delay_commit);
+}
+
+future<> sstable::change_state(sstring to, delayed_commit_changes* delay_commit) {
+    co_await _storage.change_state(*this, to, _generation, delay_commit);
 }
 
 future<> sstable::delayed_commit_changes::commit() {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2224,18 +2224,6 @@ future<> sstable::filesystem_storage::move(const sstable& sst, sstring new_dir, 
     }
 }
 
-future<> sstable::filesystem_storage::quarantine(const sstable& sst, delayed_commit_changes* delay_commit) {
-    auto path = fs::path(dir);
-    if (path.filename().native() == staging_dir) {
-        path = path.parent_path();
-    }
-    // Note: moving a sstable in a snapshot or in the uploads dir to quarantine
-    // will move it into a "quarantine" subdirectory of its current directory.
-    auto new_dir = (path / sstables::quarantine_dir).native();
-    sstlog.info("Moving SSTable {} to quarantine in {}", sst.get_filename(), new_dir);
-    co_await move(sst, std::move(new_dir), sst.generation(), delay_commit);
-}
-
 future<> sstable::filesystem_storage::change_state(const sstable& sst, sstring to, generation_type new_generation, delayed_commit_changes* delay_commit) {
     auto path = fs::path(dir);
     auto current = path.filename().native();
@@ -2263,14 +2251,6 @@ future<> sstable::filesystem_storage::change_state(const sstable& sst, sstring t
 
     sstlog.info("Moving sstable {} to {} in {}", sst.get_filename(), to, path);
     co_await move(sst, path.native(), std::move(new_generation), delay_commit);
-}
-
-future<> sstable::move_to_quarantine(delayed_commit_changes* delay_commit) {
-    if (is_quarantined()) {
-        return make_ready_future<>();
-    }
-
-    return _storage.quarantine(*this, delay_commit);
 }
 
 future<> sstable::change_state(sstring to, delayed_commit_changes* delay_commit) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -209,7 +209,6 @@ public:
     // Call as the last method before the object is destroyed.
     // No other uses of the object can happen at this point.
     future<> destroy();
-    future<> move_to_new_dir(sstring new_dir, generation_type generation, delayed_commit_changes* delay = nullptr);
 
     // Move the sstable to the quarantine_dir
     //
@@ -494,6 +493,7 @@ public:
         future<> create_links(const sstable& sst, const sstring& dir) const;
         future<> create_links_common(const sstable& sst, sstring dst_dir, generation_type dst_gen, mark_for_removal mark_for_removal) const;
         future<> touch_temp_dir(const sstable& sst);
+        future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
 
     public:
         explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
@@ -509,7 +509,6 @@ public:
         // Moving in a snapshot or upload will move to a subdirectory of the current directory.
         future<> change_state(const sstable& sst, sstring to, generation_type generation, delayed_commit_changes* delay);
 
-        future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);
         future<> wipe(const sstable& sst) noexcept;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -227,6 +227,10 @@ public:
     // It's up to the storage driver how to implement this.
     future<> change_state(sstring to, delayed_commit_changes* delay = nullptr);
 
+    // Filesystem-specific call to grab an sstable from upload dir and
+    // put it into the desired destination assigning the given generation
+    future<> pick_up_from_upload(sstring to, generation_type new_generation);
+
     generation_type generation() const {
         return _generation;
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -210,16 +210,6 @@ public:
     // No other uses of the object can happen at this point.
     future<> destroy();
 
-    // Move the sstable to the quarantine_dir
-    //
-    // If the sstable is alredy quarantined, this is a noop.
-    // If the sstable is in the base directory or in the staging_dir,
-    // it is moved into the quarantine_dir subdirectory of the base directory.
-    //
-    // Note: moving a sstable in any other dir to quarantine
-    // will move it into a quarantine_dir subdirectory of its current directory.
-    future<> move_to_quarantine(delayed_commit_changes* delay = nullptr);
-
     // Move the sstable between states
     //
     // Known states are normal, staging, upload and quarantine.
@@ -501,7 +491,6 @@ public:
         using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;
-        future<> quarantine(const sstable& sst, delayed_commit_changes* delay);
 
         // Moves the files around with .move() method. States are basedir subdirectories
         // with the exception that normal state maps to the basedir itself. If the sstable

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -113,6 +113,7 @@ private:
     friend class sstables_manager;
 };
 
+constexpr const char* normal_dir = "";
 constexpr const char* staging_dir = "staging";
 constexpr const char* upload_dir = "upload";
 constexpr const char* snapshots_dir = "snapshots";
@@ -219,6 +220,12 @@ public:
     // Note: moving a sstable in any other dir to quarantine
     // will move it into a quarantine_dir subdirectory of its current directory.
     future<> move_to_quarantine(delayed_commit_changes* delay = nullptr);
+
+    // Move the sstable between states
+    //
+    // Known states are normal, staging, upload and quarantine.
+    // It's up to the storage driver how to implement this.
+    future<> change_state(sstring to, delayed_commit_changes* delay = nullptr);
 
     generation_type generation() const {
         return _generation;
@@ -491,6 +498,13 @@ public:
         future<> seal(const sstable& sst);
         future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const;
         future<> quarantine(const sstable& sst, delayed_commit_changes* delay);
+
+        // Moves the files around with .move() method. States are basedir subdirectories
+        // with the exception that normal state maps to the basedir itself. If the sstable
+        // is already in the target state, this is a noop.
+        // Moving in a snapshot or upload will move to a subdirectory of the current directory.
+        future<> change_state(const sstable& sst, sstring to, generation_type generation, delayed_commit_changes* delay);
+
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
         // runs in async context
         void open(sstable& sst, const io_priority_class& pc);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1137,7 +1137,7 @@ SEASTAR_TEST_CASE(populate_from_quarantine_works) {
                     auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
                     testlog.debug("Moving sstable #{} out of {} to quarantine", idx, sstables.size());
                     auto sst = sstables[idx];
-                    co_await sst->move_to_quarantine();
+                    co_await sst->change_state(sstables::quarantine_dir);
                     found |= true;
                 });
                 co_return found;
@@ -1191,7 +1191,7 @@ SEASTAR_TEST_CASE(snapshot_with_quarantine_works) {
                     }
                     auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
                     auto sst = sstables[idx];
-                    co_await sst->move_to_quarantine();
+                    co_await sst->change_state(sstables::quarantine_dir);
                 });
             });
         }

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -42,7 +42,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
         ++gen;
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
-        sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
+        test(sst).move_to_new_dir(new_dir, generation_from_value(gen)).get();
         // the source directory must be empty now
         remove_file(cur_dir).get();
         cur_dir = new_dir;
@@ -96,7 +96,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
         done = partial_create_links(sst, fs::path(new_dir), gen, count++);
-        sst->move_to_new_dir(new_dir, generation_from_value(gen)).get();
+        test(sst).move_to_new_dir(new_dir, generation_from_value(gen)).get();
         remove_file(cur_dir).get();
         cur_dir = new_dir;
     } while (!done);
@@ -112,5 +112,5 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     auto [ dst_sst, new_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), ++gen);
 
     dst_sst->close_files().get();
-    BOOST_REQUIRE_THROW(src_sst->move_to_new_dir(new_dir, generation_from_value(gen)).get(), malformed_sstable_exception);
+    BOOST_REQUIRE_THROW(test(src_sst).move_to_new_dir(new_dir, generation_from_value(gen)).get(), malformed_sstable_exception);
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -214,6 +214,11 @@ public:
         return sst._storage.create_links(sst, dir);
     }
 
+    future<> move_to_new_dir(sstring new_dir, generation_type new_generation) {
+        co_await _sst->_storage.move(*_sst, std::move(new_dir), new_generation, nullptr);
+        _sst->_generation = std::move(new_generation);
+    }
+
     static fs::path filename(const sstable& sst, component_type c) {
         return fs::path(sst.filename(c));
     }


### PR DESCRIPTION
This method requires callers to remember that the sstable is the collection of files on a filesystem and to know what exact directory they are all in. That's not going to work for object storage, instead, sstable should be moved between more abstract states.

This PR replaces move_to_new_dir() call with the change_state() one that accepts target sub-directory string and moves files around. Currently supported state changes:

* staging -> normal
* upload -> normal | staging
* any -> quarantine

All are pretty straightforward and move files between table basedir subdirectories with the exception that upload -> quarantine should move into upload/quarantine subdirectory. Another thing to keep in mind, that normal state doesn't have its subdir but maps directory to table's base directory.