### PR TITLE
Update seastar submodule and main

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1352,7 +1352,6 @@ warnings = [
     '-Wno-overloaded-virtual',
     '-Wno-stringop-overflow',
     '-Wno-unused-command-line-argument',
-    '-Wno-defaulted-function-deleted',
     '-Wno-redeclared-class-member',
     '-Wno-unsupported-friend',
     '-Wno-delete-non-abstract-non-virtual-dtor',

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2276,10 +2276,15 @@ public:
             struct stats {
                 // take the pre-reserved memory into account, as seastar only returns
                 // the stats of memory managed by the seastar allocator, but we instruct
-                // it to reserve addition memory for system.
-                uint64_t total = db::config::wasm_udf_reserved_memory;
+                // it to reserve addition memory for non-seastar allocator on per-shard
+                // basis.
+                uint64_t total = 0;
                 uint64_t free = 0;
-                static stats reduce(stats a, stats b) { return stats{a.total + b.total, a.free + b.free}; }
+                static stats reduce(stats a, stats b) {
+                    return stats{
+                        a.total + b.total + db::config::wasm_udf_reserved_memory,
+                        a.free + b.free};
+                    };
             };
             return map_reduce_shards<stats>([] () {
                 const auto& s = memory::stats();

--- a/main.cc
+++ b/main.cc
@@ -476,7 +476,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     // We need to have the entire app config to run the app, but we need to
     // run the app to read the config file with UDF specific options so that
     // we know whether we need to reserve additional memory for UDFs.
-    app_cfg.reserve_additional_memory = db::config::wasm_udf_reserved_memory;
+    app_cfg.reserve_additional_memory_per_shard = db::config::wasm_udf_reserved_memory;
     app_template app(std::move(app_cfg));
 
     auto ext = std::make_shared<db::extensions>();


### PR DESCRIPTION
this change also includes change to main, to make this commit compile.
see below:

* seastar 9b6e181e42...9cbc1fe889 (46):
  > Merge 'Make io-tester jobs share sched classes' from Pavel Emelyanov
  > io_tester.md: Update the `rps` configuration option description
  > io_tester: Add option to limit total number of requests sent
  > Merge 'Keep outgoing queue all cancellable while negotiating (again)' from Pavel Emelyanov
  > io_tester: Add option to share classes between jobs
  > rpc: Abort connection if send_entry() fails
  > Merge 'build: build dpdk with `-fPIC` if BUILD_SHARED_LIBS' from Kefu Chai
  > build: cooking.sh: use the same BUILD_SHARED_LIBS when building ingredients
  > build: cooking.sh: use the same generator when building ingredients
  > core/memory: handle `strerror_r` returning static string
  > Merge 'build, rpc: lz4 related cleanups' from Kefu Chai
  > build, rpc: do not support lz4 < 1.7.3
  > build: set the correct version when finding lz4
  > build: include CheckSymbolExists
  > rpc: do not include lz4.h in header
  > build: set CMP0135 for Cooking.cmake
  > docs: drop building-*.md
  > Merge 'seastar-addr2line: cleanups' from Kefu Chai
  > seastar-addr2line: refactor tests using unittest
  > seastar-addr2line: extract do_test() and main()
  > seastar-addr2line: do not import unused modules
  > scheduling: add a `rename` callback to scheduling_group_key_config
  > reactor: syscall thread: wakeup up reactor with finer granularity
  > build: build dpdk with `-fPIC` if BUILD_SHARED_LIBS
  > build: extract dpdk_extra_cflags out
  > core/sstring: remove a temporary variable
  > Merge 'treewide: include what we use, and add a checkheaders target' from Kefu Chai
  > perftune.py: auto-select the same number of IRQ cores on each NUMA
  > prometheus: remove unused headers
  > core/sstring: define <=> operator for sstring
  > Merge 'core: s/reserve_additional_memory/reserve_additional_memory_per_shard/' from Kefu Chai
  > include: do not include <concepts> directly
  > coding_style: note on self-contained header requirement
  > circileci: build checkheaders in addition to default target
  > build: add checkheaders target
  > net/toeplitz: s/u_int/unsigned/
  > net/tcp-stack: add forward declaration for seastar::socket
  > core, net, util: include used headers

* main: set reserved memory for wasm on per-shard basis

  this change is a follow-up of
  f05d612da8854b9bc4be0a2cf03f906bccb76330 and
  4a0134a097fad3144f7b7d005d92cd87a08d6576.

  this change depends on the related change in Seastar to reserve
  additional memory on a per-shard basis.

  per Wojciech Mitros's comment:

  > it should have probably been 50MB per shard

  in other words, as we always execute the same set of udf on all
  shards. and since one cannot predict the number of shards, but she
  could have a rough estimation on the size of memory a regular (set
  of) udf could use. so a per-shard setting makes more sense.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>