### PR TITLE
cql3: expr: simplify user/debug formatting

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -428,12 +428,8 @@ namespace {
 bool_or_null like(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
     data_type lhs_type = type_of(lhs)->underlying_type();
     if (!lhs_type->is_string()) {
-        expression::printer lhs_printer {
-            .expr_to_print = lhs,
-            .debug_mode = false
-        };
         throw exceptions::invalid_request_exception(
-                format("LIKE is allowed only on string types, which {} is not", lhs_printer));
+                format("LIKE is allowed only on string types, which {:user} is not", lhs));
     }
     std::optional<std::pair<managed_bytes, managed_bytes>> sides_bytes =
         evaluate_binop_sides(lhs, rhs, oper_t::LIKE, inputs);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1259,11 +1259,9 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
         bool rhs_is_null = is<constant>(prepared_rhs) && as<constant>(prepared_rhs).is_null();
 
         if (!rhs_is_null) {
-            expression binop_expr = binop;
-            expression::printer binop_printer{.expr_to_print = binop_expr, .debug_mode = false};
             throw exceptions::invalid_request_exception(format(
-                "IS NOT NULL is the only expression that is allowed when using IS NOT. Invalid binary operator: {}",
-                binop_printer));
+                "IS NOT NULL is the only expression that is allowed when using IS NOT. Invalid binary operator: {:user}",
+                binop));
         }
     }
 

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -133,21 +133,15 @@ void validate_token_relation(const std::vector<const column_definition*> column_
 }
 
 void preliminary_binop_vaidation_checks(const binary_operator& binop) {
-    // Needed to print unprepared expressions in non-debug mode
-    expression::printer pretty_binop_printer {
-        .expr_to_print = binop,
-        .debug_mode = false
-    };
-
     if (binop.op == oper_t::NEQ) {
-        throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {}", pretty_binop_printer));
+        throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {:user}", binop));
     }
 
     if (binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = (is<untyped_constant>(binop.rhs) && as<untyped_constant>(binop.rhs).partial_type == untyped_constant::type_class::null)
                            || (is<constant>(binop.rhs) && as<constant>(binop.rhs).is_null());
         if (!rhs_is_null) {
-            throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {}", pretty_binop_printer));
+            throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {:user}", binop));
         }
     }
 

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -123,11 +123,7 @@ void validate_timestamp(const db::config& config, const query_options& options, 
 
 sstring relations_to_where_clause(const expr::expression& e) {
     auto expr_to_pretty_string = [](const expr::expression& e) -> sstring {
-        expr::expression::printer p {
-            .expr_to_print = e,
-            .debug_mode = false,
-        };
-        return fmt::format("{}", p);
+        return fmt::format("{:user}", e);
     };
     auto relations = expr::boolean_factors(e);
     auto expressions = relations | boost::adaptors::transformed(expr_to_pretty_string);

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -99,11 +99,7 @@ BOOST_AUTO_TEST_CASE(expr_visit_visitor_rvalue) {
 }
 
 static sstring expr_print(const expression& e) {
-    expression::printer p {
-        .expr_to_print = e,
-        .debug_mode = false
-    };
-    return format("{}", p);
+    return format("{:user}", e);
 }
 
 static sstring value_print(const cql3::raw_value& v, const expression& e) {


### PR DESCRIPTION
We have a cql3::expr::expression::printer wrapper that annotates an expression with a debug_mode boolean prior to formatting. The fmt library, however, provides a much simpler alterantive: a custom format specifier. With this, we can write format("{:u}", expr) for user-oriented prints, or format("{:d}", expr) for debug-oriented prints (if nothing is specified, the default remains debug).

This is done by implementing fmt::formatter::parse() for the expression type, can using expression::printer internally.

Since sometimes we pass expression element types rather than the expression variant, we also provide a custom formatter for all ExpressionElement Types.

Uses for expression::printer are updated to use the nicer syntax.