### PR TITLE
treewide: use (defaulted) operator<=> when appropriate

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -108,18 +108,6 @@ bool stream_id::is_set() const {
     return !_value.empty();
 }
 
-bool stream_id::operator==(const stream_id& o) const {
-    return _value == o._value;
-}
-
-bool stream_id::operator!=(const stream_id& o) const {
-    return !(*this == o);
-}
-
-bool stream_id::operator<(const stream_id& o) const {
-    return _value < o._value;
-}
-
 static int64_t bytes_to_int64(bytes_view b, size_t offset) {
     assert(b.size() >= offset + sizeof(int64_t));
     int64_t res;

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -56,9 +56,7 @@ public:
     stream_id(dht::token, size_t);
 
     bool is_set() const;
-    bool operator==(const stream_id&) const;
-    bool operator!=(const stream_id&) const;
-    bool operator<(const stream_id&) const;
+    auto operator<=>(const stream_id&) const noexcept = default;
 
     uint8_t version() const;
     size_t index() const;

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -42,18 +42,7 @@ struct replay_position {
         }
     }
 
-    bool operator<(const replay_position & r) const {
-        return id < r.id ? true : (r.id < id ? false : pos < r.pos);
-    }
-    bool operator<=(const replay_position & r) const {
-        return !(r < *this);
-    }
-    bool operator==(const replay_position & r) const {
-        return id == r.id && pos == r.pos;
-    }
-    bool operator!=(const replay_position & r) const {
-        return !(*this == r);
-    }
+    auto operator<=>(const replay_position&) const noexcept = default;
 
     unsigned shard_id() const {
         return unsigned(id >> max_ts_bits);

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -132,14 +132,7 @@ struct qualified_name {
             , table_name(s->cf_name())
     { }
 
-    bool operator<(const qualified_name& o) const {
-        return keyspace_name < o.keyspace_name
-               || (keyspace_name == o.keyspace_name && table_name < o.table_name);
-    }
-
-    bool operator==(const qualified_name& o) const {
-        return keyspace_name == o.keyspace_name && table_name == o.table_name;
-    }
+    auto operator<=>(const qualified_name&) const = default;
 };
 
 static future<schema_mutations> read_table_mutations(distributed<service::storage_proxy>& proxy, const qualified_name& table, schema_ptr s);

--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <compare>
 #include <cstddef>
 #include <limits>
 
@@ -28,28 +29,11 @@ struct update_backlog {
         return float(current) / float(max);
     }
 
-    friend bool operator==(const update_backlog& lhs, const update_backlog& rhs) {
-        return lhs.relative_size() == rhs.relative_size();
+    std::partial_ordering operator<=>(const update_backlog &rhs) const {
+        return relative_size() <=> rhs.relative_size();
     }
-
-    friend bool operator<(const update_backlog& lhs, const update_backlog& rhs) {
-        return lhs.relative_size() < rhs.relative_size();
-    }
-
-    friend bool operator!=(const update_backlog& lhs, const update_backlog& rhs) {
-        return !(lhs == rhs);
-    }
-
-    friend bool operator<=(const update_backlog& lhs, const update_backlog& rhs) {
-        return !(rhs < lhs);
-    }
-
-    friend bool operator>(const update_backlog& lhs, const update_backlog& rhs) {
-        return rhs < lhs;
-    }
-
-    friend bool operator>=(const update_backlog& lhs, const update_backlog& rhs) {
-        return !(lhs < rhs);
+    bool operator==(const update_backlog& rhs) const {
+        return relative_size() == rhs.relative_size();
     }
 
     static update_backlog no_backlog() {

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -191,21 +191,7 @@ inline std::strong_ordering uuid_tri_compare_timeuuid(bytes_view o1, bytes_view 
 template<typename Tag>
 struct tagged_uuid {
     utils::UUID id;
-    bool operator==(const tagged_uuid& o) const noexcept {
-        return id == o.id;
-    }
-    bool operator<(const tagged_uuid& o) const noexcept {
-        return id < o.id;
-    }
-    bool operator>(const tagged_uuid& o) const noexcept {
-        return id > o.id;
-    }
-    bool operator<=(const tagged_uuid& o) const noexcept {
-        return id <= o.id;
-    }
-    bool operator>=(const tagged_uuid& o) const noexcept {
-        return id >= o.id;
-    }
+    std::strong_ordering operator<=>(const tagged_uuid&) const noexcept = default;
     explicit operator bool() const noexcept {
         // The default constructor sets the id to nil, which is
         // guaranteed to not match any valid id.


### PR DESCRIPTION
- db/view: use operator<=> to define comparison operators
- utils: UUID: use defaulted operator<=>
- db: schema_tables: use defaulted operator<=>
- cdc: generation: schema_tables: use defaulted operator<=>
- db::commitlog::replay_position: use defaulted operator<=>