### PR TITLE
cql3: improve support for C-style parenthesis casts

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -745,7 +745,7 @@ lw_shared_ptr<column_specification>
 casted_spec_of(const cast& c, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver) {
     data_type cast_type = cast_get_prepared_type(c, db, keyspace);
 
-    sstring display_name = format("({}){}", cast_type->cql3_type_name(), c.arg);
+    sstring display_name = format("({}){:user}", cast_type->cql3_type_name(), c.arg);
 
     return make_lw_shared<column_specification>(receiver.ks_name, receiver.cf_name,
             ::make_shared<column_identifier>(display_name, true), cast_type);
@@ -791,13 +791,13 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
     // test_assignment uses is_value_compatible_with to check if the binary representation is compatible
     // between the two types.
     if (!is_assignable(test_assignment(c.arg, db, keyspace, *cast_type_receiver))) {
-        throw exceptions::invalid_request_exception(format("Cannot cast value {} to type {}", c.arg, cast_type->as_cql3_type()));
+        throw exceptions::invalid_request_exception(format("Cannot cast value {:user} to type {}", c.arg, cast_type->as_cql3_type()));
     }
 
     // Then check if a value of type c.type can be assigned(converted) to the receiver type.
     // cast_test_assignment also uses is_value_compatible_with to check binary representation compatibility.
     if (!is_assignable(cast_test_assignment(c, db, keyspace, *receiver))) {
-        throw exceptions::invalid_request_exception(format("Cannot assign value {} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
+        throw exceptions::invalid_request_exception(format("Cannot assign value {:user} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
     }
 
     // Now we know that c.arg is compatible with c.type, and c.type is compatible with receiver->type.

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -798,8 +798,12 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
     // This means that the cast is correct - we can take the binary representation of c.arg value and
     // reinterpret it as a value of type receiver->type without any problems.
 
+    // Prepare the argument using cast_type_receiver.
+    // Using this receiver makes it possible to write things like: (blob)(int)1234
+    // Using the original receiver wouldn't work in such cases - it would complain
+    // that untyped_constant(1234) isn't a valid blob constant.
     return cast{
-        .arg = prepare_expression(c.arg, db, keyspace, schema_opt, receiver),
+        .arg = prepare_expression(c.arg, db, keyspace, schema_opt, cast_type_receiver),
         .type = receiver->type,
     };
 }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -780,8 +780,9 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
     data_type cast_type = cast_get_prepared_type(c, db, keyspace);
 
     if (!receiver) {
-        // TODO: It is possible to infer the type of a cast (it's a given)
-        return std::nullopt;
+        sstring receiver_name = format("cast({}){:user}", cast_type->cql3_type_name(), c.arg);
+        receiver = make_lw_shared<column_specification>(
+            keyspace, "unknown_cf", ::make_shared<column_identifier>(receiver_name, true), cast_type);
     }
 
     // casted_spec_of creates a receiver with type equal to c.type

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1419,6 +1419,77 @@ BOOST_AUTO_TEST_CASE(prepare_cast_bind_var_no_receiver) {
     BOOST_REQUIRE(expr::type_of(prepared) == utf8_type);
 }
 
+// Test preparing (text)? with a known text receiver.
+// Corresponds to `text_col = (text)?`
+BOOST_AUTO_TEST_CASE(prepare_cast_bind_var_text_type_hint_and_text_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = bind_variable{.bind_index = 0, .receiver = nullptr}, .type = cql3_type::raw::from(utf8_type)};
+
+    expression prepared = prepare_expression(cast_expr, db, "test_ks", table_schema.get(), make_receiver(utf8_type));
+
+    // Can't do a direct comparison because we don't have prepared.arg.receiver
+    BOOST_REQUIRE(is<cast>(prepared) && is<bind_variable>(as<cast>(prepared).arg));
+    ::lw_shared_ptr<column_specification> bind_var_receiver = as<bind_variable>(as<cast>(prepared).arg).receiver;
+    BOOST_REQUIRE(bind_var_receiver->type == utf8_type);
+
+    expression expected = cast{.arg = bind_variable{.bind_index = 0, .receiver = bind_var_receiver}, .type = utf8_type};
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+
+    BOOST_REQUIRE(expr::type_of(prepared) == utf8_type);
+}
+
+// Test preparing (int)? with a known int receiver.
+// Corresponds to `int_col = (int)?`
+BOOST_AUTO_TEST_CASE(prepare_cast_bind_var_int_type_hint_and_int_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = bind_variable{.bind_index = 0, .receiver = nullptr}, .type = cql3_type::raw::from(int32_type)};
+
+    expression prepared = prepare_expression(cast_expr, db, "test_ks", table_schema.get(), make_receiver(int32_type));
+
+    // Can't do a direct comparison because we don't have prepared.arg.receiver
+    BOOST_REQUIRE(is<cast>(prepared) && is<bind_variable>(as<cast>(prepared).arg));
+    ::lw_shared_ptr<column_specification> bind_var_receiver = as<bind_variable>(as<cast>(prepared).arg).receiver;
+    BOOST_REQUIRE(bind_var_receiver->type == int32_type);
+
+    expression expected =
+        cast{.arg = bind_variable{.bind_index = 0, .receiver = bind_var_receiver}, .type = int32_type};
+    BOOST_REQUIRE_EQUAL(prepared, expected);
+
+    BOOST_REQUIRE(expr::type_of(prepared) == int32_type);
+}
+
+// Test preparing (text)? with a known int receiver.
+// Corresponds to `int_col = (text)?`
+BOOST_AUTO_TEST_CASE(prepare_cast_bind_var_text_type_hint_and_int_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = bind_variable{.bind_index = 0, .receiver = nullptr}, .type = cql3_type::raw::from(utf8_type)};
+
+    BOOST_REQUIRE_THROW(prepare_expression(cast_expr, db, "test_ks", table_schema.get(), make_receiver(int32_type)),
+                        exceptions::invalid_request_exception);
+}
+
+// Test preparing (int)? with a known text receiver.
+// Corresponds to `text_col = (int)?`
+BOOST_AUTO_TEST_CASE(prepare_cast_bind_var_int_type_hint_and_text_receiver) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    expression cast_expr =
+        cast{.arg = bind_variable{.bind_index = 0, .receiver = nullptr}, .type = cql3_type::raw::from(int32_type)};
+
+    BOOST_REQUIRE_THROW(prepare_expression(cast_expr, db, "test_ks", table_schema.get(), make_receiver(utf8_type)),
+                        exceptions::invalid_request_exception);
+}
+
 BOOST_AUTO_TEST_CASE(prepare_null) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);

