### PR TITLE
Move service levels information to `system_distributed_everywhere` keyspace

### DIFF
--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "bytes.hh"
+#include "db/consistency_level_type.hh"
 #include "schema/schema_fwd.hh"
 #include "service/qos/qos_common.hh"
 #include "utils/UUID.hh"
@@ -44,6 +45,7 @@ public:
 
     static constexpr auto VIEW_BUILD_STATUS = "view_build_status";
     static constexpr auto SERVICE_LEVELS = "service_levels";
+    static constexpr auto SERVICE_LEVELS_V2 = "service_levels_v2";
 
     /* Nodes use this table to communicate new CDC stream generations to other nodes. */
     static constexpr auto CDC_TOPOLOGY_DESCRIPTION = "cdc_generation_descriptions";
@@ -117,6 +119,19 @@ public:
     future<qos::service_levels_info> get_service_level(sstring service_level_name) const;
     future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const;
     future<> drop_service_level(sstring service_level_name) const;
+
+    future<> migrate_service_levels_to_v2() const;
+
+    future<qos::service_levels_info> get_service_levels_v2() const;
+    future<qos::service_levels_info> get_service_level_v2(sstring service_level_name) const;
+    future<> set_service_level_v2(sstring service_level_name, qos::service_level_options slo) const;
+    future<> drop_service_level_v2(sstring service_level_name) const;
+
+private:
+    future<qos::service_levels_info> internal_get_service_levels(sstring ks, sstring table, db::consistency_level cl) const;
+    future<qos::service_levels_info> internal_get_service_level(sstring ks, sstring table, sstring service_level_name, db::consistency_level cl) const;
+    future<> internal_set_service_level(sstring ks, sstring table, sstring service_level_name, qos::service_level_options slo, db::consistency_level cl) const;
+    future<> internal_drop_service_level(sstring ks, sstring table, sstring service_level_name, db::consistency_level cl) const;
 };
 
 }

--- a/docs/dev/service_levels.md
+++ b/docs/dev/service_levels.md
@@ -34,7 +34,14 @@ SELECT * FROM  system_auth.role_attributes WHERE role='r' and attribute_name='se
     service_level text PRIMARY KEY,
     timeout duration,
     workload_type text)
+
+    CREATE TABLE system_distributed_everywhere.service_levels_v2 (
+    service_level text PRIMARY KEY,
+    timeout duration,
+    workload_type text)
 ```
+
+The table `system_distributed.service_levels` is the old one and should not be queried, since it may contain outdated configuration. Instead, the configuration is stored in `system_distributed_everywhere.service_levels_v2`.
 
 The table is used to store and distribute the service levels configuration.
 The table column names meanings are:
@@ -43,7 +50,7 @@ The table column names meanings are:
 *workload_type* - type of workload declared for this service level (unspecified, interactive or batch)
 
 ```
-select * from system_distributed.service_levels ;
+select * from system_distributed_everywhere.service_levels_v2 ;
 
  service_level | timeout | workload_type
 ---------------+---------+---------------

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -111,6 +111,7 @@ public:
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
     gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
+    gms::feature service_levels_table_v2 { *this, "SERVICE_LEVELS_TABLE_V2"sv };
 
 public:
 

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -49,10 +49,18 @@ class service_level_controller : public peering_sharded_service<service_level_co
 public:
     class service_level_distributed_data_accessor {
     public:
+        virtual future<> init() = 0;
+        virtual future<> stop() = 0;
+
+        // virtual bool is_data_source_ready() const = 0;
         virtual future<qos::service_levels_info> get_service_levels() const = 0;
         virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const = 0;
         virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const = 0;
         virtual future<> drop_service_level(sstring service_level_name) const = 0;
+
+        // virtual bool is_v2_upgraded() const = 0;
+        // virtual future<> start_upgrade_to_v2() const = 0;
+        // virtual future<> end_upgrade_to_v2() = 0;
     };
     using service_level_distributed_data_accessor_ptr = ::shared_ptr<service_level_distributed_data_accessor>;
 
@@ -93,7 +101,7 @@ public:
      */
     future<> start();
 
