### PR TITLE
materialized views: verify CLUSTERING ORDER BY clause

### DIFF
--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -879,7 +879,7 @@ SEASTAR_TEST_CASE(test_static_data) {
     return do_with_cql_env_thread([] (auto& e) {
         e.execute_cql("create table  ab ( a int, b int , c int static , primary key(a,b)) with clustering order by (b asc);").get();
         e.execute_cql("create materialized view ba as select a ,b from ab "
-                       "where a is not null and b is not null primary key (b,a) with clustering order by (b asc);").get();
+                       "where a is not null and b is not null primary key (b,a) with clustering order by (a asc);").get();
 
         e.execute_cql("insert into ab (a, b) values (1, 2);").get();
         auto msg = e.execute_cql("select a, b from ab where a = 1;").get0();


### PR DESCRIPTION
Cassandra is very strict in the CLUSTERING ORDER BY clause which it allows when creating a materialized view - if it appears, it must list all the clustering columns of the view. Scylla is less strict - a subset of the clustering columns may be specified. But Scylla was *too* lenient - a user could specify non-clustering columns and even non-existent columns and Scylla would not fail the MV creation. This patch fixes that - with it MV creation fails if anything besides clustering columns are listed on CLUSTERING ORDER BY.

An xfailing test we had for this case no longer fails after this patch so its xfail mark is removed. We also add a few more corner cases to the tests.

Fixes #10767