### PR TITLE
wasm: deserialize counters as integers

### DIFF
--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -178,7 +178,13 @@ struct from_val_visitor {
         if (ret_size == -1) {
             return bytes_opt{};
         }
-        bytes_opt ret = t.decompose(t.deserialize(bytes_view(reinterpret_cast<int8_t*>(data), ret_size)));
+        bytes_opt ret;
+        const counter_type_impl* counter = dynamic_cast<const counter_type_impl*>(&t);
+        if (counter) {
+            ret = long_type->decompose(t.deserialize(bytes_view(reinterpret_cast<int8_t*>(data), ret_size)));
+        } else {
+            ret = t.decompose(t.deserialize(bytes_view(reinterpret_cast<int8_t*>(data), ret_size)));
+        }
 
         if (wasmtime::get_abi(instance, store, *memory) == 2) {
             auto free_func = wasmtime::create_func(instance, store, "_scylla_free");

--- a/test/cql-pytest/test_wasm.py
+++ b/test/cql-pytest/test_wasm.py
@@ -78,6 +78,16 @@ def test_fib(cql, test_keyspace, table1, scylla_with_wasm_only):
         with pytest.raises(InvalidRequest, match="wasm"):
             cql.execute(f"SELECT {test_keyspace}.{fib_name}(p) AS result FROM {table} WHERE p = 997")
 
+# Reads WASM UDF from a file. For a function "foo", the file should be named "foo.wat" and
+# be located in the "test/resource/wasm" directory. Supports renaming the exported function.
+def read_function_from_file(func_name, rename=None):
+    wat_path = os.path.realpath(os.path.join(__file__, f"../../resource/wasm/{func_name}.wat"))
+    with open(wat_path, "r") as f:
+        if rename:
+            return f.read().replace(f'export "{func_name}"', f'export "{rename}"')
+        else:
+            return f.read()
+
 # Test that calling a fibonacci function that claims to accept null input works.
 # Note that since the int field is nullable, it's no longer
 # passed as a simple param, but instead as a pointer to a structure with a serialized
@@ -117,13 +127,12 @@ def test_fib(cql, test_keyspace, table1, scylla_with_wasm_only):
 # }
 #
 # with:
-# $ clang -O2  --target=wasm32 --no-standard-libraries -Wl,--export=fib -Wl,--export=_scylla_abi -Wl,--no-entry fibnull.c -o fibnull.wasm
-# $ wasm2wat fibnull.wasm > fibnull.wat
+# $ clang -O2  --target=wasm32 --no-standard-libraries -Wl,--export=fib -Wl,--export=_scylla_abi -Wl,--no-entry fib.c -o fib.wasm
+# $ wasm2wat fib.wasm > fib.wat
 def test_fib_called_on_null(cql, test_keyspace, table1, scylla_with_wasm_only):
     table = table1
     fib_name = unique_name()
-    wat_path = os.path.realpath(os.path.join(__file__, '../../resource/wasm/fib.wat'))
-    fib_source = open(wat_path, 'r').read().replace('export "fib"', f'export "{fib_name}"')
+    fib_source = read_function_from_file('fib', fib_name)
     src = f"(input bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE xwasm AS '{fib_source}'"
     with new_function(cql, test_keyspace, src, fib_name):
         cql.execute(f"INSERT INTO {table1} (p) VALUES (3)")
@@ -297,8 +306,7 @@ def test_short_ints(cql, test_keyspace, table1, scylla_with_wasm_only):
         res = [row for row in cql.execute(f"SELECT {test_keyspace}.{plus_name}(s, s2) AS result FROM {table} WHERE p = 43")]
         assert len(res) == 1 and res[0].result == -9535
     # Check whether we can use a different function under the same name
-    wat_path = os.path.realpath(os.path.join(__file__, '../../resource/wasm/plus42.wat'))
-    plus42_source = open(wat_path, 'r').read().replace('export "plus42"', f'export "{plus_name}"')
+    plus42_source = read_function_from_file('plus42', plus_name)
     plus42_src = f"(input smallint, input2 smallint) RETURNS NULL ON NULL INPUT RETURNS smallint LANGUAGE xwasm AS '{plus42_source}'"
     # Repeat a number of times so the wasm instances get cached on all shards
     with new_function(cql, test_keyspace, src, plus_name):
@@ -567,8 +575,7 @@ def test_validate_params(cql, test_keyspace, table1, scylla_with_wasm_only):
 def test_word_double(cql, test_keyspace, table1, scylla_with_wasm_only):
     table = table1
     dbl_name = unique_name()
-    wat_path = os.path.realpath(os.path.join(__file__, '../../resource/wasm/dbl.wat'))
-    dbl_source = open(wat_path, 'r').read().replace('export "dbl"', f'export "{dbl_name}"')
+    dbl_source = read_function_from_file('dbl', dbl_name)
     src = f"(input text) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE xwasm AS '{dbl_source}'"
     with new_function(cql, test_keyspace, src, dbl_name):
         cql.execute(f"INSERT INTO {table1} (p, txt) VALUES (1000, 'doggo')")
@@ -614,8 +621,7 @@ def test_word_double(cql, test_keyspace, table1, scylla_with_wasm_only):
 def test_abi_v2(cql, test_keyspace, table1, scylla_with_wasm_only):
     table = table1
     ri_name = unique_name()
-    wat_path = os.path.realpath(os.path.join(__file__, '../../resource/wasm/return_input.wat'))
-    ri_source = open(wat_path, 'r').read().replace('export "return_input"', f'export "{ri_name}"')
+    ri_source = read_function_from_file('return_input', ri_name)
     text_src = f"(input text) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE xwasm AS '{ri_source}'"
     with new_function(cql, test_keyspace, text_src, ri_name):
         cql.execute(f"INSERT INTO {table1} (p, txt) VALUES (2000, 'doggo')")


### PR DESCRIPTION
Currently, because serialize_visitor::operator() is not implemented for counters, we cannot convert a counter returned by a WASM UDF to bytes when returning from wasm::run_script().

We could disallow using counters as WASM UDF return types, but an easier solution which we're already using in Lua UDFs is treating the returned counters as 64-bit integers when deserializing. This patch implements the latter approach and adds a test for it.