### PR TITLE
raft: fsm: extend log limiter semaphore lifetime

### DIFF
--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -396,11 +396,16 @@ public:
         _ping_leader = true;
     }
 
+    struct memory_permit {
+        lw_shared_ptr<seastar::semaphore> sem;
+        semaphore_units<> units;
+    };
+
     // Call this function to wait for the total size in bytes of log entries to
     // go below max_log_size.
     // Can only be called on a leader.
     // On abort throws `semaphore_aborted`.
-    future<semaphore_units<>> wait_for_memory_permit(seastar::abort_source* as, size_t size);
+    future<memory_permit> wait_for_memory_permit(seastar::abort_source* as, size_t size);
 
     // Return current configuration.
     const configuration& get_configuration() const;

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -88,7 +88,7 @@ struct leader {
     // Used to access new leader to set semaphore exception
     const raft::fsm& fsm;
     // Used to limit log size
-    std::unique_ptr<seastar::semaphore> log_limiter_semaphore;
+    lw_shared_ptr<seastar::semaphore> log_limiter_semaphore;
     // If the leader is in the process of transferring the leadership
     // contains a time point in the future the transfer will be aborted at
     // unless completes successfully till then.
@@ -105,7 +105,7 @@ struct leader {
     bool last_read_id_changed = false;
     read_id max_read_id_with_quorum{0};
 
-    leader(size_t max_log_size, const class fsm& fsm_) : fsm(fsm_), log_limiter_semaphore(std::make_unique<seastar::semaphore>(max_log_size)) {}
+    leader(size_t max_log_size, const class fsm& fsm_) : fsm(fsm_), log_limiter_semaphore(make_lw_shared<seastar::semaphore>(max_log_size)) {}
     leader(leader&&) = default;
     ~leader();
 };

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -507,15 +507,10 @@ future<entry_id> server_impl::add_entry_on_leader(command cmd, seastar::abort_so
     }
     logger.trace("[{}] adding entry after waiting for memory permit", id());
 
-    try {
+    // FIXME: indentation
         const log_entry& e = _fsm->add_entry(std::move(cmd));
         memory_permit.units.release();
         co_return entry_id{.term = e.term, .idx = e.idx};
-    } catch (const not_a_leader&) {
-        // the semaphore is already destroyed, prevent memory_permit from accessing it
-        memory_permit.units.release();
-        throw;
-    }
 }
 
 future<add_entry_reply> server_impl::execute_add_entry(server_id from, command cmd, seastar::abort_source* as) {

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -507,10 +507,9 @@ future<entry_id> server_impl::add_entry_on_leader(command cmd, seastar::abort_so
     }
     logger.trace("[{}] adding entry after waiting for memory permit", id());
 
-    // FIXME: indentation
-        const log_entry& e = _fsm->add_entry(std::move(cmd));
-        memory_permit.units.release();
-        co_return entry_id{.term = e.term, .idx = e.idx};
+    const log_entry& e = _fsm->add_entry(std::move(cmd));
+    memory_permit.units.release();
+    co_return entry_id{.term = e.term, .idx = e.idx};
 }
 
 future<add_entry_reply> server_impl::execute_add_entry(server_id from, command cmd, seastar::abort_source* as) {


### PR DESCRIPTION
Make sure to extend the lifetime of the log_limiter_semaphore so it outlives any outstanding semaphore_units pointing to it.

Use-after-free has been detected with scylladb/seastar@3061b2f53a9a89596786763db03e3ae44398d33c as seen in e.g.
https://jenkins.scylladb.com/view/master/job/scylla-master/job/next/5633/artifact/testlog/x86_64/debug/raft.replication_test.drops_04_dueling_repro.3.log
```
==121045==ERROR: AddressSanitizer: heap-use-after-free on address 0x608000020330 at pc 0x0000019c7fd3 bp 0x7fe4b18f7c70 sp 0x7fe4b18f7c68
READ of size 8 at 0x608000020330 thread T1
    #0 0x19c7fd2 in seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>::add_outstanding_units(unsigned long) ./seastar/include/seastar/core/semaphore.hh:171:28
    #1 0x19c7fd2 in seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>::semaphore_units(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>*, unsigned long) ./seastar/include/seastar/core/semaphore.hh:485:15
    #2 0x19c9233 in seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>::semaphore_units(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long) ./seastar/include/seastar/core/semaphore.hh:489:89
    #3 0x19c9233 in seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::get_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long)::'lambda'()::operator()() const ./seastar/include/seastar/core/semaphore.hh:596:16
    #4 0x19c9233 in seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::futurize<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>::invoke<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::get_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long)::'lambda'()&>(seastar::semaphore_default_exception_factory&&) ./seastar/include/seastar/core/future.hh:2149:28
    #5 0x19c9233 in auto seastar::futurize_invoke<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::get_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long)::'lambda'()&>(seastar::semaphore_default_exception_factory&&) ./seastar/include/seastar/core/future.hh:2178:12
    #6 0x19c90cc in auto std::chrono::_V2::steady_clock seastar::future<void>::then<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::get_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long)::'lambda'(), seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::semaphore_default_exception_factory&&)::'lambda'(auto&&...)::operator()<>(auto&&...) ./seastar/include/seastar/core/future.hh:1539:24
    #7 0x19c90cc in seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>::direct_vtable_for<std::chrono::_V2::steady_clock seastar::future<void>::then<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::get_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>(seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>&, unsigned long)::'lambda'(), seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::semaphore_default_exception_factory&&)::'lambda'(auto&&...)>::call(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()> const*) ./seastar/include/seastar/util/noncopyable_function.hh:124:20
    #8 0x19c8b01 in seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>::operator()() const ./seastar/include/seastar/util/noncopyable_function.hh:210:16
    #9 0x19c89d0 in seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> std::__invoke_impl<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&>(std::__invoke_other, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:61:14
    #10 0x19c89d0 in std::__invoke_result<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&>::type std::__invoke<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:96:14
    #11 0x19c89d0 in std::invoke_result<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&>::type std::invoke<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/functional:110:14
    #12 0x19c89d0 in auto seastar::internal::future_invoke<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::internal::monostate>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::internal::monostate&&) ./seastar/include/seastar/core/future.hh:1221:16
    #13 0x19c89d0 in seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::future<void>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>, seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&&)::'lambda'(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&) const::'lambda'()::operator()() const ./seastar/include/seastar/core/future.hh:1594:28
    #14 0x19c88c9 in void seastar::futurize<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>::satisfy_with_result_of<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::future<void>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>, seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&&)::'lambda'(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&) const::'lambda'()>(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&&) ./seastar/include/seastar/core/future.hh:2132:9
    #15 0x19c8784 in seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::future<void>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>, seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&&)::'lambda'(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&) const ./seastar/include/seastar/core/future.hh:1587:17
    #16 0x19c85b5 in seastar::continuation<seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>, seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> seastar::future<void>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>, seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>(seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&&)::'lambda'(seastar::internal::promise_base_with_type<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>&&, seastar::noncopyable_function<seastar::future<seastar::semaphore_units<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>> ()>&, seastar::future_state<seastar::internal::monostate>&&), void>::run_and_dispose() ./seastar/include/seastar/core/future.hh:781:13
    #17 0x1bd1db9 in seastar::reactor::run_tasks(seastar::reactor::task_queue&) build/debug/seastar/./seastar/src/core/reactor.cc:2517:14
    #18 0x1bd94ee in seastar::reactor::run_some_tasks() build/debug/seastar/./seastar/src/core/reactor.cc:2954:9
    #19 0x1bdd63f in seastar::reactor::do_run() build/debug/seastar/./seastar/src/core/reactor.cc:3123:9
    #20 0x1bdb20f in seastar::reactor::run() build/debug/seastar/./seastar/src/core/reactor.cc:3006:16
    #21 0x29e820e in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:266:31
    #22 0x29e5a06 in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:157:12
    #23 0x29beaa8 in seastar::testing::test_runner::start_thread(int, char**)::$_0::operator()() build/debug/seastar/./seastar/src/testing/test_runner.cc:75:26
    #24 0x29be3a3 in void std::__invoke_impl<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(std::__invoke_other, seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:61:14
    #25 0x29be293 in std::enable_if<is_invocable_r_v<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>, void>::type std::__invoke_r<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:111:2
    #26 0x29bdcd2 in std::_Function_handler<void (), seastar::testing::test_runner::start_thread(int, char**)::$_0>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_function.h:290:9
    #27 0x2014deb in seastar::posix_thread::start_routine(void*) build/debug/seastar/./seastar/src/core/posix.cc:73:5
    #28 0x7fe4b64ff14c in start_thread (/lib64/libc.so.6+0x8b14c) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)
    #29 0x7fe4b65809ff in __GI___clone3 (/lib64/libc.so.6+0x10c9ff) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)

0x608000020330 is located 16 bytes inside of 88-byte region [0x608000020320,0x608000020378)
freed by thread T1 here:
    #0 0x167aff8 in operator delete(void*) (/jenkins/workspace/scylla-master/next/scylla/build/debug/test/raft/replication_test+0x167aff8) (BuildId: 77f0e3fadbcca3921cdd32cfb092b17f14149577)
    #1 0x19bca71 in std::unique_ptr<seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>, std::default_delete<seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>>::~unique_ptr() /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:396:4
    #2 0x1959274 in std::__detail::__variant::_Variant_storage<false, raft::follower, raft::candidate, raft::leader>::_M_reset() /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/variant:470:2
    #3 0x19aaa6d in std::__detail::__variant::_Variant_storage<false, raft::follower, raft::candidate, raft::leader>::~_Variant_storage() /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/variant:480:9
    #4 0x19aaa6d in raft::fsm::become_follower(utils::tagged_uuid<raft::server_id_tag>) raft/fsm.cc:198:5
    #5 0x18f22e6 in void raft::fsm::step<raft::append_reply>(utils::tagged_uuid<raft::server_id_tag>, raft::append_reply&&) ./raft/fsm.hh:589:13
    #6 0x1917d13 in raft::server_impl::append_entries_reply(utils::tagged_uuid<raft::server_id_tag>, raft::append_reply) raft/server.cc:743:11
    #7 0x189734e in raft_cluster<seastar::lowres_clock>::rpc::send_append_entries_reply(utils::tagged_uuid<raft::server_id_tag>, raft::append_reply const&) test/raft/replication.hh:662:36
    #8 0x193cc01 in void raft::server_impl::send_message<std::variant<raft::append_request, raft::append_reply, raft::vote_request, raft::vote_reply, raft::install_snapshot, raft::snapshot_reply, raft::timeout_now, raft::read_quorum, raft::read_quorum_reply>>(utils::tagged_uuid<raft::server_id_tag>, std::variant<raft::append_request, raft::append_reply, raft::vote_request, raft::vote_reply, raft::install_snapshot, raft::snapshot_reply, raft::timeout_now, raft::read_quorum, raft::read_quorum_reply>) raft/server.cc:845:5
    #9 0x193cc01 in raft::server_impl::io_fiber(raft::internal::tagged_uint64<raft::index_tag>) (.resume) raft/server.cc:991:21
    #10 0x1832ad6 in std::__n4861::coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume() const /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/coroutine:244:29
    #11 0x1832ad6 in seastar::internal::coroutine_traits_base<void>::promise_type::run_and_dispose() ./seastar/include/seastar/core/coroutine.hh:120:20
    #12 0x1bd94ee in seastar::reactor::run_some_tasks() build/debug/seastar/./seastar/src/core/reactor.cc:2954:9
    #13 0x1bdd63f in seastar::reactor::do_run() build/debug/seastar/./seastar/src/core/reactor.cc:3123:9
    #14 0x1bdb20f in seastar::reactor::run() build/debug/seastar/./seastar/src/core/reactor.cc:3006:16
    #15 0x29e820e in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:266:31
    #16 0x29e5a06 in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:157:12
    #17 0x29beaa8 in seastar::testing::test_runner::start_thread(int, char**)::$_0::operator()() build/debug/seastar/./seastar/src/testing/test_runner.cc:75:26
    #18 0x29be3a3 in void std::__invoke_impl<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(std::__invoke_other, seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:61:14
    #19 0x29be293 in std::enable_if<is_invocable_r_v<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>, void>::type std::__invoke_r<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:111:2
    #20 0x29bdcd2 in std::_Function_handler<void (), seastar::testing::test_runner::start_thread(int, char**)::$_0>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_function.h:290:9
    #21 0x2014deb in seastar::posix_thread::start_routine(void*) build/debug/seastar/./seastar/src/core/posix.cc:73:5
    #22 0x7fe4b64ff14c in start_thread (/lib64/libc.so.6+0x8b14c) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)

previously allocated by thread T1 here:
    #0 0x167a5b8 in operator new(unsigned long) (/jenkins/workspace/scylla-master/next/scylla/build/debug/test/raft/replication_test+0x167a5b8) (BuildId: 77f0e3fadbcca3921cdd32cfb092b17f14149577)
    #1 0x19c1fd2 in std::__detail::_MakeUniq<seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>>::__single_object std::make_unique<seastar::basic_semaphore<seastar::semaphore_default_exception_factory, std::chrono::_V2::steady_clock>, unsigned long&>(unsigned long&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:1065:30
    #2 0x19c1fd2 in raft::leader::leader(unsigned long, raft::fsm const&) raft/fsm.hh:108:91
    #3 0x19b5f37 in raft::fsm::request_vote_reply(utils::tagged_uuid<raft::server_id_tag>, raft::vote_reply&&) raft/fsm.cc:849:13
    #4 0x18f3a87 in void raft::fsm::step<raft::vote_reply>(utils::tagged_uuid<raft::server_id_tag>, raft::vote_reply&&) ./raft/fsm.hh:648:5
    #5 0x191804b in raft::server_impl::request_vote_reply(utils::tagged_uuid<raft::server_id_tag>, raft::vote_reply) raft/server.cc:753:11
    #6 0x1897fed in raft_cluster<seastar::lowres_clock>::rpc::send_vote_reply(utils::tagged_uuid<raft::server_id_tag>, raft::vote_reply const&) test/raft/replication.hh:702:32
    #7 0x193cc01 in void raft::server_impl::send_message<std::variant<raft::append_request, raft::append_reply, raft::vote_request, raft::vote_reply, raft::install_snapshot, raft::snapshot_reply, raft::timeout_now, raft::read_quorum, raft::read_quorum_reply>>(utils::tagged_uuid<raft::server_id_tag>, std::variant<raft::append_request, raft::append_reply, raft::vote_request, raft::vote_reply, raft::install_snapshot, raft::snapshot_reply, raft::timeout_now, raft::read_quorum, raft::read_quorum_reply>) raft/server.cc:845:5
    #8 0x193cc01 in raft::server_impl::io_fiber(raft::internal::tagged_uint64<raft::index_tag>) (.resume) raft/server.cc:991:21
    #9 0x1832ad6 in std::__n4861::coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume() const /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/coroutine:244:29
    #10 0x1832ad6 in seastar::internal::coroutine_traits_base<void>::promise_type::run_and_dispose() ./seastar/include/seastar/core/coroutine.hh:120:20
    #11 0x1bd94ee in seastar::reactor::run_some_tasks() build/debug/seastar/./seastar/src/core/reactor.cc:2954:9
    #12 0x1bdd63f in seastar::reactor::do_run() build/debug/seastar/./seastar/src/core/reactor.cc:3123:9
    #13 0x1bdb20f in seastar::reactor::run() build/debug/seastar/./seastar/src/core/reactor.cc:3006:16
    #14 0x29e820e in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:266:31
    #15 0x29e5a06 in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) build/debug/seastar/./seastar/src/core/app-template.cc:157:12
    #16 0x29beaa8 in seastar::testing::test_runner::start_thread(int, char**)::$_0::operator()() build/debug/seastar/./seastar/src/testing/test_runner.cc:75:26
    #17 0x29be3a3 in void std::__invoke_impl<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(std::__invoke_other, seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:61:14
    #18 0x29be293 in std::enable_if<is_invocable_r_v<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>, void>::type std::__invoke_r<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:111:2
    #19 0x29bdcd2 in std::_Function_handler<void (), seastar::testing::test_runner::start_thread(int, char**)::$_0>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_function.h:290:9
    #20 0x2014deb in seastar::posix_thread::start_routine(void*) build/debug/seastar/./seastar/src/core/posix.cc:73:5
    #21 0x7fe4b64ff14c in start_thread (/lib64/libc.so.6+0x8b14c) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)
```

The root cause here is that the `log_limiter_semaphore` is broken and destroyed while there are outstanding semaphore_units pointing to, that are acquired in https://github.com/scylladb/scylladb/blob/53366db6c66798808143b1e3170f2bb6dbcae5f6/raft/fsm.cc#L48-L53
called from https://github.com/scylladb/scylladb/blob/53366db6c66798808143b1e3170f2bb6dbcae5f6/raft/server.cc#L504

These are released later on in https://github.com/scylladb/scylladb/blob/53366db6c66798808143b1e3170f2bb6dbcae5f6/raft/server.cc#L510-L518
possibly after the semaphore is gone when the leader is destroyed, see https://github.com/scylladb/scylladb/blob/53366db6c66798808143b1e3170f2bb6dbcae5f6/raft/fsm.cc#L15-L19
In this case, for example, from https://github.com/scylladb/scylladb/blob/53366db6c66798808143b1e3170f2bb6dbcae5f6/raft/fsm.cc#L198

This mini-series turns `log_limiter_semaphore` into a lw_shared_ptr and keeps it along with the units got from it a new `struct memory_permit` that makes sure the semaphore outlives units pointing to it.

Fixes #12741