### PR TITLE
build: reenable disabled warnings

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1341,10 +1341,7 @@ warnings = [
     '-Wno-tautological-compare',
     '-Wno-parentheses-equality',
     '-Wno-c++11-narrowing',
-    '-Wno-sometimes-uninitialized',
-    '-Wno-return-stack-address',
     '-Wno-missing-braces',
-    '-Wno-overflow',
     '-Wno-noexcept-type',
     '-Wno-nonnull-compare',
     '-Wno-error=cpp',
@@ -1359,17 +1356,14 @@ warnings = [
     '-Wno-braced-scalar-init',
     '-Wno-implicit-int-float-conversion',
     '-Wno-delete-abstract-non-virtual-dtor',
-    '-Wno-uninitialized-const-reference',
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
     '-Wno-psabi',
     '-Wno-narrowing',
-    '-Wno-array-bounds',
     '-Wno-nonnull',
     '-Wno-catch-value',
     '-Wno-stringop-overread', # false positives with gcc 12
     '-Wno-uninitialized',  # false positives with gcc 12,
     '-Wno-missing-attributes', # something in seastar's memory.cc, TBD,
-    '-Wno-use-after-free', # false positives with gcc 12
     '-Wno-dangling-pointer', # false positives with gcc 12
 ]
 


### PR DESCRIPTION
in general, the more static analysis the merrier. these warnings were previously added to silence warnings from Clang and/or GCC, but since we've addressed all of them, let's reenable them to detect potential issues early.