### PR TITLE
abstract_replication_strategy: add for_each_natural_endpoint_until

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -101,6 +101,8 @@ public:
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
     virtual inet_address_vector_replica_set get_natural_endpoints(const token& search_token, const effective_replication_map& erm) const;
+    // Returns the last stop_iteration result of the called func
+    virtual stop_iteration for_each_natural_endpoint_until(const token& search_token, const effective_replication_map& erm, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
     virtual void validate_options() const = 0;
     virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const = 0;
     virtual size_t get_replication_factor(const token_metadata& tm) const = 0;
@@ -202,6 +204,7 @@ public:
     future<replication_map> clone_endpoints_gently() const;
 
     inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const;
+    virtual stop_iteration for_each_natural_endpoint_until(const token& search_token, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const;
 
     // get_ranges() returns the list of ranges held by the given endpoint.
@@ -233,7 +236,7 @@ public:
     get_range_addresses() const;
 
 private:
-    dht::token_range_vector do_get_ranges(noncopyable_function<bool(inet_address_vector_replica_set)> should_add_range) const;
+    dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
 
 public:
     static factory_key make_factory_key(const abstract_replication_strategy::ptr_type& rs, const token_metadata_ptr& tmptr);

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -36,6 +36,19 @@ inet_address_vector_replica_set everywhere_replication_strategy::get_natural_end
     return boost::copy_range<inet_address_vector_replica_set>(tm.get_all_endpoints());
 }
 
+stop_iteration everywhere_replication_strategy::for_each_natural_endpoint_until(const token&, const effective_replication_map& erm, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
+    const auto& tm = *erm.get_token_metadata_ptr();
+    if (tm.sorted_tokens().empty()) {
+        return func(utils::fb_utilities::get_broadcast_address());
+    }
+    for (const auto& ep : tm.get_all_endpoints()) {
+        if (func(ep)) {
+            return stop_iteration::yes;
+        }
+    }
+    return stop_iteration::no;
+}
+
 using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, const replication_strategy_config_options&>;
 static registry registrator("org.apache.cassandra.locator.EverywhereStrategy");
 static registry registrator_short_name("EverywhereStrategy");

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -40,5 +40,6 @@ public:
      * on token calculations but everywhere_replication_strategy may be used before tokens are set up.
      */
     virtual inet_address_vector_replica_set get_natural_endpoints(const token&, const effective_replication_map&) const override;
+    virtual stop_iteration for_each_natural_endpoint_until(const token&, const effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const override;
 };
 }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -37,6 +37,10 @@ inet_address_vector_replica_set local_strategy::get_natural_endpoints(const toke
     return inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()});
 }
 
+stop_iteration local_strategy::for_each_natural_endpoint_until(const token&, const effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
+    return func(utils::fb_utilities::get_broadcast_address());
+}
+
 using registry = class_registrator<abstract_replication_strategy, local_strategy, const replication_strategy_config_options&>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -44,6 +44,7 @@ public:
      * on token calculations but LocalStrategy may be used before tokens are set up.
      */
     inet_address_vector_replica_set get_natural_endpoints(const token&, const effective_replication_map&) const override;
+    virtual stop_iteration for_each_natural_endpoint_until(const token&, const effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const override;
 };
 
 }


### PR DESCRIPTION
Currently, effective_replication_map::do_get_ranges accepts
a functor that traverses the natural endpoints of each token
to decide whether a token range should be returned or not.

This is done by copying the natural endpoints vector for
each token.  However, other than special strategies like
everywhere and local, the functor can be called on the
precalculated inet_address_vector_replica_set in the
replication_map and there's no need to copy it for each call.

for_each_natural_endpoint_until passes a reference to the function
down to the abstract replication strategy to let it work either
on the precalculated inet_address_vector_replica_set or
on a ad-hoc vector prepared by the replication strategy.
The function returns stop_iteration::yes when a match or mismatch
are found, or stop_iteration::no while it has no definite result.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>