### PR TITLE
docs: Update suggested AWS instance types in benchmark tips

### DIFF
--- a/docs/operating-scylla/procedures/tips/benchmark-tips.rst
+++ b/docs/operating-scylla/procedures/tips/benchmark-tips.rst
@@ -292,7 +292,7 @@ They have already been correctly configured for use in those public cloud enviro
 AWS
 ===
 
-AWS EC2 i3, i3en and cd5 bare metal instances are **highly recommended** because they are optimized for high I/O.
+AWS EC2 i3, i3en, i4i and c5d bare metal instances are **highly recommended** because they are optimized for high I/O.
 
 Read more about :ref:`Scylla Supported Platforms <system-requirements-supported-platforms>`.
 


### PR DESCRIPTION
The list of suggested instances had a misspelling of c5d, and didn't include the i4i instances recommended by https://www.scylladb.com/2022/05/09/scylladb-on-the-new-aws-ec2-i4i-instances-twice-the-throughput-lower-latency/