### PR TITLE
treewide: do not define/capture unused variables

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1543,7 +1543,7 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
             // This is the old, unsafe, read before write which does first
             // a read, then a write. TODO: remove this mode entirely.
             return get_previous_item(proxy, client_state, schema(), _pk, _ck, permit, stats).then(
-                    [this, &client_state, &proxy, trace_state, permit = std::move(permit)] (std::unique_ptr<rjson::value> previous_item) mutable {
+                    [this, &proxy, trace_state, permit = std::move(permit)] (std::unique_ptr<rjson::value> previous_item) mutable {
                 std::optional<mutation> m = apply(std::move(previous_item), api::new_timestamp());
                 if (!m) {
                     return make_ready_future<executor::request_return_type>(api_error::conditional_check_failed("Failed condition."));

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -265,7 +265,6 @@ position_in_partition pos_from_json(const rjson::value& item, schema_ptr schema)
     if (bool(region_item) != bool(weight_item)) {
         throw api_error::validation("Malformed value object: region and weight has to be either both missing or both present");
     }
-    partition_region region;
     bound_weight weight;
     if (region_item) {
         auto region_view = rjson::to_string_view(get_typed_value(*region_item, "S", scylla_paging_region, "key region"));

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -145,7 +145,7 @@ public:
             std::unique_ptr<request> req, std::unique_ptr<reply> rep) override {
         handle_CORS(*req, *rep, false);
         return _f_handle(std::move(req), std::move(rep)).then(
-                [this](std::unique_ptr<reply> rep) {
+                [](std::unique_ptr<reply> rep) {
                     rep->set_mime_type("application/x-amz-json-1.0");
                     rep->done();
                     return make_ready_future<std::unique_ptr<reply>>(std::move(rep));

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -506,7 +506,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     // filter out cdc generations older than the table or now() - cdc::ttl (typically dynamodb_streams_max_window - 24h)
     auto low_ts = std::max(as_timepoint(schema->id()), db_clock::now() - ttl);
 
-    return _sdks.cdc_get_versioned_streams(low_ts, { normal_token_owners }).then([this, db, shard_start, limit, ret = std::move(ret), stream_desc = std::move(stream_desc)] (std::map<db_clock::time_point, cdc::streams_version> topologies) mutable {
+    return _sdks.cdc_get_versioned_streams(low_ts, { normal_token_owners }).then([db, shard_start, limit, ret = std::move(ret), stream_desc = std::move(stream_desc)] (std::map<db_clock::time_point, cdc::streams_version> topologies) mutable {
 
         auto e = topologies.end();
         auto prev = e;

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -164,14 +164,14 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_hits_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_key_hits_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_key_requests_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_key_requests_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
         // TBD
         // FIXME
         // See above
@@ -287,14 +287,14 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_hits_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_counter_hits_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_counter_requests_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_counter_requests_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
         // TBD
         // FIXME
         // See above

--- a/api/collectd.cc
+++ b/api/collectd.cc
@@ -52,7 +52,7 @@ static const char* str_to_regex(const sstring& v) {
 }
 
 void set_collectd(http_context& ctx, routes& r) {
-    cd::get_collectd.set(r, [&ctx](std::unique_ptr<request> req) {
+    cd::get_collectd.set(r, [](std::unique_ptr<request> req) {
 
         auto id = ::make_shared<scollectd::type_instance_id>(req->param["pluginid"],
                 req->get_query_param("instance"), req->get_query_param("type"),

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -966,13 +966,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return ctx.db.local().find_column_family(get_uuid(req.param["name"], ctx.db.local())).get_compaction_strategy().name();
     });
 
-    cf::set_compression_parameters.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::set_compression_parameters.set(r, [](std::unique_ptr<request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cf::set_crc_check_chance.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::set_crc_check_chance.set(r, [](std::unique_ptr<request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -65,8 +65,8 @@ void set_compaction_manager(http_context& ctx, routes& r) {
     });
 
     cm::get_pending_tasks_by_table.set(r, [&ctx] (std::unique_ptr<request> req) {
-        return ctx.db.map_reduce0([&ctx](replica::database& db) {
-            return do_with(std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>(), [&ctx, &db](std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>& tasks) {
+        return ctx.db.map_reduce0([](replica::database& db) {
+            return do_with(std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>(), [&db](std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>& tasks) {
                 return do_for_each(db.get_column_families(), [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) -> future<> {
                     replica::table& cf = *i.second.get();
                     tasks[std::make_pair(cf.schema()->ks_name(), cf.schema()->cf_name())] = cf.estimate_pending_compactions();

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -190,7 +190,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return make_ready_future<json::json_return_type>(0);
     });
 
-    sp::get_hinted_handoff_enabled.set(r, [&ctx](std::unique_ptr<request> req)  {
+    sp::get_hinted_handoff_enabled.set(r, [](std::unique_ptr<request> req)  {
         const auto& filter = service::get_storage_proxy().local().get_hints_host_filter();
         return make_ready_future<json::json_return_type>(!filter.is_disabled_for_all());
     });
@@ -481,7 +481,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return sum_timer_stats(ctx.sp, &proxy::stats::cas_read);
     });
 
-    sp::get_view_write_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_view_write_metrics_latency_histogram.set(r, [](std::unique_ptr<request> req) {
         //TBD
         // FIXME
         // No View metrics are available, so just return empty moving average

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -654,7 +654,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                 req.get_query_param("key")));
     });
 
-    ss::cdc_streams_check_and_repair.set(r, [&ctx, &cdc_gs] (std::unique_ptr<request> req) {
+    ss::cdc_streams_check_and_repair.set(r, [&cdc_gs] (std::unique_ptr<request> req) {
         if (!cdc_gs.local_is_initialized()) {
             throw std::runtime_error("get_cdc_generation_service: not initialized yet");
         }
@@ -712,7 +712,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                         return int64_t(-1);
                     }
                 });
-                auto& cm = db.get_compaction_manager();
                 auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(keyspace));
                 co_await run_on_existing_tables("force_keyspace_cleanup", db, keyspace, local_tables, [&] (replica::table& t) {
                     return t.perform_cleanup_compaction(owned_ranges_ptr);

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -95,7 +95,7 @@ void set_task_manager_test(http_context& ctx, routes& r, db::config& cfg) {
         co_return json_void();
     });
 
-    tmt::get_and_update_ttl.set(r, [&ctx, &cfg] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tmt::get_and_update_ttl.set(r, [&cfg] (std::unique_ptr<request> req) -> future<json::json_return_type> {
         uint32_t ttl = cfg.task_ttl_seconds();
         co_await cfg.task_ttl_seconds.set_value_on_all_shards(req->query_parameters["ttl"], utils::config_file::config_source::API);
         co_return json::json_return_type(ttl);

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -74,7 +74,7 @@ future<bool> default_authorizer::any_granted() const {
             query,
             db::consistency_level::LOCAL_ONE,
             {},
-            cql3::query_processor::cache_internal::yes).then([this](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> results) {
         return !results->empty();
     });
 }

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -470,7 +470,7 @@ standard_role_manager::grant(std::string_view grantee_name, std::string_view rol
 
 future<>
 standard_role_manager::revoke(std::string_view revokee_name, std::string_view role_name) {
-    return this->exists(role_name).then([this, revokee_name, role_name](bool role_exists) {
+    return this->exists(role_name).then([role_name](bool role_exists) {
         if (!role_exists) {
             throw nonexistant_role(sstring(role_name));
         }

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -784,10 +784,10 @@ static managed_bytes merge(const set_type_impl& ctype, const managed_bytes_opt& 
 }
 static managed_bytes merge(const user_type_impl& type, const managed_bytes_opt& prev, const managed_bytes_opt& next, const managed_bytes_opt& deleted) {
     std::vector<managed_bytes_view_opt> res(type.size());
-    udt_for_each(prev, [&res, i = res.begin()](managed_bytes_view_opt k) mutable {
+    udt_for_each(prev, [i = res.begin()](managed_bytes_view_opt k) mutable {
         *i++ = k;
     });
-    udt_for_each(next, [&res, i = res.begin()](managed_bytes_view_opt k) mutable {
+    udt_for_each(next, [i = res.begin()](managed_bytes_view_opt k) mutable {
         if (k) {
             *i = k;
         }
@@ -1781,8 +1781,8 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
     mutations.reserve(2 * mutations.size());
 
     return do_with(std::move(mutations), service::query_state(service::client_state::for_internal_calls(), empty_service_permit()), operation_details{},
-            [this, timeout, i, tr_state = std::move(tr_state), write_cl] (std::vector<mutation>& mutations, service::query_state& qs, operation_details& details) {
-        return transform_mutations(mutations, 1, [this, &mutations, timeout, &qs, tr_state = tr_state, &details, write_cl] (int idx) mutable {
+            [this, tr_state = std::move(tr_state), write_cl] (std::vector<mutation>& mutations, service::query_state& qs, operation_details& details) {
+        return transform_mutations(mutations, 1, [this, &mutations, &qs, tr_state = tr_state, &details, write_cl] (int idx) mutable {
             auto& m = mutations[idx];
             auto s = m.schema();
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1628,7 +1628,7 @@ public:
     }
 
     reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) override {
-        return [this, end_consumer = std::move(end_consumer)] (flat_mutation_reader_v2 reader) mutable -> future<> {
+        return [end_consumer = std::move(end_consumer)] (flat_mutation_reader_v2 reader) mutable -> future<> {
             return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
         };
     }

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -137,7 +137,7 @@ compaction_descriptor
 leveled_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> input, schema_ptr schema, const ::io_priority_class& iop, reshape_mode mode) {
     std::array<std::vector<shared_sstable>, leveled_manifest::MAX_LEVELS> level_info;
 
-    auto is_disjoint = [this, schema] (const std::vector<shared_sstable>& sstables, unsigned tolerance) -> std::tuple<bool, unsigned> {
+    auto is_disjoint = [schema] (const std::vector<shared_sstable>& sstables, unsigned tolerance) -> std::tuple<bool, unsigned> {
         auto overlapping_sstables = sstable_set_overlapping_count(schema, sstables);
         return { overlapping_sstables <= tolerance, overlapping_sstables };
     };
@@ -167,7 +167,6 @@ leveled_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> input
     }
 
     size_t offstrategy_threshold = (mode == reshape_mode::strict) ? std::max(schema->min_compaction_threshold(), 4) : std::max(schema->max_compaction_threshold(), 32);
-    size_t max_sstables = std::max(schema->max_compaction_threshold(), int(offstrategy_threshold));
     auto tolerance = [mode] (unsigned level) -> unsigned {
         if (mode == reshape_mode::strict) {
             return 0;

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -434,7 +434,7 @@ private:
         const schema& s = *_schema;
         // for non-L0 compactions, pick up where we left off last time
         auto& sstables = get_level(level);
-        boost::sort(sstables, [&s] (auto& i, auto& j) {
+        boost::sort(sstables, [] (auto& i, auto& j) {
             return i->compare_by_first_key(*j) < 0;
         });
 

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -985,7 +985,6 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             if (!schema_opt) {
                 throw exceptions::invalid_request_exception("cannot process token() function without schema");
             }
-            auto& schema = *schema_opt;
 
             std::vector<expression> prepared_token_args;
             prepared_token_args.reserve(tk.args.size());

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -225,7 +225,7 @@ inline
 shared_ptr<function>
 make_from_json_function(data_dictionary::database db, const sstring& keyspace, data_type t) {
     return make_native_scalar_function<true>("fromjson", t, {utf8_type},
-            [&db, keyspace, t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [keyspace, t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
         try {
             rjson::value json_value = rjson::parse(utf8_type->to_string(parameters[0].value()));
             bytes_opt parsed_json_value;

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -508,7 +508,7 @@ query_processor::execute_prepared_without_checking_exception_message(
     future<> fut = make_ready_future<>();
     if (needs_authorization) {
         fut = statement->check_access(*this, query_state.get_client_state()).then([this, &query_state, prepared = std::move(prepared), cache_key = std::move(cache_key)] () mutable {
-            return _authorized_prepared_cache.insert(*query_state.get_client_state().user(), std::move(cache_key), std::move(prepared)).handle_exception([this] (auto eptr) {
+            return _authorized_prepared_cache.insert(*query_state.get_client_state().user(), std::move(cache_key), std::move(prepared)).handle_exception([] (auto eptr) {
                 log.error("failed to cache the entry: {}", eptr);
             });
         });
@@ -866,7 +866,7 @@ query_processor::execute_batch_without_checking_exception_message(
         std::unordered_map<prepared_cache_key_type, authorized_prepared_statements_cache::value_type> pending_authorization_entries) {
     return batch->check_access(*this, query_state.get_client_state()).then([this, &query_state, &options, batch, pending_authorization_entries = std::move(pending_authorization_entries)] () mutable {
         return parallel_for_each(pending_authorization_entries, [this, &query_state] (auto& e) {
-            return _authorized_prepared_cache.insert(*query_state.get_client_state().user(), e.first, std::move(e.second)).handle_exception([this] (auto eptr) {
+            return _authorized_prepared_cache.insert(*query_state.get_client_state().user(), e.first, std::move(e.second)).handle_exception([] (auto eptr) {
                 log.error("failed to cache the entry: {}", eptr);
             });
         }).then([this, &query_state, &options, batch] {

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -104,7 +104,7 @@ static logging::logger mylogger("alter_keyspace");
 future<::shared_ptr<cql_transport::messages::result_message>>
 cql3::statements::alter_keyspace_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
     std::optional<sstring> warning = check_restricted_replication_strategy(qp, keyspace(), *_attrs);
-    return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
+    return schema_altering_statement::execute(qp, state, options).then([warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);
             mylogger.warn("{}", *warning);

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -411,7 +411,7 @@ future<::shared_ptr<messages::result_message>>
 alter_table_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
     auto s = validation::validate_column_family(qp.db(), keyspace(), column_family());
     std::optional<sstring> warning = check_restricted_table_properties(qp, s, keyspace(), column_family(), *_properties);
-    return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
+    return schema_altering_statement::execute(qp, state, options).then([warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);
             mylogger.warn("{}", *warning);

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -181,7 +181,7 @@ std::optional<sstring> check_restricted_replication_strategy(
 future<::shared_ptr<messages::result_message>>
 create_keyspace_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
     std::optional<sstring> warning = check_restricted_replication_strategy(qp, keyspace(), *_attrs);
-    return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
+    return schema_altering_statement::execute(qp, state, options).then([warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);
             mylogger.warn("{}", *warning);

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -513,7 +513,7 @@ std::optional<sstring> check_restricted_table_properties(
 future<::shared_ptr<messages::result_message>>
 create_table_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
     std::optional<sstring> warning = check_restricted_table_properties(qp, std::nullopt, keyspace(), column_family(), *_properties);
-    return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
+    return schema_altering_statement::execute(qp, state, options).then([warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);
             mylogger.warn("{}", *warning);

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -49,7 +49,7 @@ future<> cql3::statements::list_permissions_statement::check_access(query_proces
     const auto& as = *state.get_auth_service();
     const auto user = state.user();
 
-    return auth::has_superuser(as, *user).then([this, &state, &as, user](bool has_super) {
+    return auth::has_superuser(as, *user).then([this, &as, user](bool has_super) {
         if (has_super) {
             return make_ready_future<>();
         }
@@ -109,7 +109,7 @@ cql3::statements::list_permissions_statement::execute(
                 as,
                 _permissions,
                 _role_name,
-                resource_filter).then([this](std::vector<auth::permission_details> all_details) {
+                resource_filter).then([](std::vector<auth::permission_details> all_details) {
             std::sort(all_details.begin(), all_details.end());
 
             auto rs = std::make_unique<result_set>(metadata);

--- a/cql3/statements/list_service_level_attachments_statement.cc
+++ b/cql3/statements/list_service_level_attachments_statement.cc
@@ -70,7 +70,7 @@ list_service_level_attachments_statement::execute(query_processor& qp,
             });
 
         }
-    }).then([this, &state] (std::unordered_map<sstring, sstring> roles_to_att_val) {
+    }).then([] (std::unordered_map<sstring, sstring> roles_to_att_val) {
 
         auto rs = std::make_unique<result_set>(metadata);
         for (auto&& role_to_sl : roles_to_att_val) {

--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -61,7 +61,7 @@ list_service_level_statement::execute(query_processor& qp,
                                       return state.get_service_level_controller().get_distributed_service_level(_service_level);
                                   }
                               })
-            .then([this] (qos::service_levels_info sl_info) {
+            .then([] (qos::service_levels_info sl_info) {
                 auto d = [] (const qos::service_level_options::timeout_type& duration) -> bytes_opt {
                     return std::visit(overloaded_functor{
                         [&] (const qos::service_level_options::unset_marker&) {

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -187,7 +187,7 @@ bool modification_statement::applies_to(const selection::selection* selection,
         .options = &options,
     };
 
-    auto condition_applies = [&row, &inputs](const lw_shared_ptr<column_condition>& cond) {
+    auto condition_applies = [&inputs](const lw_shared_ptr<column_condition>& cond) {
         return cond->applies_to(inputs);
     };
     return (std::all_of(_static_conditions.begin(), _static_conditions.end(), condition_applies) &&

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -366,7 +366,7 @@ list_roles_statement::execute(query_processor&, service::query_state& state, con
     const auto& cs = state.get_client_state();
     const auto& as = *cs.get_auth_service();
 
-    return auth::has_superuser(as, *cs.user()).then([this, &state, &cs, &as](bool super) {
+    return auth::has_superuser(as, *cs.user()).then([this, &cs, &as](bool super) {
         auto& rm = as.underlying_role_manager();
         const auto& a = as.underlying_authenticator();
         const auto query_mode = _recursive ? auth::recursive_role_query::yes : auth::recursive_role_query::no;
@@ -409,7 +409,7 @@ std::unique_ptr<prepared_statement> grant_role_statement::prepare(
 future<> grant_role_statement::check_access(query_processor& qp, const service::client_state& state) const {
     state.ensure_not_anonymous();
 
-    return do_with(auth::make_role_resource(_role), [this, &state](const auto& r) {
+    return do_with(auth::make_role_resource(_role), [&state](const auto& r) {
         return state.ensure_has_permission({auth::permission::AUTHORIZE, r});
     });
 }
@@ -437,7 +437,7 @@ std::unique_ptr<prepared_statement> revoke_role_statement::prepare(
 future<> revoke_role_statement::check_access(query_processor& qp, const service::client_state& state) const {
     state.ensure_not_anonymous();
 
-    return do_with(auth::make_role_resource(_role), [this, &state](const auto& r) {
+    return do_with(auth::make_role_resource(_role), [&state](const auto& r) {
         return state.ensure_has_permission({auth::permission::AUTHORIZE, r});
     });
 }

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -126,9 +126,9 @@ future<> db::commitlog_replayer::impl::init() {
                 }
             }
         }
-    }, [this](replica::database& db) {
-        return do_with(shard_rpm_map{}, [this, &db](shard_rpm_map& map) {
-            return parallel_for_each(db.get_column_families(), [&map, &db](auto& cfp) {
+    }, [](replica::database& db) {
+        return do_with(shard_rpm_map{}, [&db](shard_rpm_map& map) {
+            return parallel_for_each(db.get_column_families(), [&map](auto& cfp) {
                 auto uuid = cfp.first;
                 // We do this on each cpu, for each CF, which technically is a little wasteful, but the values are
                 // cached, this is only startup, and it makes the code easier.
@@ -246,7 +246,7 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
 
         const auto& schema = *_db.local().find_column_family(uuid).schema();
         auto shard = fm.shard_of(schema);
-        return _db.invoke_on(shard, [this, cer = std::move(cer), &src_cm, rp, shard, s] (replica::database& db) mutable -> future<> {
+        return _db.invoke_on(shard, [this, cer = std::move(cer), &src_cm, rp] (replica::database& db) mutable -> future<> {
             auto& fm = cer.mutation();
             // TODO: might need better verification that the deserialized mutation
             // is schema compatible. My guess is that just applying the mutation

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -183,7 +183,7 @@ future<> manager::wait_for_sync_point(abort_source& as, const sync_point::shard_
     }
 
     bool was_aborted = false;
-    co_await coroutine::parallel_for_each(_ep_managers, [this, &was_aborted, &rps, &local_as] (auto& p) {
+    co_await coroutine::parallel_for_each(_ep_managers, [&was_aborted, &rps, &local_as] (auto& p) {
         const auto addr = p.first;
         auto& ep_man = p.second;
 
@@ -873,9 +873,9 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
                     return make_ready_future<>();
                 }
 
-                return this->send_one_mutation(std::move(m)).then([this, rp, ctx_ptr] {
+                return this->send_one_mutation(std::move(m)).then([this, ctx_ptr] {
                     ++this->shard_stats().sent;
-                }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
+                }).handle_exception([this, ctx_ptr] (auto eptr) {
                     manager_logger.trace("send_one_hint(): failed to send to {}: {}", end_point_key(), eptr);
                     return make_exception_future<>(std::move(eptr));
                 });
@@ -913,7 +913,7 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
             }
             f.ignore_ready_future();
         });
-    }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
+    }).handle_exception([ctx_ptr, rp] (auto eptr) {
         manager_logger.trace("send_one_file(): Hmmm. Something bad had happend: {}", eptr);
         ctx_ptr->on_hint_send_failure(rp);
     });

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -136,7 +136,7 @@ public:
                         _qp.execute_internal(cq, { dst.name, cf_name }, cql3::query_processor::cache_internal::yes),
                         _qp.execute_internal(zq, { dst.name, cf_name }, cql3::query_processor::cache_internal::yes),
                         db::schema_tables::legacy::read_table_mutations(_sp, dst.name, cf_name, db::system_keyspace::legacy::column_families()))
-                    .then([this, &dst, cf_name, timestamp](result_tuple&& t) {
+                    .then([&dst, cf_name, timestamp](result_tuple&& t) {
 
             result_set_type tables = std::get<0>(t).get0();
             result_set_type columns = std::get<1>(t).get0();
@@ -473,7 +473,7 @@ public:
 
     future<> read_functions(keyspace& dst) {
         auto query = fmt_query("SELECT * FROM {}.{} WHERE keyspace_name = ?", db::system_keyspace::legacy::FUNCTIONS);
-        return _qp.execute_internal(query, {dst.name}, cql3::query_processor::cache_internal::yes).then([this, &dst](result_set_type result) {
+        return _qp.execute_internal(query, {dst.name}, cql3::query_processor::cache_internal::yes).then([](result_set_type result) {
             if (!result->empty()) {
                 throw unsupported_feature("functions");
             }
@@ -482,7 +482,7 @@ public:
 
     future<> read_aggregates(keyspace& dst) {
         auto query = fmt_query("SELECT * FROM {}.{} WHERE keyspace_name = ?", db::system_keyspace::legacy::AGGREGATES);
-        return _qp.execute_internal(query, {dst.name}, cql3::query_processor::cache_internal::yes).then([this, &dst](result_set_type result) {
+        return _qp.execute_internal(query, {dst.name}, cql3::query_processor::cache_internal::yes).then([](result_set_type result) {
             if (!result->empty()) {
                 throw unsupported_feature("aggregates");
             }
@@ -501,7 +501,7 @@ public:
             return read_functions(*ks);
         }).then([this, ks] {
             return read_aggregates(*ks);
-        }).then([this, ks] {
+        }).then([ks] {
             return make_ready_future<keyspace>(std::move(*ks));
         });
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1335,11 +1335,11 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     // was already dropped (see https://github.com/scylladb/scylla/issues/5614)
     auto& db = proxy.local().get_db();
     auto ts = db_clock::now();
-    co_await max_concurrent_for_each(views_diff.dropped, max_concurrent, [&db, ts] (schema_diff::dropped_schema& dt) {
+    co_await max_concurrent_for_each(views_diff.dropped, max_concurrent, [&db] (schema_diff::dropped_schema& dt) {
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, s.ks_name(), s.cf_name());
     });
-    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [&db, ts] (schema_diff::dropped_schema& dt) -> future<> {
+    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [&db] (schema_diff::dropped_schema& dt) -> future<> {
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, s.ks_name(), s.cf_name());
     });
@@ -1397,7 +1397,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
             store_column_mapping(proxy, altered.old_schema.get(), true),
             store_column_mapping(proxy, altered.new_schema.get(), false));
     });
-    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [&proxy] (schema_diff::dropped_schema& dropped) -> future<> {
+    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [] (schema_diff::dropped_schema& dropped) -> future<> {
         schema_ptr s = dropped.schema.get();
         co_await drop_column_mapping(s->id(), s->version());
     });

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -358,7 +358,7 @@ future<std::unordered_map<locator::host_id, sstring>> system_distributed_keyspac
             db::consistency_level::ONE,
             internal_distributed_query_state(),
             { std::move(ks_name), std::move(view_name) },
-            cql3::query_processor::cache_internal::no).then([this] (::shared_ptr<cql3::untyped_result_set> cql_result) {
+            cql3::query_processor::cache_internal::no).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
         return boost::copy_range<std::unordered_map<locator::host_id, sstring>>(*cql_result
                 | boost::adaptors::transformed([] (const cql3::untyped_result_set::row& row) {
                     auto host_id = locator::host_id(row.get_as<utils::UUID>("host_id"));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1391,8 +1391,6 @@ namespace db {
 typedef utils::UUID truncation_key;
 typedef std::unordered_map<truncation_key, truncation_record> truncation_map;
 
-static constexpr uint8_t current_version = 1;
-
 future<truncation_record> system_keyspace::get_truncation_record(table_id cf_id) {
     if (qctx->qp().db().get_config().ignore_truncation_record.is_set()) {
         truncation_record r{truncation_record::current_magic};
@@ -2850,7 +2848,6 @@ future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::
 
     auto& db = dist_db.local();
     auto& db_config = db.get_config();
-    auto enable_cache = db_config.enable_cache();
     bool durable = db_config.data_file_directories().size() > 0;
     for (auto&& table : system_keyspace::all_tables(db_config)) {
         if (!tables.contains(table)) {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -456,7 +456,6 @@ dht::token_range_vector split_token_range_msb(unsigned most_significant_bits) {
     ret.reserve(number_of_ranges);
     assert(most_significant_bits < 64);
     uint8_t log2_shift = (64 - most_significant_bits);
-    uint64_t keys_per_range = 1ULL << log2_shift;
     uint64_t unbiased_key = 0;
     dht::token token;
     for (uint64_t i = 0; i < number_of_ranges; ) {

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -246,7 +246,7 @@ future<> range_streamer::stream_async() {
     _nr_total_ranges = nr_ranges_remaining;
     logger.info("{} starts, nr_ranges_remaining={}", _description, nr_ranges_remaining);
     auto start = lowres_clock::now();
-    return do_for_each(_to_stream, [this, start, description = _description] (auto& stream) {
+    return do_for_each(_to_stream, [this, description = _description] (auto& stream) {
         const auto& keyspace = stream.first;
         auto& ip_range_vec = stream.second;
         auto ips = boost::copy_range<std::list<inet_address>>(ip_range_vec | boost::adaptors::map_keys);

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -166,7 +166,7 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
 future<> server::do_accepts(int which, bool keepalive, socket_address server_addr) {
     return repeat([this, which, keepalive, server_addr] {
         ++_connections_being_accepted;
-        return _listeners[which].accept().then_wrapped([this, which, keepalive, server_addr] (future<accept_result> f_cs_sa) mutable {
+        return _listeners[which].accept().then_wrapped([this, keepalive, server_addr] (future<accept_result> f_cs_sa) mutable {
             --_connections_being_accepted;
             if (_stopping) {
                 f_cs_sa.ignore_ready_future();

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1913,7 +1913,7 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) 
                 }).handle_exception_type([node, &fall_back_to_syn_msg] (seastar::rpc::unknown_verb_error&) {
                     logger.warn("Node {} does not support get_endpoint_states verb", node);
                     fall_back_to_syn_msg = true;
-                }).handle_exception_type([node, &nodes_down] (seastar::rpc::timeout_error&) {
+                }).handle_exception_type([node] (seastar::rpc::timeout_error&) {
                     logger.warn("The get_endpoint_states verb to node {} was timeout", node);
                 }).handle_exception_type([node, &nodes_down] (seastar::rpc::closed_error&) {
                     nodes_down++;

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1466,7 +1466,7 @@ def add_view(cout, cls):
             elem_type = element_type(m.type)
             fprintln(cout, reindent(4, """
                 auto {name}() const {{
-                  return seastar::with_serialized_stream(v, [this] (auto& v) {{
+                  return seastar::with_serialized_stream(v, [] (auto& v) {{
                    auto in = v;
                    {skip}
                    return vector_deserializer<{elem_type}>(in);

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -136,7 +136,7 @@ future<sstring> ec2_snitch::aws_api_call_once(sstring addr, uint16_t port, sstri
             auto content_len = std::stoi(it->second);
 
             // Read HTTP response body
-            return _in.read_exactly(content_len).then([this] (temporary_buffer<char> buf) {
+            return _in.read_exactly(content_len).then([] (temporary_buffer<char> buf) {
                 sstring res(buf.get(), buf.size());
 
                 return make_ready_future<sstring>(std::move(res));

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -17,7 +17,7 @@
 namespace locator {
 future<bool> gossiping_property_file_snitch::property_file_was_modified() {
     return open_file_dma(_prop_file_name, open_flags::ro)
-    .then([this](file f) {
+    .then([](file f) {
         return do_with(std::move(f), [] (file& f) {
             return f.stat();
         });

--- a/main.cc
+++ b/main.cc
@@ -1298,7 +1298,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // group that was effectively used in the bulk of it (compaction). Soon it will become
             // streaming
 
-            db.invoke_on_all([&proxy] (replica::database& db) {
+            db.invoke_on_all([] (replica::database& db) {
                 for (auto& x : db.get_column_families()) {
                     replica::column_family& cf = *(x.second);
                     cf.trigger_compaction();

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -477,7 +477,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_compaction_state(de
 
 future<> read_context::save_reader(shard_id shard, full_position_view last_pos) {
   return do_with(std::exchange(_readers[shard], {}), [this, shard, last_pos] (reader_meta& rm) mutable {
-    return _db.invoke_on(shard, [this, query_uuid = _cmd.query_uuid, query_ranges = _ranges, &rm,
+    return _db.invoke_on(shard, [query_uuid = _cmd.query_uuid, query_ranges = _ranges, &rm,
             last_pos, gts = tracing::global_trace_state_ptr(_trace_state)] (replica::database& db) mutable {
         try {
             auto rparts = rm.rparts.release(); // avoid another round-trip when destroying rparts

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -433,7 +433,7 @@ utils::coroutine partition_entry::apply_to_incomplete(const schema& s,
     // of allocating sections, so we return here to get out of the current allocating section and
     // give the caller a chance to store the coroutine object. The code inside coroutine below
     // runs outside allocating section.
-    return utils::coroutine([self = this, &tracker, &s, &alloc, &reg, &acc, can_move, preemptible,
+    return utils::coroutine([&tracker, &s, &alloc, &reg, &acc, can_move, preemptible,
             cur = partition_snapshot_row_cursor(s, *dst_snp),
             src_cur = partition_snapshot_row_cursor(s, *src_snp, can_move),
             dst_snp = std::move(dst_snp),

--- a/querier.cc
+++ b/querier.cc
@@ -230,7 +230,7 @@ void querier_cache::insert_querier(
     // current partition when the page ends so it cannot be reused across
     // pages.
     if (q.is_reversed()) {
-        (void)with_gate(_closing_gate, [this, q = std::move(q)] () mutable {
+        (void)with_gate(_closing_gate, [q = std::move(q)] () mutable {
             return q.close().finally([q = std::move(q)] {});
         });
         return;
@@ -342,7 +342,7 @@ std::optional<Querier> querier_cache::lookup_querier(
     // Close and drop the querier in the background.
     // It is safe to do so, since _closing_gate is closed and
     // waited on in querier_cache::stop()
-    (void)with_gate(_closing_gate, [this, q = std::move(q)] () mutable {
+    (void)with_gate(_closing_gate, [q = std::move(q)] () mutable {
         return q.close().finally([q = std::move(q)] {});
     });
 

--- a/querier.hh
+++ b/querier.hh
@@ -39,7 +39,7 @@ auto consume_page(flat_mutation_reader_v2& reader,
         uint64_t row_limit,
         uint32_t partition_limit,
         gc_clock::time_point query_time) {
-    return reader.peek().then([=, &reader, consumer = std::move(consumer), &slice] (
+    return reader.peek().then([=, &reader, consumer = std::move(consumer)] (
                 mutation_fragment_v2* next_fragment) mutable {
         const auto next_fragment_region = next_fragment ? next_fragment->position().region() : partition_region::partition_start;
         compaction_state->start_new_page(row_limit, partition_limit, query_time, next_fragment_region, consumer);

--- a/query.cc
+++ b/query.cc
@@ -318,7 +318,7 @@ std::ostream& operator<<(std::ostream& os, const query::result::printer& p) {
 void result::ensure_counts() {
     if (!_partition_count || !row_count()) {
         uint64_t row_count;
-        std::tie(_partition_count, row_count) = result_view::do_with(*this, [this] (auto&& view) {
+        std::tie(_partition_count, row_count) = result_view::do_with(*this, [] (auto&& view) {
             return view.count_partitions_and_rows();
         });
         set_row_count(row_count);

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1326,7 +1326,7 @@ public:
 
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc) override {
         return _permit.request_memory(range_size).then([this, offset, range_size, &pc] (reader_permit::resource_units units) {
-            return get_file_impl(_tracked_file)->dma_read_bulk(offset, range_size, pc).then([this, units = std::move(units)] (temporary_buffer<uint8_t> buf) mutable {
+            return get_file_impl(_tracked_file)->dma_read_bulk(offset, range_size, pc).then([units = std::move(units)] (temporary_buffer<uint8_t> buf) mutable {
                 return make_ready_future<temporary_buffer<uint8_t>>(make_tracked_temporary_buffer(std::move(buf), std::move(units)));
             });
         });

--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -322,7 +322,7 @@ public:
         // This method returns whatever is returned from Consumer::consume_end_of_stream().S
         auto consume(Consumer consumer) {
             return do_with(consumer_adapter<Consumer>(*this, std::move(consumer)), [this] (consumer_adapter<Consumer>& adapter) {
-                return consume_pausable(std::ref(adapter)).then([this, &adapter] {
+                return consume_pausable(std::ref(adapter)).then([&adapter] {
                     return adapter._consumer.consume_end_of_stream();
                 });
             });

--- a/readers/mutation_fragment_v1_stream.hh
+++ b/readers/mutation_fragment_v1_stream.hh
@@ -195,7 +195,7 @@ public:
     // This method returns whatever is returned from Consumer::consume_end_of_stream().
     auto consume(Consumer consumer) {
         return do_with(consumer_adapter<Consumer>(*this, std::move(consumer)), [this] (consumer_adapter<Consumer>& adapter) {
-            return consume_pausable(std::ref(adapter)).then([this, &adapter] {
+            return consume_pausable(std::ref(adapter)).then([&adapter] {
                 return adapter._consumer.consume_end_of_stream();
             });
         });

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -355,7 +355,7 @@ static size_t compute_buffer_size(const schema& s, const flat_mutation_reader_v2
 {
     return boost::accumulate(
         buffer
-        | boost::adaptors::transformed([&s] (const mutation_fragment_v2& mf) {
+        | boost::adaptors::transformed([] (const mutation_fragment_v2& mf) {
             return mf.memory_usage();
         }), size_t(0)
     );

--- a/redis/query_utils.cc
+++ b/redis/query_utils.cc
@@ -96,7 +96,7 @@ private:
     void add_cell(const bytes& ckey, const column_definition& col, const std::optional<query::result_atomic_cell_view>& cell)
     {
         if (cell) {
-            cell->value().with_linearized([this, &col, &cell, &ckey] (bytes_view cell_view) {
+            cell->value().with_linearized([this, &col, &ckey] (bytes_view cell_view) {
                 auto&& dv = col.type->deserialize_value(cell_view);
                 auto&& d = dv.serialize_nonnull();
                 _data->emplace(std::move(ckey), std::move(d));

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -354,7 +354,7 @@ distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<r
         std::function<bool (const sstables::shared_sstable&)> filter, io_priority_class iop) {
 
     auto start = std::chrono::steady_clock::now();
-    auto total_size = co_await dir.map_reduce0([&dir, &db, ks_name = std::move(ks_name), table_name = std::move(table_name), creator = std::move(creator), mode, filter, iop] (sstables::sstable_directory& d) {
+    auto total_size = co_await dir.map_reduce0([&db, ks_name = std::move(ks_name), table_name = std::move(table_name), creator = std::move(creator), mode, filter, iop] (sstables::sstable_directory& d) {
         auto& table = db.local().find_column_family(ks_name, table_name);
         return ::replica::reshape(d, table, creator, mode, filter, iop);
     }, uint64_t(0), std::plus<uint64_t>());
@@ -848,7 +848,7 @@ future<> distributed_loader::init_non_system_keyspaces(distributed<replica::data
 
         ks_dirs dirs;
 
-        parallel_for_each(cfg.data_file_directories(), [&db, &dirs] (sstring directory) {
+        parallel_for_each(cfg.data_file_directories(), [&dirs] (sstring directory) {
             // we want to collect the directories first, so we can get a full set of potential dirs
             return lister::scan_dir(directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [&dirs] (fs::path datadir, directory_entry de) {
                 if (!is_system_keyspace(de.name)) {

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -767,7 +767,7 @@ future<>
 memtable::apply(memtable& mt, reader_permit permit) {
     if (auto reader_opt = mt.make_flat_reader_opt(_schema, std::move(permit), query::full_partition_range, _schema->full_slice())) {
         return with_closeable(std::move(*reader_opt), [this] (auto&& rd) mutable {
-            return consume_partitions(rd, [self = this->shared_from_this(), &rd] (mutation&& m) {
+            return consume_partitions(rd, [self = this->shared_from_this()] (mutation&& m) {
                 self->apply(m);
                 return stop_iteration::no;
             });

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -491,7 +491,7 @@ public:
     template<typename Func>
     void run_in_update_section_with_allocator(Func &&func) {
         return _cache._update_section(_cache._tracker.region(), [this, &func]() {
-            return with_allocator(_cache._tracker.region().allocator(), [this, &func]() mutable {
+            return with_allocator(_cache._tracker.region().allocator(), [&func]() mutable {
                 return func();
             });
         });

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -66,7 +66,6 @@ future<query_result> execute_broadcast_table_query(
     return std::visit(make_visitor(
         std::bind_front([] (storage_proxy& proxy, const service::broadcast_tables::select_query& q) -> future<query_result> {
             const auto schema = db::system_keyspace::broadcast_kv_store();
-            const auto* column_definition = schema->get_column_definition("value");
 
             // Read mutations
             const auto [read_cmd, range] = prepare_read_command(proxy, *schema, q.key);

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -300,7 +300,7 @@ public:
     virtual ~ghost_row_deleting_query_pager() {}
 
     virtual future<result<>> fetch_page_result(cql3::selection::result_set_builder& builder, uint32_t page_size, gc_clock::time_point now, db::timeout_clock::time_point timeout) override {
-        return do_fetch_page(page_size, now, timeout).then(utils::result_wrap([this, &builder, page_size, now] (service::storage_proxy::coordinator_query_result qr) {
+        return do_fetch_page(page_size, now, timeout).then(utils::result_wrap([this, page_size, now] (service::storage_proxy::coordinator_query_result qr) {
             _last_replicas = std::move(qr.last_replicas);
             _query_read_repair_decision = qr.read_repair_decision;
             qr.query_result->ensure_counts();

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -206,7 +206,7 @@ future<std::optional<service_level_options>> service_level_controller::find_serv
                 return std::nullopt;
             }
         });
-    }, std::optional<service_level_options>{}, [this] (std::optional<service_level_options> first, std::optional<service_level_options> second) -> std::optional<service_level_options> {
+    }, std::optional<service_level_options>{}, [] (std::optional<service_level_options> first, std::optional<service_level_options> second) -> std::optional<service_level_options> {
         if (!second) {
             return first;
         } else if (!first) {

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -152,7 +152,7 @@ void raft_group_registry::init_rpc_verbs() {
             const rpc::client_info& cinfo,
             const raft::group_id& gid, raft::server_id from, raft::server_id dst, auto handler) {
         return container().invoke_on(shard_for_group(gid),
-                [addr = netw::messaging_service::get_source(cinfo).addr, from, dst, gid, handler] (raft_group_registry& self) mutable {
+                [addr = netw::messaging_service::get_source(cinfo).addr, from, gid, handler] (raft_group_registry& self) mutable {
             // Update the address mappings for the rpc module
             // in case the sender is encountered for the first time
             auto& rpc = self.get_rpc(gid);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -714,7 +714,7 @@ private:
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
-                                     local, cmd = make_lw_shared<query::read_command>(std::move(cmd)), key = std::move(key),
+                                     cmd = make_lw_shared<query::read_command>(std::move(cmd)), key = std::move(key),
                                      ballot, only_digest, da, timeout, src_ip] (storage_proxy& sp) {
                 tracing::trace_state_ptr tr_state = gt;
                 return paxos::paxos_state::prepare(sp, tr_state, gs, *cmd, key, ballot, only_digest, da, *timeout).then([src_ip, tr_state] (paxos::prepare_response r) {
@@ -744,7 +744,7 @@ private:
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
-                                     local, proposal = std::move(proposal), timeout, token] (storage_proxy& sp) {
+                                     proposal = std::move(proposal), timeout, token] (storage_proxy& sp) {
                 return paxos::paxos_state::accept(sp, gt, gs, token, proposal, *timeout);
             });
         });

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -514,8 +514,8 @@ private:
                 end = summary.entries[summary_idx + 1].position;
             }
 
-            return advance_context(bound, position, end, quantity).then([this, summary_idx, &bound] {
-                return bound.context->consume_input().then_wrapped([this, summary_idx, &bound] (future<> f) {
+            return advance_context(bound, position, end, quantity).then([this, &bound] {
+                return bound.context->consume_input().then_wrapped([this, &bound] (future<> f) {
                     std::exception_ptr ex;
                     if (f.failed()) {
                         ex = f.get_exception();
@@ -528,7 +528,7 @@ private:
                         // if the associated reader is forwarding despite having singular range, we prepare for that
                         _single_page_read = false;
                         auto& ctx = *bound.context;
-                        return ctx.close().then([bc = std::move(bound.context), &bound, this] { return std::move(bound.consumer->indexes); });
+                        return ctx.close().then([bc = std::move(bound.context), &bound] { return std::move(bound.consumer->indexes); });
                     }
                     return make_ready_future<index_list>(std::move(bound.consumer->indexes));
                 });
@@ -997,7 +997,6 @@ public:
                 " sstable version (expected >= mc): {}", fmt::ptr(this), static_cast<int>(_sstable->get_version())));
         }
 
-        index_entry& e = current_partition_entry(*_upper_bound);
         return cur_bsearch->advance_past(pos).then([this, partition_start_pos = get_data_file_position()]
                 (std::optional<clustered_index_cursor::skip_info> si) {
             if (!si) {

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1313,7 +1313,7 @@ private:
                 if (index_position.start <= _context->position()) {
                     return make_ready_future<>();
                 }
-                return skip_to(idx.element_kind(), index_position.start).then([this, &idx] {
+                return skip_to(idx.element_kind(), index_position.start).then([this] {
                     _sst->get_stats().on_partition_seek();
                 });
             });

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -195,7 +195,7 @@ private:
 
     future<pi_offset_type> read_block_offset(pi_index_type idx, tracing::trace_state_ptr trace_state) {
         _stream = _cached_file.read(_promoted_index_start + get_offset_entry_pos(idx), _pc, _permit, trace_state);
-        return _stream.next_page_view().then([this, idx] (cached_file::page_view page) {
+        return _stream.next_page_view().then([this] (cached_file::page_view page) {
             temporary_buffer<char> buf = page.get_buf();
             static_assert(noexcept(std::declval<data_consumer::primitive_consumer>().read_32(buf)));
             if (__builtin_expect(_primitive_parser.read_32(buf) == data_consumer::read_status::ready, true)) {
@@ -333,7 +333,7 @@ public:
         }
         auto& block = const_cast<promoted_index_block&>(*i);
         if (!block.end) {
-            return read_block(block, trace_state).then([this, &block] {
+            return read_block(block, trace_state).then([&block] {
                 return make_ready_future<std::optional<uint64_t>>(block.data_file_offset);
             });
         }
@@ -562,7 +562,7 @@ public:
             return make_ready_future<std::optional<uint64_t>>();
         }
         return _promoted_index.get_block(_blocks_count - 1, _trace_state)
-                .then([this] (promoted_index_block* block) {
+                .then([] (promoted_index_block* block) {
             return std::optional<uint64_t>(block->data_file_offset);
         });
     }

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1151,7 +1151,7 @@ void writer::write_cells(bytes_ostream& writer, const clustering_key_prefix* clu
     // is compared with the set of all columns filled in the memtable. So our encoding may be less optimal in some cases
     // but still valid.
     write_missing_columns(writer, kind == column_kind::static_column ? _sst_schema.static_columns : _sst_schema.regular_columns, row_body);
-    row_body.for_each_cell([this, &writer, kind, &properties, has_complex_deletion, clustering_key] (column_id id, const atomic_cell_or_collection& c) {
+    row_body.for_each_cell([this, &writer, kind, &properties, clustering_key] (column_id id, const atomic_cell_or_collection& c) {
         auto&& column_definition = _schema.column_at(kind, id);
         if (!column_definition.is_atomic()) {
             _collections.push_back({&column_definition, c});

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -362,7 +362,7 @@ future<>
 sstable_directory::parallel_for_each_restricted(Container&& C, Func&& func) {
     return do_with(std::move(C), std::move(func), [this] (Container& c, Func& func) mutable {
       return max_concurrent_for_each(c, _manager.dir_semaphore()._concurrency, [this, &func] (auto& el) mutable {
-        return with_semaphore(_manager.dir_semaphore()._sem, 1, [this, &func,  el = std::move(el)] () mutable {
+        return with_semaphore(_manager.dir_semaphore()._sem, 1, [&func,  el = std::move(el)] () mutable {
             return func(el);
         });
       });

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -43,7 +43,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
             };
 
             auto consumer = make_interposer_consumer(metadata,
-                    [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path, &vug, origin = std::move(origin), offstrategy, reason] (flat_mutation_reader_v2 reader) {
+                    [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path, &vug, origin = std::move(origin), offstrategy] (flat_mutation_reader_v2 reader) {
                 sstables::shared_sstable sst;
                 try {
                     sst = use_view_update_path ? cf->make_streaming_staging_sstable() : cf->make_streaming_sstable_for_write();
@@ -59,7 +59,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                                              cf->get_sstables_manager().configure_writer(origin),
                                              encoding_stats{}, pc).then([sst] {
                     return sst->open_data();
-                }).then([cf, sst, offstrategy, reason, origin] {
+                }).then([cf, sst, offstrategy, origin] {
                     if (offstrategy && sstables::repair_origin == origin) {
                         sstables::sstlog.debug("Enabled automatic off-strategy trigger for table {}.{}",
                                 cf->schema()->ks_name(), cf->schema()->cf_name());

--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -92,7 +92,7 @@ void stream_result_future::maybe_complete() {
         auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - _start_time).count();
         auto stats = make_lw_shared<sstring>("");
         //FIXME: discarded future.
-        (void)_mgr.get_progress_on_all_shards(plan_id).then([plan_id, duration, stats] (auto sbytes) {
+        (void)_mgr.get_progress_on_all_shards(plan_id).then([duration, stats] (auto sbytes) {
             auto tx_bw = sstring("0");
             auto rx_bw = sstring("0");
             if (std::fabs(duration) > FLT_EPSILON) {

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -94,7 +94,7 @@ void stream_manager::init_messaging_service_handler() {
         const auto& from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         auto dst_cpu_id = this_shard_id();
         auto reason = reason_opt ? *reason_opt : stream_reason::unspecified;
-        return container().invoke_on(dst_cpu_id, [msg = std::move(msg), plan_id, description = std::move(description), from, src_cpu_id, dst_cpu_id, reason] (auto& sm) mutable {
+        return container().invoke_on(dst_cpu_id, [msg = std::move(msg), plan_id, description = std::move(description), from, src_cpu_id, reason] (auto& sm) mutable {
             auto sr = stream_result_future::init_receiving_side(sm, plan_id, description, from);
             auto session = sm.get_session(plan_id, from, "PREPARE_MESSAGE");
             session->init(sr);
@@ -119,8 +119,8 @@ void stream_manager::init_messaging_service_handler() {
             return make_exception_future<rpc::sink<int>>(std::runtime_error(format("Node {} is not fully initialized for streaming, try again later",
                     utils::fb_utilities::get_broadcast_address())));
         }
-        return _mm.local().get_schema_for_write(schema_id, from, _ms.local()).then([this, from, estimated_partitions, plan_id, cf_id, schema_id, source, reason] (schema_ptr s) mutable {
-          return _db.local().obtain_reader_permit(s, "stream-session", db::no_timeout).then([this, from, estimated_partitions, plan_id, cf_id, schema_id, source, reason, s] (reader_permit permit) mutable {
+        return _mm.local().get_schema_for_write(schema_id, from, _ms.local()).then([this, from, estimated_partitions, plan_id, cf_id, source, reason] (schema_ptr s) mutable {
+          return _db.local().obtain_reader_permit(s, "stream-session", db::no_timeout).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, s] (reader_permit permit) mutable {
             auto sink = _ms.local().make_sink_for_stream_mutation_fragments(source);
             struct stream_mutation_fragments_cmd_status {
                 bool got_cmd = false;

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -145,7 +145,7 @@ void task_manager::task::start() {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
         (void)with_gate(_impl->_module->async_gate(), [f = done(), module = _impl->_module, id = id()] () mutable {
-            return std::move(f).finally([module, id] {
+            return std::move(f).finally([module] {
                 return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
             }).then_wrapped([module, id] (auto f) {
                 f.ignore_ready_future();

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -108,7 +108,7 @@ future<> thrift_controller::request_stop_server() {
 }
 
 future<> thrift_controller::do_stop_server() {
-    return do_with(std::move(_server), [this] (std::unique_ptr<distributed<thrift_server>>& tserver) {
+    return do_with(std::move(_server), [] (std::unique_ptr<distributed<thrift_server>>& tserver) {
         if (tserver) {
             return tserver->stop().then([] {
                 clogger.info("Thrift server stopped");

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -255,7 +255,7 @@ public:
     }
 
     void get(thrift_fn::function<void(ColumnOrSuperColumn const& _return)> cob, thrift_fn::function<void(::apache::thrift::TDelayedException* _throw)> exn_cob, const std::string& key, const ColumnPath& column_path, const ConsistencyLevel::type consistency_level) {
-        return get_slice([cob = std::move(cob), &column_path](auto&& results) {
+        return get_slice([cob = std::move(cob)](auto&& results) {
             if (results.empty()) {
                 throw NotFoundException();
             }

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -260,8 +260,8 @@ thrift_server::do_accepts(int which, bool keepalive, int num_attempts) {
             fd.set_keepalive(keepalive);
             // Future is waited on indirectly in `stop()` (via `_stop_gate`).
             (void)with_gate(_stop_gate, [&, this] {
-                return do_with(connection(*this, std::move(fd), addr), [this] (auto& conn) {
-                    return conn.process().then_wrapped([this, &conn] (future<> f) {
+                return do_with(connection(*this, std::move(fd), addr), [] (auto& conn) {
+                    return conn.process().then_wrapped([&conn] (future<> f) {
                         conn.shutdown();
                         try {
                             f.get();

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -265,7 +265,6 @@ int8_t normalize_weight(int w) {
 
 int new_ring_position_l(lua_State* l) {
     const auto weight = normalize_weight(lua_tointeger(l, 1));
-    const auto n = lua_gettop(l);
 
     const auto& s = get_schema_l(l);
 
@@ -374,7 +373,6 @@ int position_in_partition_index_l(lua_State* l) {
 
 int new_position_in_partition_l(lua_State* l) {
     const auto weight = normalize_weight(lua_tointeger(l, 1));
-    const auto n = lua_gettop(l);
 
     std::optional<clustering_key> ck;
 
@@ -445,7 +443,6 @@ int partition_start_index_l(lua_State* l) {
     auto field = lua_tostring(l, 2);
     auto& ps = pop_userdata_as_ref<partition_start>(l, 1);
     lua_pop(l, 2);
-    auto& s = get_schema_l(l);
     if (strcmp(field, "key") == 0) {
         push_userdata<partition_key>(l, ps.key().key());
         return 1;
@@ -954,7 +951,7 @@ public:
     json_writer(const schema& s) : _writer(s)
     { }
     static int null_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.writer().Null();
         });
     }
@@ -981,7 +978,7 @@ public:
         });
     }
     static int start_object_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.writer().StartObject();
         });
     }
@@ -993,22 +990,22 @@ public:
         });
     }
     static int end_object_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.writer().EndObject();
         });
     }
     static int start_array_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.writer().StartArray();
         });
     }
     static int end_array_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.writer().EndArray();
         });
     }
     static int start_stream_l(lua_State* l) {
-        return invoke(l, __FUNCTION__, LUA_TNIL, [l] (json_writer& w) {
+        return invoke(l, __FUNCTION__, LUA_TNIL, [] (json_writer& w) {
             w._writer.start_stream();
         });
     }

--- a/utils/bptree.hh
+++ b/utils/bptree.hh
@@ -485,8 +485,8 @@ public:
     void clear_and_dispose(Func&& disp) noexcept {
         if (_root != nullptr) {
             _root->clear(
-                [this, &disp] (data* d) noexcept { data::destroy(*d, disp); },
-                [this] (node* n) noexcept { node::destroy(*n); }
+                [&disp] (data* d) noexcept { data::destroy(*d, disp); },
+                [] (node* n) noexcept { node::destroy(*n); }
             );
 
             node::destroy(*_root);

--- a/utils/compact-radix-tree.hh
+++ b/utils/compact-radix-tree.hh
@@ -1389,7 +1389,6 @@ private:
 
     template <typename FN, typename Cloner>
     static std::exception_ptr copy_slots(const node_head& h, const T* slots, unsigned nr, unsigned depth, auto& into, FN&& node_index_of, Cloner&& cloner) noexcept {
-        unsigned count = 0;
         for (unsigned i = 0; i < nr; i++) {
             node_index_t ni = node_index_of(i);
             if (ni != unused_node_index) {
@@ -1405,7 +1404,6 @@ private:
 
     template <typename FN, typename Cloner>
     static std::exception_ptr copy_slots(const node_head& h, const node_head_ptr* slots, unsigned nr, unsigned depth, auto& into, FN&& node_index_of, Cloner&& cloner) noexcept {
-        unsigned count = 0;
         for (unsigned i = 0; i < nr; i++) {
             node_index_t ni = node_index_of(i);
             if (ni != unused_node_index) {


### PR DESCRIPTION
these warnings are found by Clang-17 after removing `-Wno-unused-lambda-capture` and `-Wno-unused-variable` from the list of disabled warnings in `configure.py`.