### PR TITLE
uda: improve checking whether UDFs are used in UDAs in DROP statements

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -150,10 +150,11 @@ void functions::remove_function(const function_name& name, const std::vector<dat
     with_udf_iter(name, arg_types, [] (functions::declared_t::iterator i) { _declared.erase(i); });
 }
 
-std::optional<function_name> functions::used_by_user_aggregate(const function_name& name) {
+std::optional<function_name> functions::used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types) {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
-        if (aggregate && (aggregate->sfunc().name() == name || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name))) {
+        if (aggregate && ((aggregate->sfunc().name() == name && aggregate->sfunc().arg_types() == arg_types)
+            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -154,7 +154,8 @@ std::optional<function_name> functions::used_by_user_aggregate(const function_na
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
         if (aggregate && ((aggregate->sfunc().name() == name && aggregate->sfunc().arg_types() == arg_types)
-            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types))) {
+            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types)
+            || (aggregate->is_reducible() && aggregate->reducefunc().name() == name && aggregate->reducefunc().arg_types() == arg_types))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -71,7 +71,7 @@ public:
     static void add_function(shared_ptr<function>);
     static void replace_function(shared_ptr<function>);
     static void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    static std::optional<function_name> used_by_user_aggregate(const function_name& name);
+    static std::optional<function_name> used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types);
     static std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
     template <typename F>

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -35,7 +35,7 @@ drop_function_statement::prepare_schema_mutations(query_processor& qp, api::time
         if (!user_func) {
             throw exceptions::invalid_request_exception(format("'{}' is not a user defined function", func));
         }
-        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func->name()); bool(aggregate)) {
+        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func->name(), user_func->arg_types())) {
             throw exceptions::invalid_request_exception(format("Cannot delete function {}, as it is used by user-defined aggregate {}", func, *aggregate));
         }
         m = co_await qp.get_migration_manager().prepare_function_drop_announcement(user_func, ts);

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -101,13 +101,16 @@ def new_type(cql, keyspace, cmd):
 
 # A utility function for creating a new temporary user-defined function.
 @contextmanager
-def new_function(cql, keyspace, body, name=None):
+def new_function(cql, keyspace, body, name=None, args=None):
     fun = name if name else unique_name()
     cql.execute(f"CREATE FUNCTION {keyspace}.{fun} {body}")
     try:
         yield fun
     finally:
-        cql.execute(f"DROP FUNCTION {keyspace}.{fun}")
+        if args:
+            cql.execute(f"DROP FUNCTION {keyspace}.{fun}({args})")
+        else:
+            cql.execute(f"DROP FUNCTION {keyspace}.{fun}")
 
 # A utility function for creating a new temporary user-defined aggregate.
 @contextmanager


### PR DESCRIPTION
This patch fixes 2 issues with checking whether UDFs are used in UDAs:
1) UDFs types are not considered during the check, which prevents us from dropping a UDF that isn't used in any UDAs, but shares its name with one of them.
2) the REDUCEFUNC is not considered during the check, which allows dropping a UDF even though it's used in a UDA as the REDUCEFUNC.

Additionally, tests for these issues are added