### PR TITLE
sstables: mx/writer: remove defaulted move ctor

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -802,7 +802,6 @@ public:
     }
 
     ~writer();
-    writer(writer&& o) = default;
     void consume_new_partition(const dht::decorated_key& dk) override;
     void consume(tombstone t) override;
     stop_iteration consume(static_row&& sr) override;


### PR DESCRIPTION
because its base class of `writer_impl` has a member variable `_validator`, which has its copy ctor deleted. let's just drop the defaulted move ctor, as compiler is not able to generate one for us.

```
/home/kefu/dev/scylladb/sstables/mx/writer.cc:805:5: error: explicitly defaulted move constructor is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
    writer(writer&& o) = default;
    ^
/home/kefu/dev/scylladb/sstables/mx/writer.cc:528:16: note: move constructor of 'writer' is implicitly deleted because base class 'sstable_writer::writer_impl' has a deleted move constructor
class writer : public sstable_writer::writer_impl {
               ^
/home/kefu/dev/scylladb/sstables/writer_impl.hh:29:48: note: copy constructor of 'writer_impl' is implicitly deleted because field '_validator' has a deleted copy constructor
    mutation_fragment_stream_validating_filter _validator;
                                               ^
/home/kefu/dev/scylladb/mutation/mutation_fragment_stream_validator.hh:188:5: note: 'mutation_fragment_stream_validating_filter' has been explicitly marked deleted here
    mutation_fragment_stream_validating_filter(const mutation_fragment_stream_validating_filter&) = delete;
    ^
```