### PR TITLE
test: reproducers for store mutation with schema change and host down

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -48,10 +48,11 @@ class ManagerClient():
         """Close driver"""
         self.driver_close()
 
-    async def driver_connect(self) -> None:
+    async def driver_connect(self, server=None) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:
-            servers = [s_info.ip_addr for s_info in await self.running_servers()]
+            targets = [server] if server else await self.running_servers()
+            servers = [s_info.ip_addr for s_info in targets]
             logger.debug("driver connecting to %s", servers)
             self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
             self.cql = self.ccluster.connect()

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -245,7 +245,8 @@ class RandomTable():
 
 class RandomTables():
     """A list of managed random tables"""
-    def __init__(self, test_name: str, manager: ManagerClient, keyspace: str):
+    def __init__(self, test_name: str, manager: ManagerClient, keyspace: str,
+                 replication_factor: int):
         self.test_name = test_name
         self.manager = manager
         self.keyspace = keyspace
@@ -253,7 +254,8 @@ class RandomTables():
         self.removed_tables: List[RandomTable] = []
         assert self.manager.cql is not None
         self.manager.cql.execute(f"CREATE KEYSPACE {keyspace} WITH REPLICATION = "
-                                 "{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
+                                 "{ 'class' : 'NetworkTopologyStrategy', "
+                                 f"'replication_factor' : {replication_factor} }}")
 
     async def add_tables(self, ntables: int = 1, ncolumns: int = 5, if_not_exists: bool = False) -> None:
         """Add random tables to the list.

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -190,6 +190,12 @@ class ScyllaRESTAPIClient():
         assert(type(data) == list)
         return data
 
+    async def get_alive_endpoints(self, node_ip: str) -> list:
+        """Get the list of alive nodes according to `node_ip`."""
+        data = await self.client.get_json(f"/gossiper/endpoint/live", host=node_ip)
+        assert(type(data) == list)
+        return data
+
     async def enable_injection(self, node_ip: str, injection: str, one_shot: bool) -> None:
         """Enable error injection named `injection` on `node_ip`. Depending on `one_shot`,
            the injection will be executed only once or every time the process passes the injection point.

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -17,6 +17,8 @@ from cassandra.cluster import Session, ResponseFuture                    # type:
 from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore # pylint: disable=no-name-in-module
 from cassandra.policies import RoundRobinPolicy                          # type: ignore
+from cassandra.policies import TokenAwarePolicy                          # type: ignore
+from cassandra.policies import WhiteListRoundRobinPolicy                 # type: ignore
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
@@ -122,6 +124,11 @@ def cluster_con(hosts: List[IPAddress], port: int, use_ssl: bool):
         # See issue #11289.
         # NOTE: request_timeout is the main cause of timeouts, even if logs say heartbeat
         request_timeout=200)
+    whitelist_profile = ExecutionProfile(
+        load_balancing_policy=TokenAwarePolicy(WhiteListRoundRobinPolicy(hosts)),
+        consistency_level=ConsistencyLevel.LOCAL_QUORUM,
+        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
+        request_timeout=200)
     if use_ssl:
         # Scylla does not support any earlier TLS protocol. If you try,
         # you will get mysterious EOF errors (see issue #6971) :-(
@@ -129,7 +136,7 @@ def cluster_con(hosts: List[IPAddress], port: int, use_ssl: bool):
     else:
         ssl_context = None
 
