### PR TITLE
sstables: Remove always-false sstable_writer_config::leave_unsealed

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1475,9 +1475,7 @@ void writer::consume_end_of_stream() {
         }
     });
     _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
-    if (!_cfg.leave_unsealed) {
-        _sst.seal_sstable(_cfg.backup).get();
-    }
+    _sst.seal_sstable(_cfg.backup).get();
 }
 
 std::unique_ptr<sstable_writer::writer_impl> make_writer(sstable& sst,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -99,7 +99,6 @@ struct sstable_writer_config {
     size_t promoted_index_auto_scale_threshold;
     uint64_t max_sstable_size = std::numeric_limits<uint64_t>::max();
     bool backup = false;
-    bool leave_unsealed = false;
     mutation_fragment_stream_validation_level validation_level;
     std::optional<db::replay_position> replay_position;
     std::optional<int> sstable_level;


### PR DESCRIPTION
It was used in sstables streaming code up until e5be3352 (database, streaming, messaging: drop streaming memtables) or nearby, then the whole feature was reworked.