### PR TITLE
features: Enable persisted features on all shards

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3284,9 +3284,11 @@ future<> system_keyspace::enable_features_on_startup(sharded<gms::feature_servic
             }
         }
         if (is_registered_feat) {
-            // `gms::feature::enable` should be run within a seastar thread context
-            co_await seastar::async([&local_feat_srv, f] {
-                local_feat_srv.enable(sstring(f));
+            co_await feat.invoke_on_all([f] (auto& srv) -> future<> {
+                // `gms::feature::enable` should be run within a seastar thread context
+                co_await seastar::async([&srv, f] {
+                    srv.enable(sstring(f));
+                });
             });
         }
         // If a feature is not in `registered_features` but still in `known_features` list


### PR DESCRIPTION
Commit 1365e2f13e3 (gms: feature_service: re-enable features on node startup) re-enabled features on feature service very early, so that on boot a node sees its "correct" features state before it starts loading system tables and replaying commitlog.

However, checking features happens on all shards independently, so re-enabling should also happen on all shards.

One faced problem is in extract_scylla_specific_keyspace_info(). This helper is used when loading non-system keyspace to read scylla-specific keyspace options. The helper is called on all shards and on all-but-zero it evaluates the checked SCYLLA_KEYSPACES feature to false leaving the specific data empty. As the result, different shards have different view of keyspaces' configuration.