### PR TITLE
doc: remove the information that the CDC options are experimental

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -746,9 +746,7 @@ CDC options
 
 .. versionadded:: 3.2 Scylla Open Source
 
-The following options are to be used with Change Data Capture. Available as an experimental feature from Scylla Open Source 3.2. 
-To use this feature, you must enable the :ref:`experimental tag <yaml_enabling_experimental_features>` in the scylla.yaml.
-
+The following options can be used with Change Data Capture.
 
 +---------------------------+-----------------+------------------------------------------------------------------------------------------------------------------------+
 | option                    |  default        | description                                                                                                            |


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12964

The documentation includes the information that the CDC is experimental: https://docs.scylladb.com/stable/cql/ddl.html#cdc-options. The information is long outdated. This PR removes the information.