### PR TITLE
auth: use zero initialization

### DIFF
--- a/auth/passwords.cc
+++ b/auth/passwords.cc
@@ -18,7 +18,7 @@ extern "C" {
 
 namespace auth::passwords {
 
-static thread_local crypt_data tlcrypt = { 0, };
+static thread_local crypt_data tlcrypt = {};
 
 namespace detail {
 


### PR DESCRIPTION
instead of passing '0' in the initializer list to do aggregate initialization, just use zero initialization. simpler this way.

also, this helps to silence a `-Wmissing-braces` warning, like

```
/home/kefu/dev/scylladb/auth/passwords.cc:21:43: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
static thread_local crypt_data tlcrypt = {0, };
                                          ^
                                          {}
```