### PR TITLE
build: disable Seastar's io_uring backend again

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1605,6 +1605,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
+        '-DSeastar_IO_URING=OFF', # io_uring backend is not stable enough
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:


### PR DESCRIPTION
this partially reverts 49157370bcbd59660ce62b8080bc6d243099ba9a

according the reports in #12173, at least two developers ran into test failures which are correlated with the lastest Seastar change, which enables the io_uring backend by default. they are using linux kernel 6.0.12 and 6.1.7. it's also reported that reverting the the commit of eedca15f16c3b6eae3d3d8af9510624a93f5d186 in seastar helps. that very commit enables the io_uring by default. although we are not able to identify the exact root cause of the failures in #12173 at this moment, to rule out the potential problem of io_uring should help with further investigation.

in this change, io_uring backend is disabled when building Seastar.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>