### PR TITLE
test/perf: mark output_writer::~output_writer() as virtual

### DIFF
--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -219,6 +219,7 @@ using stats_values = std::tuple<
 
 
 struct output_writer {
+    virtual ~output_writer() = default;
     virtual void write_test_group(const test_group& group, const dataset& ds, bool running) = 0;
 
     virtual void write_dataset_population(const dataset& ds) = 0;


### PR DESCRIPTION
as an abstract base class `output_writer` is inherited by both `json_output_writer` and `text_output_writer`. and `output_manager` manages the lifecycles of used writers using
`std::unique_ptr<output_writer>`.

before this change, the dtor of `output_writer` is not marked as virtual, so when its dtor is invoked, what gets called is the base class's dtor. but the dtor of `json_output_writer` is non-trivial in the sense that this class is aggregated by a bunch of member variables. if we don't invoke its dtor when destroying this object, leakage is expected.

so, in this change, the dtor of `output_writer` is marked as virtual, this makes all of its derived classes' dtor virtual. and the right dtor is always called.

test/perf is only designed for testing, and not used in production, also, this feature was recently integrated into scylla executable in 228ccdc1c797ac366430ec04f9a9c0e01b9b95b6.

so there is no need to backport this change.

change should also silence the warning from Clang 17:

```
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:100:2: error: delete called on 'output_writer' that is abstract but has non-virtual destructor [-Werror,-Wdelete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:405:4: note: in instantiation of member function 'std::default_delete<output_writer>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/stl_construct.h:88:15: note: in instantiation of member function 'std::unique_ptr<output_writer>::~unique_ptr' requested here
        __location->~_Tp();
                     ^
```