### PR TITLE
doc: add the missing information about reporting latencies to the upgrade guide 5.1 to 5.2

### DIFF
--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.1-to-5.2/metric-update-5.1-to-5.2.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.1-to-5.2/metric-update-5.1-to-5.2.rst
@@ -55,3 +55,13 @@ The following metrics are renamed in ScyllaDB 5.2
      - scylla_memory_system_unspooled_dirty_bytes
    * - scylla_memory_virtual_dirty_bytes
      - scylla_memory_unspooled_dirty_bytes
+
+Reporting Latencies
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+ScyllaDB 5.2 comes with a new approach to reporting latencies, which are reported using histograms and summaries:
+
+* Histograms are reported per node.
+* Summaries are reported per shard and contain P50, P95, and P99 latency.
+
+For more information on Prometheus histograms and summaries, see the `Prometheus documentation <https://prometheus.io/docs/practices/histograms/>`_.


### PR DESCRIPTION
Related https://github.com/scylladb/scylladb/issues/12754
This PR adds the missing information to the metrics update page of the 5.1 to 5.2 upgrade guide, as requested by @tzach: https://github.com/scylladb/scylladb/commit/bcca706ff569b17be351e2436fe5811e10a38146#commitcomment-101193460

Then approved, this PR needs to be merged to master and backported to branch-5.2.