### PR TITLE
test/pylib: use larger timeout for decommission/removenode

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -157,7 +157,7 @@ class ManagerClient():
             if cmdline:
                 data['cmdline'] = cmdline
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
-                                                     timeout=ScyllaServer.START_TIMEOUT)
+                                                     timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except Exception as exc:
             raise Exception("Failed to add server") from exc
         try:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -175,13 +175,15 @@ class ManagerClient():
         """Invoke remove node Scylla REST API for a specified server"""
         logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
         data = {"server_id": server_id, "ignore_dead": ignore_dead}
-        await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data)
+        await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data,
+                                   timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         self._driver_update()
 
     async def decommission_node(self, server_id: ServerNum) -> None:
         """Tell a node to decommission with Scylla REST API"""
         logger.debug("ManagerClient decommission %s", server_id)
-        await self.client.get_text(f"/cluster/decommission-node/{server_id}")
+        await self.client.get_text(f"/cluster/decommission-node/{server_id}",
+                                   timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         self._driver_update()
 
     async def server_get_config(self, server_id: ServerNum) -> dict[str, object]:

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -94,9 +94,9 @@ class RESTClient(metaclass=ABCMeta):
 
     async def post(self, resource_uri: str, host: Optional[str] = None,
                    port: Optional[int] = None, params: Optional[Mapping[str, str]] = None,
-                   json: Mapping = None) -> None:
+                   json: Mapping = None, timeout: Optional[float] = None) -> None:
         await self._fetch("POST", resource_uri, host = host, port = port, params = params,
-                          json = json)
+                          json = json, timeout = timeout)
 
     async def put_json(self, resource_uri: str, data: Mapping, host: Optional[str] = None,
                        port: Optional[int] = None, params: Optional[dict[str, str]] = None,
@@ -161,19 +161,20 @@ class ScyllaRESTAPIClient():
         return result
 
     async def remove_node(self, initiator_ip: IPAddress, host_id: HostID,
-                          ignore_dead: list[IPAddress]) -> None:
+                          ignore_dead: list[IPAddress], timeout: float) -> None:
         """Initiate remove node of host_id in initiator initiator_ip"""
         logger.info("remove_node for %s on %s", host_id, initiator_ip)
         await self.client.post("/storage_service/remove_node",
                                params = {"host_id": host_id,
                                          "ignore_nodes": ",".join(ignore_dead)},
-                               host = initiator_ip)
+                               host = initiator_ip, timeout = timeout)
         logger.debug("remove_node for %s finished", host_id)
 
-    async def decommission_node(self, host_ip: str) -> None:
+    async def decommission_node(self, host_ip: str, timeout: float) -> None:
         """Initiate decommission node of host_ip"""
         logger.debug("decommission_node %s", host_ip)
-        await self.client.post("/storage_service/decommission", host = host_ip)
+        await self.client.post("/storage_service/decommission", host = host_ip,
+                               timeout = timeout)
         logger.debug("decommission_node %s finished", host_ip)
 
     async def get_gossip_generation_number(self, node_ip: str, target_ip: str) -> int:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1067,7 +1067,8 @@ class ScyllaClusterManager:
 
         # initate remove
         try:
-            await self.cluster.api.remove_node(initiator.ip_addr, to_remove.host_id, ignore_dead)
+            await self.cluster.api.remove_node(initiator.ip_addr, to_remove.host_id, ignore_dead,
+                                               timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except RuntimeError as exc:
             self.logger.error("_cluster_remove_node failed initiator %s server %s ignore_dead %s, check log at %s",
                           initiator, to_remove, ignore_dead, initiator.log_filename)
@@ -1086,7 +1087,7 @@ class ScyllaClusterManager:
             self.logger.warning("_cluster_decommission_node %s is only running node left", server_id)
         server = self.cluster.running[server_id]
         try:
-            await self.cluster.api.decommission_node(server.ip_addr)
+            await self.cluster.api.decommission_node(server.ip_addr, timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except RuntimeError as exc:
             self.logger.error("_cluster_decommission_node %s, check log at %s", server,
                           server.log_filename)


### PR DESCRIPTION
Recently we enabled RBNO by default in all topology operations. This
made the operations a bit slower (repair-based topology ops are a bit
slower than classic streaming - they do more work), and in debug mode
with large number of concurrent tests running, they might timeout.

The timeout for bootstrap was already increased before, do the same for
decommission/removenode. The previously used timeout was 300 seconds
(this is the default used by aiohttp library when it makes HTTP
requests), now use the TOPOLOGY_TIMEOUT constant from ScyllaServer which
is 1000 seconds.

