### PR TITLE
Convert datadir paths on table and keyspace into locations

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -761,7 +761,7 @@ void set_column_family(http_context& ctx, routes& r) {
 
     cf::get_true_snapshots_size.set(r, [&ctx] (std::unique_ptr<request> req) {
         auto uuid = get_uuid(req->param["name"], ctx.db.local());
-        return ctx.db.local().find_column_family(uuid).get_snapshot_details().then([](
+        return ctx.db.local().find_column_family(uuid).get_snapshot_details(ctx.db.local().get_config()).then([](
                 const std::unordered_map<sstring, replica::column_family::snapshot_details>& sd) {
             int64_t res = 0;
             for (auto i : sd) {

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -409,7 +409,9 @@ public:
                 l0_old_ssts.push_back(std::move(sst));
             }
         }
-        _l0_scts.replace_sstables(std::move(l0_old_ssts), std::move(l0_new_ssts));
+        if (l0_old_ssts.size() || l0_new_ssts.size()) {
+            _l0_scts.replace_sstables(std::move(l0_old_ssts), std::move(l0_new_ssts));
+        }
     }
 };
 

--- a/configure.py
+++ b/configure.py
@@ -1605,6 +1605,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
+        '-DSeastar_IO_URING=OFF', # io_uring backend is not stable enough
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -27,7 +27,7 @@ future<> snapshot_ctl::check_snapshot_not_exist(sstring ks_name, sstring name, s
             return make_ready_future<>();
         }        
         auto& cf = _db.local().find_column_family(pair.second);
-        return cf.snapshot_exists(name).then([ks_name = std::move(ks_name), name] (bool exists) {
+        return cf.snapshot_exists(_db.local().get_config(), name).then([ks_name = std::move(ks_name), name] (bool exists) {
             if (exists) {
                 throw std::runtime_error(format("Keyspace {}: snapshot {} already exists.", ks_name, name));
             }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2074,7 +2074,7 @@ public:
                     if (table->schema()->ks_name() != ks_name) {
                         continue;
                     }
-                    const auto unordered_snapshots = co_await table->get_snapshot_details();
+                    const auto unordered_snapshots = co_await table->get_snapshot_details(db.get_config());
                     snapshots_by_tables.emplace(table->schema()->cf_name(), std::map<sstring, replica::table::snapshot_details>(unordered_snapshots.begin(), unordered_snapshots.end()));
                 }
                 co_return snapshots_by_tables;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1362,7 +1362,8 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
     }
 
     if (datadir != "") {
-        co_await io_check([&datadir] { return touch_directory(datadir); });
+        auto& sstm = system ? get_system_sstables_manager() : get_user_sstables_manager();
+        co_await sstm.initialize_keyspace_storage(datadir);
     }
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1242,11 +1242,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     column_family::config cfg;
     const db::config& db_config = db.get_config();
 
-    for (auto& extra : db_config.data_file_directories()) {
-        cfg.all_datadirs.push_back(column_family_directory(format("{}/{}", extra, _config.location), s.cf_name(), s.id()));
-    }
     cfg.location = column_family_directory(_config.location, s.cf_name(), s.id());
-    cfg.datadir = format("{}/{}", db_config.data_file_directories()[0], cfg.location);
     cfg.enable_disk_reads = _config.enable_disk_reads;
     cfg.enable_disk_writes = _config.enable_disk_writes;
     cfg.enable_commitlog = _config.enable_commitlog;
@@ -2045,10 +2041,6 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
     keyspace::config cfg;
     if (_cfg.data_file_directories().size() > 0) {
         cfg.location = ksm.name();
-        cfg.datadir = format("{}/{}", _cfg.data_file_directories()[0], cfg.location);
-        for (auto& extra : _cfg.data_file_directories()) {
-            cfg.all_datadirs.push_back(format("{}/{}", extra, ksm.name()));
-        }
         cfg.enable_disk_writes = !_cfg.enable_in_memory_data_store();
         cfg.enable_disk_reads = true; // we allways read from disk
         cfg.enable_commitlog = _cfg.enable_commitlog() && !_cfg.enable_in_memory_data_store();
@@ -2056,7 +2048,6 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
 
     } else {
         cfg.location = "";
-        cfg.datadir = "";
         cfg.enable_disk_writes = false;
         cfg.enable_disk_reads = false;
         cfg.enable_commitlog = false;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1353,7 +1353,6 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
 
     co_await create_in_memory_keyspace(ksm, erm_factory, system);
     auto& ks = _keyspaces.at(ksm->name());
-    auto& datadir = ks.datadir();
 
     // keyspace created by either cql or migration 
     // is by definition populated
@@ -1361,9 +1360,9 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
         ks.mark_as_populated();
     }
 
-    if (datadir != "") {
+    if (ks.location() != "") {
         auto& sstm = system ? get_system_sstables_manager() : get_user_sstables_manager();
-        co_await sstm.initialize_keyspace_storage(datadir);
+        co_await sstm.initialize_keyspace_storage(ks.location());
     }
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1241,8 +1241,8 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     column_family::config cfg;
     const db::config& db_config = db.get_config();
 
-    for (auto& extra : _config.all_datadirs) {
-        cfg.all_datadirs.push_back(column_family_directory(extra, s.cf_name(), s.id()));
+    for (auto& extra : db_config.data_file_directories()) {
+        cfg.all_datadirs.push_back(column_family_directory(format("{}/{}", extra, _config.location), s.cf_name(), s.id()));
     }
     cfg.datadir = cfg.all_datadirs[0];
     cfg.enable_disk_reads = _config.enable_disk_reads;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2042,7 +2042,8 @@ keyspace::config
 database::make_keyspace_config(const keyspace_metadata& ksm) {
     keyspace::config cfg;
     if (_cfg.data_file_directories().size() > 0) {
-        cfg.datadir = format("{}/{}", _cfg.data_file_directories()[0], ksm.name());
+        cfg.location = ksm.name();
+        cfg.datadir = format("{}/{}", _cfg.data_file_directories()[0], cfg.location);
         for (auto& extra : _cfg.data_file_directories()) {
             cfg.all_datadirs.push_back(format("{}/{}", extra, ksm.name()));
         }
@@ -2052,6 +2053,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
         cfg.enable_cache = _cfg.enable_cache();
 
     } else {
+        cfg.location = "";
         cfg.datadir = "";
         cfg.enable_disk_writes = false;
         cfg.enable_disk_reads = false;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1244,7 +1244,8 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     for (auto& extra : db_config.data_file_directories()) {
         cfg.all_datadirs.push_back(column_family_directory(format("{}/{}", extra, _config.location), s.cf_name(), s.id()));
     }
-    cfg.datadir = cfg.all_datadirs[0];
+    cfg.location = column_family_directory(_config.location, s.cf_name(), s.id());
+    cfg.datadir = format("{}/{}", db_config.data_file_directories()[0], cfg.location);
     cfg.enable_disk_reads = _config.enable_disk_reads;
     cfg.enable_disk_writes = _config.enable_disk_writes;
     cfg.enable_commitlog = _config.enable_commitlog;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1281,21 +1281,6 @@ keyspace::column_family_directory(const sstring& base_path, const sstring& name,
     return format("{}/{}-{}", base_path, name, uuid_sstring);
 }
 
-future<>
-table::make_directory_for_column_family() {
-    std::vector<sstring> cfdirs;
-    for (auto& extra : _config.all_datadirs) {
-        cfdirs.push_back(extra);
-    }
-    return parallel_for_each(cfdirs, [] (sstring cfdir) {
-        return io_check([cfdir] { return recursive_touch_directory(cfdir); });
-    }).then([cfdirs0 = cfdirs[0]] {
-        return io_check([cfdirs0] { return touch_directory(cfdirs0 + "/upload"); });
-    }).then([cfdirs0 = cfdirs[0]] {
-        return io_check([cfdirs0] { return touch_directory(cfdirs0 + "/staging"); });
-    });
-}
-
 column_family& database::find_column_family(const schema_ptr& schema) {
     return find_column_family(schema->id());
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1108,6 +1108,7 @@ public:
     compaction::table_state& as_table_state() const noexcept;
     // Safely iterate through table states, while performing async operations on them.
     future<> parallel_foreach_table_state(std::function<future<>(compaction::table_state&)> action);
+    future<> make_directory_for_column_family();
 
     friend class compaction_group;
 };
@@ -1191,7 +1192,6 @@ public:
     }
 
     column_family::config make_column_family_config(const schema& s, const database& db) const;
-    future<> make_directory_for_column_family(const sstring& name, table_id uuid);
     void add_or_update_column_family(const schema_ptr& s);
     void add_user_type(const user_type ut);
     void remove_user_type(const user_type ut);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -837,7 +837,7 @@ public:
     // sitting in the memtable, will be compacted with shadowed data.
     future<> compact_all_sstables();
 
-    future<bool> snapshot_exists(sstring name);
+    future<bool> snapshot_exists(const db::config& cfg, sstring name);
 
     db::replay_position set_low_replay_position_mark();
 
@@ -852,7 +852,7 @@ private:
 public:
     static future<> snapshot_on_all_shards(sharded<database>& sharded_db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>& table_shards, sstring name);
 
-    future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
+    future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details(const db::config& cfg);
 
     /*!
      * \brief write the schema to a 'schema.cql' file at the given directory.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -349,9 +349,7 @@ struct table_stats {
 class table : public enable_lw_shared_from_this<table> {
 public:
     struct config {
-        std::vector<sstring> all_datadirs;
         sstring location;
-        sstring datadir;
         bool enable_disk_writes = true;
         bool enable_disk_reads = true;
         bool enable_cache = true;
@@ -619,9 +617,6 @@ private:
              mutation_reader::forwarding fwd_mr,
              std::function<void(size_t)> reserve_fn) const;
 public:
-    sstring dir() const {
-        return _config.datadir;
-    }
 
     const sstring& location() const noexcept { return _config.location; }
 
@@ -1123,9 +1118,7 @@ using keyspace_metadata = data_dictionary::keyspace_metadata;
 class keyspace {
 public:
     struct config {
-        std::vector<sstring> all_datadirs;
         sstring location;
-        sstring datadir;
         bool enable_commitlog = true;
         bool enable_disk_reads = true;
         bool enable_disk_writes = true;
@@ -1206,10 +1199,6 @@ public:
 
     void set_incremental_backups(bool val) {
         _config.enable_incremental_backups = val;
-    }
-
-    const sstring& datadir() const {
-        return _config.datadir;
     }
 
     const sstring& location() const noexcept { return _config.location; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -702,7 +702,7 @@ public:
     flat_mutation_reader_v2 make_streaming_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
             lw_shared_ptr<sstables::sstable_set> sstables) const;
 
-    sstables::shared_sstable make_streaming_sstable_for_write(std::optional<sstring> subdir = {});
+    sstables::shared_sstable make_streaming_sstable_for_write();
     sstables::shared_sstable make_streaming_staging_sstable();
 
     mutation_source as_mutation_source() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1121,6 +1121,7 @@ class keyspace {
 public:
     struct config {
         std::vector<sstring> all_datadirs;
+        sstring location;
         sstring datadir;
         bool enable_commitlog = true;
         bool enable_disk_reads = true;
@@ -1207,6 +1208,8 @@ public:
     const sstring& datadir() const {
         return _config.datadir;
     }
+
+    const sstring& location() const noexcept { return _config.location; }
 
     sstring column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -350,6 +350,7 @@ class table : public enable_lw_shared_from_this<table> {
 public:
     struct config {
         std::vector<sstring> all_datadirs;
+        sstring location;
         sstring datadir;
         bool enable_disk_writes = true;
         bool enable_disk_reads = true;
@@ -621,6 +622,8 @@ public:
     sstring dir() const {
         return _config.datadir;
     }
+
+    const sstring& location() const noexcept { return _config.location; }
 
     seastar::gate& async_gate() { return _async_gate; }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -398,48 +398,6 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
     });
 }
 
-future<> distributed_loader::cleanup_column_family_temp_sst_dirs(sstring sstdir) {
-    std::vector<future<>> futures;
-
-    co_await lister::scan_dir(sstdir, lister::dir_entry_types::of<directory_entry_type::directory>(), [&] (fs::path sstdir, directory_entry de) {
-        // push futures that remove files/directories into an array of futures,
-        // so that the supplied callback will not block scan_dir() from
-        // reading the next entry in the directory.
-        fs::path dirpath = sstdir / de.name;
-        if (sstables::sstable::is_temp_dir(dirpath)) {
-            dblog.info("Found temporary sstable directory: {}, removing", dirpath);
-            futures.push_back(io_check([dirpath = std::move(dirpath)] () { return lister::rmdir(dirpath); }));
-        }
-        return make_ready_future<>();
-    });
-
-    co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
-}
-
-future<> distributed_loader::handle_sstables_pending_delete(sstring pending_delete_dir) {
-    std::vector<future<>> futures;
-
-    co_await lister::scan_dir(pending_delete_dir, lister::dir_entry_types::of<directory_entry_type::regular>(), [&futures] (fs::path dir, directory_entry de) {
-        // push nested futures that remove files/directories into an array of futures,
-        // so that the supplied callback will not block scan_dir() from
-        // reading the next entry in the directory.
-        fs::path file_path = dir / de.name;
-        if (file_path.extension() == ".tmp") {
-            dblog.info("Found temporary pending_delete log file: {}, deleting", file_path);
-            futures.push_back(remove_file(file_path.string()));
-        } else if (file_path.extension() == ".log") {
-            dblog.info("Found pending_delete log file: {}, replaying", file_path);
-            auto f = sstables::sstable_directory::replay_pending_delete_log(std::move(file_path));
-            futures.push_back(std::move(f));
-        } else {
-            dblog.debug("Found unknown file in pending_delete directory: {}, ignoring", file_path);
-        }
-        return make_ready_future<>();
-    });
-
-    co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
-}
-
 class table_population_metadata {
     distributed<replica::database>& _db;
     sstring _ks;
@@ -521,28 +479,13 @@ public:
 
 private:
     future<> start_subdir(sstring subdir);
-    future<> garbage_collect(sstring subdir);
 };
-
-future<> table_population_metadata::garbage_collect(sstring subdir) {
-    sstring sstdir = get_path(subdir).native();
-
-    // First pass, cleanup temporary sstable directories and sstables pending delete.
-    co_await distributed_loader::cleanup_column_family_temp_sst_dirs(sstdir);
-    auto pending_delete_dir = sstdir + "/" + sstables::sstable::pending_delete_dir_basename();
-    auto exists = co_await file_exists(pending_delete_dir);
-    if (exists) {
-        co_await distributed_loader::handle_sstables_pending_delete(pending_delete_dir);
-    }
-}
 
 future<> table_population_metadata::start_subdir(sstring subdir) {
     sstring sstdir = get_path(subdir).native();
     if (!co_await file_exists(sstdir)) {
         co_return;
     }
-
-    co_await garbage_collect(subdir);
 
     auto dptr = make_lw_shared<sharded<sstables::sstable_directory>>();
     auto& directory = *dptr;
@@ -558,6 +501,7 @@ future<> table_population_metadata::start_subdir(sstring subdir) {
     // directory must be stopped using table_population_metadata::stop below
     _sstable_directories[subdir] = dptr;
 
+    co_await directory.invoke_on(0, [] (auto& d) { return d.garbage_collect(); });
     co_await distributed_loader::lock_table(directory, _db, _ks, _cf);
 
     sstables::sstable_directory::process_flags flags {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -586,7 +586,7 @@ future<> distributed_loader::populate_column_family(table_population_metadata& m
 
     assert(this_shard_id() == 0);
 
-    if (!co_await file_exists(sstdir.native())) {
+    if (!metadata.sstable_directories().contains(subdir)) {
         if (dir_must_exist) {
             throw std::runtime_error(format("Populating {}/{} failed: {} does not exist", metadata.ks(), metadata.cf(), sstdir));
         }
@@ -594,9 +594,6 @@ future<> distributed_loader::populate_column_family(table_population_metadata& m
     }
 
     auto& global_table = metadata.global_table();
-    if (!metadata.sstable_directories().contains(subdir)) {
-        dblog.error("Could not find sstables directory {}.{}/{}", ks, cf, subdir);
-    }
     auto& directory = *metadata.sstable_directories().at(subdir);
     auto sst_version = metadata.highest_version();
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -661,7 +661,7 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         std::exception_ptr ex;
 
         try {
-            co_await ks.make_directory_for_column_family(cfname, uuid);
+            co_await metadata.global_table()->make_directory_for_column_family();
 
             co_await metadata.start();
             co_await distributed_loader::populate_column_family(metadata, sstables::staging_dir, allow_offstrategy_compaction::no);

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -30,7 +30,6 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include "db/view/view_update_generator.hh"
-#include "utils/directories.hh"
 
 extern logging::logger dblog;
 
@@ -102,8 +101,8 @@ public:
 
 future<>
 distributed_loader::process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags) {
-    co_await dir.invoke_on(0, [] (const sstables::sstable_directory& d) {
-        return utils::directories::verify_owner_and_mode(d.sstable_dir());
+    co_await dir.invoke_on(0, [] (const sstables::sstable_directory& d) -> future<> {
+        co_await d.verify();
     });
 
     co_await dir.invoke_on_all([&dir, flags] (sstables::sstable_directory& d) -> future<> {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -262,13 +262,13 @@ table::make_reader_v2(schema_ptr s,
 }
 
 sstables::shared_sstable table::make_streaming_sstable_for_write() {
-    auto newtab = make_sstable(_config.datadir);
+    auto newtab = make_sstable(_config.location);
     tlogger.debug("Created sstable for streaming: ks={}, cf={}", schema()->ks_name(), schema()->cf_name());
     return newtab;
 }
 
 sstables::shared_sstable table::make_streaming_staging_sstable() {
-    auto newtab = make_sstable(_config.datadir + "/" + sstables::staging_dir);
+    auto newtab = make_sstable(_config.location + "/" + sstables::staging_dir);
     tlogger.debug("Created staging sstable for streaming: ks={}, cf={}", schema()->ks_name(), schema()->cf_name());
     return newtab;
 }
@@ -387,13 +387,13 @@ static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {
     return shards.size() != size_t(belongs_to_current_shard(shards));
 }
 
-sstables::shared_sstable table::make_sstable(sstring dir) {
+sstables::shared_sstable table::make_sstable(sstring location) {
     auto& sstm = get_sstables_manager();
-    return sstm.make_sstable(_schema, dir, calculate_generation_for_new_table(), sstm.get_highest_supported_format(), sstables::sstable::format_types::big);
+    return sstm.make_sstable(_schema, calculate_generation_for_new_table(), sstm.get_highest_supported_format(), sstables::sstable::format_types::big, location);
 }
 
 sstables::shared_sstable table::make_sstable() {
-    return make_sstable(_config.datadir);
+    return make_sstable(_config.location);
 }
 
 future<> table::make_directory_for_column_family() {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1659,7 +1659,7 @@ future<> table::finalize_snapshot(database& db, sstring jsondir, std::vector<sna
     }
 }
 
-future<bool> table::snapshot_exists(sstring tag) {
+future<bool> table::snapshot_exists(const db::config& cfg, sstring tag) {
     sstring jsondir = _config.datadir + "/snapshots/" + tag;
     return open_checked_directory(general_disk_error_handler, std::move(jsondir)).then_wrapped([] (future<file> f) {
         try {
@@ -1674,7 +1674,7 @@ future<bool> table::snapshot_exists(sstring tag) {
     });
 }
 
-future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot_details() {
+future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot_details(const db::config& cfg) {
     return seastar::async([this] {
         std::unordered_map<sstring, snapshot_details> all_snapshots;
         for (auto& datadir : _config.all_datadirs) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -399,7 +399,7 @@ sstables::shared_sstable table::make_sstable() {
 }
 
 future<> table::make_directory_for_column_family() {
-    return get_sstables_manager().initialize_storage(_config.all_datadirs);
+    return get_sstables_manager().initialize_storage(_config.location);
 }
 
 void table::notify_bootstrap_or_replace_start() {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -398,6 +398,10 @@ sstables::shared_sstable table::make_sstable() {
     return make_sstable(_config.datadir);
 }
 
+future<> table::make_directory_for_column_family() {
+    return get_sstables_manager().initialize_storage(_config.all_datadirs);
+}
+
 void table::notify_bootstrap_or_replace_start() {
     _is_bootstrap_or_replace = true;
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -261,18 +261,16 @@ table::make_reader_v2(schema_ptr s,
     return rd;
 }
 
-sstables::shared_sstable table::make_streaming_sstable_for_write(std::optional<sstring> subdir) {
-    sstring dir = _config.datadir;
-    if (subdir) {
-        dir += "/" + *subdir;
-    }
-    auto newtab = make_sstable(dir);
-    tlogger.debug("Created sstable for streaming: ks={}, cf={}, dir={}", schema()->ks_name(), schema()->cf_name(), dir);
+sstables::shared_sstable table::make_streaming_sstable_for_write() {
+    auto newtab = make_sstable(_config.datadir);
+    tlogger.debug("Created sstable for streaming: ks={}, cf={}", schema()->ks_name(), schema()->cf_name());
     return newtab;
 }
 
 sstables::shared_sstable table::make_streaming_staging_sstable() {
-    return make_streaming_sstable_for_write(sstables::staging_dir);
+    auto newtab = make_sstable(_config.datadir + "/" + sstables::staging_dir);
+    tlogger.debug("Created staging sstable for streaming: ks={}, cf={}", schema()->ks_name(), schema()->cf_name());
+    return newtab;
 }
 
 flat_mutation_reader_v2

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -575,4 +575,10 @@ future<> sstable_directory::initialize_storage(std::vector<sstring> dirs) {
     co_await io_check([cfdirs0 = dirs[0]] { return touch_directory(cfdirs0 + "/staging"); });
 }
 
+future<> sstable_directory::initialize_keyspace_storage(sstring dir) {
+    // FIXME: is this really needed? The initialize_storage() calls
+    // recursive_touch_directory() anyway
+    co_await io_check([&dir] { return touch_directory(dir); });
+}
+
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -489,7 +489,7 @@ future<> sstable_directory::delete_atomically(std::vector<shared_sstable> ssts) 
             } else {
                 // All sstables are assumed to be in the same column_family, hence
                 // sharing their base directory.
-                assert (sstdir == sst->_storage.prefix());
+                assert (fs::equivalent(fs::path(sstdir), fs::path(sst->_storage.prefix())));
             }
         }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/file.hh>
 #include <boost/range/adaptor/map.hpp>
@@ -64,6 +65,10 @@ sstable_directory::sstable_directory(sstables_manager& manager,
 
 future<> sstable_directory::verify() const {
     return utils::directories::verify_owner_and_mode(_sstable_dir);
+}
+
+future<bool> sstable_directory::exists() const {
+    return file_exists(_sstable_dir.native());
 }
 
 void

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -586,4 +586,56 @@ future<> sstable_directory::initialize_keyspace_storage(sstring dir) {
     co_await io_check([&dir] { return touch_directory(dir); });
 }
 
+future<> sstable_directory::cleanup_column_family_temp_sst_dirs() {
+    std::vector<future<>> futures;
+
+    co_await lister::scan_dir(_sstable_dir, lister::dir_entry_types::of<directory_entry_type::directory>(), [&] (fs::path sstdir, directory_entry de) {
+        // push futures that remove files/directories into an array of futures,
+        // so that the supplied callback will not block scan_dir() from
+        // reading the next entry in the directory.
+        fs::path dirpath = sstdir / de.name;
+        if (sstables::sstable::is_temp_dir(dirpath)) {
+            sstlog.info("Found temporary sstable directory: {}, removing", dirpath);
+            futures.push_back(io_check([dirpath = std::move(dirpath)] () { return lister::rmdir(dirpath); }));
+        }
+        return make_ready_future<>();
+    });
+
+    co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
+}
+
+future<> sstable_directory::handle_sstables_pending_delete(fs::path pending_delete_dir) {
+    std::vector<future<>> futures;
+
+    co_await lister::scan_dir(pending_delete_dir, lister::dir_entry_types::of<directory_entry_type::regular>(), [&futures] (fs::path dir, directory_entry de) {
+        // push nested futures that remove files/directories into an array of futures,
+        // so that the supplied callback will not block scan_dir() from
+        // reading the next entry in the directory.
+        fs::path file_path = dir / de.name;
+        if (file_path.extension() == ".tmp") {
+            sstlog.info("Found temporary pending_delete log file: {}, deleting", file_path);
+            futures.push_back(remove_file(file_path.string()));
+        } else if (file_path.extension() == ".log") {
+            sstlog.info("Found pending_delete log file: {}, replaying", file_path);
+            auto f = sstables::sstable_directory::replay_pending_delete_log(std::move(file_path));
+            futures.push_back(std::move(f));
+        } else {
+            sstlog.debug("Found unknown file in pending_delete directory: {}, ignoring", file_path);
+        }
+        return make_ready_future<>();
+    });
+
+    co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
+}
+
+future<> sstable_directory::garbage_collect() {
+    // First pass, cleanup temporary sstable directories and sstables pending delete.
+    co_await cleanup_column_family_temp_sst_dirs();
+    auto pending_delete_dir = _sstable_dir / sstables::sstable::pending_delete_dir_basename();
+    auto exists = co_await file_exists(pending_delete_dir.native());
+    if (exists) {
+        co_await handle_sstables_pending_delete(pending_delete_dir);
+    }
+}
+
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -20,6 +20,7 @@
 #include "utils/lister.hh"
 #include "utils/disk-error-handler.hh"
 #include "replica/database.hh"
+#include "utils/directories.hh"
 
 static logging::logger dirlog("sstable_directory");
 
@@ -60,6 +61,10 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _error_handler_gen(error_handler_gen)
     , _unshared_remote_sstables(smp::count)
 {}
+
+future<> sstable_directory::verify() const {
+    return utils::directories::verify_owner_and_mode(_sstable_dir);
+}
 
 void
 sstable_directory::handle_component(scan_state& state, sstables::entry_descriptor desc, fs::path filename) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -51,12 +51,12 @@ future<> sstable_directory::components_lister::close() {
 
 sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
-        fs::path sstable_dir,
+        sstring location,
         ::io_priority_class io_prio,
         io_error_handler_gen error_handler_gen)
     : _manager(manager)
     , _schema(std::move(schema))
-    , _sstable_dir(std::move(sstable_dir))
+    , _sstable_dir(_manager.sstable_directory(location))
     , _io_priority(std::move(io_prio))
     , _error_handler_gen(error_handler_gen)
     , _unshared_remote_sstables(smp::count)

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -139,7 +139,7 @@ private:
 public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
-            std::filesystem::path sstable_dir,
+            sstring location,
             ::io_priority_class io_prio,
             io_error_handler_gen error_handler_gen);
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -225,6 +225,8 @@ public:
     // This function only solves the second problem for now.
     static future<> delete_atomically(std::vector<shared_sstable> ssts);
     static future<> replay_pending_delete_log(std::filesystem::path log_file);
+
+    static future<> initialize_storage(std::vector<sstring> dirs);
 };
 
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -207,9 +207,7 @@ public:
     // is called.
     sstable_info_vector retrieve_shared_sstables();
 
-    std::filesystem::path sstable_dir() const noexcept {
-        return _sstable_dir;
-    }
+    future<> verify() const;
 
     // When we compact sstables, we have to atomically instantiate the new
     // sstable and delete the old ones.  Otherwise, if we compact A+B into C,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -132,6 +132,9 @@ private:
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
     future<> load_foreign_sstables(sstable_info_vector info_vec);
 
+    future<> handle_sstables_pending_delete(fs::path pending_delete_dir);
+    future<> cleanup_column_family_temp_sst_dirs();
+
     std::vector<sstables::shared_sstable> _unsorted_sstables;
 public:
     sstable_directory(sstables_manager& manager,
@@ -208,6 +211,7 @@ public:
     sstable_info_vector retrieve_shared_sstables();
 
     future<> verify() const;
+    future<> garbage_collect();
 
     // When we compact sstables, we have to atomically instantiate the new
     // sstable and delete the old ones.  Otherwise, if we compact A+B into C,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -211,6 +211,7 @@ public:
     sstable_info_vector retrieve_shared_sstables();
 
     future<> verify() const;
+    future<bool> exists() const;
     future<> garbage_collect();
 
     // When we compact sstables, we have to atomically instantiate the new

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -227,6 +227,7 @@ public:
     static future<> replay_pending_delete_log(std::filesystem::path log_file);
 
     static future<> initialize_storage(std::vector<sstring> dirs);
+    static future<> initialize_keyspace_storage(sstring dir);
 };
 
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -44,13 +44,25 @@ const locator::host_id& sstables_manager::get_local_host_id() const {
 }
 
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
-        sstring dir,
+        fs::path path,
         generation_type generation,
         sstable_version_types v,
         sstable_format_types f,
         gc_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
+    return make_lw_shared<sstable>(std::move(schema), path.native(), generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+}
+
+shared_sstable sstables_manager::make_sstable(schema_ptr schema,
+        generation_type generation,
+        sstable_version_types v,
+        sstable_format_types f,
+        sstring location,
+        gc_clock::time_point now,
+        io_error_handler_gen error_handler_gen,
+        size_t buffer_size) {
+    auto dir = format("{}/{}", _db_config.data_file_directories()[0], location);
     return make_lw_shared<sstable>(std::move(schema), std::move(dir), generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -62,6 +62,11 @@ future<> sstables_manager::initialize_storage(sstring location) {
     return sstable_directory::initialize_storage(std::move(dirs));
 }
 
+
+future<> sstables_manager::initialize_keyspace_storage(sstring dir) {
+    return sstable_directory::initialize_keyspace_storage(std::move(dir));
+}
+
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     sstable_writer_config cfg;
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -68,6 +68,11 @@ future<> sstables_manager::initialize_keyspace_storage(sstring location) {
     return sstable_directory::initialize_keyspace_storage(std::move(dir));
 }
 
+future<> sstables_manager::remove_table_directory_if_has_no_snapshots(sstring location) {
+    auto dir = format("{}/{}", _db_config.data_file_directories()[0], location);
+    return sstables::remove_table_directory_if_has_no_snapshots(fs::path(std::move(dir)));
+}
+
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     sstable_writer_config cfg;
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -63,7 +63,8 @@ future<> sstables_manager::initialize_storage(sstring location) {
 }
 
 
-future<> sstables_manager::initialize_keyspace_storage(sstring dir) {
+future<> sstables_manager::initialize_keyspace_storage(sstring location) {
+    auto dir = format("{}/{}", _db_config.data_file_directories()[0], location);
     return sstable_directory::initialize_keyspace_storage(std::move(dir));
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -74,6 +74,9 @@ future<> sstables_manager::initialize_storage(sstring location) {
     return sstable_directory::initialize_storage(std::move(dirs));
 }
 
+fs::path sstables_manager::sstable_directory(sstring location) {
+    return fs::path(format("{}/{}", _db_config.data_file_directories()[0], location));
+}
 
 future<> sstables_manager::initialize_keyspace_storage(sstring location) {
     auto dir = format("{}/{}", _db_config.data_file_directories()[0], location);

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -54,7 +54,11 @@ shared_sstable sstables_manager::make_sstable(schema_ptr schema,
     return make_lw_shared<sstable>(std::move(schema), std::move(dir), generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 
-future<> sstables_manager::initialize_storage(std::vector<sstring> dirs) {
+future<> sstables_manager::initialize_storage(sstring location) {
+    std::vector<sstring> dirs;
+    auto& d_dirs = _db_config.data_file_directories();
+    dirs.reserve(d_dirs.size());
+    std::transform(d_dirs.begin(), d_dirs.end(), std::back_inserter(dirs), [&location] (auto& d_dir) { return format("{}/{}", d_dir, location); });
     return sstable_directory::initialize_storage(std::move(dirs));
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -10,6 +10,7 @@
 #include "sstables/sstables_manager.hh"
 #include "sstables/partition_index_cache.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstable_directory.hh"
 #include "db/config.hh"
 #include "gms/feature.hh"
 #include "gms/feature_service.hh"
@@ -51,6 +52,10 @@ shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
     return make_lw_shared<sstable>(std::move(schema), std::move(dir), generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+}
+
+future<> sstables_manager::initialize_storage(std::vector<sstring> dirs) {
+    return sstable_directory::initialize_storage(std::move(dirs));
 }
 
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -77,10 +77,18 @@ public:
 
     // Constructs a shared sstable
     shared_sstable make_sstable(schema_ptr schema,
-            sstring dir,
+            fs::path path,
             generation_type generation,
             sstable_version_types v,
             sstable_format_types f,
+            gc_clock::time_point now = gc_clock::now(),
+            io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
+            size_t buffer_size = default_sstable_buffer_size);
+    shared_sstable make_sstable(schema_ptr schema,
+            generation_type generation,
+            sstable_version_types v,
+            sstable_format_types f,
+            sstring location,
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -84,7 +84,7 @@ public:
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
-    future<> initialize_storage(std::vector<sstring> dirs);
+    future<> initialize_storage(sstring location);
 
     sstable_directory::components_lister get_components_lister(std::filesystem::path dir);
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -88,6 +88,7 @@ public:
     future<> initialize_keyspace_storage(sstring dir);
 
     sstable_directory::components_lister get_components_lister(std::filesystem::path dir);
+    future<> remove_table_directory_if_has_no_snapshots(sstring location);
 
     virtual sstable_writer_config configure_writer(sstring origin) const;
     const db::config& config() const { return _db_config; }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -85,6 +85,7 @@ public:
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
     future<> initialize_storage(sstring location);
+    future<> initialize_keyspace_storage(sstring dir);
 
     sstable_directory::components_lister get_components_lister(std::filesystem::path dir);
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -84,6 +84,7 @@ public:
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
+    future<> initialize_storage(std::vector<sstring> dirs);
 
     sstable_directory::components_lister get_components_lister(std::filesystem::path dir);
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -108,6 +108,7 @@ public:
     const locator::host_id& get_local_host_id() const;
 
     reader_concurrency_semaphore& sstable_metadata_concurrency_sem() noexcept { return _sstable_metadata_concurrency_sem; }
+    fs::path sstable_directory(sstring location); // ATTN: for sstable_directory only!
 
     // Wait until all sstables managed by this sstables_manager instance
     // (previously created by make_sstable()) have been disposed of:

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -577,7 +577,7 @@ SEASTAR_TEST_CASE(snapshot_list_okay) {
         auto& cf = e.local_db().find_column_family("ks", "cf");
         take_snapshot(e).get();
 
-        auto details = cf.get_snapshot_details().get0();
+        auto details = cf.get_snapshot_details(e.local_db().get_config()).get0();
         BOOST_REQUIRE_EQUAL(details.size(), 1);
 
         auto sd = details["test"];
@@ -589,7 +589,7 @@ SEASTAR_TEST_CASE(snapshot_list_okay) {
             return make_ready_future<>();
         }).get();
 
-        auto sd_post_deletion = cf.get_snapshot_details().get0().at("test");
+        auto sd_post_deletion = cf.get_snapshot_details(e.local_db().get_config()).get0().at("test");
 
         BOOST_REQUIRE_EQUAL(sd_post_deletion.total, sd_post_deletion.live);
         BOOST_REQUIRE_EQUAL(sd.total, sd_post_deletion.live);
@@ -639,7 +639,7 @@ SEASTAR_TEST_CASE(snapshot_list_contains_dropped_tables) {
 SEASTAR_TEST_CASE(snapshot_list_inexistent) {
     return do_with_some_data({"cf"}, [] (cql_test_env& e) {
         auto& cf = e.local_db().find_column_family("ks", "cf");
-        auto details = cf.get_snapshot_details().get0();
+        auto details = cf.get_snapshot_details(e.local_db().get_config()).get0();
         BOOST_REQUIRE_EQUAL(details.size(), 0);
         return make_ready_future<>();
     });
@@ -756,7 +756,7 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_details) {
         auto& cf = e.local_db().find_column_family("ks", "cf");
         take_snapshot(e).get();
 
-        auto details = cf.get_snapshot_details().get0();
+        auto details = cf.get_snapshot_details(e.local_db().get_config()).get0();
         BOOST_REQUIRE_EQUAL(details.size(), 1);
 
         auto sd = details["test"];
@@ -779,7 +779,7 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_details) {
             return make_ready_future<>();
         }).get();
 
-        auto sd_post_deletion = cf.get_snapshot_details().get0().at("test");
+        auto sd_post_deletion = cf.get_snapshot_details(e.local_db().get_config()).get0().at("test");
 
         BOOST_REQUIRE_EQUAL(sd_post_deletion.total, sd_post_deletion.live);
         BOOST_REQUIRE_EQUAL(sd.total, sd_post_deletion.live);
@@ -806,7 +806,7 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_true_snapshots_size) {
         auto& cf = e.local_db().find_column_family("ks", "cf");
         take_snapshot(e).get();
 
-        auto details = cf.get_snapshot_details().get0();
+        auto details = cf.get_snapshot_details(e.local_db().get_config()).get0();
         BOOST_REQUIRE_EQUAL(details.size(), 1);
 
         auto sd = details["test"];
@@ -821,7 +821,7 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_true_snapshots_size) {
             return make_ready_future<>();
         }).get();
 
-        auto sd_post_deletion = cf.get_snapshot_details().get0().at("test");
+        auto sd_post_deletion = cf.get_snapshot_details(e.local_db().get_config()).get0().at("test");
 
         BOOST_REQUIRE_EQUAL(sd_post_deletion.total, sd_post_deletion.live);
         BOOST_REQUIRE_EQUAL(sd.total, sd_post_deletion.live);

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -96,8 +96,11 @@ with_column_family(sstables::test_env& env, schema_ptr s, replica::column_family
     std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 3 /* 8 CGs */ };
     for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
         auto tracker = make_lw_shared<cache_tracker>();
-        auto dir = tmpdir();
-        cfg.datadir = dir.path().string();
+        auto subdir = std::to_string(x_log2_compaction_groups);
+        auto dir = env.tempdir().path() / subdir;
+        co_await touch_directory(dir.native());
+        cfg.datadir = dir.native();
+        cfg.location = subdir;
         cfg.x_log2_compaction_groups = x_log2_compaction_groups;
         auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
         auto cl_stats = make_lw_shared<cell_locker_stats>();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -99,7 +99,6 @@ with_column_family(sstables::test_env& env, schema_ptr s, replica::column_family
         auto subdir = std::to_string(x_log2_compaction_groups);
         auto dir = env.tempdir().path() / subdir;
         co_await touch_directory(dir.native());
-        cfg.datadir = dir.native();
         cfg.location = subdir;
         cfg.x_log2_compaction_groups = x_log2_compaction_groups;
         auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -92,7 +92,7 @@ static mutation_partition get_partition(reader_permit permit, replica::memtable&
 }
 
 future<>
-with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::sstables_manager& sm, noncopyable_function<future<> (replica::column_family&)> func) {
+with_column_family(sstables::test_env& env, schema_ptr s, replica::column_family::config cfg, noncopyable_function<future<> (replica::column_family&)> func) {
     std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 3 /* 8 CGs */ };
     for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
         auto tracker = make_lw_shared<cache_tracker>();
@@ -101,7 +101,7 @@ with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::s
         cfg.x_log2_compaction_groups = x_log2_compaction_groups;
         auto cm = make_lw_shared<compaction_manager>(compaction_manager::for_testing_tag{});
         auto cl_stats = make_lw_shared<cell_locker_stats>();
-        auto cf = make_lw_shared<replica::column_family>(s, cfg, replica::column_family::no_commitlog(), *cm, sm, *cl_stats, *tracker);
+        auto cf = make_lw_shared<replica::column_family>(s, cfg, replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker);
         cf->mark_ready_for_writes();
         co_await func(*cf);
         co_await cf->stop();
@@ -499,7 +499,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
     cfg.enable_incremental_backups = false;
     cfg.cf_stats = &*cf_stats;
 
-    with_column_family(s, cfg, env.manager(), [s, &env] (replica::column_family& cf) -> future<> {
+    with_column_family(env, s, cfg, [s, &env] (replica::column_family& cf) -> future<> {
         const column_definition& r1_col = *s->get_column_definition("r1");
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
 
@@ -551,7 +551,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
     cfg.enable_incremental_backups = false;
     cfg.cf_stats = &*cf_stats;
 
-    return with_column_family(s, cfg, env.manager(), [&env, s](replica::column_family& cf) {
+    return with_column_family(env, s, cfg, [&env, s](replica::column_family& cf) {
         return seastar::async([&env, s, &cf] {
             // populate
             auto new_key = [&] {
@@ -632,7 +632,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
     cfg.enable_incremental_backups = false;
     cfg.cf_stats = &*cf_stats;
 
-    with_column_family(s, cfg, env.manager(), [s, &env] (auto& cf) mutable {
+    with_column_family(env, s, cfg, [s, &env] (auto& cf) mutable {
         std::map<int32_t, std::map<int32_t, int32_t>> shadow, result;
 
         const column_definition& r1_col = *s->get_column_definition("r1");

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3852,8 +3852,7 @@ future<> test_twcs_interposer_on_flush(bool split_during_flush) {
             return m;
         };
 
-        auto tmp = tmpdir();
-        table_for_tests cf(env.manager(), s, tmp.path().string());
+        table_for_tests cf(env.manager(), s, env.tempdir().path().string());
         auto close_cf = deferred_stop(cf);
         cf->start();
 
@@ -4596,14 +4595,13 @@ SEASTAR_TEST_CASE(test_major_does_not_miss_data_in_memtable) {
                 .with_column("value", int32_type);
         auto s = builder.build();
 
-        auto tmp = tmpdir();
         auto tokens = token_generation_for_shard(1, this_shard_id(), db::default_murmur3_partitioner_ignore_msb_bits, smp::count);
         auto pkey = partition_key::from_exploded(*s, {to_bytes(tokens[0].first)});
 
-        table_for_tests cf(env.manager(), s, tmp.path().string());
+        table_for_tests cf(env.manager(), s, env.tempdir().path().string());
         auto close_cf = deferred_stop(cf);
-        auto sst_gen = [&env, &cf, s, &tmp] () mutable {
-            return env.make_sstable(s, tmp.path().string(), column_family_test::calculate_generation_for_new_table(*cf),
+        auto sst_gen = [&env, &cf, s] () mutable {
+            return env.make_sstable(s, env.tempdir().path().string(), column_family_test::calculate_generation_for_new_table(*cf),
                 sstables::get_highest_sstable_version(), big);
         };
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3821,9 +3821,8 @@ SEASTAR_TEST_CASE(lcs_reshape_test) {
     });
 }
 
-SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
-    return test_env::do_with_async([] (test_env& env) {
-      auto test_interposer_on_flush = [&] (bool split_during_flush) {
+future<> test_twcs_interposer_on_flush(bool split_during_flush) {
+    return test_env::do_with_async([split_during_flush] (test_env& env) {
         auto builder = schema_builder("tests", "test_twcs_interposer_on_flush")
                 .with_column("id", utf8_type, column_kind::partition_key)
                 .with_column("cl", int32_type, column_kind::clustering_key)
@@ -3873,11 +3872,15 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
         auto expected_ssts = (split_during_flush) ? target_windows_span : 1;
         testlog.info("split_during_flush={}, actual={}, expected={}", split_during_flush, cf->get_sstables()->size(), expected_ssts);
         BOOST_REQUIRE(cf->get_sstables()->size() == expected_ssts);
-      };
-
-      test_interposer_on_flush(true);
-      test_interposer_on_flush(false);
   });
+}
+
+SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush_split) {
+    return test_twcs_interposer_on_flush(true);
+}
+
+SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush_nosplit) {
+    return test_twcs_interposer_on_flush(false);
 }
 
 SEASTAR_TEST_CASE(test_twcs_compaction_across_buckets) {

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -469,6 +469,10 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_lock_works) {
     });
 }
 
+fs::path path_to_sstables(cql_test_env& e, const replica::table& t) {
+    return fs::path(e.local_db().get_config().data_file_directories()[0]) / t.location();
+}
+
 SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
     if (smp::count == 1) {
         fmt::print("Skipping sstable_directory_shared_sstables_reshard_correctly, smp == 1\n");
@@ -478,7 +482,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
         auto& cf = e.local_db().find_column_family("ks", "cf");
-        auto upload_path = fs::path(cf.dir()) / sstables::upload_dir;
+        auto upload_path = path_to_sstables(e, cf) / sstables::upload_dir;
 
         e.db().invoke_on_all([] (replica::database& db) {
             auto& cf = db.find_column_family("ks", "cf");
@@ -520,7 +524,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
         auto& cf = e.local_db().find_column_family("ks", "cf");
-        auto upload_path = fs::path(cf.dir()) / sstables::upload_dir;
+        auto upload_path = path_to_sstables(e, cf) / sstables::upload_dir;
 
         e.db().invoke_on_all([] (replica::database& db) {
             auto& cf = db.find_column_family("ks", "cf");
@@ -562,7 +566,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
         auto& cf = e.local_db().find_column_family("ks", "cf");
-        auto upload_path = fs::path(cf.dir()) / sstables::upload_dir;
+        auto upload_path = path_to_sstables(e, cf) / sstables::upload_dir;
 
         e.db().invoke_on_all([] (replica::database& db) {
             auto& cf = db.find_column_family("ks", "cf");

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -779,9 +779,9 @@ public:
             replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, db::table_selector::all()).get();
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
-            parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {
-                auto cfm = pair.second;
-                return ks.make_directory_for_column_family(cfm->cf_name(), cfm->id());
+            parallel_for_each(ks.metadata()->cf_meta_data(), [&ks, &db] (auto& pair) {
+                auto& cf = db.local().find_column_family(pair.second);
+                return cf.make_directory_for_column_family();
             }).get();
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -75,7 +75,7 @@ public:
     shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
-        return _impl->mgr.make_sstable(std::move(schema), dir, generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
+        return _impl->mgr.make_sstable(std::move(schema), fs::path(dir), generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
     }
 
     struct sst_not_found : public std::runtime_error {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -304,8 +304,7 @@ public:
 
     static future<> do_with_tmp_directory(std::function<future<> (test_env&, sstring tmpdir_path)>&& fut) {
         return test_env::do_with_async([fut = std::move(fut)] (test_env& env) {
-            auto tmp = tmpdir();
-            fut(env, tmp.path().string()).get();
+            fut(env, env.tempdir().path().string()).get();
         });
     }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -155,8 +155,8 @@ std::unique_ptr<db::config> make_db_config(sstring temp_dir) {
 }
 
 test_env::impl::impl(test_env_config cfg)
-    : dir()
-    , db_config(make_db_config(dir.path().native()))
+    : dir(cfg.shared_tmpdir ? : std::make_shared<tmpdir>())
+    , db_config(make_db_config(dir->path().native()))
     , dir_sem(1)
     , feature_service(gms::feature_config_from_db_config(*db_config))
     , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -126,7 +126,6 @@ table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, s
     _data->s = s;
     _data->cfg = replica::table::config{.compaction_concurrency_semaphore = &_data->semaphore};
     _data->cfg.enable_disk_writes = bool(datadir);
-    _data->cfg.datadir = datadir.value_or(sstring());
     _data->cfg.cf_stats = &_data->cf_stats;
     _data->cfg.enable_commitlog = false;
     _data->cm.enable();


### PR DESCRIPTION
The goal of this PR is to make sstables layer get some sane identifiers of where to put/get files to/from. As for today, by the time the sstable layer gets control it might get a string e.g. like "/var/lib/scylla/data/keyspace/table-0123456789/staging" to get me-5-big-TOC.txt file from. Though that works perfectly for filesystem storage, it's not nice for object storage for several reasons.

First, that long string contains two pieces of information -- sstable object ID and its state (staging in this case). The object storage driver would have to parse this string to cut the state from.

Second, S3 doesn't like double-slashes in object paths, but it's not guaranteed that that string won't contain such. And there's no test for that, even if such a string accidentally or intentionally pops up, Linux FS layer would just accept it with no problems.

And third, this string is excessive for an on-S3 identifier. There's no point in keeping the "/var/lib/scylla/data" prefix on each of the object name.

First step towards fixing it is to keep only the "location" part on the table and keyspace configs. Passed down to the sstables layer, they are next prepended with the datadir path by the sstables manager itself (more exactly -- by the sstable storage driver, but it's not yet in this PR).


The PR depends on the #12648 one and starts after the "Merge branch 'br-sstable-split-move-to-new-dir-a" commit.