### PR TITLE
commitlog: mark request_controller_timeout_exception_factory::timeout() noexcept

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -242,7 +242,7 @@ public:
                 return "commitlog: timed out";
             }
         };
-        static auto timeout() {
+        static auto timeout() noexcept {
             return request_controller_timed_out_error();
         }
     };


### PR DESCRIPTION
request_controller_timeout_exception_factory::timeout() creates an instance of `request_controller_timed_out_error` whose ctor is default-created by compiler from that of timed_out_error, which is in turn default-created from the one of `std::exception`. and `std::exception::exception` does not throw. so it's safe to mark this factory method `noexcept`.

with this specifier, we don't need to worry about the exception thrown by it, and don't need to handle them if any in `seastar::semaphore`, where `timeout()` is called for the customized exception.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>