### PR TITLE
test_shed_too_large_request fix: disable compression

### DIFF
--- a/test/cql-pytest/test_shedding.py
+++ b/test/cql-pytest/test_shedding.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute(f"CREATE TABLE {table} (p int primary key, t1 text, t2 text, t3 text, t4 text, t5 text, t6 text)")
+    cql.execute(f"CREATE TABLE {table} (p int primary key, t text)")
     yield table
     cql.execute("DROP TABLE " + table)
 
@@ -33,6 +33,39 @@ def disable_compression():
         yield
     finally:
         cassandra.connection.locally_supported_compressions = saved
+
+
+class ScyllaMetrics:
+    def __init__(self, lines):
+        self._lines = lines
+    @staticmethod
+    def query(cql):
+        url = f'http://{cql.cluster.contact_points[0]}:9180/metrics'
+        return ScyllaMetrics(requests.get(url).text.split('\n'))
+    def get(self, name, labels = None, shard='total'):
+        result = None
+        for l in self._lines:
+            if not l.startswith(name):
+                continue
+            labels_start = l.find('{')
+            labels_finish = l.find('}')
+            if labels_start == -1 or labels_finish == -1:
+                raise ValueError(f'invalid metric format [{l}]')
+            def match_kv(kv):
+                key, val = kv.split('=')
+                val = val.strip('"')
+                return shard == 'total' or val == shard if key == 'shard' \
+                    else labels is None or labels.get(key, None) == val
+            match = all(match_kv(kv) for kv in l[labels_start + 1:labels_finish].split(','))
+            if match:
+                value = float(l[labels_finish + 2:])
+                if result is None:
+                    result = value
+                else:
+                    result += value
+                if shard != 'total':
+                    break
+        return result
 
 
 # When a too large request comes, it should be rejected in full.
@@ -54,29 +87,24 @@ def disable_compression():
 # Such errors occurred before, when before closing the connection, the remaining
 # bytes of the current request were not read to the end and were treated as
 # the beginning of the next request.
-#
-# Have no idea why, but on CI the actual memory limit for CQL requests is ~100MiB,
-# so we use ~60MiB request (which is estimated to take ~120MiB according to the logic above)
-# to guarantee shedding.
 def test_shed_too_large_request(cql, table1, scylla_only):
-    def get_protocol_errors():
-        result = 0
-        for line in requests.get(f'http://{cql.cluster.contact_points[0]}:9180/metrics').text.split('\n'):
-            if not line.startswith('scylla_transport_cql_errors_total') or 'protocol_error' not in line:
-                continue
-            result += int(line.split(' ')[1])
-        return result
+    def get_protocol_errors(metrics):
+        return metrics.get('scylla_transport_cql_errors_total', {'type': 'protocol_error'})
 
-    # protocol_errors metric is always non-zero, since the
-    # cassandra python driver use these errors to negotiate the protocol version
-    protocol_errors_before = get_protocol_errors()
+    initial_metrics = ScyllaMetrics.query(cql)
+
+    # See comments above
+    expected_shard_count = 2
+    expected_limit = initial_metrics.get('scylla_memory_total_memory') / expected_shard_count / 10
+    request_size_limit = (expected_limit - 8 * 1024) / 2
+    request_size = int(request_size_limit + 1024)
 
     # disable compression since we rely on specific request size
     with disable_compression():
         # separate session is needed due to the cql_test_connection fixture,
         # which checks that the session is not broken at the end of the test
         with new_cql(cql) as ncql:
-            prepared = ncql.prepare(f"INSERT INTO {table1} (p,t1,t2,t3,t4,t5,t6) VALUES (42,?,?,?,?,?,?)")
+            prepared = ncql.prepare(f"INSERT INTO {table1} (p,t) VALUES (42,?)")
 
             # With release builds of Scylla, information that the socket is closed reaches the client driver
             # before it has time to process the error message written by Scylla to the socket.
@@ -86,12 +114,12 @@ def test_shed_too_large_request(cql, table1, scylla_only):
             # and we get InvalidRequest exception.
             with pytest.raises((NoHostAvailable, InvalidRequest),
                                match="request size too large|Unable to complete the operation against any hosts"):
-                a_5mb_string = 'x'*10*1024*1024
-                ncql.execute(prepared, [a_5mb_string]*6)
-    protocol_errors_after = get_protocol_errors()
-    assert protocol_errors_after == protocol_errors_before
-    cql.execute(prepared, ["small_string"]*6)
-    res = [row for row in cql.execute(f"SELECT p, t3 FROM {table1}")]
-    assert len(res) == 1 and res[0].p == 42 and res[0].t3 == "small_string"
+                ncql.execute(prepared, ['x'*request_size])
+    current_metrics = ScyllaMetrics.query(cql)
+    # protocol_errors metric is always non-zero, since the
+    # cassandra python driver use these errors to negotiate the protocol version
+    assert get_protocol_errors(current_metrics) == get_protocol_errors(initial_metrics)
 
-
+    cql.execute(prepared, ["small_string"])
+    res = [row for row in cql.execute(f"SELECT p, t FROM {table1}")]
+    assert len(res) == 1 and res[0].p == 42 and res[0].t == "small_string"


### PR DESCRIPTION
The test relies on exact request size, this doesn't work if compression is applied. The driver enables compression only if both the server and the client agree on the codec to use. If compression package
(e.g. lz4) is not installed, the compression
is not used.

The trick with locally_supported_compressions is needed since I couldn't find any standard means to disable compression other than the compression flag
on the cluster object, which seemed too broad.

fixes: #12836 