### PR TITLE
doc: document the workaround to install a non-latest ScyllaDB version

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -254,7 +254,7 @@ Alternatively, you can explicitly install **all** the ScyllaDB packages for the 
 
 .. code-block:: console
 
-   apt-get install scylla-enterprise{,-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=2021.1.0-0.20210511.9e8e7d58b-1
+   sudo apt-get install scylla-enterprise{,-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=2021.1.0-0.20210511.9e8e7d58b-1
    sudo apt-get install scylla-enterprise-machine-image=2021.1.0-0.20210511.9e8e7d58b-1  # only execute on AMI instance
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -228,6 +228,32 @@ Scylla comes with its own version of the Apache Cassandra client tools, in the p
 
 We recommend uninstalling Apache Cassandra before installing :code:`scylla-tools`.
 
+.. _faq-pinning:
+
+Can I install or upgrade to a patch release other than latest on Debian or Ubuntu?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The APT package manager used for Ubuntu, Debian, and image installations of ScyllaDB installs the latest patch 
+release (x.y.z) of a given major release (x.y). To remain on a ScyllaDB patch release that is not the latest, you can 
+use pinning as a workaround.
+
+The following example shows pinning ScyllaDB Enterprise version 2021.1.0-0.20210511.9e8e7d58b-1:
+
+.. code-block:: console
+
+   $ cat <<EOF | sudo tee /etc/apt/preferences.d/99scylla-enterprise
+   Package: scylla-enterprise*
+   Pin: version 2021.1.0-0.20210511.9e8e7d58b-1
+   Pin-Priority: 1001
+   EOF
+
+Pinning may be particularly useful when you want to downgrade ScyllaDB or upgrade to a version that is not the latest 
+available version.
+
+See `this topic <https://unix.stackexchange.com/questions/350192/apt-get-not-properly-resolving-a-dependency-on-a-fixed-version-in-a-debian-ubunt>`_ 
+and `this article <https://help.ubuntu.com/community/PinningHowto>`_ for details about pinning on Debian-based systems.
+
+
 .. _faq-snitch-strategy:
 
 Which snitch or replication strategy should I use?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -248,10 +248,15 @@ The following example shows pinning ScyllaDB Enterprise version 2021.1.0-0.20210
    EOF
 
 Pinning may be particularly useful when you want to downgrade ScyllaDB or upgrade to a version that is not the latest 
-available version.
+available version. See `this article <https://help.ubuntu.com/community/PinningHowto>`_ for details about pinning on Debian-based systems.
 
-See `this topic <https://unix.stackexchange.com/questions/350192/apt-get-not-properly-resolving-a-dependency-on-a-fixed-version-in-a-debian-ubunt>`_ 
-and `this article <https://help.ubuntu.com/community/PinningHowto>`_ for details about pinning on Debian-based systems.
+Alternatively, you can explicitly install **all** the ScyllaDB packages for the desired non-latest version. For example:
+
+.. code-block:: console
+
+   apt-get install scylla-enterprise{,-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=2021.1.0-0.20210511.9e8e7d58b-1
+   sudo apt-get install scylla-enterprise-machine-image=2021.1.0-0.20210511.9e8e7d58b-1  # only execute on AMI instance
+
 
 
 .. _faq-snitch-strategy:

--- a/docs/upgrade/_common/upgrade-guide-from-2021.x.y-to-2021.x.z-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2021.x.y-to-2021.x.z-ubuntu-and-debian.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - Scylla Enterprise 2021.x.y to 2021.x.z for |OS|
 ======================================================================
 
-This document is a step by step procedure for upgrading from Scylla Enterprise 2021.x.y to 2021.x.z.
+This document is a step by step procedure for upgrading from Scylla Enterprise 2021.x.y to 2021.x.z (where "z" is the :ref:`latest available version <faq-pinning>`).
 
 
 Applicable versions

--- a/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
@@ -2,7 +2,8 @@
 Upgrade Guide - ScyllaDB Enterprise 2022.x.y to 2022.x.z for |OS|
 ======================================================================
 
-This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2022.x.y to 2022.x.z.
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2022.x.y to 2022.x.z 
+(where "z" is the :ref:`latest available version <faq-pinning>`).
 
 
 Applicable versions

--- a/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p1.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - |SCYLLA_NAME| |SRC_VERSION| to |NEW_VERSION| for |OS|
 ======================================================================
 
-This document is a step-by-step procedure for upgrading from |SCYLLA_NAME| |FROM| to |SCYLLA_NAME| |TO|, and rollback to 2021.1 if required.
+This document is a step-by-step procedure for upgrading from |SCYLLA_NAME| |FROM| to |SCYLLA_NAME| |TO| (where "z" is the :ref:`latest available version <faq-pinning>`), and rollback to 2021.1 if required.
 
 Applicable versions
 ===================


### PR DESCRIPTION
This PR is related to https://github.com/scylladb/scylla-enterprise/issues/2176.
It adds a FAQ about a workaround to install a ScyllaDB version that is not the most recent patch version.
In addition, the link to that FAQ is added to the patch upgrade guides 2021 and 2022 .