### PR TITLE
Get compaction history without using qctx

### DIFF
--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -154,7 +154,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
         std::function<future<>(output_stream<char>&&)> f = [](output_stream<char>&& s) {
             return do_with(output_stream<char>(std::move(s)), true, [] (output_stream<char>& s, bool& first){
                 return s.write("[").then([&s, &first] {
-                    return db::system_keyspace::get_compaction_history([&s, &first](const db::system_keyspace::compaction_history_entry& entry) mutable {
+                    return db::system_keyspace::get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable {
                         cm::history h;
                         h.id = entry.id.to_sstring();
                         h.ks = std::move(entry.ks);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -361,6 +361,14 @@ future<> compaction_manager::task::update_history(compaction::table_state& t, co
     }
 }
 
+future<> compaction_manager::get_compaction_history(compaction_history_consumer&& f) {
+    if (!_sys_ks) {
+        return make_ready_future<>();
+    }
+
+    return _sys_ks->get_compaction_history(std::move(f)).finally([s = _sys_ks] {});
+}
+
 class compaction_manager::major_compaction_task : public compaction_manager::task {
 public:
     major_compaction_task(compaction_manager& mgr, compaction::table_state* t)

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -41,6 +41,7 @@
 
 namespace db {
 class system_keyspace;
+class compaction_history_entry;
 }
 
 class compacting_sstable_registration;
@@ -421,6 +422,9 @@ public:
     // The compaction manager is still alive after drain but it will not accept new compactions
     // unless it is moved back to enabled state.
     future<> drain();
+
+    using compaction_history_consumer = noncopyable_function<future<>(const db::compaction_history_entry&)>;
+    future<> get_compaction_history(compaction_history_consumer&& f);
 
     // Submit a table to be compacted.
     void submit(compaction::table_state& t);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2982,9 +2982,9 @@ future<> system_keyspace::update_compaction_history(utils::UUID uuid, sstring ks
 
 future<> system_keyspace::get_compaction_history(compaction_history_consumer&& f) {
     return do_with(compaction_history_consumer(std::move(f)),
-            [](compaction_history_consumer& consumer) mutable {
+            [this](compaction_history_consumer& consumer) mutable {
         sstring req = format("SELECT * from system.{}", COMPACTION_HISTORY);
-        return qctx->qp().query_internal(req, [&consumer] (const cql3::untyped_result_set::row& row) mutable {
+        return _qp.local().query_internal(req, [&consumer] (const cql3::untyped_result_set::row& row) mutable {
             compaction_history_entry entry;
             entry.id = row.get_as<utils::UUID>("id");
             entry.ks = row.get_as<sstring>("keyspace_name");

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -89,6 +89,18 @@ public:
     virtual bool contains_keyspace(std::string_view) = 0;
 };
 
+struct compaction_history_entry {
+    utils::UUID id;
+    sstring ks;
+    sstring cf;
+    int64_t compacted_at = 0;
+    int64_t bytes_in = 0;
+    int64_t bytes_out = 0;
+    // Key: number of rows merged
+    // Value: counter
+    std::unordered_map<int32_t, int64_t> rows_merged;
+};
+
 class system_keyspace : public seastar::peering_sharded_service<system_keyspace>, public seastar::async_sharded_service<system_keyspace> {
     sharded<cql3::query_processor>& _qp;
     sharded<replica::database>& _db;
@@ -295,18 +307,6 @@ public:
         COMPLETED,
         IN_PROGRESS,
         DECOMMISSIONED
-    };
-
-    struct compaction_history_entry {
-        utils::UUID id;
-        sstring ks;
-        sstring cf;
-        int64_t compacted_at = 0;
-        int64_t bytes_in = 0;
-        int64_t bytes_out = 0;
-        // Key: number of rows merged
-        // Value: counter
-        std::unordered_map<int32_t, int64_t> rows_merged;
     };
 
     future<> update_compaction_history(utils::UUID uuid, sstring ksname, sstring cfname, int64_t compacted_at, int64_t bytes_in, int64_t bytes_out,

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -312,7 +312,7 @@ public:
     future<> update_compaction_history(utils::UUID uuid, sstring ksname, sstring cfname, int64_t compacted_at, int64_t bytes_in, int64_t bytes_out,
                                        std::unordered_map<int32_t, int64_t> rows_merged);
     using compaction_history_consumer = noncopyable_function<future<>(const compaction_history_entry&)>;
-    static future<> get_compaction_history(compaction_history_consumer&& f);
+    future<> get_compaction_history(compaction_history_consumer&& f);
 
     struct repair_history_entry {
         tasks::task_id id;


### PR DESCRIPTION
There are two methods to mess with compaction history -- update and get. The former had been patched to use local system-keyspace instance by 907fd2d3 (system_keyspace: De-static compaction history update) now it's time for the latter (spoiler: it's only used by the API handler)