### PR TITLE
dist/debian: add libexec/* to source/include-binaries

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -12,6 +12,7 @@ import string
 import os
 import shutil
 import re
+import subprocess
 from pathlib import Path
 
 class DebianFilesTemplate(string.Template):
@@ -69,3 +70,6 @@ with open('build/debian/debian/changelog', 'w') as f:
 with open('build/debian/debian/control', 'w') as f:
     f.write(control_applied)
 
+include_binaries = subprocess.run("./scripts/create-relocatable-package.py --print-libexec -", shell=True, check=True, capture_output=True, encoding='utf-8').stdout
+with open('build/debian/debian/source/include-binaries', 'w') as f:
+    f.write(include_binaries)

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -15,6 +15,7 @@ import subprocess
 import tarfile
 import pathlib
 import shutil
+import sys
 
 
 RELOC_PREFIX='scylla'
@@ -71,6 +72,8 @@ ap.add_argument('--mode', dest='mode', default='release',
                 help='Build mode (debug/release) to use')
 ap.add_argument('--stripped', action='store_true',
                 help='use stripped binaries')
+ap.add_argument('--print-libexec', action='store_true',
+                help='print libexec executables and exit script')
 
 args = ap.parse_args()
 
@@ -90,6 +93,11 @@ executables_distrocmd = [
                 '/usr/bin/lsblk']
 
 executables = executables_scylla + executables_distrocmd
+
+if args.print_libexec:
+    for exec in executables:
+        print(f'libexec/{os.path.basename(exec)}')
+    sys.exit(0)
 
 output = args.dest
 


### PR DESCRIPTION
* scripts/create-relocatable-package.py: add a command to print out
   executables under libexec
* dist/debian/debian_files_gen.py: call create-relocatable-package.py
   for a list of files under libexec and create source/include-binaries
   with the list.

we repackage the precompiled binaries in the relocatable package into a debian source package using `./scylla/install.sh`, which edits the executable to use the specified dynamic library loader. but dpkg-source does not like this, as it wants to ensure that the files in original tarball (*.orig.tar.gz) is identical to the files in the source package created by dpkg-source.

so we have following failure when running reloc/build_deb.sh

```
dpkg-source: error: cannot represent change to scylla/libexec/scylla: binary file contents changed
dpkg-source: error: add scylla/libexec/scylla in debian/source/include-binaries if you want to store the modified binary in the debian tarball
dpkg-source: error: unrepresentable changes to source
dpkg-buildpackage: error: dpkg-source -b . subprocess returned exit status 1
debuild: fatal error at line 1182:
dpkg-buildpackage -rfakeroot -us -uc -ui failed
```

in this change, to address the build failure, as proposed by dpkg, the path to the patched/edited executable is added to
`debian/source/include-binaries`. see the "Building" section in https://manpages.debian.org/bullseye/dpkg-dev/dpkg-source.1.en.html for more details.

if we plan to package more executables in `libexec/`, we will need to list them as well in `debian/source/include-binaries`. please search `adjust_bin()` in `scylladb/install.sh` for more details.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>