### PR TITLE
test/cql-pytest: allow "run-cassandra" without building Scylla

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -21,7 +21,7 @@ if '--aws' in sys.argv:
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-print('Scylla is: ' + run.scylla + '.')
+print('Scylla is: ' + run.find_scylla() + '.')
 
 # If the "--raft" option is given, switch to the experimental Raft-based
 # implementation of schema operations. When the experimental feature becomes

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -4,7 +4,7 @@ import sys
 
 import run   # run.py in this directory
 
-print('Scylla is: ' + run.scylla + '.')
+print('Scylla is: ' + run.find_scylla() + '.')
 
 ssl = '--ssl' in sys.argv
 if ssl:

--- a/test/redis/run
+++ b/test/redis/run
@@ -6,7 +6,7 @@ import run
 
 import redis
 
-print('Scylla is: ' + run.scylla + '.')
+print('Scylla is: ' + run.find_scylla() + '.')
 
 REDIS_PORT = 6379
 

--- a/test/rest_api/run
+++ b/test/rest_api/run
@@ -6,7 +6,7 @@ import sys
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 import run
 
-print('Scylla is: ' + run.scylla + '.')
+print('Scylla is: ' + run.find_scylla() + '.')
 
 ssl = '--ssl' in sys.argv
 if ssl:

--- a/test/scylla-gdb/run
+++ b/test/scylla-gdb/run
@@ -8,7 +8,7 @@ import subprocess
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 import run
 
-print('Scylla is: ' + run.scylla + '.')
+print('Scylla is: ' + run.find_scylla() + '.')
 
 # Gdb will only work if the executable was built with debug symbols
 # (e.g., Scylla's release or debug build modes mode, but not dev mode).


### PR DESCRIPTION
Before this patch, all scripts which use test/cql-pytest/run.py looked for the Scylla executable as their first step. This is usually the right thing to do, except in two cases where Scylla is *not* needed:

1. The script test/cql-pytest/run-cassandra.
2. The script test/alternator/run with the "--aws" option.

So in this patch we change run.py to only look for Scylla when actually needed (the find_scylla() function is called). In both cases mentioned above, find_scylla() will never get called and the script can work even if Scylla was never built.