### PR TITLE
configurables: Add optional service lookup to init callback

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -581,7 +581,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             ::stop_signal stop_signal; // we can move this earlier to support SIGINT during initialization
             read_config(opts, *cfg).get();
-            auto notify_set = configurable::init_all(opts, *cfg, *ext).get0();
+            auto notify_set = configurable::init_all(opts, *cfg, *ext, service_set(
+                db, ss, mm, proxy, feature_service, messaging, qp, bm
+            )).get0();
 
             auto stop_configurables = defer_verbose_shutdown("configurables", [&] {
                 notify_set.notify_all(configurable::system_state::stopped).get();


### PR DESCRIPTION
Simplified, more direct version of "dependency injection".
I.e. caller/initiator (main/cql_test_env) provides a set of services it will eventually start. Configurable can remember these. And use, at least after "start" notification.

Fixes #13036

(Note: this depends on #13035 and includes this patch here as well. Please disregard)