### PR TITLE
test/pylib: shorten UNIX-domain sock paths

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from aiohttp import request, BaseConnector, UnixConnector, ClientTimeout
 import pytest
 from test.pylib.internal_types import IPAddress, HostID
+from test.pylib.shorten_sockpath import ShortenSockpath
 
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,10 @@ class UnixRESTClient(RESTClient):
         #       host parameter is ignored but set to socket name as convention
         self.uri_scheme: str = "http+unix"
         self.default_host: str = f"{os.path.basename(sock_path)}"
-        self.connector = UnixConnector(path=sock_path)
+        # ShortenSockpath needs to be kept alive while it is used, so we
+        # keep it in self:
+        self.sock_path = ShortenSockpath(sock_path)
+        self.connector = UnixConnector(path = self.sock_path)
 
 
 class TCPRESTClient(RESTClient):

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -27,6 +27,7 @@ from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
 from test.pylib.util import LogPrefixAdapter
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo
+from test.pylib.shorten_sockpath import ShortenSockpath
 import aiohttp
 import aiohttp.web
 import yaml
@@ -853,7 +854,7 @@ class ScyllaClusterManager:
         # API
         # NOTE: need to make a safe temp dir as tempfile can't make a safe temp sock name
         self.manager_dir: str = tempfile.mkdtemp(prefix="manager-", dir=base_dir)
-        self.sock_path: str = f"{self.manager_dir}/api"
+        self.sock_path: ShortenSockPath = ShortenSockpath(f"{self.manager_dir}/api")
         app = aiohttp.web.Application()
         self._setup_routes(app)
         self.runner = aiohttp.web.AppRunner(app)

--- a/test/pylib/shorten_sockpath.py
+++ b/test/pylib/shorten_sockpath.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# The address of a UNIX-domain socket is a file path. For historic reasons,
+# the length of this path is limited to just a little over 100 bytes.
+# In our test/pylib code, we prefered to put the socket file in the test
+# output directory, which may have a very long path and result in socket
+# paths that cannot be used.
+#
+# So the following code has a Linux-specific workaround inspired by a similar
+# implementation in OpenvSwitch. It uses the fact that in Linux (and probably
+# other Unix-like systems as well), the socket is looked up by inode, not
+# name. So if we can use a shorter name to refer to the same file, it will
+# work. What we do is open the long-named directory, and then refer to it
+# using /proc/self/fd/NUM. The implementation is a class, which needs to be
+# held alive while it is used as a os.PathLike (we need to keep the file
+# descriptor open).
+
+from contextlib import contextmanager
+import os
+
+class ShortenSockpath:
+    def __init__(self, long_sockpath):
+        self.dirname, self.basename = os.path.split(long_sockpath)
+        self.dirfd = os.open(self.dirname, os.O_DIRECTORY | os.O_RDONLY)
+    # __fspath__() is needed to make ShortenSockpath comply with os.PathLike
+    def __fspath__(self):
+        return f"/proc/self/fd/{self.dirfd}/{self.basename}"
+    def __del__(self):
+        os.close(self.dirfd)
+    def orig(self):
+        return f"{self.dirname}/{self.basename}"
+    # hack: __str__() is used by test.py to print pass a "--manager-api" 
+    # option to the individual test. Pass the original socket name - the test
+    # will shorten it on its own to make the connection.
+    def __str__(self):
+        return self.orig()


### PR DESCRIPTION
The "pylib" library we use in the topology test suite uses a UNIX-domain socket to communicate between the cluster manager and the individual tests. The socket is located in the test directory (where both server and client can easily find it) but there is a problem: In Linux the length of the path used as a UNIX-domain socket address is limited to just a little over 100 bytes. In Jenkins run, the test directory names are very long, and we sometimes go over this path-size limit and the result is that test.py fails creating this socket.

In this path we add a simple "socket-path shortening" context manager, which temporarily gives us a shorter name for the long path, by opening the directory containing it and then referring to it using "/proc/self/fd/NUM". We then use this socket-path shortener in the two places in the code that open the UNIX-domain socket (the server and the client).

Tested by cloning Scylla in a very long directory name. A test like `./test.py --mode=dev test_concurrent_schema` fails before this patch, and passes with it.

Fixes #12622

Signed-off-by: Nadav Har'El <nyh@scylladb.com>