### PR TITLE
treewide: rename the "xwasm" UDF language to "wasm"

### DIFF
--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -27,7 +27,7 @@ shared_ptr<functions::function> create_function_statement::create(query_processo
     if (old && !dynamic_cast<functions::user_function*>(old)) {
         throw exceptions::invalid_request_exception(format("Cannot replace '{}' which is not a user defined function", *old));
     }
-    if (_language != "lua" && _language != "xwasm") {
+    if (_language != "lua" && _language != "wasm") {
         throw exceptions::invalid_request_exception(format("Language '{}' is not supported", _language));
     }
     data_type return_type = prepare_type(qp, *_return_type);
@@ -46,7 +46,7 @@ shared_ptr<functions::function> create_function_statement::create(query_processo
 
         return ::make_shared<functions::user_function>(_name, _arg_types, std::move(arg_names), _body, _language,
             std::move(return_type), _called_on_null_input, std::move(ctx));
-    } else if (_language == "xwasm") {
+    } else if (_language == "wasm") {
        // FIXME: need better way to test wasm compilation without real_database()
        wasm::context ctx{db.real_database().wasm_engine(), _name.name, qp.get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
        try {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1874,7 +1874,7 @@ static shared_ptr<cql3::functions::user_function> create_func(replica::database&
         return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
-    } else if (language == "xwasm") {
+    } else if (language == "wasm") {
         wasm::context ctx{db.wasm_engine(), name.name, qctx->qp().get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
         wasm::precompile(ctx, arg_names, body);
         return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
@@ -1940,7 +1940,7 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
 
 static void drop_cached_func(replica::database& db, const query::result_set_row& row) {
     auto language = row.get_nonnull<sstring>("language");
-    if (language == "xwasm") {
+    if (language == "wasm") {
         cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("function_name")};
         auto arg_types = read_arg_types(db, row, name.keyspace);

--- a/docs/dev/wasm.md
+++ b/docs/dev/wasm.md
@@ -4,10 +4,9 @@ This document describes the details of WASM language support in user-defined fun
 
 ## Experimental status
 
-Before the design of WebAssembly integration and ABI is finalized, it's only available in experimental mode.
-User-defined functions are already experimental at the time of this writing, but in order to be ready
-for backward incompatible changes, the language accepted by CQL is currently named "xwasm".
-Once the ABI is set in stone, it should be changed to "wasm".
+WebAssembly UDFs are still experimental due to insufficient testing. If backwards incompatible changes
+to the ABI are implemented in the future, they should be submitted as new ABI-versions, and use the same
+LANGUAGE clause ("wasm") in the CQL statements.
 
 ## ABI versions
 
@@ -226,7 +225,7 @@ For those who want to use precompiled WASM modules, it's enough to translate WAS
 Here's how a `wasm` function can be declared:
 
 ```cql
-CREATE FUNCTION ks.fib (input bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE xwasm
+CREATE FUNCTION ks.fib (input bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE wasm
 AS '(module
   (func $fib (param $n i64) (result i64)
     (if


### PR DESCRIPTION
When the WASM UDFs were first introduced, the LANGUAGE required in the CQL statements to use them was "xwasm", because the ABI for the UDFs was still not specified and changes to it could be backwards incompatible.
Now, the ABI is stabilized, but if backwards incompatible changes are made in the future, we will add a new ABI version for them, so the name "xwasm" is no longer needed and we can finally change it to "wasm".