### PR TITLE
sstables, replica: add generation generator

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -432,7 +432,7 @@ private:
     // generation number in the table so that newly created sstables
     // will use numeric generation numbers larger than this one.
     // Initialized when the table is populated via update_sstables_known_generation.
-    std::optional<sstables::generation_type> _sstable_generation = {};
+    std::optional<sstables::sstable_generation_generator> _sstable_generation_generator;
 
     db::replay_position _highest_rp;
     db::replay_position _flush_rp;
@@ -533,7 +533,6 @@ public:
                        const std::vector<sstables::shared_sstable>& old_sstables);
     };
 
-    static sstables::generation_type make_new_generation(std::optional<sstables::generation_type> prev = std::nullopt);
 private:
     using compaction_group_ptr = std::unique_ptr<compaction_group>;
     std::vector<std::unique_ptr<compaction_group>> make_compaction_groups();
@@ -650,7 +649,7 @@ public:
     }
 
     bool is_ready_for_writes() const {
-        return _sstable_generation.has_value();
+        return _sstable_generation_generator.has_value();
     }
 
     // Creates a mutation reader which covers all data sources for this column family.

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -409,14 +409,12 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
 
     const sstring toc_text = "TOC.txt\nData.db\n";
 
-    std::optional<sstables::generation_type> prev_gen;
     std::vector<sstables::generation_type> gen;
-    size_t num_gens = 9;
-    gen.reserve(num_gens);
-    for (auto i = 0; i < num_gens; i++) {
+    constexpr size_t num_gens = 9;
+    std::generate_n(std::back_inserter(gen), num_gens, [prev_gen = std::optional<sstables::generation_type>()]() mutable {
         prev_gen = replica::table::make_new_generation(prev_gen);
-        gen.emplace_back(*prev_gen);
-    }
+        return *prev_gen;
+    });
 
     // Regular log file with single entry
     write_file(gen_filename(gen[2], component_type::TOC), toc_text);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -8,6 +8,7 @@
 
 
 #include <seastar/core/seastar.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/file.hh>
@@ -409,11 +410,11 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
 
     const sstring toc_text = "TOC.txt\nData.db\n";
 
+    sstables::sstable_generation_generator gen_generator(0);
     std::vector<sstables::generation_type> gen;
     constexpr size_t num_gens = 9;
-    std::generate_n(std::back_inserter(gen), num_gens, [prev_gen = std::optional<sstables::generation_type>()]() mutable {
-        prev_gen = replica::table::make_new_generation(prev_gen);
-        return *prev_gen;
+    std::generate_n(std::back_inserter(gen), num_gens, [&] {
+        return gen_generator();
     });
 
     // Regular log file with single entry

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -58,16 +58,14 @@ class test_env {
         db::nop_large_data_handler nop_ld_handler;
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
-        std::optional<sstables::generation_type> generation;
+        sstables::sstable_generation_generator gen{0};
 
         impl(test_env_config cfg);
         impl(impl&&) = delete;
         impl(const impl&) = delete;
 
         sstables::generation_type new_generation() noexcept {
-            auto ret = replica::table::make_new_generation(generation);
-            generation = ret;
-            return ret;
+            return gen();
         }
     };
     std::unique_ptr<impl> _impl;


### PR DESCRIPTION
this is the first step to the uuid-based generation identifier. the goal is to encapsulate the generation related logic in generator, so its consumers do not have to understand the difference between the int64_t based generation and UUID v1 based generation.

this commit should not change the behavior of existing scylla. it just allows us to derive from `generation_generator` so we can have another generator which generates UUID based generation identifier.