### PR TITLE
sstables: generation_type: define fmt::formatter for generation_type

### DIFF
--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <fmt/core.h>
 #include <cstdint>
 #include <compare>
 #include <limits>
@@ -62,8 +63,12 @@ struct numeric_limits<sstables::generation_type> : public numeric_limits<int64_t
         return sstables::generation_type{numeric_limits<int64_t>::max()};
     }
 };
-
-[[maybe_unused]] static ostream& operator<<(ostream& s, const sstables::generation_type& generation) {
-    return s << generation.value();
-}
 } //namespace std
+
+template <>
+struct fmt::formatter<sstables::generation_type> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::generation_type& generation, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", generation.value());
+    }
+};


### PR DESCRIPTION
turns out what we need is a fmt::formatter<sstables::generation_type> not operator<<(ostream&, sstables::generation_type), as its only use case is the formatter used by seastar::format().

to specialize fmt::formatter<sstables::generation_type>

* allows us to be one step closer to drop `FMT_DEPRECATED_OSTREAM`
* allows us to customize the way how generation_type is printed by customizing the format specifier.