### PR TITLE
Remove qctx from helpers that retrieve truncation record

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -190,8 +190,8 @@ future<> db::batchlog_manager::replay_all_failed_batches() {
 
         auto size = data.size();
 
-        return map_reduce(*fms, [written_at] (canonical_mutation& fm) {
-            return system_keyspace::get_truncated_at(fm.column_family_id()).then([written_at, &fm] (db_clock::time_point t) ->
+        return map_reduce(*fms, [this, written_at] (canonical_mutation& fm) {
+            return _sys_ks.get_truncated_at(fm.column_family_id()).then([written_at, &fm] (db_clock::time_point t) ->
                     std::optional<std::reference_wrapper<canonical_mutation>> {
                 if (written_at > t) {
                     return { std::ref(fm) };

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -43,8 +43,9 @@ static logging::logger blogger("batchlog_manager");
 const uint32_t db::batchlog_manager::replay_interval;
 const uint32_t db::batchlog_manager::page_size;
 
-db::batchlog_manager::batchlog_manager(cql3::query_processor& qp, batchlog_manager_config config)
+db::batchlog_manager::batchlog_manager(cql3::query_processor& qp, db::system_keyspace& sys_ks, batchlog_manager_config config)
         : _qp(qp)
+        , _sys_ks(sys_ks)
         , _write_request_timeout(std::chrono::duration_cast<db_clock::duration>(config.write_request_timeout))
         , _replay_rate(config.replay_rate)
         , _started(make_ready_future<>())

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -35,6 +35,8 @@ class query_processor;
 
 namespace db {
 
+class system_keyspace;
+
 struct batchlog_manager_config {
     std::chrono::duration<double> write_request_timeout;
     uint64_t replay_rate = std::numeric_limits<uint64_t>::max();
@@ -56,6 +58,7 @@ private:
 
     size_t _total_batches_replayed = 0;
     cql3::query_processor& _qp;
+    db::system_keyspace& _sys_ks;
     db_clock::duration _write_request_timeout;
     uint64_t _replay_rate;
     shared_future<> _started;
@@ -70,7 +73,7 @@ public:
     // Takes a QP, not a distributes. Because this object is supposed
     // to be per shard and does no dispatching beyond delegating the the
     // shard qp (which is what you feed here).
-    batchlog_manager(cql3::query_processor&, batchlog_manager_config config);
+    batchlog_manager(cql3::query_processor&, db::system_keyspace& sys_ks, batchlog_manager_config config);
 
     future<> start();
     // abort the replay loop and return its future.

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -101,12 +101,9 @@ public:
         return j != i->second.end() ? j->second : replay_position();
     }
 
-    seastar::sharded<replica::database>&
-        _db;
-    shard_rpm_map
-        _rpm;
-    shard_rp_map
-        _min_pos;
+    seastar::sharded<replica::database>& _db;
+    shard_rpm_map _rpm;
+    shard_rp_map _min_pos;
 };
 
 db::commitlog_replayer::impl::impl(seastar::sharded<replica::database>& db)

--- a/db/commitlog/commitlog_replayer.hh
+++ b/db/commitlog/commitlog_replayer.hh
@@ -22,19 +22,20 @@ class database;
 namespace db {
 
 class commitlog;
+class system_keyspace;
 
 class commitlog_replayer {
 public:
     commitlog_replayer(commitlog_replayer&&) noexcept;
     ~commitlog_replayer();
 
-    static future<commitlog_replayer> create_replayer(seastar::sharded<replica::database>&);
+    static future<commitlog_replayer> create_replayer(seastar::sharded<replica::database>&, seastar::sharded<db::system_keyspace>&);
 
     future<> recover(std::vector<sstring> files, sstring fname_prefix);
     future<> recover(sstring file, sstring fname_prefix);
 
 private:
-    commitlog_replayer(seastar::sharded<replica::database>&);
+    commitlog_replayer(seastar::sharded<replica::database>&, seastar::sharded<db::system_keyspace>&);
 
     class impl;
     std::unique_ptr<impl> _impl;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1392,12 +1392,12 @@ typedef utils::UUID truncation_key;
 typedef std::unordered_map<truncation_key, truncation_record> truncation_map;
 
 future<truncation_record> system_keyspace::get_truncation_record(table_id cf_id) {
-    if (qctx->qp().db().get_config().ignore_truncation_record.is_set()) {
+    if (_db.local().get_config().ignore_truncation_record.is_set()) {
         truncation_record r{truncation_record::current_magic};
         return make_ready_future<truncation_record>(std::move(r));
     }
     sstring req = format("SELECT * from system.{} WHERE table_uuid = ?", TRUNCATED);
-    return qctx->qp().execute_internal(req, {cf_id.uuid()}, cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> rs) {
+    return execute_cql(req, {cf_id.uuid()}).then([](::shared_ptr<cql3::untyped_result_set> rs) {
         truncation_record r{truncation_record::current_magic};
 
         for (const cql3::untyped_result_set_row& row : *rs) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1447,17 +1447,6 @@ future<> system_keyspace::save_truncation_record(const replica::column_family& c
     return save_truncation_record(cf.schema()->id(), truncated_at, rp);
 }
 
-future<db::replay_position> system_keyspace::get_truncated_position(table_id cf_id, uint32_t shard) {
-    return get_truncated_position(std::move(cf_id)).then([shard](replay_positions positions) {
-       for (auto& rp : positions) {
-           if (shard == rp.shard_id()) {
-               return make_ready_future<db::replay_position>(rp);
-           }
-       }
-       return make_ready_future<db::replay_position>();
-    });
-}
-
 future<replay_positions> system_keyspace::get_truncated_position(table_id cf_id) {
     return get_truncation_record(cf_id).then([](truncation_record e) {
         return make_ready_future<replay_positions>(e.positions);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -334,7 +334,6 @@ public:
     static future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_position(table_id);
     future<db_clock::time_point> get_truncated_at(table_id);
-    static future<truncation_record> get_truncation_record(table_id cf_id);
 
     /**
      * Return a map of stored tokens to IP addresses
@@ -382,6 +381,8 @@ private:
      * Sets the local host ID explicitly.  Used only internally when intializing the host_id
      */
     future<locator::host_id> set_local_random_host_id();
+    future<truncation_record> get_truncation_record(table_id cf_id);
+
 public:
     static api::timestamp_type schema_creation_timestamp();
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -332,7 +332,7 @@ public:
 
     static future<> save_truncation_record(table_id, db_clock::time_point truncated_at, db::replay_position);
     static future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
-    static future<replay_positions> get_truncated_position(table_id);
+    future<replay_positions> get_truncated_position(table_id);
     static future<db_clock::time_point> get_truncated_at(table_id);
     static future<truncation_record> get_truncation_record(table_id cf_id);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -333,7 +333,6 @@ public:
     static future<> save_truncation_record(table_id, db_clock::time_point truncated_at, db::replay_position);
     static future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     static future<replay_positions> get_truncated_position(table_id);
-    static future<db::replay_position> get_truncated_position(table_id, uint32_t shard);
     static future<db_clock::time_point> get_truncated_at(table_id);
     static future<truncation_record> get_truncation_record(table_id cf_id);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -333,7 +333,7 @@ public:
     static future<> save_truncation_record(table_id, db_clock::time_point truncated_at, db::replay_position);
     static future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_position(table_id);
-    static future<db_clock::time_point> get_truncated_at(table_id);
+    future<db_clock::time_point> get_truncated_at(table_id);
     static future<truncation_record> get_truncation_record(table_id cf_id);
 
     /**

--- a/main.cc
+++ b/main.cc
@@ -1163,7 +1163,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             bm_cfg.replay_rate = cfg->batchlog_replay_throttle_in_kb() * 1000;
             bm_cfg.delay = std::chrono::milliseconds(cfg->ring_delay_ms());
 
-            bm.start(std::ref(qp), bm_cfg).get();
+            bm.start(std::ref(qp), std::ref(sys_ks), bm_cfg).get();
 
             if (raft_gr.local().is_enabled()) {
                 auto my_raft_id = raft::server_id{cfg->host_id.uuid()};

--- a/main.cc
+++ b/main.cc
@@ -1242,7 +1242,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 auto paths = sch_cl->get_segments_to_replay().get();
                 if (!paths.empty()) {
                     supervisor::notify("replaying schema commit log");
-                    auto rp = db::commitlog_replayer::create_replayer(db).get0();
+                    auto rp = db::commitlog_replayer::create_replayer(db, sys_ks).get0();
                     rp.recover(paths, db::schema_tables::COMMITLOG_FILENAME_PREFIX).get();
                     supervisor::notify("replaying schema commit log - flushing memtables");
                     db.invoke_on_all([] (replica::database& db) {
@@ -1268,7 +1268,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 auto paths = cl->get_segments_to_replay().get();
                 if (!paths.empty()) {
                     supervisor::notify("replaying commit log");
-                    auto rp = db::commitlog_replayer::create_replayer(db).get0();
+                    auto rp = db::commitlog_replayer::create_replayer(db, sys_ks).get0();
                     rp.recover(paths, db::commitlog::descriptor::FILENAME_PREFIX).get();
                     supervisor::notify("replaying commit log - flushing memtables");
                     db.invoke_on_all([] (replica::database& db) {

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -637,7 +637,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
         {
             auto paths = cl.get_active_segment_names();
             BOOST_REQUIRE(!paths.empty());
-            auto rp = db::commitlog_replayer::create_replayer(env.db()).get0();
+            auto rp = db::commitlog_replayer::create_replayer(env.db(), env.get_system_keyspace()).get0();
             rp.recover(paths, db::commitlog::descriptor::FILENAME_PREFIX).get();
         }
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -133,7 +133,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
 
         e.db().invoke_on_all([&] (replica::database& db) -> future<> {
             auto cl = db.commitlog();
-            auto rp = co_await db::commitlog_replayer::create_replayer(e.db());
+            auto rp = co_await db::commitlog_replayer::create_replayer(e.db(), e.get_system_keyspace());
             auto paths = co_await cl->list_existing_segments();
             co_await rp.recover(paths, db::commitlog::descriptor::FILENAME_PREFIX);
         }).get();

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -74,7 +74,7 @@ SEASTAR_TEST_CASE(test_builder_with_large_partition) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
@@ -109,7 +109,7 @@ SEASTAR_TEST_CASE(test_builder_with_large_partition_2) {
                       "primary key (p, c)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
@@ -134,7 +134,7 @@ SEASTAR_TEST_CASE(test_builder_with_multiple_partitions) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
@@ -158,7 +158,7 @@ SEASTAR_TEST_CASE(test_builder_with_multiple_partitions_of_batch_size_rows) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
@@ -191,7 +191,7 @@ SEASTAR_TEST_CASE(test_builder_view_added_during_ongoing_build) {
 
         f2.get();
         f1.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
         auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
@@ -249,7 +249,7 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_large_partitions) {
 
         f2.get();
         f1.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
         auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
@@ -292,7 +292,7 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_small_partitions) {
         f2.get();
         f1.get();
 
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
         auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
@@ -322,7 +322,7 @@ SEASTAR_TEST_CASE(test_builder_with_tombstones) {
                       "primary key ((v, p), c1, c2)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get0();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
 
         auto msg = e.execute_cql("select * from vcf").get0();
@@ -881,6 +881,6 @@ SEASTAR_TEST_CASE(test_load_view_build_progress_with_values_missing) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, format("INSERT INTO system.{} (keyspace_name, view_name, cpu_id) VALUES ('ks', 'v', {})",
                 db::system_keyspace::v3::SCYLLA_VIEWS_BUILDS_IN_PROGRESS, this_shard_id()));
-        BOOST_REQUIRE(e.get_system_keyspace().load_view_build_progress().get0().empty());
+        BOOST_REQUIRE(e.get_system_keyspace().local().load_view_build_progress().get0().empty());
     });
 }

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -33,7 +33,7 @@ using namespace std::literals::chrono_literals;
 
 SEASTAR_TEST_CASE(test_query_size_estimates_virtual_table) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db(), e.get_system_keyspace()).get0();
+        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db(), e.get_system_keyspace().local()).get0();
         auto start_token1 = utf8_type->to_string(ranges[3].start);
         auto start_token2 = utf8_type->to_string(ranges[5].start);
         auto end_token1 = utf8_type->to_string(ranges[3].end);
@@ -177,16 +177,16 @@ SEASTAR_TEST_CASE(test_query_view_built_progress_virtual_table) {
         auto rand = [] { return dht::token::get_random_token(); };
         auto next_token = rand();
         auto next_token_str = next_token.to_sstring();
-        e.get_system_keyspace().register_view_for_building("ks", "v1", rand()).get();
-        e.get_system_keyspace().register_view_for_building("ks", "v2", rand()).get();
-        e.get_system_keyspace().register_view_for_building("ks", "v3", rand()).get();
-        e.get_system_keyspace().update_view_build_progress("ks", "v3", next_token).get();
-        e.get_system_keyspace().register_view_for_building("ks", "v4", rand()).get();
-        e.get_system_keyspace().update_view_build_progress("ks", "v4", next_token).get();
-        e.get_system_keyspace().register_view_for_building("ks", "v5", rand()).get();
-        e.get_system_keyspace().register_view_for_building("ks", "v6", rand()).get();
-        e.get_system_keyspace().remove_view_build_progress_across_all_shards("ks", "v5").get();
-        e.get_system_keyspace().remove_view_build_progress_across_all_shards("ks", "v6").get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v1", rand()).get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v2", rand()).get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v3", rand()).get();
+        e.get_system_keyspace().local().update_view_build_progress("ks", "v3", next_token).get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v4", rand()).get();
+        e.get_system_keyspace().local().update_view_build_progress("ks", "v4", next_token).get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v5", rand()).get();
+        e.get_system_keyspace().local().register_view_for_building("ks", "v6", rand()).get();
+        e.get_system_keyspace().local().remove_view_build_progress_across_all_shards("ks", "v5").get();
+        e.get_system_keyspace().local().remove_view_build_progress_across_all_shards("ks", "v6").get();
         auto rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks'").get0();
         assert_that(rs).is_rows().with_rows_ignore_order({
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("v1"))}, {int32_type->decompose(0)}, { } },

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -770,7 +770,7 @@ public:
             bmcfg.replay_rate = 100000000;
             bmcfg.write_request_timeout = 2s;
             distributed<db::batchlog_manager> bm;
-            bm.start(std::ref(qp), bmcfg).get();
+            bm.start(std::ref(qp), std::ref(sys_ks), bmcfg).get();
             auto stop_bm = defer([&bm] {
                 bm.stop().get();
             });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -430,8 +430,8 @@ public:
         return _group0_registry;
     }
 
-    virtual db::system_keyspace& get_system_keyspace() override {
-        return _sys_ks.local();
+    virtual sharded<db::system_keyspace>& get_system_keyspace() override {
+        return _sys_ks;
     }
 
     virtual future<> refresh_client_state() override {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -170,7 +170,7 @@ public:
 
     virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
-    virtual db::system_keyspace& get_system_keyspace() = 0;
+    virtual sharded<db::system_keyspace>& get_system_keyspace() = 0;
 
     data_dictionary::database data_dictionary();
 };


### PR DESCRIPTION
There are two places that do it -- commitlog and batchlog replayers. Both can have local system-keyspace reference and use system-keyspace local query-processor for it. The peering save_truncation_record() is not that simple and is not patched by this PR