### PR TITLE
reader_concurrency_semaphore: handle read blocked on memory being registered as inactive

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -196,6 +196,8 @@ private:
             maybe_dump_reader_permit_diagnostics(_semaphore, "timed out");
 
             _semaphore.dequeue_permit(*this);
+        } else if (_state == state::inactive) {
+            _semaphore.evict(*this, reader_concurrency_semaphore::evict_reason::time);
         }
     }
 

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -703,6 +703,30 @@ void reader_concurrency_semaphore::inactive_read_handle::abandon() noexcept {
     }
 }
 
+void reader_concurrency_semaphore::wait_queue::push_to_admission_queue(reader_permit&& e, db::timeout_clock::time_point timeout) {
+    _admission_queue.push_back(std::move(e), timeout);
+}
+
+void reader_concurrency_semaphore::wait_queue::push_to_memory_queue(reader_permit&& e, db::timeout_clock::time_point timeout) {
+    _memory_queue.push_back(std::move(e), timeout);
+}
+
+reader_permit& reader_concurrency_semaphore::wait_queue::front() {
+    if (_memory_queue.empty()) {
+        return _admission_queue.front();
+    } else {
+        return _memory_queue.front();
+    }
+}
+
+void reader_concurrency_semaphore::wait_queue::pop_front() {
+    if (_memory_queue.empty()) {
+        _admission_queue.pop_front();
+    } else {
+        _memory_queue.pop_front();
+    }
+}
+
 namespace {
 
 struct stop_execution_loop {

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1253,9 +1253,11 @@ std::string reader_concurrency_semaphore::dump_diagnostics(unsigned max_lines) c
     return os.str();
 }
 
-void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(const reader_permit&)> func) {
+void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(const reader_permit&)> func) const {
     for (auto& p : _permit_list) {
-        func(reader_permit(p.shared_from_this()));
+        // We cast away const to construct a reader_permit but the resulting
+        // object is passed as const& so there is no const violation here.
+        func(reader_permit(const_cast<reader_permit::impl&>(p).shared_from_this()));
     }
 }
 

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -439,6 +439,14 @@ reader_concurrency_semaphore& reader_permit::semaphore() {
     return _impl->semaphore();
 }
 
+const ::schema* reader_permit::get_schema() const {
+    return _impl->get_schema();
+}
+
+std::string_view reader_permit::get_op_name() const {
+    return _impl->get_op_name();
+}
+
 reader_permit::state reader_permit::get_state() const {
     return _impl->get_state();
 }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -658,7 +658,7 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
 }
 
 static void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, const reader_concurrency_semaphore::permit_list_type& list,
-        std::string_view problem) {
+        std::string_view problem) noexcept {
     static thread_local logger::rate_limit rate_limit(std::chrono::seconds(30));
 
     rcslog.log(log_level::info, rate_limit, "{}", value_of([&] {

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -527,7 +527,7 @@ public:
         return _stats.current_permits - _stats.inactive_reads - waiters();
     }
 
-    void foreach_permit(noncopyable_function<void(const reader_permit&)> func);
+    void foreach_permit(noncopyable_function<void(const reader_permit&)> func) const;
 
     uintptr_t get_blessed_permit() const noexcept { return reinterpret_cast<uintptr_t>(_blessed_permit); }
 };

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -527,6 +527,7 @@ public:
         return _stats.current_permits - _stats.inactive_reads - waiters();
     }
 
+    void foreach_permit(noncopyable_function<void(const reader_permit::impl&)> func) const;
     void foreach_permit(noncopyable_function<void(const reader_permit&)> func) const;
 
     uintptr_t get_blessed_permit() const noexcept { return reinterpret_cast<uintptr_t>(_blessed_permit); }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -506,10 +506,6 @@ public:
         return _initial_resources - _resources;
     }
 
-    size_t waiters() const {
-        return _stats.waiters;
-    }
-
     void broken(std::exception_ptr ex = {});
 
     /// Dump diagnostics printout
