### PR TITLE
db/virtual_table: mark dtor of base class `virtual`

### DIFF
--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -70,6 +70,7 @@ public:
         : _schema(std::move(s))
         , _permit(std::move(p))
     { }
+    virtual ~result_collector() = default;
 
     // Subsequent calls should pass fragments which form a valid mutation fragment stream (see mutation_fragment.hh).
     // Concurrent calls not allowed.


### PR DESCRIPTION
as `my_result_collector` has virtual function,
and its dtor is not marked virtual, Clang complains. let's mark it final to be clear that it does not
have derived classes.

```
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:100:2: error: delete called on non-final 'my_result_collector' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:405:4: note: in instantiation of member function 'std::default_delete<my_result_collector>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/dev/scylladb/db/virtual_table.cc:134:25: note: in instantiation of member function 'std::unique_ptr<my_result_collector>::~unique_ptr' requested here
        auto consumer = std::make_unique<my_result_collector>(s, permit, &pr, std::move(reader_and_handle.second));
                        ^
```