### PR TITLE
Backport compaction-backlog-tracker fixes to branch-5.1

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -409,7 +409,9 @@ public:
                 l0_old_ssts.push_back(std::move(sst));
             }
         }
-        _l0_scts.replace_sstables(std::move(l0_old_ssts), std::move(l0_new_ssts));
+        if (l0_old_ssts.size() || l0_new_ssts.size()) {
+            _l0_scts.replace_sstables(std::move(l0_old_ssts), std::move(l0_new_ssts));
+        }
     }
 };
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1135,10 +1135,12 @@ void table::set_compaction_strategy(sstables::compaction_strategy_type strategy)
     _compaction_strategy.get_backlog_tracker().transfer_ongoing_charges(new_cs.get_backlog_tracker(), move_read_charges);
 
     auto new_sstables = new_cs.make_sstable_set(_schema);
+    std::vector<sstables::shared_sstable> new_sstables_for_backlog_tracker;
     _main_sstables->for_each_sstable([&] (const sstables::shared_sstable& s) {
-        add_sstable_to_backlog_tracker(new_cs.get_backlog_tracker(), s);
         new_sstables.insert(s);
+        new_sstables_for_backlog_tracker.push_back(s);
     });
+    new_cs.get_backlog_tracker().replace_sstables({}, std::move(new_sstables_for_backlog_tracker));
 
     // now exception safe:
     _compaction_strategy = std::move(new_cs);


### PR DESCRIPTION
Both patches are important to fix inefficiencies when updating the backlog tracker, which can manifest as a reactor stall, on a special event like schema change.

A simple conflict was resolved in the first patch, since master has compaction groups. It was very easy to resolve.

Regression since https://github.com/scylladb/scylladb/commit/1d9f53c881c562b276250c4503801ee92d6d2aa6, which is present in 5.1 onwards. So probably it merits a backport to 5.2 too.