### PR TITLE
dist/redhat: specify version in `Obsoletes:`

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -199,7 +199,7 @@ License:        AGPLv3
 URL:            http://www.scylladb.com/
 Requires:       kmod
 # tuned overwrites our sysctl settings
-Obsoletes:	tuned
+Obsoletes:      tuned >= 2.11.0
 
 %description kernel-conf
 This package contains Linux kernel configuration changes for the Scylla database.  Install this package


### PR DESCRIPTION
to silence the warning from rpmbuild, like
```
RPM build warnings:
      line 202: It's not recommended to have unversioned Obsoletes: Obsoletes:	tuned
```

more specific this way. quote from the commit message of 303865d9799b350899cd07bdbf818a5a6f3dd7f9 for the version number:

> tuned 2.11.0-9 and later writes to kerned.sched_wakeup_granularity_ns
> and other sysctl tunables that we so laboriously tuned, dropping
> performance by a factor of 5 (due to increased latency). Fix by
> obsoleting tuned during install (in effect, we are a better tuned,
> at least for us).

with this change, it'd be easier to identify potential issues when building / packaging.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>