### PR TITLE
[branch-5.1] Make UNSET_VALUE forbidden for primary key columns and inside the WHERE clause

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1457,7 +1457,7 @@ expression search_and_replace(const expression& e,
                     };
                 },
                 [&] (const binary_operator& oper) -> expression {
-                    return binary_operator(recurse(oper.lhs), oper.op, recurse(oper.rhs));
+                    return binary_operator(recurse(oper.lhs), oper.op, recurse(oper.rhs), oper.order);
                 },
                 [&] (const column_mutation_attribute& cma) -> expression {
                     return column_mutation_attribute{cma.kind, recurse(cma.column)};

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1825,6 +1825,10 @@ static cql3::raw_value evaluate(const bind_variable& bind_var, const evaluation_
     }
 
     if (value.is_unset_value()) {
+        if (bind_var.disallow_unset_value) {
+            throw exceptions::invalid_request_exception(format("Invalid unset value for {}", bind_var.receiver->name));
+        }
+
         return cql3::raw_value::make_unset_value();
     }
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1521,6 +1521,20 @@ expression search_and_replace(const expression& e,
     }
 }
 
+expression make_unset_value_forbidden(const expression& e) {
+    return search_and_replace(e, [](const expression& to_maybe_replace) -> std::optional<expression> {
+        if (auto bind_var = as_if<bind_variable>(&to_maybe_replace)) {
+            return bind_variable {
+                .bind_index = bind_var->bind_index,
+                .receiver = bind_var->receiver,
+                .disallow_unset_value = true
+            };
+        }
+
+        return std::nullopt;
+    });
+}
+
 std::ostream& operator<<(std::ostream& s, oper_t op) {
     switch (op) {
     case oper_t::EQ:

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -359,6 +359,8 @@ struct bind_variable {
     // Contains value type and other useful information.
     ::lw_shared_ptr<column_specification> receiver;
 
+    bool disallow_unset_value = false;
+
     friend bool operator==(const bind_variable&, const bind_variable&) = default;
 };
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -698,6 +698,9 @@ extern expression replace_token(const expression&, const column_definition*);
 extern expression search_and_replace(const expression& e,
         const noncopyable_function<std::optional<expression> (const expression& candidate)>& replace_candidate);
 
+// Uses search_and_replace to disallow unset value for all bind variables within the expression
+extern expression make_unset_value_forbidden(const expression& e);
+
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -692,7 +692,8 @@ bind_variable_prepare_expression(const bind_variable& bv, data_dictionary::datab
 {   
     return bind_variable {
         .bind_index = bv.bind_index,
-        .receiver = receiver
+        .receiver = receiver,
+        .disallow_unset_value = bv.disallow_unset_value
     };
 }
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -326,13 +326,18 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 statement_restrictions::statement_restrictions(data_dictionary::database db,
         schema_ptr schema,
         statements::statement_type type,
-        const expr::expression& where_clause,
+        const expr::expression& where_clause_in,
         prepare_context& ctx,
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering)
     : statement_restrictions(schema, allow_filtering)
 {
+    // Bind markers with UNSET_VALUE are not allowed inside the WHERE clause.
+    // They are used to set fields in INSERT and UPDATE, but they don't fit
+    // in the WHERE clause.
+    expr::expression where_clause = expr::make_unset_value_forbidden(where_clause_in);
+
     for (auto&& relation_expr : boolean_factors(where_clause)) {
         const expr::binary_operator* relation_binop = expr::as_if<expr::binary_operator>(&relation_expr);
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5322,7 +5322,7 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         };
 
         auto check_unset_msg = [](std::experimental::source_location loc = std::experimental::source_location::current()) {
-            return exception_predicate::message_equals("unset value is not supported inside collections", loc);
+            return exception_predicate::message_contains("unset value", loc);
         };
 
         // Test null when specified inside a collection literal

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -305,7 +305,7 @@ def testListWithUnsetValues(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT l FROM %s WHERE k = 10"), [l])
 
         # select with in clause
-        assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * FROM %s WHERE k IN ?", UNSET_VALUE)
+        assert_invalid_message(cql, table, "Invalid unset value for", "SELECT * FROM %s WHERE k IN ?", UNSET_VALUE)
         # The following cannot be tested with the Python driver because it
         # captures this case before sending it to the server.
         #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * FROM %s WHERE k IN (?)", UNSET_VALUE)

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -476,9 +476,9 @@ def testFunctionCallWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
         # The error messages in Scylla and Cassandra here are slightly
         # different.
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset value for",
                              "SELECT * FROM %s WHERE token(k) >= token(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value for argument",
+        assert_invalid_message(cql, table, "unset value for",
                              "SELECT * FROM %s WHERE k = blobAsInt(?)", UNSET_VALUE)
 
 def testLimitWithUnset(cql, test_keyspace):

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -220,7 +220,7 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # the scan brings up several rows, it may exercise different code
         # paths.
         assert list(cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")) == []
-        with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+        with pytest.raises(InvalidRequest, match='unset'):
             cql.execute(stmt, [UNSET_VALUE])
 
         # check subscripted list filtering

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -1,0 +1,199 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Tests for the UNSET_VALUE value introduced in CQL version 4. Unset values
+# can be bound to variables, which cause certain CQL assignments to be skipped,
+# and may have other effects on other requests - and cause errors in places
+# where it's not allowed.
+#############################################################################
+
+import pytest
+from util import new_test_table, unique_key_int
+from cassandra.query import UNSET_VALUE
+from cassandra.cluster import NoHostAvailable
+from cassandra.protocol import InvalidRequest
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int, li list<int>") as table:
+        yield table
+
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+# A basic test that in a prepared statement with three assignments, one
+# bound by an UNSET_VALUE is simply not done, but the other ones are.
+# Try all 2^3 combinations of a 3 column updates with each one set to either
+# a real value or an UNSET_VALUE.
+def test_update_unset_value_basic(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET a=?, b=?, c=? WHERE p={p}')
+    a = 1
+    b = 2
+    c = 3
+    cql.execute(stmt, [a, b, c])
+    assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+    i = 4
+    for unset_a in [False, True]:
+        for unset_b in [False, True]:
+            for unset_c in [False, True]:
+                if unset_a:
+                    newa = UNSET_VALUE
+                else:
+                    newa = i
+                    a = i
+                    i += 1
+                if unset_b:
+                    newb = UNSET_VALUE
+                else:
+                    newb = i
+                    b = i
+                    i += 1
+                if unset_c:
+                    newc = UNSET_VALUE
+                else:
+                    newc = i
+                    c = i
+                    i += 1
+                cql.execute(stmt, [newa, newb, newc])
+                assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+
+# The expression "SET a=?" is skipped if the bound value is UNSET_VALUE.
+# But what if it is part of a more complex expression like "SET a=(int)?+1"
+# (arithmetic expression on the bind variable)? Does the SET also get
+# skipped? Cassandra, and Scylla, decided that the answer will be no:
+# We refuse to evaluate expressions involving an UNSET_VALUE, and in
+# such case the whole write request will fail instead of parts of it being
+# skipped. See discussion in pull request #12517.
+
+@pytest.mark.xfail(reason="issue #2693 - Scylla doesn't yet support arithmetic expressions")
+def test_update_unset_value_expr_arithmetic(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET a=(int)?+1 WHERE p={p}')
+    cql.execute(stmt, [7])
+    assert [(8,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+    with pytest.raises(InvalidRequest):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Despite the decision that expressions will not allow UNSET_VALUE, Cassandra
+# decided that (quoting its NEWS.txt) "an unset bind counter operation does
+# not change the counter value.".  So "c = c + ?" for a counter, when given
+# an UNSET_VALUE, will causes the write to be skipped, without error.
+# The rationale is that "c = c + ?" is not an expression - it doesn't actually
+# calculate c + ?, but rather it is a primitive increment operation, and
+# passing ?=UNSET_VALUE should be able to skip this primitive operation.
+def test_unset_counter_increment(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table:
+        p = unique_key_int()
+        stmt = cql.prepare(f'UPDATE {table} SET c=c+? WHERE p={p}')
+        cql.execute(stmt, [3])
+        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+        cql.execute(stmt, [UNSET_VALUE])
+        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+
+# Like the counter increment, a list append operation (li=li+?) is a primitive
+# operation and not expression, so we believe UNSET_VALUE should be able
+# to skip it, and Scylla indeed does as this test shows. Cassandra fails
+# this test - it produces an internal error on a bad cast, and we consider
+# this a Cassandra bug and hence the cassandra_bug tag.
+def test_unset_list_append(cql, table1, cassandra_bug):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET li=li+? WHERE p={p}')
+    cql.execute(stmt, [[7]])
+    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+    cql.execute(stmt, [UNSET_VALUE])
+    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+
+# According to Cassandra's NEWS.txt, "an unset bind ttl is treated as
+# 'unlimited'". It shouldn't skip the write.
+def test_unset_ttl(cql, table1):
+    p = unique_key_int()
+    # First write using a normal TTL:
+    stmt = cql.prepare(f'UPDATE {table1} USING TTL ? SET a=? WHERE p={p}')
+    cql.execute(stmt, [20000, 3])
+    res = list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+    assert res[0].a == 3
+    assert res[0].ttl_a > 10000
+    # Check that an UNSET_VALUE ttl didn't skip the write but reset the TTL
+    # to unlimited (None)
+    cql.execute(stmt, [UNSET_VALUE, 4])
+    assert [(4, None)] == list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+
+# According to Cassadra's NEWS.txt, "an unset bind timestamp is treated
+# as 'now'". It shouldn't skip the write.
+def test_unset_timestamp(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} USING TIMESTAMP ? SET a=? WHERE p={p}')
+    cql.execute(stmt, [UNSET_VALUE, 3])
+    assert [(3,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+
+# According to Cassandra's NEWS.txt, "In a QUERY request an unset limit
+# is treated as 'unlimited'.". It mustn't cause the query to fail (let alone
+# be skipped somehow).
+def test_unset_limit(cql, table2):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 1)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 2)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 3)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 4)')
+    stmt = cql.prepare(f'SELECT c FROM {table2} WHERE p={p} limit ?')
+    assert [(1,),(2,)] == list(cql.execute(stmt, [2]))
+    assert [(1,),(2,),(3,),(4,)] == list(cql.execute(stmt, [UNSET_VALUE]))
+
+# According Cassandra's NEWS.txt, "Unset WHERE clauses with unset
+# partition column, clustering column or index column are not allowed.".
+# For partition column, the Python driver itself complains that it's
+# bound to UNSET_VALUE because it can't decide which node to send the
+# request. So let's test the behavior for a clustering key column.
+# Reproduces #10358
+def test_unset_where_clustering(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p = {p} and c = ?')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# ... but the NEWS.txt doesn't say what happens in other WHERE restrictions
+# that involve a non-key column. In practice, those should be an error as
+# well, and do cause an error in Cassandra.
+# Reproduces #10358
+def test_unset_where_regular(cql, table1):
+    p = unique_key_int()
+    # We need to add some data for the filtering to find, otherwise the
+    # expression never gets evaluated and the UNSET_VALUE error is never
+    # detected. Cassandra does detect this error even if there is no data,
+    # but we don't care about reproducing that specific error case.
+    cql.execute(f'INSERT INTO {table1} (p, a) VALUES ({p}, 1)')
+    stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = {p} and a = ? ALLOW FILTERING')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# TODO: check that (according to NEWS.txt documentation): "Unset tuple field,
+# UDT field and map key are not allowed.".
+
+# Although UNSET_VALUE is designed to skip part of a SET, it is not designed
+# to skip an entire write which uses a an UNSET_VALUE in its WHERE clause -
+# this should be treated as an error, not a silent skip.
+#
+# As in test_unset_where_clustering() above (the SELECT version of this test)
+# we need to check the UNSET_VALUE on the clustering key because if we try
+# an UNSET_VALUE on the partition key, the Python driver will refuse to
+# send the request (it uses the partition key to decide which node to send
+# the request).
+def test_unset_insert_where(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Similar to test_unset_insert_where() above, just use an LWT write ("IF
+# NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condtion causes
+# a clear error, not silent skip and not a crash as in issue #13001.
+def test_unset_insert_where_lwt(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -25,6 +25,11 @@ def table2(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
         yield table
 
+@pytest.fixture(scope="module")
+def table3(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, r int, PRIMARY KEY (p, c)") as table:
+        yield table
+
 # A basic test that in a prepared statement with three assignments, one
 # bound by an UNSET_VALUE is simply not done, but the other ones are.
 # Try all 2^3 combinations of a 3 column updates with each one set to either
@@ -197,3 +202,28 @@ def test_unset_insert_where_lwt(cql, table2):
     stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
+
+# Like test_unset_insert_where, but using UPDATE
+def test_unset_update_where(cql, table3):
+    stmt = cql.prepare(f"UPDATE {table3} SET r = 42 WHERE p = ? AND c = ?")
+    
+    # Python driver doesn't allow sending an UNSET_VALUE for the partition key
+    with pytest.raises(ValueError):
+        cql.execute(stmt, [UNSET_VALUE, 0])
+    
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [0, UNSET_VALUE])
+
+# Like test_unset_insert_where_lwt, but using UPDATE
+def test_unset_update_where_lwt(cql, table3):
+    stmt = cql.prepare(f"UPDATE {table3} SET r = 42 WHERE p = ? AND c = ? IF r = ?")
+    
+    # Python driver doesn't allow sending an UNSET_VALUE for the partition key
+    with pytest.raises(ValueError):
+        cql.execute(stmt, [UNSET_VALUE, 1, 2])
+    
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [0, UNSET_VALUE, 2])
+
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [0, 1, UNSET_VALUE])


### PR DESCRIPTION
In #13001 we found a test case which causes a crash on `branch-5.1` because it didn't handle `UNSET_VALUE` properly:

```python3
def test_unset_insert_where(cql, table2):
    p = unique_key_int()
    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
    with pytest.raises(InvalidRequest, match="unset"):
        cql.execute(stmt, [UNSET_VALUE])

def test_unset_insert_where_lwt(cql, table2):
    p = unique_key_int()
    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
    with pytest.raises(InvalidRequest, match="unset"):
        cql.execute(stmt, [UNSET_VALUE])
```

This problem has been fixed on `master` by PR #12517. I tried to backport it to `branch-5.1` (#13029), but this didn't go well - it was a big change that touched a lot of components. It's hard to make sure that it won't cause some unexpected issues.

Since the original PR is difficult to backport, the alternative was to make a custom fix for `branch-5.1`.
It's probably worth doing, CQL crashes are bad because they can crash the whole cluster multiple times.

This PR fixes the issue on `branch-5.1`. The effect is similar to what whould happen if we successfully backported #12517, but the change is smaller and more managable.
I copied unset value tests (`test_unset.py`) from the master branch and they are now passing on `branch-5.1`.