--- a/test/cql-pytest/test_cast.py
+++ b/test/cql-pytest/test_cast.py
@@ -1,0 +1,182 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+###############################################################################
+# Tests for CQL casting, e.g `blob_column = (blob)(int)123`
+###############################################################################
+
+# CQL supports type casting using C-style casts, although it's pretty limited.
+# We only allow such casts between types that have a compatible binary representation.
+# Compatible means that the bytes will stay unchanged after the conversion.
+# This means that it's legal to cast an int to blob (int is just a 4 byte blob),
+# but it's illegal to cast a bigint to int (change 4 bytes -> 8 bytes).
+# This simplifies things, to cast we can just reinterpret the value as the other type.
+
+# Another useful use of C-style casts is type hints.
+# Sometimes it's impossible to infer the exact type of an expression from the context.
+# In such cases the type can be specified by casting the expression to this type.
+# For example: `overloadedFunction((int)?)`
+# Without the cast it's impossible to guess what should be the bind marker's type.
+# The function is overloaded, so there are many possible argument types.
+# The type hint specifies that the bind marker has type int.
+
+# An interesting thing is that such casts don't have to be explicit.
+# CQL allows to put an int value in a place where a blob value is expected
+# and it will be automatically converted without any explicit casting.
+
+
+import pytest
+from cassandra.protocol import InvalidRequest
+from util import unique_name, unique_key_int
+import uuid
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (pk int PRIMARY KEY, blob_col blob, int_col int, bigint_col bigint)")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (pk int PRIMARY KEY, d date)")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
+# Implicitly casting an integer constant to blob fails, it's unknown what the exact type is - is it tinyint, bigint?
+# It's important that it stays this way - in the future we might implement guessing the type of untyped constants
+# by assigning the smallest type that can fit the constant, but I think that we shouldn't allow converting them
+# to blob without explicitly specifying size of the integer.
+def test_cast_int_literal_to_blob(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, 12)")
+
+# Putting (blob) before the integer also fails, it's still unknown what the exact type is.
+def test_cast_int_literal_to_blob_with_blob_cast(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, (blob)123)")
+
+# Putting (int) before the integer specifies the exact type and it's possible to cast the value.
+# This type of assignment isn't currently allowed, will work in the future.
+def test_cast_int_literal_with_type_hint_to_blob(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, (int)1234)")
+
+# Converting an int to blob is allowed, but converting a blob to int isn't.
+# An int can always be converted to a valid blob, but blobs might have wrong amount of bytes
+# and can't be converted to a valid int.
+def test_cast_blob_literal_to_int(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='HEX'):
+        cql.execute(f"INSERT INTO {table1} (pk) VALUES (0xBAAAAAAD)")
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk) VALUES ((blob)0xBAAAAAAD)")
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk) VALUES ((int)(blob)0xBAAAAAAD)")
+
+# The function blobasint() takes a blob and returns an int. Then this int can be converted back to a blob.
+def test_cast_int_func_result_to_blob_implicit(cql, table1):
+    pk = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint(0xdeadbeef))")
+    assert list(cql.execute(f"SELECT pk, blob_col FROM {table1} WHERE pk = {pk}")) == [(pk, 0xdeadbeef.to_bytes(4, 'big'))]
+
+# An int can't be cast to bigint because the binary representation is different.
+def test_cast_int_to_bigint(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='bigint'):
+        cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, blobasint(0xbeefdead))")
+    with pytest.raises(InvalidRequest, match='bigint'):
+        cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, (bigint)blobasint(0xbeefdead))")
+
+# The function token() returns a bigint, which can be converted to blob.
+def test_cast_bigint_token_to_blobl(cql, table1):
+    pk = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUEs ({pk}, token(1234))")
+    assert list(cql.execute(f"SELECT pk, blob_col FROM {table1} WHERE pk = {pk}")) == [(pk, int(8821045555241575141).to_bytes(8, 'big'))]
+
+# Doing (blob)(int)4321 should be allowed - the (int) specifies an exact type for the constant, and an int can be cast to blob.
+# Will work in the future.
+def test_cast_int_with_type_hint_to_blob_explicit(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, (blob)(int)4321)")
+
+# Passing (int)123432 as an argument of type blob should be allowed - it's a value of int type, so it can be implicitly cast to blob.
+# Will work in the future.
+def test_cast_int_literal_with_type_hint_to_blob_func_arg(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint((int)123432))")
+
+# Passing (blob)(int)567 as an argument of type blob should be allowed - same as (int)123432
+# Will work in the future.
+def test_cast_int_literal_with_type_hint_to_blob_func_arg_explicit(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint((blob)(int)567))")
+
+# Executing the function blobasint(bigint) should fail. The bigint has 8 bytes, but blobasint expects 4 bytes.
+# For now it fails on the cast, but in the future the cast will work and it should fail when executing blobasint.
+def test_blobasint_with_bigint_arg(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint((bigint)1234))")
+
+# Function arguments allow implicit conversions between compatible types. blobasint takes a blob as an argument
+# and returns an int, chaining them should be possible.
+def test_blobasint_with_blobasint_arg(cql, table1):
+    pk = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint(blobasint(0xFEEDF00D)))")
+    assert list(cql.execute(f"SELECT pk, blob_col FROM {table1} WHERE pk = {pk}")) == [(pk, 0xFEEDF00D.to_bytes(4, 'big'))]
+
+# Long cast that should work just like the other examples.
+# Will work in the future.
+def test_cast_long_chain(cql, table1):
+    pk = unique_key_int()
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, (blob)(blob)(blob)(blob)(blob)(blob)(blob)(blob)(tinyint)42)")
+
+# Casting should also work in a WHERE comparison.
+# Will work in the future.
+def test_cast_int_to_blob_in_where_clause(cql, table1):
+    pk = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, 0x00BA0BAB)") 
+    with pytest.raises(InvalidRequest, match='blob'):
+        cql.execute(f"SELECT pk FROM {table1} WHERE pk = {pk} AND blob_col = (blob)(int)12192683 ALLOW FILTERING")
+
+# Test type hints using C-style casts.
+# toDate() has overloads, so preparing toDate(?) can't infer the type for ?.
+# Specifying the type toDate((timestamp)?) or toDate((timeuuid)?) fixes the problem.
+def test_function_arg_type_hint(cql, table2):
+    pk = unique_key_int()
+
+    # toDate has overloads toDate(timestamp) and toDate(timeuuid).
+    # Can't infer the type for ?, so preparing the query fails.
+    with pytest.raises(InvalidRequest, match='Ambiguous'):
+        cql.prepare(f"INSERT INTO {table2} (pk, d) VALUES ({pk}, toDate(?))")
+
+    timestamp_value = 2*86400000 # 2 days after 1970-01-01
+    timeuuid_value = uuid.UUID('{53e99c40-b81b-11ed-be60-134dd121e491}')
+
+    # Explictly specifying the type using a type hint fixes the issue - the type for ? is now known.
+    prepared_timestamp = cql.prepare(f"INSERT INTO {table2} (pk, d) VALUES ({pk}, toDate((timestamp)?))")
+    prepared_timeuuid = cql.prepare(f"INSERT INTO {table2} (pk, d) VALUES ({pk}, toDate((timeuuid)?))")
+
+    cql.execute(prepared_timestamp, [timestamp_value])
+    assert list(cql.execute(f"SELECT d FROM {table2} WHERE pk = {pk}")) == [(2,)]
+
+    # In prepared_timestamp the bind variable has type timestamp, so passing a timeuuid value should fail.
+    with pytest.raises(TypeError):
+        cql.execute(prepared_timestamp, [timeuuid_value])
+
+    cql.execute(prepared_timeuuid, [timeuuid_value])
+    assert list(cql.execute(f"SELECT d FROM {table2} WHERE pk = {pk}")) == [(19417,)]
+
+    # In prepared_timeuuid the bind variable has type timeuuid, so passing a timestamp value should fail
+    with pytest.raises(TypeError):
+        cql.execute(prepared_timeuuid, [timestamp_value])


