### PR TITLE
doc: fix the service name from "scylla-enterprise-server" "to "scylla-server"

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
@@ -68,7 +68,7 @@ Gracefully stop the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the new release
 ------------------------------------
@@ -92,13 +92,13 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
 1. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
 2. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
-3. Check scylla-enterprise-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+3. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
 4. Check again after 2 minutes to validate no new issues are introduced.
 
 Once you are sure the node upgrade is successful, move to the next node in the cluster.
@@ -130,7 +130,7 @@ Gracefully shutdown ScyllaDB
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Downgrade to the previous release
 ----------------------------------
@@ -164,7 +164,7 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------

--- a/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p1.rst
@@ -66,7 +66,7 @@ Gracefully stop the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the new release
 ------------------------------------

--- a/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-patch-ubuntu-and-debian-p2.rst
@@ -16,13 +16,13 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
 #. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
 #. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
-#. Check scylla-enterprise-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+#. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
 #. Check again after 2 minutes to validate no new issues are introduced.
 
 Once you are sure the node upgrade is successful, move to the next node in the cluster.
@@ -54,7 +54,7 @@ Gracefully shutdown ScyllaDB
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Downgrade to the previous release
 ----------------------------------
@@ -88,7 +88,7 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
@@ -69,7 +69,7 @@ Gracefully stop the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the new release
 ------------------------------------

--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p2.rst
@@ -36,13 +36,13 @@ A new io.conf format was introduced in Scylla 2.3 and 2019.1. If your io.conf do
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
 #. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
 #. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
-#. Check scylla-enterprise-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+#. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
 #. Check again after two minutes to validate no new issues are introduced.
 
 Once you are sure the node upgrade is successful, move to the next node in the cluster.
@@ -75,7 +75,7 @@ Gracefully shutdown ScyllaDB
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the old release
 ------------------------------------
@@ -120,7 +120,7 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-rpm.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-rpm.rst
@@ -63,7 +63,7 @@ Stop ScyllaDB
 
 .. code:: sh
 
-   sudo systemctl stop scylla-enterprise-server
+   sudo systemctl stop scylla-server
 
 Download and install the new release
 ------------------------------------
@@ -84,7 +84,7 @@ Start the node
 
 .. code:: sh
 
-   sudo systemctl start scylla-enterprise-server
+   sudo systemctl start scylla-server
 
 Validate
 --------
@@ -125,7 +125,7 @@ Gracefully shutdown ScyllaDB
 .. code:: sh
 
    nodetool drain
-   sudo systemctl stop scylla-enterprise-server
+   sudo systemctl stop scylla-server
 
 Downgrade to the previous release
 -----------------------------------
@@ -149,7 +149,7 @@ Start the node
 
 .. code:: sh
 
-   sudo systemctl start scylla-enterprise-server
+   sudo systemctl start scylla-server
 
 Validate
 --------


### PR DESCRIPTION
Related https://github.com/scylladb/scylladb/issues/12658. 

This issue fixes the bug in the upgrade guides for the released versions.

