### PR TITLE
[branch-5.1] backport: cql3, transport, tests: remove "unset" from value type system

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -20,7 +20,9 @@ std::unique_ptr<attributes> attributes::none() {
 attributes::attributes(std::optional<cql3::expr::expression>&& timestamp,
                        std::optional<cql3::expr::expression>&& time_to_live,
                        std::optional<cql3::expr::expression>&& timeout)
-    : _timestamp{std::move(timestamp)}
+    : _timestamp_unset_guard(timestamp)
+    , _timestamp{std::move(timestamp)}
+    , _time_to_live_unset_guard(time_to_live)
     , _time_to_live{std::move(time_to_live)}
     , _timeout{std::move(timeout)}
 { }
@@ -38,16 +40,13 @@ bool attributes::is_timeout_set() const {
 }
 
 int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
-    if (!_timestamp.has_value()) {
+    if (!_timestamp.has_value() || _timestamp_unset_guard.is_unset(options)) {
         return now;
     }
 
     cql3::raw_value tval = expr::evaluate(*_timestamp, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of timestamp");
-    }
-    if (tval.is_unset_value()) {
-        return now;
     }
     try {
         return tval.view().validate_and_deserialize<int64_t>(*long_type, cql_serialization_format::internal());
@@ -57,15 +56,12 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
 }
 
 int32_t attributes::get_time_to_live(const query_options& options) {
-    if (!_time_to_live.has_value())
+    if (!_time_to_live.has_value() || _time_to_live_unset_guard.is_unset(options))
         return 0;
 
     cql3::raw_value tval = expr::evaluate(*_time_to_live, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of TTL");
-    }
-    if (tval.is_unset_value()) {
-        return 0;
     }
 
     int32_t ttl;
@@ -91,8 +87,8 @@ int32_t attributes::get_time_to_live(const query_options& options) {
 
 db::timeout_clock::duration attributes::get_timeout(const query_options& options) const {
     cql3::raw_value timeout = expr::evaluate(*_timeout, options);
-    if (timeout.is_null() || timeout.is_unset_value()) {
-        throw exceptions::invalid_request_exception("Timeout value cannot be unset/null");
+    if (timeout.is_null()) {
+        throw exceptions::invalid_request_exception("Timeout value cannot be null");
     }
     cql_duration duration = timeout.view().deserialize<cql_duration>(*duration_type);
     if (duration.months || duration.days) {

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cql3/expr/expression.hh"
+#include "cql3/expr/unset.hh"
 #include "db/timeout_clock.hh"
 
 namespace cql3 {
@@ -24,7 +25,9 @@ class prepare_context;
  */
 class attributes final {
 private:
+    expr::unset_bind_variable_guard _timestamp_unset_guard;
     std::optional<cql3::expr::expression> _timestamp;
+    expr::unset_bind_variable_guard _time_to_live_unset_guard;
     std::optional<cql3::expr::expression> _time_to_live;
     std::optional<cql3::expr::expression> _timeout;
 public:

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -139,10 +139,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
 
         cql3::raw_value key_constant = expr::evaluate(*_collection_element, options);
         cql3::raw_value_view key = key_constant.view();
-        if (key.is_unset_value()) {
-            throw exceptions::invalid_request_exception(
-                    format("Invalid 'unset' value in {} element access", cell_type.cql3_type_name()));
-        }
         if (key.is_null()) {
             throw exceptions::invalid_request_exception(
                     format("Invalid null value for {} element access", cell_type.cql3_type_name()));
@@ -196,9 +192,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         // <, >, >=, <=, !=
         cql3::raw_value param = expr::evaluate(*_value, options);
 
-        if (param.is_unset_value()) {
-            throw exceptions::invalid_request_exception("Invalid 'unset' value in condition");
-        }
         if (param.is_null()) {
             if (_op == expr::oper_t::EQ) {
                 return cell_value == nullptr;
@@ -224,9 +217,6 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
             return (*_matcher)(bytes_view(cell_value->serialize_nonnull()));
         } else {
             auto param = expr::evaluate(*_value, options);  // LIKE pattern
-            if (param.is_unset_value()) {
-                throw exceptions::invalid_request_exception("Invalid 'unset' value in LIKE pattern");
-            }
             if (param.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid NULL value in LIKE pattern");
             }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -28,9 +28,9 @@ public:
     private static final Logger logger = LoggerFactory.getLogger(Constants.class);
 #endif
 public:
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
             auto value = expr::evaluate(*_e, params._options);
@@ -46,30 +46,26 @@ public:
         }
     };
 
-    struct adder final : operation {
-        using operation::operation;
+    struct adder final : operation_skip_if_unset {
+        using operation_skip_if_unset::operation_skip_if_unset;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
             auto value = expr::evaluate(*_e, params._options);
             if (value.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid null value for counter increment");
-            } else if (value.is_unset_value()) {
-                return;
             }
             auto increment = value.view().deserialize<int64_t>(*long_type);
             m.set_cell(prefix, column, params.make_counter_update_cell(increment));
         }
     };
 
-    struct subtracter final : operation {
-        using operation::operation;
+    struct subtracter final : operation_skip_if_unset {
+        using operation_skip_if_unset::operation_skip_if_unset;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
             auto value = expr::evaluate(*_e, params._options);
             if (value.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid null value for counter increment");
-            } else if (value.is_unset_value()) {
-                return;
             }
             auto increment = value.view().deserialize<int64_t>(*long_type);
             if (increment == std::numeric_limits<int64_t>::min()) {
@@ -79,10 +75,10 @@ public:
         }
     };
 
-    class deleter : public operation {
+    class deleter : public operation_no_unset_support {
     public:
         deleter(const column_definition& column)
-            : operation(column, std::nullopt)
+            : operation_no_unset_support(column, std::nullopt)
         { }
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -383,7 +383,6 @@ struct constant {
 
     constant(cql3::raw_value value, data_type type);
     static constant make_null(data_type val_type = empty_type);
-    static constant make_unset_value(data_type val_type = empty_type);
     static constant make_bool(bool bool_val);
 
     bool is_null() const;

--- a/cql3/expr/unset.hh
+++ b/cql3/expr/unset.hh
@@ -1,0 +1,30 @@
+// Copyright (C) 2023-present ScyllaDB
+// SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+
+#pragma once
+
+#include <optional>
+#include "expression.hh"
+
+namespace cql3 {
+
+class query_options;
+
+}
+
+namespace cql3::expr {
+
+// Some expression users can behave differently if the expression is a bind variable
+// and if that bind variable is unset. unset_bind_variable_guard encapsulates the two
+// conditions.
+class unset_bind_variable_guard {
+    // Disengaged if the operand is not exactly a single bind variable.
+    std::optional<bind_variable> _var;
+public:
+    explicit unset_bind_variable_guard(const expr::expression& operand);
+    explicit unset_bind_variable_guard(std::nullopt_t) {}
+    explicit unset_bind_variable_guard(const std::optional<expr::expression>& operand);
+    bool is_unset(const query_options& qo) const;
+};
+
+}

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -27,21 +27,21 @@ public:
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification&);
     static lw_shared_ptr<column_specification> uuid_index_spec_of(const column_specification&);
 public:
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_index : public operation {
+    class setter_by_index : public operation_skip_if_unset {
     protected:
         expr::expression _idx;
     public:
         setter_by_index(const column_definition& column, expr::expression idx, expr::expression e)
-            : operation(column, std::move(e)), _idx(std::move(idx)) {
+            : operation_skip_if_unset(column, std::move(e)), _idx(std::move(idx)) {
         }
         virtual bool requires_read() const override;
         virtual void fill_prepare_context(prepare_context& ctx) override;
@@ -57,9 +57,9 @@ public:
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class appender : public operation {
+    class appender : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
@@ -69,25 +69,25 @@ public:
             const column_definition& column,
             const update_parameters& params);
 
-    class prepender : public operation {
+    class prepender : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class discarder : public operation {
+    class discarder : public operation_skip_if_unset {
     public:
         discarder(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual bool requires_read() const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class discarder_by_index : public operation {
+    class discarder_by_index : public operation_skip_if_unset {
     public:
         discarder_by_index(const column_definition& column, expr::expression idx)
-                : operation(column, std::move(idx)) {
+                : operation_skip_if_unset(column, std::move(idx)) {
         }
         virtual bool requires_read() const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -27,30 +27,30 @@ public:
     static lw_shared_ptr<column_specification> key_spec_of(const column_specification& column);
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification& column);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_key : public operation {
+    class setter_by_key : public operation_skip_if_unset {
         expr::expression _k;
     public:
         setter_by_key(const column_definition& column, expr::expression k, expr::expression e)
-            : operation(column, std::move(e)), _k(std::move(k)) {
+            : operation_skip_if_unset(column, std::move(e)), _k(std::move(k)) {
         }
         virtual void fill_prepare_context(prepare_context& ctx) override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    class putter : public operation {
+    class putter : public operation_skip_if_unset {
     public:
         putter(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
@@ -58,10 +58,10 @@ public:
     static void do_put(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params,
             const cql3::raw_value& value, const column_definition& column);
 
-    class discarder_by_key : public operation {
+    class discarder_by_key : public operation_no_unset_support {
     public:
         discarder_by_key(const column_definition& column, expr::expression k)
-                : operation(column, std::move(k)) {
+                : operation_no_unset_support(column, std::move(k)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -267,9 +267,9 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
     auto v = prepare_expression(_value, db, keyspace, nullptr, spec);
 
     // Will not be used elsewhere, so make it local.
-    class counter_setter : public operation {
+    class counter_setter : public operation_no_unset_support {
     public:
-        using operation::operation;
+        using operation_no_unset_support::operation_no_unset_support;
 
         bool is_raw_counter_shard_write() const override {
             return true;

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -16,6 +16,7 @@
 #include "update_parameters.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/expr/expression.hh"
+#include "cql3/expr/unset.hh"
 
 #include <optional>
 
@@ -49,10 +50,13 @@ protected:
     // may require none of more than one expression, but most need 1 so it simplify things a bit.
     std::optional<expr::expression> _e;
 
+    // A guard to check if the operation should be skipped due to unset operand.
+    expr::unset_bind_variable_guard _unset_guard;
 public:
-    operation(const column_definition& column_, std::optional<expr::expression> e)
+    operation(const column_definition& column_, std::optional<expr::expression> e, expr::unset_bind_variable_guard ubvg)
         : column{column_}
         , _e(std::move(e))
+        , _unset_guard(std::move(ubvg))
     { }
 
     virtual ~operation() {}
@@ -82,9 +86,13 @@ public:
     }
 
     /**
-     * Execute the operation.
+     * Execute the operation. Check should_skip_operation() first.
      */
     virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) = 0;
+
+    bool should_skip_operation(const query_options& qo) const {
+        return _unset_guard.is_unset(qo);
+    }
 
     /**
      * A parsed raw UPDATE operation.
@@ -256,6 +264,20 @@ public:
         virtual const column_identifier::raw& affected_column() const override;
         virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
     };
+};
+
+class operation_skip_if_unset : public operation {
+public:
+    operation_skip_if_unset(const column_definition& column, expr::expression e)
+            : operation(column, e, expr::unset_bind_variable_guard(e)) {
+    }
+};
+
+class operation_no_unset_support : public operation {
+public:
+    operation_no_unset_support(const column_definition& column, std::optional<expr::expression> e)
+            : operation(column, std::move(e), expr::unset_bind_variable_guard(std::nullopt)) {
+    }
 };
 
 }

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -30,6 +30,7 @@ query_options::query_options(const cql_config& cfg,
                            std::optional<std::vector<sstring_view>> names,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
+                           cql3::unset_bind_variable_vector unset,
                            bool skip_metadata,
                            specific_options options,
                            cql_serialization_format sf)
@@ -38,6 +39,7 @@ query_options::query_options(const cql_config& cfg,
    , _names(std::move(names))
    , _values(std::move(values))
    , _value_views(value_views)
+   , _unset(unset)
    , _skip_metadata(skip_metadata)
    , _options(std::move(options))
    , _cql_serialization_format(sf)
@@ -47,15 +49,16 @@ query_options::query_options(const cql_config& cfg,
 query_options::query_options(const cql_config& cfg,
                              db::consistency_level consistency,
                              std::optional<std::vector<sstring_view>> names,
-                             std::vector<cql3::raw_value> values,
+                             cql3::raw_value_vector_with_unset values,
                              bool skip_metadata,
                              specific_options options,
                              cql_serialization_format sf)
     : _cql_config(cfg)
     , _consistency(consistency)
     , _names(std::move(names))
-    , _values(std::move(values))
+    , _values(std::move(values.values))
     , _value_views()
+    , _unset(std::move(values.unset))
     , _skip_metadata(skip_metadata)
     , _options(std::move(options))
     , _cql_serialization_format(sf)
@@ -66,7 +69,7 @@ query_options::query_options(const cql_config& cfg,
 query_options::query_options(const cql_config& cfg,
                              db::consistency_level consistency,
                              std::optional<std::vector<sstring_view>> names,
-                             std::vector<cql3::raw_value_view> value_views,
+                             cql3::raw_value_view_vector_with_unset value_views,
                              bool skip_metadata,
                              specific_options options,
                              cql_serialization_format sf)
@@ -74,14 +77,15 @@ query_options::query_options(const cql_config& cfg,
     , _consistency(consistency)
     , _names(std::move(names))
     , _values()
-    , _value_views(std::move(value_views))
+    , _value_views(std::move(value_views.values))
+    , _unset(std::move(value_views.unset))
     , _skip_metadata(skip_metadata)
     , _options(std::move(options))
     , _cql_serialization_format(sf)
 {
 }
 
-query_options::query_options(db::consistency_level cl, std::vector<cql3::raw_value> values,
+query_options::query_options(db::consistency_level cl, cql3::raw_value_vector_with_unset values,
         specific_options options)
     : query_options(
           default_cql_config,
@@ -101,6 +105,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_names),
         std::move(qo->_values),
         std::move(qo->_value_views),
+        std::move(qo->_unset),
         qo->_skip_metadata,
         query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
         qo->_cql_serialization_format) {
@@ -113,13 +118,14 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_names),
         std::move(qo->_values),
         std::move(qo->_value_views),
+        std::move(qo->_unset),
         qo->_skip_metadata,
         query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
         qo->_cql_serialization_format) {
 
 }
 
-query_options::query_options(std::vector<cql3::raw_value> values)
+query_options::query_options(cql3::raw_value_vector_with_unset values)
     : query_options(
           db::consistency_level::ONE, std::move(values))
 {}

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <concepts>
+#include <initializer_list>
 #include "timestamp.hh"
 #include "bytes.hh"
 #include "db/consistency_level_type.hh"
@@ -18,6 +19,7 @@
 #include "service/pager/paging_state.hh"
 #include "cql3/values.hh"
 #include "cql_serialization_format.hh"
+#include "utils/small_vector.hh"
 
 namespace cql3 {
 
@@ -27,6 +29,38 @@ extern const cql_config default_cql_config;
 class column_specification;
 
 using computed_function_values = std::unordered_map<uint8_t, bytes_opt>;
+
+using unset_bind_variable_vector = utils::small_vector<bool, 16>;
+
+// Matches a raw_value_view with an unset vector to support CQL binary protocol
+// "unset" values.
+struct raw_value_view_vector_with_unset {
+    std::vector<raw_value_view> values;
+    unset_bind_variable_vector unset;
+
+    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    // Constructor with no unset support, for tests and internal queries
+    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_) : values(std::move(values_)) {
+        unset.resize(values.size());
+    }
+    raw_value_view_vector_with_unset() = default;
+};
+
+// Matches a raw_value with an unset vector to support CQL binary protocol
+// "unset" values.
+struct raw_value_vector_with_unset {
+    std::vector<raw_value> values;
+    unset_bind_variable_vector unset;
+
+    raw_value_vector_with_unset(std::vector<raw_value> values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    // Constructor with no unset support, for tests and internal queries
+    raw_value_vector_with_unset(std::vector<raw_value> values_) : values(std::move(values_)) {
+        unset.resize(values.size());
+    }
+    // Mostly for testing.
+    raw_value_vector_with_unset(std::initializer_list<raw_value> values_) : raw_value_vector_with_unset(std::vector(values_)) {}
+    raw_value_vector_with_unset() = default;
+};
 
 /**
  * Options for a query.
@@ -48,6 +82,7 @@ private:
     const std::optional<std::vector<sstring_view>> _names;
     std::vector<cql3::raw_value> _values;
     std::vector<cql3::raw_value_view> _value_views;
+    unset_bind_variable_vector _unset;
     const bool _skip_metadata;
     const specific_options _options;
     cql_serialization_format _cql_serialization_format;
@@ -83,23 +118,10 @@ private:
     // evaluation sites and we only have a const reference to `query_options`.
     mutable computed_function_values _cached_pk_fn_calls;
 private:
-    /**
-     * @brief Batch query_options constructor.
-     *
-     * Requirements:
-     *   - @tparam OneMutationDataRange has a begin() and end() iterators.
-     *   - The values of @tparam OneMutationDataRange are of either raw_value_view or raw_value types.
-     *
-     * @param o Base query_options object. query_options objects for each statement in the batch will derive the values from it.
-     * @param values_ranges a vector of values ranges for each statement in the batch.
-     */
-    template<typename OneMutationDataRange>
-    requires requires (OneMutationDataRange range) {
-         std::begin(range);
-         std::end(range);
-    } && ( requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value_view>; } ||
-           requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value>; } )
-    explicit query_options(query_options&& o, std::vector<OneMutationDataRange> values_ranges);
+    // Batch constructor.
+    template <typename Values>
+    requires std::same_as<Values, raw_value_vector_with_unset> || std::same_as<Values, raw_value_view_vector_with_unset>
+    explicit query_options(query_options&& o, std::vector<Values> values_ranges);
 
 public:
     query_options(query_options&&) = default;
@@ -108,7 +130,7 @@ public:
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<sstring_view>> names,
-                           std::vector<cql3::raw_value> values,
+                           raw_value_vector_with_unset values,
                            bool skip_metadata,
                            specific_options options,
                            cql_serialization_format sf);
@@ -117,34 +139,21 @@ public:
                            std::optional<std::vector<sstring_view>> names,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
+                           unset_bind_variable_vector unset,
                            bool skip_metadata,
                            specific_options options,
                            cql_serialization_format sf);
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<sstring_view>> names,
-                           std::vector<cql3::raw_value_view> value_views,
+                           raw_value_view_vector_with_unset value_views,
                            bool skip_metadata,
                            specific_options options,
                            cql_serialization_format sf);
 
-    /**
-     * @brief Batch query_options factory.
-     *
-     * Requirements:
-     *   - @tparam OneMutationDataRange has a begin() and end() iterators.
-     *   - The values of @tparam OneMutationDataRange are of either raw_value_view or raw_value types.
-     *
-     * @param o Base query_options object. query_options objects for each statement in the batch will derive the values from it.
-     * @param values_ranges a vector of values ranges for each statement in the batch.
-     */
-    template<typename OneMutationDataRange>
-    requires requires (OneMutationDataRange range) {
-         std::begin(range);
-         std::end(range);
-    } && ( requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value_view>; } ||
-           requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value>; } )
-    static query_options make_batch_options(query_options&& o, std::vector<OneMutationDataRange> values_ranges) {
+    template <typename Values>
+    requires std::same_as<Values, raw_value_vector_with_unset> || std::same_as<Values, raw_value_view_vector_with_unset>
+    static query_options make_batch_options(query_options&& o, std::vector<Values> values_ranges) {
         return query_options(std::move(o), std::move(values_ranges));
     }
 
@@ -152,8 +161,8 @@ public:
     static thread_local query_options DEFAULT;
 
     // forInternalUse
-    explicit query_options(std::vector<cql3::raw_value> values);
-    explicit query_options(db::consistency_level, std::vector<cql3::raw_value> values, specific_options options = specific_options::DEFAULT);
+    explicit query_options(raw_value_vector_with_unset values);
+    explicit query_options(db::consistency_level, raw_value_vector_with_unset values, specific_options options = specific_options::DEFAULT);
     explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<service::pager::paging_state> paging_state);
     explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<service::pager::paging_state> paging_state, int32_t page_size);
 
@@ -162,7 +171,14 @@ public:
     }
 
     cql3::raw_value_view get_value_at(size_t idx) const {
-        return _value_views.at(idx);
+        if (_unset.at(idx)) {
+            throw exceptions::invalid_request_exception(fmt::format("Unexpected unset value for bind variable {}", idx));
+        }
+        return _value_views[idx];
+    }
+
+    bool is_unset(size_t idx) const {
+        return _unset.at(idx);
     }
 
     size_t get_values_count() const {
@@ -278,13 +294,9 @@ private:
     void fill_value_views();
 };
 
-template<typename OneMutationDataRange>
-requires requires (OneMutationDataRange range) {
-     std::begin(range);
-     std::end(range);
-} && ( requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value_view>; } ||
-       requires (OneMutationDataRange range) { { *range.begin() } -> std::convertible_to<raw_value>; } )
-query_options::query_options(query_options&& o, std::vector<OneMutationDataRange> values_ranges)
+template <typename Values>
+requires std::same_as<Values, raw_value_vector_with_unset> || std::same_as<Values, raw_value_view_vector_with_unset>
+query_options::query_options(query_options&& o, std::vector<Values> values_ranges)
     : query_options(std::move(o))
 {
     std::vector<query_options> tmp;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1784,7 +1784,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
             oper_t::EQ,
             // TODO: This should be a unique marker whose value we set at execution time.  There is currently no
             // handy mechanism for doing that in query_options.
-            expr::constant::make_unset_value(token_column->type));
+            expr::constant::make_null(token_column->type));
 }
 
 void statement_restrictions::prepare_indexed_local(const schema& idx_tbl_schema) {

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -21,9 +21,6 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 
 void
 sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
-    if (value.is_unset_value()) {
-        return;
-    }
     if (column.type->is_multi_cell()) {
         // Delete all cells first, then add new ones
         collection_mutation_description mut;
@@ -36,9 +33,6 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 void
 sets::adder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     const cql3::raw_value value = expr::evaluate(*_e, params._options);
-    if (value.is_unset_value()) {
-        return;
-    }
     assert(column.type->is_multi_cell()); // "Attempted to add items to a frozen set";
     do_add(m, row_key, params, value, column);
 }
@@ -79,7 +73,7 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
     assert(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
 
     cql3::raw_value svalue = expr::evaluate(*_e, params._options);
-    if (svalue.is_null_or_unset()) {
+    if (svalue.is_null()) {
         return;
     }
 

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -27,19 +27,19 @@ class sets {
 public:
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification& column);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
         setter(const column_definition& column, expr::expression e)
-                : operation(column, std::move(e)) {
+                : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class adder : public operation {
+    class adder : public operation_skip_if_unset {
     public:
         adder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
@@ -47,18 +47,18 @@ public:
     };
 
     // Note that this is reused for Map subtraction too (we subtract a set from a map)
-    class discarder : public operation {
+    class discarder : public operation_skip_if_unset {
     public:
         discarder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) {
+            : operation_skip_if_unset(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 
-    class element_discarder : public operation {
+    class element_discarder : public operation_no_unset_support {
     public:
         element_discarder(const column_definition& column, expr::expression e)
-            : operation(column, std::move(e)) { }
+            : operation_no_unset_support(column, std::move(e)) { }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 };

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -48,6 +48,9 @@ void delete_statement::add_update_for_key(mutation& m, const query::clustering_r
     }
 
     for (auto&& op : _column_operations) {
+        if (op->should_skip_operation(params._options)) {
+            continue;
+        }
         op->execute(m, range.start() ? std::move(range.start()->value()) : clustering_key_prefix::make_empty(), params);
     }
 }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -92,6 +92,9 @@ bool update_statement::allow_clustering_key_slices() const {
 
 void update_statement::execute_operations_for_key(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const json_cache_opt& json_cache) const {
     for (auto&& update : _column_operations) {
+        if (update->should_skip_operation(params._options)) {
+            continue;
+        }
         update->execute(m, prefix, params);
     }
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -25,10 +25,6 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
 }
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& ut_value) {
-    if (ut_value.is_unset_value()) {
-        return;
-    }
-
     auto& type = static_cast<const user_type_impl&>(*column.type);
     if (type.is_multi_cell()) {
         // Non-frozen user defined type.
@@ -79,9 +75,6 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
     assert(column.type->is_user_type() && column.type->is_multi_cell());
 
     auto value = expr::evaluate(*_e, params._options);
-    if (value.is_unset_value()) {
-        return;
-    }
 
     auto& type = static_cast<const user_type_impl&>(*column.type);
 

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -26,29 +26,29 @@ class user_types {
 public:
     static lw_shared_ptr<column_specification> field_spec_of(const column_specification& column, size_t field);
 
-    class setter : public operation {
+    class setter : public operation_skip_if_unset {
     public:
-        using operation::operation;
+        using operation_skip_if_unset::operation_skip_if_unset;
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
-    class setter_by_field : public operation {
+    class setter_by_field : public operation_skip_if_unset {
         size_t _field_idx;
     public:
         setter_by_field(const column_definition& column, size_t field_idx, expr::expression e)
-            : operation(column, std::move(e)), _field_idx(field_idx) {
+            : operation_skip_if_unset(column, std::move(e)), _field_idx(field_idx) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
     };
 
-    class deleter_by_field : public operation {
+    class deleter_by_field : public operation_no_unset_support {
         size_t _field_idx;
     public:
         deleter_by_field(const column_definition& column, size_t field_idx)
-            : operation(column, std::nullopt), _field_idx(field_idx) {
+            : operation_no_unset_support(column, std::nullopt), _field_idx(field_idx) {
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -206,7 +206,7 @@ future<> raft_sys_table_storage::do_store_log_entries(const std::vector<raft::lo
     // fragmented storage for log_entries data
     std::vector<fragmented_temporary_buffer> stmt_data_views;
     // statement value views -- required for `query_options` to consume `fragmented_temporary_buffer::view`
-    std::vector<std::vector<cql3::raw_value_view>> stmt_value_views;
+    std::vector<cql3::raw_value_view_vector_with_unset> stmt_value_views;
     const size_t entries_size = entries.size();
     batch_stmts.reserve(entries_size);
     stmt_values.reserve(entries_size);

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -393,10 +393,8 @@ SEASTAR_TEST_CASE(test_bound_var_in_collection_literal) {
                 exceptions::invalid_request_exception
             );
 
-            // Unset value is not allowed as a collections element
-            const auto unset_value = cql3::raw_value::make_unset_value();
             BOOST_REQUIRE_THROW(
-                e.execute_prepared(stmt, {unset_value}).get(),
+                e.execute_prepared(stmt, cql3::raw_value_vector_with_unset({null_value}, {true})).get(),
                 exceptions::invalid_request_exception
             );
 
@@ -5300,8 +5298,6 @@ cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vecto
     for (const cql3::raw_value& val : elements_to_write) {
         if (val.is_null()) {
                 write_int32(out, -1);
-        } else if (val.is_unset_value()) {
-                write_int32(out, -2);
         } else {
             val.view().with_value([&](const FragmentedView auto& val_view) {
                 write_collection_value(out, sf, linearized(val_view));
@@ -5322,7 +5318,7 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         };
 
         auto check_unset_msg = [](std::experimental::source_location loc = std::experimental::source_location::current()) {
-            return exception_predicate::message_equals("unset value is not supported inside collections", loc);
+            return exception_predicate::message_contains("unset", loc);
         };
 
         // Test null when specified inside a collection literal
@@ -5344,7 +5340,6 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         auto insert_map_with_value_marker = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, {0:1, 2:?, 4:5})").get0();
 
         cql3::raw_value null_value = cql3::raw_value::make_null();
-        cql3::raw_value unset_value = cql3::raw_value::make_unset_value();
 
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_list_with_marker, {null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
@@ -5355,13 +5350,15 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map_with_value_marker, {null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
 
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_list_with_marker, {unset_value}).get(),
+        auto bind_variable_list_with_unset = cql3::raw_value_vector_with_unset({null_value}, {true});
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_list_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_set_with_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_set_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map_with_key_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map_with_key_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map_with_value_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map_with_value_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
 
 
@@ -5394,27 +5391,6 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
                                 exceptions::invalid_request_exception, check_null_msg());
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map, {map_with_null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
-
-
-        cql3::raw_value list_with_unset = make_collection_raw_value(3, {make_int(1), unset_value, make_int(2)});
-        cql3::raw_value set_with_unset = make_collection_raw_value(3, {make_int(1), unset_value, make_int(2)});
-
-        cql3::raw_value map_with_unset_key = make_collection_raw_value(3, {make_int(0), make_int(1),
-                                                                     unset_value, make_int(3),
-                                                                     make_int(4), make_int(5)});
-
-        cql3::raw_value map_with_unset_value = make_collection_raw_value(3, {make_int(0), make_int(1),
-                                                                       make_int(2), unset_value,
-                                                                       make_int(4), make_int(5)});
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_list, {list_with_unset}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_set, {set_with_unset}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map, {map_with_unset_key}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(insert_map, {map_with_unset_value}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
 
 
         // Update setting to bad collection value
@@ -5462,14 +5438,13 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map_with_value_marker, {null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
 
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_list_with_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_list_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_set_with_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_set_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map_with_key_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map_with_key_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map_with_value_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map_with_value_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
 
         // Update adding a collection value with bad bind marker
@@ -5486,15 +5461,6 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map, {map_with_null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
 
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_list, {list_with_unset}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_set, {set_with_unset}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map, {map_with_unset_key}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_map, {map_with_unset_value}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
-
         // List of IN values is also a list that can't contain nulls
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT * FROM null_in_col WHERE p IN (1, null, 2)").get(),
                                 exceptions::invalid_request_exception, check_null_msg());
@@ -5503,15 +5469,13 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
 
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_with_marker, {null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_with_marker, {unset_value}).get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
 
         auto where_in_list_marker = e.prepare("SELECT * FROM null_in_col WHERE p IN ?").get0();
 
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_marker, {list_with_null}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
-        BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_marker, {list_with_unset}).get(),
-                                exceptions::invalid_request_exception, check_unset_msg());
     });
 }
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -19,10 +19,10 @@
 using namespace cql3;
 using namespace cql3::expr;
 
-bind_variable new_bind_variable(int bind_index) {
+bind_variable new_bind_variable(int bind_index, data_type type = int32_type) {
     return bind_variable {
         .bind_index = bind_index,
-        .receiver = nullptr
+        .receiver = make_lw_shared<column_specification>("ks", "tab", make_shared<column_identifier>("?", true), std::move(type)),
     };
 }
 

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -273,10 +273,10 @@ def testMapWithUnsetValues(cql, test_keyspace):
         # test unset variables in a map update operation, should not delete the contents
         execute(cql, table, "UPDATE %s SET m['k'] = ? WHERE k = 10", UNSET_VALUE)
         assert_rows(execute(cql, table, "SELECT m FROM %s WHERE k = 10"), [m])
-        assert_invalid_message(cql, table, "Invalid unset map key", "UPDATE %s SET m[?] = 'foo' WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset", "UPDATE %s SET m[?] = 'foo' WHERE k = 10", UNSET_VALUE)
 
         # test unset value for map key
-        assert_invalid_message(cql, table, "Invalid unset map key", "DELETE m[?] FROM %s WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset", "DELETE m[?] FROM %s WHERE k = 10", UNSET_VALUE)
 
 def testListWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, l list<text>)") as table:
@@ -294,7 +294,7 @@ def testListWithUnsetValues(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT l FROM %s WHERE k = 10"), [l])
 
         # set in index
-        assert_invalid_message(cql, table, "Invalid unset value for list index", "UPDATE %s SET l[?] = 'foo' WHERE k = 10", UNSET_VALUE)
+        assert_invalid_message(cql, table, "unset value", "UPDATE %s SET l[?] = 'foo' WHERE k = 10", UNSET_VALUE)
 
         # remove element by index
         execute(cql, table, "DELETE l[?] FROM %s WHERE k = 10", UNSET_VALUE)

--- a/test/cql-pytest/cassandra_tests/validation/entities/tuple_type_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/tuple_type_test.py
@@ -92,7 +92,7 @@ def testInvalidQueries(cql, test_keyspace):
 def testTupleWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, t tuple<int, text, double>)") as table:
         # invalid positional field substitution
-        assert_invalid_message(cql, table, "Invalid unset value for tuple field number 1",
+        assert_invalid_message(cql, table, "unset",
                              "INSERT INTO %s (k, t) VALUES(0, (3, ?, 2.1))", UNSET_VALUE)
 
         #FIXME: The Python driver doesn't agree to send such a command to the server,

--- a/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
@@ -159,10 +159,10 @@ def testUDTWithUnsetValues(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(x int, y int)") as myType:
         with create_type(cql, test_keyspace, f"(a frozen<{myType}>)") as myOtherType:
             with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v frozen<{myType}>, z frozen<{myOtherType}>)") as table:
-                assert_invalid_message(cql, table, "Invalid unset value for field 'y' of user defined type ",
+                assert_invalid_message(cql, table, "unset",
                     "INSERT INTO %s (k, v) VALUES (10, {x:?, y:?})", 1, UNSET_VALUE)
                 # Reproduces issue #9671:
-                assert_invalid_message(cql, table, "Invalid unset value for field 'y' of user defined type ",
+                assert_invalid_message(cql, table, "unset",
                     "INSERT INTO %s (k, v, z) VALUES (10, {x:?, y:?}, {a:{x: ?, y: ?}})", 1, 1, 1, UNSET_VALUE)
 
 def testAlteringUserTypeNestedWithinMap(cql, test_keyspace):

--- a/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
@@ -1,0 +1,206 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit a87055d56a33a9b17606f14535f48eb461965b82
+#
+# The original Apache Cassandra license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cassandra_tests.porting import *
+
+def testInsertWithUnset(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
+        # insert using nulls
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", "text", 10)
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", null, null)
+        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k = 10"),
+                   row(null, null) # sending null deletes the data
+        )
+        # insert using UNSET
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", "text", 10)
+        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", unset(), unset())
+        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k=11"),
+                   row("text", 10) # unset columns does not delete the existing data
+        )
+
+        # The Python driver doesn't allow unset() as partition key (needed
+        # for selecting the coordinator), so we can't test this:
+        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "UPDATE %s SET i = 0 WHERE k = ?", unset())
+        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "DELETE FROM %s WHERE k = ?", unset())
+        # Scylla and Cassandra have slightly different messages here. Cassandra
+        # has "Invalid unset value for argument in call to function blobasint"
+        # Scylla has "Invalid null or unset value for argument to
+        # system.blobasint : (blob) -> int"
+        assertInvalidMessageRE(cql, table, "unset", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset())
+
+# Both Scylla and Cassandra define MAX_TTL or max_ttl with the same formula,
+# 20 years in seconds. In both systems, it is not configurable.
+MAX_TTL = 20 * 365 * 24 * 60 * 60
+
+# Reproduces #12243:
+@pytest.mark.xfail(reason="Issue #12243")
+def testInsertWithTtl(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v int)") as table:
+        # test with unset
+        execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, 1) USING TTL ?", unset()); # treat as 'unlimited'
+        assertRows(execute(cql, table, "SELECT ttl(v) FROM %s"), row(null))
+
+        # test with null
+        # Reproduces #12243:
+        execute(cql, table, "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, null)
+        assertRows(execute(cql, table, "SELECT k, v, TTL(v) FROM %s"), row(1, 1, null))
+
+        # test error handling
+        assertInvalidMessage(cql, table, "TTL must be greater or equal to 0",
+                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, -5)
+
+        assertInvalidMessage(cql, table, "ttl is too large.",
+                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, MAX_TTL + 1)
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsert(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering) VALUES (0, 0)")
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
+        if forceFlush:
+            flush(cql, table)
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(0, 0, null),
+                   row(0, 1, 1))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering, value) VALUES (0, 1)")
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*clustering",
+                             "INSERT INTO %s (partitionKey, value) VALUES (0, 2)")
+
+        # multiple time the same value
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)")
+
+        # multiple time same primary key element in WHERE clause
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)")
+
+        # unknown identifiers
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clusteringx",
+                             "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)")
+
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
+                             "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)")
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsertWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)")
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
+        if forceFlush:
+            flush(cql, table)
+
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(0, 0, 0, null),
+                   row(0, 0, 1, 1))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)")
+        assertInvalidMessageRE(cql, table, "clustering_1",
+                             "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)")
+
+        # multiple time the same value
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)")
+
+        # multiple time same primary key element in WHERE clause
+        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
+                             "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)")
+
+        # unknown identifiers
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clustering_1x",
+                             "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)")
+
+        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
+                             "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)")
+
+@pytest.mark.parametrize("forceFlush", [False, True])
+def testInsertWithAStaticColumn(cql, test_keyspace, forceFlush):
+    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, staticValue) VALUES (0, 0, 0, 'A')")
+        execute(cql, table, "INSERT INTO %s (partitionKey, staticValue) VALUES (1, 'B')")
+        if forceFlush:
+            flush(cql, table)
+
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(1, null, null, "B", null),
+                   row(0, 0, 0, "A", null))
+
+        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 0)")
+        if forceFlush:
+            flush(cql, table)
+        assertRows(execute(cql, table, "SELECT * FROM %s"),
+                   row(1, 0, 0, "B", 0),
+                   row(0, 0, 0, "A", null))
+
+        # Missing primary key columns
+        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
+                             "INSERT INTO %s (clustering_1, clustering_2, staticValue) VALUES (0, 0, 'A')")
+        assertInvalidMessageRE(cql, table, "clustering_1",
+                             "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')")
+
+# Reproduces #6447 and #12243:
+@pytest.mark.xfail(reason="Issue #6447, #12243")
+def testInsertWithDefaultTtl(cql, test_keyspace):
+    secondsPerMinute = 60
+    with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10*secondsPerMinute}") as table:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 1"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (2, 2) USING TTL ?", (5 * secondsPerMinute))
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 2"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') <= 5 * secondsPerMinute
+
+        # Reproduces #6447:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (3, 3) USING TTL ?", 0)
+        assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 3"), row(null))
+
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (4, 4) USING TTL ?", unset())
+        results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"))
+        assert len(results) == 1
+        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+
+        # Reproduces #12243:
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?) USING TTL ?", 4, 4, null)
+        assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"), row(null))
+
+
+TOO_BIG = 1024 * 65
+
+# Reproduces #12247:
+@pytest.mark.xfail(reason="Issue #12247")
+def testPKInsertWithValueOver64K(cql, test_keyspace):
+    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
+        assertInvalidThrow(cql, table, InvalidRequest,
+                           "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
+
+# Reproduces #12247:
+@pytest.mark.xfail(reason="Issue #12247")
+def testCKInsertWithValueOver64K(cql, test_keyspace):
+    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
+        assertInvalidThrow(cql, table, InvalidRequest,
+                           "INSERT INTO %s (a, b) VALUES ('foo', ?)", 'x'*TOO_BIG)

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -476,9 +476,9 @@ def testFunctionCallWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
         # The error messages in Scylla and Cassandra here are slightly
         # different.
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset",
                              "SELECT * FROM %s WHERE token(k) >= token(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset",
                              "SELECT * FROM %s WHERE k = blobAsInt(?)", UNSET_VALUE)
 
 def testLimitWithUnset(cql, test_keyspace):

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -220,7 +220,7 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # the scan brings up several rows, it may exercise different code
         # paths.
         assert list(cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")) == []
-        with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+        with pytest.raises(InvalidRequest, match='unset'):
             cql.execute(stmt, [UNSET_VALUE])
 
         # check subscripted list filtering

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -1,0 +1,33 @@
+import pytest
+from util import new_test_table, unique_key_int
+from cassandra.query import UNSET_VALUE
+from cassandra.protocol import InvalidRequest
+
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+# Although UNSET_VALUE is designed to skip part of a SET, it is not designed
+# to skip an entire write which uses a an UNSET_VALUE in its WHERE clause -
+# this should be treated as an error, not a silent skip.
+#
+# As in test_unset_where_clustering() above (the SELECT version of this test)
+# we need to check the UNSET_VALUE on the clustering key because if we try
+# an UNSET_VALUE on the partition key, the Python driver will refuse to
+# send the request (it uses the partition key to decide which node to send
+# the request).
+def test_unset_insert_where(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Similar to test_unset_insert_where() above, just use an LWT write ("IF
+# NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condtion causes
+# a clear error, not silent skip and not a crash as in issue #13001.
+def test_unset_insert_where_lwt(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -234,7 +234,7 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared(
         cql3::prepared_cache_key_type id,
-        std::vector<cql3::raw_value> values,
+        cql3::raw_value_vector_with_unset values,
         db::consistency_level cl = db::consistency_level::ONE) override {
 
         const auto& so = cql3::query_options::specific_options::DEFAULT;

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -112,7 +112,7 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared(
         cql3::prepared_cache_key_type id,
-        std::vector<cql3::raw_value> values,
+        cql3::raw_value_vector_with_unset values,
         db::consistency_level cl = db::consistency_level::ONE) = 0;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_prepared_with_qo(

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -1,0 +1,513 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "expr_test_utils.hh"
+
+namespace cql3 {
+namespace expr {
+namespace test_utils {
+template <class T>
+raw_value make_raw(T t) {
+    data_type val_type = data_type_for<T>();
+    data_value data_val(t);
+    return raw_value::make_value(val_type->decompose(data_val));
+}
+
+raw_value make_empty_raw() {
+    return raw_value::make_value(managed_bytes());
+}
+
+raw_value make_bool_raw(bool val) {
+    return make_raw(val);
+}
+
+raw_value make_tinyint_raw(int8_t val) {
+    return make_raw(val);
+}
+
+raw_value make_smallint_raw(int16_t val) {
+    return make_raw(val);
+}
+
+raw_value make_int_raw(int32_t val) {
+    return make_raw(val);
+}
+
+raw_value make_bigint_raw(int64_t val) {
+    return make_raw(val);
+}
+
+raw_value make_text_raw(const sstring_view& text) {
+    return raw_value::make_value(utf8_type->decompose(text));
+}
+
+template <class T>
+constant make_const(T t) {
+    data_type val_type = data_type_for<T>();
+    return constant(make_raw(t), val_type);
+}
+
+constant make_empty_const(data_type type) {
+    return constant(make_empty_raw(), type);
+}
+
+constant make_bool_const(bool val) {
+    return make_const(val);
+}
+
+constant make_tinyint_const(int8_t val) {
+    return make_const(val);
+}
+
+constant make_smallint_const(int16_t val) {
+    return make_const(val);
+}
+
+constant make_int_const(int32_t val) {
+    return make_const(val);
+}
+
+constant make_bigint_const(int64_t val) {
+    return make_const(val);
+}
+
+constant make_text_const(const sstring_view& text) {
+    return constant(make_text_raw(text), utf8_type);
+}
+
+// This function implements custom serialization of collection values.
+// Some tests require the collection to contain an empty value,
+// which is impossible to express using the existing code.
+cql3::raw_value make_collection_raw(size_t size_to_write, const std::vector<cql3::raw_value>& elements_to_write) {
+    size_t serialized_len = 0;
+    serialized_len += collection_size_len();
+    for (const cql3::raw_value& val : elements_to_write) {
+        serialized_len += collection_value_len();
+        if (val.is_value()) {
+            serialized_len += val.view().with_value([](const FragmentedView auto& view) { return view.size_bytes(); });
+        }
+    }
+
+    bytes b(bytes::initialized_later(), serialized_len);
+    bytes::iterator out = b.begin();
+
+    write_collection_size(out, size_to_write);
+    for (const cql3::raw_value& val : elements_to_write) {
+        if (val.is_null()) {
+            write_int32(out, -1);
+        } else {
+            val.view().with_value(
+                [&](const FragmentedView auto& val_view) { write_collection_value(out, linearized(val_view)); });
+        }
+    }
+
+    return cql3::raw_value::make_value(b);
+}
+
+raw_value make_list_raw(const std::vector<raw_value>& values) {
+    return make_collection_raw(values.size(), values);
+}
+
+raw_value make_set_raw(const std::vector<raw_value>& values) {
+    return make_collection_raw(values.size(), values);
+}
+
+raw_value make_map_raw(const std::vector<std::pair<raw_value, raw_value>>& values) {
+    std::vector<raw_value> flattened_values;
+    for (const std::pair<raw_value, raw_value>& pair_val : values) {
+        flattened_values.push_back(pair_val.first);
+        flattened_values.push_back(pair_val.second);
+    }
+    return make_collection_raw(values.size(), flattened_values);
+}
+
+// This function implements custom serialization of tuples.
+// Some tests require the tuple to contain an empty value,
+// which is impossible to express using the existing code.
+raw_value make_tuple_raw(const std::vector<raw_value>& values) {
+    size_t serialized_len = 0;
+    for (const raw_value& val : values) {
+        serialized_len += 4;
+        if (val.is_value()) {
+            serialized_len += val.view().size_bytes();
+        }
+    }
+    managed_bytes ret(managed_bytes::initialized_later(), serialized_len);
+    managed_bytes_mutable_view out(ret);
+    for (const raw_value& val : values) {
+        if (val.is_null()) {
+            write<int32_t>(out, -1);
+        } else {
+            val.view().with_value([&](const FragmentedView auto& bytes_view) {
+                write<int32_t>(out, bytes_view.size_bytes());
+                write_fragmented(out, bytes_view);
+            });
+        }
+    }
+    return raw_value::make_value(std::move(ret));
+}
+
+template <class T>
+raw_value to_raw_value(const T& t) {
+    if constexpr (std::same_as<T, raw_value>) {
+        return t;
+    } else if constexpr (std::same_as<T, constant>) {
+        return t.value;
+    } else {
+        return make_raw<T>(t);
+    }
+}
+
+// A concept which expresses that it's possible to convert T to raw_value.
+// Satisfied for raw_value, constant, int32_t, and various other types.
+template <class T>
+concept ToRawValue = requires(T t) {
+    data_value(t);
+    { to_raw_value(t) } -> std::same_as<raw_value>;
+}
+|| std::same_as<T, constant> || std::same_as<T, raw_value>;
+
+template <ToRawValue T>
+std::vector<raw_value> to_raw_values(const std::vector<T>& values) {
+    std::vector<raw_value> raw_vals;
+    for (const T& val : values) {
+        raw_vals.push_back(to_raw_value(val));
+    }
+    return raw_vals;
+}
+
+template <ToRawValue T1, ToRawValue T2>
+std::vector<std::pair<raw_value, raw_value>> to_raw_value_pairs(const std::vector<std::pair<T1, T2>>& values) {
+    std::vector<std::pair<raw_value, raw_value>> raw_vals;
+    for (const std::pair<T1, T2>& val : values) {
+        raw_vals.emplace_back(to_raw_value(val.first), to_raw_value(val.second));
+    }
+    return raw_vals;
+}
+
+constant make_list_const(const std::vector<raw_value>& vals, data_type elements_type) {
+    raw_value raw_list = make_list_raw(vals);
+    data_type list_type = list_type_impl::get_instance(elements_type, true);
+    return constant(std::move(raw_list), std::move(list_type));
+}
+
+constant make_list_const(const std::vector<constant>& vals, data_type elements_type) {
+    return make_list_const(to_raw_values(vals), elements_type);
+}
+
+constant make_set_const(const std::vector<raw_value>& vals, data_type elements_type) {
+    raw_value raw_set = make_set_raw(vals);
+    data_type set_type = set_type_impl::get_instance(elements_type, true);
+    return constant(std::move(raw_set), std::move(set_type));
+}
+
+constant make_set_const(const std::vector<constant>& vals, data_type elements_type) {
+    return make_set_const(to_raw_values(vals), elements_type);
+}
+
+constant make_map_const(const std::vector<std::pair<raw_value, raw_value>>& vals,
+                        data_type key_type,
+                        data_type value_type) {
+    raw_value raw_map = make_map_raw(vals);
+    data_type map_type = map_type_impl::get_instance(key_type, value_type, true);
+    return constant(std::move(raw_map), std::move(map_type));
+}
+
+constant make_map_const(const std::vector<std::pair<constant, constant>>& vals,
+                        data_type key_type,
+                        data_type value_type) {
+    return make_map_const(to_raw_value_pairs(vals), key_type, value_type);
+}
+
+constant make_tuple_const(const std::vector<raw_value>& vals, const std::vector<data_type>& element_types) {
+    raw_value raw_tuple = make_tuple_raw(vals);
+    data_type tuple_type = tuple_type_impl::get_instance(element_types);
+    return constant(std::move(raw_tuple), std::move(tuple_type));
+}
+
+constant make_tuple_const(const std::vector<constant>& vals, const std::vector<data_type>& element_types) {
+    return test_utils::make_tuple_const(to_raw_values(vals), element_types);
+}
+
+raw_value make_int_list_raw(const std::vector<int32_t>& values) {
+    return make_list_raw(to_raw_values(values));
+}
+
+raw_value make_int_set_raw(const std::vector<int32_t>& values) {
+    return make_set_raw(to_raw_values(values));
+}
+
+raw_value make_int_int_map_raw(const std::vector<std::pair<int32_t, int32_t>>& values) {
+    return make_map_raw(to_raw_value_pairs(values));
+}
+
+constant make_int_list_const(const std::vector<int32_t>& values) {
+    return constant(make_int_list_raw(values), list_type_impl::get_instance(int32_type, true));
+}
+
+constant make_int_set_const(const std::vector<int32_t>& values) {
+    return constant(make_int_set_raw(values), set_type_impl::get_instance(int32_type, true));
+}
+
+constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& values) {
+    return constant(make_int_int_map_raw(values), map_type_impl::get_instance(int32_type, int32_type, true));
+}
+
+collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type) {
+    return collection_constructor{.style = collection_constructor::style_type::list,
+                                  .elements = std::move(elements),
+                                  .type = list_type_impl::get_instance(elements_type, true)};
+}
+
+collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type) {
+    return collection_constructor{.style = collection_constructor::style_type::set,
+                                  .elements = std::move(elements),
+                                  .type = set_type_impl::get_instance(elements_type, true)};
+}
+
+collection_constructor make_map_constructor(const std::vector<expression> elements,
+                                            data_type key_type,
+                                            data_type element_type) {
+    return collection_constructor{.style = collection_constructor::style_type::map,
+                                  .elements = std::move(elements),
+                                  .type = map_type_impl::get_instance(key_type, element_type, true)};
+}
+
+collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
+                                            data_type key_type,
+                                            data_type element_type) {
+    std::vector<expression> map_element_pairs;
+    for (const std::pair<expression, expression>& element : elements) {
+        map_element_pairs.push_back(tuple_constructor{.elements = {element.first, element.second},
+                                                      .type = tuple_type_impl::get_instance({key_type, element_type})});
+    }
+    return make_map_constructor(map_element_pairs, key_type, element_type);
+}
+
+tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types) {
+    return tuple_constructor{.elements = std::move(elements),
+                             .type = tuple_type_impl::get_instance(std::move(element_types))};
+}
+
+usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values) {
+    usertype_constructor::elements_map_type elements_map;
+    std::vector<bytes> field_names;
+    std::vector<data_type> field_types;
+    for (auto& [field_name, field_value] : field_values) {
+        field_names.push_back(field_name.data());
+        field_types.push_back(field_value.type);
+        elements_map.emplace(column_identifier(sstring(field_name), true), field_value);
+    }
+    data_type type = user_type_impl::get_instance("test_ks", "test_user_type", field_names, field_types, true);
+    return usertype_constructor{.elements = std::move(elements_map), .type = std::move(type)};
+}
+
+::lw_shared_ptr<column_specification> make_receiver(data_type receiver_type, sstring receiver_name) {
+    return ::make_lw_shared<column_specification>(
+        "test_ks", "test_cf", ::make_shared<cql3::column_identifier>(receiver_name, true), receiver_type);
+}
+
+// Creates evaluation_inputs that can be used to evaluate columns and bind variables using evaluate()
+std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evaluation_inputs(
+    const schema_ptr& table_schema,
+    const column_values& column_vals,
+    const std::vector<raw_value>& bind_marker_values) {
+    auto throw_error = [&](const auto&... fmt_args) -> sstring {
+        sstring error_msg = format(fmt_args...);
+        sstring final_msg = format("make_evaluation_inputs error: {}. (table_schema: {}, column_vals: {})", error_msg,
+                                   *table_schema, column_vals);
+        throw std::runtime_error(final_msg);
+    };
+
+    auto get_col_val = [&](const column_definition& col) -> const raw_value& {
+        auto col_value_iter = column_vals.find(col.name_as_text());
+        if (col_value_iter == column_vals.end()) {
+            throw_error("no value for column {}", col.name_as_text());
+        }
+        return col_value_iter->second;
+    };
+
+    std::vector<bytes> partition_key;
+    for (const column_definition& pk_col : table_schema->partition_key_columns()) {
+        const raw_value& col_value = get_col_val(pk_col);
+
+        if (col_value.is_null()) {
+            throw_error("Passed NULL as value for {}. This is not allowed for partition key columns.",
+                        pk_col.name_as_text());
+        }
+        partition_key.push_back(raw_value(col_value).to_bytes());
+    }
+
+    std::vector<bytes> clustering_key;
+    for (const column_definition& ck_col : table_schema->clustering_key_columns()) {
+        const raw_value& col_value = get_col_val(ck_col);
+
+        if (col_value.is_null()) {
+            throw_error("Passed NULL as value for {}. This is not allowed for clustering key columns.",
+                        ck_col.name_as_text());
+        }
+        clustering_key.push_back(raw_value(col_value).to_bytes());
+    }
+
+    std::vector<const column_definition*> selection_columns;
+    for (const column_definition& cdef : table_schema->regular_columns()) {
+        selection_columns.push_back(&cdef);
+    }
+    for (const column_definition& cdef : table_schema->static_columns()) {
+        selection_columns.push_back(&cdef);
+    }
+
+    ::shared_ptr<selection::selection> selection =
+        cql3::selection::selection::for_columns(table_schema, std::move(selection_columns));
+    std::vector<managed_bytes_opt> static_and_regular_columns(table_schema->regular_columns_count() +
+                                                              table_schema->static_columns_count());
+
+    for (const column_definition& col : table_schema->regular_columns()) {
+        const raw_value& col_value = get_col_val(col);
+        int32_t index = selection->index_of(col);
+        static_and_regular_columns[index] = raw_value(col_value).to_managed_bytes_opt();
+    }
+
+    for (const column_definition& col : table_schema->static_columns()) {
+        const raw_value& col_value = get_col_val(col);
+        int32_t index = selection->index_of(col);
+        static_and_regular_columns[index] = raw_value(col_value).to_managed_bytes_opt();
+    }
+
+    query_options options(default_cql_config, db::consistency_level::ONE, std::nullopt, bind_marker_values, true,
+                          query_options::specific_options::DEFAULT);
+
+    std::unique_ptr<evaluation_inputs_data> data = std::make_unique<evaluation_inputs_data>(
+        evaluation_inputs_data{.partition_key = std::move(partition_key),
+                               .clustering_key = std::move(clustering_key),
+                               .static_and_regular_columns = std::move(static_and_regular_columns),
+                               .selection = std::move(selection),
+                               .options = std::move(options)});
+
+    evaluation_inputs inputs{.partition_key = &data->partition_key,
+                             .clustering_key = &data->clustering_key,
+                             .static_and_regular_columns = &data->static_and_regular_columns,
+                             .selection = data->selection.get(),
+                             .options = &data->options};
+
+    return std::pair(std::move(inputs), std::move(data));
+}
+
+// A mock implementation of data_dictionary::database, used in tests
+class mock_database_impl : public data_dictionary::impl {
+    schema_ptr _table_schema;
+    ::lw_shared_ptr<data_dictionary::keyspace_metadata> _keyspace_metadata;
+
+    db::config _config;
+
+public:
+    explicit mock_database_impl(schema_ptr table_schema)
+        : _table_schema(table_schema),
+          _keyspace_metadata(data_dictionary::keyspace_metadata::new_keyspace(_table_schema->ks_name(),
+                                                                              "MockReplicationStrategy",
+                                                                              {},
+                                                                              false,
+                                                                              {_table_schema})) {}
+
+    static std::pair<data_dictionary::database, std::unique_ptr<mock_database_impl>> make(schema_ptr table_schema) {
+        std::unique_ptr<mock_database_impl> mock_db = std::make_unique<mock_database_impl>(table_schema);
+        data_dictionary::database db = make_database(mock_db.get(), nullptr);
+        return std::pair(std::move(db), std::move(mock_db));
+    }
+
+    virtual std::optional<data_dictionary::keyspace> try_find_keyspace(data_dictionary::database db,
+                                                                       std::string_view name) const override {
+        if (_table_schema->ks_name() == name) {
+            return make_keyspace(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual std::vector<data_dictionary::keyspace> get_keyspaces(data_dictionary::database db) const override {
+        return {make_keyspace(this, nullptr)};
+    }
+    virtual std::vector<sstring> get_user_keyspaces(data_dictionary::database db) const override {
+        return {_table_schema->ks_name()};
+    }
+    virtual std::vector<sstring> get_all_keyspaces(data_dictionary::database db) const override {
+        return {_table_schema->ks_name()};
+    }
+    virtual std::vector<data_dictionary::table> get_tables(data_dictionary::database db) const override {
+        return {make_table(this, nullptr)};
+    }
+    virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db,
+                                                                 std::string_view ks,
+                                                                 std::string_view tab) const override {
+        if (_table_schema->ks_name() == ks && _table_schema->cf_name() == tab) {
+            return make_table(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db,
+                                                                 table_id id) const override {
+        if (_table_schema->id() == id) {
+            return make_table(this, nullptr);
+        }
+        return std::nullopt;
+    }
+    virtual const secondary_index::secondary_index_manager& get_index_manager(data_dictionary::table t) const override {
+        throw std::bad_function_call();
+    }
+    virtual schema_ptr get_table_schema(data_dictionary::table t) const override { return _table_schema; }
+    virtual lw_shared_ptr<data_dictionary::keyspace_metadata> get_keyspace_metadata(
+        data_dictionary::keyspace ks) const override {
+        return _keyspace_metadata;
+    }
+
+    virtual bool is_internal(data_dictionary::keyspace ks) const override { return false; }
+    virtual const locator::abstract_replication_strategy& get_replication_strategy(
+        data_dictionary::keyspace ks) const override {
+        throw std::bad_function_call();
+    }
+    virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {
+        return {view_ptr(_table_schema)};
+    }
+    virtual sstring get_available_index_name(data_dictionary::database db,
+                                             std::string_view ks_name,
+                                             std::string_view table_name,
+                                             std::optional<sstring> index_name_root) const override {
+        return {};
+    }
+    virtual std::set<sstring> existing_index_names(data_dictionary::database db,
+                                                   std::string_view ks_name,
+                                                   std::string_view cf_to_exclude = {}) const override {
+        return {};
+    }
+    virtual schema_ptr find_indexed_table(data_dictionary::database db,
+                                          std::string_view ks_name,
+                                          std::string_view index_name) const override {
+        return nullptr;
+    }
+    virtual schema_ptr get_cdc_base_table(data_dictionary::database db, const schema&) const override {
+        return nullptr;
+    }
+    virtual const db::config& get_config(data_dictionary::database db) const override { return _config; }
+    virtual const db::extensions& get_extensions(data_dictionary::database db) const override {
+        return _config.extensions();
+    }
+    virtual const gms::feature_service& get_features(data_dictionary::database db) const override {
+        throw std::bad_function_call();
+    }
+    virtual replica::database& real_database(data_dictionary::database db) const override {
+        throw std::bad_function_call();
+    }
+
+    virtual ~mock_database_impl() = default;
+};
+
+std::pair<data_dictionary::database, std::unique_ptr<data_dictionary::impl>> make_data_dictionary_database(
+    const schema_ptr& table_schema) {
+    return mock_database_impl::make(table_schema);
+}
+}  // namespace test_utils
+}  // namespace expr
+}  // namespace cql3

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -392,7 +392,7 @@ future<> trace_keyspace_helper::apply_events_mutation(cql3::query_processor& qp,
         tlogger.trace("{}: storing {} events records: parent_id {} span_id {}", records->session_id, events_records.size(), records->parent_id, records->my_span_id);
 
         std::vector<cql3::statements::batch_statement::single_statement> modifications(events_records.size(), cql3::statements::batch_statement::single_statement(_events.insert_stmt(), false));
-        std::vector<std::vector<cql3::raw_value>> values;
+        std::vector<cql3::raw_value_vector_with_unset> values;
 
         values.reserve(events_records.size());
         std::for_each(events_records.begin(), events_records.end(), [&values, all_records = records, this] (event_record& one_event_record) { values.emplace_back(make_event_mutation_data(*all_records, one_event_record)); });

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -25,6 +25,7 @@
 namespace cql3{
 class query_options;
 struct raw_value_view;
+struct raw_value_view_vector_with_unset;
 
 namespace statements {
 class prepared_statement;
@@ -318,7 +319,7 @@ private:
      * @param t type object corresponding to the given raw value.
      * @return the string with the representation of the given raw value.
      */
-    sstring raw_value_to_sstring(const cql3::raw_value_view& v, const data_type& t);
+    sstring raw_value_to_sstring(const cql3::raw_value_view& v, bool is_unset, const data_type& t);
 
     /**
      * Stores a page size of a query being traced.
@@ -419,7 +420,7 @@ private:
      */
     void build_parameters_map_for_one_prepared(const prepared_checked_weak_ptr& prepared_ptr,
             std::optional<std::vector<sstring_view>>& names_opt,
-            std::vector<cql3::raw_value_view>& values, const sstring& param_name_prefix);
+            cql3::raw_value_view_vector_with_unset& values, const sstring& param_name_prefix);
 
     /**
      * The actual trace message storing method.

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -985,7 +985,8 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
     auto& query_state = q_state->query_state;
     if (version == 1) {
         std::vector<cql3::raw_value_view> values;
-        in.read_value_view_list(version, values);
+        cql3::unset_bind_variable_vector unset;
+        in.read_value_view_list(version, values, unset);
         auto consistency = in.read_consistency();
         q_state->options = std::make_unique<cql3::query_options>(qp.local().get_cql_config(), consistency, std::nullopt, values, false,
                                                                  cql3::query_options::specific_options::DEFAULT, serialization_format);
@@ -1057,7 +1058,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     const unsigned n = in.read_short();
 
     std::vector<cql3::statements::batch_statement::single_statement> modifications;
-    std::vector<std::vector<cql3::raw_value_view>> values;
+    std::vector<cql3::raw_value_view_vector_with_unset> values;
     std::unordered_map<cql3::prepared_cache_key_type, cql3::authorized_prepared_statements_cache::value_type> pending_authorization_entries;
 
     modifications.reserve(n);
@@ -1123,14 +1124,15 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
         modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
 
         std::vector<cql3::raw_value_view> tmp;
-        in.read_value_view_list(version, tmp);
+        cql3::unset_bind_variable_vector unset;
+        in.read_value_view_list(version, tmp, unset);
 
         auto stmt = ps->statement;
         if (stmt->get_bound_terms() != tmp.size()) {
             throw exceptions::invalid_request_exception(format("There were {:d} markers(?) in CQL but {:d} bound variables",
                             stmt->get_bound_terms(), tmp.size()));
         }
-        values.emplace_back(std::move(tmp));
+        values.emplace_back(cql3::raw_value_view_vector_with_unset(std::move(tmp), std::move(unset)));
     }
 
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -107,7 +107,7 @@ private:
     }
 
     [[noreturn]] [[gnu::cold]] [[gnu::noinline]]
-    void throw_out_of_range() {
+    void throw_out_of_range() const {
         throw std::out_of_range("out of range small vector access");
     }
 


### PR DESCRIPTION
Backport of PR #12517 to `branch-5.1`, as requested in #13001.

I cherry-picked the changes from master, but they didn't apply cleanly. There was a bunch of merge conflicts that I fixed according to my intuition, but I'm not very familiar with this change, so I can't guarantee that there aren't any hidden issues. It was a big change that touched a lot of components. It would be good if the original author (@avikivity) took a look, to see if I didn't do something stupid there, or maybe even redid the backport.

I added the test cases from #13007, but sadly it looks like cql-pytest is broken on `branch-5.1`. Trying to run `dev-test` in dbuild gave me a bunch of pytest errors. I ran the tests manually and they started passing after the change.