### PR TITLE
sstables: The generation_type is not formattable

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -961,7 +961,7 @@ void sstable::filesystem_storage::open(sstable& sst, const io_priority_class& pc
         // the generation of a sstable that exists.
         w.close();
         remove_file(file_path).get();
-        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {:d} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
+        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {:d} of {}.{}", sst._generation.value(), sst._schema->ks_name(), sst._schema->cf_name()));
     }
 
     for (auto&& key : sst._recognized_components) {


### PR DESCRIPTION
If TOC writing hits TOC file conflict it tries to throw an exception with sstable generation in it. However, generation_type is not formattable at all, let alone the {:d} option.

This bug generates an obscure 'fmt::v9::format_error (invalid type specifier)' error in unknown location making the debugging hard.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>