### PR TITLE
api::failure_detector: mark set_phi_convict_threshold unimplemented

### DIFF
--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -62,7 +62,9 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 
     fd::set_phi_convict_threshold.set(r, [](std::unique_ptr<request> req) {
-        double phi = atof(req->get_query_param("phi").c_str());
+        // TBD
+        unimplemented();
+        std::ignore = atof(req->get_query_param("phi").c_str());
         return make_ready_future<json::json_return_type>("");
     });
 


### PR DESCRIPTION
let it throw if "set_phi_convict_threshold" is called, as we never populate the specified \Phi.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>