### PR TITLE
cmake: sync with `configure.py` (8/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,7 @@ include(add_version_library)
 add_version_library(scylla_version
     release.cc)
 add_executable(scylla
-    ${scylla_sources}
-    ${swagger_gen_files})
+    ${scylla_sources})
 
 target_link_libraries(scylla PRIVATE
     api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,3 @@ set(CMAKE_EXE_LINKER_FLAGS "${default_linker_flags}" CACHE INTERNAL "")
 target_include_directories(scylla PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${scylla_gen_build_dir}")
-
-
-# TODO: create cmake/ directory and move utilities (generate functions etc) there
-# TODO: Build tests if BUILD_TESTING=on (using CTest module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,95 +42,32 @@ file(MAKE_DIRECTORY "${scylla_gen_build_dir}")
 set(scylla_sources
     absl-flat_hash_map.cc
     bytes.cc
-    cdc/cdc_partitioner.cc
-    cdc/generation.cc
-    cdc/log.cc
-    cdc/metadata.cc
-    cdc/split.cc
     client_data.cc
     clocks-impl.cc
     collection_mutation.cc
-    compaction/compaction.cc
-    compaction/compaction_manager.cc
-    compaction/compaction_strategy.cc
-    compaction/leveled_compaction_strategy.cc
-    compaction/size_tiered_compaction_strategy.cc
-    compaction/task_manager_module.cc
-    compaction/time_window_compaction_strategy.cc
     compress.cc
     converting_mutation_partition_applier.cc
     counters.cc
     data_dictionary/data_dictionary.cc
-    dht/boot_strapper.cc
-    dht/i_partitioner.cc
-    dht/murmur3_partitioner.cc
-    dht/range_streamer.cc
-    dht/token.cc
     direct_failure_detector/failure_detector.cc
     duration.cc
     exceptions/exceptions.cc
     frozen_schema.cc
     generic_server.cc
-    gms/application_state.cc
-    gms/endpoint_state.cc
-    gms/failure_detector.cc
-    gms/feature_service.cc
-    gms/gossip_digest_ack2.cc
-    gms/gossip_digest_ack.cc
-    gms/gossip_digest_syn.cc
-    gms/gossiper.cc
-    gms/inet_address.cc
-    gms/versioned_value.cc
-    gms/version_generator.cc
     debug.cc
     index/secondary_index.cc
     index/secondary_index_manager.cc
     init.cc
     keys.cc
-    locator/abstract_replication_strategy.cc
-    locator/azure_snitch.cc
-    locator/simple_strategy.cc
-    locator/local_strategy.cc
-    locator/network_topology_strategy.cc
-    locator/everywhere_replication_strategy.cc
-    locator/token_metadata.cc
-    locator/snitch_base.cc
-    locator/simple_snitch.cc
-    locator/rack_inferring_snitch.cc
-    locator/gossiping_property_file_snitch.cc
-    locator/production_snitch_base.cc
-    locator/ec2_snitch.cc
-    locator/ec2_multi_region_snitch.cc
-    locator/gce_snitch.cc
-    locator/topology.cc
-    locator/util.cc
-    lang/lua.cc
-    lang/wasm.cc
-    lang/wasm_instance_cache.cc
     main.cc
     message/messaging_service.cc
     multishard_mutation_query.cc
     mutation_query.cc
-    mutation_writer/feed_writers.cc
-    mutation_writer/multishard_writer.cc
-    mutation_writer/partition_based_splitting_writer.cc
-    mutation_writer/shard_based_splitting_writer.cc
-    mutation_writer/timestamp_based_splitting_writer.cc
     partition_slice_builder.cc
     querier.cc
     query.cc
     query_ranges_to_vnodes.cc
     query-result-set.cc
-    raft/fsm.cc
-    raft/log.cc
-    raft/raft.cc
-    raft/server.cc
-    raft/tracker.cc
-    readers/combined.cc
-    readers/multishard.cc
-    readers/mutation_reader.cc
-    readers/mutation_readers.cc
-    service/broadcast_tables/experimental/lang.cc
     tombstone_gc_options.cc
     tombstone_gc.cc
     reader_concurrency_semaphore.cc
@@ -139,48 +76,10 @@ set(scylla_sources
     row_cache.cc
     schema_mutations.cc
     serializer.cc
-    service/client_state.cc
-    service/forward_service.cc
-    service/migration_manager.cc
-    service/misc_services.cc
-    service/pager/paging_state.cc
-    service/pager/query_pagers.cc
-    service/paxos/paxos_state.cc
-    service/paxos/prepare_response.cc
-    service/paxos/prepare_summary.cc
-    service/paxos/proposal.cc
-    service/priority_manager.cc
-    service/qos/qos_common.cc
-    service/qos/service_level_controller.cc
-    service/qos/standard_service_level_distributed_data_accessor.cc
-    service/raft/discovery.cc
-    service/raft/group0_state_machine.cc
-    service/raft/raft_group0.cc
-    service/raft/raft_group0_client.cc
-    service/raft/raft_group_registry.cc
-    service/raft/raft_rpc.cc
-    service/raft/raft_sys_table_storage.cc
-    service/storage_proxy.cc
-    service/storage_service.cc
     sstables_loader.cc
     table_helper.cc
     tasks/task_manager.cc
     timeout_config.cc
-    tools/scylla-types.cc
-    tools/scylla-sstable.cc
-    tools/schema_loader.cc
-    tools/utils.cc
-    tools/lua_sstable_consumer.cc
-    tracing/tracing.cc
-    tracing/trace_keyspace_helper.cc
-    tracing/trace_state.cc
-    tracing/traced_file.cc
-    transport/controller.cc
-    transport/cql_protocol_extension.cc
-    transport/event.cc
-    transport/event_notifier.cc
-    transport/messages/result_message.cc
-    transport/server.cc
     unimplemented.cc
     validation.cc
     vint-serialization.cc
@@ -190,18 +89,31 @@ add_subdirectory(api)
 add_subdirectory(alternator)
 add_subdirectory(db)
 add_subdirectory(auth)
+add_subdirectory(cdc)
+add_subdirectory(compaction)
 add_subdirectory(cql3)
+add_subdirectory(dht)
+add_subdirectory(gms)
 add_subdirectory(idl)
 add_subdirectory(interface)
+add_subdirectory(lang)
+add_subdirectory(locator)
 add_subdirectory(mutation)
+add_subdirectory(mutation_writer)
+add_subdirectory(readers)
 add_subdirectory(redis)
 add_subdirectory(replica)
+add_subdirectory(raft)
 add_subdirectory(rust)
 add_subdirectory(schema)
+add_subdirectory(service)
 add_subdirectory(sstables)
 add_subdirectory(streaming)
 add_subdirectory(test)
 add_subdirectory(thrift)
+add_subdirectory(tools)
+add_subdirectory(tracing)
+add_subdirectory(transport)
 add_subdirectory(types)
 add_subdirectory(utils)
 include(add_version_library)
@@ -216,20 +128,32 @@ target_link_libraries(scylla PRIVATE
     auth
     alternator
     db
+    cdc
+    compaction
     cql3
+    dht
+    gms
     idl
+    lang
+    locator
     mutation
+    mutation_writer
+    raft
+    readers
     redis
     replica
     schema
     scylla_version
+    service
     sstables
     streaming
     test-perf
     thrift
+    tools
+    tracing
+    transport
     types
-    utils
-    wasmtime_bindings)
+    utils)
 target_link_libraries(Boost::regex
   INTERFACE
     ICU::i18n)
@@ -272,7 +196,6 @@ target_link_libraries(scylla PRIVATE
     systemd
     zstd
     snappy
-    ${LUA_LIBRARIES}
     xxHash::xxhash)
 
 # Force SHA1 build-id generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(scylla)
 include(CTest)
 
 list(APPEND CMAKE_MODULE_PATH
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/seastar/cmake)
 
 set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE
     STRING "Choose the type of build." FORCE)

--- a/cdc/CMakeLists.txt
+++ b/cdc/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(cdc STATIC)
+target_sources(cdc
+  PRIVATE
+    cdc_partitioner.cc
+    generation.cc
+    log.cc
+    metadata.cc
+    split.cc)
+target_include_directories(cdc
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(cdc
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    replica)

--- a/compaction/CMakeLists.txt
+++ b/compaction/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(compaction STATIC)
+target_sources(compaction
+  PRIVATE
+    compaction.cc
+    compaction_manager.cc
+    compaction_strategy.cc
+    leveled_compaction_strategy.cc
+    size_tiered_compaction_strategy.cc
+    task_manager_module.cc
+    time_window_compaction_strategy.cc)
+target_include_directories(compaction
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(compaction
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    replica)

--- a/dht/CMakeLists.txt
+++ b/dht/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(dht STATIC)
+target_sources(dht
+  PRIVATE
+    boot_strapper.cc
+    i_partitioner.cc
+    murmur3_partitioner.cc
+    range_streamer.cc
+    token.cc)
+target_include_directories(dht
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(dht
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    replica)

--- a/gms/CMakeLists.txt
+++ b/gms/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(gms STATIC)
+target_sources(gms
+  PRIVATE
+    application_state.cc
+    endpoint_state.cc
+    failure_detector.cc
+    feature_service.cc
+    gossip_digest_ack2.cc
+    gossip_digest_ack.cc
+    gossip_digest_syn.cc
+    gossiper.cc
+    inet_address.cc
+    versioned_value.cc
+    version_generator.cc)
+target_include_directories(gms
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(gms
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    db)

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(lang STATIC)
+target_sources(lang
+  PRIVATE
+    lua.cc
+    wasm.cc
+    wasm_instance_cache.cc)
+target_include_directories(lang
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(lang
+  PUBLIC
+    wasmtime_bindings
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    ${LUA_LIBRARIES})

--- a/locator/CMakeLists.txt
+++ b/locator/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(locator STATIC)
+target_sources(locator
+  PRIVATE
+    abstract_replication_strategy.cc
+    azure_snitch.cc
+    simple_strategy.cc
+    local_strategy.cc
+    network_topology_strategy.cc
+    everywhere_replication_strategy.cc
+    token_metadata.cc
+    snitch_base.cc
+    simple_snitch.cc
+    rack_inferring_snitch.cc
+    gossiping_property_file_snitch.cc
+    production_snitch_base.cc
+    ec2_snitch.cc
+    ec2_multi_region_snitch.cc
+    gce_snitch.cc
+    topology.cc
+    util.cc)
+target_include_directories(locator
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(locator
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    db)

--- a/mutation_writer/CMakeLists.txt
+++ b/mutation_writer/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(mutation_writer STATIC)
+target_sources(mutation_writer
+  PRIVATE
+    feed_writers.cc
+    multishard_writer.cc
+    partition_based_splitting_writer.cc
+    shard_based_splitting_writer.cc
+    timestamp_based_splitting_writer.cc)
+target_include_directories(mutation_writer
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(mutation_writer
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    schema)

--- a/raft/CMakeLists.txt
+++ b/raft/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(raft STATIC)
+target_sources(raft
+  PRIVATE
+    fsm.cc
+    log.cc
+    raft.cc
+    server.cc
+    tracker.cc)
+target_include_directories(raft
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(raft
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash)

--- a/readers/CMakeLists.txt
+++ b/readers/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(readers STATIC)
+target_sources(readers
+  PRIVATE
+    combined.cc
+    multishard.cc
+    mutation_reader.cc
+    mutation_readers.cc)
+target_include_directories(readers
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(readers
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    schema)

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -14,5 +14,6 @@ target_include_directories(replica
 target_link_libraries(replica
   PUBLIC
     db
+    wasmtime_bindings
     Seastar::seastar
     xxHash::xxhash)

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -73,6 +73,6 @@ target_sources(wasmtime_bindings
     ${wasmtime_bindings_sources})
 target_include_directories(wasmtime_bindings
   INTERFACE
-    ${binding_gen_build_dir})
+    ${scylla_gen_build_dir})
 target_link_libraries(wasmtime_bindings
   INTERFACE Rust::rust_combined)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_library(service STATIC)
+target_sources(service
+  PRIVATE
+    broadcast_tables/experimental/lang.cc
+    client_state.cc
+    forward_service.cc
+    migration_manager.cc
+    misc_services.cc
+    pager/paging_state.cc
+    pager/query_pagers.cc
+    paxos/paxos_state.cc
+    paxos/prepare_response.cc
+    paxos/prepare_summary.cc
+    paxos/proposal.cc
+    priority_manager.cc
+    qos/qos_common.cc
+    qos/service_level_controller.cc
+    qos/standard_service_level_distributed_data_accessor.cc
+    raft/discovery.cc
+    raft/group0_state_machine.cc
+    raft/raft_group0.cc
+    raft/raft_group0_client.cc
+    raft/raft_group_registry.cc
+    raft/raft_rpc.cc
+    raft/raft_sys_table_storage.cc
+    storage_proxy.cc
+    storage_service.cc)
+target_include_directories(service
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(service
+  PUBLIC
+    db
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    mutation)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,8 @@ target_link_libraries(test-perf
     xxHash::xxhash
     wasmtime_bindings)
 
+add_subdirectory(perf)
+
 if(BUILD_TESTING)
     add_subdirectory(boost)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,13 +9,7 @@ target_sources(test-perf
     perf/perf_row_cache_update.cc
     perf/perf_simple_query.cc
     perf/perf_sstable.cc
-    perf/perf.cc
-    lib/alternator_test_env.cc
-    lib/cql_test_env.cc
-    lib/test_services.cc
-    lib/key_utils.cc
-    lib/random_schema.cc
-    lib/data_model.cc)
+    perf/perf.cc)
 target_include_directories(test-perf
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -113,3 +113,6 @@ add_scylla_test(bptree_test
 add_scylla_test(utf8_test
   KIND BOOST
   LIBRARIES utils)
+add_scylla_test(expr_test
+  KIND BOOST
+  LIBRARIES cql3)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -2,15 +2,18 @@ function(add_scylla_test name)
   cmake_parse_arguments(parsed_args
     ""
     "KIND"
-    "LIBRARIES"
+    "LIBRARIES;SOURCES"
     ${ARGN})
   if(parsed_args_KIND)
     set(kind ${parsed_args_KIND})
   else()
     set(kind "SEASTAR")
   endif()
-
-  set(src "${name}.cc")
+  if(parsed_args_SOURCES)
+    set(src "${parsed_args_SOURCES}")
+  else()
+    set(src "${name}.cc")
+  endif()
   add_executable(${name} ${src})
   target_include_directories(${name}
     PRIVATE

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(test-lib
     tmpdir.cc
     alternator_test_env.cc
     cql_test_env.cc
+    expr_test_utils.cc
     test_services.cc
     key_utils.cc
     random_schema.cc

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -3,7 +3,13 @@ target_sources(test-lib
   PRIVATE
     log.cc
     test_utils.cc
-    tmpdir.cc)
+    tmpdir.cc
+    alternator_test_env.cc
+    cql_test_env.cc
+    test_services.cc
+    key_utils.cc
+    random_schema.cc
+    data_model.cc)
 target_include_directories(test-lib
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -1,0 +1,57 @@
+function(add_perf_test name)
+  cmake_parse_arguments(parsed_args
+    ""
+    ""
+    "LIBRARIES"
+    ${ARGN})
+  set(src "${name}.cc")
+  add_executable(${name} ${src})
+  target_include_directories(${name}
+    PRIVATE
+      ${CMAKE_SOURCE_DIR})
+  target_link_libraries(${name}
+    PRIVATE
+      perf-lib
+      test-lib
+      seastar_perf_testing
+      Seastar::seastar
+      xxHash::xxhash)
+  if(parsed_args_LIBRARIES)
+    target_link_libraries(${name}
+      PRIVATE
+        ${parsed_args_LIBRARIES})
+  endif()
+endfunction()
+
+add_library(perf-lib OBJECT perf.cc)
+target_include_directories(perf-lib
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(perf-lib
+  PUBLIC
+    Seastar::seastar
+  PRIVATE
+    xxHash::xxhash)
+
+add_perf_test(perf_mutation_readers
+  LIBRARIES
+    auth
+    cql3
+    dht
+    mutation
+    readers
+    replica
+    schema
+    service
+    types
+    utils)
+add_perf_test(perf_checksum)
+add_perf_test(perf_mutation_fragment)
+add_perf_test(perf_idl
+  LIBRARIES
+    idl)
+add_perf_test(perf_vint)
+add_perf_test(perf_big_decimal
+  LIBRARIES
+    mutation
+    schema)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(tools STATIC)
+target_sources(tools
+  PRIVATE
+    scylla-types.cc
+    scylla-sstable.cc
+    schema_loader.cc
+    utils.cc
+    lua_sstable_consumer.cc)
+target_include_directories(tools
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(tools
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    db)

--- a/tracing/CMakeLists.txt
+++ b/tracing/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(tracing STATIC)
+target_sources(tracing
+  PRIVATE
+    tracing.cc
+    trace_keyspace_helper.cc
+    trace_state.cc
+    traced_file.cc)
+target_include_directories(tracing
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(tracing
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    service)

--- a/transport/CMakeLists.txt
+++ b/transport/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(transport STATIC)
+target_sources(transport
+  PRIVATE
+    controller.cc
+    cql_protocol_extension.cc
+    event.cc
+    event_notifier.cc
+    messages/result_message.cc
+    server.cc)
+target_include_directories(transport
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(transport
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    cql3)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(utils
   PRIVATE
     UUID_gen.cc
     arch/powerpc/crc32-vpmsum/crc32_wrapper.cc
+    arch/powerpc/crc32-vpmsum/crc32.S
     array-search.cc
     ascii.cc
     base64.cc

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(cryptopp REQUIRED)
+
 add_library(utils STATIC)
 target_sources(utils
   PRIVATE
@@ -45,4 +47,6 @@ target_include_directories(utils
 target_link_libraries(utils
   PUBLIC
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    cryptopp)


### PR DESCRIPTION
- build: cmake: extract more subsystem out into its own CMakeLists.txt
- build: cmake: remove swagger_gen_files
- build: cmake: remove stale TODO comments
- build: cmake: expose scylla_gen_build_dir
- build: cmake: link against cryptopp
- build: cmake: add missing source to utils
- build: cmake: move lib sources into test-lib
- build: cmake: add test/perf