### PR TITLE
tools/schema_loader: drop unused functions

### DIFF
--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -328,23 +328,6 @@ future<std::vector<schema_ptr>> load_schemas(std::string_view schema_str) {
     });
 }
 
-future<schema_ptr> load_one_schema(std::string_view schema_str) {
-    return async([schema_str] () mutable {
-        auto schemas = do_load_schemas(schema_str);
-        if (schemas.size() != 1) {
-            throw std::runtime_error(fmt::format("Schema string expected to contain exactly 1 schema, actually has {}", schemas.size()));
-        }
-        return std::move(schemas.front());
-    });
-
-}
-
-future<std::vector<schema_ptr>> load_schemas_from_file(std::filesystem::path path) {
-    return async([path] () mutable {
-        return do_load_schemas(read_file(path));
-    });
-}
-
 future<schema_ptr> load_one_schema_from_file(std::filesystem::path path) {
     return async([path] () mutable {
         auto schemas = do_load_schemas(read_file(path));

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -30,22 +30,10 @@ namespace tools {
 /// be able to load the schema(s), these survive the call.
 future<std::vector<schema_ptr>> load_schemas(std::string_view schema_str);
 
-/// Load exactly one schema from the specified string
-///
-/// If the string contains more or less then one schema, an exception will be
-/// thrown. See \ref load_schemas().
-future<schema_ptr> load_one_schema(std::string_view schema_str);
-
-/// Load the schema(s) from the specified path
-///
-/// Same as \ref load_schemas() except it loads the schema from
-/// the file at the specified path.
-future<std::vector<schema_ptr>> load_schemas_from_file(std::filesystem::path path);
-
 /// Load exactly one schema from the specified path
 ///
-/// Same as \ref load_one_schema() except it loads the schema from
-/// the file at the specified path.
+/// If the file at the specified path contains more or less then one schema,
+/// an exception will be thrown. See \ref load_schemas().
 future<schema_ptr> load_one_schema_from_file(std::filesystem::path path);
 
 /// Load the system schema, with the given keyspace and table


### PR DESCRIPTION
`load_one_schema()` and `load_schemas_from_file()` are dropped, as they are neither used by `scylla-sstable` or tested by `schema_loader_test.cc` . the latter tests `load_schemas()`, which is quite the same as `load_one_schema_from_file()`, but is more permissive in the sense that it allows zero schema or more than one schema in the specified path.