### PR TITLE
test: mutation_test: Fix sporadic failure due to continuity mismatch

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1082,8 +1082,8 @@ SEASTAR_TEST_CASE(test_v2_apply_monotonically_is_monotonic_on_alloc_failures) {
             auto expected_cont = mutation_partition_v2(s, expected.partition()).get_continuity(s);
 
             testlog.trace("target: {}", target);
-            testlog.trace("second: {}", target);
-            testlog.trace("expected: {}", target);
+            testlog.trace("second: {}", second);
+            testlog.trace("expected: {}", expected);
 
             auto preempt_check = [] () noexcept {
                 try {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1119,7 +1119,7 @@ SEASTAR_TEST_CASE(test_v2_apply_monotonically_is_monotonic_on_alloc_failures) {
                     }
                 });
                 apply_resume res;
-                if (m.apply_monotonically(s, std::move(m2), no_cache_tracker, app_stats, preempt_check, res, is_evictable::no) == stop_iteration::yes) {
+                if (m.apply_monotonically(s, std::move(m2), no_cache_tracker, app_stats, preempt_check, res, is_evictable::yes) == stop_iteration::yes) {
                     continuity_check.cancel();
                     seastar::memory::local_failure_injector().cancel();
                 }


### PR DESCRIPTION
In test_v2_apply_monotonically_is_monotonic_on_alloc_failures we
generate mutations with non-full continuity, so we should pass
is_evictable::yes to apply_monotonically(). Otherwise, it will assume
fully-continuous versions and not try to maintain continuity by
inserting sentinels.

This manifested in sporadic failures on continuity check.

Fixes #12882
