### PR TITLE
api: column_family: rebuild table statistics before getting them

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -920,7 +920,8 @@ public:
         return _compaction_manager;
     }
 
-    table_stats& get_stats() {
+    const table_stats& mutate_stats(std::function<void(table_stats&)> func) {
+        func(_stats);
         return _stats;
     }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -926,6 +926,7 @@ public:
     }
 
     const table_stats& get_stats() const {
+        const_cast<table*>(this)->rebuild_statistics();
         return _stats;
     }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/execution_stage.hh>
+#include "seastar/core/lowres_clock.hh"
 #include "utils/hash.hh"
 #include "db_clock.hh"
 #include "gc_clock.hh"
@@ -394,6 +395,7 @@ public:
 private:
     schema_ptr _schema;
     config _config;
+    lowres_clock::time_point _last_stats_updated;
     mutable table_stats _stats;
     mutable db::view::stats _view_stats;
     mutable row_locker::stats _row_locker_stats;
@@ -571,6 +573,7 @@ private:
     }
 private:
     void rebuild_statistics();
+    const table_stats& rebuild_statistics_periodic(lowres_clock::duration period = std::chrono::seconds(1));
 
     // Called on schema change.
     void update_optimized_twcs_queries_flag();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -920,7 +920,11 @@ public:
         return _compaction_manager;
     }
 
-    table_stats& get_stats() const {
+    table_stats& get_stats() {
+        return _stats;
+    }
+
+    const table_stats& get_stats() const {
         return _stats;
     }
 

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -133,8 +133,9 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, tracing::trace_
                 }
             });
         }).finally([&sp, schema, lc] () mutable {
-            auto& stats = sp.get_db().local().find_column_family(schema).get_stats();
-            stats.cas_prepare.mark(lc.stop().latency());
+            sp.get_db().local().find_column_family(schema).mutate_stats([latency = lc.stop().latency()] (replica::table_stats& stats) {
+                stats.cas_prepare.mark(latency);
+            });
         });
     });
 }
@@ -172,8 +173,9 @@ future<bool> paxos_state::accept(storage_proxy& sp, tracing::trace_state_ptr tr_
                 }
             });
         }).finally([&sp, schema, lc] () mutable {
-            auto& stats = sp.get_db().local().find_column_family(schema).get_stats();
-            stats.cas_accept.mark(lc.stop().latency());
+            sp.get_db().local().find_column_family(schema).mutate_stats([latency = lc.stop().latency()] (replica::table_stats& stats) {
+                stats.cas_accept.mark(latency);
+            });
         });
     });
 }
@@ -232,8 +234,9 @@ future<> paxos_state::learn(storage_proxy& sp, schema_ptr schema, proposal decis
             });
         });
     }).finally([&sp, schema, lc] () mutable {
-        auto& stats = sp.get_db().local().find_column_family(schema).get_stats();
-        stats.cas_learn.mark(lc.stop().latency());
+        sp.get_db().local().find_column_family(schema).mutate_stats([latency = lc.stop().latency()] (replica::table_stats& stats) {
+            stats.cas_learn.mark(latency);
+        });
     });
 }
 


### PR DESCRIPTION
55a8421e3d35b85ca1497d615540aafe2e02bffd) made sstable stats
update more efficient, but OTOH, it delays the stats update
to rebuild_statistics time.

this change compensates for that by calling `rebuild_statistics`
before `get_stats` from the api layer to make sure we return
the most up-to-date statistics.

Fixes #12808