### PR TITLE
replica: table: Update stats for newly added SSTables

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -543,6 +543,7 @@ private:
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();
     }
+    void update_stats_for_new_sstable(const sstables::shared_sstable& sst) noexcept;
     future<> do_add_sstable_and_update_cache(sstables::shared_sstable sst, sstables::offstrategy offstrategy);
     // Helpers which add sstable on behalf of a compaction group and refreshes compound set.
     void add_sstable(compaction_group& cg, sstables::shared_sstable sstable);


### PR DESCRIPTION
Patch 55a8421e3d35b85ca1497d6 fixed an inefficiency when rebuilding statistics with many compaction groups, but it incorrectly removed the update for newly added SSTables. This patch restores it. When a new SSTable is added to any of the groups, the stats are incrementally updated (as before). On compaction completion, statistics are still rebuilt by simply iterating through each group, which keeps track of its own stats.
Unit tests are added to guarantee the stats are correct both after compaction completion and memtable flush.

Fixes #12808.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>