### PR TITLE
db/hints: migrate to locator::node_ptr

### DIFF
--- a/api/endpoint_snitch.cc
+++ b/api/endpoint_snitch.cc
@@ -28,7 +28,7 @@ void set_endpoint_snitch(http_context& ctx, routes& r, sharded<locator::snitch_p
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return sstring(locator::production_snitch_base::default_dc);
+            return locator::endpoint_dc_rack::default_location.dc;
         }
         return topology.get_datacenter(ep);
     });
@@ -39,7 +39,7 @@ void set_endpoint_snitch(http_context& ctx, routes& r, sharded<locator::snitch_p
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return sstring(locator::production_snitch_base::default_rack);
+            return locator::endpoint_dc_rack::default_location.rack;
         }
         return topology.get_rack(ep);
     });

--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -32,8 +32,10 @@ bool host_filter::can_hint_for(const locator::topology& topo, gms::inet_address 
     switch (_enabled_kind) {
     case enabled_kind::enabled_for_all:
         return true;
-    case enabled_kind::enabled_selectively:
-        return topo.has_endpoint(ep) && _dcs.contains(topo.get_datacenter(ep));
+    case enabled_kind::enabled_selectively: {
+        auto node = topo.find_node(ep);
+        return node && _dcs.contains(node->dc_rack().dc);
+    }
     case enabled_kind::disabled_for_all:
         return false;
     }

--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -28,12 +28,11 @@ host_filter::host_filter(std::unordered_set<sstring> allowed_dcs)
         , _dcs(std::move(allowed_dcs)) {
 }
 
-bool host_filter::can_hint_for(const locator::topology& topo, gms::inet_address ep) const {
+bool host_filter::can_hint_for(const locator::node_ptr& node) const {
     switch (_enabled_kind) {
     case enabled_kind::enabled_for_all:
         return true;
     case enabled_kind::enabled_selectively: {
-        auto node = topo.find_node(ep);
         return node && _dcs.contains(node->dc_rack().dc);
     }
     case enabled_kind::disabled_for_all:

--- a/db/hints/host_filter.hh
+++ b/db/hints/host_filter.hh
@@ -15,12 +15,11 @@
 
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
+#include "locator/topology_fwd.hh"
 
 namespace gms {
     class inet_address;
 } // namespace gms
-
-namespace locator { class topology; }
 
 namespace db {
 namespace hints {
@@ -58,7 +57,7 @@ public:
     // Parses hint filtering configuration from a list of DCs.
     static host_filter parse_from_dc_list(sstring opt);
 
-    bool can_hint_for(const locator::topology& topo, gms::inet_address ep) const;
+    bool can_hint_for(const locator::node_ptr& node) const;
 
     inline const std::unordered_set<sstring>& get_dcs() const {
         return _dcs;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -151,7 +151,8 @@ void manager::forbid_hints_for_eps_with_pending_hints() {
     manager_logger.trace("space_watchdog: Going to block hints to: {}", _eps_with_pending_hints);
     boost::for_each(_ep_managers, [this] (auto& pair) {
         end_point_hints_manager& ep_man = pair.second;
-        if (has_ep_with_pending_hints(ep_man.end_point_key())) {
+        auto node = get_topology().find_node(ep_man.end_point_key());
+        if (has_ep_with_pending_hints(node)) {
             ep_man.forbid_hints();
         } else {
             ep_man.allow_hints();

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -334,7 +334,7 @@ manager::end_point_hints_manager::~end_point_hints_manager() {
 
 future<hints_store_ptr> manager::end_point_hints_manager::get_or_load() {
     if (!_hints_store_anchor) {
-        return _shard_manager.store_factory().get_or_load(_key->endpoint(), [this] (const gms::inet_address&) noexcept {
+        return _shard_manager.store_factory().get_or_load(_key, [this] (const key_type&) noexcept {
             return add_store();
         }).then([this] (hints_store_ptr log_ptr) {
             _hints_store_anchor = log_ptr;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -358,7 +358,8 @@ manager::end_point_hints_manager& manager::get_ep_manager(const locator::node_pt
     return it->second;
 }
 
-inline bool manager::have_ep_manager(ep_key_type ep) const noexcept {
+inline bool manager::have_ep_manager(const locator::node_ptr& node) const noexcept {
+    const auto ep = node->endpoint();
     return find_ep_manager(ep) != ep_managers_end();
 }
 
@@ -696,7 +697,7 @@ bool manager::check_dc_for(locator::node_ptr node) const noexcept {
     try {
         // If target's DC is not a "hintable" DCs - don't hint.
         // If there is an end point manager then DC has already been checked and found to be ok.
-        return _host_filter.is_enabled_for_all() || have_ep_manager(node->endpoint()) || _host_filter.can_hint_for(node);
+        return _host_filter.is_enabled_for_all() || have_ep_manager(node) || _host_filter.can_hint_for(node);
     } catch (...) {
         // if we failed to check the DC - block this hint
         return false;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -701,6 +701,10 @@ bool manager::check_dc_for(locator::node_ptr node) const noexcept {
     }
 }
 
+const locator::topology& manager::get_topology() const noexcept {
+    return _proxy_anchor->get_token_metadata_ptr()->get_topology();
+}
+
 void manager::drain_for(locator::node_ptr node) {
     if (!started() || stopping() || draining_all()) {
         return;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -598,7 +598,8 @@ const column_mapping& manager::end_point_hints_manager::sender::get_column_mappi
     return cm_it->second;
 }
 
-bool manager::too_many_in_flight_hints_for(ep_key_type ep) const noexcept {
+bool manager::too_many_in_flight_hints_for(locator::node_ptr node) const noexcept {
+    auto ep = node->endpoint();
     // There is no need to check the DC here because if there is an in-flight hint for this end point then this means that
     // its DC has already been checked and found to be ok.
     return _stats.size_of_hints_in_progress > max_size_of_hints_in_progress && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -694,10 +694,12 @@ bool manager::check_dc_for(ep_key_type ep) const noexcept {
     }
 }
 
-void manager::drain_for(gms::inet_address endpoint) {
+void manager::drain_for(locator::node_ptr node) {
     if (!started() || stopping() || draining_all()) {
         return;
     }
+
+    auto endpoint = node->endpoint();
 
     manager_logger.trace("on_leave_cluster: {} is removed/decommissioned", endpoint);
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -604,7 +604,7 @@ bool manager::too_many_in_flight_hints_for(locator::node_ptr node) const noexcep
     auto ep = node->endpoint();
     // There is no need to check the DC here because if there is an in-flight hint for this end point then this means that
     // its DC has already been checked and found to be ok.
-    return _stats.size_of_hints_in_progress > max_size_of_hints_in_progress && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
+    return _stats.size_of_hints_in_progress > max_size_of_hints_in_progress && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(node) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
 }
 
 bool manager::can_hint_for(locator::node_ptr node) const noexcept {
@@ -622,8 +622,8 @@ bool manager::can_hint_for(locator::node_ptr node) const noexcept {
     // hints is more than the maximum allowed value.
     //
     // In the worst case there's going to be (_max_size_of_hints_in_progress + N - 1) in-flight hints, where N is the total number Nodes in the cluster.
-    if (_stats.size_of_hints_in_progress > max_size_of_hints_in_progress && hints_in_progress_for(ep) > 0) {
-        manager_logger.trace("size_of_hints_in_progress {} hints_in_progress_for({}) {}", _stats.size_of_hints_in_progress, ep, hints_in_progress_for(ep));
+    if (_stats.size_of_hints_in_progress > max_size_of_hints_in_progress && hints_in_progress_for(node) > 0) {
+        manager_logger.trace("size_of_hints_in_progress {} hints_in_progress_for({}) {}", _stats.size_of_hints_in_progress, ep, hints_in_progress_for(node));
         return false;
     }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -360,7 +360,7 @@ inline bool manager::have_ep_manager(ep_key_type ep) const noexcept {
 
 bool manager::store_hint(locator::node_ptr node, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept {
     const auto ep = node->endpoint();
-    if (stopping() || draining_all() || !started() || !can_hint_for(ep)) {
+    if (stopping() || draining_all() || !started() || !can_hint_for(node)) {
         manager_logger.trace("Can't store a hint to {}", ep);
         ++_stats.dropped;
         return false;
@@ -605,7 +605,8 @@ bool manager::too_many_in_flight_hints_for(locator::node_ptr node) const noexcep
     return _stats.size_of_hints_in_progress > max_size_of_hints_in_progress && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
 }
 
-bool manager::can_hint_for(ep_key_type ep) const noexcept {
+bool manager::can_hint_for(locator::node_ptr node) const noexcept {
+    auto ep = node->endpoint();
     if (utils::fb_utilities::is_me(ep)) {
         return false;
     }

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -157,10 +157,10 @@ void manager::forbid_hints_for_eps_with_pending_hints() {
     });
 }
 
-sync_point::shard_rps manager::calculate_current_sync_point(const std::vector<gms::inet_address>& target_hosts) const {
+sync_point::shard_rps manager::calculate_current_sync_point(const locator::node_set& target_hosts) const {
     sync_point::shard_rps rps;
-    for (auto addr : target_hosts) {
-        auto it = _ep_managers.find(addr);
+    for (auto node : target_hosts) {
+        auto it = _ep_managers.find(node->endpoint());
         if (it != _ep_managers.end()) {
             const end_point_hints_manager& ep_man = it->second;
             rps[ep_man.end_point_key()] = ep_man.last_written_replay_position();

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -358,7 +358,8 @@ inline bool manager::have_ep_manager(ep_key_type ep) const noexcept {
     return find_ep_manager(ep) != ep_managers_end();
 }
 
-bool manager::store_hint(ep_key_type ep, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept {
+bool manager::store_hint(locator::node_ptr node, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept {
+    const auto ep = node->endpoint();
     if (stopping() || draining_all() || !started() || !can_hint_for(ep)) {
         manager_logger.trace("Can't store a hint to {}", ep);
         ++_stats.dropped;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -740,6 +740,8 @@ private:
     bool have_ep_manager(ep_key_type ep) const noexcept;
 
 public:
+    const locator::topology& get_topology() const noexcept;
+
     /// \brief Initiate the draining when we detect that the node has left the cluster.
     ///
     /// If the node that has left is the current node - drains all pending hints to all nodes.

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -604,8 +604,8 @@ public:
         _eps_with_pending_hints.reserve(_ep_managers.size());
     }
 
-    bool has_ep_with_pending_hints(ep_key_type key) const {
-        return _eps_with_pending_hints.contains(key);
+    bool has_ep_with_pending_hints(locator::node_ptr node) const {
+        return _eps_with_pending_hints.contains(node->endpoint());
     }
 
     size_t ep_managers_size() const {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -748,8 +748,8 @@ public:
     /// In both cases - removes the corresponding hints' directories after all hints have been drained and erases the
     /// corresponding end_point_hints_manager objects.
     ///
-    /// \param endpoint node that left the cluster
-    void drain_for(gms::inet_address endpoint);
+    /// \param node that left the cluster
+    void drain_for(locator::node_ptr node);
 
 private:
     void update_backlog(size_t backlog, size_t max_backlog);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -736,7 +736,7 @@ private:
         return _local_db;
     }
 
-    end_point_hints_manager& get_ep_manager(ep_key_type ep);
+    end_point_hints_manager& get_ep_manager(const locator::node_ptr& node);
     bool have_ep_manager(ep_key_type ep) const noexcept;
 
 public:

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -633,7 +633,7 @@ public:
     }
 
     /// \brief Returns a set of replay positions for hint queues towards endpoints from the `target_hosts`.
-    sync_point::shard_rps calculate_current_sync_point(const std::vector<gms::inet_address>& target_hosts) const;
+    sync_point::shard_rps calculate_current_sync_point(const locator::node_set& target_hosts) const;
 
     /// \brief Waits until hint replay reach replay positions described in `rps`.
     future<> wait_for_sync_point(abort_source& as, const sync_point::shard_rps& rps);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -548,9 +548,9 @@ public:
     }
 
     /// \brief Check if a hint may be generated to the give end point
-    /// \param ep end point to check
+    /// \param node to check
     /// \return true if we should generate the hint to the given end point if it becomes unavailable
-    bool can_hint_for(ep_key_type ep) const noexcept;
+    bool can_hint_for(locator::node_ptr node) const noexcept;
 
     /// \brief Check if there aren't too many in-flight hints
     ///

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -588,7 +588,7 @@ public:
     /// \param ep End point identificator
     /// \return Number of hints in-flight to \param ep.
     uint64_t hints_in_progress_for(const locator::node_ptr& node) const noexcept {
-        auto it = find_ep_manager(node->endpoint());
+        auto it = find_ep_manager(node);
         if (it == ep_managers_end()) {
             return 0;
         }
@@ -785,12 +785,12 @@ private:
     }
 
 public:
-    ep_managers_map_type::iterator find_ep_manager(ep_key_type ep_key) noexcept {
-        return _ep_managers.find(ep_key);
+    ep_managers_map_type::iterator find_ep_manager(const locator::node_ptr& node) noexcept {
+        return _ep_managers.find(node->endpoint());
     }
 
-    ep_managers_map_type::const_iterator find_ep_manager(ep_key_type ep_key) const noexcept {
-        return _ep_managers.find(ep_key);
+    ep_managers_map_type::const_iterator find_ep_manager(const locator::node_ptr& node) const noexcept {
+        return _ep_managers.find(node->endpoint());
     }
 
     ep_managers_map_type::iterator ep_managers_end() noexcept {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -737,7 +737,7 @@ private:
     }
 
     end_point_hints_manager& get_ep_manager(const locator::node_ptr& node);
-    bool have_ep_manager(ep_key_type ep) const noexcept;
+    bool have_ep_manager(const locator::node_ptr& node) const noexcept;
 
 public:
     const locator::topology& get_topology() const noexcept;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -27,6 +27,7 @@
 #include "db/hints/resource_manager.hh"
 #include "db/hints/host_filter.hh"
 #include "db/hints/sync_point.hh"
+#include "locator/topology.hh"
 
 class fragmented_temporary_buffer;
 
@@ -535,7 +536,7 @@ public:
     void register_metrics(const sstring& group_name);
     future<> start(shared_ptr<service::storage_proxy> proxy_ptr, shared_ptr<gms::gossiper> gossiper_ptr);
     future<> stop();
-    bool store_hint(gms::inet_address ep, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept;
+    bool store_hint(locator::node_ptr node, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept;
 
     /// \brief Changes the host_filter currently used, stopping and starting ep_managers relevant to the new host_filter.
     /// \param filter the new host_filter

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -42,7 +42,7 @@ class gossiper;
 namespace db {
 namespace hints {
 
-using node_to_hint_store_factory_type = utils::loading_shared_values<gms::inet_address, db::commitlog>;
+using node_to_hint_store_factory_type = utils::loading_shared_values<locator::node_ptr, db::commitlog>;
 using hints_store_ptr = node_to_hint_store_factory_type::entry_ptr;
 using hint_entry_reader = commitlog_entry_reader;
 using timer_clock_type = seastar::lowres_clock;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -91,7 +91,7 @@ private:
 public:
     class end_point_hints_manager {
     public:
-        using key_type = gms::inet_address;
+        using key_type = locator::node_ptr;
 
         class sender {
             // Important: clock::now() must be noexcept.

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -498,7 +498,7 @@ public:
 
 private:
     using ep_key_type = typename end_point_hints_manager::key_type;
-    using ep_managers_map_type = std::unordered_map<ep_key_type, end_point_hints_manager>;
+    using ep_managers_map_type = std::unordered_map<locator::node_ptr, end_point_hints_manager>;
 
 public:
     static const std::string FILENAME_PREFIX;
@@ -525,7 +525,7 @@ private:
     ep_managers_map_type _ep_managers;
     stats _stats;
     seastar::metrics::metric_groups _metrics;
-    std::unordered_set<ep_key_type> _eps_with_pending_hints;
+    std::unordered_set<locator::node_ptr> _eps_with_pending_hints;
     seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
 
 public:
@@ -596,7 +596,7 @@ public:
     }
 
     void add_ep_with_pending_hints(locator::node_ptr node) {
-        _eps_with_pending_hints.insert(node->endpoint());
+        _eps_with_pending_hints.insert(node);
     }
 
     void clear_eps_with_pending_hints() {
@@ -605,7 +605,7 @@ public:
     }
 
     bool has_ep_with_pending_hints(locator::node_ptr node) const {
-        return _eps_with_pending_hints.contains(node->endpoint());
+        return _eps_with_pending_hints.contains(node);
     }
 
     size_t ep_managers_size() const {
@@ -786,11 +786,11 @@ private:
 
 public:
     ep_managers_map_type::iterator find_ep_manager(const locator::node_ptr& node) noexcept {
-        return _ep_managers.find(node->endpoint());
+        return _ep_managers.find(node);
     }
 
     ep_managers_map_type::const_iterator find_ep_manager(const locator::node_ptr& node) const noexcept {
-        return _ep_managers.find(node->endpoint());
+        return _ep_managers.find(node);
     }
 
     ep_managers_map_type::iterator ep_managers_end() noexcept {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -595,8 +595,8 @@ public:
         return it->second.hints_in_progress();
     }
 
-    void add_ep_with_pending_hints(ep_key_type key) {
-        _eps_with_pending_hints.insert(key);
+    void add_ep_with_pending_hints(locator::node_ptr node) {
+        _eps_with_pending_hints.insert(node->endpoint());
     }
 
     void clear_eps_with_pending_hints() {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -571,7 +571,7 @@ public:
     /// \brief Check if DC \param ep belongs to is "hintable"
     /// \param ep End point identificator
     /// \return TRUE if hints are allowed to be generated to \param ep.
-    bool check_dc_for(ep_key_type ep) const noexcept;
+    bool check_dc_for(locator::node_ptr node) const noexcept;
 
     /// \brief Checks if hints are disabled for all endpoints
     /// \return TRUE if hints are disabled.

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -564,9 +564,9 @@ public:
     /// Note that we can't consider the disk usage consumption here because the disk usage is not promissed to drop down shortly
     /// because it requires the remote node to be UP.
     ///
-    /// \param ep end point to check
+    /// \param node to check
     /// \return TRUE if we are allowed to generate hint to the given end point but there are too many in-flight hints
-    bool too_many_in_flight_hints_for(ep_key_type ep) const noexcept;
+    bool too_many_in_flight_hints_for(locator::node_ptr node) const noexcept;
 
     /// \brief Check if DC \param ep belongs to is "hintable"
     /// \param ep End point identificator

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -587,8 +587,8 @@ public:
     /// \brief Get the number of in-flight (to the disk) hints to a given end point.
     /// \param ep End point identificator
     /// \return Number of hints in-flight to \param ep.
-    uint64_t hints_in_progress_for(ep_key_type ep) const noexcept {
-        auto it = find_ep_manager(ep);
+    uint64_t hints_in_progress_for(const locator::node_ptr& node) const noexcept {
+        auto it = find_ep_manager(node->endpoint());
         if (it == ep_managers_end()) {
             return 0;
         }

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -102,7 +102,7 @@ future<> space_watchdog::scan_one_ep_dir(fs::path path, manager& shard_manager, 
                 return lister::scan_dir(path, lister::dir_entry_types::of<directory_entry_type::regular>(), [this, node, &shard_manager] (fs::path dir, directory_entry de) {
                     // Put the current end point ID to state.eps_with_pending_hints when we see the second hints file in its directory
                     if (_files_count == 1) {
-                        shard_manager.add_ep_with_pending_hints(node->endpoint());
+                        shard_manager.add_ep_with_pending_hints(node);
                     }
                     ++_files_count;
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -149,7 +149,7 @@ void space_watchdog::on_timer() {
                 const auto& topo = shard_manager.get_topology();
                 auto ep = gms::inet_address(de.name);
                 auto node = topo.find_node(ep);
-                auto it = shard_manager.find_ep_manager(de.name);
+                auto it = shard_manager.find_ep_manager(node);
                 if (it != shard_manager.ep_managers_end()) {
                     return with_file_update_mutex(it->second, [this, &shard_manager, dir = std::move(dir), ep_name = std::move(de.name), node = std::move(node)] () mutable {
                         return scan_one_ep_dir(dir / ep_name, shard_manager, std::move(node));

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -91,18 +91,18 @@ future<> space_watchdog::stop() noexcept {
 }
 
 // Called under the end_point_hints_manager::file_update_mutex() of the corresponding end_point_hints_manager instance.
-future<> space_watchdog::scan_one_ep_dir(fs::path path, manager& shard_manager, ep_key_type ep_key) {
-    return do_with(std::move(path), [this, ep_key, &shard_manager] (fs::path& path) {
+future<> space_watchdog::scan_one_ep_dir(fs::path path, manager& shard_manager, locator::node_ptr node) {
+    return do_with(std::move(path), [this, node, &shard_manager] (fs::path& path) {
         // It may happen that we get here and the directory has already been deleted in the context of manager::drain_for().
         // In this case simply bail out.
-        return file_exists(path.native()).then([this, ep_key, &shard_manager, &path] (bool exists) {
+        return file_exists(path.native()).then([this, node, &shard_manager, &path] (bool exists) {
             if (!exists) {
                 return make_ready_future<>();
             } else {
-                return lister::scan_dir(path, lister::dir_entry_types::of<directory_entry_type::regular>(), [this, ep_key, &shard_manager] (fs::path dir, directory_entry de) {
+                return lister::scan_dir(path, lister::dir_entry_types::of<directory_entry_type::regular>(), [this, node, &shard_manager] (fs::path dir, directory_entry de) {
                     // Put the current end point ID to state.eps_with_pending_hints when we see the second hints file in its directory
                     if (_files_count == 1) {
-                        shard_manager.add_ep_with_pending_hints(ep_key);
+                        shard_manager.add_ep_with_pending_hints(node->endpoint());
                     }
                     ++_files_count;
 
@@ -146,13 +146,16 @@ void space_watchdog::on_timer() {
                 // not hintable).
                 // If exists - let's take a file update lock so that files are not changed under our feet. Otherwise, simply
                 // continue to enumeration - there is no one to change them.
+                const auto& topo = shard_manager.get_topology();
+                auto ep = gms::inet_address(de.name);
+                auto node = topo.find_node(ep);
                 auto it = shard_manager.find_ep_manager(de.name);
                 if (it != shard_manager.ep_managers_end()) {
-                    return with_file_update_mutex(it->second, [this, &shard_manager, dir = std::move(dir), ep_name = std::move(de.name)] () mutable {
-                        return scan_one_ep_dir(dir / ep_name, shard_manager, ep_key_type(ep_name));
+                    return with_file_update_mutex(it->second, [this, &shard_manager, dir = std::move(dir), ep_name = std::move(de.name), node = std::move(node)] () mutable {
+                        return scan_one_ep_dir(dir / ep_name, shard_manager, std::move(node));
                     });
                 } else {
-                    return scan_one_ep_dir(dir / de.name, shard_manager, ep_key_type(de.name));
+                    return scan_one_ep_dir(dir / de.name, shard_manager, std::move(node));
                 }
             }).get();
         }

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -20,6 +20,7 @@
 #include "utils/small_vector.hh"
 #include "utils/updateable_value.hh"
 #include "enum_set.hh"
+#include "locator/topology_fwd.hh"
 
 // Usually we don't define namespace aliases in our headers
 // but this one is already entrenched.
@@ -46,7 +47,6 @@ class manager;
 
 class space_watchdog {
 private:
-    using ep_key_type = gms::inet_address;
     static const std::chrono::seconds _watchdog_period;
 
     struct manager_hash {
@@ -110,9 +110,9 @@ private:
     /// value.
     ///
     /// \param path directory to scan
-    /// \param ep_name end point ID (as a string)
+    /// \param node
     /// \return future that resolves when scanning is complete
-    future<> scan_one_ep_dir(fs::path path, manager& shard_manager, ep_key_type ep_key);
+    future<> scan_one_ep_dir(fs::path path, manager& shard_manager, locator::node_ptr node);
 };
 
 class resource_manager {

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -28,10 +28,6 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-bool operator==(const endpoint_dc_rack& d1, const endpoint_dc_rack& d2) {
-    return std::tie(d1.dc, d1.rack) == std::tie(d2.dc, d2.rack);
-}
-
 network_topology_strategy::network_topology_strategy(
     const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options,

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -521,6 +521,7 @@ void token_metadata_impl::debug_show() const {
 }
 
 void token_metadata_impl::update_host_id(const host_id& host_id, inet_address endpoint) {
+    _topology.update_endpoint(endpoint, host_id);
     _endpoint_to_host_id_map[endpoint] = host_id;
 }
 
@@ -1261,7 +1262,7 @@ future<> shared_token_metadata::mutate_on_all_shards(sharded<shared_token_metada
     auto lk = co_await stm.local().get_lock();
 
     std::vector<mutable_token_metadata_ptr> pending_token_metadata_ptr;
-    pending_token_metadata_ptr.reserve(smp::count);
+    pending_token_metadata_ptr.resize(smp::count);
     auto tmptr = make_token_metadata_ptr(co_await stm.local().get()->clone_async());
     auto& tm = *tmptr;
     // bump the token_metadata ring_version

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -102,8 +102,8 @@ public:
         return _bootstrap_tokens;
     }
 
-    void update_topology(inet_address ep, endpoint_dc_rack dr) {
-        _topology.update_endpoint(ep, std::move(dr));
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
+        _topology.update_endpoint(ep, std::move(dr), std::move(opt_st));
     }
 
     /**
@@ -852,7 +852,7 @@ void token_metadata_impl::calculate_pending_ranges_for_bootstrap(
     for (auto& x : tmp) {
         auto& endpoint = x.first;
         auto& tokens = x.second;
-        all_left_metadata->update_topology(endpoint, get_dc_rack(endpoint));
+        all_left_metadata->update_topology(endpoint, get_dc_rack(endpoint), node::state::joining);
         all_left_metadata->update_normal_tokens(tokens, endpoint).get();
         auto address_ranges = strategy.get_ranges(endpoint, *all_left_metadata).get0();
         for (const dht::token_range& x : address_ranges) {
@@ -1025,8 +1025,8 @@ token_metadata::get_bootstrap_tokens() const {
 }
 
 void
-token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr) {
-    _impl->update_topology(ep, std::move(dr));
+token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
+    _impl->update_topology(ep, std::move(dr), std::move(opt_st));
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>
@@ -1046,6 +1046,11 @@ token_metadata::get_topology() {
 
 const topology&
 token_metadata::get_topology() const {
+    return _impl->get_topology();
+}
+
+topology&
+token_metadata::get_mutable_topology() const {
     return _impl->get_topology();
 }
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -117,6 +117,10 @@ public:
     const std::unordered_map<token, inet_address>& get_token_to_endpoint() const;
     const std::unordered_set<inet_address>& get_leaving_endpoints() const;
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
+
+    /**
+     * Update or add endpoint given its inet_address and endpoint_dc_rack.
+     */
     void update_topology(inet_address ep, endpoint_dc_rack dr);
     /**
      * Creates an iterable range of the sorted tokens starting at the token next

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -121,7 +121,7 @@ public:
     /**
      * Update or add endpoint given its inet_address and endpoint_dc_rack.
      */
-    void update_topology(inet_address ep, endpoint_dc_rack dr);
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st = std::nullopt);
     /**
      * Creates an iterable range of the sorted tokens starting at the token next
      * after the given one.
@@ -136,6 +136,7 @@ public:
 
     topology& get_topology();
     const topology& get_topology() const;
+    topology& get_mutable_topology() const;
     void debug_show() const;
 
     /**

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -20,6 +20,11 @@ namespace locator {
 
 static logging::logger tlogger("topology");
 
+thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
+    .dc = locator::production_snitch_base::default_dc,
+    .rack = locator::production_snitch_base::default_rack,
+};
+
 future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_dc_endpoints);
     co_await utils::clear_gently(_dc_racks);
@@ -128,13 +133,8 @@ const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with
     // on_internal_error()
-    static thread_local endpoint_dc_rack default_location = {
-        .dc = locator::production_snitch_base::default_dc,
-        .rack = locator::production_snitch_base::default_rack,
-    };
-
     tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
-    return default_location;
+    return endpoint_dc_rack::default_location;
 }
 
 // FIXME -- both methods below should rather return data from the

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -25,81 +25,264 @@ thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
     .rack = locator::production_snitch_base::default_rack,
 };
 
+node::node(::locator::host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, local is_local)
+    : _host_id(id)
+    , _endpoint(endpoint)
+    , _dc_rack(std::move(dc_rack))
+    , _is_local(is_local)
+{}
+
 future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_dc_endpoints);
     co_await utils::clear_gently(_dc_racks);
-    co_await utils::clear_gently(_current_locations);
     _datacenters.clear();
-    co_return;
+    _dc_rack_nodes.clear();
+    _dc_nodes.clear();
+    _nodes_by_endpoint.clear();
+    _nodes_by_host_id.clear();
+    _local_node = {};
+    co_await utils::clear_gently(_all_nodes);
+}
+
+topology::topology() noexcept
+        : _shard(this_shard_id())
+{
+    tlogger.trace("topology[{}]: default-constructed", fmt::ptr(this));
 }
 
 topology::topology(config cfg)
-        : _sort_by_proximity(!cfg.disable_proximity_sorting)
+        : _shard(this_shard_id())
+        , _sort_by_proximity(!cfg.disable_proximity_sorting)
 {
-    update_endpoint(utils::fb_utilities::get_broadcast_address(), cfg.local_dc_rack);
+    tlogger.trace("topology[{}]: constructing using config: host_id={} endpoint={} dc={} rack={}", fmt::ptr(this),
+            cfg.local_host_id, cfg.local_endpoint, cfg.local_dc_rack.dc, cfg.local_dc_rack.rack);
+    if (cfg.local_host_id || cfg.local_endpoint != inet_address{}) {
+        add_node(make_lw_shared<node>(cfg.local_host_id, cfg.local_endpoint, cfg.local_dc_rack, node::local::yes));
+    }
+}
+
+topology::topology(topology&& o) noexcept
+    : _shard(o._shard)
+    , _all_nodes(std::move(o._all_nodes))
+    , _local_node(std::move(o._local_node))
+    , _nodes_by_host_id(std::move(o._nodes_by_host_id))
+    , _nodes_by_endpoint(std::move(o._nodes_by_endpoint))
+    , _dc_nodes(std::move(o._dc_nodes))
+    , _dc_rack_nodes(std::move(o._dc_rack_nodes))
+    , _dc_endpoints(std::move(o._dc_endpoints))
+    , _dc_racks(std::move(o._dc_racks))
+    , _sort_by_proximity(o._sort_by_proximity)
+    , _datacenters(std::move(o._datacenters))
+{
+    assert(_shard == this_shard_id());
+    tlogger.trace("topology[{}]: move from [{}]", fmt::ptr(this), fmt::ptr(&o));
 }
 
 future<topology> topology::clone_gently() const {
     topology ret;
-    ret._dc_endpoints.reserve(_dc_endpoints.size());
-    for (const auto& p : _dc_endpoints) {
-        ret._dc_endpoints.emplace(p);
-    }
-    co_await coroutine::maybe_yield();
-    ret._dc_racks.reserve(_dc_racks.size());
-    for (const auto& [dc, rack_endpoints] : _dc_racks) {
-        ret._dc_racks[dc].reserve(rack_endpoints.size());
-        for (const auto& p : rack_endpoints) {
-            ret._dc_racks[dc].emplace(p);
+    if (this_shard_id() == _shard) {
+        tlogger.debug("topology[{}]: clone_gently to {} on same shard", fmt::ptr(this), fmt::ptr(&ret));
+        ret._all_nodes = _all_nodes;
+        co_await coroutine::maybe_yield();
+        ret._local_node = _local_node;
+        ret._nodes_by_host_id = _nodes_by_host_id;
+        ret._nodes_by_endpoint = _nodes_by_endpoint;
+        ret._dc_nodes = _dc_nodes;
+        ret._dc_rack_nodes = _dc_rack_nodes;
+        ret._dc_endpoints = _dc_endpoints;
+        ret._dc_racks = _dc_racks;
+        ret._datacenters = _datacenters;
+    } else {
+        tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);
+        for (const auto& n : _all_nodes) {
+            ret.add_node(make_lw_shared<node>(*n));
+            co_await coroutine::maybe_yield();
+        }
+        // local node may be detached for _all_nodes
+        // if it was decommissioned.
+        if (!ret._local_node && _local_node) {
+            ret.add_node(make_lw_shared<node>(*_local_node));
         }
     }
     co_await coroutine::maybe_yield();
-    ret._current_locations.reserve(_current_locations.size());
-    for (const auto& p : _current_locations) {
-        ret._current_locations.emplace(p);
-    }
-    co_await coroutine::maybe_yield();
-    ret._datacenters = _datacenters;
     ret._sort_by_proximity = _sort_by_proximity;
     co_return ret;
 }
 
-void topology::update_endpoint(const inet_address& ep, endpoint_dc_rack dr)
-{
-    auto current = _current_locations.find(ep);
-
-    if (current != _current_locations.end()) {
-        if (current->second.dc == dr.dc && current->second.rack == dr.rack) {
-            return;
-        }
-        remove_endpoint(ep);
+node_ptr topology::add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr) {
+    if (dr.dc.empty() || dr.rack.empty()) {
+        on_internal_error(tlogger, "Node must have valid dc and rack");
     }
-
-    tlogger.debug("update_endpoint: {} {}/{}", ep, dr.dc, dr.rack);
-    _dc_endpoints[dr.dc].insert(ep);
-    _dc_racks[dr.dc][dr.rack].insert(ep);
-    _datacenters.insert(dr.dc);
-    _current_locations[ep] = std::move(dr);
+    auto is_local = node::local(ep == utils::fb_utilities::get_broadcast_address());
+    if (is_local && _local_node) {
+        if (_local_node->host_id() == id) {
+            on_internal_error_noexcept(tlogger, format("Local node already set: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={} endpoint={}",
+                    id, ep, dr.dc, dr.rack,
+                    _local_node->host_id(), _local_node->endpoint()));
+            return _local_node;
+        }
+        // Replacing node with the same ip address
+        is_local = node::local::no;
+    }
+    return add_node(make_lw_shared<node>(id, ep, dr, is_local));
 }
 
-void topology::remove_endpoint(inet_address ep)
-{
-    auto cur_dc_rack = _current_locations.find(ep);
+node_ptr topology::add_node(mutable_node_ptr node) {
+    tlogger.debug("topology[{}]: add_node: node={} host_id={} endpoint={} dc={} rack={} local={}, at {}", fmt::ptr(this), fmt::ptr(node.get()),
+            node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack, node->is_local(), current_backtrace());
+    if (node->is_local() && _local_node && _local_node != node) {
+        on_internal_error(tlogger, format("Local node already set: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={} endpoint={}",
+                node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack,
+                _local_node->host_id(), _local_node->endpoint()));
+    }
+    if (_all_nodes.contains(node)) {
+        return node;
+    }
+    try {
+        // FIXME: for now we allow adding nodes with null host_id
+        if (node->host_id()) {
+            auto [nit, inserted_host_id] = _nodes_by_host_id.emplace(node->host_id(), node.get());
+            if (!inserted_host_id) {
+                on_internal_error(tlogger, format("Node already exists: host_id={} endpoint={} dc={} rack={}",
+                        node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack));
+            }
+        }
+        if (node->endpoint() != inet_address{}) {
+            auto [eit, inserted_endpoint] = _nodes_by_endpoint.emplace(node->endpoint(), node.get());
+            if (!inserted_endpoint) {
+                if (node->host_id()) {
+                    _nodes_by_host_id.erase(node->host_id());
+                }
+                on_internal_error(tlogger, format("Node endpoint already mapped: host_id={} endpoint={} dc={} rack={}: currently mapped to host_id={}",
+                        node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack,
+                        eit->second->host_id()));
+            }
+        }
 
-    if (cur_dc_rack == _current_locations.end()) {
-        return;
+        const auto& dc = node->dc_rack().dc;
+        const auto& rack = node->dc_rack().rack;
+        const auto& endpoint = node->endpoint();
+        _dc_nodes[dc].emplace(node.get());
+        _dc_rack_nodes[dc][rack].emplace(node.get());
+        _dc_endpoints[dc].insert(endpoint);
+        _dc_racks[dc][rack].insert(endpoint);
+        _datacenters.insert(dc);
+
+        if (node->is_local()) {
+            _local_node = node;
+        }
+        _all_nodes.emplace(node);
+    } catch (...) {
+        do_remove_node(node);
+        throw;
+    }
+    return node;
+}
+
+topology::mutable_node_ptr topology::make_mutable(const node_ptr& nptr) {
+    return const_cast<class node*>(nptr.get())->shared_from_this();
+}
+
+node_ptr topology::update_node(node_ptr node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr) {
+    tlogger.debug("topology[{}]: update_node: node={} host_id={} endpoint={} dc={} rack={}, at {}", fmt::ptr(this), fmt::ptr(node.get()),
+            opt_id.value_or(host_id::create_null_id()), opt_ep.value_or(inet_address{}), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack,
+            current_backtrace());
+    bool changed = false;
+    if (opt_id) {
+        if (*opt_id != node->host_id()) {
+            // FIXME: allow updating host_id for replace node.
+            // if (node->host_id()) {
+            //    on_internal_error(tlogger, format("Updating non-null node host_id is disallowed: host_id={} endpoint={}: new host_id={}",
+            //            node->host_id(), node->endpoint(), *opt_id));
+            // }
+            if (!*opt_id) {
+                on_internal_error(tlogger, format("Updating node host_id to null is disallowed: host_id={} endpoint={}: new host_id={}",
+                        node->host_id(), node->endpoint(), *opt_id));
+            }
+            if (_nodes_by_host_id.contains(*opt_id)) {
+                on_internal_error(tlogger, format("Cannot update node host_id: new host_id={} already exists: endpoint={}: ",
+                        *opt_id, node->endpoint()));
+            }
+            changed = true;
+        } else {
+            opt_id.reset();
+        }
+    }
+    if (opt_ep) {
+        if (*opt_ep != node->endpoint()) {
+            if (*opt_ep == inet_address{}) {
+                on_internal_error(tlogger, format("Updating node endpoint to null is disallowed: host_id={} endpoint={}: new endpoint={}",
+                        node->host_id(), node->endpoint(), *opt_ep));
+            }
+            changed = true;
+        } else {
+            opt_ep.reset();
+        }
+    }
+    if (opt_dr) {
+        if (opt_dr->dc.empty() || opt_dr->dc == production_snitch_base::default_dc) {
+            opt_dr->dc = node->dc_rack().dc;
+        }
+        if (opt_dr->rack.empty() || opt_dr->rack == production_snitch_base::default_rack) {
+            opt_dr->rack = node->dc_rack().rack;
+        }
+        if (*opt_dr != node->dc_rack()) {
+            changed = true;
+        } else {
+            opt_dr.reset();
+        }
     }
 
-    const auto& dc = cur_dc_rack->second.dc;
-    const auto& rack = cur_dc_rack->second.rack;
-    tlogger.debug("remove_endpoint: {} {}/{}", ep, dc, rack);
+    if (!changed) {
+        return node;
+    }
+
+    auto mutable_node = make_mutable(node);
+    do_remove_node(mutable_node);
+    if (opt_id) {
+        mutable_node->_host_id = *opt_id;
+    }
+    if (opt_ep) {
+        mutable_node->_endpoint = *opt_ep;
+    }
+    if (opt_dr) {
+        mutable_node->_dc_rack = std::move(*opt_dr);
+    }
+    return add_node(mutable_node);
+}
+
+void topology::remove_node(host_id id, must_exist require_exist) {
+    if (id == _local_node->host_id()) {
+        on_internal_error(tlogger, format("Cannot remove the local node: host_id={} endpoint={}",
+                _local_node->host_id(), _local_node->endpoint()));
+    }
+    tlogger.trace("topology[{}]: remove_node: host_id={}", fmt::ptr(this), id);
+    auto it = _nodes_by_host_id.find(id);
+    if (it != _nodes_by_host_id.end()) {
+        do_remove_node(make_mutable(it->second->shared_from_this()));
+    } else if (require_exist) {
+        on_internal_error(tlogger, format("Node not found: host_id={}", id));
+    }
+}
+
+void topology::remove_node(node_ptr node) {
+    if (node) {
+        do_remove_node(make_mutable(node));
+    }
+}
+
+void topology::do_remove_node(mutable_node_ptr node) {
+    tlogger.debug("remove_node: node={} host_id={} endpoint={}, at {}", fmt::ptr(node.get()), node->host_id(), node->endpoint(), current_backtrace());
+ 
+    const auto& dc = node->dc_rack().dc;
+    const auto& rack = node->dc_rack().rack;
     if (auto dit = _dc_endpoints.find(dc); dit != _dc_endpoints.end()) {
+        const auto& ep = node->endpoint();
         auto& eps = dit->second;
         eps.erase(ep);
         if (eps.empty()) {
-            _dc_endpoints.erase(dit);
-            _datacenters.erase(dc);
             _dc_racks.erase(dc);
+            _dc_endpoints.erase(dit);
         } else {
             auto& racks = _dc_racks[dc];
             if (auto rit = racks.find(rack); rit != racks.end()) {
@@ -111,51 +294,105 @@ void topology::remove_endpoint(inet_address ep)
             }
         }
     }
-
-    // Keep the local endpoint around
-    // Just unlist it from _dc_endpoints and _dc_racks
-    // This is needed after it is decommissioned
-    if (ep != utils::fb_utilities::get_broadcast_address()) {
-        _current_locations.erase(cur_dc_rack);
+    if (auto dit = _dc_nodes.find(dc); dit != _dc_nodes.end()) {
+        auto& nodes = dit->second;
+        nodes.erase(node.get());
+        if (nodes.empty()) {
+            _dc_rack_nodes.erase(dc);
+            _datacenters.erase(dc);
+            _dc_nodes.erase(dit);
+        } else {
+            auto& racks = _dc_rack_nodes[dc];
+            if (auto rit = racks.find(rack); rit != racks.end()) {
+                nodes = rit->second;
+                nodes.erase(node.get());
+                if (nodes.empty()) {
+                    racks.erase(rit);
+                }
+            }
+        }
     }
+    _nodes_by_host_id.erase(node->host_id());
+    _nodes_by_endpoint.erase(node->endpoint());
+    _all_nodes.erase(node);
+}
+
+// Finds a node by its host_id
+// Returns nullptr if not found
+node_ptr topology::find_node(host_id id, must_exist must_exist) const noexcept {
+    auto it = _nodes_by_host_id.find(id);
+    if (it != _nodes_by_host_id.end()) {
+        return it->second->shared_from_this();
+    }
+    if (must_exist) {
+        on_internal_error(tlogger, format("Could not find node: host_id={}", id));
+    }
+    return nullptr;
+}
+
+// Finds a node by its endpoint
+// Returns nullptr if not found
+node_ptr topology::find_node(const inet_address& ep, must_exist must_exist) const noexcept {
+    auto it = _nodes_by_endpoint.find(ep);
+    if (it != _nodes_by_endpoint.end()) {
+        return it->second->shared_from_this();
+    }
+    if (must_exist) {
+        on_internal_error(tlogger, format("Could not find node: endpoint={}", ep));
+    }
+    return nullptr;
+}
+
+node_ptr topology::update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr)
+{
+    tlogger.trace("topology[{}]: update_endpoint: ep={} host_id={} dc={} rack={}, at {}", fmt::ptr(this),
+            ep, opt_id.value_or(host_id::create_null_id()), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack,
+            current_backtrace());
+    node_ptr n = find_node(ep);
+    if (n) {
+        return update_node(make_mutable(n), opt_id, std::nullopt, std::move(opt_dr));
+    } else if (opt_id && (n = find_node(*opt_id))) {
+        return update_node(make_mutable(n), std::nullopt, ep, std::move(opt_dr));
+    } else {
+        return add_node(opt_id.value_or(host_id::create_null_id()), ep, opt_dr.value_or(endpoint_dc_rack::default_location));
+    }
+}
+
+void topology::remove_endpoint(inet_address ep)
+{
+    tlogger.trace("topology[{}]: remove_endpoint: endpoint={}", fmt::ptr(this), ep);
+    remove_node(find_node(ep));
+}
+
+bool topology::has_node(host_id id) const noexcept {
+    auto node = find_node(id);
+    tlogger.trace("topology[{}]: has_node: host_id={}: node={}", fmt::ptr(this), id, fmt::ptr(node.get()));
+    return bool(node);
+}
+
+bool topology::has_node(inet_address ep) const noexcept {
+    auto node = find_node(ep);
+    tlogger.trace("topology[{}]: has_node: endpoint={}: node={}", fmt::ptr(this), ep, fmt::ptr(node.get()));
+    return bool(node);
 }
 
 bool topology::has_endpoint(inet_address ep) const
 {
-    return _current_locations.contains(ep);
+    return has_node(ep);
 }
 
 const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
-    if (_current_locations.contains(ep)) {
-        return _current_locations.at(ep);
+    if (ep == utils::fb_utilities::get_broadcast_address()) {
+        return get_location();
     }
-
+    if (auto node = find_node(ep, must_exist::no)) {
+        return node->dc_rack();
+    }
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with
     // on_internal_error()
     tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
     return endpoint_dc_rack::default_location;
-}
-
-// FIXME -- both methods below should rather return data from the
-// get_location() result, but to make it work two things are to be fixed:
-// - topology should be aware of internal-ip conversions
-// - topology should be pre-populated with data loaded from system ks
-
-sstring topology::get_rack() const {
-    return get_rack(utils::fb_utilities::get_broadcast_address());
-}
-
-sstring topology::get_rack(inet_address ep) const {
-    return get_location(ep).rack;
-}
-
-sstring topology::get_datacenter() const {
-    return get_datacenter(utils::fb_utilities::get_broadcast_address());
-}
-
-sstring topology::get_datacenter(inet_address ep) const {
-    return get_location(ep).dc;
 }
 
 void topology::sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const {

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -453,3 +453,11 @@ int topology::compare_endpoints(const inet_address& address, const inet_address&
 }
 
 } // namespace locator
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const locator::node_ptr& node) {
+    return out << node->host_id() << '/' << node->endpoint();
+}
+
+} // namespace std

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -24,24 +24,113 @@ using namespace seastar;
 
 namespace locator {
 
+class topology;
+
+class node : public enable_lw_shared_from_this<node> {
+public:
+    using local = bool_class<struct local_tag>;
+
+private:
+    host_id _host_id;
+    inet_address _endpoint;
+    endpoint_dc_rack _dc_rack;
+
+    // Private state of this instance.
+    // May change across topology generations
+    local _is_local;
+
+    friend class topology;
+public:
+    node(host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, local is_local);
+
+    node(const node&) = default;
+    node(node&&) = delete;
+
+    const host_id& host_id() const noexcept {
+        return _host_id;
+    }
+
+    const inet_address& endpoint() const noexcept {
+        return _endpoint;
+    }
+
+    const endpoint_dc_rack& dc_rack() const noexcept {
+        return _dc_rack;
+    }
+
+    local is_local() const noexcept { return _is_local; }
+};
+
+using node_ptr = lw_shared_ptr<const node>;
+using node_set = std::unordered_set<node_ptr>;
+
 class topology {
 public:
     struct config {
+        host_id local_host_id;
+        inet_address local_endpoint;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;
     };
     topology(config cfg);
-    topology(topology&&) = default;
+    topology(topology&&) noexcept;
 
     topology& operator=(topology&&) = default;
 
     future<topology> clone_gently() const;
     future<> clear_gently() noexcept;
 
+public:
+    const node_ptr& local_node() const noexcept {
+        return _local_node;
+    }
+
+    // Adds a node with given host_id, endpoint, and DC/rack.
+    node_ptr add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr);
+
+    // Optionally updates node's current host_id, endpoint, or DC/rack.
+    node_ptr update_node(node_ptr node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr);
+
+    using must_exist = bool_class<struct must_exist_tag>;
+
+    // Removes a node using its host_id
+    //
+    // If host_id is not found and must_exist is true:
+    //   the function throws internal error.
+    void remove_node(host_id id, must_exist must_exist = must_exist::no);
+
+    // Finds a node by its host_id
+    //
+    // If host_id is not found:
+    //   the function throws internal error if must_exist is true,
+    //   or returns nullptr otherwise.
+    node_ptr find_node(host_id id, must_exist must_exist = must_exist::no) const noexcept;
+
+    // Finds a node by its endpoint
+    //
+    // If endpoint is not found,
+    //   the function throws internal error if must_exist is true,
+    //   or returns nullptr otherwise.
+    node_ptr find_node(const inet_address& ep, must_exist must_exist = must_exist::no) const noexcept;
+
+    // Returns true if a node with given host_id is found
+    bool has_node(host_id id) const noexcept;
+    bool has_node(inet_address id) const noexcept;
+
     /**
      * Stores current DC/rack assignment for ep
+     *
+     * Adds or updates a node with given endpoint
      */
-    void update_endpoint(const inet_address& ep, endpoint_dc_rack dr);
+    node_ptr update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr);
+
+    // Legacy entry point from token_metadata::update_topology
+    node_ptr update_endpoint(inet_address ep, endpoint_dc_rack dr) {
+        return update_endpoint(ep, std::nullopt, std::move(dr));
+    }
+    node_ptr update_endpoint(inet_address ep, host_id id) {
+        return update_endpoint(ep, id, std::nullopt);
+    }
 
     /**
      * Removes current DC/rack assignment for ep
@@ -70,11 +159,42 @@ public:
         return _datacenters;
     }
 
+    // Get dc/rack location of the local node
+    const endpoint_dc_rack& get_location() const noexcept{
+        return _local_node->dc_rack();
+    }
+    // Get dc/rack location of a node identified by host_id
+    const endpoint_dc_rack& get_location(host_id id) const {
+        return find_node(id, must_exist::yes)->dc_rack();
+    }
+    // Get dc/rack location of a node identified by endpoint
     const endpoint_dc_rack& get_location(const inet_address& ep) const;
-    sstring get_rack() const;
-    sstring get_rack(inet_address ep) const;
-    sstring get_datacenter() const;
-    sstring get_datacenter(inet_address ep) const;
+
+    // Get rack of the local node
+    const sstring& get_rack() const noexcept {
+        return get_location().rack;
+    }
+    // Get rack of a node identified by host_id
+    const sstring& get_rack(host_id id) const {
+        return get_location(id).rack;
+    }
+    // Get rack of a node identified by endpoint
+    const sstring& get_rack(inet_address ep) const {
+        return get_location(ep).rack;
+    }
+
+    // Get datacenter of the local node
+    const sstring& get_datacenter() const noexcept {
+        return get_location().dc;
+    }
+    // Get datacenter of a node identified by host_id
+    const sstring& get_datacenter(host_id id) const {
+        return get_location(id).dc;
+    }
+    // Get datacenter of a node identified by endpoint
+    const sstring& get_datacenter(inet_address ep) const {
+        return get_location(ep).dc;
+    }
 
     auto get_local_dc_filter() const noexcept {
         return [ this, local_dc = get_datacenter() ] (inet_address ep) {
@@ -94,14 +214,29 @@ public:
     void sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const;
 
 private:
+    using mutable_node_ptr = lw_shared_ptr<node>;
+
     // default constructor for cloning purposes
-    topology() = default;
+    topology() noexcept;
+
+    node_ptr add_node(mutable_node_ptr node);
+    void remove_node(node_ptr node);
+    void do_remove_node(mutable_node_ptr node);
 
     /**
      * compares two endpoints in relation to the target endpoint, returning as
      * Comparator.compare would
      */
     int compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
+
+    unsigned _shard;
+    std::unordered_set<mutable_node_ptr> _all_nodes;
+    node_ptr _local_node;
+    std::unordered_map<host_id, const node*> _nodes_by_host_id;
+    std::unordered_map<inet_address, const node*> _nodes_by_endpoint;
+
+    std::unordered_map<sstring, std::unordered_set<const node*>> _dc_nodes;
+    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<const node*>>> _dc_rack_nodes;
 
     /** multi-map: DC -> endpoints in that DC */
     std::unordered_map<sstring,
@@ -114,15 +249,13 @@ private:
                                           std::unordered_set<inet_address>>>
         _dc_racks;
 
-    /** reverse-lookup map: endpoint -> current known dc/rack assignment */
-    std::unordered_map<inet_address, endpoint_dc_rack> _current_locations;
-
     bool _sort_by_proximity = true;
 
     // pre-calculated
     std::unordered_set<sstring> _datacenters;
 
     void calculate_datacenters();
+    static mutable_node_ptr make_mutable(const node_ptr& node);
 };
 
 } // namespace locator

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -12,6 +12,7 @@
 
 #include <unordered_set>
 #include <unordered_map>
+#include <iostream>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -259,3 +260,9 @@ private:
 };
 
 } // namespace locator
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const locator::node_ptr& node);
+
+} // namespace std

--- a/locator/topology_fwd.hh
+++ b/locator/topology_fwd.hh
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include <seastar/core/shared_ptr.hh>
+
+namespace locator {
+
+class node;
+
+using node_ptr = lw_shared_ptr<const node>;
+
+} // namespace locator

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -25,6 +25,9 @@ using inet_address = gms::inet_address;
 struct endpoint_dc_rack {
     sstring dc;
     sstring rack;
+
+    bool operator==(const endpoint_dc_rack&) const = default;
+    bool operator!=(const endpoint_dc_rack&) const = default;
 };
 
 using dc_rack_fn = seastar::noncopyable_function<endpoint_dc_rack(inet_address)>;

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -26,6 +26,8 @@ struct endpoint_dc_rack {
     sstring dc;
     sstring rack;
 
+    static thread_local const endpoint_dc_rack default_location;
+
     bool operator==(const endpoint_dc_rack&) const = default;
     bool operator!=(const endpoint_dc_rack&) const = default;
 };

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -10,7 +10,12 @@
 
 #pragma once
 
+#include <unordered_set>
+
+#include <boost/intrusive/list.hpp>
+
 #include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
 
 #include "gms/inet_address.hh"
 #include "locator/host_id.hh"
@@ -20,6 +25,8 @@ using namespace seastar;
 namespace locator {
 
 using inet_address = gms::inet_address;
+
+class shared_token_metadata;
 
 // Endpoint Data Center and Rack names
 struct endpoint_dc_rack {

--- a/main.cc
+++ b/main.cc
@@ -751,6 +751,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting tokens manager");
             locator::token_metadata::config tm_cfg;
+            // The local node's host_id is updated after loading from system.local
+            // or making a random one for a new node
+            tm_cfg.topo_cfg.local_host_id = host_id::create_null_id();
+            tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             if (snitch.local()->get_name() == "org.apache.cassandra.locator.SimpleSnitch") {
                 //
@@ -1164,6 +1168,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return sys_ks.start(snitch.local());
             }).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+            shared_token_metadata::mutate_on_all_shards(token_metadata, [hostid = cfg->host_id, endpoint = utils::fb_utilities::get_broadcast_address()] (locator::token_metadata& tm) {
+                tm.get_topology().update_endpoint(endpoint, hostid);
+                return make_ready_future<>();
+            }).get();
 
             if (raft_gr.local().is_enabled()) {
                 auto my_raft_id = raft::server_id{cfg->host_id.uuid()};

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1370,7 +1370,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
 
             //Pending ranges
-            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack());
+            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
             metadata_clone.update_normal_tokens(tokens, myip).get();
             auto pending_range_addresses = strat.get_range_addresses(metadata_clone).get0();
             metadata_clone.clear_gently().get();
@@ -1825,7 +1825,7 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     // update a cloned version of tmptr
     // no need to set the original version
     auto cloned_tmptr = make_token_metadata_ptr(std::move(cloned_tm));
-    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack());
+    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::joining);
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, utils::fb_utilities::get_broadcast_address());
     co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6146,13 +6146,16 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(const std::v
     spoint.regular_per_shard_rps.resize(smp::count);
     spoint.mv_per_shard_rps.resize(smp::count);
     spoint.host_id = _db.local().get_config().host_id;
-    co_await coroutine::parallel_for_each(boost::irange<unsigned>(0, smp::count), [this, &target_hosts, &spoint] (unsigned shard) -> future<> {
+
+    const auto& topo = _shared_token_metadata.get()->get_topology();
+    auto target_nodes = to_nodes(topo, target_hosts);
+    co_await coroutine::parallel_for_each(boost::irange<unsigned>(0, smp::count), [this, &target_nodes, &spoint] (unsigned shard) -> future<> {
         const auto& sharded_sp = container();
         // sharded::invoke_on does not have a const-method version, so we cannot use it here
-        auto p = co_await smp::submit_to(shard, [&sharded_sp, &target_hosts] {
+        auto p = co_await smp::submit_to(shard, [&sharded_sp, &target_nodes] {
             const storage_proxy& sp = sharded_sp.local();
-            auto regular_rp = sp._hints_manager.calculate_current_sync_point(target_hosts);
-            auto mv_rp = sp._hints_for_views_manager.calculate_current_sync_point(target_hosts);
+            auto regular_rp = sp._hints_manager.calculate_current_sync_point(target_nodes);
+            auto mv_rp = sp._hints_for_views_manager.calculate_current_sync_point(target_nodes);
             return std::make_pair(std::move(regular_rp), std::move(mv_rp));
         });
         spoint.regular_per_shard_rps[shard] = std::move(p.first);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3739,12 +3739,12 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
     auto local_dc = topology.get_datacenter();
 
     for(auto dest: handler.get_targets()) {
-        sstring dc = topology.get_datacenter(dest);
+        auto node = topology.find_node(dest);
         // read repair writes do not go through coordinator since mutations are per destination
-        if (handler.read_repair_write() || dc == local_dc) {
+        if (handler.read_repair_write() || !node || node->dc_rack().dc == local_dc) {
             local.emplace_back("", inet_address_vector_replica_set({dest}));
         } else {
-            dc_groups[dc].push_back(dest);
+            dc_groups[node->dc_rack().dc].push_back(dest);
         }
     }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6238,8 +6238,10 @@ future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spo
 void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {};
 
 void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint) {
-    _hints_manager.drain_for(endpoint);
-    _hints_for_views_manager.drain_for(endpoint);
+    const auto& topo = _shared_token_metadata.get()->get_topology();
+    const auto node = topo.find_node(endpoint, locator::topology::must_exist::yes);
+    _hints_manager.drain_for(node);
+    _hints_for_views_manager.drain_for(node);
 }
 
 void storage_proxy::on_up(const gms::inet_address& endpoint) {};

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2884,7 +2884,7 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
 
     auto all = boost::range::join(natural_endpoints, pending_endpoints);
 
-    if (cannot_hint(all, type)) {
+    if (cannot_hint(to_nodes(erm->get_topology(), all), type)) {
         get_stats().writes_failed_due_to_too_many_in_flight_hints++;
         // avoid OOMing due to excess hints.  we need to do this check even for "live" nodes, since we can
         // still generate hints for those if it's overloaded or simply dead but not yet known-to-be-dead.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1326,8 +1326,8 @@ locator::endpoint_dc_rack storage_service::get_dc_rack_for(inet_address endpoint
     auto* dc = _gossiper.get_application_state_ptr(endpoint, gms::application_state::DC);
     auto* rack = _gossiper.get_application_state_ptr(endpoint, gms::application_state::RACK);
     return locator::endpoint_dc_rack{
-        .dc = dc ? dc->value : locator::production_snitch_base::default_dc,
-        .rack = rack ? rack->value : locator::production_snitch_base::default_rack,
+        .dc = dc ? dc->value : locator::endpoint_dc_rack::default_location.dc,
+        .rack = rack ? rack->value : locator::endpoint_dc_rack::default_location.rack,
     };
 }
 
@@ -1406,10 +1406,7 @@ future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,
                 if (loaded_dc_rack.contains(ep)) {
                     return loaded_dc_rack[ep];
                 } else {
-                    return locator::endpoint_dc_rack {
-                        .dc = locator::production_snitch_base::default_dc,
-                        .rack = locator::production_snitch_base::default_rack,
-                    };
+                    return locator::endpoint_dc_rack::default_location;
                 }
             };
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -333,7 +333,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         slogger.info("Replacing a node with {} IP address, my address={}, node being replaced={}",
             get_broadcast_address() == *replace_address ? "the same" : "a different",
             get_broadcast_address(), *replace_address);
-        tmptr->update_topology(*replace_address, std::move(ri->dc_rack));
+        tmptr->update_topology(*replace_address, ri->dc_rack, locator::node::state::leaving);
         co_await tmptr->update_normal_tokens(bootstrap_tokens, *replace_address);
         replaced_host_id = ri->host_id;
         raft_replace_info = raft_group0::replace_info {
@@ -375,7 +375,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         // This node must know about its chosen tokens before other nodes do
         // since they may start sending writes to this node after it gossips status = NORMAL.
         // Therefore we update _token_metadata now, before gossip starts.
-        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack());
+        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::normal);
         co_await tmptr->update_normal_tokens(my_tokens, get_broadcast_address());
 
         cdc_gen_id = co_await _sys_ks.local().get_cdc_generation_id();
@@ -552,7 +552,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         // This node must know about its chosen tokens before other nodes do
         // since they may start sending writes to this node after it gossips status = NORMAL.
         // Therefore, in case we haven't updated _token_metadata with our tokens yet, do it now.
-        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack());
+        tmptr->update_topology(get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::normal);
         return tmptr->update_normal_tokens(bootstrap_tokens, get_broadcast_address());
     });
 
@@ -695,7 +695,7 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
                 slogger.debug("bootstrap: update pending ranges: endpoint={} bootstrap_tokens={}", get_broadcast_address(), bootstrap_tokens);
                 mutate_token_metadata([this, &bootstrap_tokens] (mutable_token_metadata_ptr tmptr) {
                     auto endpoint = get_broadcast_address();
-                    tmptr->update_topology(endpoint, _sys_ks.local().local_dc_rack());
+                    tmptr->update_topology(endpoint, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(bootstrap_tokens, endpoint);
                     return update_pending_ranges(std::move(tmptr), format("bootstrapping node {}", endpoint));
                 }).get();
@@ -824,7 +824,7 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
         tmptr->remove_endpoint(endpoint);
     }
 
-    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::joining);
     tmptr->add_bootstrap_tokens(tokens, endpoint);
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
@@ -960,7 +960,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
             do_notify_joined = true;
         }
 
-        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::normal);
         co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
     }
 
@@ -1012,7 +1012,7 @@ future<> storage_service::handle_state_leaving(inet_address endpoint) {
         // FIXME: this code should probably resolve token collisions too, like handle_state_normal
         slogger.info("Node {} state jump to leaving", endpoint);
 
-        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::leaving);
         co_await tmptr->update_normal_tokens(tokens, endpoint);
     } else {
         auto tokens_ = tmptr->get_tokens(endpoint);
@@ -1427,7 +1427,7 @@ future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,
                     // entry has been mistakenly added, delete it
                     _sys_ks.local().remove_endpoint(ep).get();
                 } else {
-                    tmptr->update_topology(ep, get_dc_rack(ep));
+                    tmptr->update_topology(ep, get_dc_rack(ep), locator::node::state::normal);
                     tmptr->update_normal_tokens(tokens, ep).get();
                     if (loaded_host_ids.contains(ep)) {
                         tmptr->update_host_id(loaded_host_ids.at(ep), ep);
@@ -2763,7 +2763,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     auto existing_node = x.first;
                     auto replacing_node = x.second;
                     slogger.info("replace[{}]: Added replacing_node={} to replace existing_node={}, coordinator={}", req.ops_uuid, replacing_node, existing_node, coordinator);
-                    tmptr->update_topology(replacing_node, get_dc_rack_for(replacing_node));
+                    tmptr->update_topology(replacing_node, get_dc_rack_for(replacing_node), locator::node::state::joining);
                     tmptr->add_replacing_endpoint(existing_node, replacing_node);
                 }
                 return make_ready_future<>();
@@ -2817,7 +2817,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     auto& endpoint = x.first;
                     auto tokens = std::unordered_set<dht::token>(x.second.begin(), x.second.end());
                     slogger.info("bootstrap[{}]: Added node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
-                    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
+                    tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(tokens, endpoint);
                 }
                 return update_pending_ranges(tmptr, format("bootstrap {}", req.bootstrap_nodes));

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -8,6 +8,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include "gms/inet_address.hh"
+#include "locator/types.hh"
+#include "utils/UUID_gen.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/sequenced_set.hh"
 #include "locator/network_topology_strategy.hh"
@@ -35,6 +38,7 @@ using namespace locator;
 struct ring_point {
     double point;
     inet_address host;
+    host_id id = host_id::create_random_id();
 };
 
 void print_natural_endpoints(double point, const inet_address_vector_replica_set v) {
@@ -140,9 +144,9 @@ auto d2t = [](double d) -> int64_t {
 void full_ring_check(const std::vector<ring_point>& ring_points,
                      const std::map<sstring, sstring>& options,
                      abstract_replication_strategy::ptr_type ars_ptr,
-                     locator::token_metadata_ptr tmptr,
-                     const locator::topology& topo) {
+                     locator::token_metadata_ptr tmptr) {
     auto& tm = *tmptr;
+    const auto& topo = tm.get_topology();
     strategy_sanity_check(ars_ptr, tm, options);
 
     auto erm = calculate_effective_replication_map(ars_ptr, tmptr).get0();
@@ -171,18 +175,12 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
     }
 }
 
-std::unique_ptr<locator::topology> generate_topology(const std::vector<ring_point>& pts) {
-    auto topo = std::make_unique<locator::topology>(locator::topology::config{});
-
+locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
     // This resembles rack_inferring_snitch dc/rack generation which is
     // still in use by this test via token_metadata internals
-    for (const auto& p : pts) {
-        auto rack = std::to_string(uint8_t(p.host.bytes()[2]));
-        auto dc = std::to_string(uint8_t(p.host.bytes()[1]));
-        topo->update_endpoint(p.host, { dc, rack });
-    }
-
-    return topo;
+    auto dc = std::to_string(uint8_t(endpoint.bytes()[1]));
+    auto rack = std::to_string(uint8_t(endpoint.bytes()[2]));
+    return locator::endpoint_dc_rack{dc, rack};
 }
 
 // Run in a seastar thread.
@@ -198,7 +196,11 @@ void simple_test() {
     auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
-    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, locator::token_metadata::config{});
+    locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.local_host_id = host_id::create_random_id();
+    tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
+    tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
+    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
 
     std::vector<ring_point> ring_points = {
         { 1.0,  inet_address("192.100.10.1") },
@@ -214,18 +216,14 @@ void simple_test() {
         { 11.0, inet_address("192.102.40.2") }
     };
 
-    auto topo = generate_topology(ring_points);
-
-    std::unordered_map<inet_address, std::unordered_set<token>> endpoint_tokens;
-    for (const auto& [ring_point, endpoint] : ring_points) {
-        endpoint_tokens[endpoint].insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
-    }
-
     // Initialize the token_metadata
-    stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
-        for (auto&& i : endpoint_tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
-            co_await tm.update_normal_tokens(std::move(i.second), i.first);
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        auto& topo = tm.get_topology();
+        for (const auto& [ring_point, endpoint, id] : ring_points) {
+            std::unordered_set<token> tokens;
+            tokens.insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint));
+            co_await tm.update_normal_tokens(std::move(tokens), endpoint);
         }
     }).get();
 
@@ -240,8 +238,7 @@ void simple_test() {
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", options323);
 
-
-    full_ring_check(ring_points, options323, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
     ///////////////
     // Create the replication strategy
@@ -254,7 +251,7 @@ void simple_test() {
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", options320);
 
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
     //
     // Check cache invalidation: invalidate the cache and run a full ring
@@ -266,7 +263,7 @@ void simple_test() {
         tm.invalidate_cached_rings();
         return make_ready_future<>();
     }).get();
-    full_ring_check(ring_points, options320, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, options320, ars_ptr, stm.get());
 }
 
 // Run in a seastar thread.
@@ -326,19 +323,18 @@ void heavy_origin_test() {
         }
     }
 
-    auto topo = generate_topology(ring_points);
-
-    stm.mutate_token_metadata([&tokens, &topo] (token_metadata& tm) -> future<> {
-        for (auto&& i : tokens) {
-            tm.update_topology(i.first, topo->get_location(i.first));
-            co_await tm.update_normal_tokens(std::move(i.second), i.first);
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        auto& topo = tm.get_topology();
+        for (const auto& [ring_point, endpoint, id] : ring_points) {
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint));
+            co_await tm.update_normal_tokens(std::move(tokens[endpoint]), endpoint);
         }
     }).get();
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", config_options);
 
-    full_ring_check(ring_points, config_options, ars_ptr, stm.get(), *topo);
+    full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
 
 
@@ -394,7 +390,7 @@ static bool has_sufficient_replicas(
 
 static locator::endpoint_set calculate_natural_endpoints(
                 const token& search_token, const token_metadata& tm,
-                locator::topology& topo,
+                const locator::topology& topo,
                 const std::unordered_map<sstring, size_t>& datacenters) {
     //
     // We want to preserve insertion order so that the first added endpoint
@@ -432,7 +428,7 @@ static locator::endpoint_set calculate_natural_endpoints(
     // the members of a DC
     //
     const std::unordered_map<sstring,
-                       std::unordered_set<inet_address>>&
+                       std::unordered_set<inet_address>>
         all_endpoints = tp.get_datacenter_endpoints();
     //
     // all racks in a DC so we can check when we have exhausted all racks in a
@@ -440,7 +436,7 @@ static locator::endpoint_set calculate_natural_endpoints(
     //
     const std::unordered_map<sstring,
                        std::unordered_map<sstring,
-                                          std::unordered_set<inet_address>>>&
+                                          std::unordered_set<inet_address>>>
         racks = tp.get_datacenter_racks();
 
     // not aware of any cluster members
@@ -504,7 +500,7 @@ static locator::endpoint_set calculate_natural_endpoints(
 }
 
 // Called in a seastar thread.
-static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<locator::topology> topo, const std::unordered_map<sstring, size_t>& datacenters) {
+static void test_equivalence(const shared_token_metadata& stm, const locator::topology& topo, const std::unordered_map<sstring, size_t>& datacenters) {
     class my_network_topology_strategy : public network_topology_strategy {
     public:
         using network_topology_strategy::network_topology_strategy;
@@ -522,7 +518,7 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {
         auto token = dht::token::get_random_token();
-        auto expected = calculate_natural_endpoints(token, tm, *topo, datacenters);
+        auto expected = calculate_natural_endpoints(token, tm, topo, datacenters);
         auto actual = nts.calculate_natural_endpoints(token, tm).get0();
 
         // Because the old algorithm does not put the nodes in the correct order in the case where more replicas
@@ -537,7 +533,7 @@ static void test_equivalence(const shared_token_metadata& stm, std::unique_ptr<l
 }
 
 
-std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
+void generate_topology(topology& topo, const std::unordered_map<sstring, size_t> datacenters, const std::vector<inet_address>& nodes) {
     auto& e1 = seastar::testing::local_random_engine;
 
     std::unordered_map<sstring, size_t> racks_per_dc;
@@ -557,16 +553,12 @@ std::unique_ptr<locator::topology> generate_topology(const std::unordered_map<ss
         out = std::fill_n(out, rf, std::cref(dc));
     }
 
-    auto topo = std::make_unique<locator::topology>(locator::topology::config{});
-
     for (auto& node : nodes) {
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo->update_endpoint(node, { dc, to_sstring(r) });
+        topo.add_node(host_id::create_random_id(), node, { dc, to_sstring(r) });
     }
-
-    return topo;
 }
 
 SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
@@ -593,7 +585,6 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
     for (size_t run = 0; run < RUNS; ++run) {
         semaphore sem(1);
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{});
-        auto topo = generate_topology(datacenters, nodes);
 
         std::unordered_set<dht::token> random_tokens;
         while (random_tokens.size() < nodes.size() * VNODES) {
@@ -608,13 +599,13 @@ SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
             }
         }
         
-        stm.mutate_token_metadata([&endpoint_tokens, &topo] (token_metadata& tm) -> future<> {
+        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+            generate_topology(tm.get_topology(), datacenters, nodes);
             for (auto&& i : endpoint_tokens) {
-                tm.update_topology(i.first, topo->get_location(i.first));
                 co_await tm.update_normal_tokens(std::move(i.second), i.first);
             }
         }).get();
-        test_equivalence(stm, std::move(topo), datacenters);
+        test_equivalence(stm, stm.get()->get_topology(), datacenters);
     }
 }
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -56,7 +56,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
                 const auto endpoint = gms::inet_address("10.0.0.1");
                 const auto endpoint_token = ring[2].token();
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(endpoint, {});
+                tmptr->update_topology(endpoint, {"dc1", "rack1"});
                 tmptr->update_normal_tokens({endpoint_token}, endpoint).get();
 
                 const auto next_token = dht::token::from_int64(dht::token::to_int64(endpoint_token) + 1);
@@ -75,7 +75,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
             {
                 // Ring with minimum token
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.1"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({dht::minimum_token()}), gms::inet_address("10.0.0.1")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {
@@ -89,9 +89,9 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
 
             {
                 auto tmptr = locator::make_token_metadata_ptr(locator::token_metadata::config{});
-                tmptr->update_topology(gms::inet_address("10.0.0.1"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.1"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[2].token()}), gms::inet_address("10.0.0.1")).get();
-                tmptr->update_topology(gms::inet_address("10.0.0.2"), {});
+                tmptr->update_topology(gms::inet_address("10.0.0.2"), {"dc1", "rack1"});
                 tmptr->update_normal_tokens(std::unordered_set<dht::token>({ring[5].token()}), gms::inet_address("10.0.0.2")).get();
 
                 check(tmptr, dht::partition_range::make_singular(ring[0]), {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -65,6 +65,7 @@
 #include "db/schema_tables.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service/raft/raft_group0.hh"
+#include "utils/fb_utilities.hh"
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -542,6 +543,8 @@ public:
 
             sharded<locator::shared_token_metadata> token_metadata;
             locator::token_metadata::config tm_cfg;
+            tm_cfg.topo_cfg.local_host_id = cfg->host_id;
+            tm_cfg.topo_cfg.local_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg).get();
             auto stop_token_metadata = defer([&token_metadata] { token_metadata.stop().get(); });


### PR DESCRIPTION
From gms::inet_address. Currently, HH use raw ip addresses to identify nodes. We are trying to move away from identifying nodes by their ip address as it is problematic in severeal ways:
* With serverless and k8s, the ip address of nodes can change during its lifetime.
* A new node added to the cluster can get the same ip address a previous node had (but not the same tokens).

To get closer to this goal of identifying all nodes by their host_id, this PR refactors HH to use locator::node_ptr, only converting to ip address just before sending hints on the network.
The conversion is done one interface method at a time, to avoid huge messy commits. It is mostly mechanical, but there are two difficult problems that need to be solved:
* Currently, HH stores hints in a separate directory per node. Of course this directory has the node's ip address as its name. We either need to have a update path from ip addr directories to host_id directories. Or ensure all HH is wiped during upgrade.
* There is a sync point mechanism that I don't fully understand yet. This has an IDL component, which seems to be an inter-node ABI. This also has ip addresses in it. I need to look into this further to find out how could we migrate this to host_id.

This PR is incomplete as of yet, as the above two questions are unaddressed, nodes are just converted back to ip addresses on the boundaries of these components.

Depends on https://github.com/scylladb/scylladb/pull/11987.