### PR TITLE
Keep reshape and reshard logic in distributed loader

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -241,7 +241,7 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
             auto result = co_await sstables::compact_sstables(std::move(desc), info, table.as_table_state());
             // input sstables are moved, to guarantee their resources are released once we're done
             // resharding them.
-            co_await when_all_succeed(dir.collect_output_unshared_sstables(std::move(result.new_sstables), sstables::sstable_directory::can_be_remote::yes), dir.remove_input_sstables_from_resharding(std::move(sstlist))).discard_result();
+            co_await when_all_succeed(dir.collect_output_unshared_sstables(std::move(result.new_sstables), sstables::sstable_directory::can_be_remote::yes), dir.remove_sstables(std::move(sstlist))).discard_result();
         });
     });
 }

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -326,7 +326,7 @@ future<uint64_t> reshape(sstables::sstable_directory& dir, replica::table& table
 
             return table.get_compaction_manager().run_custom_job(table.as_table_state(), sstables::compaction_type::Reshape, "Reshape compaction", [&dir, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
                 return sstables::compact_sstables(std::move(desc), info, table.as_table_state()).then([&dir, sstlist = std::move(sstlist)] (sstables::compaction_result result) mutable {
-                    return dir.remove_input_sstables_from_reshaping(std::move(sstlist)).then([&dir, new_sstables = std::move(result.new_sstables)] () mutable {
+                    return dir.remove_unshared_sstables(std::move(sstlist)).then([&dir, new_sstables = std::move(result.new_sstables)] () mutable {
                         return dir.collect_output_unshared_sstables(std::move(new_sstables), sstables::sstable_directory::can_be_remote::no);
                     });
                 });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -213,8 +213,7 @@ future<> sstable_directory::reshard(sstable_info_vector shared_info, compaction_
 
     std::vector<std::vector<sstables::shared_sstable>> buckets(1);
     co_await coroutine::parallel_for_each(shared_info, [this, sstables_per_job, num_jobs, &buckets] (sstables::foreign_sstable_open_info& info) -> future<> {
-        auto sst = _manager.make_sstable(_schema, _sstable_dir.native(), info.generation, info.version, info.format, gc_clock::now(), _error_handler_gen);
-        co_await sst->load(std::move(info));
+        auto sst = co_await load_foreign_sstable(info);
         // Last bucket gets leftover SSTables
         if ((buckets.back().size() >= sstables_per_job) && (buckets.size() < num_jobs)) {
             buckets.emplace_back();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -246,6 +246,60 @@ highest_version_seen(sharded<sstables::sstable_directory>& dir, sstables::sstabl
     });
 }
 
+} namespace sstables {
+
+future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::table& table, sstables::compaction_sstable_creator_fn creator,
+                                            sstables::reshape_mode mode, sstable_filter_func_t sstable_filter)
+{
+    return do_with(uint64_t(0), std::move(sstable_filter), [this, &cm, &table, creator = std::move(creator), mode] (uint64_t& reshaped_size, sstable_filter_func_t& filter) mutable {
+        return repeat([this, &cm, &table, creator = std::move(creator), &reshaped_size, mode, &filter] () mutable {
+            auto reshape_candidates = boost::copy_range<std::vector<shared_sstable>>(_unshared_local_sstables
+                    | boost::adaptors::filtered([this, &filter] (const auto& sst) {
+                return filter(sst);
+            }));
+            auto desc = table.get_compaction_strategy().get_reshaping_job(std::move(reshape_candidates), table.schema(), _io_priority, mode);
+            if (desc.sstables.empty()) {
+                return make_ready_future<stop_iteration>(stop_iteration::yes);
+            }
+
+            if (!reshaped_size) {
+                dblog.info("Table {}.{} with compaction strategy {} found SSTables that need reshape. Starting reshape process", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name());
+            }
+
+            std::vector<sstables::shared_sstable> sstlist;
+            for (auto& sst : desc.sstables) {
+                reshaped_size += sst->data_size();
+                sstlist.push_back(sst);
+            }
+
+            desc.creator = creator;
+
+            return cm.run_custom_job(table.as_table_state(), compaction_type::Reshape, "Reshape compaction", [this, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
+                return sstables::compact_sstables(std::move(desc), info, table.as_table_state()).then([this, sstlist = std::move(sstlist)] (sstables::compaction_result result) mutable {
+                    return remove_input_sstables_from_reshaping(std::move(sstlist)).then([this, new_sstables = std::move(result.new_sstables)] () mutable {
+                        return collect_output_sstables_from_reshaping(std::move(new_sstables));
+                    });
+                });
+            }).then_wrapped([&table] (future<> f) {
+                try {
+                    f.get();
+                } catch (sstables::compaction_stopped_exception& e) {
+                    dblog.info("Table {}.{} with compaction strategy {} had reshape successfully aborted.", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name());
+                    return make_ready_future<stop_iteration>(stop_iteration::yes);
+                } catch (...) {
+                    dblog.info("Reshape failed for Table {}.{} with compaction strategy {} due to {}", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name(), std::current_exception());
+                    return make_ready_future<stop_iteration>(stop_iteration::yes);
+                }
+                return make_ready_future<stop_iteration>(stop_iteration::no);
+            });
+        }).then([&reshaped_size] {
+            return make_ready_future<uint64_t>(reshaped_size);
+        });
+    });
+}
+
+} namespace replica {
+
 future<>
 distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
         sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator,

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -253,7 +253,7 @@ future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::tab
 {
     return do_with(uint64_t(0), std::move(sstable_filter), [this, &cm, &table, creator = std::move(creator), mode, iop] (uint64_t& reshaped_size, sstable_filter_func_t& filter) mutable {
         return repeat([this, &cm, &table, creator = std::move(creator), &reshaped_size, mode, &filter, iop] () mutable {
-            auto reshape_candidates = boost::copy_range<std::vector<shared_sstable>>(_unshared_local_sstables
+            auto reshape_candidates = boost::copy_range<std::vector<shared_sstable>>(get_unshared_local_sstables()
                     | boost::adaptors::filtered([this, &filter] (const auto& sst) {
                 return filter(sst);
             }));

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -246,15 +246,15 @@ highest_version_seen(sharded<sstables::sstable_directory>& dir, sstables::sstabl
     });
 }
 
-} namespace sstables {
+using sstable_filter_func_t = std::function<bool (const sstables::shared_sstable&)>;
 
-future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::table& table, sstables::compaction_sstable_creator_fn creator,
+future<uint64_t> reshape(sstables::sstable_directory& dir, compaction_manager& cm, replica::table& table, sstables::compaction_sstable_creator_fn creator,
                                             sstables::reshape_mode mode, sstable_filter_func_t sstable_filter, io_priority_class iop)
 {
-    return do_with(uint64_t(0), std::move(sstable_filter), [this, &cm, &table, creator = std::move(creator), mode, iop] (uint64_t& reshaped_size, sstable_filter_func_t& filter) mutable {
-        return repeat([this, &cm, &table, creator = std::move(creator), &reshaped_size, mode, &filter, iop] () mutable {
-            auto reshape_candidates = boost::copy_range<std::vector<shared_sstable>>(get_unshared_local_sstables()
-                    | boost::adaptors::filtered([this, &filter] (const auto& sst) {
+    return do_with(uint64_t(0), std::move(sstable_filter), [&dir, &cm, &table, creator = std::move(creator), mode, iop] (uint64_t& reshaped_size, sstable_filter_func_t& filter) mutable {
+        return repeat([&dir, &cm, &table, creator = std::move(creator), &reshaped_size, mode, &filter, iop] () mutable {
+            auto reshape_candidates = boost::copy_range<std::vector<sstables::shared_sstable>>(dir.get_unshared_local_sstables()
+                    | boost::adaptors::filtered([&filter] (const auto& sst) {
                 return filter(sst);
             }));
             auto desc = table.get_compaction_strategy().get_reshaping_job(std::move(reshape_candidates), table.schema(), iop, mode);
@@ -274,10 +274,10 @@ future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::tab
 
             desc.creator = creator;
 
-            return cm.run_custom_job(table.as_table_state(), compaction_type::Reshape, "Reshape compaction", [this, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
-                return sstables::compact_sstables(std::move(desc), info, table.as_table_state()).then([this, sstlist = std::move(sstlist)] (sstables::compaction_result result) mutable {
-                    return remove_input_sstables_from_reshaping(std::move(sstlist)).then([this, new_sstables = std::move(result.new_sstables)] () mutable {
-                        return collect_output_sstables_from_reshaping(std::move(new_sstables));
+            return cm.run_custom_job(table.as_table_state(), sstables::compaction_type::Reshape, "Reshape compaction", [&dir, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
+                return sstables::compact_sstables(std::move(desc), info, table.as_table_state()).then([&dir, sstlist = std::move(sstlist)] (sstables::compaction_result result) mutable {
+                    return dir.remove_input_sstables_from_reshaping(std::move(sstlist)).then([&dir, new_sstables = std::move(result.new_sstables)] () mutable {
+                        return dir.collect_output_sstables_from_reshaping(std::move(new_sstables));
                     });
                 });
             }).then_wrapped([&table] (future<> f) {
@@ -298,8 +298,6 @@ future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::tab
     });
 }
 
-} namespace replica {
-
 future<>
 distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
         sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator,
@@ -309,7 +307,7 @@ distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<r
     auto total_size = co_await dir.map_reduce0([&dir, &db, ks_name = std::move(ks_name), table_name = std::move(table_name), creator = std::move(creator), mode, filter, iop] (sstables::sstable_directory& d) {
         auto& table = db.local().find_column_family(ks_name, table_name);
         auto& cm = db.local().get_compaction_manager();
-        return d.reshape(cm, table, creator, mode, filter, iop);
+        return ::replica::reshape(d, cm, table, creator, mode, filter, iop);
     }, uint64_t(0), std::plus<uint64_t>());
 
     if (total_size > 0) {

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -68,7 +68,8 @@ class distributed_loader {
 
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
             sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter, io_priority_class iop);
-    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator);
+    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator,
+            io_priority_class iop);
     static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags);
     static future<> lock_table(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring cf_name);
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -67,7 +67,7 @@ class distributed_loader {
     friend class table_population_metadata;
 
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
-            sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter);
+            sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter, io_priority_class iop);
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator);
     static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags);
     static future<> lock_table(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring cf_name);

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -323,11 +323,11 @@ sstable_directory::collect_output_unshared_sstables(std::vector<sstables::shared
 }
 
 future<>
-sstable_directory::remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist) {
+sstable_directory::remove_unshared_sstables(std::vector<sstables::shared_sstable> sstlist) {
     // When removing input sstables from reshaping: Those SSTables used to be in the unshared local
     // list. So not only do we have to remove them, we also have to update the list. Because we're
     // dealing with a vector it's easier to just reconstruct the list.
-    dirlog.debug("Removing {} reshaped SSTables", sstlist.size());
+    dirlog.debug("Removing {} unshared SSTables", sstlist.size());
     return do_with(std::move(sstlist), std::unordered_set<sstables::shared_sstable>(),
             [this] (std::vector<sstables::shared_sstable>& sstlist, std::unordered_set<sstables::shared_sstable>& exclude) {
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -354,48 +354,6 @@ sstable_directory::collect_output_sstables_from_reshaping(std::vector<sstables::
 }
 
 future<>
-sstable_directory::reshard(sstable_info_vector shared_info, compaction_manager& cm, replica::table& table,
-                           unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator)
-{
-    // Resharding doesn't like empty sstable sets, so bail early. There is nothing
-    // to reshard in this shard.
-    if (shared_info.empty()) {
-        co_return;
-    }
-
-    // We want to reshard many SSTables at a time for efficiency. However if we have to many we may
-    // be risking OOM.
-    auto num_jobs = (shared_info.size() + max_sstables_per_job - 1) / max_sstables_per_job;
-    auto sstables_per_job = shared_info.size() / num_jobs;
-
-    std::vector<std::vector<sstables::shared_sstable>> buckets(1);
-    co_await coroutine::parallel_for_each(shared_info, [this, sstables_per_job, num_jobs, &buckets] (sstables::foreign_sstable_open_info& info) -> future<> {
-        auto sst = _manager.make_sstable(_schema, _sstable_dir.native(), info.generation, info.version, info.format, gc_clock::now(), _error_handler_gen);
-        co_await sst->load(std::move(info));
-        // Last bucket gets leftover SSTables
-        if ((buckets.back().size() >= sstables_per_job) && (buckets.size() < num_jobs)) {
-            buckets.emplace_back();
-        }
-        buckets.back().push_back(std::move(sst));
-    });
-    // There is a semaphore inside the compaction manager in run_resharding_jobs. So we
-    // parallel_for_each so the statistics about pending jobs are updated to reflect all
-    // jobs. But only one will run in parallel at a time
-    co_await coroutine::parallel_for_each(buckets, [this, &cm, &table, creator = std::move(creator)] (std::vector<sstables::shared_sstable>& sstlist) mutable {
-        return cm.run_custom_job(table.as_table_state(), compaction_type::Reshard, "Reshard compaction", [this, &cm, &table, creator, &sstlist] (sstables::compaction_data& info) -> future<> {
-            sstables::compaction_descriptor desc(sstlist, _io_priority);
-            desc.options = sstables::compaction_type_options::make_reshard();
-            desc.creator = std::move(creator);
-
-            auto result = co_await sstables::compact_sstables(std::move(desc), info, table.as_table_state());
-            // input sstables are moved, to guarantee their resources are released once we're done
-            // resharding them.
-            co_await when_all_succeed(collect_output_sstables_from_resharding(std::move(result.new_sstables)), remove_input_sstables_from_resharding(std::move(sstlist))).discard_result();
-        });
-    });
-}
-
-future<>
 sstable_directory::do_for_each_sstable(std::function<future<>(sstables::shared_sstable)> func) {
     return parallel_for_each_restricted(_unshared_local_sstables, std::move(func));
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -192,7 +192,8 @@ public:
     future<uint64_t> reshape(compaction_manager& cm, replica::table& table,
                      sstables::compaction_sstable_creator_fn creator,
                      sstables::reshape_mode mode,
-                     sstable_filter_func_t sstable_filter);
+                     sstable_filter_func_t sstable_filter,
+                     io_priority_class iop);
 
     // Store a phased operation. Usually used to keep an object alive while the directory is being
     // processed. One example is preventing table drops concurrent to the processing of this

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -122,8 +122,6 @@ private:
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
     void handle_component(scan_state& state, sstables::entry_descriptor desc, std::filesystem::path filename);
-    future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
-    future<> collect_output_sstables_from_resharding(std::vector<sstables::shared_sstable> resharded_sstables);
 
     template <typename Container, typename Func>
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
@@ -172,19 +170,6 @@ public:
     // If files were scheduled to be removed, they will be removed after this call.
     future<> commit_directory_changes();
 
-    // reshards a collection of SSTables.
-    //
-    // A reference to the compaction manager must be passed so we can register with it. Knowing
-    // which table is being processed is a requirement of the compaction manager, so this must be
-    // passed too.
-    //
-    // We will reshard max_sstables_per_job at once.
-    //
-    // A creator function must be passed that will create an SSTable object in the correct shard,
-    // and an I/O priority must be specified.
-    future<> reshard(sstable_info_vector info, compaction_manager& cm, replica::table& table,
-                     unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator, io_priority_class iop);
-
     // Store a phased operation. Usually used to keep an object alive while the directory is being
     // processed. One example is preventing table drops concurrent to the processing of this
     // directory.
@@ -198,6 +183,9 @@ public:
     // is called.
     sstable_info_vector retrieve_shared_sstables();
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
+
+    future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
+    future<> collect_output_sstables_from_resharding(std::vector<sstables::shared_sstable> resharded_sstables);
 
     future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
     future<> collect_output_sstables_from_reshaping(std::vector<sstables::shared_sstable> reshaped_sstables);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -185,7 +185,7 @@ public:
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
 
     future<> remove_sstables(std::vector<sstables::shared_sstable> sstlist);
-    future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
+    future<> remove_unshared_sstables(std::vector<sstables::shared_sstable> sstlist);
 
     using can_be_remote = bool_class<struct can_be_remote_tag>;
     future<> collect_output_unshared_sstables(std::vector<sstables::shared_sstable> resharded_sstables, can_be_remote);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -125,9 +125,6 @@ private:
     future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
     future<> collect_output_sstables_from_resharding(std::vector<sstables::shared_sstable> resharded_sstables);
 
-    future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
-    future<> collect_output_sstables_from_reshaping(std::vector<sstables::shared_sstable> reshaped_sstables);
-
     template <typename Container, typename Func>
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
     future<> load_foreign_sstables(sstable_info_vector info_vec);
@@ -186,15 +183,6 @@ public:
     future<> reshard(sstable_info_vector info, compaction_manager& cm, replica::table& table,
                      unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator);
 
-    using sstable_filter_func_t = std::function<bool (const sstables::shared_sstable&)>;
-
-    // reshapes a collection of SSTables, and returns the total amount of bytes reshaped.
-    future<uint64_t> reshape(compaction_manager& cm, replica::table& table,
-                     sstables::compaction_sstable_creator_fn creator,
-                     sstables::reshape_mode mode,
-                     sstable_filter_func_t sstable_filter,
-                     io_priority_class iop);
-
     // Store a phased operation. Usually used to keep an object alive while the directory is being
     // processed. One example is preventing table drops concurrent to the processing of this
     // directory.
@@ -208,6 +196,9 @@ public:
     // is called.
     sstable_info_vector retrieve_shared_sstables();
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
+
+    future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
+    future<> collect_output_sstables_from_reshaping(std::vector<sstables::shared_sstable> reshaped_sstables);
 
     std::filesystem::path sstable_dir() const noexcept {
         return _sstable_dir;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -181,7 +181,7 @@ public:
     // A creator function must be passed that will create an SSTable object in the correct shard,
     // and an I/O priority must be specified.
     future<> reshard(sstable_info_vector info, compaction_manager& cm, replica::table& table,
-                     unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator);
+                     unsigned max_sstables_per_job, sstables::compaction_sstable_creator_fn creator, io_priority_class iop);
 
     // Store a phased operation. Usually used to keep an object alive while the directory is being
     // processed. One example is preventing table drops concurrent to the processing of this

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -184,7 +184,7 @@ public:
     sstable_info_vector retrieve_shared_sstables();
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
 
-    future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
+    future<> remove_sstables(std::vector<sstables::shared_sstable> sstlist);
     future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
 
     using can_be_remote = bool_class<struct can_be_remote_tag>;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -141,6 +141,8 @@ public:
         return _unsorted_sstables;
     }
 
+    future<shared_sstable> load_foreign_sstable(foreign_sstable_open_info& info);
+
     // moves unshared SSTables that don't belong to this shard to the right shards.
     future<> move_foreign_sstables(sharded<sstable_directory>& source_directory);
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -185,10 +185,10 @@ public:
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
 
     future<> remove_input_sstables_from_resharding(std::vector<sstables::shared_sstable> sstlist);
-    future<> collect_output_sstables_from_resharding(std::vector<sstables::shared_sstable> resharded_sstables);
-
     future<> remove_input_sstables_from_reshaping(std::vector<sstables::shared_sstable> sstlist);
-    future<> collect_output_sstables_from_reshaping(std::vector<sstables::shared_sstable> reshaped_sstables);
+
+    using can_be_remote = bool_class<struct can_be_remote_tag>;
+    future<> collect_output_unshared_sstables(std::vector<sstables::shared_sstable> resharded_sstables, can_be_remote);
 
     std::filesystem::path sstable_dir() const noexcept {
         return _sstable_dir;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -207,6 +207,7 @@ public:
     // Retrieves the list of shared SSTables in this object. The list will be reset once this
     // is called.
     sstable_info_vector retrieve_shared_sstables();
+    std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
 
     std::filesystem::path sstable_dir() const noexcept {
         return _sstable_dir;

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -30,7 +30,7 @@ public:
         return replica::distributed_loader::lock_table(dir, db, std::move(ks_name), std::move(cf_name));
     }
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator) {
-        return replica::distributed_loader::reshard(dir, db, std::move(ks_name), std::move(table_name), std::move(creator));
+        return replica::distributed_loader::reshard(dir, db, std::move(ks_name), std::move(table_name), std::move(creator), default_priority_class());
     }
 };
 


### PR DESCRIPTION
Now it's scattered between dist. loader and sstable directory code making the latter quite bloated. Keeping everything in distributed loader makes the sstable_directory code compact and easier to patch to support object storage backend.