### PR TITLE
treewide: remove invalid defaulted move ctor

### DIFF
--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -26,7 +26,6 @@ class truncate_statement : public cql_statement_no_metadata {
 public:
     truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs);
     truncate_statement(const truncate_statement&);
-    truncate_statement(truncate_statement&&) = default;
 
     const sstring& keyspace() const;
 

--- a/sstables/mx/partition_reversing_data_source.cc
+++ b/sstables/mx/partition_reversing_data_source.cc
@@ -473,7 +473,6 @@ public:
     { }
 
     partition_reversing_data_source_impl(partition_reversing_data_source_impl&&) noexcept = default;
-    partition_reversing_data_source_impl& operator=(partition_reversing_data_source_impl&&) noexcept = default;
 
     virtual future<temporary_buffer<char>> get() override {
         if (!_partition_header_context) {

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -149,7 +149,6 @@ public:
         }
         return *this;
     }
-    exception_safe_class& operator=(exception_safe_class&&) = default;
 };
 
 BOOST_AUTO_TEST_CASE(tests_constructor_exception_safety) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2298,7 +2298,6 @@ private:
             , _handler(std::move(schema), std::move(permit), _queue)
             , _thread([this] { _reader.Parse(_stream, _handler); })
         { }
-        impl(impl&&) = default;
         ~impl() {
             _thread.join().get();
         }


### PR DESCRIPTION
- test/boost/chunked_vector_test: remove defaulted exception_safe_class's move ctor
- tools/scylla-sstable: remove defaulted move ctor
- sstables/mx/partition_reversing_data_source: remove defaulted move ctor
- cql3/statements/truncate_statement: remove defaulted move ctor