### PR TITLE
build: nix: switch to non-static zstd

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -157,7 +157,7 @@ in derive ({
     xorg.libpciaccess
     xxHash
     zlib
-    zstdStatic
+    zstd
   ];
 
   JAVA8_HOME = "${pkgs.openjdk8_headless}/lib/openjdk";


### PR DESCRIPTION
When we added zstd (f14e6e73bb5), we used the static library as we used some experimental APIs. However, now the dynamic library works, so apparently the experimenal API is now standard.

Switch to the dynamic library. It doesn't improve anything, but it aligns with how we do things.