### PR TITLE
cql3: functions: validate arguments for 'token()' also

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -337,7 +337,9 @@ functions::get(data_dictionary::database db,
     if (name.has_keyspace()
                 ? name == TOKEN_FUNCTION_NAME
                 : name.name == TOKEN_FUNCTION_NAME.name) {
-        return ::make_shared<token_fct>(db.find_schema(receiver_ks, receiver_cf));
+        auto fun = ::make_shared<token_fct>(db.find_schema(receiver_ks, receiver_cf));
+        validate_types(db, keyspace, fun, provided_args, receiver_ks, receiver_cf);
+        return fun;
     }
 
     if (name.has_keyspace()

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -2630,14 +2630,12 @@ def testTokenFctRejectsInvalidColumnName(cql, test_keyspace):
         # Slightly different error messages in Scylla and Cassandra
         assert_invalid_message(cql, table, "name s1", "SELECT token(s1, k1) FROM %s")
 
-@pytest.mark.xfail(reason="issue #10448")
 def testTokenFctRejectsInvalidColumnType(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         assert_invalid_message(cql, table, "Type error: k2 cannot be passed as argument 0 of function system.token of type uuid",
                              "SELECT token(k2, k1) FROM %s")
 
-@pytest.mark.xfail(reason="issue #10448")
 def testTokenFctRejectsInvalidColumnCount(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")

--- a/test/cql/token_from_null_test.result
+++ b/test/cql/token_from_null_test.result
@@ -18,22 +18,10 @@ OK
 > INSERT INTO reproducer.t2 (pk) VALUES (1);
 OK
 > SELECT TOKEN(pk, a, b) FROM reproducer.t2;
-+--------------------------+
-| system.token(pk, a, b)   |
-|--------------------------|
-| null                     |
-+--------------------------+
+Error from server: code=2200 [Invalid query] message="Invalid number of arguments in call to function system.token: 1 required but 3 provided"
 > SELECT TOKEN(pk, b) FROM reproducer.t2;
-+-----------------------+
-| system.token(pk, b)   |
-|-----------------------|
-| null                  |
-+-----------------------+
+Error from server: code=2200 [Invalid query] message="Invalid number of arguments in call to function system.token: 1 required but 2 provided"
 > SELECT TOKEN(a, b) FROM reproducer.t2;
-+----------------------+
-| system.token(a, b)   |
-|----------------------|
-| null                 |
-+----------------------+
+Error from server: code=2200 [Invalid query] message="Invalid number of arguments in call to function system.token: 1 required but 2 provided"
 > 
 > DROP KEYSPACE reproducer;OK


### PR DESCRIPTION
since "token()" computes the token for a given partition key, if we pass the key of the wrong type, it should reject.

in this change, we validate the keys before returning the "token()" function.

Fixes #10448
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>