### PR TITLE
test/topology: pytest driver version use print instead of log

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -7,7 +7,6 @@
 # defines common test fixtures for all of them to use
 
 import asyncio
-import logging
 import ssl
 from typing import List
 from test.pylib.random_tables import RandomTables
@@ -22,9 +21,7 @@ from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disa
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
 
-logger = logging.getLogger(__name__)
-logger.warning("Driver name %s", DRIVER_NAME)
-logger.warning("Driver version %s", DRIVER_VERSION)
+print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Use print instead of logging.

This will match `cql-pytest` and will avoid the need to change `logging` log levels or use `warning()`.