### PR TITLE
git: remove Cargo.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ compile_commands.json
 .ccls-cache/
 .mypy_cache
 .envrc
-rust/Cargo.lock


### PR DESCRIPTION
When rust wasmtime bindings were added, we commited Cargo.lock to make sure a given version of Scylla always builds using the same versions of rust dependencies. Therefore, it should not be present in .gitignore.