### PR TITLE
doc:  adds the minimal version from which the 2021.1-to-2022.1 upgrade is supported 

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2022-ubuntu-and-debian-p1.rst
@@ -7,7 +7,7 @@ This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise
 
 Applicable Versions
 ===================
-This guide covers upgrading ScyllaDB Enterprise from version 2021.1.x to ScyllaDB Enterprise version 2022.1.y on |OS|. See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
+This guide covers upgrading ScyllaDB Enterprise from version **2021.1.8** or later to ScyllaDB Enterprise version 2022.1.y on |OS|. See :doc:`OS Support by Platform and Version </getting-started/os-support>` for information about supported versions.
 
 Upgrade Procedure
 =================


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12954

The change affects the upgrade guides for Ubuntu, Debian, and image, but this PR updates only one source file in the "_common" folder, as it is shared by the three upgrade guides.
