### PR TITLE
alternator: eliminate duplicated rjson::find() of ExpressionAttributeNames and ExpressionAttributeValues

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3218,7 +3218,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         rs.cl = get_read_consistency(it->value);
         std::unordered_set<std::string> used_attribute_names;
         rs.attrs_to_get = ::make_shared<const std::optional<attrs_to_get>>(calculate_attrs_to_get(it->value, used_attribute_names));
-        const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
+        const rjson::value* expression_attribute_names = rjson::find(it->value, "ExpressionAttributeNames");
         verify_all_are_used(expression_attribute_names, used_attribute_names,"ExpressionAttributeNames", "GetItem");
         auto& keys = (it->value)["Keys"];
         for (rjson::value& key : keys.GetArray()) {


### PR DESCRIPTION
Summary of the patch set:
- eliminates not needed calls to rjson::find (~1% tps improvement in `perf-simple-query --write`)
- adds some very specific test in this area (more general cases were covered already)
- fixes some minor validation bug

Fixes https://github.com/scylladb/scylladb/issues/13251