### PR TITLE
[RFC] mutate_locally: destroy mutations gently

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -264,7 +264,7 @@ future<> db::batchlog_manager::replay_all_failed_batches(post_replay_cleanup cle
             mutation m(schema, key);
             auto now = service::client_state(service::client_state::internal_tag()).get_timestamp();
             m.partition().apply_delete(*schema, clustering_key_prefix::make_empty(), tombstone(now, gc_clock::now()));
-            return _qp.proxy().mutate_locally(m, tracing::trace_state_ptr(), db::commitlog::force_sync::no);
+            return _qp.proxy().mutate_locally(std::move(m), tracing::trace_state_ptr(), db::commitlog::force_sync::no);
         }).then([] { return make_ready_future<stop_iteration>(stop_iteration::no); });
     };
 

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -44,6 +44,19 @@ mutation::data::data(schema_ptr&& schema, dht::decorated_key&& key, mutation_par
     , _p(std::move(mp))
 { }
 
+future<> mutation::data::clear_gently() noexcept {
+    _schema = nullptr;
+    return repeat([this] { return _p.clear_gently(nullptr); });
+}
+
+future<> mutation::clear_gently() noexcept {
+    if (auto p = std::exchange(_ptr, nullptr)) {
+        auto f = p->clear_gently();
+        return f.available() ? std::move(f) : f.finally([p = std::move(p)] {});
+    }
+    return make_ready_future();
+}
+
 void mutation::set_static_cell(const column_definition& def, atomic_cell_or_collection&& value) {
     partition().static_row().apply(def, std::move(value));
 }

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -72,6 +72,8 @@ private:
         data(partition_key&& key, schema_ptr&& schema);
         data(schema_ptr&& schema, dht::decorated_key&& key, const mutation_partition& mp);
         data(schema_ptr&& schema, dht::decorated_key&& key, mutation_partition&& mp);
+
+        future<> clear_gently() noexcept;
     };
     std::unique_ptr<data> _ptr;
 private:
@@ -186,6 +188,8 @@ public:
     mutation compacted() const;
 
     size_t memory_usage(const ::schema& s) const;
+
+    future<> clear_gently() noexcept;
 };
 
 inline std::vector<mutation> make_mutation_vector(mutation&& m) {

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -117,7 +117,7 @@ future<query_result> execute_broadcast_table_query(
 
                 auto value = utf8_type->deserialize(q.new_value);
                 new_mutation.set_clustered_cell(clustering_key::make_empty(), "value", std::move(value), ts);
-                co_await proxy.mutate_locally(new_mutation, {}, {});
+                co_await proxy.mutate_locally(std::move(new_mutation), {}, {});
             }
 
             if (is_conditional) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4017,7 +4017,7 @@ storage_proxy::mutate_atomically_result(std::vector<mutation> mutations, db::con
     }).then_wrapped(std::move(cleanup));
 }
 
-mutation storage_proxy::get_batchlog_mutation_for(const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now) {
+mutation storage_proxy::get_batchlog_mutation_for(const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now) const {
     auto schema = local_db().find_schema(db::system_keyspace::NAME, db::system_keyspace::BATCHLOG);
     return do_get_batchlog_mutation_for(std::move(schema), mutations, id, version, now);
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3081,6 +3081,17 @@ void storage_proxy::destroy_mutation_gently(mutation&& m) {
     });
 }
 
+frozen_mutation storage_proxy::freeze_and_destroy_mutation(mutation&& m) {
+    auto fm = freeze(m);
+    destroy_mutation_gently(std::move(m));
+    return fm;
+}
+
+frozen_mutation_and_schema storage_proxy::freeze_mutation_and_schema_and_destroy_mutation(mutation&& m) {
+    auto s = m.schema();
+    return frozen_mutation_and_schema{freeze_and_destroy_mutation(std::move(m)), std::move(s)};
+}
+
 future<>
 storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
     auto erm = _db.local().find_column_family(m.schema()).get_effective_replication_map();

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -475,6 +475,8 @@ private:
         inet_address_vector_replica_set& l2) const;
 
     void destroy_mutation_gently(mutation&& m);
+    frozen_mutation freeze_and_destroy_mutation(mutation&& m);
+    frozen_mutation_and_schema freeze_mutation_and_schema_and_destroy_mutation(mutation&& m);
 
 public:
     storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -554,7 +554,7 @@ private:
         return _pending_writes_phaser.start();
     }
 
-    mutation do_get_batchlog_mutation_for(schema_ptr schema, const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
+    static mutation do_get_batchlog_mutation_for(schema_ptr schema, const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
     future<> drain_on_shutdown();
 public:
     // Applies mutation on this node.
@@ -700,7 +700,7 @@ public:
             db::consistency_level cl_for_paxos, db::consistency_level cl_for_learn,
             clock_type::time_point write_timeout, clock_type::time_point cas_timeout, bool write = true);
 
-    mutation get_batchlog_mutation_for(const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
+    mutation get_batchlog_mutation_for(const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now) const;
 
     future<> stop();
     future<> start_hints_manager();

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -317,6 +317,9 @@ private:
 
     // Needed by sstable cleanup fiber to wait for all ongoing writes to complete
     utils::phased_barrier _pending_writes_phaser;
+
+    // Gate for async work like destroying mutation in the background.
+    gate _async_gate;
 private:
     future<result<coordinator_query_result>> query_singular(lw_shared_ptr<query::read_command> cmd,
             dht::partition_range_vector&& partition_ranges,
@@ -470,6 +473,8 @@ private:
         inet_address_vector_replica_set& merged,
         inet_address_vector_replica_set& l1,
         inet_address_vector_replica_set& l2) const;
+
+    void destroy_mutation_gently(mutation&& m);
 
 public:
     storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -49,7 +49,7 @@ SEASTAR_TEST_CASE(test_execute_batch) {
             auto version = netw::messaging_service::current_version;
             auto bm = qp.proxy().get_batchlog_mutation_for({ m }, s->id().uuid(), version, db_clock::now() - db_clock::duration(3h));
 
-            return qp.proxy().mutate_locally(bm, tracing::trace_state_ptr(), db::commitlog::force_sync::no).then([&bp] () mutable {
+            return qp.proxy().mutate_locally(std::move(bm), tracing::trace_state_ptr(), db::commitlog::force_sync::no).then([&bp] () mutable {
                 return bp.count_all_batches().then([](auto n) {
                     BOOST_CHECK_EQUAL(n, 1);
                 }).then([&bp] () mutable {


### PR DESCRIPTION
change the function signatures of mutate_locally
and create_write_response_handler functions to accept
the mutation(s) as rvalue refrences so they can be
destroyed gently in the background and being frozen
via the following helpers:
- freeze_mutation_and_schema_and_destroy_mutation
- freeze_and_destroy_mutation
- destroy_mutation_gently

Destroying the mutation in the background is done
to prevent reactor stalls when either large mutations
or a vector of (large) mutations are destroyed in the
mutate_locally path, on the return path.

Fixes #12999