### PR TITLE
readers/nonforwarding: don't emit partition_end on next_partition,fast_forward_to

### DIFF
--- a/db/chained_delegating_reader.hh
+++ b/db/chained_delegating_reader.hh
@@ -59,7 +59,7 @@ public:
         }
 
         _end_of_stream = false;
-        forward_buffer_to(pr.start());
+        clear_buffer();
         return _underlying->fast_forward_to(std::move(pr));
     }
 

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -295,7 +295,7 @@ future<> size_estimates_mutation_reader::fast_forward_to(const dht::partition_ra
 }
 
 future<> size_estimates_mutation_reader::fast_forward_to(position_range pr) {
-    forward_buffer_to(pr.start());
+    clear_buffer();
     _end_of_stream = false;
     if (_partition_reader) {
         return _partition_reader->fast_forward_to(std::move(pr));

--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -172,7 +172,7 @@ class build_progress_virtual_reader {
         }
 
         virtual future<> fast_forward_to(position_range range) override {
-            forward_buffer_to(range.start());
+            clear_buffer();
             _end_of_stream = false;
             return _underlying.fast_forward_to(std::move(range));
         }

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -175,7 +175,7 @@ class built_indexes_virtual_reader {
         }
 
         virtual future<> fast_forward_to(position_range range) override {
-            forward_buffer_to(range.start());
+            clear_buffer();
             _end_of_stream = false;
             // range contains index names (e.g., xyz) but the underlying table
             // contains view names (e.g., xyz_index) so we need to add the

--- a/readers/combined.cc
+++ b/readers/combined.cc
@@ -658,7 +658,7 @@ future<> merging_reader<P>::fast_forward_to(const dht::partition_range& pr) {
 
 template <FragmentProducer P>
 future<> merging_reader<P>::fast_forward_to(position_range pr) {
-    forward_buffer_to(pr.start());
+    clear_buffer();
     _end_of_stream = false;
     return _merger.fast_forward_to(std::move(pr));
 }

--- a/readers/delegating_v2.hh
+++ b/readers/delegating_v2.hh
@@ -40,7 +40,7 @@ public:
     }
     virtual future<> fast_forward_to(position_range pr) override {
         _end_of_stream = false;
-        forward_buffer_to(pr.start());
+        clear_buffer();
         return _underlying->fast_forward_to(std::move(pr));
     }
     virtual future<> next_partition() override {

--- a/readers/filtering.hh
+++ b/readers/filtering.hh
@@ -54,7 +54,7 @@ public:
         return _rd.fast_forward_to(pr);
     }
     virtual future<> fast_forward_to(position_range pr) override {
-        forward_buffer_to(pr.start());
+        clear_buffer();
         _end_of_stream = false;
         return _rd.fast_forward_to(std::move(pr));
     }

--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -153,7 +153,6 @@ public:
         void reserve_additional(size_t n) {
             _buffer.reserve(_buffer.size() + n);
         }
-        void forward_buffer_to(const position_in_partition& pos);
         void clear_buffer_to_next_partition();
         template<typename Source>
         future<bool> fill_buffer_from(Source&);
@@ -722,7 +721,7 @@ flat_mutation_reader_v2 transform(flat_mutation_reader_v2 r, T t) {
             return _reader.fast_forward_to(pr);
         }
         virtual future<> fast_forward_to(position_range pr) override {
-            forward_buffer_to(pr.start());
+            clear_buffer();
             _end_of_stream = false;
             return _reader.fast_forward_to(std::move(pr));
         }

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -158,7 +158,7 @@ future<> foreign_reader::fast_forward_to(const dht::partition_range& pr) {
 }
 
 future<> foreign_reader::fast_forward_to(position_range pr) {
-    forward_buffer_to(pr.start());
+    clear_buffer();
     _end_of_stream = false;
     return forward_operation([reader = _reader.get(), pr = std::move(pr)] () {
         return reader->fast_forward_to(std::move(pr));

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -385,11 +385,6 @@ flat_mutation_reader_v2::~flat_mutation_reader_v2() {
     }
 }
 
-void flat_mutation_reader_v2::impl::forward_buffer_to(const position_in_partition& pos) {
-    clear_buffer();
-    _buffer_size = compute_buffer_size(*_schema, _buffer);
-}
-
 void flat_mutation_reader_v2::impl::clear_buffer_to_next_partition() {
     auto next_partition_start = std::find_if(_buffer.begin(), _buffer.end(), [] (const mutation_fragment_v2& mf) {
         return mf.is_partition_start();

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -171,12 +171,15 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
             return make_ready_future<>();
         }
         virtual future<> next_partition() override {
+            clear_buffer_to_next_partition();
+            if (!is_buffer_empty()) {
+                co_return;
+            }
             _end_of_stream = false;
             if (!_next || !_next->is_partition_start()) {
                 co_await _underlying.next_partition();
                 _next = {};
             }
-            clear_buffer_to_next_partition();
             _current = {
                 position_in_partition::for_partition_start(),
                 position_in_partition(position_in_partition::after_static_row_tag_t())

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -461,6 +461,8 @@ flat_mutation_reader_v2 make_nonforwardable(flat_mutation_reader_v2 r, bool sing
             clear_buffer_to_next_partition();
             auto maybe_next_partition = make_ready_future<>();;
             if (is_buffer_empty()) {
+                _partition_is_open = false;
+                _static_row_done = false;
                 maybe_next_partition = _underlying.next_partition();
             }
           return maybe_next_partition.then([this] {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -428,11 +428,11 @@ flat_mutation_reader_v2 make_nonforwardable(flat_mutation_reader_v2 r, bool sing
                 _end_of_stream = true;
                 return make_ready_future<>();
             }
-          return _underlying.next_partition().then([this] {
-            return _underlying.fill_buffer().then([this] {
-                _end_of_stream = is_end_end_of_underlying_stream();
+            return _underlying.next_partition().then([this] {
+                return _underlying.fill_buffer().then([this] {
+                    _end_of_stream = is_end_end_of_underlying_stream();
+                });
             });
-          });
         }
         void reset_partition() {
             _partition_is_open = false;
@@ -467,9 +467,9 @@ flat_mutation_reader_v2 make_nonforwardable(flat_mutation_reader_v2 r, bool sing
                 reset_partition();
                 maybe_next_partition = _underlying.next_partition();
             }
-          return maybe_next_partition.then([this] {
-            _end_of_stream = is_end_end_of_underlying_stream();
-          });
+            return maybe_next_partition.then([this] {
+                _end_of_stream = is_end_end_of_underlying_stream();
+            });
         }
         virtual future<> fast_forward_to(const dht::partition_range& pr) override {
             _end_of_stream = false;

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -472,6 +472,8 @@ flat_mutation_reader_v2 make_nonforwardable(flat_mutation_reader_v2 r, bool sing
         virtual future<> fast_forward_to(const dht::partition_range& pr) override {
             _end_of_stream = false;
             clear_buffer();
+            _partition_is_open = false;
+            _static_row_done = false;
             return _underlying.fast_forward_to(pr);
         }
         virtual future<> close() noexcept override {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -167,7 +167,7 @@ flat_mutation_reader_v2 make_forwardable(flat_mutation_reader_v2 m) {
             _current = std::move(pr);
             _end_of_stream = false;
             _current_has_content = false;
-            forward_buffer_to(_current.start());
+            clear_buffer();
             return make_ready_future<>();
         }
         virtual future<> next_partition() override {
@@ -267,7 +267,7 @@ flat_mutation_reader_v2 make_slicing_filtering_reader(flat_mutation_reader_v2 rd
         }
 
         virtual future<> fast_forward_to(position_range pr) override {
-            forward_buffer_to(pr.start());
+            clear_buffer();
             _end_of_stream = false;
             return _rd.fast_forward_to(std::move(pr));
         }
@@ -1544,7 +1544,7 @@ public:
         return _reader.fast_forward_to(pr);
     }
     virtual future<> fast_forward_to(position_range pr) override {
-        forward_buffer_to(pr.start());
+        clear_buffer();
         _end_of_stream = false;
         return _reader.fast_forward_to(std::move(pr));
     }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -354,8 +354,9 @@ future<> read_context::create_underlying() {
     });
 }
 
-static flat_mutation_reader_v2 read_directly_from_underlying(read_context& reader) {
+static flat_mutation_reader_v2 read_directly_from_underlying(read_context& reader, mutation_fragment_v2 partition_start) {
     auto res = make_delegating_reader(reader.underlying().underlying());
+    res.unpop_mutation_fragment(std::move(partition_start));
     res.upgrade_schema(reader.schema());
     return make_nonforwardable(std::move(res), true);
 }
@@ -388,8 +389,7 @@ private:
                 });
             } else {
                 _cache._tracker.on_mispopulate();
-                _reader = read_directly_from_underlying(*_read_context);
-                this->push_mutation_fragment(std::move(*mfopt));
+                _reader = read_directly_from_underlying(*_read_context, std::move(*mfopt));
             }
           });
         });
@@ -514,15 +514,13 @@ public:
         , _read_context(ctx)
     {}
 
-    using read_result = std::tuple<flat_mutation_reader_v2_opt, mutation_fragment_v2_opt>;
-
-    future<read_result> operator()() {
+    future<flat_mutation_reader_v2_opt> operator()() {
         return _reader.move_to_next_partition().then([this] (auto&& mfopt) mutable {
             {
                 if (!mfopt) {
                     return _cache._read_section(_cache._tracker.region(), [&] {
                         this->handle_end_of_stream();
-                        return make_ready_future<read_result>(read_result(std::nullopt, std::nullopt));
+                        return make_ready_future<flat_mutation_reader_v2_opt>(std::nullopt);
                     });
                 }
                 _cache.on_partition_miss();
@@ -533,14 +531,12 @@ public:
                         cache_entry& e = _cache.find_or_create_incomplete(ps, _reader.creation_phase(),
                                                                this->can_set_continuity() ? &*_last_key : nullptr);
                         _last_key = row_cache::previous_entry_pointer(key);
-                        return make_ready_future<read_result>(
-                                read_result(e.read(_cache, _read_context, _reader.creation_phase()), std::nullopt));
+                        return make_ready_future<flat_mutation_reader_v2_opt>(e.read(_cache, _read_context, _reader.creation_phase()));
                     });
                 } else {
                     _cache._tracker.on_mispopulate();
                     _last_key = row_cache::previous_entry_pointer(key);
-                    return make_ready_future<read_result>(
-                            read_result(read_directly_from_underlying(_read_context), std::move(mfopt)));
+                    return make_ready_future<flat_mutation_reader_v2_opt>(read_directly_from_underlying(_read_context, std::move(*mfopt)));
                 }
             }
         });
@@ -644,12 +640,8 @@ private:
     }
 
     future<flat_mutation_reader_v2_opt> read_from_secondary() {
-        return _secondary_reader().then([this] (range_populating_reader::read_result&& res) {
-            auto&& [fropt, ps] = res;
+        return _secondary_reader().then([this] (flat_mutation_reader_v2_opt&& fropt) {
             if (fropt) {
-                if (ps) {
-                    push_mutation_fragment(std::move(*ps));
-                }
                 return make_ready_future<flat_mutation_reader_v2_opt>(std::move(fropt));
             } else {
                 _secondary_in_progress = false;

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1465,7 +1465,7 @@ public:
         // If _ds is not created then next_partition() has no effect because there was no partition_start emitted yet.
     }
     virtual future<> fast_forward_to(position_range cr) override {
-        forward_buffer_to(cr.start());
+        clear_buffer();
         if (!_partition_finished) {
             _end_of_stream = false;
             return advance_context(_consumer.fast_forward_to(std::move(cr)));

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1653,7 +1653,7 @@ public:
         // If _ds is not created then next_partition() has no effect because there was no partition_start emitted yet.
     }
     virtual future<> fast_forward_to(position_range cr) override {
-        forward_buffer_to(cr.start());
+        clear_buffer();
         if (!_partition_finished) {
             _end_of_stream = false;
             return advance_context(_consumer.fast_forward_to(std::move(cr)));

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -858,13 +858,24 @@ SEASTAR_THREAD_TEST_CASE(test_make_nonforwardable) {
 
         rd.produces_partition_start(m1.decorated_key(), m1.partition().partition_tombstone());
         rd.produces_row_with_key(m1.partition().clustered_rows().begin()->key());
-        rd.produces_partition_end();
+
+        rd.next_partition();
         rd.produces_end_of_stream();
 
         rd.next_partition();
-        rd.produces_partition_start(m2.decorated_key(), m2.partition().partition_tombstone());
-        rd.produces_row_with_key(m2.partition().clustered_rows().begin()->key());
-        rd.produces_partition_end();
+        rd.produces_end_of_stream();
+    }
+
+    // single_partition with fast_forward_to
+    {
+        const auto m1_range = dht::partition_range::make_singular(m1.decorated_key());
+        auto rd = make_reader({m1, m2}, true, m1_range);
+        rd.set_max_buffer_size(1);
+
+        rd.produces_partition_start(m1.decorated_key(), m1.partition().partition_tombstone());
+
+        const auto m2_range = dht::partition_range::make_singular(m2.decorated_key());
+        rd.fast_forward_to(m2_range);
         rd.produces_end_of_stream();
 
         rd.next_partition();

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -789,6 +789,24 @@ SEASTAR_THREAD_TEST_CASE(test_make_nonforwardable) {
             check(std::move(rd));
         }
     }
+
+    // fast_forward_to()
+    {
+        const auto m1_range = dht::partition_range::make_singular(m1.decorated_key());
+        auto rd = make_reader({m1, m2}, false, m1_range);
+        rd.set_max_buffer_size(1);
+
+        rd.produces_partition_start(m1.decorated_key(), m1.partition().partition_tombstone());
+
+        const auto m2_range = dht::partition_range::make_singular(m2.decorated_key());
+        rd.fast_forward_to(m2_range);
+        rd.produces_partition_start(m2.decorated_key(), m2.partition().partition_tombstone());
+        rd.produces_row_with_key(m2.partition().clustered_rows().begin()->key());
+        rd.produces_partition_end();
+
+        rd.next_partition();
+        rd.produces_end_of_stream();
+    }
 }
 
 SEASTAR_TEST_CASE(test_abandoned_flat_mutation_reader_from_mutation) {


### PR DESCRIPTION
The series fixes the `make_nonforwardable` reader, it shouldn't emit `partition_end` for previous partition after `next_partition()` and `fast_forward_to()`

Fixes: #12249