### PR TITLE
service:forward_service: use long type instead of counter in function mocking

### DIFF
--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -34,6 +34,7 @@
 #include "service/pager/query_pagers.hh"
 #include "tracing/trace_state.hh"
 #include "tracing/tracing.hh"
+#include "types/types.hh"
 #include "utils/fb_utilities.hh"
 #include "service/storage_proxy.hh"
 
@@ -151,7 +152,12 @@ static std::vector<::shared_ptr<db::functions::aggregate_function>> get_function
     std::vector<::shared_ptr<db::functions::aggregate_function>> aggrs;
 
     auto name_as_type = [&] (const sstring& name) -> data_type {
-        return schema->get_column_definition(to_bytes(name))->type->underlying_type();
+        auto t = schema->get_column_definition(to_bytes(name))->type->underlying_type();
+
+        if (t->is_counter()) {
+            return long_type;
+        }
+        return t;
     };
 
     for (size_t i = 0; i < request.reduction_types.size(); i++) {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5340,6 +5340,36 @@ SEASTAR_TEST_CASE(test_parallelized_select_sum_group_by) {
     });
 }
 
+SEASTAR_TEST_CASE(test_parallelized_select_counter_type) {
+    return with_parallelized_aggregation_enabled_thread([](cql_test_env& e) {
+        auto& qp = e.local_qp();
+        auto stat_parallelized = qp.get_cql_stats().select_parallelized;
+
+        e.execute_cql("CREATE TABLE tbl (k int, c counter, PRIMARY KEY (k));").get();
+        e.execute_cql("UPDATE tbl SET c = c + 4 WHERE k = 0;").get();
+        e.execute_cql("UPDATE tbl SET c = c + 2 WHERE k = 1;").get();
+
+        auto msg_sum = e.execute_cql("SELECT SUM(c) FROM tbl;").get();
+        assert_that(msg_sum).is_rows().with_rows({
+            {long_type->decompose(int64_t(6))}
+        });
+        auto msg_min = e.execute_cql("SELECT MIN(c) FROM tbl;").get();
+        assert_that(msg_min).is_rows().with_rows({
+            {long_type->decompose(int64_t(2))}
+        });
+        auto msg_max = e.execute_cql("SELECT MAX(c) FROM tbl;").get();
+        assert_that(msg_max).is_rows().with_rows({
+            {long_type->decompose(int64_t(4))}
+        });
+        auto msg_avg = e.execute_cql("SELECT AVG(c) FROM tbl;").get();
+        assert_that(msg_avg).is_rows().with_rows({
+            {long_type->decompose(int64_t(3))}
+        });
+
+        BOOST_CHECK_EQUAL(stat_parallelized + 4, qp.get_cql_stats().select_parallelized);
+    });
+}
+
 static future<> with_udf_and_parallel_aggregation_enabled_thread(std::function<void(cql_test_env&)>&& func) {
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;


### PR DESCRIPTION
Aggregation query on counter column is failing because forward_service is looking for function with counter as an argument and such function doesn't exist. Instead the long type should be used. 

Fixes: #12939