### PR TITLE
Handle EDQUOT error just like ENOSPC

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1038,7 +1038,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 };
             });
             cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source()), std::ref(task_manager)).get();
-            auto stop_cm = deferred_stop(cm);
+            auto stop_cm = defer_verbose_shutdown("compaction_manager", [&cm] {
+               cm.stop().get();
+            });
 
             supervisor::notify("starting database");
             debug::the_database = &db;

--- a/main.cc
+++ b/main.cc
@@ -400,7 +400,7 @@ static auto defer_verbose_shutdown(const char* what, Func&& func) {
                 // System error codes we consider "environmental",
                 // i.e. not scylla's fault, therefore there is no point in
                 // aborting and dumping core.
-                for (int i : {EIO, EACCES, ENOSPC}) {
+                for (int i : {EIO, EACCES, EDQUOT, ENOSPC}) {
                     if (e.code() == std::error_code(i, std::system_category())) {
                         do_abort = false;
                         break;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -711,13 +711,17 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
                 ex = std::current_exception();
                 _config.cf_stats->failed_memtables_flushes_count++;
 
+                auto should_retry = [](auto* ep) {
+                    int ec = ep->code().value();
+                    return ec == ENOSPC;
+                };
                 if (try_catch<std::bad_alloc>(ex)) {
                     // There is a chance something else will free the memory, so we can try again
                     allowed_retries--;
                 } else if (auto ep = try_catch<std::system_error>(ex)) {
-                    allowed_retries = ep->code().value() == ENOSPC ? default_retries : 0;
+                    allowed_retries = should_retry(ep) ? default_retries : 0;
                 } else if (auto ep = try_catch<storage_io_error>(ex)) {
-                    allowed_retries = ep->code().value() == ENOSPC ? default_retries : 0;
+                    allowed_retries = should_retry(ep) ? default_retries : 0;
                 } else {
                     allowed_retries = 0;
                 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -713,7 +713,7 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
 
                 auto should_retry = [](auto* ep) {
                     int ec = ep->code().value();
-                    return ec == ENOSPC;
+                    return ec == ENOSPC || ec == EDQUOT;
                 };
                 if (try_catch<std::bad_alloc>(ex)) {
                     // There is a chance something else will free the memory, so we can try again


### PR DESCRIPTION
- main: consider EDQUOT as environmental failure also
- main: use defer_verbose_shutdown() to shutdown compaction manager
- replica/table: extract should_retry() int with_retry
- replica/table: retry on EDQUOT when flushing memtable

Fixes #12626