### PR TITLE
Metrics relabel from file

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -406,6 +406,7 @@ public:
     named_value<uint64_t> wasm_udf_yield_fuel;
     named_value<uint64_t> wasm_udf_total_fuel;
     named_value<size_t> wasm_udf_memory_limit;
+    named_value<sstring> relabel_config_file;
     // wasm_udf_reserved_memory is static because the options in db::config
     // are parsed using seastar::app_template, while this option is used for
     // configuring the Seastar memory subsystem.
@@ -464,4 +465,11 @@ inline bool is_true(sstring val) {
 
 future<> configure_tls_creds_builder(seastar::tls::credentials_builder& creds, db::config::string_map options);
 future<gms::inet_address> resolve(const config_file::named_value<sstring>&, gms::inet_address::opt_family family = {}, gms::inet_address::opt_family preferred = {});
+
+/*!
+ * \brief read the the relabel config from a file
+ *
+ * Will throw an exception if there is a conflict with the metrics names
+ */
+future<> update_relabel_config_from_file(const std::string& name);
 }

--- a/main.cc
+++ b/main.cc
@@ -569,6 +569,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 &token_metadata, &erm_factory, &snapshot_ctl, &messaging, &sst_dir_semaphore, &raft_gr, &service_memory_limiter,
                 &repair, &sst_loader, &ss, &lifecycle_notifier, &stream_manager, &task_manager] {
           try {
+              if (opts.contains("relabel-config-file") && !opts["relabel-config-file"].as<sstring>().empty()) {
+                  // calling update_relabel_config_from_file can cause an exception that would stop startup
+                  // that's on purpose, it means the configuration is broken and needs to be fixed
+                  utils::update_relabel_config_from_file(opts["relabel-config-file"].as<sstring>()).get();
+              }
             // disable reactor stall detection during startup
             auto blocked_reactor_notify_ms = engine().get_blocked_reactor_notify_ms();
             smp::invoke_on_all([] {


### PR DESCRIPTION
This series adds an option to read the relabel config from file.

Most of Scylla's metrics are reported per-shard, some times they are also reported per scheduling
groups or per tables.  With modern hardware, this can quickly grow to a large number of metrics that 
overload Scylla and the  collecting server. 

One of the main issues around metrics reduction is that many of the metrics are only
helpful in certain situations.

For example, Scylla monitoring only looks at a subset of the metrics. So in large deployments
it would be helpful to scrap only those.

An option to do that, would be to mark all dashboards related metrics with a label value, and then Prometheus
will request only metrics with that label value.

There are two main limitations to scrap by label values:
1. some of the metrics we want to report are in seastar, so we'll need to label them somehow (we cannot just add random labels to seastar metrics)
2. things change, new metrics are introduce and we may want them, it's not practicall to re-compile and wait
for a new release whenever we want to change a label just for monitoring.

It will be best to have the option to add metrics freely and choose at runtime what to report. 

This series make use of Seastar API to perform metrics manipulation dynamically. It includes adding, removing, and changing labels and also enable and disable metrics, and enable and disable the skip_when_empty option.

After this series the configuration could be used with:
```--relabel-config-file conf.yaml```

The general logic and format follows Prometheus metrics_relabel_config configuration.

Where the configuration file looks like:
```
$ cat conf.yaml 
relabel_configs:
  - source_labels: [shard]
    action: drop 
    target_label: shard 
    regex: (2)
  - source_labels: [shard]
    action: replace
    target_label: level 
    replacement: $1
    regex: (.*3)

```