### PR TITLE
doc: fix the service name from "scylla-enterprise-server" "to "scylla-server" - part 2

### DIFF
--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.1-to-2022.2/upgrade-guide-from-2022.1-to-2022.2-generic.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.1-to-2022.2/upgrade-guide-from-2022.1-to-2022.2-generic.rst
@@ -102,7 +102,7 @@ Gracefully stop the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 .. _upgrade-debian-ubuntu-enterprise-2022.2: 
 
@@ -138,7 +138,7 @@ Download and install the new release
 
                sudo apt-get clean all
                sudo apt-get update
-               sudo apt-get dist-upgrade scylla-enterprise-server
+               sudo apt-get dist-upgrade scylla-enterprise
 
 
         Answer ‘y’ to the first two questions.
@@ -213,13 +213,13 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
 #. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in ``UN`` status.
 #. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version. Validate that the version matches the one you upgraded to.
-#. Check scylla-enterprise-server log (using ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no new errors in the log.
+#. Check scylla-server log (using ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no new errors in the log.
 #. Check again after two minutes, to validate no new issues are introduced.
 
 Once you are sure the node upgrade was successful, move to the next node in the cluster.
@@ -260,7 +260,7 @@ Drain and gracefully stop the node
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the old release
 ------------------------------------
@@ -359,7 +359,7 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------


### PR DESCRIPTION
Related https://github.com/scylladb/scylladb/issues/12658.

This issue fixes the bug in the upgrade guide for the version about to be released (2022.2).
In addition, it fixes the package name from "scylla-enterprise-server" to "scylla-enterprise" (one occurrence).