@@ -523,7 +519,7 @@ public:
     }
 
     uint64_t active_reads() const noexcept {
-        return _stats.current_permits - _stats.inactive_reads - waiters();
+        return _stats.current_permits - _stats.inactive_reads - _stats.waiters;
     }
 
     void foreach_permit(noncopyable_function<void(const reader_permit::impl&)> func) const;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -11,7 +11,7 @@
 #include <boost/intrusive/list.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/queue.hh>
+#include <seastar/core/condition-variable.hh>
 #include "reader_permit.hh"
 #include "readers/flat_mutation_reader_v2.hh"
 #include "utils/updateable_value.hh"
@@ -197,7 +197,8 @@ private:
     };
 
     wait_queue _wait_list;
-    queue<reader_permit> _ready_list;
+    permit_list_type _ready_list;
+    condition_variable _ready_list_cv;
 
     sstring _name;
     size_t _max_queue_length = std::numeric_limits<size_t>::max();
@@ -276,7 +277,7 @@ private:
     void consume(reader_permit::impl& permit, resources r);
     void signal(const resources& r) noexcept;
 
-    future<> with_ready_permit(reader_permit permit);
+    future<> with_ready_permit(reader_permit::impl& permit);
 
 public:
     struct no_limits { };

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -201,26 +201,10 @@ private:
         bool empty() const {
             return _admission_queue.empty() && _memory_queue.empty();
         }
-        void push_to_admission_queue(reader_permit&& e, db::timeout_clock::time_point timeout) {
-            _admission_queue.push_back(std::move(e), timeout);
-        }
-        void push_to_memory_queue(reader_permit&& e, db::timeout_clock::time_point timeout) {
-            _memory_queue.push_back(std::move(e), timeout);
-        }
-        reader_permit& front() {
-            if (_memory_queue.empty()) {
-                return _admission_queue.front();
-            } else {
-                return _memory_queue.front();
-            }
-        }
-        void pop_front() {
-            if (_memory_queue.empty()) {
-                _admission_queue.pop_front();
-            } else {
-                _memory_queue.pop_front();
-            }
-        }
+        void push_to_admission_queue(reader_permit&& e, db::timeout_clock::time_point timeout);
+        void push_to_memory_queue(reader_permit&& e, db::timeout_clock::time_point timeout);
+        reader_permit& front();
+        void pop_front();
     };
 
     wait_queue _wait_list;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -107,6 +107,8 @@ public:
         uint64_t disk_reads = 0;
         // The number of sstables read currently.
         uint64_t sstables_read = 0;
+        // Permits waiting on something: admission, memory or execution
+        uint64_t waiters = 0;
     };
 
     using permit_list_type = bi::list<
@@ -204,9 +206,6 @@ private:
         expiring_fifo<entry, expiry_handler, db::timeout_clock> _memory_queue;
     public:
         wait_queue(expiry_handler eh) : _admission_queue(eh), _memory_queue(eh) { }
-        size_t size() const {
-            return _admission_queue.size() + _memory_queue.size();
-        }
         bool empty() const {
             return _admission_queue.empty() && _memory_queue.empty();
         }
@@ -508,7 +507,7 @@ public:
     }
 
     size_t waiters() const {
-        return _wait_list.size();
+        return _stats.waiters;
     }
 
     void broken(std::exception_ptr ex = {});

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -166,13 +166,14 @@ private:
     permit_list_type _ready_list;
     condition_variable _ready_list_cv;
     permit_list_type _inactive_reads;
+    // Stores permits that are not in any of the above list.
+    permit_list_type _permit_list;
 
     sstring _name;
     size_t _max_queue_length = std::numeric_limits<size_t>::max();
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
     stats _stats;
-    permit_list_type _permit_list;
     bool _stopped = false;
     bool _evicting = false;
     gate _close_readers_gate;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -145,31 +145,11 @@ public:
     private:
         void abandon() noexcept;
 