-    void set_distributed_data_accessor(service_level_distributed_data_accessor_ptr sl_data_accessor);
+    future<> set_distributed_data_accessor(service_level_distributed_data_accessor_ptr sl_data_accessor);
 
     /**
      *  Adds a service level configuration if it doesn't exists, and updates

--- a/service/qos/standard_service_level_distributed_data_accessor.cc
+++ b/service/qos/standard_service_level_distributed_data_accessor.cc
@@ -8,27 +8,92 @@
 
 #include "standard_service_level_distributed_data_accessor.hh"
 #include "db/system_distributed_keyspace.hh"
+#include "db/system_keyspace.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "gms/feature_service.hh"
 
 namespace qos {
 
-standard_service_level_distributed_data_accessor::standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks):
-_sys_dist_ks(sys_dist_ks) {
+static logging::logger dda_logger("service_level_distributed_data_accessor");
+
+static const sstring SERVICE_LEVEL_UPGRADE_KEY = "service_level_upgrade_status";
+static const sstring SL_UPGRADE_DONE_VALUE = "sl_upgraded_v2";
+
+standard_service_level_distributed_data_accessor::standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks, gms::feature_service& feat) 
+: _sys_dist_ks(sys_dist_ks)
+, _feat(feat)
+, _v2_upgraded(false) {}
+
+future<> standard_service_level_distributed_data_accessor::init() {
+    auto upgrade_status = co_await db::system_keyspace::get_scylla_local_param(SERVICE_LEVEL_UPGRADE_KEY);
+    
+    if (upgrade_status && *upgrade_status == SL_UPGRADE_DONE_VALUE) {
+        _v2_upgraded = true;
+    } else {
+        if (_data_accessor_upgrade.available()) {
+            _data_accessor_upgrade = upgrade_loop();
+        }
+    }
+}
+
+future<> standard_service_level_distributed_data_accessor::stop() {
+    if (!_data_accessor_upgrade_aborter.abort_requested()) {
+        _data_accessor_upgrade_aborter.request_abort();
+    }
+
+    return std::exchange(_data_accessor_upgrade, make_ready_future<>()).then_wrapped([] (future<> f) {
+        try {
+            f.get();
+        } catch (const broken_semaphore& ignored) {
+        } catch (const sleep_aborted& ignored) {
+        } catch (const exceptions::unavailable_exception& ignored) {
+        } catch (const exceptions::read_timeout_exception& ignored) {
+        }
+    });
 }
 
 future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_levels() const {
-    return _sys_dist_ks.get_service_levels();
+    return (_v2_upgraded) ? _sys_dist_ks.get_service_levels_v2() : _sys_dist_ks.get_service_levels();
 }
 
 future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_level(sstring service_level_name) const {
-    return _sys_dist_ks.get_service_level(service_level_name);
+    return (_v2_upgraded) ? _sys_dist_ks.get_service_level_v2(service_level_name) : _sys_dist_ks.get_service_level(service_level_name);
 }
 
 future<> standard_service_level_distributed_data_accessor::set_service_level(sstring service_level_name, qos::service_level_options slo) const {
-    return _sys_dist_ks.set_service_level(service_level_name, slo);
+    if (!_v2_upgraded) {
+        co_await _sys_dist_ks.set_service_level(service_level_name, slo);
+    }
+    co_await _sys_dist_ks.set_service_level_v2(service_level_name, slo);
 }
 
 future<> standard_service_level_distributed_data_accessor::drop_service_level(sstring service_level_name) const {
-    return _sys_dist_ks.drop_service_level(service_level_name);
+    if (!_v2_upgraded) {
+        co_await _sys_dist_ks.drop_service_level(service_level_name);
+    }
+    co_await _sys_dist_ks.drop_service_level_v2(service_level_name);
+}
+
+future<> standard_service_level_distributed_data_accessor::upgrade_loop() {
+    return seastar::async([this] {
+        static std::chrono::duration<float> wait_time = std::chrono::seconds(10);
+
+        while (!_sys_dist_ks.started() || !_feat.service_levels_table_v2) {
+            try {
+                sleep_abortable<steady_clock_type>(
+                    std::chrono::duration_cast<steady_clock_type::duration>(wait_time),
+                    _data_accessor_upgrade_aborter
+                ).get();
+            } catch (const sleep_aborted& e) {
+                dda_logger.info("update_from_distributed_data: upgrade waiting loop aborted");
+                return;
+            }
+        }
+
+        _sys_dist_ks.migrate_service_levels_to_v2().get();
+        db::system_keyspace::set_scylla_local_param(SERVICE_LEVEL_UPGRADE_KEY, SL_UPGRADE_DONE_VALUE).get();
+        _v2_upgraded = true;
+    });
 }
 
 }

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -15,16 +15,33 @@
 namespace db {
     class system_distributed_keyspace;
 }
+namespace gms {
+    class feature_service;
+}
 namespace qos {
+
 class standard_service_level_distributed_data_accessor : public service_level_controller::service_level_distributed_data_accessor,
          public ::enable_shared_from_this<standard_service_level_distributed_data_accessor> {
-private:
+    using service_level_controller_dda_ptr = ::shared_ptr<service_level_controller::service_level_distributed_data_accessor>;
+
     db::system_distributed_keyspace& _sys_dist_ks;
+    gms::feature_service& _feat;
+    bool _v2_upgraded;
+
+    future<> _data_accessor_upgrade = make_ready_future();
+    abort_source _data_accessor_upgrade_aborter;
 public:
-    standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks);
+    standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks, gms::feature_service& feat);
+    virtual future<> init() override;
+    virtual future<> stop() override;
+    
     virtual future<qos::service_levels_info> get_service_levels() const override;
     virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const override;
     virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const override;
     virtual future<> drop_service_level(sstring service_level_name) const override;
+
+private:
+    future<> upgrade_loop();
 };
+
 }

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -233,14 +233,14 @@ SEASTAR_TEST_CASE(test_alter_with_timeouts) {
         // Avoid reading from memtables, which does not check timeouts due to being too fast
         e.db().invoke_on_all([] (replica::database& db) { return db.flush_all_memtables(); }).get();
 
-	    auto msg = cquery_nofail(e, "SELECT timeout FROM system_distributed.service_levels");
+	    auto msg = cquery_nofail(e, "SELECT timeout FROM system_distributed_everywhere.service_levels_v2");
         assert_that(msg).is_rows().with_rows({{
             duration_type->from_string("5ms")
         }});
 
         cquery_nofail(e, "ALTER SERVICE LEVEL sl WITH timeout = 35s");
 
-	    msg = cquery_nofail(e, "SELECT timeout FROM system_distributed.service_levels WHERE service_level = 'sl'");
+	    msg = cquery_nofail(e, "SELECT timeout FROM system_distributed_everywhere.service_levels_v2 WHERE service_level = 'sl'");
         assert_that(msg).is_rows().with_rows({{
             duration_type->from_string("35s")
         }});
@@ -328,7 +328,7 @@ SEASTAR_TEST_CASE(test_alter_with_workload_type) {
         cquery_nofail(e, "CREATE SERVICE LEVEL sl");
         cquery_nofail(e, "ATTACH SERVICE LEVEL sl TO user1");
 
-	    auto msg = cquery_nofail(e, "SELECT workload_type FROM system_distributed.service_levels");
+	    auto msg = cquery_nofail(e, "SELECT workload_type FROM system_distributed_everywhere.service_levels_v2");
         assert_that(msg).is_rows().with_rows({{
             {}
         }});

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -850,7 +850,7 @@ public:
             sl_controller.invoke_on_all([&sys_dist_ks, &sl_controller] (qos::service_level_controller& service) {
                 qos::service_level_controller::service_level_distributed_data_accessor_ptr service_level_data_accessor =
                         ::static_pointer_cast<qos::service_level_controller::service_level_distributed_data_accessor>(
-                                make_shared<qos::unit_test_service_levels_accessor>(sl_controller,sys_dist_ks));
+                                make_shared<qos::unit_test_service_levels_accessor>(sl_controller,sys_dist_ks,true));
                 return service.set_distributed_data_accessor(std::move(service_level_data_accessor));
             }).get();
 

--- a/test/lib/unit_test_service_levels_accessor.hh
+++ b/test/lib/unit_test_service_levels_accessor.hh
@@ -6,9 +6,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "seastar/core/future.hh"
 #include "service/qos/service_level_controller.hh"
 #include "service/qos/qos_common.hh"
 #include "db/system_distributed_keyspace.hh"
+#include <seastar/core/sleep.hh>
 #pragma once
 
 namespace qos {
@@ -19,29 +21,47 @@ namespace qos {
  *  of this class over the standard implementation is that it makes sure that updates are
  *  Immediately propagated to the underlying service level controller.
  */
