### PR TITLE
cql3: prepare_expr: improve prepare_expression for token()

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -986,6 +986,12 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             }
             auto& schema = *schema_opt;
 
+            if (receiver.get() != nullptr && &receiver->type->without_reversed() != long_type.get()) {
+                throw exceptions::invalid_request_exception(
+                    format("token() produces a value fo type long, which doesn't match the type: {} of {}",
+                           receiver->type->name(), receiver->name->text()));
+            }
+
             std::vector<expression> prepared_token_args;
             prepared_token_args.reserve(tk.args.size());
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1338,8 +1338,7 @@ BOOST_AUTO_TEST_CASE(prepare_token) {
     BOOST_REQUIRE_THROW(prepare_expression(tok, db, "test_ks", table_schema.get(), make_receiver(utf8_type)), exceptions::invalid_request_exception);
 }
 
-// prepare_expression(token) doesn't validate its arguments,
-// validation is done in a different place
+// Calling token() with no arguments should fail, it requires all partition key columns as arguments.
 BOOST_AUTO_TEST_CASE(prepare_token_no_args) {
     schema_ptr table_schema = schema_builder("test_ks", "test_cf")
                                   .with_column("p1", int32_type, column_kind::partition_key)
@@ -1351,12 +1350,10 @@ BOOST_AUTO_TEST_CASE(prepare_token_no_args) {
     expression tok = token(std::vector<expression>());
     expression expected = tok;
 
-    // Preparing works as expected, both with and without a reciever
-    BOOST_REQUIRE_EQUAL(prepare_expression(tok, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(tok, db, "test_ks", table_schema.get(), make_receiver(long_type)), expected);
-
-    // Preparing with the wrong receiver fails
-    BOOST_REQUIRE_THROW(prepare_expression(tok, db, "test_ks", table_schema.get(), make_receiver(utf8_type)), exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(prepare_expression(tok, db, "test_ks", table_schema.get(), nullptr),
+                        exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(prepare_expression(tok, db, "test_ks", table_schema.get(), make_receiver(long_type)),
+                        exceptions::invalid_request_exception);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_cast_int_int) {


### PR DESCRIPTION
`prepare_expression` takes care of type inference, checking and general validation of expressions received from the parser.

The implementation for `token{}` was pretty rudimentary and could use some improvements:
* It didn't check the type of the `receiver` argument. This argument specifies what's the type of the value that the prepared expression will be assigned to. Generally `prepare_expression` should check that the type is correct, e.g we're not trying to assign an int to a text value. The code evolved in a way where some value types don't have these checks because everything works without them for now, but they should be eventually added for all types.

* There was no validation for the arguments to the `token()` function. It was never needed to perform this validation here, so it was never implemented. As a part of moving everything to `prepare_expression()` and `evaluate()` it needs to be implemented sooner or later.

  Currently token argument validation takes place in `statement_restrictions`, but it would be better to have it work on generic expressions and not only on the `WHERE` clause. If this were the case and selectable was based on prepared expressions we wouldn't have bugs like #10448
  
I was hoping that this would solve #10448, but the bug occurs when one tries to do `SELECT token(invalid, args)`, not `WHERE token(invalid, args) = 0` and it looks like it doesn't hit `preapare_expression` because of that :/
While it's not a fix yet, it should be a step in the right direction to finally get it fixed.