### PR TITLE
build: add wasm compilation target for rust

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -106,6 +106,7 @@ fedora_packages=(
     rust
     cargo
     rapidxml-devel
+    rust-std-static-wasm32-wasi
 )
 
 # lld is not available on s390x, see


### PR DESCRIPTION
In the future, when testing WASM UDFs, we will only store the Rust source codes of them, and compile them to WASM. To be able to do that, we need rust standard library for the wasm32-wasi target, which is available as an RPM called rust-std-static-wasm32-wasi.