### PR TITLE
dist/debian: drop unused Makefile variable

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -3,7 +3,6 @@
 include /usr/share/dpkg/pkg-info.mk
 
 export PYBUILD_DISABLE=1
-jobs := $(shell echo $$DEB_BUILD_OPTIONS | sed -r "s/.*parallel=([0-9]+).*/-j\1/")
 ifneq ($(findstring housekeeping, $(DEB_BUILD_OPTIONS)),)
     install_arg := --housekeeping
 else


### PR DESCRIPTION
this change was previously reverted by
cbc005c6f5f1cea85a7542378a2896d471ef5ecc . it turns out this change was not the offending change. so let's resurrect it.

`job` was introduced back in 782ebcece4f860238abc4dbc5dc4f81fdd1f02f9, so we could consume the option specified in DEB_BUILD_OPTIONS environmental variable. but now that we always repackage the artifacts prebuilt in the relocatable package. we don't build them anymore when packaging debian packages. see
9388f3d626ce9f366f5fa16c2a683c419e427cc2 . and `job` is not passed to `ninja` anymore.

so, in this change, `job` is removed from debian/rules as well, as it is not used.