### PR TITLE
doc: remove the incorrect information about IPs from the Restore page

### DIFF
--- a/docs/operating-scylla/procedures/backup-restore/_common/manager.rst
+++ b/docs/operating-scylla/procedures/backup-restore/_common/manager.rst
@@ -1,4 +1,4 @@
 
 .. note::
 
-   For cluster wide backup and restore, see `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_.
+   For cluster-wide backup and restore, see the `ScyllaDB Manager <https://manager.docs.scylladb.com/stable/restore/>`_ documentation.

--- a/docs/operating-scylla/procedures/backup-restore/restore.rst
+++ b/docs/operating-scylla/procedures/backup-restore/restore.rst
@@ -11,7 +11,6 @@ Restoring a keyspace from a backup requires all snapshot files of the tables, an
    The following procedure assumes data is restored to the same cluster that was backed-up:
 
    - same number of nodes
-   - same IPs
    - same token range per node
 
    The procedure restores each node using the backup file of the **same node**.


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12945

This PR removes the incorrect information and updates the link to the relevant page in the Manager docs.