### PR TITLE
cql3: expr: don't pass empty evaluation_inputs in is_one_of

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -460,7 +460,7 @@ bool_or_null is_one_of(const expression& lhs, const expression& rhs, const evalu
     expression lhs_constant = constant(raw_value::make_value(std::move(lhs_bytes)), type_of(lhs));
     utils::chunked_vector<managed_bytes_opt> list_elems = get_list_elements(raw_value::make_value(std::move(rhs_bytes)));
     for (const managed_bytes_opt& elem : list_elems) {
-        if (equal(lhs_constant, elem, evaluation_inputs{}).is_true()) {
+        if (equal(lhs_constant, elem, inputs).is_true()) {
             return true;
         }
     }

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -312,6 +312,12 @@ def test_filter_in_restriction(cql, test_keyspace, cassandra_bug):
         assert [(1,)] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (2, 7) ALLOW FILTERING'))
         assert [] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (3, 7) ALLOW FILTERING'))
 
+        prepared_select1 = cql.prepare(f'SELECT ck FROM {table} WHERE x IN (?, 4) ALLOW FILTERING')
+        assert [(1,), (2,)] == list(cql.execute(prepared_select1, [2]))
+
+        prepared_select2 = cql.prepare(f'SELECT ck FROM {table} WHERE x IN ? ALLOW FILTERING')
+        assert [(1,), (2,)] == list(cql.execute(prepared_select2, [[2, 4]]))
+
 
 # Both Cassandra and Scylla allow filtering restrictions on frozen UDTs,
 # and the "frozen=True" case of the following test verifies their behavior


### PR DESCRIPTION
`evaluation_inputs` is a struct which contains data needed to evaluate expressions - values of columns, bind variables and other data.
`is_on_of()` is a function used to to evaluate `IN` restrictions. It checks whether the LHS is one of elements on the RHS list.

Generally when evaluating expressions we get the `evaluation_inputs` as an argument and we should pass them along to any functions that evaluate subexpressions.

`is_one_of()` got the inputs as an argument, but didn't pass them along to `equal()`, instead it creates new empty `evaluation_inputs{}` and gives that to `equal()`.

At first [I thought this was a bug](https://github.com/scylladb/scylladb/pull/12356#discussion_r1084300969) - with missing information there could be a crash if `equal()` tried to evaluate an expression with a `bind_variable`.
It turns out that in this particular case `equal()` won't use the `evaluation_inputs` at all. The LHS and RHS passed to it are just constant values, which were already evaluated to serialized bytes before calling `evaluate()`, so there is no bug.

It's still better to pass the inputs argument along if possible. If in the future `equal()` required these inputs for some reason, missing inputs could lead to an unexpected crash.
I couldn't find any tests that would detect this case, so such a bug could stay undetected until an unhappy user finds it because their cluster crashed.
I added some tests to make sure that it's covered from now on.