### PR TITLE
test/alternator: unskip test which works on modern Scylla

### DIFF
--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -55,9 +55,8 @@ def assert_index_scan(table, index_name, expected_items, **kwargs):
 
 # Although quite silly, it is actually allowed to create an index which is
 # identical to the base table.
-# The following test does not work for KA/LA tables due to #6157,
-# so it's hereby skipped.
-@pytest.mark.skip
+# The following test does not work for KA/LA tables due to #6157, but we
+# no longer allow writing those in Scylla.
 def test_gsi_identical(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],


### PR DESCRIPTION
We had one test test_gsi.py::test_gsi_identical that didn't work on KA/LA sstables due to #6157, so it was skipped. Today, Scylla no longer supports writing these old sstable formats, so the test can never find itself running on these versions, so should pass. And indeed it does, and the "skip" marker can be removed.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>