-    return Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+    return Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile, 'whitelist': whitelist_profile},
                    contact_points=hosts,
                    port=port,
                    # TODO: make the protocol version an option, to allow testing with

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -216,7 +216,7 @@ def fails_without_consistent_cluster_management(request, check_pre_consistent_cl
 # unless the cluster is dirty or the test has failed.
 @pytest.fixture(scope="function")
 async def random_tables(request, manager):
-    tables = RandomTables(request.node.name, manager, unique_name())
+    tables = RandomTables(request.node.name, manager, unique_name(), 1)
     yield tables
 
     # Don't drop tables at the end if we failed or the cluster is dirty - it may be impossible

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -216,7 +216,9 @@ def fails_without_consistent_cluster_management(request, check_pre_consistent_cl
 # unless the cluster is dirty or the test has failed.
 @pytest.fixture(scope="function")
 async def random_tables(request, manager):
-    tables = RandomTables(request.node.name, manager, unique_name(), 1)
+    rf_marker = request.node.get_closest_marker("replication_factor")
+    replication_factor = rf_marker.args[0] if rf_marker is not None else 3  # Default 3
+    tables = RandomTables(request.node.name, manager, unique_name(), replication_factor)
     yield tables
 
     # Don't drop tables at the end if we failed or the cluster is dirty - it may be impossible

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -1,0 +1,159 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Reproducer for a failure during lwt operation due to missing of a column mapping in schema history table.
+"""
+import asyncio
+import logging
+import time
+from functools import partial
+from test.pylib.rest_client import inject_error_one_shot, inject_error
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import IPAddress, ServerInfo
+import pytest
+from cassandra.cluster import Cluster, ConsistencyLevel  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement              # type: ignore # pylint: disable=no-name-in-module
+
+
+logger = logging.getLogger(__name__)
+
+
+async def server_sees_another_server(server: ServerInfo, manager: ManagerClient):
+    alive_nodes = await manager.api.get_alive_endpoints(server.ip_addr)
+    if len(alive_nodes) > 1:
+        return True
+
+@pytest.mark.asyncio
+async def test_mutation_schema_change(manager, random_tables):
+    """
+        Cluster A, B, C
+        create table
+        stop C
+        change schema + do lwt write + change schema
+        stop B
+        start C
+        do lwt write to the same key through C
+    """
+    server_a, server_b, server_c = await manager.running_servers()
+    t = await random_tables.add_table(ncolumns=5, pks=1)
+    manager.driver_close()
+    # Reduce the snapshot thresholds
+    await manager.mark_dirty()
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
+            for s in [server_a, server_b, server_c]]
+    await asyncio.gather(*errs)
+
+
+    logger.info("Stopping C %s", server_c)
+    await manager.server_stop_gracefully(server_c.server_id)
+    await manager.driver_connect()
+
+    async with inject_error(manager.api, server_b.ip_addr, 'paxos_error_before_learn'):
+        await t.add_column()
+        ROWS = 1
+        seeds = [t.next_seq() for _ in range(ROWS)]
+        stmt = f"INSERT INTO {t} ({','.join(c.name for c in t.columns)}) " \
+               f"VALUES ({', '.join(['%s'] * len(t.columns))}) "           \
+               f"IF NOT EXISTS"
+        query = SimpleStatement(stmt, consistency_level=ConsistencyLevel.ONE)
+        for seed in seeds:
+            logger.info("INSERT row seed %s", seed)
+            await manager.cql.run_async(query, parameters=[c.val(seed) for c in t.columns])
+        await t.add_column()
+
+    logger.info("Stopping B %s", server_b)
+    await manager.server_stop_gracefully(server_b.server_id)
+    logger.info("Starting C %s", server_c)
+    await manager.server_start(server_c.server_id)
+
+    await wait_for(partial(server_sees_another_server, server_c, manager), time.time() + 45, period=.1)
+
+    logger.info("Driver connecting to C %s", server_c)
+    await manager.driver_connect(server=server_c)
+    await wait_for_cql_and_get_hosts(manager.cql, [server_a, server_c], time.time() + 60)
+
+    stmt = f"UPDATE {t} "                        \
+           f"SET   {t.columns[3].name} = %s "  \
+           f"WHERE {t.columns[0].name} = %s "  \
+           f"IF    {t.columns[3].name} = %s"
+    query = SimpleStatement(stmt, consistency_level=ConsistencyLevel.ONE)
+    for seed in seeds:
+        logger.info("UPDATE with seed %s", seed)
+        await manager.cql.run_async(query, parameters=[t.columns[3].val(seed + 1), # v_01 = seed + 1
+                                                       t.columns[0].val(seed),     # pk = seed
+                                                       t.columns[3].val(seed)],    # v_01 == seed
+                                    execution_profile='whitelist')
+
+
+@pytest.mark.asyncio
+async def test_mutation_schema_change_restart(manager, random_tables):
+    """
+        Cluster A, B, C
+        create table
+        stop C
+        change schema + do lwt write + change schema
+        stop B
+        restart A
+        start C
+        do lwt write to the same key through A
+    """
+    server_a, server_b, server_c = await manager.running_servers()
+    t = await random_tables.add_table(ncolumns=5, pks=1)
+    manager.driver_close()
+    # Reduce the snapshot thresholds
+    await manager.mark_dirty()
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
+            for s in [server_a, server_b, server_c]]
+    await asyncio.gather(*errs)
+
+    logger.info("Stopping C %s", server_c)
+    await manager.server_stop_gracefully(server_c.server_id)
+    await manager.driver_connect()
+
+    await inject_error_one_shot(manager.api, server_a.ip_addr,
+                                'raft_server_reduce_threshold')
+    async with inject_error(manager.api, server_b.ip_addr, 'paxos_error_before_learn'):
+        await t.add_column()
+        ROWS = 1
+        seeds = [t.next_seq() for _ in range(ROWS)]
+        stmt = f"INSERT INTO {t} ({','.join(c.name for c in t.columns)}) " \
+               f"VALUES ({', '.join(['%s'] * len(t.columns))}) "           \
+               f"IF NOT EXISTS"
+        query = SimpleStatement(stmt, consistency_level=ConsistencyLevel.ONE)
+        for seed in seeds:
+            logger.info("INSERT row seed %s", seed)
+            await manager.cql.run_async(query, parameters=[c.val(seed) for c in t.columns])
+        await t.add_column()
+
+    manager.driver_close()
+
+    logger.info("Stopping B %s", server_b)
+    await manager.server_stop_gracefully(server_b.server_id)
+    logger.info("Restarting A %s", server_a)
+    await manager.server_restart(server_a.server_id)
+    logger.info("Starting C %s", server_c)
+    await manager.server_start(server_c.server_id)
+
+    # Wait for C and A to see each other
+    await wait_for(partial(server_sees_another_server, server_c, manager), time.time() + 45, period=.1)
+    await wait_for(partial(server_sees_another_server, server_a, manager), time.time() + 45, period=.1)
+
+    logger.info("Driver connecting to A %s", server_a)
+    await manager.driver_connect(server=server_a)
+
+    await wait_for_cql_and_get_hosts(manager.cql, [server_a, server_c], time.time() + 60)
+    stmt = f"UPDATE {t} "                        \
+           f"SET   {t.columns[3].name} = %s "  \
+           f"WHERE {t.columns[0].name} = %s "  \
+           f"IF    {t.columns[3].name} = %s"
+    query = SimpleStatement(stmt, consistency_level=ConsistencyLevel.ONE)
+    for seed in seeds:
+        logger.info("UPDATE with seed %s", seed)
+        await manager.cql.run_async(query, parameters=[t.columns[3].val(seed + 1), # v_01 = seed + 1
+                                                       t.columns[0].val(seed),     # pk = seed
+                                                       t.columns[3].val(seed)],    # v_01 == seed
+                                    execution_profile='whitelist')

--- a/test/topology_custom/test_custom.py
+++ b/test/topology_custom/test_custom.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_custom(request, manager: ManagerClient):
     servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
-    tables = RandomTables(request.node.name, manager, unique_name())
+    tables = RandomTables(request.node.name, manager, unique_name(), 3)
     table = await tables.add_table(ncolumns=5)
     await table.insert_seq()
     await table.add_index(2)

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -166,6 +166,7 @@ async def test_upgrade_with_no_schema_commitlog(manager: ManagerClient, random_t
 
 @pytest.mark.asyncio
 @log_run_time
+@pytest.mark.replication_factor(1)
 async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):
     """
     kbr-: the test takes about 7 seconds in dev mode on my laptop.
@@ -200,6 +201,7 @@ async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomT
 
 @pytest.mark.asyncio
 @log_run_time
+@pytest.mark.replication_factor(1)
 async def test_recover_stuck_raft_upgrade(manager: ManagerClient, random_tables: RandomTables):
     """
     We enable Raft on every server and the upgrade procedure starts.  All servers join group 0. Then one
@@ -284,6 +286,7 @@ async def test_recover_stuck_raft_upgrade(manager: ManagerClient, random_tables:
 
 @pytest.mark.asyncio
 @log_run_time
+@pytest.mark.replication_factor(1)
 async def test_recovery_after_majority_loss(manager: ManagerClient, random_tables: RandomTables):
     """
     We successfully upgrade a cluster. Eventually however all servers but one fail - group 0


### PR DESCRIPTION
Reproducers for https://github.com/scylladb/scylladb/issues/10770.

(Already fixed in https://github.com/scylladb/scylladb/commit/15ebd5907177ba8709bc40ad2fa9ae773a9cf674)

Includes necessary improvements and fixes to `pylib`.