### PR TITLE
docs: Update ScyllaDB Enterprise link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@
 
 .. topic-box::
   :title: ScyllaDB Enterprise
-  :link: getting-started
+  :link: https://enterprise.docs.scylladb.com
   :image: /_static/img/mascots/scylla-enterprise.svg
   :class: topic-box--product,large-3,small-6
 


### PR DESCRIPTION
Updates the ScyllaDB Enterprise docs link so that it points to the new site https://enterprise.docs.scylladb.com