### PR TITLE
treewide: remove implicitly deleted copy ctor and assignment operator

### DIFF
--- a/query-result.hh
+++ b/query-result.hh
@@ -382,9 +382,7 @@ public:
         w.reduce_chunk_count();
     }
     result(result&&) = default;
-    result(const result&) = default;
     result& operator=(result&&) = default;
-    result& operator=(const result&) = default;
 
     const bytes_ostream& buf() const {
         return _w;

--- a/range_tombstone_list.hh
+++ b/range_tombstone_list.hh
@@ -119,7 +119,6 @@ class range_tombstone_list final {
             revert();
         }
         reverter(reverter&&) = default;
-        reverter& operator=(reverter&&) = default;
         reverter(const reverter&) = delete;
         reverter& operator=(reverter&) = delete;
         virtual range_tombstones_type::iterator insert(range_tombstones_type::iterator it, range_tombstone_entry& new_rt);

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -356,7 +356,6 @@ public:
     row_cache(schema_ptr, snapshot_source, cache_tracker&, is_continuous = is_continuous::no);
     row_cache(row_cache&&) = default;
     row_cache(const row_cache&) = delete;
-    row_cache& operator=(row_cache&&) = default;
 public:
     // Implements mutation_source for this cache, see mutation_reader.hh
     // User needs to ensure that the row_cache object stays alive

--- a/utils/histogram.hh
+++ b/utils/histogram.hh
@@ -437,9 +437,7 @@ public:
     timed_rate_moving_average met;
     timed_rate_moving_average_and_histogram() = default;
     timed_rate_moving_average_and_histogram(timed_rate_moving_average_and_histogram&&) = default;
-    timed_rate_moving_average_and_histogram(const timed_rate_moving_average_and_histogram&) = default;
     timed_rate_moving_average_and_histogram(size_t size, int64_t _sample_mask = 0x80) : hist(size, _sample_mask) {}
-    timed_rate_moving_average_and_histogram& operator=(const timed_rate_moving_average_and_histogram&) = default;
 
     template <typename Rep, typename Ratio>
     void mark(std::chrono::duration<Rep, Ratio> dur) {
@@ -505,7 +503,6 @@ public:
     }
 
     timed_rate_moving_average_summary_and_histogram(timed_rate_moving_average_summary_and_histogram&&) = default;
-    timed_rate_moving_average_summary_and_histogram(const timed_rate_moving_average_summary_and_histogram&) = default;
     timed_rate_moving_average_summary_and_histogram(size_t size) : _timer([this]{
         _rates.update();
         _last_update++;
@@ -515,7 +512,6 @@ public:
         _last_update = 0;
         _summary.update();}), hist(size, 0) {
     }
-    timed_rate_moving_average_summary_and_histogram& operator=(const timed_rate_moving_average_summary_and_histogram&) = default;
 
     template <typename Rep, typename Ratio>
     void mark(std::chrono::duration<Rep, Ratio> dur) noexcept {


### PR DESCRIPTION
clang 17 trunk helped to identify these issues. so let's fix them.