### PR TITLE
test/perf: do not brace interger with {}

### DIFF
--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1393,7 +1393,7 @@ void test_large_partition_single_key_slice(replica::column_family& cf, clustered
     run_test_case([&] { // adjacent, contained
         return test_result_vector {
             test(int_range::make({1}, {100})),
-            check_no_disk_reads(test(int_range::make_singular({100}))),
+            check_no_disk_reads(test(int_range::make_singular(100))),
         };
     });
 
@@ -1422,14 +1422,14 @@ void test_large_partition_single_key_slice(replica::column_family& cf, clustered
     run_test_case([&] { // adjacent, singular excluded
         return test_result_vector {
             test(int_range::make({0}, {100, false})),
-            test(int_range::make_singular({100})),
+            test(int_range::make_singular(100)),
         };
     });
 
     run_test_case([&] { // adjacent, singular excluded
         return test_result_vector {
             test(int_range::make({100, false}, {200})),
-            test(int_range::make_singular({100})),
+            test(int_range::make_singular(100)),
         };
     });
 
@@ -1437,7 +1437,7 @@ void test_large_partition_single_key_slice(replica::column_family& cf, clustered
         return test_result_vector {
             test(int_range::make_ending_with({100})),
             check_no_disk_reads(test(int_range::make({10}, {20}))),
-            check_no_disk_reads(test(int_range::make_singular({-1}))),
+            check_no_disk_reads(test(int_range::make_singular(-1))),
         };
     });
 
@@ -1445,8 +1445,8 @@ void test_large_partition_single_key_slice(replica::column_family& cf, clustered
         return test_result_vector {
             test(int_range::make_starting_with({100})),
             check_no_disk_reads(test(int_range::make({150}, {159}))),
-            check_no_disk_reads(test(int_range::make_singular({n_rows - 1}))),
-            check_no_disk_reads(test(int_range::make_singular({n_rows + 1}))),
+            check_no_disk_reads(test(int_range::make_singular(n_rows - 1))),
+            check_no_disk_reads(test(int_range::make_singular(n_rows + 1))),
         };
     });
 


### PR DESCRIPTION
`int_range::make_singular()` accepts a single `int` as its parameter, so there is no need to brace the paramter with `{}`. this helps to silence the warning from Clang, like:

```
/home/kefu/dev/scylladb/test/perf/perf_fast_forward.cc:1396:63: error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]
            check_no_disk_reads(test(int_range::make_singular({100}))),
                                                              ^~~~~
```