### PR TITLE
Revert "dist/debian: drop unused Makefile variable"

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -3,6 +3,7 @@
 include /usr/share/dpkg/pkg-info.mk
 
 export PYBUILD_DISABLE=1
+jobs := $(shell echo $$DEB_BUILD_OPTIONS | sed -r "s/.*parallel=([0-9]+).*/-j\1/")
 ifneq ($(findstring housekeeping, $(DEB_BUILD_OPTIONS)),)
     install_arg := --housekeeping
 else


### PR DESCRIPTION
This reverts commit d2e3a60.

Since it's causing a regression preventing from Scylla service to start in deb OS

Fixes: https://github.com/scylladb/scylladb/issues/12738