### PR TITLE
dht: incremental_owned_ranges_checker: use lower_bound()

### DIFF
--- a/dht/partition_filter.hh
+++ b/dht/partition_filter.hh
@@ -11,6 +11,7 @@
 
 #include "dht/i_partitioner.hh"
 #include "readers/flat_mutation_reader_v2.hh"
+#include <algorithm>
 
 namespace dht {
 
@@ -28,10 +29,10 @@ public:
         // While token T is after a range Rn, advance the iterator.
         // iterator will be stopped at a range which either overlaps with T (if T belongs to node),
         // or at a range which is after T (if T doesn't belong to this node).
-        while (_it != _sorted_owned_ranges.end() && _it->after(t, dht::token_comparator())) {
-            _it++;
-        }
-
+        _it = std::lower_bound(_it, _sorted_owned_ranges.end(), t,
+                               [] (const dht::token_range& range, const dht::token& token) {
+            return range.after(token, dht::token_comparator());
+        });
         return _it != _sorted_owned_ranges.end() && _it->contains(t, dht::token_comparator());
     }
 


### PR DESCRIPTION
instead of using a while loop for finding the lower_bound, just use std::lower_bound() for finding if current node owns given token. this has two advantages:

* better readability: as lower_bound is exactly what this loop calculates.
* lower_bound uses binary search for searching the element, this algorithm should be faster than linear search under most circumstances.
* lower_bound uses std::advance() and prefix increment operator, this should be more performant than the postfix increment operator. as it does not create a temporary instance of iterator.