### PR TITLE
utils: small_vector: define operator<=>

### DIFF
--- a/test/boost/small_vector_test.cc
+++ b/test/boost/small_vector_test.cc
@@ -380,6 +380,34 @@ BOOST_AUTO_TEST_CASE(exception_safety) {
     BOOST_REQUIRE_EQUAL(fails_on_copy::live, 0);
 }
 
+BOOST_AUTO_TEST_CASE(compare) {
+    {
+        auto lhs = utils::small_vector<int, 4>({1, 2, 3, 4});
+        auto rhs = utils::small_vector<int, 4>({1, 3, 3, 4});
+        BOOST_CHECK_LT(lhs, rhs);
+    }
+    {
+        auto lhs = utils::small_vector<int, 4>({1, 2, 3, 4});
+        auto rhs = utils::small_vector<int, 4>({1, 3, 4});
+        BOOST_CHECK_LT(lhs, rhs);
+    }
+    {
+        auto lhs = utils::small_vector<int, 4>({1, 2, 3, 4});
+        auto rhs = utils::small_vector<int, 4>({1, 3, 4});
+        BOOST_CHECK_LT(lhs, rhs);
+    }
+    {
+        auto lhs = utils::small_vector<int, 4>({4, 2, 1});
+        auto rhs = utils::small_vector<int, 4>({1, 3, 3, 4});
+        BOOST_CHECK_GT(lhs, rhs);
+    }
+    {
+        auto lhs = utils::small_vector<int, 4>({4, 2, 1});
+        auto rhs = utils::small_vector<int, 4>({1, 3, 3, 4});
+        BOOST_CHECK_GE(lhs, rhs);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(resize) {
     auto vec = utils::small_vector<int, 4>();
     vec.emplace_back(1);

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <compare>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
@@ -442,12 +443,13 @@ public:
         std::swap(*this, other);
     }
 
-    bool operator==(const small_vector& other) const noexcept {
-        return size() == other.size() && std::equal(_begin, _end, other.begin());
+    auto operator<=>(const small_vector& other) const noexcept requires std::three_way_comparable<T> {
+        return std::lexicographical_compare_three_way(this->begin(), this->end(),
+                                                      other.begin(), other.end());
     }
 
-    bool operator!=(const small_vector& other) const noexcept {
-        return !(*this == other);
+    bool operator==(const small_vector& other) const noexcept {
+        return size() == other.size() && std::equal(_begin, _end, other.begin());
     }
 };
 


### PR DESCRIPTION
small_vector should be feature-wise compatible with std::vector<>, let's add operator<=> for it.

also, there is no needd to define operator!=() explicitly, C++20 define this for us if operator==() is defined, so let's drop it.