### PR TITLE
api: move get_and_update_ttl to task manager api

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -175,7 +175,31 @@
             ]
          }
       ]
-    }
+     },
+     {
+         "path":"/task_manager/ttl",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Set ttl in seconds and get last value",
+               "type":"long",
+               "nickname":"get_and_update_ttl",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"ttl",
+                     "description":"The number of seconds for which the tasks will be kept in memory after it finishes",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"long",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+     }
     ],
     "models":{
        "task_stats" :{

--- a/api/api-doc/task_manager_test.json
+++ b/api/api-doc/task_manager_test.json
@@ -148,30 +148,6 @@
                 ]
              }
           ]
-       },
-       {
-         "path":"/task_manager_test/ttl",
-         "operations":[
-            {
-               "method":"POST",
-               "summary":"Set ttl in seconds and get last value",
-               "type":"long",
-               "nickname":"get_and_update_ttl",
-               "produces":[
-                  "application/json"
-               ],
-               "parameters":[
-                  {
-                     "name":"ttl",
-                     "description":"The number of seconds for which the tasks will be kept in memory after it finishes",
-                     "required":true,
-                     "allowMultiple":false,
-                     "type":"long",
-                     "paramType":"query"
-                  }
-               ]
-            }
-         ]
-      }
+       }
     ]
  }

--- a/api/api.cc
+++ b/api/api.cc
@@ -259,25 +259,25 @@ future<> set_server_done(http_context& ctx) {
     });
 }
 
-future<> set_server_task_manager(http_context& ctx) {
+future<> set_server_task_manager(http_context& ctx, lw_shared_ptr<db::config> cfg) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx](routes& r) {
+    return ctx.http_server.set_routes([rb, &ctx, &cfg = *cfg](routes& r) {
         rb->register_function(r, "task_manager",
                 "The task manager API");
-        set_task_manager(ctx, r);
+        set_task_manager(ctx, r, cfg);
     });
 }
 
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
-future<> set_server_task_manager_test(http_context& ctx, lw_shared_ptr<db::config> cfg) {
+future<> set_server_task_manager_test(http_context& ctx) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx, &cfg = *cfg](routes& r) mutable {
+    return ctx.http_server.set_routes([rb, &ctx](routes& r) mutable {
         rb->register_function(r, "task_manager_test",
                 "The task manager test API");
-        set_task_manager_test(ctx, r, cfg);
+        set_task_manager_test(ctx, r);
     });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -115,7 +115,7 @@ future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g);
 future<> set_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
-future<> set_server_task_manager(http_context& ctx);
-future<> set_server_task_manager_test(http_context& ctx, lw_shared_ptr<db::config> cfg);
+future<> set_server_task_manager(http_context& ctx, lw_shared_ptr<db::config> cfg);
+future<> set_server_task_manager_test(http_context& ctx);
 
 }

--- a/api/task_manager.hh
+++ b/api/task_manager.hh
@@ -9,9 +9,10 @@
 #pragma once
 
 #include "api.hh"
+#include "db/config.hh"
 
 namespace api {
 
-void set_task_manager(http_context& ctx, routes& r);
+void set_task_manager(http_context& ctx, routes& r, db::config& cfg);
 
 }

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -19,7 +19,7 @@ namespace api {
 namespace tmt = httpd::task_manager_test_json;
 using namespace json;
 
-void set_task_manager_test(http_context& ctx, routes& r, db::config& cfg) {
+void set_task_manager_test(http_context& ctx, routes& r) {
     tmt::register_test_module.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
         co_await ctx.tm.invoke_on_all([] (tasks::task_manager& tm) {
             auto m = make_shared<tasks::test_module>(tm);
@@ -93,12 +93,6 @@ void set_task_manager_test(http_context& ctx, routes& r, db::config& cfg) {
             return make_ready_future<>();
         });
         co_return json_void();
-    });
-
-    tmt::get_and_update_ttl.set(r, [&cfg] (std::unique_ptr<request> req) -> future<json::json_return_type> {
-        uint32_t ttl = cfg.task_ttl_seconds();
-        co_await cfg.task_ttl_seconds.set_value_on_all_shards(req->query_parameters["ttl"], utils::config_file::config_source::API);
-        co_return json::json_return_type(ttl);
     });
 }
 

--- a/api/task_manager_test.hh
+++ b/api/task_manager_test.hh
@@ -11,11 +11,10 @@
 #pragma once
 
 #include "api.hh"
-#include "db/config.hh"
 
 namespace api {
 
-void set_task_manager_test(http_context& ctx, routes& r, db::config& cfg);
+void set_task_manager_test(http_context& ctx, routes& r);
 
 }
 

--- a/main.cc
+++ b/main.cc
@@ -1419,9 +1419,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_repair(ctx).get();
             });
 
-            api::set_server_task_manager(ctx).get();
+            api::set_server_task_manager(ctx, cfg).get();
 #ifndef SCYLLA_BUILD_MODE_RELEASE
-            api::set_server_task_manager_test(ctx, cfg).get();
+            api::set_server_task_manager_test(ctx).get();
 #endif
             supervisor::notify("starting sstables loader");
             sst_loader.start(std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(messaging)).get();

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -72,11 +72,11 @@ def new_test_task(rest_api, args):
 
 @contextmanager
 def set_tmp_task_ttl(rest_api, seconds):
-    resp = rest_api.send("POST", "task_manager_test/ttl", { "ttl" : seconds })
+    resp = rest_api.send("POST", "task_manager/ttl", { "ttl" : seconds })
     resp.raise_for_status()
     old_ttl = resp.json()
     try:
         yield old_ttl
     finally:
-        resp = rest_api.send("POST", "task_manager_test/ttl", { "ttl" : old_ttl })
+        resp = rest_api.send("POST", "task_manager/ttl", { "ttl" : old_ttl })
         resp.raise_for_status()


### PR DESCRIPTION
Task ttl can be set with task manager test api, which is disabled in release mode.

Move get_and_update_ttl from task manager test api to task manager api, so that it can be used in release mode.