### PR TITLE
test/pylib: handle ScyllaCluster start failure

### DIFF
--- a/test.py
+++ b/test.py
@@ -914,11 +914,12 @@ class TopologyTest(PythonTest):
                 await manager.start()
                 self.success = await run_test(self, options)
             except Exception as e:
-                self.server_log = manager.cluster.read_server_log()
-                self.server_log_filename = manager.cluster.server_log_filename()
                 if manager.is_before_test_ok is False:
-                    print("Test {} pre-check failed: {}".format(self.name, str(e)))
-                    print("Server log of the first server:\n{}".format(self.server_log))
+                    if hasattr(manager, 'cluster'):
+                        self.server_log = manager.cluster.read_server_log()
+                        self.server_log_filename = manager.cluster.server_log_filename()
+                        print("Test {} pre-check failed: {}".format(self.name, str(e)))
+                        print("Server log of the first server:\n{}".format(self.server_log))
                     # Don't try to continue if the cluster is broken
                     raise
             manager.logger.info("Test %s %s", self.uname, "succeeded" if self.success else "failed ")

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -902,14 +902,15 @@ class ScyllaClusterManager:
         if hasattr(self, "site"):
             await self.site.stop()
             del self.site
-        if not self.cluster.is_dirty:
-            self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
-            await self.clusters.put(self.cluster, is_dirty=False)
-        else:
-            self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
-                            self.cluster, self.test_uname)
-            await self.clusters.put(self.cluster, is_dirty=True)
-        del self.cluster
+        if hasattr(self, "cluster"):
+            if not self.cluster.is_dirty:
+                self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
+                await self.clusters.put(self.cluster, is_dirty=False)
+            else:
+                self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
+                                self.cluster, self.test_uname)
+                await self.clusters.put(self.cluster, is_dirty=True)
+            del self.cluster
         if os.path.exists(self.manager_dir):
             shutil.rmtree(self.manager_dir)
         self.is_running = False


### PR DESCRIPTION
If ScyllaCluster fails to initialize don't try to get its logs and don't try to stop it.