### PR TITLE
Sequence CDC preimage select with Paxos learn write

### DIFF
--- a/test/cql/cdc_with_lwt_test.cql
+++ b/test/cql/cdc_with_lwt_test.cql
@@ -17,6 +17,6 @@ DELETE FROM ks.tbl_cdc_lwt WHERE pk = 1 AND ck = 1 IF EXISTS;
 
 SELECT "cdc$batch_seq_no", "cdc$operation", ck, pk, val FROM ks.tbl_cdc_lwt_scylla_cdc_log;
 
--- there should be 6 rows in total: (0) + preimg(0) + (2) + preimg(2) + (4) + preimg(4)
+-- there should be 5 rows in total: (0) + preimg(0) + (2) + preimg(2) + (4)
 SELECT count(*) FROM ks.tbl_cdc_lwt_scylla_cdc_log;
 DROP KEYSPACE ks;

--- a/test/cql/cdc_with_lwt_test.result
+++ b/test/cql/cdc_with_lwt_test.result
@@ -58,7 +58,7 @@ OK
 |                  1 |               3 |    1 |    1 | null  |
 +--------------------+-----------------+------+------+-------+
 > 
-> -- there should be 6 rows in total: (0) + preimg(0) + (2) + preimg(2) + (4) + preimg(4)
+> -- there should be 5 rows in total: (0) + preimg(0) + (2) + preimg(2) + (4)
 > SELECT count(*) FROM ks.tbl_cdc_lwt_scylla_cdc_log;
 +---------+
 |   count |

--- a/test/cql/suite.yaml
+++ b/test/cql/suite.yaml
@@ -1,3 +1,1 @@
 type: Approval
-flaky:
-    - cdc_with_lwt_test


### PR DESCRIPTION
`paxos_response_handler::learn_decision` was calling
`cdc_service::augment_mutation_call` concurrently with
`storage_proxy::mutate_internal`. `augment_mutation_call` was selecting
rows from the base table in order to create the preimage, while
`mutate_internal` was writing rows to the table. It was therefore
possible for the preimage to observe the update that it accompanied,
which doesn't make any sense, because the preimage is supposed to show
the state before the update.

Fix this by performing the operations sequentially. We can still perform
the CDC mutation write concurrently with the base mutation write.

`cdc_with_lwt_test` was sometimes failing in debug mode due to this bug
and was marked flaky. Unmark it.

Also fix a comment in `cdc_with_lwt_test`.

Fixes #12098

