### PR TITLE
test: Don't populate / with sstables

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4660,7 +4660,7 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
         auto manager = compaction_manager(std::move(cfg), as, task_manager);
 
         auto add_sstable = [&env, gen = make_lw_shared<unsigned>(1)] (table_for_tests& t, uint64_t data_size, int level) {
-            auto sst = env.make_sstable(t.schema(), "", (*gen)++, la, big);
+            auto sst = env.make_sstable(t.schema(), env.tempdir().path().native(), (*gen)++, la, big);
             auto key = tests::generate_partition_key(t.schema()).key();
             sstables::test(sst).set_values_for_leveled_strategy(data_size, level, 0 /*max ts*/, key, key);
             assert(sst->data_size() == data_size);


### PR DESCRIPTION
The sstable_compaction_test::simple_backlog_controller_test makes sstables with empty dir argument. Eventually this means that sstables happen in / directory [1], which's not nice.

As a side effect this also makes sstable::storage::prefix() returns empty string which, in turn, confuses the code that tries to analyze the prefix contents (refs: #13090)

[1] See, e.g. logs from https://jenkins.scylladb.com/job/releng/job/Scylla-CI/4757/consoleText

```
INFO  2023-03-06 21:23:04,536 [shard 0] compaction - [Compact ks.cf 51489760-bc54-11ed-a08c-7d3f1d77e2e4] Compacting [/la-1-big-Data.db:level=0:origin=]
```