### PR TITLE
sstable_test_env: Remove working_sst helper

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -41,7 +41,7 @@ bytes as_bytes(const sstring& s) {
 
 future<> test_using_working_sst(schema_ptr s, sstring dir, int64_t gen) {
     return test_env::do_with([s = std::move(s), dir = std::move(dir), gen] (test_env& env) {
-        return env.working_sst(std::move(s), std::move(dir), gen);
+        return env.reusable_sst(std::move(s), std::move(dir), gen).discard_result();
     });
 }
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -110,10 +110,6 @@ public:
         return replica::table::config{.compaction_concurrency_semaphore = &_impl->semaphore};
     }
 
-    future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {
-        return reusable_sst(std::move(schema), dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
-    }
-
     template <typename Func>
     static inline auto do_with(Func&& func, test_env_config cfg = {}) {
         return seastar::do_with(test_env(std::move(cfg)), [func = std::move(func)] (test_env& env) mutable {


### PR DESCRIPTION
It's only used by the single test and apparently exists since the times seastar was missing the future::discard_result() sugar

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>