### PR TITLE
headers: Refine view_update_generator.hh and around

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -8,6 +8,7 @@
 
 #include <seastar/util/defer.hh>
 #include <boost/range/adaptor/map.hpp>
+#include "replica/database.hh"
 #include "view_update_generator.hh"
 #include "service/priority_manager.hh"
 #include "utils/error_injection.hh"

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -8,12 +8,19 @@
 
 #pragma once
 
-#include "replica/database.hh"
 #include "sstables/shared_sstable.hh"
 
+#include <seastar/core/metrics_registration.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/semaphore.hh>
+
+using namespace seastar;
+
+namespace replica {
+class database;
+class table;
+}
 
 namespace db::view {
 

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/coroutine.hh>
 
 #include "consumer.hh"
+#include "replica/database.hh"
 #include "mutation/mutation_source_metadata.hh"
 #include "service/priority_manager.hh"
 #include "db/view/view_update_generator.hh"

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -31,7 +31,7 @@
 #include "db/view/view_update_checks.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include "../db/view/view_update_generator.hh"
+#include "replica/database.hh"
 #include "mutation/mutation_source_metadata.hh"
 #include "streaming/stream_mutation_fragments_cmd.hh"
 #include "consumer.hh"

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -11,6 +11,7 @@
 #include "replica/database.hh"
 #include "db/view/view_builder.hh"
 #include "db/view/view_updating_consumer.hh"
+#include "db/view/view_update_generator.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_keyspace_view_types.hh"
 #include "db/config.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -49,6 +49,7 @@
 #include "unit_test_service_levels_accessor.hh"
 #include "db/view/view_builder.hh"
 #include "db/view/node_view_update_backlog.hh"
+#include "db/view/view_update_generator.hh"
 #include "replica/distributed_loader.hh"
 // TODO: remove (#293)
 #include "message/messaging_service.hh"

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -16,7 +16,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 
-#include "db/view/view_update_generator.hh"
+#include "replica/database.hh"
 #include "transport/messages/result_message_base.hh"
 #include "cql3/query_options_fwd.hh"
 #include "cql3/values.hh"
@@ -36,6 +36,7 @@ class batchlog_manager;
 
 namespace db::view {
 class view_builder;
+class view_update_generator;
 }
 
 namespace auth {


### PR DESCRIPTION
The initial intent was to reduce the fanout of shared_sstable.hh through v.u.g.hh -> cql_test_env.hh chain, but it also resulted in some shots around v.u.g.hh -> database.hh inclusion.

By and large:
- v.u.g.hh doesn't need database.hh
- cql_test_env.hh doesn't need v.u.g.hh (and thus -- the shared_sstable.hh) but needs database.hh instead
- few other .cc files need v.u.g.hh directly as they pulled it via cql_test_env.hh before
- add forward declarations in few other places