### PR TITLE
tools/schema_loader: do not return ref to local variable

### DIFF
--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -143,7 +143,8 @@ private:
         throw std::bad_function_call();
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {
-        return {};
+        static const std::vector<view_ptr> empty;
+        return empty;
     }
     virtual sstring get_available_index_name(data_dictionary::database db, std::string_view ks_name, std::string_view table_name,
             std::optional<sstring> index_name_root) const override {


### PR DESCRIPTION
we should never return a reference to local variable. so in this change, a reference to a static variable is returned instead. this should address following warning from Clang 17:

```
/home/kefu/dev/scylladb/tools/schema_loader.cc:146:16: error: returning reference to local temporary object [-Werror,-Wreturn-stack-address]
        return {};
               ^~
```

Fixes #12875
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>