### PR TITLE
test/pylib: require Scylla driver for ScyllaCluster

### DIFF
--- a/test.py
+++ b/test.py
@@ -899,11 +899,12 @@ class TopologyTest(PythonTest):
                 await manager.start()
                 self.success = await run_test(self, options)
             except Exception as e:
-                self.server_log = manager.cluster.read_server_log()
-                self.server_log_filename = manager.cluster.server_log_filename()
                 if manager.is_before_test_ok is False:
-                    print("Test {} pre-check failed: {}".format(self.name, str(e)))
-                    print("Server log of the first server:\n{}".format(self.server_log))
+                    if hasattr(manager, 'cluster'):
+                        self.server_log = manager.cluster.read_server_log()
+                        self.server_log_filename = manager.cluster.server_log_filename()
+                        print("Test {} pre-check failed: {}".format(self.name, str(e)))
+                        print("Server log of the first server:\n{}".format(self.server_log))
                     # Don't try to continue if the cluster is broken
                     raise
             manager.logger.info("Test %s %s", self.uname, "succeeded" if self.success else "failed ")

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -893,16 +893,17 @@ class ScyllaClusterManager:
         if hasattr(self, "site"):
             await self.site.stop()
             del self.site
-        if not self.cluster.is_dirty:
-            self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
-            await self.clusters.put(self.cluster)
-        else:
-            self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
-                            self.cluster, self.test_uname)
-            await self.cluster.stop()
-            await self.cluster.release_ips()
-            await self.clusters.steal()
-        del self.cluster
+        if hasattr(self, "cluster"):
+            if not self.cluster.is_dirty:
+                self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
+                await self.clusters.put(self.cluster)
+            else:
+                self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
+                                self.cluster, self.test_uname)
+                await self.cluster.stop()
+                await self.cluster.release_ips()
+                await self.clusters.steal()
+            del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)
         self.is_running = False

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -41,6 +41,7 @@ from cassandra.cluster import Session           # pylint: disable=no-name-in-mod
 from cassandra.cluster import ExecutionProfile  # pylint: disable=no-name-in-module
 from cassandra.cluster import EXEC_PROFILE_DEFAULT  # pylint: disable=no-name-in-module
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
+from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 
 
 class ReplaceConfig(NamedTuple):
@@ -543,6 +544,7 @@ class ScyllaCluster:
     def __init__(self, logger: Union[logging.Logger, logging.LoggerAdapter],
                  host_registry: HostRegistry, replicas: int,
                  create_server: Callable[[CreateServerParams], ScyllaServer]) -> None:
+        assert "scylla" in DRIVER_NAME.lower(), "ScyllaCluster requires Scylla driver"
         self.logger = logger
         self.host_registry = host_registry
         self.leased_ips = set[IPAddress]()


### PR DESCRIPTION
The `ScyllaCluster` class requires Scylla driver to work properly for detection, so check the driver before starting it.

While there, fix handling failed initialization of `ScyllaCluster`.