-        explicit inactive_read_handle(reader_concurrency_semaphore& sem, inactive_read& ir) noexcept
-            : _sem(&sem), _irp(&ir) {
-            _irp->handle = this;
-        }
+        explicit inactive_read_handle(reader_concurrency_semaphore& sem, inactive_read& ir) noexcept;
     public:
         inactive_read_handle() = default;
-        inactive_read_handle(inactive_read_handle&& o) noexcept
-            : _sem(std::exchange(o._sem, nullptr))
-            , _irp(std::exchange(o._irp, nullptr)) {
-            if (_irp) {
-                _irp->handle = this;
-            }
-        }
-        inactive_read_handle& operator=(inactive_read_handle&& o) noexcept {
-            if (this == &o) {
-                return *this;
-            }
-            abandon();
-            _sem = std::exchange(o._sem, nullptr);
-            _irp = std::exchange(o._irp, nullptr);
-            if (_irp) {
-                _irp->handle = this;
-            }
-            return *this;
-        }
+        inactive_read_handle(inactive_read_handle&& o) noexcept;
+        inactive_read_handle& operator=(inactive_read_handle&& o) noexcept;
         ~inactive_read_handle() {
             abandon();
         }

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -135,6 +135,8 @@ public:
 
     reader_concurrency_semaphore& semaphore();
 
+    const ::schema* get_schema() const;
+    std::string_view get_op_name() const;
     state get_state() const;
 
     bool needs_readmission() const;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -166,6 +166,10 @@ public:
 
     void set_timeout(db::timeout_clock::time_point timeout) noexcept;
 
+    // If the read was aborted, throw the exception the read was aborted with.
+    // Otherwise no-op.
+    void check_abort();
+
     query::max_result_size max_result_size() const;
     void set_max_result_size(query::max_result_size);
 

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -101,12 +101,8 @@ private:
     explicit reader_permit(reader_concurrency_semaphore& semaphore, const schema* const schema, sstring&& op_name,
             reader_resources base_resources, db::timeout_clock::time_point timeout);
 
-    void on_waiting_for_admission();
-    void on_waiting_for_memory(future<> f);
-    void on_admission();
-    void on_granted_memory();
-
-    future<> get_memory_future();
+    reader_permit::impl& operator*() { return *_impl; }
+    reader_permit::impl* operator->() { return _impl.get(); }
 
     void mark_used() noexcept;
 

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -81,6 +81,7 @@ public:
     enum class state {
         waiting_for_admission,
         waiting_for_memory,
+        waiting_for_execution,
         active_unused,
         active_used,
         active_blocked,

--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -580,6 +580,7 @@ public:
     void unpop_mutation_fragment(mutation_fragment_v2 mf) { _impl->unpop_mutation_fragment(std::move(mf)); }
     const schema_ptr& schema() const { return _impl->_schema; }
     const reader_permit& permit() const { return _impl->_permit; }
+    reader_permit& permit() { return _impl->_permit; }
     db::timeout_clock::time_point timeout() const noexcept { return _impl->timeout(); }
     void set_timeout(db::timeout_clock::time_point timeout) noexcept { _impl->set_timeout(timeout); }
     void set_max_buffer_size(size_t size) {

--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -377,10 +377,8 @@ public:
             }
         }
 
-        void maybe_timed_out() {
-            if (db::timeout_clock::now() >= timeout()) {
-                throw timed_out_error();
-            }
+        void check_abort() {
+            _permit.check_abort();
         }
 
         db::timeout_clock::time_point timeout() const noexcept {

--- a/readers/multishard.hh
+++ b/readers/multishard.hh
@@ -10,6 +10,7 @@
 
 #include "reader_concurrency_semaphore.hh"
 #include "readers/flat_mutation_reader_fwd.hh"
+#include "readers/flat_mutation_reader_v2.hh"
 #include "tracing/trace_state.hh"
 #include "seastarx.hh"
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -231,7 +231,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
                         name,
                         initial_res.count - available_res.count,
                         utils::to_hr_size(initial_res.memory - available_res.memory),
-                        sem.waiters());
+                        sem.get_stats().waiters);
             } else {
                 writeln("    {}: {}/{}, {}/{}, queued: {}\n",
                         name,
@@ -239,7 +239,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
                         initial_res.count,
                         utils::to_hr_size(initial_res.memory - available_res.memory),
                         utils::to_hr_size(initial_res.memory),
-                        sem.waiters());
+                        sem.get_stats().waiters);
             }
         }
 
