### PR TITLE
docs/alternator: fix links to open issues

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -267,7 +267,7 @@ they should be easy to detect. Here is a list of these unimplemented features:
   estimates, and also part of the information about indexes enabled on 
   the table.
   <https://github.com/scylladb/scylla/issues/5013>
-  <https://github.com/scylladb/scylla/issues/5026>
+  <https://github.com/scylladb/scylla/issues/5320>
   <https://github.com/scylladb/scylla/issues/7550>
   <https://github.com/scylladb/scylla/issues/7551>
 


### PR DESCRIPTION
The docs/alternator/compatibility.md file links to various open issues on unimplemented features. One of the links was to an already-closed issue. Replace it by a link to an open issue that was missing.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>