### PR TITLE
test.py: improve test failure handling

### DIFF
--- a/test.py
+++ b/test.py
@@ -706,7 +706,7 @@ class CQLApprovalTest(Test):
                 self.is_before_test_ok = True
                 cluster.take_log_savepoint()
                 self.is_executed_ok = await run_test(self, options, env=self.env)
-                cluster.after_test(self.uname)
+                cluster.after_test(self.uname, self.is_executed_ok)
                 self.is_after_test_ok = True
 
                 if self.is_executed_ok is False:
@@ -860,7 +860,7 @@ class PythonTest(Test):
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
             status = await run_test(self, options)
-            cluster.after_test(self.uname)
+            cluster.after_test(self.uname, status)
             self.is_after_test_ok = True
             self.success = status
         except Exception as e:

--- a/test.py
+++ b/test.py
@@ -696,7 +696,7 @@ class CQLApprovalTest(Test):
                 logger.info("Server log:\n%s", self.server_log)
 
         # TODO: consider dirty_on_exception=True
-        async with self.suite.clusters.instance(False, logger) as cluster:
+        async with (cm := self.suite.clusters.instance(False, logger)) as cluster:
             try:
                 cluster.before_test(self.uname)
                 logger.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
@@ -707,6 +707,7 @@ class CQLApprovalTest(Test):
                 cluster.take_log_savepoint()
                 self.is_executed_ok = await run_test(self, options, env=self.env)
                 cluster.after_test(self.uname, self.is_executed_ok)
+                cm.dirty = cluster.is_dirty
                 self.is_after_test_ok = True
 
                 if self.is_executed_ok is False:
@@ -874,9 +875,7 @@ class PythonTest(Test):
                 print("Test {} post-check failed: {}".format(self.name, str(e)))
                 print("Server log of the first server:\n{}".format(self.server_log))
                 logger.info(f"Discarding cluster after failed test %s...", self.name)
-            await self.suite.clusters.put(cluster, is_dirty=True)
-        else:
-            await self.suite.clusters.put(cluster, is_dirty=False)
+        await self.suite.clusters.put(cluster, is_dirty=cluster.is_dirty)
         logger.info("Test %s %s", self.uname, "succeeded" if self.success else "failed ")
         return self
 

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -86,10 +86,10 @@ class ManagerClient():
             # await self._wait_for_cluster()
             await self.driver_connect()  # Connect driver to new cluster
 
-    async def after_test(self, test_case_name: str) -> None:
+    async def after_test(self, test_case_name: str, success: bool) -> None:
         """Tell harness this test finished"""
-        logger.debug("after_test for %s", test_case_name)
-        cluster_str = await self.client.get_text(f"/cluster/after-test")
+        logger.debug("after_test for %s (success: %s)", test_case_name, success)
+        cluster_str = await self.client.get_text(f"/cluster/after-test/{success}")
         logger.info("Cluster after test %s: %s", test_case_name, cluster_str)
 
     async def is_manager_up(self) -> bool:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -89,7 +89,8 @@ class ManagerClient():
     async def after_test(self, test_case_name: str) -> None:
         """Tell harness this test finished"""
         logger.debug("after_test for %s", test_case_name)
-        await self.client.get(f"/cluster/after-test")
+        cluster_str = await self.client.get_text(f"/cluster/after-test")
+        logger.info("Cluster after test %s: %s", test_case_name, cluster_str)
 
     async def is_manager_up(self) -> bool:
         """Check if Manager server is up"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -735,7 +735,7 @@ class ScyllaCluster:
         if self.start_exception:
             # Mark as dirty so further test cases don't try to reuse this cluster.
             self.is_dirty = True
-            raise self.start_exception
+            raise Exception(f'Exception when starting cluster {self}:\n{self.start_exception}')
 
         for server in self.running.values():
             server.write_log_marker(f"------ Starting test {name} ------\n")
@@ -993,7 +993,8 @@ class ScyllaClusterManager:
         finally:
             self.current_test_case_full_name = ''
         self.is_after_test_ok = True
-        return aiohttp.web.Response(text="True")
+        cluster_str = str(self.cluster)
+        return aiohttp.web.Response(text=cluster_str)
 
     async def _mark_dirty(self, _request) -> aiohttp.web.Response:
         """Mark current cluster dirty"""

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -192,9 +192,11 @@ def fails_without_consistent_cluster_management(request, check_pre_consistent_cl
 
 
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
-# used in tests to make schema changes. Tables are dropped after finished.
+# used in tests to make schema changes. Tables are dropped after test finishes
+# unless the cluster is dirty.
 @pytest.fixture(scope="function")
-def random_tables(request, manager):
+async def random_tables(request, manager):
     tables = RandomTables(request.node.name, manager, unique_name())
     yield tables
-    tables.drop_all()
+    if not await manager.is_dirty():
+        tables.drop_all()


### PR DESCRIPTION
Improve logging by printing the cluster at the end of each test.

Stop performing operations like attempting queries or dropping keyspaces on dirty clusters. Dirty clusters might be completely dead and these operations would only cause more "errors" to happen after a failed test, making it harder to find the real cause of failure.

Mark cluster as dirty when a test that uses it fails - after a failed test, we shouldn't assume that the cluster is in a usable state, so we shouldn't reuse it for another test.

Rely on the `is_dirty` flag in `PythonTest`s and `CQLApprovalTest`s, similarly to what `TopologyTest`s do.