### PR TITLE
sstables: generation_type: do not specialize to_sstring

### DIFF
--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -38,13 +38,6 @@ constexpr int64_t generation_value(generation_type generation) {
 
 } //namespace sstables
 
-namespace seastar {
-template <typename string_type = sstring>
-string_type to_sstring(sstables::generation_type generation) {
-    return to_sstring(sstables::generation_value(generation));
-}
-} //namespace seastar
-
 namespace std {
 template <>
 struct hash<sstables::generation_type> {


### PR DESCRIPTION
because `seastar::to_sstring()` defaults to `fmt::format_to()`. so any type which is supported by `fmt::formatter()` is also supported by `seastar::to_sstring()`. and the behavior of existing implementation is exactly the same as the defaulted one.

so let's drop the specialization and let
`fmt::formatter<sstables::generation_type>` do its job.