### PR TITLE
utils: UUID: throw marshal_exception when fail to parse uuid

### DIFF
--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -52,6 +52,22 @@ BOOST_AUTO_TEST_CASE(test_from_string) {
     check("e596c2f2-d29d-44a0-bb89-0a90ff928490");
     check("f28f86f5-cbc2-4526-ba25-db90c226ec6a");
     check("ce84997b-6ea2-4468-9f02-8a65abf4141a");
+
+    // shorter than 16 bytes
+    BOOST_CHECK_THROW(UUID(""), marshal_exception);
+    BOOST_CHECK_THROW(UUID("dead-beef"), marshal_exception);
+    // longer than 16 bytes
+    BOOST_CHECK_THROW(UUID("ce84997b-6ea2-4468-9f02-8a65abf4141-long-long-ago"), marshal_exception);
+    // unconvertible string
+    BOOST_CHECK_THROW(UUID("hellowol-dea2-4468-9f02-8a65abf4141a"), marshal_exception);
+    // trailing garbage in msb
+    BOOST_CHECK_THROW(UUID("ce84997b-6ea2-wxyz-9f02-8a65abf4141a"), marshal_exception);
+    // trailing garbage in lsb
+    BOOST_CHECK_THROW(UUID("ce84997b-6ea2-4468-9f02-8a65abf4wxyz"), marshal_exception);
+    // spaces at the beginning
+    BOOST_CHECK_THROW(UUID("   4997b-6ea2-wxyz-9f02-8a65abf4141a"), marshal_exception);
+    // spaces at the end
+    BOOST_CHECK_THROW(UUID("ce84997b-6ea2-4468-9f02-8a65abf4    "), marshal_exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_make_random_uuid) {

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -47,8 +47,19 @@ UUID::UUID(sstring_view uuid) {
     sstring most = sstring(uuid_string.begin(), uuid_string.begin() + size);
     sstring least = sstring(uuid_string.begin() + size, uuid_string.end());
     int base = 16;
-    this->most_sig_bits = std::stoull(most, nullptr, base);
-    this->least_sig_bits = std::stoull(least, nullptr, base);
+    try {
+        std::size_t pos = 0;
+        this->most_sig_bits = std::stoull(most, &pos, base);
+        if (pos != most.size()) {
+            throw std::invalid_argument("");
+        }
+        this->least_sig_bits = std::stoull(least, &pos, base);
+        if (pos != least.size()) {
+            throw std::invalid_argument("");
+        }
+    } catch (const std::logic_error&) {
+        throw marshal_exception(format("invalid UUID: '{}'", uuid));
+    }
 }
 
 }


### PR DESCRIPTION
* throw marshal_exception if not the whole string is parsed, we should error out if the parsed string contains gabage at the end. before this change, we silent accept uuid like "ce84997b-6ea2-4468-9f02-8a65abf4wxyz", and parses it as "ce84997b-6ea2-4468-9f02-8a65abf4". this is not correct.
* throw marshal_exception if stoull() throws, `stoull()` throws if it fails to parse a string to an unsigned long long, we should translate the exception to `marshal_exception`, so we can handle these exception in a consistent manner.

test is updated accordingly.