### PR TITLE
readers/multishard: shard_reader: fast-forward created reader to current range

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -249,6 +249,8 @@ public:
             tracing::trace_state_ptr trace_state,
             mutation_reader::forwarding fwd_mr) override;
 
+    virtual const dht::partition_range* get_read_range() const override;
+
     virtual void update_read_range(lw_shared_ptr<const dht::partition_range> range) override;
 
     virtual future<> destroy_reader(stopped_reader reader) noexcept override;
@@ -348,6 +350,14 @@ flat_mutation_reader_v2 read_context::create_reader(
 
     return table.as_mutation_source().make_reader_v2(std::move(schema), rm.rparts->permit, *rm.rparts->range, *rm.rparts->slice, pc,
             std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
+}
+
+const dht::partition_range* read_context::get_read_range() const {
+    auto& rm = _readers[this_shard_id()];
+    if (rm.rparts) {
+        return rm.rparts->range.get();
+    }
+    return nullptr;
 }
 
 void read_context::update_read_range(lw_shared_ptr<const dht::partition_range> range) {

--- a/readers/multishard.hh
+++ b/readers/multishard.hh
@@ -57,6 +57,12 @@ public:
             tracing::trace_state_ptr trace_state,
             mutation_reader::forwarding fwd_mr) = 0;
 
+    /// Retrieves the read-range for the shard reader.
+    ///
+    /// That lives on the current shard. Returns nullptr if there is no
+    /// reader on the current shard.
+    virtual const dht::partition_range* get_read_range() const = 0;
+
     /// Updates the read-range of the shard reader.
     ///
     /// Gives the lifecycle-policy a chance to update its stored read-range (if

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2753,6 +2753,10 @@ flat_mutation_reader_v2 make_multishard_streaming_reader(distributed<replica::da
 
             return cf.make_streaming_reader(std::move(schema), std::move(permit), *_contexts[shard].range, slice, fwd_mr);
         }
+        virtual const dht::partition_range* get_read_range() const override {
+            const auto shard = this_shard_id();
+            return _contexts[shard].range.get();
+        }
         virtual void update_read_range(lw_shared_ptr<const dht::partition_range> range) override {
             const auto shard = this_shard_id();
             _contexts[shard].range = make_foreign(std::move(range));

--- a/test/lib/reader_lifecycle_policy.hh
+++ b/test/lib/reader_lifecycle_policy.hh
@@ -62,6 +62,11 @@ public:
         }
         return _factory_function(std::move(schema), std::move(permit), *_contexts[shard]->range, *_contexts[shard]->slice, pc, std::move(trace_state), fwd_mr);
     }
+    virtual const dht::partition_range* get_read_range() const override {
+        const auto shard = this_shard_id();
+        assert(_contexts[shard]);
+        return _contexts[shard]->range.get();
+    }
     void update_read_range(lw_shared_ptr<const dht::partition_range> range) override {
         const auto shard = this_shard_id();
         assert(_contexts[shard]);


### PR DESCRIPTION
When creating the reader, the lifecycle policy might return one that was saved on the last page and survived in the cache. This reader might have skipped some fast-forwarding ranges while sitting in the cache. To avoid using a reader reading a stale range (from the read's POV), check its read range and fast forward it if necessary.

Fixes: https://github.com/scylladb/scylladb/issues/12916