### PR TITLE
cql3, locator: call fmt::format_to() explicitly and include used headers

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -821,10 +821,10 @@ struct fmt::formatter<cql3::expr::expression> {
     }
 
     template <typename FormatContext>
-    auto format(const cql3::expr::expression& expr, FormatContext& ctx) {
+    auto format(const cql3::expr::expression& expr, FormatContext& ctx) const {
         std::ostringstream os;
         os << expr;
-        return format_to(ctx.out(), "{}", os.str());
+        return fmt::format_to(ctx.out(), "{}", os.str());
     }
 };
 
@@ -836,10 +836,10 @@ struct fmt::formatter<cql3::expr::expression::printer> {
     }
 
     template <typename FormatContext>
-    auto format(const cql3::expr::expression::printer& pr, FormatContext& ctx) {
+    auto format(const cql3::expr::expression::printer& pr, FormatContext& ctx) const {
         std::ostringstream os;
         os << pr;
-        return format_to(ctx.out(), "{}", os.str());
+        return fmt::format_to(ctx.out(), "{}", os.str());
     }
 };
 
@@ -854,6 +854,6 @@ struct fmt::formatter<cql3::expr::column_value> {
     auto format(const cql3::expr::column_value& col, FormatContext& ctx) {
         std::ostringstream os;
         os << col;
-        return format_to(ctx.out(), "{}", os.str());
+        return fmt::format_to(ctx.out(), "{}", os.str());
     }
 };

--- a/cql3/stats.hh
+++ b/cql3/stats.hh
@@ -12,6 +12,8 @@
 
 #include "cql3/statements/statement_type.hh"
 
+#include <cstdint>
+
 namespace cql3 {
 
 /** Enums for selecting counters in `cql_stats', like:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -308,7 +308,7 @@ struct fmt::formatter<locator::effective_replication_map::factory_key> {
     auto format(const locator::effective_replication_map::factory_key& key, FormatContext& ctx) {
         std::ostringstream os;
         os << key;
-        return format_to(ctx.out(), "{}", os.str());
+        return fmt::format_to(ctx.out(), "{}", os.str());
     }
 };
 


### PR DESCRIPTION
these fixes address the FTBFS of scylla with GCC-13.