@@ -595,7 +595,7 @@ database::setup_metrics() {
                        sm::description("Holds the amount of memory consumed by current read operations. "),
                        {user_label_instance}),
 
-        sm::make_gauge("queued_reads", [this] { return _read_concurrency_sem.waiters(); },
+        sm::make_gauge("queued_reads", [this] { return _read_concurrency_sem.get_stats().waiters; },
                        sm::description("Holds the number of currently queued read operations."),
                        {user_label_instance}),
 
@@ -630,7 +630,7 @@ database::setup_metrics() {
                        sm::description("Holds the amount of memory consumed by current read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
 
-        sm::make_gauge("queued_reads", [this] { return _streaming_concurrency_sem.waiters(); },
+        sm::make_gauge("queued_reads", [this] { return _streaming_concurrency_sem.get_stats().waiters; },
                        sm::description("Holds the number of currently queued read operations on behalf of streaming."),
                        {streaming_label_instance}),
 
@@ -665,7 +665,7 @@ database::setup_metrics() {
                        sm::description("Holds the amount of memory consumed by all read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
 
-        sm::make_gauge("queued_reads", [this] { return _system_read_concurrency_sem.waiters(); },
+        sm::make_gauge("queued_reads", [this] { return _system_read_concurrency_sem.get_stats().waiters; },
                        sm::description("Holds the number of currently queued read operations from \"system\" keyspace tables."),
                        {system_label_instance}),
 

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2043,7 +2043,7 @@ class scylla_memory(gdb.Command):
         used_count = initial_count - int(semaphore["_resources"]["count"])
         used_memory = initial_memory - int(semaphore["_resources"]["memory"])
         try:
-            waiters = int(semaphore["_wait_list"]["_admission_queue"]["_size"])
+            waiters = int(semaphore["_stats"]["waiters"])
         except gdb.error: # 5.1 compatibility
             waiters = int(semaphore["_wait_list"]["_size"])
         return f'{semaphore_name:<16} {used_count:>3}/{initial_count:>3}, {used_memory:>13}/{initial_memory:>13}, queued: {waiters}'
@@ -5235,7 +5235,7 @@ class scylla_read_stats(gdb.Command):
 
 
         try:
-            waiters = int(semaphore["_wait_list"]["_admission_queue"]["_size"])
+            waiters = int(semaphore["_stats"]["waiters"])
         except gdb.error: # 5.1 compatibility
             waiters = int(semaphore["_wait_list"]["_size"])
 

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1610,7 +1610,7 @@ public:
         }
         return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
             if (_partition_finished) {
-                maybe_timed_out();
+                check_abort();
                 if (_before_partition) {
                     return read_partition();
                 } else {
@@ -1622,7 +1622,7 @@ public:
                     if (is_buffer_full() || _partition_finished || _end_of_stream) {
                         return make_ready_future<>();
                     }
-                    maybe_timed_out();
+                    check_abort();
                     return advance_context(_consumer.maybe_skip()).then([this] {
                         return _context->consume_input();
                     });

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -731,7 +731,7 @@ SEASTAR_THREAD_TEST_CASE(test_immediate_evict_on_insert) {
 
     auto fut = sem.obtain_permit(t.get_schema().get(), get_name(), 1, db::no_timeout);
 
-    BOOST_CHECK_EQUAL(sem.waiters(), 1);
+    BOOST_CHECK_EQUAL(sem.get_stats().waiters, 1);
 
     const auto entry = t.produce_first_page_and_save_mutation_querier();
     t.assert_cache_lookup_mutation_querier(entry.key, *t.get_schema(), entry.expected_range, entry.expected_slice)

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1021,7 +1021,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
     // * 1 waiter
     // * no more count resources left
     auto p3_fut = semaphore.obtain_permit(&s, get_name(), 1024, db::no_timeout);
-    BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+    BOOST_REQUIRE_EQUAL(semaphore.waiters(), 2); // (waiters includes _ready_list entries)
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().used_permits, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().blocked_permits, 0);

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1023,7 +1023,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
     auto p3_fut = semaphore.obtain_permit(&s, get_name(), 1024, db::no_timeout);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2); // (waiters includes _ready_list entries)
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
-    BOOST_REQUIRE_EQUAL(semaphore.get_stats().used_permits, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().used_permits, 0); // permit looses used status while waiting for execution
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().blocked_permits, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 0);

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -161,7 +161,7 @@ void execute_reads(const schema& s, reader_concurrency_semaphore& sem, unsigned 
                 const auto res = sem.available_resources();
                 testlog.error("Read failed: {}", eptr);
                 testlog.trace("Reads remaining: count: {}/{}, memory: {}/{}, waiters: {}", (initial_res.count - res.count), initial_res.count,
-                        (initial_res.memory - res.memory), initial_res.memory, sem.waiters());
+                        (initial_res.memory - res.memory), initial_res.memory, sem.get_stats().waiters);
                 e = std::move(eptr);
             });
             thread::yield();
@@ -171,9 +171,9 @@ void execute_reads(const schema& s, reader_concurrency_semaphore& sem, unsigned 
 
         const auto res = sem.available_resources();
         testlog.trace("Initiated reads: {}/{}, count: {}/{}, memory: {}/{}, waiters: {}", n, reads, (initial_res.count - res.count), initial_res.count,
-                (initial_res.memory - res.memory), initial_res.memory, sem.waiters());
+                (initial_res.memory - res.memory), initial_res.memory, sem.get_stats().waiters);
 
-        if (sem.waiters()) {
+        if (sem.get_stats().waiters) {
             testlog.trace("Waiting for queue to drain");
             sem.obtain_permit(&s, "drain", 1, db::no_timeout).get();
         }


### PR DESCRIPTION
A read that requested memory and has to wait for it can be registered as inactive. This can happen for example if the memory request originated from a background I/O operation (a read-ahead maybe).
Handling this case is currently very difficult. What we want to do is evict such a read on-the-spot: the fact that there is a read waiting on memory means memory is in demand and so inactive reads should be evicted. To evict this reader, we'd first have to remove it from the memory wait list, which is almost impossible currently, because `expiring_fifo<>`, the type used for the wait list, doesn't allow for that. So in this PR we set out to make this possible first, by transforming all current queues to be intrusive lists of permits. Permits are already linked into an intrusive list, to allow for enumerating all existing permits. We use these existing hooks to link the permits into the appropriate queue, and back to `_permit_list` when they are not in any special queue. To make this possible we first have to make all lists store naked permits, moving all auxiliary data fields currently stored in wrappers like `entry` into the permit itself. With this, all queues and lists in the semaphore are intrusive lists, storing permits directly, which has the following implications:
* queues no longer take extra memory, as all of them are intrusive
* permits are completely self-sufficient w.r.t to queuing: code can queue or dequeue permits just with a reference to a permit at hand, no other wrapper, iterator, pointer, etc. is necessary.
* queues don't keep permits alive anymore; destroying a permit will automatically unlink it from the respective queue, although this might lead to use-after-free. Not a problem in practice, only one code-path (`reader_concurrenc_semaphore::with_permit()`) had to be adjusted.

After all that extensive preparations, we can now handle the case of evicting a reader which is queued on memory.

Fixes: #12700