### PR DESCRIPTION
CQL supports type casting using C-style casts.
For example it's possible to do: `blob_column = (blob)funcReturningInt()`

This functionality is pretty limited, we only allow such casts between types that have a compatible binary representation. Compatible means that the bytes will stay unchanged after the conversion.
This means that it's legal to cast an int to blob (int is just a 4 byte blob), but it's illegal to cast a bigint to int (change 4 bytes -> 8 bytes).
This simplifies things, to cast we can just reinterpret the value as the other type.

Another use of C-style casts are type hints. Sometimes it's impossible to infer the exact type of an expression from the context. In such cases the type can be specified by casting the expression to this type.
For example: `overloadedFunction((int)?)`
Without the cast it would be impossible to guess what should be the bind marker's type. The function is overloaded, so there are many possible argument types. The type hint specifies that the bind marker has type int.

An interesting thing is that such casts don't have to be explicit. CQL allows to put an int value in a place where a blob value is expected and it will be automatically converted without any explicit casting.

---

I started looking at our implementation of casts because of #12900. In there the author expressed the need to specify a type hint for bind marker used to pass the WASM code. It could be either `(text)?` for text WASM, or `(blob)?` for binary WASM. This specific use of type hints wasn't supported because there was no `receiver` and the implementation of `prepare_expression` didn't handle that. Preparing casts without a receiver should be easy to implement - we can infer the type of the expression by looking at the type to which the expression is cast.

