### PR TITLE
replica: Fix undefined behavior in table::generate_and_propagate_view_updates()

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1974,11 +1974,12 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
         tracing::trace_state_ptr tr_state,
         gc_clock::time_point now) const {
     auto base_token = m.token();
+    auto m_schema = m.schema();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
             *this,
             base,
             std::move(views),
-            make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), std::move(m)),
+            make_flat_mutation_reader_from_mutations_v2(std::move(m_schema), std::move(permit), std::move(m)),
             std::move(existings),
             now);
 


### PR DESCRIPTION
Undefined behavior because the evaluation order is undefined.

With GCC, where evaluation is right-to-left, schema will be moved
once it's forwarded to make_flat_mutation_reader_from_mutations_v2().

The consequence is that memory tracking of mutation_fragment_v2
(for tracking only permit used by view update), which uses the schema,
can be incorrect. However, it's more likely that Scylla will crash
when estimating memory usage for row, which access schema column
information using schema::column_at(), which in turn asserts that
the requested column does really exist.

Fixes #13093.