### PR TITLE
reader_concurrency_semaphore: un-bless permits when they become inactive

### DIFF
--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -528,4 +528,6 @@ public:
     }
 
     void foreach_permit(noncopyable_function<void(const reader_permit&)> func);
+
+    uintptr_t get_blessed_permit() const noexcept { return reinterpret_cast<uintptr_t>(_blessed_permit); }
 };


### PR DESCRIPTION
When the memory consumption of the semaphore reaches the configured serialize threshold, all but the blessed permit is blocked from consuming any more memory. This ensures that past this limit, only one permit at a time can consume memory.
Such a blessed permit can be registered inactive. Before this patch, it would still retain its belssed status when doing so. This could result in this permit being re-queued for admission if it was evicted in the meanwhile, potentially resulting in a complete deadlock of the semaphore: 
* admission queue permits cannot be admitted because there is no memory
* admitter permits are all queued on memory, as none of them are blessed

This patch strips the blessed status from the permit when it is registered as inactive. It also adds a unit test to verify this happens.

Fixes: #12603