But while reading `prepare_expression` for `expr::cast` I noticed that the code there is a bit strange. The implementation prepared the expression to cast using the original `receiver` instead of a receiver with the cast type. This caused some issues because of which casting didn't work as expected.
For example it was possible to do:
```cql
blob_column = (blob)funcReturningInt()
```
But this didn't work at all:
```cql
blob_column = (blob)(int)12323
```
It tried to prepare `untyped_contant(12323)` with a `blob` receiver, which fails.

This makes `expr::cast` useless for casting. Casting when the representation is compatible is already implicit. I couldn't find a single case where adding a cast would change the behavior in any way.
There was some use for it as a type hint to choose a specific overload of a function, but it was worthless for casting.

Cassandra has the same issue, I created a `cql-pytest` test and it showed that we behave in the same way as Cassandra does.

I decided to improve this. By preparing the expression using a receiver with the cast type, `expr::cast` becomes actually useful for casting values. Things like `(blob)(int)12323` now work without any issues.
This diverges from the behavior in Cassandra, but it's an extension, not a breaking incompatibility.

---

This PR improves `prepare_expression` for `expr::cast` in the following ways:
1) Support for more complex casts by preparing the expression using a different receiver. This makes casts like `(blob)(int)123` possible
2) Support preparing `expr::cast` without a receiver. Type inference chooses the cast type as the type of the expression.
3) Add pytest tests for C-style casts


`2)` Is needed for #12900, the other changes is just something I decided to do since I was already working on this piece of code.