### PR TITLE
Move population code into table_population_metadata

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -274,7 +274,7 @@ using sstable_list = sstables::sstable_list;
 namespace replica {
 
 class distributed_loader;
-struct table_population_metadata;
+class table_populator;
 
 // The CF has a "stats" structure. But we don't want all fields here,
 // since some of them are fairly complex for exporting to collectd. Also,
@@ -1094,7 +1094,7 @@ public:
     friend class ::column_family_test;
 
     friend class distributed_loader;
-    friend class table_population_metadata;
+    friend class table_populator;
 
 private:
     timer<> _off_strategy_trigger;

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -75,9 +75,6 @@ class distributed_loader {
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,
             std::filesystem::path datadir, sstring ks, sstring cf);
-    using allow_offstrategy_compaction = bool_class<struct allow_offstrategy_compaction_tag>;
-    using must_exist = bool_class<struct must_exist_tag>;
-    static future<> populate_column_family(table_population_metadata& metadata, sstring subdir, allow_offstrategy_compaction, must_exist = must_exist::yes);
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
     static future<> cleanup_column_family_temp_sst_dirs(sstring sstdir);
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -60,11 +60,11 @@ class distributed_loader_for_tests;
 
 namespace replica {
 
-class table_population_metadata;
+class table_populator;
 
 class distributed_loader {
     friend class ::distributed_loader_for_tests;
-    friend class table_population_metadata;
+    friend class table_populator;
 
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
             sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter, io_priority_class iop);


### PR DESCRIPTION
There's the distribtued_loader::populate_column_family() helper that manages sstables on their way towards table on boot. The method naturally belongs the the table_population_metadata -- a helper class that in fact prepares the ground for the method in question.

This PR moves the method into metadata class and removes whole lot of extra alias-references and private-fields exporting methods from it. Also it keeps start_subdir and populate_c._f. logic close to each other and relaxes several excessive checks from them.