### PR TITLE
locator: token_metadata: improve get_address_ranges()

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -211,22 +211,6 @@ effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
 }
 
 future<std::unordered_multimap<inet_address, dht::token_range>>
-abstract_replication_strategy::get_address_ranges(const token_metadata& tm) const {
-    std::unordered_multimap<inet_address, dht::token_range> ret;
-    for (auto& t : tm.sorted_tokens()) {
-        dht::token_range_vector r = tm.get_primary_ranges_for(t);
-        auto eps = co_await calculate_natural_endpoints(t, tm);
-        rslogger.debug("token={}, primary_range={}, address={}", t, r, eps);
-        for (auto ep : eps) {
-            for (auto&& rng : r) {
-                ret.emplace(ep, rng);
-            }
-        }
-    }
-    co_return ret;
-}
-
-future<std::unordered_multimap<inet_address, dht::token_range>>
 abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet_address endpoint) const {
     std::unordered_multimap<inet_address, dht::token_range> ret;
     if (!tm.is_normal_token_owner(endpoint)) {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -118,7 +118,6 @@ public:
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
 
 public:
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm) const;
     future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
 
     // Caller must ensure that token_metadata will not change throughout the call.

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -116,9 +116,7 @@ public:
     // Use the token_metadata provided by the caller instead of _token_metadata
     // Note: must be called with initialized, non-empty token_metadata.
     future<dht::token_range_vector> get_ranges(inet_address ep, token_metadata_ptr tmptr) const;
-
-public:
-    future<std::unordered_multimap<inet_address, dht::token_range>> get_address_ranges(const token_metadata& tm, inet_address endpoint) const;
+    future<dht::token_range_vector> get_ranges(inet_address ep, const token_metadata& tm) const;
 
     // Caller must ensure that token_metadata will not change throughout the call.
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_addresses(const token_metadata& tm) const;

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -779,13 +779,12 @@ void token_metadata_impl::calculate_pending_ranges_for_leaving(
     if (_leaving_endpoints.empty()) {
         return;
     }
-    std::unordered_multimap<inet_address, dht::token_range> address_ranges = strategy.get_address_ranges(unpimplified_this).get0();
     // get all ranges that will be affected by leaving nodes
     std::unordered_set<range<token>> affected_ranges;
     for (auto endpoint : _leaving_endpoints) {
-        auto r = address_ranges.equal_range(endpoint);
-        for (auto x = r.first; x != r.second; x++) {
-            affected_ranges.emplace(x->second);
+        auto r = strategy.get_address_ranges(unpimplified_this, endpoint).get0();
+        for (const auto& x : r) {
+            affected_ranges.emplace(x.second);
         }
     }
     // for each of those ranges, find what new nodes will be responsible for the range when
@@ -816,16 +815,14 @@ void token_metadata_impl::calculate_pending_ranges_for_replacing(
     if (_replacing_endpoints.empty()) {
         return;
     }
-    auto address_ranges = strategy.get_address_ranges(unpimplified_this).get0();
     for (const auto& node : _replacing_endpoints) {
         auto existing_node = node.first;
         auto replacing_node = node.second;
+        auto address_ranges = strategy.get_address_ranges(unpimplified_this, existing_node).get0();
         for (const auto& x : address_ranges) {
             seastar::thread::maybe_yield();
-            if (x.first == existing_node) {
-                tlogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x.second);
-                new_pending_ranges.emplace(x.second, replacing_node);
-            }
+            tlogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x.second);
+            new_pending_ranges.emplace(x.second, replacing_node);
         }
     }
 }

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -782,9 +782,9 @@ void token_metadata_impl::calculate_pending_ranges_for_leaving(
     // get all ranges that will be affected by leaving nodes
     std::unordered_set<range<token>> affected_ranges;
     for (auto endpoint : _leaving_endpoints) {
-        auto r = strategy.get_address_ranges(unpimplified_this, endpoint).get0();
-        for (const auto& x : r) {
-            affected_ranges.emplace(x.second);
+        auto r = strategy.get_ranges(endpoint, unpimplified_this).get0();
+        for (const dht::token_range& x : r) {
+            affected_ranges.emplace(x);
         }
     }
     // for each of those ranges, find what new nodes will be responsible for the range when
@@ -818,11 +818,11 @@ void token_metadata_impl::calculate_pending_ranges_for_replacing(
     for (const auto& node : _replacing_endpoints) {
         auto existing_node = node.first;
         auto replacing_node = node.second;
-        auto address_ranges = strategy.get_address_ranges(unpimplified_this, existing_node).get0();
-        for (const auto& x : address_ranges) {
+        auto address_ranges = strategy.get_ranges(existing_node, unpimplified_this).get0();
+        for (const dht::token_range& x : address_ranges) {
             seastar::thread::maybe_yield();
-            tlogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x.second);
-            new_pending_ranges.emplace(x.second, replacing_node);
+            tlogger.debug("Node {} replaces {} for range {}", replacing_node, existing_node, x);
+            new_pending_ranges.emplace(x, replacing_node);
         }
     }
 }
@@ -851,8 +851,9 @@ void token_metadata_impl::calculate_pending_ranges_for_bootstrap(
         auto& tokens = x.second;
         all_left_metadata->update_topology(endpoint, get_dc_rack(endpoint));
         all_left_metadata->update_normal_tokens(tokens, endpoint).get();
-        for (auto& x : strategy.get_address_ranges(*all_left_metadata, endpoint).get0()) {
-            new_pending_ranges.emplace(x.second, endpoint);
+        auto address_ranges = strategy.get_ranges(endpoint, *all_left_metadata).get0();
+        for (const dht::token_range& x : address_ranges) {
+            new_pending_ranges.emplace(x, endpoint);
         }
         all_left_metadata->_impl->remove_endpoint(endpoint);
     }


### PR DESCRIPTION
This two-patch series aims to improve `get_address_ranges()` by eliminating cases of quadratic behavior
which were noticed to cause huge allocations, and by deduplicating the code of `get_address_ranges()`
with the almost-identical `get_ranges()`.

Refs https://github.com/scylladb/scylladb/issues/10337
Refs https://github.com/scylladb/scylladb/issues/10817
Refs https://github.com/scylladb/scylladb/issues/10836
Refs https://github.com/scylladb/scylladb/issues/10837
Fixes https://github.com/scylladb/scylladb/issues/12724