### PR TITLE
build: cmake: sync with `configure.py` (4/n)

### DIFF
--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -27,5 +27,6 @@ target_link_libraries(auth
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    cql3
     idl
     wasmtime_bindings)

--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -114,5 +114,6 @@ target_include_directories(cql3
     ${CMAKE_BINARY_DIR})
 target_link_libraries(cql3
     idl
+    wasmtime_bindings
     Seastar::seastar
     xxHash::xxhash)

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -51,14 +51,16 @@ endfunction(generate_cxxbridge)
 
 add_rust_library(rust_combined)
 
-set(cxx_header "${CMAKE_CURRENT_BINARY_DIR}/cxx.h")
+set(binding_gen_build_dir "${scylla_gen_build_dir}/rust")
+
+set(cxx_header "${binding_gen_build_dir}/cxx.h")
 add_custom_command(
   OUTPUT ${cxx_header}
   COMMAND ${CXXBRIDGE} --header --output ${cxx_header})
 generate_cxxbridge(wasmtime_bindings
   INPUT wasmtime_bindings/src/lib.rs
   INCLUDE ${cxx_header}
-  OUTPUT_DIR "${scylla_gen_build_dir}"
+  OUTPUT_DIR "${binding_gen_build_dir}"
   SOURCES wasmtime_bindings_sources)
 
 set_target_properties(Rust::rust_combined PROPERTIES
@@ -71,6 +73,6 @@ target_sources(wasmtime_bindings
     ${wasmtime_bindings_sources})
 target_include_directories(wasmtime_bindings
   INTERFACE
-    ${CMAKE_BINARY_DIR})
+    ${binding_gen_build_dir})
 target_link_libraries(wasmtime_bindings
   INTERFACE Rust::rust_combined)


### PR DESCRIPTION
- build: cmake: link cql3 against wasmtime_bindings
- build: cmake: output rust binding headers in expected dir
- build: cmake: link auth against cql3