### PR TITLE
test/cql-pytest: add regression test for UNSET key in insert

### DIFF
--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -173,3 +173,27 @@ def test_unset_where_regular(cql, table1):
 
 # TODO: check that (according to NEWS.txt documentation): "Unset tuple field,
 # UDT field and map key are not allowed.".
+
+# Although UNSET_VALUE is designed to skip part of a SET, it is not designed
+# to skip an entire write which uses a an UNSET_VALUE in its WHERE clause -
+# this should be treated as an error, not a silent skip.
+#
+# As in test_unset_where_clustering() above (the SELECT version of this test)
+# we need to check the UNSET_VALUE on the clustering key because if we try
+# an UNSET_VALUE on the partition key, the Python driver will refuse to
+# send the request (it uses the partition key to decide which node to send
+# the request).
+def test_unset_insert_where(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Similar to test_unset_insert_where() above, just use an LWT write ("IF
+# NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condtion causes
+# a clear error, not silent skip and not a crash as in issue #13001.
+def test_unset_insert_where_lwt(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])


### PR DESCRIPTION
Recently, we overhauled the error handling of UNSET_VALUE in various places where it is not allowed. This patch adds two more regression tests for this error handling. Both tests pass on Scylla today, pass on Cassandra, but fail on earlier Scylla (e.g., I tested 5.1.5):

The first test does INSERT into clustering key UNSET_VALUE. An UNSET_VALUE is designed to skip part of the write - not an entire write - so this attempt should fail - not silently be skipped. The write indeed fails with an error on Cassandra, and on recent Scylla, but silently did nothing in older Scylla which leads this test to fail there.

The second test does the same thing with LWT (adding an "IF NOT EXISTS") added to the insert. Scylla's failure here was even more spectacular - it crashed (as reported in issue #13001) instead of silently skipping the right. The test passes on Scylla today and on Cassandra, which both report the failure cleanly.

Refs #13001.