### PR TITLE
cache: Fix empty partition entries being left in cache in some cases

### DIFF
--- a/mutation_partition_v2.cc
+++ b/mutation_partition_v2.cc
@@ -433,8 +433,10 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutat
             }
             if (tracker) {
                 // Newer evictable versions store complete rows
-                deletable_row& r = i->row();
-                r = std::move(src_e.row());
+                i->row() = std::move(src_e.row());
+                // Need to preserve the LRU link of the later version in case it's
+                // the last dummy entry which holds the partition entry linked in LRU.
+                i->swap(src_e);
                 tracker->remove(src_e);
             } else {
                 // Avoid row compaction if no newer range tombstone.


### PR DESCRIPTION
Merging rows from different partition versions should preserve the LRU link of the entry from the newer version. We need this in case we're merging two last dummy entries where the older dummy is already unlinked from the LRU. The newer dummy could be the last entry which is still holding the partition entry linked in the LRU.

The mutation_partition_v2 merging didn't take the LRU link from the newer entry, and we could end up with the partition entry not having any entries linked in the LRU.

Introduced in f73e2c992f77b829037833c4f46a9237cb92d76a.

Fixes #12778