### PR TITLE
logalloc: mark segment_store_backend's virtual

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -707,6 +707,7 @@ public:
         , _freed_segment_increases_general_memory_availability(freed_segment_increases_general_memory_availability)
         , _segments_base(align_up(_layout.start, static_cast<uintptr_t>(segment::size)))
     { }
+    virtual ~segment_store_backend() = default;
     memory::memory_layout memory_layout() const noexcept { return _layout; }
     uintptr_t segments_base() const noexcept { return _segments_base; }
     virtual void* alloc_segment_memory() noexcept = 0;


### PR DESCRIPTION
before this change, `seastar_memory_segment_store_backend` is class with virtual method, but it does not have a virtual dtor. but we do use a unique_ptr<segment_store_backend> to manage the lifecycle of an intance of its derived class. to enable the compiler to call the right dtor, we should mark the base class's dtor as virtual. this should address following warings from Clang-17:

```
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:100:2: error: delete called on non-final 'logalloc::seastar_memory_segment_store_backend' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:405:4: note: in instantiation of member function 'std::default_delete<logalloc::seastar_memory_segment_store_backend>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/dev/scylladb/utils/logalloc.cc:812:20: note: in instantiation of member function 'std::unique_ptr<logalloc::seastar_memory_segment_store_backend>::~unique_ptr' requested here
        : _backend(std::make_unique<seastar_memory_segment_store_backend>())
                   ^
```
and
```
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:100:2: error: delete called on 'logalloc::segment_store_backend' that is abstract but has non-virtual destructor [-Werror,-Wdelete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:405:4: note: in instantiation of member function 'std::default_delete<logalloc::segment_store_backend>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/dev/scylladb/utils/logalloc.cc:811:5: note: in instantiation of member function 'std::unique_ptr<logalloc::segment_store_backend>::~unique_ptr' requested here
    contiguous_memory_segment_store()
    ^
```
Fixes #12872
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>