### PR TITLE
Rewrite sstables keyspace compaction task

### DIFF
--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -107,11 +107,22 @@ future<> local_offstrategy_keyspace_compaction_task_impl::run() {
 
 future<> upgrade_sstables_compaction_task_impl::run() {
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(_status.keyspace));
-        co_await run_on_existing_tables("upgrade_sstables", db, _status.keyspace, _table_infos, [&] (replica::table& t) -> future<> {
-            return t.parallel_foreach_table_state([&] (compaction::table_state& ts) -> future<> {
-                return t.get_compaction_manager().perform_sstable_upgrade(owned_ranges_ptr, ts, _exclude_current_version);
-            });
+        tasks::task_info parent_info{_status.id, _status.shard};
+        auto& compaction_module = db.get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<shard_upgrade_sstables_compaction_task_impl>(parent_info, _status.keyspace, _status.id, db, _table_infos, _exclude_current_version);
+        co_await task->done();
+    });
+}
+
+tasks::is_internal shard_upgrade_sstables_compaction_task_impl::is_internal() const noexcept {
+    return tasks::is_internal::yes;
+}
+
+future<> shard_upgrade_sstables_compaction_task_impl::run() {
+    auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(_status.keyspace));
+    co_await run_on_existing_tables("upgrade_sstables", _db, _status.keyspace, _table_infos, [&] (replica::table& t) -> future<> {
+        return t.parallel_foreach_table_state([&] (compaction::table_state& ts) -> future<> {
+            return t.get_compaction_manager().perform_sstable_upgrade(owned_ranges_ptr, ts, _exclude_current_version);
         });
     });
 }

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -254,6 +254,29 @@ protected:
     virtual future<> run() override;
 };
 
+class shard_upgrade_sstables_compaction_task_impl : public rewrite_sstables_compaction_task_impl {
+private:
+    replica::database& _db;
+    std::vector<table_id> _table_infos;
+    bool _exclude_current_version;
+public:
+    shard_upgrade_sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
+            std::string keyspace,
+            tasks::task_id parent_id,
+            replica::database& db,
+            std::vector<table_id> table_infos,
+            bool exclude_current_version) noexcept
+        : rewrite_sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", parent_id)
+        , _db(db)
+        , _table_infos(std::move(table_infos))
+        , _exclude_current_version(exclude_current_version)
+    {}
+
+    virtual tasks::is_internal is_internal() const noexcept override;
+protected:
+    virtual future<> run() override;
+};
+
 class task_manager_module : public tasks::task_manager::module {
 public:
     task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -234,6 +234,26 @@ protected:
     virtual future<> run() override = 0;
 };
 
+class upgrade_sstables_compaction_task_impl : public rewrite_sstables_compaction_task_impl {
+private:
+    sharded<replica::database>& _db;
+    std::vector<table_id> _table_infos;
+    bool _exclude_current_version;
+public:
+    upgrade_sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
+            std::string keyspace,
+            sharded<replica::database>& db,
+            std::vector<table_id> table_infos,
+            bool exclude_current_version) noexcept
+        : rewrite_sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        , _db(db)
+        , _table_infos(std::move(table_infos))
+        , _exclude_current_version(exclude_current_version)
+    {}
+protected:
+    virtual future<> run() override;
+};
+
 class task_manager_module : public tasks::task_manager::module {
 public:
     task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -213,6 +213,27 @@ protected:
     virtual future<> run() override;
 };
 
+class rewrite_sstables_compaction_task_impl : public compaction_task_impl {
+public:
+    rewrite_sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
+            tasks::task_id id,
+            unsigned sequence_number,
+            std::string keyspace,
+            std::string table,
+            std::string entity,
+            tasks::task_id parent_id) noexcept
+        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+    {
+        // FIXME: add progress units
+    }
+
+    virtual std::string type() const override {
+        return "rewrite sstables compaction";
+    }
+protected:
+    virtual future<> run() override = 0;
+};
+
 class task_manager_module : public tasks::task_manager::module {
 public:
     task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "compaction") {}

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -44,3 +44,6 @@ def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
 
 def test_offstrategy_keyspace_compaction_task(cql, this_dc, rest_api):
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"))
+
+def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"))


### PR DESCRIPTION
Task manager task implementations of classes that cover
rewrite sstables keyspace compaction which can be start 
through /storage_service/keyspace_compaction/ api.

Top level task covers the whole compaction and creates child 
tasks on each shard. 