### PR TITLE
build: cmake: sync with `configure.py` (7/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(absl REQUIRED)
 find_package(libdeflate REQUIRED)
+find_package(libxcrypt REQUIRED)
 find_package(Thrift REQUIRED)
 find_package(xxHash REQUIRED)
 
@@ -323,6 +324,7 @@ target_link_libraries(scylla PRIVATE
     absl::exponential_biased
     absl::throw_delegate
     # System libs
+    libxcrypt::libxcrypt
     libdeflate::libdeflate
     ZLIB::ZLIB
     ICU::uc
@@ -331,7 +333,6 @@ target_link_libraries(scylla PRIVATE
     zstd
     snappy
     ${LUA_LIBRARIES}
-    crypt
     xxHash::xxhash)
 
 # Force SHA1 build-id generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,10 +229,6 @@ set(scylla_sources
     streaming/stream_transfer_task.cc
     table_helper.cc
     tasks/task_manager.cc
-    thrift/controller.cc
-    thrift/handler.cc
-    thrift/server.cc
-    thrift/thrift_validation.cc
     timeout_config.cc
     tools/scylla-types.cc
     tools/scylla-sstable.cc
@@ -265,6 +261,7 @@ add_subdirectory(rust)
 add_subdirectory(schema)
 add_subdirectory(sstables)
 add_subdirectory(test)
+add_subdirectory(thrift)
 add_subdirectory(types)
 add_subdirectory(utils)
 include(add_version_library)
@@ -280,12 +277,12 @@ target_link_libraries(scylla PRIVATE
     alternator
     cql3
     idl
-    interface
     redis
     schema
     scylla_version
     sstables
     test-perf
+    thrift
     types
     utils
     wasmtime_bindings)
@@ -329,7 +326,6 @@ target_link_libraries(scylla PRIVATE
     ZLIB::ZLIB
     ICU::uc
     systemd
-    Thrift::thrift
     zstd
     snappy
     ${LUA_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(absl REQUIRED)
 find_package(libdeflate REQUIRED)
+find_package(Thrift REQUIRED)
 find_package(xxHash REQUIRED)
 
 set(scylla_gen_build_dir "${CMAKE_BINARY_DIR}/gen")
@@ -326,10 +327,10 @@ target_link_libraries(scylla PRIVATE
     ZLIB::ZLIB
     ICU::uc
     systemd
+    Thrift::thrift
     zstd
     snappy
     ${LUA_LIBRARIES}
-    thrift
     crypt
     xxHash::xxhash)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,43 +61,12 @@ set(scylla_sources
     converting_mutation_partition_applier.cc
     counters.cc
     data_dictionary/data_dictionary.cc
-    db/consistency_level.cc
-    db/system_keyspace.cc
-    db/virtual_table.cc
-    db/system_distributed_keyspace.cc
-    db/size_estimates_virtual_reader.cc
-    db/schema_tables.cc
-    db/cql_type_parser.cc
-    db/legacy_schema_migrator.cc
-    db/commitlog/commitlog.cc
-    db/commitlog/commitlog_replayer.cc
-    db/commitlog/commitlog_entry.cc
-    db/data_listeners.cc
-    db/hints/manager.cc
-    db/hints/resource_manager.cc
-    db/hints/host_filter.cc
-    db/hints/sync_point.cc
-    db/config.cc
-    db/extensions.cc
-    db/heat_load_balance.cc
-    db/large_data_handler.cc
-    db/marshal/type_parser.cc
-    db/batchlog_manager.cc
-    db/tags/utils.cc
-    db/view/view.cc
-    db/view/view_update_generator.cc
-    db/view/row_locking.cc
-    db/sstables-format-selector.cc
-    db/snapshot-ctl.cc
-    db/rate_limiter.cc
-    db/per_partition_rate_limit_options.cc
     dht/boot_strapper.cc
     dht/i_partitioner.cc
     dht/murmur3_partitioner.cc
     dht/range_streamer.cc
     dht/token.cc
     direct_failure_detector/failure_detector.cc
-    replica/distributed_loader.cc
     duration.cc
     exceptions/exceptions.cc
     frozen_schema.cc
@@ -141,18 +110,6 @@ set(scylla_sources
     main.cc
     message/messaging_service.cc
     multishard_mutation_query.cc
-    mutation/atomic_cell.cc
-    mutation/canonical_mutation.cc
-    mutation/frozen_mutation.cc
-    mutation/mutation.cc
-    mutation/mutation_fragment.cc
-    mutation/mutation_partition.cc
-    mutation/mutation_partition_serializer.cc
-    mutation/mutation_partition_v2.cc
-    mutation/mutation_partition_view.cc
-    mutation/partition_version.cc
-    mutation/range_tombstone.cc
-    mutation/range_tombstone_list.cc
     mutation_query.cc
     mutation_writer/feed_writers.cc
     mutation_writer/multishard_writer.cc
@@ -179,12 +136,6 @@ set(scylla_sources
     reader_concurrency_semaphore.cc
     repair/repair.cc
     repair/row_level.cc
-    replica/database.cc
-    replica/table.cc
-    replica/distributed_loader.cc
-    replica/memtable.cc
-    replica/exceptions.cc
-    replica/dirty_memory_manager.cc
     row_cache.cc
     schema_mutations.cc
     serializer.cc
@@ -212,21 +163,6 @@ set(scylla_sources
     service/storage_proxy.cc
     service/storage_service.cc
     sstables_loader.cc
-    streaming/consumer.cc
-    streaming/progress_info.cc
-    streaming/session_info.cc
-    streaming/stream_coordinator.cc
-    streaming/stream_manager.cc
-    streaming/stream_plan.cc
-    streaming/stream_reason.cc
-    streaming/stream_receive_task.cc
-    streaming/stream_request.cc
-    streaming/stream_result_future.cc
-    streaming/stream_session.cc
-    streaming/stream_session_state.cc
-    streaming/stream_summary.cc
-    streaming/stream_task.cc
-    streaming/stream_transfer_task.cc
     table_helper.cc
     tasks/task_manager.cc
     timeout_config.cc
@@ -252,14 +188,18 @@ set(scylla_sources
 
 add_subdirectory(api)
 add_subdirectory(alternator)
+add_subdirectory(db)
 add_subdirectory(auth)
 add_subdirectory(cql3)
 add_subdirectory(idl)
 add_subdirectory(interface)
+add_subdirectory(mutation)
 add_subdirectory(redis)
+add_subdirectory(replica)
 add_subdirectory(rust)
 add_subdirectory(schema)
 add_subdirectory(sstables)
+add_subdirectory(streaming)
 add_subdirectory(test)
 add_subdirectory(thrift)
 add_subdirectory(types)
@@ -275,12 +215,16 @@ target_link_libraries(scylla PRIVATE
     api
     auth
     alternator
+    db
     cql3
     idl
+    mutation
     redis
+    replica
     schema
     scylla_version
     sstables
+    streaming
     test-perf
     thrift
     types

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library(auth STATIC)
-target_sources(auth
+add_library(scylla_auth STATIC)
+target_sources(scylla_auth
   PRIVATE
     allow_all_authenticator.cc
     allow_all_authorizer.cc
@@ -19,10 +19,10 @@ target_sources(auth
     service.cc
     standard_role_manager.cc
     transitional.cc)
-target_include_directories(auth
+target_include_directories(scylla_auth
   PUBLIC
     ${CMAKE_SOURCE_DIR})
-target_link_libraries(auth
+target_link_libraries(scylla_auth
   PUBLIC
     Seastar::seastar
     xxHash::xxhash
@@ -30,3 +30,16 @@ target_link_libraries(auth
     cql3
     idl
     wasmtime_bindings)
+
+add_library(auth INTERFACE)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    target_link_libraries(auth INTERFACE
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,scylla_auth>")
+else()
+    add_dependencies(auth scylla_auth)
+    target_include_directories(auth INTERFACE
+        ${CMAKE_SOURCE_DIR})
+    target_link_options(auth INTERFACE
+        "$<$<CXX_COMPILER_ID:Clang>:SHELL:LINKER:-force_load $<TARGET_LINKER_FILE:scylla_auth>>"
+        "$<$<CXX_COMPILER_ID:GNU>:SHELL:LINKER:--whole-archive $<TARGET_LINKER_FILE:scylla_auth> LINKER:--no-whole-archive>")
+endif()

--- a/cmake/FindThrift.cmake
+++ b/cmake/FindThrift.cmake
@@ -1,0 +1,47 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(PC_thrift QUIET thrift)
+
+find_library(thrift_LIBRARY
+  NAMES thrift
+  HINTS
+    ${PC_thrift_LIBDIR}
+    ${PC_thrift_LIBRARY_DIRS})
+
+find_path(thrift_INCLUDE_DIR
+  NAMES thrift/Thrift.h
+  HINTS
+    ${PC_thrift_INCLUDEDIR}
+    ${PC_thrift_INCLUDE_DIRS})
+
+mark_as_advanced(
+  thrift_LIBRARY
+  thrift_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(Thrift
+  REQUIRED_VARS
+    thrift_LIBRARY
+    thrift_INCLUDE_DIR
+  VERSION_VAR PC_thrift_VERSION)
+
+if(Thrift_FOUND)
+  set(thrift_LIBRARIES ${thrift_LIBRARY})
+  set(thrift_INCLUDE_DIRS ${thrift_INCLUDE_DIR})
+  if(NOT(TARGET Thrift::thrift))
+    add_library(Thrift::thrift UNKNOWN IMPORTED)
+
+    set_target_properties(Thrift::thrift
+      PROPERTIES
+        IMPORTED_LOCATION ${thrift_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${thrift_INCLUDE_DIRS})
+  endif()
+endif()

--- a/cmake/Findlibxcrypt.cmake
+++ b/cmake/Findlibxcrypt.cmake
@@ -1,0 +1,47 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(PC_xcrypt QUIET libxcrypt)
+
+find_library(xcrypt_LIBRARY
+  NAMES crypt
+  HINTS
+    ${PC_xcrypt_LIBDIR}
+    ${PC_xcrypt_LIBRARY_DIRS})
+
+find_path(xcrypt_INCLUDE_DIR
+  NAMES crypt.h
+  HINTS
+    ${PC_xcrypt_INCLUDEDIR}
+    ${PC_xcrypt_INCLUDE_DIRS})
+
+mark_as_advanced(
+  xcrypt_LIBRARY
+  xcrypt_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(libxcrypt
+  REQUIRED_VARS
+    xcrypt_LIBRARY
+    xcrypt_INCLUDE_DIR
+  VERSION_VAR PC_xcrypt_VERSION)
+
+if(libxcrypt_FOUND)
+  set(xcrypt_LIBRARIES ${xcrypt_LIBRARY})
+  set(xcrypt_INCLUDE_DIRS ${xcrypt_INCLUDE_DIR})
+  if(NOT(TARGET libxcrypt::libxcrypt))
+    add_library(libxcrypt::libxcrypt UNKNOWN IMPORTED)
+
+    set_target_properties(libxcrypt::libxcrypt
+      PROPERTIES
+        IMPORTED_LOCATION ${xcrypt_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${xcrypt_INCLUDE_DIRS})
+  endif()
+endif()

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -1,0 +1,43 @@
+add_library(db STATIC)
+target_sources(db
+  PRIVATE
+    consistency_level.cc
+    system_keyspace.cc
+    virtual_table.cc
+    system_distributed_keyspace.cc
+    size_estimates_virtual_reader.cc
+    schema_tables.cc
+    cql_type_parser.cc
+    legacy_schema_migrator.cc
+    commitlog/commitlog.cc
+    commitlog/commitlog_replayer.cc
+    commitlog/commitlog_entry.cc
+    data_listeners.cc
+    hints/manager.cc
+    hints/resource_manager.cc
+    hints/host_filter.cc
+    hints/sync_point.cc
+    config.cc
+    extensions.cc
+    heat_load_balance.cc
+    large_data_handler.cc
+    marshal/type_parser.cc
+    batchlog_manager.cc
+    tags/utils.cc
+    view/view.cc
+    view/view_update_generator.cc
+    view/row_locking.cc
+    sstables-format-selector.cc
+    snapshot-ctl.cc
+    rate_limiter.cc
+    per_partition_rate_limit_options.cc)
+target_include_directories(db
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(db
+  PUBLIC
+    mutation
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    cql3)

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Generate C++ source files from thrift definitions
 function(scylla_generate_thrift)
-    set(one_value_args TARGET VAR IN_FILE OUT_DIR SERVICE)
+    set(one_value_args TARGET VAR THRIFT_VERSION IN_FILE OUT_DIR SERVICE)
     cmake_parse_arguments(args "" "${one_value_args}" "" ${ARGN})
 
     get_filename_component(in_file_name ${args_IN_FILE} NAME_WE)
@@ -18,6 +18,14 @@ function(scylla_generate_thrift)
     if(NOT THRIFT)
       message(FATAL "thrift is required")
     endif()
+    execute_process(
+        COMMAND "${THRIFT}" -version
+        OUTPUT_VARIABLE thrift_version_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "[0-9]+\.[0-9]+\.[0-9]+$"
+        thrift_version "${thrift_version_output}")
+    set(${args_THRIFT_VERSION} ${thrift_version} PARENT_SCOPE)
+
     add_custom_command(
         DEPENDS ${args_IN_FILE}
         OUTPUT ${outputs}
@@ -33,6 +41,7 @@ endfunction()
 scylla_generate_thrift(
     TARGET scylla_thrift_gen_cassandra
     VAR scylla_thrift_gen_cassandra_files
+    THRIFT_VERSION thrift_version
     IN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cassandra.thrift"
     OUT_DIR ${scylla_gen_build_dir}
     SERVICE Cassandra)
@@ -41,3 +50,8 @@ add_library(interface STATIC)
 target_sources(interface
   PRIVATE
     ${scylla_thrift_gen_cassandra_files})
+if(thrift_version VERSION_LESS 0.11.0)
+    target_compile_definitions(interface
+      PUBLIC
+        THRIFT_USES_BOOST)
+endif()

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -50,6 +50,9 @@ add_library(interface STATIC)
 target_sources(interface
   PRIVATE
     ${scylla_thrift_gen_cassandra_files})
+target_include_directories(interface
+  PUBLIC
+    ${scylla_gen_build_dir})
 if(thrift_version VERSION_LESS 0.11.0)
     target_compile_definitions(interface
       PUBLIC

--- a/mutation/CMakeLists.txt
+++ b/mutation/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(mutation STATIC)
+target_sources(mutation
+  PRIVATE
+    atomic_cell.cc
+    canonical_mutation.cc
+    frozen_mutation.cc
+    mutation.cc
+    mutation_fragment.cc
+    mutation_partition.cc
+    mutation_partition_serializer.cc
+    mutation_partition_v2.cc
+    mutation_partition_view.cc
+    partition_version.cc
+    range_tombstone.cc
+    range_tombstone_list.cc)
+target_include_directories(mutation
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(mutation
+  PUBLIC
+    idl
+    Seastar::seastar
+    xxHash::xxhash)

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(replica STATIC)
+target_sources(replica
+  PRIVATE
+    distributed_loader.cc
+    database.cc
+    table.cc
+    distributed_loader.cc
+    memtable.cc
+    exceptions.cc
+    dirty_memory_manager.cc)
+target_include_directories(replica
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(replica
+  PUBLIC
+    db
+    Seastar::seastar
+    xxHash::xxhash)

--- a/streaming/CMakeLists.txt
+++ b/streaming/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(streaming STATIC)
+target_sources(streaming
+  PRIVATE
+    consumer.cc
+    progress_info.cc
+    session_info.cc
+    stream_coordinator.cc
+    stream_manager.cc
+    stream_plan.cc
+    stream_reason.cc
+    stream_receive_task.cc
+    stream_request.cc
+    stream_result_future.cc
+    stream_session.cc
+    stream_session_state.cc
+    stream_summary.cc
+    stream_task.cc
+    stream_transfer_task.cc)
+target_include_directories(streaming
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(streaming
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    replica)

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(thrift STATIC)
+target_sources(thrift
+  PRIVATE
+    controller.cc
+    handler.cc
+    server.cc
+    thrift_validation.cc)
+target_include_directories(thrift
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(thrift
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    interface
+    Thrift::thrift)


### PR DESCRIPTION
- build: cmake: support thrift < 0.11.0
- build: cmake: find Thrift before using it
- build: cmake: find libxcrypt before using it
- build: cmake: expose scylla_gen_build_dir from "interface"
- build: cmake: extract thrift out
- build: cmake: link the whole auth
- build: cmake: extract mutation,db,replica,streaming out