### PR TITLE
test/lib: introduce key_utils.hh

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1163,6 +1163,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
     'test/lib/data_model.cc',
     'test/lib/exception_utils.cc',
     'test/lib/random_schema.cc',
+    'test/lib/key_utils.cc',
 ]
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
@@ -1179,6 +1180,9 @@ scylla_perfs = ['test/perf/perf_fast_forward.cc',
                 'test/lib/test_services.cc',
                 'test/lib/test_utils.cc',
                 'test/lib/tmpdir.cc',
+                'test/lib/key_utils.cc',
+                'test/lib/random_schema.cc',
+                'test/lib/data_model.cc',
                 'seastar/tests/perf/linux_perf_event.cc']
 
 deps = {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -19,6 +19,7 @@
 #include "test/lib/result_set_assertions.hh"
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/key_utils.hh"
 
 #include "replica/database.hh"
 #include "utils/lister.hh"
@@ -858,9 +859,8 @@ SEASTAR_THREAD_TEST_CASE(read_max_size) {
         auto& tab = db.find_column_family("ks", "test");
         auto s = tab.schema();
 
-        auto pk = make_local_key(s);
-        const auto raw_pk = utf8_type->decompose(data_value(pk));
-        const auto cql3_pk = cql3::raw_value::make_value(raw_pk);
+        auto pk = tests::generate_partition_key(s);
+        const auto cql3_pk = cql3::raw_value::make_value(pk.key().explode().front());
 
         const auto value = sstring(1024, 'a');
         const auto raw_value = utf8_type->decompose(data_value(value));
@@ -948,9 +948,8 @@ SEASTAR_THREAD_TEST_CASE(unpaged_mutation_read_global_limit) {
         auto& tab = db.find_column_family("ks", "test");
         auto s = tab.schema();
 
-        auto pk = make_local_key(s);
-        const auto raw_pk = utf8_type->decompose(data_value(pk));
-        const auto cql3_pk = cql3::raw_value::make_value(raw_pk);
+        auto pk = tests::generate_partition_key(s);
+        const auto cql3_pk = cql3::raw_value::make_value(pk.key().explode().front());
 
         const auto value = sstring(1024, 'a');
         const auto raw_value = utf8_type->decompose(data_value(value));

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -31,6 +31,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/key_utils.hh"
 #include "utils/error_injection.hh"
 #include "db/commitlog/commitlog.hh"
 #include "test/lib/make_random_string.hh"
@@ -976,7 +977,7 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         // Insert something so that we have data in memtable to flush
         // it has to be somewhat large, as automatic flushing picks the
         // largest memtable to flush
-        mutation mt = {s, ss.make_pkey(make_local_key(s))};
+        mutation mt = {s, tests::generate_partition_key(s)};
         for (uint32_t i = 0; i < 1000; ++i) {
             ss.add_row(mt, ss.make_ckey(i), format("{}", i));
         }

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -18,6 +18,7 @@
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/key_utils.hh"
 
 #include "schema_builder.hh"
 #include "test/lib/simple_schema.hh"
@@ -4236,11 +4237,7 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
         replica::table& t = env.local_db().find_column_family(ks_name, table_name);
         schema_ptr s = t.schema();
 
-        int32_t pk = 0;
-        dht::decorated_key dk(dht::token(), partition_key::make_empty());
-        do {
-            dk = dht::decorate_key(*s, partition_key::from_single_value(*s, serialized(++pk)));
-        } while (dht::shard_of(*s, dk.token()) != this_shard_id());
+        dht::decorated_key dk = tests::generate_partition_key(s);
 
         auto ck1 = clustering_key::from_deeply_exploded(*s, {1});
         auto ck1_prefix = clustering_key_prefix::from_deeply_exploded(*s, {1});

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -18,6 +18,7 @@
 #include "test/lib/tmpdir.hh"
 #include "cell_locking.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
+#include "test/lib/key_utils.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/test_services.hh"
 #include "service/storage_proxy.hh"
@@ -53,19 +54,18 @@ void run_sstable_resharding_test() {
     // create sst shared by all shards
     {
         auto mt = make_lw_shared<replica::memtable>(s);
-        auto get_mutation = [mt, s] (sstring key_to_write, auto value) {
-            auto key = partition_key::from_exploded(*s, {to_bytes(key_to_write)});
+        auto get_mutation = [mt, s] (const dht::decorated_key& key, auto value) {
             mutation m(s, key);
             m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(value)), api::timestamp_type(0));
             return m;
         };
         auto cfg = std::make_unique<db::config>();
         for (auto i : boost::irange(0u, smp::count)) {
-            auto key_token_pair = token_generation_for_shard(keys_per_shard, i, cfg->murmur3_partitioner_ignore_msb_bits());
-            BOOST_REQUIRE(key_token_pair.size() == keys_per_shard);
+            const auto keys = tests::generate_partition_keys(keys_per_shard, s, i);
+            BOOST_REQUIRE(keys.size() == keys_per_shard);
             muts[i].reserve(keys_per_shard);
             for (auto k : boost::irange(0u, keys_per_shard)) {
-                auto m = get_mutation(key_token_pair[k].first, i);
+                auto m = get_mutation(keys[k], i);
                 muts[i].push_back(m);
                 mt->apply(std::move(m));
             }
@@ -139,8 +139,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
         auto tmp = tmpdir();
         auto cfg = std::make_unique<db::config>();
 
-        auto get_mutation = [] (const schema_ptr& s, sstring key_to_write, auto value) {
-            auto key = partition_key::from_exploded(*s, {to_bytes(key_to_write)});
+        auto get_mutation = [] (const schema_ptr& s, const dht::decorated_key& key, auto value) {
             mutation m(s, key);
             m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(value)), api::timestamp_type(0));
             return m;
@@ -154,10 +153,10 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
                 return env.make_sstable(s, tmp.path().string(), (*gen)++, version, big);
             };
 
-            auto tokens = token_generation_for_shard(smp::count * 10, this_shard_id(), cfg->murmur3_partitioner_ignore_msb_bits());
+            const auto keys = tests::generate_partition_keys(smp::count * 10, s);
             std::vector<mutation> muts;
-            for (auto& t : tokens) {
-                muts.push_back(get_mutation(s, t.first, 0));
+            for (auto& k : keys) {
+                muts.push_back(get_mutation(s, k, 0));
             }
 
             auto sst = make_sstable_containing(sst_gen, muts);
@@ -167,17 +166,17 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
         // create sstable owned by all shards
         // created unshared sstable
         {
+            auto key_s = get_schema();
             auto single_sharded_s = get_schema(1, cfg->murmur3_partitioner_ignore_msb_bits());
             auto sst_gen = [&env, single_sharded_s, &tmp, gen, version]() mutable {
                 return env.make_sstable(single_sharded_s, tmp.path().string(), (*gen)++, version, big);
             };
 
-            auto tokens = token_generation_for_shard(10, this_shard_id(), cfg->murmur3_partitioner_ignore_msb_bits());
             std::vector<mutation> muts;
             for (shard_id shard : boost::irange(0u, smp::count)) {
-                auto tokens = token_generation_for_shard(10, shard, cfg->murmur3_partitioner_ignore_msb_bits());
-                for (auto& t : tokens) {
-                    muts.push_back(get_mutation(single_sharded_s, t.first, shard));
+                const auto keys = tests::generate_partition_keys(10, key_s, shard);
+                for (auto& k : keys) {
+                    muts.push_back(get_mutation(single_sharded_s, k, shard));
                 }
             }
 

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -33,7 +33,7 @@ SEASTAR_TEST_CASE(test_sstables_sstable_set_read_modify_write) {
         auto s = ss.schema();
         fs::path tmp(tmpdir_path);
 
-        auto pk = ss.make_pkey(make_local_key(s));
+        auto pk = tests::generate_partition_key(s);
         auto mut = mutation(s, pk);
         ss.add_row(mut, ss.make_ckey(0), "val");
         int gen = 1;
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         auto s = ss.schema();
         fs::path tmp(tmpdir_path);
 
-        auto pk = ss.make_pkey(make_local_key(s));
+        auto pk = tests::generate_partition_key(s);
         auto mut = mutation(s, pk);
         ss.add_row(mut, ss.make_ckey(0), "val");
         int gen = 1;

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "test/lib/key_utils.hh"
+#include "test/lib/random_schema.hh"
+#include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
+
+namespace tests {
+
+namespace {
+
+template<typename RawKey, typename DecoratedKey, typename Comparator>
+std::vector<DecoratedKey> generate_keys(
+        size_t n,
+        schema_ptr s,
+        Comparator cmp,
+        const std::vector<data_type>& types,
+        std::function<std::optional<DecoratedKey>(const RawKey&)> decorate_fun,
+        bool allow_prefixes,
+        std::optional<key_size> size) {
+    auto keys = std::set<DecoratedKey, Comparator>(cmp);
+    const auto effective_size = size.value_or(tests::key_size{1, 128});
+
+    std::mt19937 engine(tests::random::get_int<uint32_t>());
+    std::uniform_int_distribution<size_t> component_count_dist(1, types.size());
+    tests::value_generator value_gen;
+
+    std::vector<data_value> components;
+    components.reserve(types.size());
+
+    while (keys.size() != n) {
+        components.clear();
+        auto component_count = allow_prefixes ? component_count_dist(engine) : types.size();
+        for (size_t i = 0; i < component_count; ++i) {
+            components.emplace_back(value_gen.generate_atomic_value(engine, *types.at(i), effective_size.min, effective_size.max));
+        }
+        auto raw_key = RawKey::from_deeply_exploded(*s, components);
+        // discard empty keys on the off chance that we generate one
+        if (raw_key.is_empty() || (types.size() == 1 && raw_key.begin(*s)->empty())) {
+            continue;
+        }
+        if constexpr (std::is_same_v<RawKey, DecoratedKey>) {
+            keys.emplace(std::move(raw_key));
+        } else if (auto decorated_key_opt = decorate_fun(raw_key); decorated_key_opt) {
+            keys.emplace(std::move(*decorated_key_opt));
+        }
+    }
+
+    return std::vector<DecoratedKey>(keys.begin(), keys.end());
+}
+
+}
+
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, std::optional<shard_id> shard, std::optional<key_size> size) {
+    return generate_keys<partition_key, dht::decorated_key, dht::decorated_key::less_comparator>(
+            n,
+            s,
+            dht::decorated_key::less_comparator(s),
+            s->partition_key_type()->types(),
+            [s, shard, tokens = std::set<dht::token>()] (const partition_key& pkey) mutable -> std::optional<dht::decorated_key> {
+                auto dkey = dht::decorate_key(*s, pkey);
+                if (shard && *shard != dht::shard_of(*s, dkey.token())) {
+                    return {};
+                }
+                if (!tokens.insert(dkey.token()).second) {
+                    return {};
+                }
+                return dkey;
+            },
+            false,
+            size);
+}
+
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, local_shard_only lso, std::optional<key_size> size) {
+    return generate_partition_keys(n, std::move(s), lso == local_shard_only::yes ? std::optional(this_shard_id()) : std::nullopt, size);
+}
+
+dht::decorated_key generate_partition_key(schema_ptr s, std::optional<shard_id> shard, std::optional<key_size> size) {
+    auto&& keys = generate_partition_keys(1, std::move(s), shard, size);
+    return std::move(keys.front());
+}
+
+dht::decorated_key generate_partition_key(schema_ptr s, local_shard_only lso, std::optional<key_size> size) {
+    return generate_partition_key(std::move(s), lso == local_shard_only::yes ? std::optional(this_shard_id()) : std::nullopt, size);
+}
+
+std::vector<clustering_key> generate_clustering_keys(size_t n, schema_ptr s, bool allow_prefixes, std::optional<key_size> size) {
+    return generate_keys<clustering_key, clustering_key, clustering_key::less_compare>(
+            n,
+            s,
+            clustering_key::less_compare(*s),
+            s->clustering_key_type()->types(),
+            {},
+            allow_prefixes,
+            size);
+}
+
+clustering_key generate_clustering_key(schema_ptr s, bool allow_prefix, std::optional<key_size> size) {
+    auto&& keys = generate_clustering_keys(1, std::move(s), allow_prefix, size);
+    return std::move(keys.front());
+}
+
+} // namespace tests

--- a/test/lib/key_utils.hh
+++ b/test/lib/key_utils.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "dht/i_partitioner.hh"
+
+struct local_shard_only_tag { };
+using local_shard_only = bool_class<local_shard_only_tag>;
+
+namespace tests {
+
+struct key_size {
+    size_t min;
+    size_t max;
+};
+
+// Generate n partition keys for the given schema.
+//
+// Returned keys are unique (their token too), ordered and never empty.
+// Parameters:
+// * n - number of keys
+// * s - schema of the keys, used also to obtain the sharder
+// * shard - only generate keys for this shard (if engaged)
+// * size - the min and max size of the key in bytes, if disengaged default
+//          limits (1-128) are used. If you want exactly sized keys, use
+//          ascii or bytes types only as the key types.
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, std::optional<shard_id> shard = this_shard_id(), std::optional<key_size> size = {});
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, local_shard_only lso, std::optional<key_size> size = {});
+// Overload for a single key
+dht::decorated_key generate_partition_key(schema_ptr s, std::optional<shard_id> shard = this_shard_id(), std::optional<key_size> size = {});
+dht::decorated_key generate_partition_key(schema_ptr s, local_shard_only lso, std::optional<key_size> size = {});
+
+// Generate n clustering keys
+//
+// Returned keys are unique, ordered and never empty.
+// Parameters are the same as that of generate_partition_keys().
+// If allow_prefixes is true, prefix keys may be generated too.
+std::vector<clustering_key> generate_clustering_keys(size_t n, schema_ptr s, bool allow_prefixes = false, std::optional<key_size> size = {});
+// Overload for a single key
+clustering_key generate_clustering_key(schema_ptr s, bool allow_prefix = false, std::optional<key_size> size = {});
+
+} // namespace tests

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -83,7 +83,7 @@ std::unique_ptr<random_schema_specification> make_random_schema_specification(
 /// TODO: counters
 class value_generator {
 public:
-    using atomic_value_generator = std::function<data_value(std::mt19937&, size_t)>;
+    using atomic_value_generator = std::function<data_value(std::mt19937&, size_t, size_t)>;
     using generator = std::function<data_model::mutation_description::value(std::mt19937&)>;
 
     static const size_t no_size_in_bytes_limit{std::numeric_limits<size_t>::max()};
@@ -100,7 +100,10 @@ public:
     size_t min_size(const abstract_type& type);
 
     atomic_value_generator get_atomic_value_generator(const abstract_type& type);
+    // Generate a value for the given type, according to the provided size constraints.
+    // Controlling the size of values only really works with string-like types and collections of these.
     data_value generate_atomic_value(std::mt19937& engine, const abstract_type& type, size_t max_size_in_bytes = no_size_in_bytes_limit);
+    data_value generate_atomic_value(std::mt19937& engine, const abstract_type& type, size_t min_size_in_bytes, size_t max_size_in_bytes);
 
     generator get_generator(const abstract_type& type);
     data_model::mutation_description::value generate_value(std::mt19937& engine, const abstract_type& type);

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -20,10 +20,8 @@
 #include "schema_builder.hh"
 #include "reader_permit.hh"
 #include "types/map.hh"
+#include "test/lib/key_utils.hh"
 #include "atomic_cell_or_collection.hh"
-
-struct local_shard_only_tag { };
-using local_shard_only = bool_class<local_shard_only_tag>;
 
 //
 // Make set of keys sorted by token for current or remote shard.

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -266,14 +266,11 @@ public:
 
     // Creates a sequence of keys in ring order
     std::vector<dht::decorated_key> make_pkeys(int n) {
-        auto local_keys = make_local_keys(n, _s);
-        return boost::copy_range<std::vector<dht::decorated_key>>(local_keys | boost::adaptors::transformed([this] (sstring& key) {
-            return make_pkey(std::move(key));
-        }));
+        return tests::generate_partition_keys(n, _s);
     }
 
     dht::decorated_key make_pkey() {
-        return make_pkey(make_local_key(_s));
+        return tests::generate_partition_key(_s);
     }
 
     static std::vector<dht::ring_position> to_ring_positions(const std::vector<dht::decorated_key>& keys) {

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -23,32 +23,6 @@
 #include "test/lib/key_utils.hh"
 #include "atomic_cell_or_collection.hh"
 
-//
-// Make set of keys sorted by token for current or remote shard.
-//
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, std::optional<shard_id> shard);
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1, local_shard_only lso = local_shard_only::yes);
-
-inline std::vector<sstring> make_keys_for_shard(shard_id shard, unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, shard);
-}
-
-inline sstring make_key_for_shard(shard_id shard, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(1, s, min_key_size, shard).front();
-}
-
-inline std::vector<sstring> make_local_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, local_shard_only::yes);
-}
-
-inline sstring make_local_key(const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(1, s, min_key_size, local_shard_only::yes).front();
-}
-
-inline std::vector<sstring> make_keys(unsigned n, const schema_ptr& s, size_t min_key_size = 1) {
-    return do_make_keys(n, s, min_key_size, local_shard_only::no);
-}
-
 // Helper for working with the following table:
 //
 //   CREATE TABLE ks.cf (pk text, ck text, v text, s1 text static, PRIMARY KEY (pk, ck));

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -34,13 +34,6 @@ inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstabl
 shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now());
 
-std::vector<std::pair<sstring, dht::token>>
-token_generation_for_shard(unsigned tokens_to_generate, unsigned shard,
-        unsigned ignore_msb = 0, unsigned smp_count = smp::count);
-
-std::vector<std::pair<sstring, dht::token>>
-token_generation_for_current_shard(unsigned tokens_to_generate);
-
 namespace sstables {
 
 using sstable_ptr = shared_sstable;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -168,7 +168,7 @@ public:
     }
 
     // Used to create synthetic sstables for testing leveled compaction strategy.
-    void set_values_for_leveled_strategy(uint64_t fake_data_size, uint32_t sstable_level, int64_t max_timestamp, sstring first_key, sstring last_key) {
+    void set_values_for_leveled_strategy(uint64_t fake_data_size, uint32_t sstable_level, int64_t max_timestamp, const partition_key& first_key, const partition_key& last_key) {
         _sst->_data_file_size = fake_data_size;
         _sst->_bytes_on_disk = fake_data_size;
         // Create a synthetic stats metadata
@@ -177,21 +177,21 @@ public:
         stats.max_timestamp = max_timestamp;
         stats.sstable_level = sstable_level;
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
-        _sst->_components->summary.first_key.value = bytes(reinterpret_cast<const signed char*>(first_key.c_str()), first_key.size());
-        _sst->_components->summary.last_key.value = bytes(reinterpret_cast<const signed char*>(last_key.c_str()), last_key.size());
+        _sst->_components->summary.first_key.value = sstables::key::from_partition_key(*_sst->_schema, first_key).get_bytes();
+        _sst->_components->summary.last_key.value = sstables::key::from_partition_key(*_sst->_schema, last_key).get_bytes();
         _sst->set_first_and_last_keys();
         _sst->_run_identifier = run_id::create_random_id();
         _sst->_shards.push_back(this_shard_id());
     }
 
-    void set_values(sstring first_key, sstring last_key, stats_metadata stats, uint64_t data_file_size = 1) {
+    void set_values(const partition_key& first_key, const partition_key& last_key, stats_metadata stats, uint64_t data_file_size = 1) {
         _sst->_data_file_size = data_file_size;
         _sst->_bytes_on_disk = data_file_size;
         // scylla component must be present for a sstable to be considered fully expired.
         _sst->_recognized_components.insert(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
-        _sst->_components->summary.first_key.value = bytes(reinterpret_cast<const signed char*>(first_key.c_str()), first_key.size());
-        _sst->_components->summary.last_key.value = bytes(reinterpret_cast<const signed char*>(last_key.c_str()), last_key.size());
+        _sst->_components->summary.first_key.value = sstables::key::from_partition_key(*_sst->_schema, first_key).get_bytes();
+        _sst->_components->summary.last_key.value = sstables::key::from_partition_key(*_sst->_schema, last_key).get_bytes();
         _sst->set_first_and_last_keys();
         _sst->_components->statistics.contents[metadata_type::Compaction] = std::make_unique<compaction_metadata>();
         _sst->_run_identifier = run_id::create_random_id();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -39,12 +39,16 @@ table_for_tests::data::data()
 
 table_for_tests::data::~data() {}
 
+schema_ptr table_for_tests::make_default_schema() {
+    return schema_builder(some_keyspace, some_column_family)
+        .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
+        .build();
+}
+
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager)
     : table_for_tests(
         sstables_manager,
-        schema_builder(some_keyspace, some_column_family)
-            .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
-            .build()
+        make_default_schema()
     )
 { }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -14,22 +14,6 @@
 #include "gms/feature_service.hh"
 #include "repair/row_level.hh"
 
-dht::token create_token_from_key(const dht::i_partitioner& partitioner, sstring key) {
-    sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
-    dht::token token = partitioner.get_token(key_view);
-    assert(token == partitioner.get_token(key_view));
-    return token;
-}
-
-range<dht::token> create_token_range_from_keys(const dht::sharder& sinfo, const dht::i_partitioner& partitioner, sstring start_key, sstring end_key) {
-    dht::token start = create_token_from_key(partitioner, start_key);
-    assert(this_shard_id() == sinfo.shard_of(start));
-    dht::token end = create_token_from_key(partitioner, end_key);
-    assert(this_shard_id() == sinfo.shard_of(end));
-    assert(end >= start);
-    return range<dht::token>::make(start, end);
-}
-
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -51,6 +51,8 @@ struct table_for_tests {
     };
     lw_shared_ptr<data> _data;
 
+    static schema_ptr make_default_schema();
+
     explicit table_for_tests(sstables::sstables_manager& sstables_manager);
 
     explicit table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir = {});

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -76,6 +76,3 @@ struct table_for_tests {
         return stop().finally([cf = *this] {});
     }
 };
-
-dht::token create_token_from_key(const dht::i_partitioner&, sstring key);
-range<dht::token> create_token_range_from_keys(const dht::sharder& sharder, const dht::i_partitioner&, sstring start_key, sstring end_key);

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -72,32 +72,3 @@ sstring make_random_numeric_string(size_t size) {
     }
     return str;
 }
-
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, std::optional<shard_id> shard) {
-    std::vector<std::pair<sstring, dht::decorated_key>> p;
-    p.reserve(n);
-
-    auto key_id = 0U;
-    auto generated = 0U;
-    while (generated < n) {
-        auto raw_key = sstring(std::max(min_key_size, sizeof(key_id)), int8_t(0));
-        std::copy_n(reinterpret_cast<int8_t*>(&key_id), sizeof(key_id), raw_key.begin());
-        auto dk = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes(raw_key)));
-        key_id++;
-        if (shard) {
-            if (*shard != shard_of(*s, dk.token())) {
-                continue;
-            }
-        }
-        generated++;
-        p.emplace_back(std::move(raw_key), std::move(dk));
-    }
-    boost::sort(p, [&] (auto& p1, auto& p2) {
-        return p1.second.less_compare(*s, p2.second);
-    });
-    return boost::copy_range<std::vector<sstring>>(p | boost::adaptors::map_keys);
-}
-
-std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t min_key_size, local_shard_only lso) {
-    return do_make_keys(n, s, min_key_size, lso ? std::optional(this_shard_id()) : std::nullopt);
-}


### PR DESCRIPTION
We currently have two method families to generate partition keys:
* make_keys() in test/lib/simple_schema.hh
* token_generation_for_shard() in test/lib/sstable_utils.hh

Both work only for schemas with a single partition key column of `text` type and both generate keys of fixed size.
This is very restrictive and simplistic. Tests, which wanted anything more complicated than that had to rely on open-coded key generation.
Also, many tests started to rely on the simplistic nature of these keys, in particular two tests started failing because the new key generation method generated keys of varying size:
* sstable_compaction_test.sstable_run_based_compaction_test
* sstable_mutation_test.test_key_count_estimation

These two tests seems to depend on generated keys all being of the same size. This makes some sense in the case of the key count estimation test, but makes no sense at all to me in the case of the sstable run test.