### PR TITLE
Fix inefficiency when rebuilding table statistics with compaction groups

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -45,6 +45,8 @@ class compaction_group {
     // have not been deleted yet, so must not GC any tombstones in other sstables
     // that may delete data in these sstables:
     std::vector<sstables::shared_sstable> _sstables_compacted_but_not_deleted;
+    uint64_t _main_set_disk_space_used = 0;
+    uint64_t _maintenance_set_disk_space_used = 0;
 private:
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see
@@ -57,6 +59,7 @@ private:
                    enable_backlog_tracker backlog_tracker);
     // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
     void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
+    static uint64_t calculate_disk_space_used_for(const sstables::sstable_set& set);
 public:
     compaction_group(table& t, dht::token_range token_range);
 
@@ -109,6 +112,10 @@ public:
     void trigger_compaction();
 
     compaction_backlog_tracker& get_backlog_tracker();
+
+    size_t live_sstable_count() const noexcept;
+    uint64_t live_disk_space_used() const noexcept;
+    uint64_t total_disk_space_used() const noexcept;
 
     compaction::table_state& as_table_state() const noexcept;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -543,7 +543,6 @@ private:
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();
     }
-    void update_stats_for_new_sstable(uint64_t disk_space_used_by_sstable) noexcept;
     future<> do_add_sstable_and_update_cache(sstables::shared_sstable sst, sstables::offstrategy offstrategy);
     // Helpers which add sstable on behalf of a compaction group and refreshes compound set.
     void add_sstable(compaction_group& cg, sstables::shared_sstable sstable);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -988,17 +988,16 @@ void table::set_metrics() {
 }
 
 void table::rebuild_statistics() {
-    // zeroing live_disk_space_used and live_sstable_count because the
-    // sstable list was re-created
     _stats.live_disk_space_used = 0;
     _stats.live_sstable_count = 0;
+    _stats.total_disk_space_used = 0;
 
     _sstables->for_each_sstable([this] (const sstables::shared_sstable& tab) {
         update_stats_for_new_sstable(tab->bytes_on_disk());
     });
     for (const compaction_group_ptr& cg : compaction_groups()) {
         for (auto& tab: cg->compacted_undeleted_sstables()) {
-            update_stats_for_new_sstable(tab->bytes_on_disk());
+            _stats.total_disk_space_used += tab->bytes_on_disk();
         }
     }
 }


### PR DESCRIPTION
[table: Fix disk-space related metrics](https://github.com/scylladb/scylladb/commit/529a1239a98eefd2b1aa6a6785e8c4b88d43de60) fixes the table's disk space  related metrics.

whereas second patch fixes an inefficiency when computing statistics which can be triggered with multiple compaction groups.