### PR TITLE
init: Add life cycle notifications to configurables

### DIFF
--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -97,6 +97,10 @@ public:
     ~cql_test_config();
 };
 
+struct cql_test_init_configurables {
+    db::extensions& extensions;
+};
+
 class cql_test_env {
 public:
     virtual ~cql_test_env() {};
@@ -175,8 +179,8 @@ public:
     data_dictionary::database data_dictionary();
 };
 
-future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {});
-future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {});
+future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
+future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, std::optional<cql_test_init_configurables> = {});
 
 reader_permit make_reader_permit(cql_test_env&);
 


### PR DESCRIPTION
Fixes #13034

Allows a configurable to subscribe to life cycle notifications for scylla app. I.e. do stuff on start/stop.
Also allow configurables in cql_test_env