-class unit_test_service_levels_accessor : public service_level_controller::service_level_distributed_data_accessor {
+
+class unit_test_service_levels_accessor final : public service_level_controller::service_level_distributed_data_accessor {
         sharded<service_level_controller> &_sl_controller;
         sharded<db::system_distributed_keyspace> &_sys_dist_ks;
+
+        bool _v2_upgraded;
 public:
-        unit_test_service_levels_accessor(sharded<service_level_controller>& sl_controller, sharded<db::system_distributed_keyspace> &sys_dist_ks)
+        unit_test_service_levels_accessor(sharded<service_level_controller>& sl_controller, sharded<db::system_distributed_keyspace> &sys_dist_ks, bool v2_upgraded)
                 : _sl_controller(sl_controller)
                 , _sys_dist_ks(sys_dist_ks)
+                , _v2_upgraded(v2_upgraded)
         {}
+
+        virtual future<> init() {
+            return make_ready_future<>();
+        }
+        virtual future<> stop() {
+            return make_ready_future<>();
+        }
         virtual future<qos::service_levels_info> get_service_levels() const {
-            return _sys_dist_ks.local().get_service_levels();
+            return (_v2_upgraded) ? _sys_dist_ks.local().get_service_levels_v2() : _sys_dist_ks.local().get_service_levels();
         }
         virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const {
-            return _sys_dist_ks.local().get_service_level(service_level_name);
+            return (_v2_upgraded) ? _sys_dist_ks.local().get_service_level_v2(service_level_name) :  _sys_dist_ks.local().get_service_level(service_level_name);
         }
         virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const {
-            return _sys_dist_ks.local().set_service_level(service_level_name, slo).then([this] () {
-                return _sl_controller.invoke_on_all(&service_level_controller::update_service_levels_from_distributed_data);
+            future<> v1 = (_v2_upgraded) ? make_ready_future<>() : _sys_dist_ks.local().set_service_level(service_level_name, slo);
+            
+            return v1.then([this, service_level_name, slo] () {
+                return _sys_dist_ks.local().set_service_level_v2(service_level_name, slo).then([this] () {
+                    return _sl_controller.invoke_on_all(&service_level_controller::update_service_levels_from_distributed_data);
+                });
             });
-
         }
         virtual future<> drop_service_level(sstring service_level_name) const {
-            return _sys_dist_ks.local().drop_service_level(service_level_name).then([this] () {
-                return _sl_controller.invoke_on_all(&service_level_controller::update_service_levels_from_distributed_data);
+            future<> v1 = (_v2_upgraded) ? make_ready_future<>() : _sys_dist_ks.local().drop_service_level(service_level_name);
+
+            return v1.then([this, service_level_name] () {
+                return _sys_dist_ks.local().drop_service_level_v2(service_level_name).then([this] () {
+                    return _sl_controller.invoke_on_all(&service_level_controller::update_service_levels_from_distributed_data);
+                });
             });
         }
 };


### PR DESCRIPTION
This PR adds upgrade mechanism to change configuration table from `system_distributed.service_levels` to `system_distributed_everywhere.service_levels_v2`.

The Scylla-code part is done, but this is draft PR because I'm writing test to check if upgrade works correctly during rolling upgrade (dtests).

The upgrade is protected under `SERVICE_LEVELS_TABLE_V2` feature.

---

Until the upgrade can be performed, `service_level_controller`'s distributed data accessor works as follow:
- reads are done to old table (`system_distributed.service_levels`)
- writes are done to both of the tables

The upgrade process copies the data by copying local mutations of the old table and applying them locally to the new one.
After the mutations are copied, data accessor will use only V2 table.

All of the queries (both before and after upgrade) are done with consistency level `LOCAL_ONE`.

---

Fixes #12706 