### PR TITLE
RFC: Efficiently provide shard owner hint for SSTables through Scylla metadata

### DIFF
--- a/sstables/random_access_reader.cc
+++ b/sstables/random_access_reader.cc
@@ -41,6 +41,14 @@ future<> random_access_reader::seek(uint64_t pos) noexcept {
     }
 }
 
+future<> random_access_reader::skip(size_t n) noexcept {
+    try {
+        return _in->skip(n);
+    } catch (...) {
+        return current_exception_as_future();
+    }
+}
+
 future<> random_access_reader::close() noexcept {
     return futurize_invoke(close_if_needed, std::move(_in));
 }

--- a/sstables/random_access_reader.hh
+++ b/sstables/random_access_reader.hh
@@ -32,6 +32,8 @@ public:
 
     future<> seek(uint64_t pos) noexcept;
 
+    future<> skip(uint64_t n) noexcept;
+
     bool eof() const noexcept { return _in->eof(); }
 
     virtual future<> close() noexcept;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -81,7 +81,7 @@ public:
             std::unordered_set<sstring> files_for_removal;
         };
 
-        void handle(sstables::entry_descriptor desc, std::filesystem::path filename);
+        void handle(sstables::entry_descriptor desc, std::filesystem::path filename, seastar::shard_id shard_owner_hint);
 
         directory_lister _lister;
         std::unique_ptr<scan_state> _state;
@@ -201,6 +201,14 @@ public:
 
     std::filesystem::path sstable_dir() const noexcept {
         return _sstable_dir;
+    }
+
+    schema_ptr schema() const noexcept {
+        return _schema;
+    }
+
+    sstables_manager& manager() noexcept {
+        return _manager;
     }
 
     // When we compact sstables, we have to atomically instantiate the new

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1719,6 +1719,8 @@ sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, ssta
     scylla_metadata::scylla_build_id build_id;
     build_id.value = bytes(to_bytes_view(sstring_view(get_build_id())));
     _components->scylla_metadata->data.set<scylla_metadata_type::ScyllaBuildId>(std::move(build_id));
+    scylla_metadata::shard_owner_hint shard_owner_hint = shard;
+    _components->scylla_metadata->data.set<scylla_metadata_type::ShardOwnerHint>(std::move(shard_owner_hint));
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata, pc);
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -453,7 +453,7 @@ struct disk_set_of_tagged_union<TagType, Members...>::serdes {
     future<> lookup_and_parse(const schema& schema, sstable_version_types v, random_access_reader& in, TagType tag, uint32_t& size, disk_set& s, value_type& value) const {
         auto i = map.find(tag);
         if (i == map.end()) {
-            return in.read_exactly(size).discard_result();
+            return in.skip(size).discard_result();
         } else {
             return i->second->do_parse(schema, v, in, value).then([tag, &s, &value] () mutable {
                 s.data.emplace(tag, std::move(value));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -340,6 +340,16 @@ public:
         return _version;
     }
 
+    // Provides a hint on which shard owns a particular SSTable by partially
+    // reading the Scylla.DB component.
+    static future<seastar::shard_id>
+    shard_owner_hint(sstables_manager& manager,
+                     schema_ptr schema,
+                     sstring dir,
+                     generation_type generation,
+                     sstable_version_types v,
+                     sstable_format_types f);
+
     // Returns the total bytes of all components.
     uint64_t bytes_on_disk() const;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -592,7 +592,7 @@ private:
     future<file> open_file(component_type, open_flags, file_open_options = {}) noexcept;
 
     template <component_type Type, typename T>
-    future<> read_simple(T& comp, const io_priority_class& pc);
+    future<> read_simple(T& comp, const io_priority_class& pc, unsigned file_stream_read_ahead = 4);
 
     template <component_type Type, typename T>
     void write_simple(const T& comp, const io_priority_class& pc);

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -529,6 +529,7 @@ enum class scylla_metadata_type : uint32_t {
     SSTableOrigin = 6,
     ScyllaBuildId = 7,
     ScyllaVersion = 8,
+    ShardOwnerHint = 9,
 };
 
 // UUID is used for uniqueness across nodes, such that an imported sstable
@@ -569,6 +570,7 @@ struct scylla_metadata {
     using sstable_origin = disk_string<uint32_t>;
     using scylla_build_id = disk_string<uint32_t>;
     using scylla_version = disk_string<uint32_t>;
+    using shard_owner_hint = uint32_t;
 
     disk_set_of_tagged_union<scylla_metadata_type,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,
@@ -578,7 +580,8 @@ struct scylla_metadata {
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::LargeDataStats, large_data_stats>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::SSTableOrigin, sstable_origin>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaBuildId, scylla_build_id>,
-            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ShardOwnerHint, shard_owner_hint>
             > data;
 
     sstable_enabled_features get_features() const {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1274,6 +1274,7 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::SSTableOrigin: return "sstable_origin";
         case sstables::scylla_metadata_type::ScyllaVersion: return "scylla_version";
         case sstables::scylla_metadata_type::ScyllaBuildId: return "scylla_build_id";
+        case sstables::scylla_metadata_type::ShardOwnerHint: return "shard_owner_hint";
     }
     std::abort();
 }
@@ -1367,6 +1368,9 @@ public:
             _writer.EndObject();
         }
         _writer.EndObject();
+    }
+    void operator()(const sstables::scylla_metadata::shard_owner_hint& val) const {
+        _writer.Uint(val);
     }
     template <typename Size>
     void operator()(const sstables::disk_string<Size>& val) const {


### PR DESCRIPTION
Shard owner hint is intended to help SSTable loader to quickly determine which
shard should load the in-memory components of a particular SSTable. That's very
important to avoid cross-shard memory reference during normal operation.

Today, the hint is provided by looking at the generation number, which encodes
the id of the shard the SSTable was generated at.
But we want to decouple the hint from generation as tampering with UUID may
increase chances of collision. Machines can grow soon to thousands of threads,
therefore embedding shard ID into UUID could result in loss of 10 bits of
information.

Therefore, we're adding shard_owner_hint metadata to Scylla.DB file, which
allows the loader to retrieve the hint reading only 4k from disk per SSTable.

With 10TB of data, we expect ~10k SSTables. Random read of 4k on good modern
disk shouldn't take more than 50us.
Therefore, we can provide shard owner hint for 10k sstables in 500 ms.
Total data read amount to ~40M per shard, meaning that on a 100 cpu setup,
SSTable loader has to read an additional of 4G data (again, ~40M per shard).

This is a reasonable trade-off for the benefits that come with it.