### PR TITLE
Use best Rust practices

### DIFF
--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -39,6 +39,8 @@ versions used in the last successful build. Dependency modification may include:
 After each such modification, a new Cargo.lock file should be submitted. Cargo.lock can be generated
 by the `cargo update` command.
 
+Before committing changes, run `cargo-fmt` and `cargo-clippy` commands to keep the Rust code clean and well formatted.
+
 ## Rust interoperability implementation
 
 Using Rust alongside C++ in scylla is made possible by the Rust crate CXX. The `cxx::bridge` macro,

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -104,6 +104,8 @@ fedora_packages=(
     curl
     rust
     cargo
+    rustfmt
+    clippy
 )
 
 # lld is not available on s390x, see

--- a/rust/wasmtime_bindings/src/lib.rs
+++ b/rust/wasmtime_bindings/src/lib.rs
@@ -142,7 +142,7 @@ pub struct Module {
 fn create_module(engine: &mut Engine, script: &str) -> Result<Box<Module>> {
     let module_bytes = engine
         .wasmtime_engine
-        .precompile_module((&script).as_bytes())
+        .precompile_module(script.as_bytes())
         .map_err(|e| anyhow!("Compilation failed: {:?}", e))?;
     let module = Box::new(Module {
         serialized_module: module_bytes,
@@ -192,10 +192,7 @@ pub struct Store {
 fn create_store(engine: &mut Engine, total_fuel: u64, yield_fuel: u64) -> Result<Box<Store>> {
     let wasi = wasmtime_wasi::WasiCtxBuilder::new().build();
     let mut store = wasmtime::Store::new(&engine.wasmtime_engine, wasi);
-    store.out_of_fuel_async_yield(
-        ((total_fuel + yield_fuel - 1) / yield_fuel) as u64,
-        yield_fuel,
-    );
+    store.out_of_fuel_async_yield((total_fuel + yield_fuel - 1) / yield_fuel, yield_fuel);
     Ok(Box::new(Store {
         wasmtime_store: store,
     }))


### PR DESCRIPTION
cargo-fmt and cargo-clippy are the useful tools for improving Rust code. We should provide them and recommend developers to use them.

This patch also includes a few small fixes recommended by these tools 