### PR TITLE
raft: broadcast_tables: remove unused asyncio mark

### DIFF
--- a/test/broadcast_tables/test_broadcast_tables.py
+++ b/test/broadcast_tables/test_broadcast_tables.py
@@ -58,8 +58,7 @@ class ConditionType(enum.Enum):
     EXISTING_KEY_FAIL = enum.auto()
     NEW_KEY = enum.auto()
 
-@pytest.mark.asyncio
-async def test_broadcast_kv_store(cql) -> None:
+def test_broadcast_kv_store(cql) -> None:
     seed = random.randint(0, 2 ** 64)
     print(f"Seed: {seed}")
     random.seed(seed)


### PR DESCRIPTION
test_broadcast_kv_store does not use await or yield at all, so there is no need to mark it with "asyncio" mark.

tested using
```
SCYLLA_HOME=$HOME/scylla build/cmake/scylla --overprovisioned --developer-mode=yes --consistent-cluster-management=true --experimental-features=broadcast-tables
...
pytest broadcast_tables/test_broadcast_tables.py
```

the test still passes.