### PR TITLE
query_ranges_to_vnodes_generator: fix for exclusive boundaries

### DIFF
--- a/query_ranges_to_vnodes.cc
+++ b/query_ranges_to_vnodes.cc
@@ -101,6 +101,18 @@ void query_ranges_to_vnodes_generator::process_one_range(size_t n, dht::partitio
 
         add_range(std::move(splits.first));
         cr = std::move(splits.second);
+
+        // The left bound of cr is bound({upper_bound_token, token_bound::end}, false),
+        // so we can end up with an empty range if the original end bound is its successor.
+        const bool is_empty = cr.end().has_value() &&
+            !cr.end()->is_inclusive() &&
+            !cr.end()->value().has_key() &&
+            cr.end()->value().bound() == dht::ring_position::token_bound::start &&
+            dht::token::to_int64(cr.end()->value().token()) - dht::token::to_int64(cr.start()->value().token()) == 1;
+        if (is_empty) {
+            _i++;
+            return;
+        }
         if (ranges.size() == n) {
             // we have enough ranges
             break;

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -44,13 +44,33 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
             auto check = [&s](locator::token_metadata_ptr tmptr, dht::partition_range input,
                               dht::partition_range_vector expected) {
                 query_ranges_to_vnodes_generator ranges_to_vnodes(tmptr, s, {input});
-                auto actual = ranges_to_vnodes(expected.size());
+                auto actual = ranges_to_vnodes(1000);
                 if (!std::equal(actual.begin(), actual.end(), expected.begin(), [&s](auto&& r1, auto&& r2) {
                     return r1.equal(r2, dht::ring_position_comparator(*s));
                 })) {
                     BOOST_FAIL(format("Ranges differ, expected {} but got {}", expected, actual));
                 }
             };
+
+            {
+                const auto endpoint = gms::inet_address("10.0.0.1");
+                const auto endpoint_token = ring[2].token();
+                auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
+                tmptr->update_topology(endpoint, {});
+                tmptr->update_normal_tokens({endpoint_token}, endpoint).get();
+
+                const auto next_token = dht::token::from_int64(dht::token::to_int64(endpoint_token) + 1);
+                const auto endpoint_token_ending_bound = dht::partition_range::bound {
+                    dht::ring_position::ending_at(endpoint_token), true
+                };
+                const auto input = dht::partition_range::make(
+                    endpoint_token_ending_bound,
+                    {dht::ring_position::starting_at(next_token), false});
+                const auto expected_output = dht::partition_range::make(
+                    endpoint_token_ending_bound,
+                    endpoint_token_ending_bound);
+                check(tmptr, input, { expected_output });
+            }
 
             {
                 // Ring with minimum token


### PR DESCRIPTION
Let the initial range passed to query_partition_key_range be [1, 2) where 2 is the successor of 1 in terms
of ring_position order and 1 is equal to vnode.
Then query_ranges_to_vnodes_generator() -> [[1, 1], (1, 2)], so we get an empty range (1,2) and subsequently will make a data request with this empty range in
storage_proxy::query_partition_key_range_concurrent, which will be redundant.

The patch checks for this condition after the main loop in process_one_range.

A test case is added for this scenario in
test_get_restricted_ranges. The helper
lambda check is changed so that not to limit
the number of ranges to the length of expected
ranges, otherwise this check passes without
the change in process_one_range.

Fixes: #12566