### PR TITLE
query_id: extract into new header

### DIFF
--- a/idl/uuid.idl.hh
+++ b/idl/uuid.idl.hh
@@ -8,7 +8,7 @@
 
 #include "utils/UUID.hh"
 #include "schema/schema_fwd.hh"
-#include "query-request.hh"
+#include "query_id.hh"
 #include "locator/host_id.hh"
 #include "tasks/types.hh"
 

--- a/query-request.hh
+++ b/query-request.hh
@@ -23,6 +23,7 @@
 #include "utils/small_vector.hh"
 #include "query_class_config.hh"
 #include "db/per_partition_rate_limit_info.hh"
+#include "query_id.hh"
 #include "utils/UUID.hh"
 #include "bytes.hh"
 #include "cql_serialization_format.hh"
@@ -30,8 +31,6 @@
 class position_in_partition_view;
 class position_in_partition;
 class partition_slice_builder;
-
-using query_id = utils::tagged_uuid<struct query_id_tag>;
 
 namespace query {
 

--- a/query_id.hh
+++ b/query_id.hh
@@ -1,0 +1,8 @@
+// Copyright (C) 2023-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include "utils/UUID.hh"
+
+using query_id = utils::tagged_uuid<struct query_id_tag>;


### PR DESCRIPTION
query_id currently lives query-request.hh, a busy place with lots of dependencies. In turn it gets pulled by uuid.idl.hh, which is also very central. This makes test/raft/randomized_nemesis_test.cc which is nominally only dependent on Raft rebuild on random header file changes.

Fix by extracting into a new header.