### PR TITLE
Fix memory leaks caused by throwing reader_concurrency_semaphore::consume()

### DIFF
--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -156,6 +156,7 @@ private:
     mutation_fragment_v2() = default;
     explicit operator bool() const noexcept { return bool(_data); }
     void destroy_data() noexcept;
+    void reset_memory(const schema& s, std::optional<reader_resources> res = {});
     friend class optimized_optional<mutation_fragment_v2>;
 
     friend class position_in_partition;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -276,7 +276,12 @@ public:
 
     T* allocate(size_t n) {
         auto p = _alloc.allocate(n);
-        _permit.consume(reader_resources::with_memory(n * sizeof(T)));
+        try {
+            _permit.consume(reader_resources::with_memory(n * sizeof(T)));
+        } catch (...) {
+            _alloc.deallocate(p, n);
+            throw;
+        }
         return p;
     }
     void deallocate(T* p, size_t n) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1384,10 +1384,12 @@ constexpr uint64_t target_memory = uint64_t(1) << 28; // 256MB
 // The test fails by OOM crashing.
 // This test should be run with 256MB of memory.
 SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_oom) {
+#ifndef DEBUG
     if (memory::stats().total_memory() != target_memory) {
         std::cerr << "Test " << get_name() << " should be run with 256M of memory, make sure you invoke with -m256M" << std::endl;
         return make_ready_future<>();
     }
+#endif
 
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
@@ -1404,7 +1406,11 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_oom) {
         auto& db = env.local_db();
         auto& semaphore = db.get_reader_concurrency_semaphore();
 
+#ifdef DEBUG
+        const auto num_reads = 16;
+#else
         const auto num_reads = 128;
+#endif
 
         auto read_id = env.prepare("SELECT value FROM ks.tbl WHERE pk = ? AND ck = ?").get0();
 
@@ -1433,10 +1439,12 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_oom) {
 // failures were caused by the limiting mechanism.
 // This test should be run with 256M memory.
 SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
+#ifndef DEBUG
     if (memory::stats().total_memory() != target_memory) {
         std::cerr << "Test " << get_name() << " should be run with 256M of memory, make sure you invoke with -m256M" << std::endl;
         return make_ready_future<>();
     }
+#endif
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
 


### PR DESCRIPTION
Said method can now throw `std::bad_alloc` since aab5954. All call-sites should have been adapted in the series introducing the throw, but some managed to slip through because the oom unit test didn't run in debug mode. This series fixes the remaining unpatched call-sites and makes sure the test runs in debug mode too, so leaks like this are detected.

Fixes: #12767 