### PR TITLE
Cleanup keyspace compaction task

### DIFF
--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -59,19 +59,28 @@ future<> shard_major_keyspace_compaction_task_impl::run() {
 
 future<> cleanup_keyspace_compaction_task_impl::run() {
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
-        auto local_tables = _table_ids;
-        // Cleanup smaller tables first, to increase chances of success if low on space.
-        std::ranges::sort(local_tables, std::less<>(), [&] (const table_id& ti) {
-            try {
-                return db.find_column_family(ti).get_stats().live_disk_space_used;
-            } catch (const replica::no_such_column_family& e) {
-                return int64_t(-1);
-            }
-        });
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(_status.keyspace));
-        co_await run_on_existing_tables("force_keyspace_cleanup", db, _status.keyspace, local_tables, [&] (replica::table& t) {
-            return t.perform_cleanup_compaction(owned_ranges_ptr);
-        });
+        auto& module = db.get_compaction_manager().get_task_manager_module();
+        auto task = co_await module.make_and_start_task<shard_cleanup_keyspace_compaction_task_impl>({_status.id, _status.shard}, _status.keyspace, _status.id, db, _table_ids);
+        co_await task->done();
+    });
+}
+
+tasks::is_internal shard_cleanup_keyspace_compaction_task_impl::is_internal() const noexcept {
+    return tasks::is_internal::yes;
+}
+
+future<> shard_cleanup_keyspace_compaction_task_impl::run() {
+    // Cleanup smaller tables first, to increase chances of success if low on space.
+    std::ranges::sort(_local_tables, std::less<>(), [&] (const table_id& ti) {
+        try {
+            return _db.find_column_family(ti).get_stats().live_disk_space_used;
+        } catch (const replica::no_such_column_family& e) {
+            return int64_t(-1);
+        }
+    });
+    auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(_status.keyspace));
+    co_await run_on_existing_tables("force_keyspace_cleanup", _db, _status.keyspace, _local_tables, [&] (replica::table& t) {
+        return t.perform_cleanup_compaction(owned_ranges_ptr);
     });
 }
 

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -129,6 +129,26 @@ protected:
     virtual future<> run() override;
 };
 
+class shard_cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
+private:
+    replica::database& _db;
+    std::vector<table_id> _local_tables;
+public:
+    shard_cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
+            std::string keyspace,
+            tasks::task_id parent_id,
+            replica::database& db,
+            std::vector<table_id> local_tables) noexcept
+        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", parent_id)
+        , _db(db)
+        , _local_tables(std::move(local_tables))
+    {}
+
+    virtual tasks::is_internal is_internal() const noexcept override;
+protected:
+    virtual future<> run() override;
+};
+
 class task_manager_module : public tasks::task_manager::module {
 public:
     task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -112,6 +112,23 @@ protected:
     virtual future<> run() override = 0;
 };
 
+class cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
+private:
+    sharded<replica::database>& _db;
+    std::vector<table_id> _table_ids;
+public:
+    cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
+            std::string keyspace,
+            sharded<replica::database>& db,
+            std::vector<table_id> table_ids) noexcept
+        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        , _db(db)
+        , _table_ids(std::move(table_ids))
+    {}
+protected:
+    virtual future<> run() override;
+};
+
 class task_manager_module : public tasks::task_manager::module {
 public:
     task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -91,6 +91,26 @@ protected:
     virtual future<> run() override;
 };
 
+class cleanup_compaction_task_impl : public compaction_task_impl {
+public:
+    cleanup_compaction_task_impl(tasks::task_manager::module_ptr module,
+            tasks::task_id id,
+            unsigned sequence_number,
+            std::string keyspace,
+            std::string table,
+            std::string entity,
+            tasks::task_id parent_id) noexcept
+        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+    {
+        // FIXME: add progress units
+    }
+
+    virtual std::string type() const override {
+        return "cleanup compaction";
+    }
+protected:
+    virtual future<> run() override = 0;
+};
 
 class task_manager_module : public tasks::task_manager::module {
 public:

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -38,3 +38,6 @@ def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
 
 def test_major_column_family_compaction_task(cql, this_dc, rest_api):
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}"))
+
+def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"))


### PR DESCRIPTION
Task manager task implementations of classes that cover
cleanup keyspace compaction which can be started through 
/storage_service/keyspace_compaction/ api.

Top level task covers the whole compaction and creates child
tasks on each shard. 