### PR TITLE
cql3: adding missing privileged on cache size eviction metric

### DIFF
--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -82,6 +82,7 @@ class authorized_prepared_statements_cache {
 public:
     struct stats {
         uint64_t authorized_prepared_statements_cache_evictions = 0;
+        uint64_t authorized_prepared_statements_privileged_entries_evictions_on_size = 0;
         uint64_t authorized_prepared_statements_unprivileged_entries_evictions_on_size = 0;
     };
 
@@ -96,6 +97,10 @@ public:
         static void inc_blocks() noexcept {}
         static void inc_evictions() noexcept {
             ++shard_stats().authorized_prepared_statements_cache_evictions;
+        }
+
+        static void inc_privileged_on_cache_size_eviction() noexcept {
+            ++shard_stats().authorized_prepared_statements_privileged_entries_evictions_on_size;
         }
 
         static void inc_unprivileged_on_cache_size_eviction() noexcept {

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -71,6 +71,7 @@ class prepared_statements_cache {
 public:
     struct stats {
         uint64_t prepared_cache_evictions = 0;
+        uint64_t privileged_entries_evictions_on_size = 0;
         uint64_t unprivileged_entries_evictions_on_size = 0;
     };
 
@@ -85,6 +86,9 @@ public:
         static void inc_blocks() noexcept {}
         static void inc_evictions() noexcept {
             ++shard_stats().prepared_cache_evictions;
+        }
+        static void inc_privileged_on_cache_size_eviction() noexcept {
+            ++shard_stats().privileged_entries_evictions_on_size;
         }
         static void inc_unprivileged_on_cache_size_eviction() noexcept {
             ++shard_stats().unprivileged_entries_evictions_on_size;

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -416,6 +416,11 @@ query_processor::query_processor(service::storage_proxy& proxy, service::forward
                             sm::description("Counts the number of authenticated prepared statements cache entries evictions.")),
 
                     sm::make_counter(
+                            "authorized_prepared_statements_privileged_entries_evictions_on_size",
+                            [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_privileged_entries_evictions_on_size; },
+                            sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used more than once.")),
+
+                    sm::make_counter(
                             "authorized_prepared_statements_unprivileged_entries_evictions_on_size",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_unprivileged_entries_evictions_on_size; },
                             sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.")),


### PR DESCRIPTION
This patch adds missing privileged on cache size eviction metric, and fixes https://github.com/scylladb/scylladb/issues/10463.