### PR TITLE
docs/alternator: link to issue about too many stream shards

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -190,6 +190,7 @@ experimental:
   Alternator streams also differ in some respects from DynamoDB Streams:
   * The number of separate "shards" in Alternator's streams is significantly
     larger than is typical on DynamoDB.
+    <https://github.com/scylladb/scylla/issues/13080>
   * While in DynamoDB data usually appears in the stream less than a second
     after it was written, in Alternator Streams there is currently a 10
     second delay by default.


### PR DESCRIPTION
docs/alternator/compatibility.md mentions a known problem that Alternator Streams are divided into too many "shards". This patch add a link to a github issue to track our work on this issue - like we did for most other differences mentioned in compatibility.md.

Refs #13080