### PR TITLE
Allow setting permissions for user-defined functions

### DIFF
--- a/auth/permission.cc
+++ b/auth/permission.cc
@@ -21,7 +21,8 @@ const auth::permission_set auth::permissions::ALL = auth::permission_set::of<
         auth::permission::SELECT,
         auth::permission::MODIFY,
         auth::permission::AUTHORIZE,
-        auth::permission::DESCRIBE>();
+        auth::permission::DESCRIBE,
+        auth::permission::EXECUTE>();
 
 const auth::permission_set auth::permissions::NONE;
 
@@ -34,7 +35,8 @@ static const std::unordered_map<sstring, auth::permission> permission_names({
         {"SELECT", auth::permission::SELECT},
         {"MODIFY", auth::permission::MODIFY},
         {"AUTHORIZE", auth::permission::AUTHORIZE},
-        {"DESCRIBE", auth::permission::DESCRIBE}});
+        {"DESCRIBE", auth::permission::DESCRIBE},
+        {"EXECUTE", auth::permission::EXECUTE}});
 
 const sstring& auth::permissions::to_string(permission p) {
     for (auto& v : permission_names) {

--- a/auth/permission.hh
+++ b/auth/permission.hh
@@ -38,6 +38,8 @@ enum class permission {
     AUTHORIZE, // required for GRANT and REVOKE.
     DESCRIBE, // required on the root-level role resource to list all roles.
 
+    // function/aggregate/procedure calls
+    EXECUTE,
 };
 
 typedef enum_set<
@@ -51,7 +53,8 @@ typedef enum_set<
                 permission::SELECT,
                 permission::MODIFY,
                 permission::AUTHORIZE,
-                permission::DESCRIBE>> permission_set;
+                permission::DESCRIBE,
+                permission::EXECUTE>> permission_set;
 
 bool operator<(const permission_set&, const permission_set&);
 

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -16,8 +16,11 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 
 #include "service/storage_proxy.hh"
+#include "data_dictionary/user_types_metadata.hh"
+#include "cql3/util.hh"
 
 namespace auth {
 
@@ -26,6 +29,7 @@ std::ostream& operator<<(std::ostream& os, resource_kind kind) {
         case resource_kind::data: os << "data"; break;
         case resource_kind::role: os << "role"; break;
         case resource_kind::service_level: os << "service_level"; break;
+        case resource_kind::functions: os << "functions"; break;
     }
 
     return os;
@@ -34,12 +38,14 @@ std::ostream& operator<<(std::ostream& os, resource_kind kind) {
 static const std::unordered_map<resource_kind, std::string_view> roots{
         {resource_kind::data, "data"},
         {resource_kind::role, "roles"},
-        {resource_kind::service_level, "service_levels"}};
+        {resource_kind::service_level, "service_levels"},
+        {resource_kind::functions, "functions"}};
 
 static const std::unordered_map<resource_kind, std::size_t> max_parts{
         {resource_kind::data, 2},
         {resource_kind::role, 1},
-        {resource_kind::service_level, 0}};
+        {resource_kind::service_level, 0},
+        {resource_kind::functions, 2}};
 
 static permission_set applicable_permissions(const data_resource_view& dv) {
     if (dv.table()) {
@@ -82,6 +88,15 @@ static permission_set applicable_permissions(const service_level_resource_view &
             permission::AUTHORIZE>();
 }
 
+static permission_set applicable_permissions(const functions_resource_view& fv) {
+    return permission_set::of<
+            permission::CREATE,
+            permission::ALTER,
+            permission::DROP,
+            permission::AUTHORIZE,
+            permission::EXECUTE>();
+}
+
 resource::resource(resource_kind kind) : _kind(kind) {
     _parts.emplace_back(roots.at(kind));
 }
@@ -106,6 +121,39 @@ resource::resource(role_resource_t, std::string_view role) : resource(resource_k
 resource::resource(service_level_resource_t): resource(resource_kind::service_level) {
 }
 
+resource::resource(functions_resource_t) : resource(resource_kind::functions) {
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+    _parts.emplace_back(function_name);
+}
+
+resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name, std::vector<sstring> function_signature) : resource(resource_kind::functions) {
+    _parts.emplace_back(keyspace);
+    sstring encoded_signature = format("{}[{}]",
+            function_name,
+            ::join("^", function_signature));
+    _parts.emplace_back(encoded_signature);
+}
+
+resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature) {
+    if (keyspace.empty()) {
+        throw exceptions::invalid_request_exception("In this context function name must be explictly qualified by a keyspace");
+    }
+    std::vector<sstring> args_types;
+    for (auto& raw_type : function_signature) {
+        // FIXME(sarna): provide information on user-defined types - this is tricky, because this information
+        // is kept in a database instance, and is thus dynamic
+        args_types.emplace_back(raw_type->prepare_internal(sstring(keyspace), data_dictionary::user_types_metadata{}).get_type()->name());
+    }
+    return resource(functions_resource_t{}, keyspace, function_name, std::move(args_types));
+}
+
 sstring resource::name() const {
     return boost::algorithm::join(_parts, "/");
 }
@@ -127,6 +175,7 @@ permission_set resource::applicable_permissions() const {
         case resource_kind::data: ps = ::auth::applicable_permissions(data_resource_view(*this)); break;
         case resource_kind::role: ps = ::auth::applicable_permissions(role_resource_view(*this)); break;
         case resource_kind::service_level: ps = ::auth::applicable_permissions(service_level_resource_view(*this)); break;
+        case resource_kind::functions: ps = ::auth::applicable_permissions(functions_resource_view(*this)); break;
     }
 
     return ps;
@@ -149,6 +198,7 @@ std::ostream& operator<<(std::ostream& os, const resource& r) {
         case resource_kind::data: return os << data_resource_view(r);
         case resource_kind::role: return os << role_resource_view(r);
         case resource_kind::service_level: return os << service_level_resource_view(r);
+        case resource_kind::functions: return os << functions_resource_view(r);
     }
 
     return os;
@@ -163,6 +213,75 @@ service_level_resource_view::service_level_resource_view(const resource &r) {
 std::ostream &operator<<(std::ostream &os, const service_level_resource_view &v) {
     os << "<all service levels>";
     return os;
+}
+
+sstring encode_signature(std::string_view name, std::vector<data_type> args) {
+    return format("{}[{}]", name,
+            ::join("^", args | boost::adaptors::transformed([] (const data_type t) {
+                return t->name();
+            })));
+}
+
+std::pair<sstring, std::vector<data_type>> decode_signature(std::string_view encoded_signature) {
+    auto name_delim = encoded_signature.find_last_of('[');
+    std::string_view function_name = encoded_signature.substr(0, name_delim);
+    encoded_signature.remove_prefix(name_delim + 1);
+    encoded_signature.remove_suffix(1);
+    std::vector<std::string_view> raw_types;
+    boost::split(raw_types, encoded_signature, boost::is_any_of("^"));
+    std::vector<data_type> decoded_types = boost::copy_range<std::vector<data_type>>(
+        raw_types | boost::adaptors::transformed([] (std::string_view raw_type) {
+            return abstract_type::parse_type(sstring(raw_type));
+        })
+    );
+    return {sstring(function_name), decoded_types};
+}
+
+// Purely for Cassandra compatibility, types in the function signature are
+// decoded from their verbose form (org.apache.cassandra.db.marshal.Int32Type)
+// to the short form (int)
+static sstring decoded_signature_string(std::string_view encoded_signature) {
+    auto [function_name, arg_types] = decode_signature(encoded_signature);
+    return format("{}({})", cql3::util::maybe_quote(sstring(function_name)),
+            boost::algorithm::join(arg_types | boost::adaptors::transformed([] (data_type t) {
+                return t->cql3_type_name();
+            }), ", "));
+}
+
+std::ostream &operator<<(std::ostream &os, const functions_resource_view &v) {
+    const auto keyspace = v.keyspace();
+    const auto function_signature = v.function_signature();
+
+    if (!keyspace) {
+        os << "<all functions>";
+    } else if (!function_signature) {
+        os << "<all functions in " << *keyspace << '>';
+    } else {
+        os << "<function " << *keyspace << '.' << decoded_signature_string(*function_signature) << '>';
+    }
+    return os;
+}
+
+functions_resource_view::functions_resource_view(const resource& r) : _resource(r) {
+    if (r._kind != resource_kind::functions) {
+        throw resource_kind_mismatch(resource_kind::functions, r._kind);
+    }
+}
+
+std::optional<std::string_view> functions_resource_view::keyspace() const {
+    if (_resource._parts.size() == 1) {
+        return {};
+    }
+
+    return _resource._parts[1];
+}
+
+std::optional<std::string_view> functions_resource_view::function_signature() const {
+    if (_resource._parts.size() <= 2) {
+        return {};
+    }
+
+    return _resource._parts[2];
 }
 
 data_resource_view::data_resource_view(const resource& r) : _resource(r) {

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -21,6 +21,7 @@
 #include "service/storage_proxy.hh"
 #include "data_dictionary/user_types_metadata.hh"
 #include "cql3/util.hh"
+#include "db/marshal/type_parser.hh"
 
 namespace auth {
 
@@ -231,7 +232,7 @@ std::pair<sstring, std::vector<data_type>> decode_signature(std::string_view enc
     boost::split(raw_types, encoded_signature, boost::is_any_of("^"));
     std::vector<data_type> decoded_types = boost::copy_range<std::vector<data_type>>(
         raw_types | boost::adaptors::transformed([] (std::string_view raw_type) {
-            return abstract_type::parse_type(sstring(raw_type));
+            return db::marshal::type_parser::parse(raw_type);
         })
     );
     return {sstring(function_name), decoded_types};

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -129,9 +129,9 @@ resource::resource(functions_resource_t, std::string_view keyspace) : resource(r
     _parts.emplace_back(keyspace);
 }
 
-resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name) : resource(resource_kind::functions) {
+resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_signature) : resource(resource_kind::functions) {
     _parts.emplace_back(keyspace);
-    _parts.emplace_back(function_name);
+    _parts.emplace_back(function_signature);
 }
 
 resource::resource(functions_resource_t, std::string_view keyspace, std::string_view function_name, std::vector<sstring> function_signature) : resource(resource_kind::functions) {

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -94,7 +94,7 @@ public:
     resource(functions_resource_t, std::string_view keyspace);
     resource(functions_resource_t, std::string_view keyspace, std::string_view function_signature);
     resource(functions_resource_t, std::string_view keyspace, std::string_view function_name,
-            std::vector<sstring> function_signature);
+            std::vector<::shared_ptr<cql3::cql3_type::raw>> function_args);
 
     resource_kind kind() const noexcept {
         return _kind;
@@ -208,6 +208,8 @@ public:
 
     std::optional<std::string_view> keyspace() const;
     std::optional<std::string_view> function_signature() const;
+    std::optional<std::string_view> function_name() const;
+    std::optional<std::vector<std::string_view>> function_args() const;
 };
 
 std::ostream& operator<<(std::ostream&, const functions_resource_view&);
@@ -254,7 +256,9 @@ inline resource make_functions_resource(std::string_view keyspace, std::string_v
     return resource(functions_resource_t{}, keyspace, function_signature);
 }
 
-resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature);
+inline resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature) {
+    return resource(functions_resource_t{}, keyspace, function_name, function_signature);
+}
 
 sstring encode_signature(std::string_view name, std::vector<data_type> args);
 

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -25,6 +25,7 @@
 #include "seastarx.hh"
 #include "utils/hash.hh"
 #include "utils/small_vector.hh"
+#include "cql3/cql3_type.hh"
 
 namespace auth {
 
@@ -36,7 +37,7 @@ public:
 };
 
 enum class resource_kind {
-    data, role, service_level
+    data, role, service_level, functions
 };
 
 std::ostream& operator<<(std::ostream&, resource_kind);
@@ -57,9 +58,14 @@ struct role_resource_t final {};
 struct service_level_resource_t final {};
 
 ///
+/// Type tag for constructing function resources.
+///
+struct functions_resource_t final {};
+
+///
 /// Resources are entities that users can be granted permissions on.
 ///
-/// There are data (keyspaces and tables) and role resources. There may be other kinds of resources in the future.
+/// There are data (keyspaces and tables), role and function resources. There may be other kinds of resources in the future.
 ///
 /// When they are stored as system metadata, resources have the form `root/part_0/part_1/.../part_n`. Each kind of
 /// resource has a specific root prefix, followed by a maximum of `n` parts (where `n` is distinct for each kind of
@@ -83,6 +89,11 @@ public:
     resource(data_resource_t, std::string_view keyspace, std::string_view table);
     resource(role_resource_t, std::string_view role);
     resource(service_level_resource_t);
+    explicit resource(functions_resource_t);
+    resource(functions_resource_t, std::string_view keyspace);
+    resource(functions_resource_t, std::string_view keyspace, std::string_view function_name);
+    resource(functions_resource_t, std::string_view keyspace, std::string_view function_name,
+            std::vector<sstring> function_signature);
 
     resource_kind kind() const noexcept {
         return _kind;
@@ -104,6 +115,7 @@ private:
     friend class data_resource_view;
     friend class role_resource_view;
     friend class service_level_resource_view;
+    friend class functions_resource_view;
 
     friend bool operator<(const resource&, const resource&);
     friend bool operator==(const resource&, const resource&);
@@ -183,6 +195,23 @@ public:
 std::ostream& operator<<(std::ostream&, const service_level_resource_view&);
 
 ///
+/// A "function" view of \ref resource.
+///
+class functions_resource_view final {
+    const resource& _resource;
+public:
+    ///
+    /// \throws \ref resource_kind_mismatch if the argument is not a "function" resource.
+    ///
+    explicit functions_resource_view(const resource&);
+
+    std::optional<std::string_view> keyspace() const;
+    std::optional<std::string_view> function_signature() const;
+};
+
+std::ostream& operator<<(std::ostream&, const functions_resource_view&);
+
+///
 /// Parse a resource from its name.
 ///
 /// \throws \ref invalid_resource_name when the name is malformed.
@@ -210,6 +239,26 @@ inline resource make_service_level_resource() {
     return resource(service_level_resource_t{});
 }
 
+const resource& root_function_resource();
+
+inline resource make_functions_resource() {
+    return resource(functions_resource_t{});
+}
+
+inline resource make_functions_resource(std::string_view keyspace) {
+    return resource(functions_resource_t{}, keyspace);
+}
+
+inline resource make_functions_resource(std::string_view keyspace, std::string_view function_name) {
+    return resource(functions_resource_t{}, keyspace, function_name);
+}
+
+resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature);
+
+sstring encode_signature(std::string_view name, std::vector<data_type> args);
+
+std::pair<sstring, std::vector<data_type>> decode_signature(std::string_view encoded_signature);
+
 }
 
 namespace std {
@@ -228,6 +277,10 @@ struct hash<auth::resource> {
             return utils::tuple_hash()(std::make_tuple(auth::resource_kind::service_level));
     }
 
+    static size_t hash_function(const auth::functions_resource_view& fv) {
+        return utils::tuple_hash()(std::make_tuple(auth::resource_kind::functions, fv.keyspace(), fv.function_signature()));
+    }
+
     size_t operator()(const auth::resource& r) const {
         std::size_t value;
 
@@ -235,6 +288,7 @@ struct hash<auth::resource> {
         case auth::resource_kind::data: value = hash_data(auth::data_resource_view(r)); break;
         case auth::resource_kind::role: value = hash_role(auth::role_resource_view(r)); break;
         case auth::resource_kind::service_level: value = hash_service_level(auth::service_level_resource_view(r)); break;
+        case auth::resource_kind::functions: value = hash_function(auth::functions_resource_view(r)); break;
         }
 
         return value;

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -18,6 +18,7 @@
 #include <vector>
 #include <unordered_set>
 
+#include <boost/range/adaptor/transformed.hpp>
 #include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -92,7 +92,7 @@ public:
     resource(service_level_resource_t);
     explicit resource(functions_resource_t);
     resource(functions_resource_t, std::string_view keyspace);
-    resource(functions_resource_t, std::string_view keyspace, std::string_view function_name);
+    resource(functions_resource_t, std::string_view keyspace, std::string_view function_signature);
     resource(functions_resource_t, std::string_view keyspace, std::string_view function_name,
             std::vector<sstring> function_signature);
 
@@ -250,8 +250,8 @@ inline resource make_functions_resource(std::string_view keyspace) {
     return resource(functions_resource_t{}, keyspace);
 }
 
-inline resource make_functions_resource(std::string_view keyspace, std::string_view function_name) {
-    return resource(functions_resource_t{}, keyspace, function_name);
+inline resource make_functions_resource(std::string_view keyspace, std::string_view function_signature) {
+    return resource(functions_resource_t{}, keyspace, function_signature);
 }
 
 resource make_functions_resource(std::string_view keyspace, std::string_view function_name, std::vector<::shared_ptr<cql3::cql3_type::raw>> function_signature);

--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -20,6 +20,9 @@ namespace data_dictionary {
 class database;
 class user_types_metadata;
 }
+namespace auth {
+class resource;
+}
 
 namespace cql3 {
 
@@ -63,6 +66,7 @@ public:
         static shared_ptr<raw> tuple(std::vector<shared_ptr<raw>> ts);
         static shared_ptr<raw> frozen(shared_ptr<raw> t);
         friend std::ostream& operator<<(std::ostream& os, const raw& r);
+        friend class auth::resource;
     };
 
 private:

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -48,6 +48,10 @@ public:
         return _fun->return_type();
     }
 
+    shared_ptr<functions::function> function() const {
+        return _fun;
+    }
+
 #if 0
     @Override
     public String toString()

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -15,6 +15,7 @@
 #include "query-result-reader.hh"
 #include "cql3/column_specification.hh"
 #include "cql3/selection/selector.hh"
+#include "cql3/selection/selectable.hh"
 #include "exceptions/exceptions.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
@@ -117,6 +118,8 @@ public:
     static ::shared_ptr<selection> for_columns(schema_ptr schema, std::vector<const column_definition*> columns);
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c);
+
+    virtual std::vector<shared_ptr<functions::function>> used_functions() const { return {}; }
 
     query::partition_slice::option_set get_query_options();
 private:

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -12,6 +12,13 @@
 #include "transport/messages/result_message.hh"
 #include "service/client_state.hh"
 #include "auth/resource.hh"
+#include "cql3/query_processor.hh"
+#include "exceptions/exceptions.hh"
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include "cql3/util.hh"
+#include "db/cql_type_parser.hh"
 
 uint32_t cql3::statements::authorization_statement::get_bound_terms() const {
     return 0;
@@ -30,7 +37,7 @@ future<> cql3::statements::authorization_statement::check_access(query_processor
     return make_ready_future<>();
 }
 
-void cql3::statements::authorization_statement::maybe_correct_resource(auth::resource& resource, const service::client_state& state){
+void cql3::statements::authorization_statement::maybe_correct_resource(auth::resource& resource, const service::client_state& state, query_processor& qp) {
     if (resource.kind() == auth::resource_kind::data) {
         const auto data_view = auth::data_resource_view(resource);
         const auto keyspace = data_view.keyspace();
@@ -39,6 +46,38 @@ void cql3::statements::authorization_statement::maybe_correct_resource(auth::res
         if (table && keyspace->empty()) {
             resource = auth::make_data_resource(state.get_keyspace(), *table);
         }
+    } else if (resource.kind() == auth::resource_kind::functions) {
+        // Maybe correct the resource for a specific function.
+        const auto functions_view = auth::functions_resource_view(resource);
+        const auto keyspace = functions_view.keyspace();
+        if (!keyspace) {
+            // This is an "ALL FUNCTIONS" resource.
+            return;
+        }
+        if (!qp.db().has_keyspace(*keyspace)) {
+            throw exceptions::invalid_request_exception(format("{} doesn't exist.", resource));
+        }
+        if (functions_view.function_signature()) {
+            // The resource is already corrected.
+            return;
+        }
+        if (!functions_view.function_name()) {
+            // This is an "ALL FUNCTIONS IN KEYSPACE" resource.
+            return;
+        }
+        const auto& utm = qp.db().find_keyspace(*keyspace).user_types();
+        auto function_name = *functions_view.function_name();
+        auto function_args = functions_view.function_args();
+        std::vector<data_type> parsed_types;
+        if (function_args) {
+            parsed_types = boost::copy_range<std::vector<data_type>>(
+                *function_args | boost::adaptors::transformed([&] (std::string_view raw_type) {
+                    auto parsed = db::cql_type_parser::parse(sstring(keyspace->data(), keyspace->size()), sstring(raw_type.data(), raw_type.size()), utm);
+                    return parsed->is_user_type() ? parsed->freeze() : parsed;
+                })
+            );
+        }
+        resource = auth::make_functions_resource(*keyspace, auth::encode_signature(function_name, parsed_types));
     }
 }
 

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -35,7 +35,7 @@ public:
     void validate(query_processor&, const service::client_state& state) const override;
 
 protected:
-    static void maybe_correct_resource(auth::resource&, const service::client_state&);
+    static void maybe_correct_resource(auth::resource&, const service::client_state&, query_processor&);
 };
 
 }

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -23,6 +23,7 @@ namespace cql3 {
 
 namespace statements {
 
+
 shared_ptr<functions::function> create_function_statement::create(query_processor& qp, functions::function* old) const {
     if (old && !dynamic_cast<functions::user_function*>(old)) {
         throw exceptions::invalid_request_exception(format("Cannot replace '{}' which is not a user defined function", *old));

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -24,7 +24,10 @@ future<> function_statement::check_access(query_processor& qp, const service::cl
 future<> create_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const {
     co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
     if (_or_replace) {
-        co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::ALTER);
+        create_arg_types(qp);
+        sstring encoded_signature = auth::encode_signature(_name.name, _arg_types);
+
+        co_await state.has_function_access(qp.db(), _name.keyspace, encoded_signature, auth::permission::ALTER);
     }
 }
 

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -20,6 +20,13 @@ namespace statements {
 
 future<> function_statement::check_access(query_processor& qp, const service::client_state& state) const { return make_ready_future<>(); }
 
+future<> create_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const {
+    co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
+    if (_or_replace) {
+        co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::ALTER);
+    }
+}
+
 function_statement::function_statement(
         functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types)
     : _name(std::move(name)), _raw_arg_types(std::move(raw_arg_types)) {}

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -65,6 +65,9 @@ protected:
 
     drop_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             bool args_present, bool if_exists);
+
+public:
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 };
 
 }

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -49,6 +49,9 @@ protected:
 
     create_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types,
             bool or_replace, bool if_not_exists);
+
+public:
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 };
 
 // common logic for dropping UDF and UDA

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -42,7 +42,7 @@ void cql3::statements::list_permissions_statement::validate(
 
 future<> cql3::statements::list_permissions_statement::check_access(query_processor& qp, const service::client_state& state) const {
     if (_resource) {
-        maybe_correct_resource(*_resource, state);
+        maybe_correct_resource(*_resource, state, qp);
         return state.ensure_exists(*_resource);
     }
 

--- a/cql3/statements/permission_altering_statement.cc
+++ b/cql3/statements/permission_altering_statement.cc
@@ -42,7 +42,7 @@ void cql3::statements::permission_altering_statement::validate(query_processor&,
 
 future<> cql3::statements::permission_altering_statement::check_access(query_processor& qp, const service::client_state& state) const {
     state.ensure_not_anonymous();
-    maybe_correct_resource(_resource, state);
+    maybe_correct_resource(_resource, state, qp);
 
     return state.ensure_exists(_resource).then([this, &state] {
         // check that the user has AUTHORIZE permission on the resource or its parents, otherwise reject

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -24,7 +24,7 @@ static ::shared_ptr<cql3::cql3_type::raw> parse_raw(const sstring& str) {
         });
 }
 
-data_type db::cql_type_parser::parse(const sstring& keyspace, const sstring& str, const data_dictionary::user_types_storage& uts) {
+data_type db::cql_type_parser::parse(const sstring& keyspace, const sstring& str, const data_dictionary::user_types_metadata& utm) {
     static const thread_local std::unordered_map<sstring, cql3::cql3_type> native_types = []{
         std::unordered_map<sstring, cql3::cql3_type> res;
         for (auto& nt : cql3::cql3_type::values()) {
@@ -39,7 +39,11 @@ data_type db::cql_type_parser::parse(const sstring& keyspace, const sstring& str
     }
 
     auto raw = parse_raw(str);
-    return raw->prepare_internal(keyspace, uts.get(keyspace)).get_type();
+    return raw->prepare_internal(keyspace, utm).get_type();
+}
+
+data_type db::cql_type_parser::parse(const sstring& keyspace, const sstring& str, const data_dictionary::user_types_storage& uts) {
+    return parse(keyspace, str, uts.get(keyspace));
 }
 
 class db::cql_type_parser::raw_builder::impl {

--- a/db/cql_type_parser.hh
+++ b/db/cql_type_parser.hh
@@ -22,11 +22,13 @@ class types_metadata;
 namespace data_dictionary {
 class keyspace_metadata;
 class user_types_storage;
+class user_types_metadata;
 }
 
 namespace db {
 namespace cql_type_parser {
 
+data_type parse(const sstring& keyspace, const sstring& type, const data_dictionary::user_types_metadata& utm);
 data_type parse(const sstring& keyspace, const sstring& type, const data_dictionary::user_types_storage& uts);
 
 class raw_builder {

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -80,6 +80,21 @@ future<> service::client_state::has_keyspace_access(data_dictionary::database db
     co_return co_await has_access(db, ks, {p, r});
 }
 
+future<> service::client_state::has_functions_access(data_dictionary::database db, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource();
+    co_return co_await ensure_has_permission({p, r});
+}
+
+future<> service::client_state::has_functions_access(data_dictionary::database db, const sstring& ks, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource(ks);
+    co_return co_await has_access(db, ks, {p, r});
+}
+
+future<> service::client_state::has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_name, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource(ks, function_name);
+    co_return co_await has_access(db, ks, {p, r});
+}
+
 future<> service::client_state::has_column_family_access(data_dictionary::database db, const sstring& ks,
                 const sstring& cf, auth::permission p, auth::command_desc::type t) const {
     // NOTICE: callers of this function tend to assume that this error will be thrown

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -90,8 +90,8 @@ future<> service::client_state::has_functions_access(data_dictionary::database d
     co_return co_await has_access(db, ks, {p, r});
 }
 
-future<> service::client_state::has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_name, auth::permission p) const {
-    auth::resource r = auth::make_functions_resource(ks, function_name);
+future<> service::client_state::has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_signature, auth::permission p) const {
+    auth::resource r = auth::make_functions_resource(ks, function_signature);
     co_return co_await has_access(db, ks, {p, r});
 }
 

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -339,6 +339,9 @@ public:
     future<> has_schema_access(data_dictionary::database db, const schema& s, auth::permission p) const;
     future<> has_schema_access(data_dictionary::database db, const sstring&, const sstring&, auth::permission p) const;
 
+    future<> has_functions_access(data_dictionary::database db, auth::permission p) const;
+    future<> has_functions_access(data_dictionary::database db, const sstring& ks, auth::permission p) const;
+    future<> has_function_access(data_dictionary::database db, const sstring& ks, const sstring& function_signature, auth::permission p) const;
 private:
     future<> has_access(data_dictionary::database db, const sstring& keyspace, auth::command_desc) const;
 

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -926,7 +926,7 @@ SEASTAR_TEST_CASE(test_schema_tables_use_null_sharder) {
 }
 
 SEASTAR_TEST_CASE(test_schema_make_reversed) {
-    auto schema = schema_builder("tests", get_name())
+    auto schema = schema_builder("ks", get_name())
             .with_column("pk", bytes_type, column_kind::partition_key)
             .with_column("ck", bytes_type, column_kind::clustering_key)
             .with_column("v1", bytes_type)
@@ -950,7 +950,7 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
 
 SEASTAR_TEST_CASE(test_schema_get_reversed) {
     return do_with_cql_env([this] (cql_test_env& e) {
-        auto schema = schema_builder("tests", get_name())
+        auto schema = schema_builder("ks", get_name())
                 .with_column("pk", bytes_type, column_kind::partition_key)
                 .with_column("ck", bytes_type, column_kind::clustering_key)
                 .with_column("v1", bytes_type)

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -998,8 +998,10 @@ SEASTAR_THREAD_TEST_CASE(test_user_function_db_init) {
 
 SEASTAR_TEST_CASE(test_user_function_mixups) {
     return with_udf_enabled([] (cql_test_env& e) {
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE OR REPLACE FUNCTION system.now() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get(),
                 exceptions::unauthorized_exception,
                 message_contains("system keyspace is not user-modifiable"));

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -1001,7 +1001,8 @@ SEASTAR_TEST_CASE(test_user_function_mixups) {
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now;").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("DROP FUNCTION system.now();").get(), ire, message_equals("'system.now : () -> timeuuid' is not a user defined function"));
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE OR REPLACE FUNCTION system.now() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get(),
-                                ire, message_equals("Cannot replace 'system.now : () -> timeuuid' which is not a user defined function"));
+                exceptions::unauthorized_exception,
+                message_contains("system keyspace is not user-modifiable"));
 
         e.execute_cql("CREATE FUNCTION my_func1(a int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get();
         e.execute_cql("CREATE FUNCTION my_func2() CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get();

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -9,7 +9,7 @@
 import pytest
 import time
 from cassandra.protocol import SyntaxException, InvalidRequest, Unauthorized
-from util import new_test_table, new_function, new_user, new_session, new_test_keyspace, unique_name
+from util import new_test_table, new_function, new_user, new_session, new_test_keyspace, unique_name, new_type
 
 # Test that granting permissions to various resources works for the default user.
 # This case does not include functions, because due to differences in implementation
@@ -376,3 +376,27 @@ def test_grant_revoke_uda_permissions(scylla_only, cql):
                             check_enforced(cql, username, permission='AUTHORIZE', resource=resource, function=grant_idempotent)
 
                         cql.execute(f"DROP AGGREGATE IF EXISTS {keyspace}.{custom_avg}(bigint)")
+
+# Test that permissions for user-defined functions created on top of user-defined types work
+# Fails on Scylla, because we currently don't properly support user-defined types in function permissions
+@pytest.mark.xfail(reason='user-defined types not supported in function permissions yet')
+def test_udf_permissions_with_udt(cql):
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_type(cql, keyspace, '(v int)') as udt:
+            schema = f"a frozen<{udt}> primary key"
+            with new_test_table(cql, keyspace, schema) as table:
+                fun_body_lua = f"(i {udt}) CALLED ON NULL INPUT RETURNS int LANGUAGE lua AS 'return 42;'"
+                fun_body_java = f"(i {udt}) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return 42;'"
+                fun_body = fun_body_lua
+                try:
+                    with new_function(cql, keyspace, fun_body) as fun:
+                        pass
+                except:
+                    fun_body = fun_body_java
+                with new_user(cql) as username:
+                    with new_session(cql, username) as user_session:
+                        with new_function(cql, keyspace, fun_body) as fun:
+                            cql.execute(f"INSERT INTO {table}(a) VALUES ((7))")
+                            grant(cql, 'SELECT', table, username)
+                            grant(cql, 'EXECUTE', f'FUNCTION {keyspace}.{fun}({udt})', username)
+                            user_session.execute(f'SELECT {keyspace}.{fun}(a) FROM {table}')

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -123,3 +123,65 @@ def test_grant_revoke_data_permissions(cql, test_keyspace):
                 # Same for DROP
                 cql.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{t}(id int primary key)")
                 check_enforced(cql, username, permission='DROP', resource='ALL KEYSPACES', function=drop_table_idempotent)
+
+# Test that permissions for user-defined functions are serialized in a Cassandra-compatible way
+def test_udf_permissions_serialization(cql):
+    schema = "a int primary key"
+    user = "cassandra"
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_test_table(cql, keyspace, schema) as table:
+            # Creating a bilingual function makes this test case work for both Scylla and Cassandra
+            div_body_lua = "(b bigint, i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return b//i'"
+            div_body_java = "(b bigint, i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return b/i;'"
+            div_body = div_body_lua
+            try:
+                with new_function(cql, keyspace, div_body) as div_fun:
+                    pass
+            except:
+                div_body = div_body_java
+            with new_function(cql, keyspace, div_body) as div_fun:
+                applicable_permissions = {
+                    'all functions': ['create', 'alter', 'drop', 'authorize', 'execute'],
+                    f'all functions in keyspace {keyspace}': ['create', 'alter', 'drop', 'authorize', 'execute'],
+                    f'function {keyspace}.{div_fun}(bigint, int)': ['alter', 'drop', 'authorize', 'execute'],
+                }
+                for resource, permissions in applicable_permissions.items():
+                    # Applicable permissions can be legally granted
+                    for permission in permissions:
+                        cql.execute(f"GRANT {permission} ON {resource} TO {user}")
+
+                permissions = {row.resource: row.permissions for row in cql.execute(f"SELECT * FROM system_auth.role_permissions")}
+                assert permissions['functions'] == set(['ALTER', 'AUTHORIZE', 'CREATE', 'DROP', 'EXECUTE'])
+                assert permissions[f'functions/{keyspace}'] == set(['ALTER', 'AUTHORIZE', 'CREATE', 'DROP', 'EXECUTE'])
+                assert permissions[f'functions/{keyspace}/{div_fun}[org.apache.cassandra.db.marshal.LongType^org.apache.cassandra.db.marshal.Int32Type]'] == set(['ALTER', 'AUTHORIZE', 'DROP', 'EXECUTE'])
+
+                resources_with_execute = [row.resource for row in cql.execute(f"LIST EXECUTE OF {user}")]
+                assert '<all functions>' in resources_with_execute
+                assert f'<all functions in {keyspace}>' in resources_with_execute
+                assert f'<function {keyspace}.{div_fun}(bigint, int)>' in resources_with_execute
+
+# Test that names that require quoting (e.g. due to having nonorthodox characters)
+# are properly handled, with right permissions granted.
+# Cassandra doesn't quote names properly, so the test fails
+def test_udf_permissions_quoted_names(cassandra_bug, cql):
+    schema = "a int primary key"
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_test_table(cql, keyspace, schema) as table:
+            weird_body_lua = "(i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return 42;'"
+            weird_body_java = "(i int) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return 42;'"
+            weird_body = weird_body_lua
+            try:
+                with new_function(cql, keyspace, weird_body) as weird_fun:
+                    pass
+            except:
+                weird_body = weird_body_java
+            with new_function(cql, keyspace, weird_body, '"weird[name]"') as weird_fun:
+                with new_user(cql) as username:
+                    with new_session(cql, username) as user_session:
+                        grant(cql, 'EXECUTE', f'FUNCTION {keyspace}.{weird_fun}(int)', username)
+                        grant(cql, 'SELECT', table, username)
+                        cql.execute(f"INSERT INTO {table}(a) VALUES (7)")
+                        assert list([r[0] for r in user_session.execute(f"SELECT {keyspace}.{weird_fun}(a) FROM {table}")]) == [42]
+
+                        resources_with_execute = [row.resource for row in cql.execute(f"LIST EXECUTE OF {username}")]
+                        assert f'<function {keyspace}.{weird_fun}(int)>' in resources_with_execute

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -327,3 +327,52 @@ def test_grant_perms_on_nonexistent_udf(cql):
         with new_function(cql, keyspace, fun_body, fun_name):
             grant(cql, 'EXECUTE', f'FUNCTION {keyspace}.{fun_name}(int)', username)
         cql.execute(f"DROP KEYSPACE IF EXISTS {keyspace}")
+
+# Test that permissions for user-defined aggregates are also enforced.
+# scylla_only, because Lua is used as the target language
+def test_grant_revoke_uda_permissions(scylla_only, cql):
+    schema = 'id bigint primary key'
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }") as keyspace:
+        with new_test_table(cql, keyspace, schema) as table:
+            for i in range(8):
+                cql.execute(f"INSERT INTO {table} (id) VALUES ({10**i})")
+            avg_partial_body = "(state tuple<bigint, bigint>, val bigint) CALLED ON NULL INPUT RETURNS tuple<bigint, bigint> LANGUAGE lua AS 'return {state[1] + val, state[2] + 1}'"
+            div_body = "(state tuple<bigint, bigint>) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state[1]//state[2]'"
+            with new_function(cql, keyspace, avg_partial_body) as avg_partial, new_function(cql, keyspace, div_body) as div_fun:
+                custom_avg_body = f"(bigint) SFUNC {avg_partial} STYPE tuple<bigint, bigint> FINALFUNC {div_fun} INITCOND (0,0)"
+                with new_user(cql) as username:
+                    with new_session(cql, username) as user_session:
+                        custom_avg = "custom_avg"
+                        def create_aggr_idempotent():
+                            user_session.execute(f"CREATE AGGREGATE IF NOT EXISTS {keyspace}.{custom_avg} {custom_avg_body}")
+                            cql.execute(f"DROP AGGREGATE IF EXISTS {keyspace}.{custom_avg}(bigint)")
+                        check_enforced(cql, username, permission='CREATE', resource=f'all functions in keyspace {keyspace}',
+                                function=create_aggr_idempotent)
+                        check_enforced(cql, username, permission='CREATE', resource='all functions',
+                                function=create_aggr_idempotent)
+
+                        grant(cql, 'CREATE', 'ALL FUNCTIONS', username)
+                        check_enforced(cql, username, permission='ALTER', resource=f'all functions in keyspace {keyspace}',
+                                function=lambda: user_session.execute(f"CREATE OR REPLACE AGGREGATE {keyspace}.{custom_avg} {custom_avg_body}"))
+                        check_enforced(cql, username, permission='ALTER', resource='all functions',
+                                function=lambda: user_session.execute(f"CREATE OR REPLACE AGGREGATE {keyspace}.{custom_avg} {custom_avg_body}"))
+
+                        grant(cql, 'SELECT', table, username)
+                        for resource in [f'function {keyspace}.{custom_avg}(bigint)', f'all functions in keyspace {keyspace}', 'all functions']:
+                            check_enforced(cql, username, permission='EXECUTE', resource=resource,
+                                    function=lambda: user_session.execute(f"SELECT {keyspace}.{custom_avg}(id) FROM {table}"))
+
+                        def drop_aggr_idempotent():
+                            user_session.execute(f"DROP AGGREGATE IF EXISTS {keyspace}.{custom_avg}(bigint)")
+                            cql.execute(f"CREATE AGGREGATE IF NOT EXISTS {keyspace}.{custom_avg} {custom_avg_body}")
+                        for resource in [f'function {keyspace}.{custom_avg}(bigint)', f'all functions in keyspace {keyspace}', 'all functions']:
+                            check_enforced(cql, username, permission='DROP', resource=resource, function=drop_aggr_idempotent)
+
+                        grant(cql, 'EXECUTE', 'ALL FUNCTIONS', username)
+                        def grant_idempotent():
+                            grant(user_session, 'EXECUTE', f'function {keyspace}.{custom_avg}(bigint)', 'cassandra')
+                            revoke(cql, 'EXECUTE', f'function {keyspace}.{custom_avg}(bigint)', 'cassandra')
+                        for resource in [f'function {keyspace}.{custom_avg}(bigint)', f'all functions in keyspace {keyspace}', 'all functions']:
+                            check_enforced(cql, username, permission='AUTHORIZE', resource=resource, function=grant_idempotent)
+
+                        cql.execute(f"DROP AGGREGATE IF EXISTS {keyspace}.{custom_avg}(bigint)")


### PR DESCRIPTION
This series aims to allow users to set permissions on user-defined functions.

The implementation is based on Cassandra's documentation and should be fully compatible: https://cassandra.apache.org/doc/latest/cassandra/cql/security.html#cql-permissions

Fixes: #5572
Fixes: #10633