### PR TITLE
api: s/request/http::request/

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -56,6 +56,8 @@
 #include "db/schema_tables.hh"
 #include "utils/rjson.hh"
 
+using namespace std::chrono_literals;
+
 logging::logger elogger("alternator-executor");
 
 namespace alternator {

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -429,6 +429,8 @@ static std::chrono::seconds confidence_interval(data_dictionary::database db) {
     return std::chrono::seconds(db.get_config().alternator_streams_time_window_s());
 }
 
+using namespace std::chrono_literals;
+
 // Dynamo docs says no data shall live longer than 24h.
 static constexpr auto dynamodb_streams_max_window = 24h;
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -35,6 +35,7 @@
 logging::logger apilog("api");
 
 namespace api {
+using namespace seastar::httpd;
 
 static std::unique_ptr<reply> exception_reply(std::exception_ptr eptr) {
     try {

--- a/api/authorization_cache.cc
+++ b/api/authorization_cache.cc
@@ -14,6 +14,7 @@
 
 namespace api {
 using namespace json;
+using namespace seastar::httpd;
 
 void set_authorization_cache(http_context& ctx, routes& r, sharded<auth::service> &auth_service) {
     httpd::authorization_cache_json::authorization_cache_reset.set(r, [&auth_service] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {

--- a/api/authorization_cache.cc
+++ b/api/authorization_cache.cc
@@ -16,7 +16,7 @@ namespace api {
 using namespace json;
 
 void set_authorization_cache(http_context& ctx, routes& r, sharded<auth::service> &auth_service) {
-    httpd::authorization_cache_json::authorization_cache_reset.set(r, [&auth_service] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    httpd::authorization_cache_json::authorization_cache_reset.set(r, [&auth_service] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         co_await auth_service.invoke_on_all([] (auth::service& auth) -> future<>  {
             auth.reset_authorization_cache();
             return make_ready_future<>();

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -15,124 +15,124 @@ using namespace json;
 namespace cs = httpd::cache_service_json;
 
 void set_cache_service(http_context& ctx, routes& r) {
-    cs::get_row_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::get_row_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // We never save the cache
         // Origin uses 0 for never
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_row_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::set_row_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto period = req->get_query_param("period");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_key_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::get_key_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // We never save the cache
         // Origin uses 0 for never
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_key_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::set_key_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto period = req->get_query_param("period");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_counter_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::get_counter_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // We never save the cache
         // Origin uses 0 for never
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_counter_cache_save_period_in_seconds.set(r, [](std::unique_ptr<request> req) {
+    cs::set_counter_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto ccspis = req->get_query_param("ccspis");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_row_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::get_row_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_row_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::set_row_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto rckts = req->get_query_param("rckts");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_key_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::get_key_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_key_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::set_key_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto kckts = req->get_query_param("kckts");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_counter_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::get_counter_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::set_counter_cache_keys_to_save.set(r, [](std::unique_ptr<request> req) {
+    cs::set_counter_cache_keys_to_save.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto cckts = req->get_query_param("cckts");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::invalidate_key_cache.set(r, [](std::unique_ptr<request> req) {
+    cs::invalidate_key_cache.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::invalidate_counter_cache.set(r, [](std::unique_ptr<request> req) {
+    cs::invalidate_counter_cache.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::set_row_cache_capacity_in_mb.set(r, [](std::unique_ptr<request> req) {
+    cs::set_row_cache_capacity_in_mb.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto capacity = req->get_query_param("capacity");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::set_key_cache_capacity_in_mb.set(r, [](std::unique_ptr<request> req) {
+    cs::set_key_cache_capacity_in_mb.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto period = req->get_query_param("period");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::set_counter_cache_capacity_in_mb.set(r, [](std::unique_ptr<request> req) {
+    cs::set_counter_cache_capacity_in_mb.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         auto capacity = req->get_query_param("capacity");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::save_caches.set(r, [](std::unique_ptr<request> req) {
+    cs::save_caches.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cs::get_key_capacity.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_capacity.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -140,7 +140,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_hits.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_hits.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -148,7 +148,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_requests.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_requests.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -156,7 +156,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_hit_rate.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_hit_rate.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -164,21 +164,21 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_hits_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_hits_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_key_requests_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_requests_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_key_size.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_size.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -186,7 +186,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_key_entries.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_key_entries.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support keys cache,
@@ -194,7 +194,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_row_capacity.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_capacity.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) -> uint64_t {
             return db.row_cache_tracker().region().occupancy().used_space();
         }, uint64_t(0), std::plus<uint64_t>()).then([](const int64_t& res) {
@@ -202,26 +202,26 @@ void set_cache_service(http_context& ctx, routes& r) {
         });
     });
 
-    cs::get_row_hits.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_hits.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.count();
         }, std::plus<uint64_t>());
     });
 
-    cs::get_row_requests.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_requests.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.count() + cf.get_row_cache().stats().misses.count();
         }, std::plus<uint64_t>());
     });
 
-    cs::get_row_hit_rate.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_hit_rate.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, ratio_holder(), [](const replica::column_family& cf) {
             return ratio_holder(cf.get_row_cache().stats().hits.count() + cf.get_row_cache().stats().misses.count(),
                     cf.get_row_cache().stats().hits.count());
         }, std::plus<ratio_holder>());
     });
 
-    cs::get_row_hits_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_hits_moving_avrage.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -229,7 +229,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         });
     });
 
-    cs::get_row_requests_moving_avrage.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_requests_moving_avrage.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.rate() + cf.get_row_cache().stats().misses.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -237,7 +237,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         });
     });
 
-    cs::get_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         // In origin row size is the weighted size.
         // We currently do not support weights, so we use num entries instead
         return ctx.db.map_reduce0([](replica::database& db) -> uint64_t {
@@ -247,7 +247,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         });
     });
 
-    cs::get_row_entries.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cs::get_row_entries.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) -> uint64_t {
             return db.row_cache_tracker().partitions();
         }, uint64_t(0), std::plus<uint64_t>()).then([](const int64_t& res) {
@@ -255,7 +255,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         });
     });
 
-    cs::get_counter_capacity.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_capacity.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,
@@ -263,7 +263,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_hits.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_hits.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,
@@ -271,7 +271,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_requests.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_requests.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,
@@ -279,7 +279,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_hit_rate.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_hit_rate.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,
@@ -287,21 +287,21 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_hits_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_hits_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_counter_requests_moving_avrage.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_requests_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // See above
         return make_ready_future<json::json_return_type>(meter_to_json(utils::rate_moving_average()));
     });
 
-    cs::get_counter_size.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_size.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,
@@ -309,7 +309,7 @@ void set_cache_service(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cs::get_counter_entries.set(r, [] (std::unique_ptr<request> req) {
+    cs::get_counter_entries.set(r, [] (std::unique_ptr<http::request> req) {
         // TBD
         // FIXME
         // we don't support counter cache,

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -12,6 +12,7 @@
 
 namespace api {
 using namespace json;
+using namespace seastar::httpd;
 namespace cs = httpd::cache_service_json;
 
 void set_cache_service(http_context& ctx, routes& r) {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -312,7 +312,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return res;
     });
 
-    cf::get_column_family.set(r, [&ctx] (std::unique_ptr<request> req){
+    cf::get_column_family.set(r, [&ctx] (std::unique_ptr<http::request> req){
             std::list<cf::column_family_info> res;
             for (auto i: ctx.db.local().get_column_families_mapping()) {
                 cf::column_family_info info;
@@ -332,13 +332,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return res;
     });
 
-    cf::get_memtable_columns_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_memtable_columns_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t{0}, [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed(std::mem_fn(&replica::memtable::partition_count)), uint64_t(0));
         }, std::plus<>());
     });
 
-    cf::get_all_memtable_columns_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_memtable_columns_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t{0}, [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed(std::mem_fn(&replica::memtable::partition_count)), uint64_t(0));
         }, std::plus<>());
@@ -352,7 +352,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return 0;
     });
 
-    cf::get_memtable_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_memtable_off_heap_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed([] (replica::memtable* active_memtable) {
                 return active_memtable->region().occupancy().total_space();
@@ -360,7 +360,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<int64_t>());
     });
 
-    cf::get_all_memtable_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_memtable_off_heap_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed([] (replica::memtable* active_memtable) {
                 return active_memtable->region().occupancy().total_space();
@@ -368,7 +368,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<int64_t>());
     });
 
-    cf::get_memtable_live_data_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_memtable_live_data_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed([] (replica::memtable* active_memtable) {
                 return active_memtable->region().occupancy().used_space();
@@ -376,7 +376,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<int64_t>());
     });
 
-    cf::get_all_memtable_live_data_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_memtable_live_data_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed([] (replica::memtable* active_memtable) {
                 return active_memtable->region().occupancy().used_space();
@@ -392,14 +392,14 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return 0;
     });
 
-    cf::get_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         warn(unimplemented::cause::INDEXES);
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             return cf.occupancy().total_space();
         }, std::plus<int64_t>());
     });
 
-    cf::get_all_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_cf_all_memtables_off_heap_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         warn(unimplemented::cause::INDEXES);
         return ctx.db.map_reduce0([](const replica::database& db){
             return db.dirty_memory_region_group().real_memory_used();
@@ -408,14 +408,14 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_cf_all_memtables_live_data_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_cf_all_memtables_live_data_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         warn(unimplemented::cause::INDEXES);
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             return cf.occupancy().used_space();
         }, std::plus<int64_t>());
     });
 
-    cf::get_all_cf_all_memtables_live_data_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_cf_all_memtables_live_data_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         warn(unimplemented::cause::INDEXES);
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
             return boost::accumulate(cf.active_memtables() | boost::adaptors::transformed([] (replica::memtable* active_memtable) {
@@ -424,16 +424,16 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<int64_t>());
     });
 
-    cf::get_memtable_switch_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_memtable_switch_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx,req->param["name"] ,&replica::column_family_stats::memtable_switch_count);
     });
 
-    cf::get_all_memtable_switch_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_memtable_switch_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx, &replica::column_family_stats::memtable_switch_count);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_estimated_row_size_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_estimated_row_size_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], utils::estimated_histogram(0), [](replica::column_family& cf) {
             utils::estimated_histogram res(0);
             for (auto sstables = cf.get_sstables(); auto& i : *sstables) {
@@ -445,7 +445,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_estimated_row_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_estimated_row_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             uint64_t res = 0;
             for (auto sstables = cf.get_sstables(); auto& i : *sstables) {
@@ -456,7 +456,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         std::plus<uint64_t>());
     });
 
-    cf::get_estimated_column_count_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_estimated_column_count_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], utils::estimated_histogram(0), [](replica::column_family& cf) {
             utils::estimated_histogram res(0);
             for (auto sstables = cf.get_sstables(); auto& i : *sstables) {
@@ -467,149 +467,149 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         utils::estimated_histogram_merge, utils_json::estimated_histogram());
     });
 
-    cf::get_all_compression_ratio.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_all_compression_ratio.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_pending_flushes.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_pending_flushes.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx,req->param["name"] ,&replica::column_family_stats::pending_flushes);
     });
 
-    cf::get_all_pending_flushes.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_pending_flushes.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx, &replica::column_family_stats::pending_flushes);
     });
 
-    cf::get_read.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_read.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_count(ctx,req->param["name"] ,&replica::column_family_stats::reads);
     });
 
-    cf::get_all_read.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_read.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_count(ctx, &replica::column_family_stats::reads);
     });
 
-    cf::get_write.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_write.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_count(ctx, req->param["name"] ,&replica::column_family_stats::writes);
     });
 
-    cf::get_all_write.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_write.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_count(ctx, &replica::column_family_stats::writes);
     });
 
-    cf::get_read_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_read_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, req->param["name"], &replica::column_family_stats::reads);
     });
 
-    cf::get_read_latency_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_read_latency_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_rate_and_histogram(ctx, req->param["name"], &replica::column_family_stats::reads);
     });
 
-    cf::get_read_latency.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_read_latency.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_sum(ctx,req->param["name"] ,&replica::column_family_stats::reads);
     });
 
-    cf::get_write_latency.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_write_latency.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats_sum(ctx, req->param["name"] ,&replica::column_family_stats::writes);
     });
 
-    cf::get_all_read_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_read_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, &replica::column_family_stats::writes);
     });
 
-    cf::get_all_read_latency_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_read_latency_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_rate_and_histogram(ctx, &replica::column_family_stats::writes);
     });
 
-    cf::get_write_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_write_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, req->param["name"], &replica::column_family_stats::writes);
     });
 
-    cf::get_write_latency_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_write_latency_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_rate_and_histogram(ctx, req->param["name"], &replica::column_family_stats::writes);
     });
 
-    cf::get_all_write_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_write_latency_histogram_depricated.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, &replica::column_family_stats::writes);
     });
 
-    cf::get_all_write_latency_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_write_latency_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_rate_and_histogram(ctx, &replica::column_family_stats::writes);
     });
 
-    cf::get_pending_compactions.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_pending_compactions.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), [](replica::column_family& cf) {
             return cf.estimate_pending_compactions();
         }, std::plus<int64_t>());
     });
 
-    cf::get_all_pending_compactions.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_pending_compactions.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, int64_t(0), [](replica::column_family& cf) {
             return cf.estimate_pending_compactions();
         }, std::plus<int64_t>());
     });
 
-    cf::get_live_ss_table_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_live_ss_table_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx, req->param["name"], &replica::column_family_stats::live_sstable_count);
     });
 
-    cf::get_all_live_ss_table_count.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_live_ss_table_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_stats(ctx, &replica::column_family_stats::live_sstable_count);
     });
 
-    cf::get_unleveled_sstables.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_unleveled_sstables.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_unleveled_sstables(ctx, req->param["name"]);
     });
 
-    cf::get_live_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_live_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return sum_sstable(ctx, req->param["name"], false);
     });
 
-    cf::get_all_live_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_live_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return sum_sstable(ctx, false);
     });
 
-    cf::get_total_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_total_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return sum_sstable(ctx, req->param["name"], true);
     });
 
-    cf::get_all_total_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_total_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return sum_sstable(ctx, true);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_min_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_min_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], INT64_MAX, min_partition_size, min_int64);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_all_min_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_min_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, INT64_MAX, min_partition_size, min_int64);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_max_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_max_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], int64_t(0), max_partition_size, max_int64);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_all_max_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_max_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, int64_t(0), max_partition_size, max_int64);
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_mean_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_mean_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         // Cassandra 3.x mean values are truncated as integrals.
         return map_reduce_cf(ctx, req->param["name"], integral_ratio_holder(), mean_partition_size, std::plus<integral_ratio_holder>());
     });
 
     // FIXME: this refers to partitions, not rows.
-    cf::get_all_mean_row_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_mean_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         // Cassandra 3.x mean values are truncated as integrals.
         return map_reduce_cf(ctx, integral_ratio_holder(), mean_partition_size, std::plus<integral_ratio_holder>());
     });
 
-    cf::get_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -618,7 +618,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_all_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -627,7 +627,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_recent_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_recent_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -636,7 +636,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_all_recent_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_recent_bloom_filter_false_positives.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -645,31 +645,31 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], ratio_holder(), [] (replica::column_family& cf) {
             return boost::accumulate(*cf.get_sstables() | boost::adaptors::transformed(filter_false_positive_as_ratio_holder), ratio_holder());
         }, std::plus<>());
     });
 
-    cf::get_all_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, ratio_holder(), [] (replica::column_family& cf) {
             return boost::accumulate(*cf.get_sstables() | boost::adaptors::transformed(filter_false_positive_as_ratio_holder), ratio_holder());
         }, std::plus<>());
     });
 
-    cf::get_recent_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_recent_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], ratio_holder(), [] (replica::column_family& cf) {
             return boost::accumulate(*cf.get_sstables() | boost::adaptors::transformed(filter_recent_false_positive_as_ratio_holder), ratio_holder());
         }, std::plus<>());
     });
 
-    cf::get_all_recent_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_recent_bloom_filter_false_ratio.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, ratio_holder(), [] (replica::column_family& cf) {
             return boost::accumulate(*cf.get_sstables() | boost::adaptors::transformed(filter_recent_false_positive_as_ratio_holder), ratio_holder());
         }, std::plus<>());
     });
 
-    cf::get_bloom_filter_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_bloom_filter_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -678,7 +678,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_all_bloom_filter_disk_space_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_bloom_filter_disk_space_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -687,7 +687,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_bloom_filter_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_bloom_filter_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -696,7 +696,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_all_bloom_filter_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_bloom_filter_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -705,7 +705,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_index_summary_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_index_summary_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -714,7 +714,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_all_index_summary_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_index_summary_off_heap_memory_used.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, uint64_t(0), [] (replica::column_family& cf) {
             auto sstables = cf.get_sstables();
             return std::accumulate(sstables->begin(), sstables->end(), uint64_t(0), [](uint64_t s, auto& sst) {
@@ -723,7 +723,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }, std::plus<uint64_t>());
     });
 
-    cf::get_compression_metadata_off_heap_memory_used.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_compression_metadata_off_heap_memory_used.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         // FIXME
         // We are missing the off heap memory calculation
@@ -733,33 +733,33 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_all_compression_metadata_off_heap_memory_used.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_all_compression_metadata_off_heap_memory_used.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_speculative_retries.set(r, [] (std::unique_ptr<request> req) {
-        //TBD
-        unimplemented();
-        //auto id = get_uuid(req->param["name"], ctx.db.local());
-        return make_ready_future<json::json_return_type>(0);
-    });
-
-    cf::get_all_speculative_retries.set(r, [] (std::unique_ptr<request> req) {
-        //TBD
-        unimplemented();
-        return make_ready_future<json::json_return_type>(0);
-    });
-
-    cf::get_key_cache_hit_rate.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_speculative_retries.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         //auto id = get_uuid(req->param["name"], ctx.db.local());
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_true_snapshots_size.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_speculative_retries.set(r, [] (std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        return make_ready_future<json::json_return_type>(0);
+    });
+
+    cf::get_key_cache_hit_rate.set(r, [] (std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        //auto id = get_uuid(req->param["name"], ctx.db.local());
+        return make_ready_future<json::json_return_type>(0);
+    });
+
+    cf::get_true_snapshots_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         auto uuid = get_uuid(req->param["name"], ctx.db.local());
         return ctx.db.local().find_column_family(uuid).get_snapshot_details().then([](
                 const std::unordered_map<sstring, replica::column_family::snapshot_details>& sd) {
@@ -771,26 +771,26 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_all_true_snapshots_size.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_all_true_snapshots_size.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_row_cache_hit_out_of_range.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_row_cache_hit_out_of_range.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         //auto id = get_uuid(req->param["name"], ctx.db.local());
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_all_row_cache_hit_out_of_range.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_all_row_cache_hit_out_of_range.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_row_cache_hit.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_row_cache_hit.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, req->param["name"], utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -798,7 +798,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_all_row_cache_hit.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_row_cache_hit.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().hits.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -806,7 +806,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_row_cache_miss.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_row_cache_miss.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, req->param["name"], utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().misses.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -814,7 +814,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_all_row_cache_miss.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_all_row_cache_miss.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, utils::rate_moving_average(), [](const replica::column_family& cf) {
             return cf.get_row_cache().stats().misses.rate();
         }, std::plus<utils::rate_moving_average>()).then([](const utils::rate_moving_average& m) {
@@ -823,40 +823,40 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     });
 
-    cf::get_cas_prepare.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_cas_prepare.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(ctx, req->param["name"], [](const replica::column_family& cf) {
             return cf.get_stats().cas_prepare.histogram();
         });
     });
 
-    cf::get_cas_propose.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_cas_propose.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(ctx, req->param["name"], [](const replica::column_family& cf) {
             return cf.get_stats().cas_accept.histogram();
         });
     });
 
-    cf::get_cas_commit.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_cas_commit.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(ctx, req->param["name"], [](const replica::column_family& cf) {
             return cf.get_stats().cas_learn.histogram();
         });
     });
 
-    cf::get_sstables_per_read_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_sstables_per_read_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return map_reduce_cf(ctx, req->param["name"], utils::estimated_histogram(0), [](replica::column_family& cf) {
             return cf.get_stats().estimated_sstable_per_read;
         },
         utils::estimated_histogram_merge, utils_json::estimated_histogram());
     });
 
-    cf::get_tombstone_scanned_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_tombstone_scanned_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, req->param["name"], &replica::column_family_stats::tombstone_scanned);
     });
 
-    cf::get_live_scanned_histogram.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::get_live_scanned_histogram.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return get_cf_histogram(ctx, req->param["name"], &replica::column_family_stats::live_scanned);
     });
 
-    cf::get_col_update_time_delta_histogram.set(r, [] (std::unique_ptr<request> req) {
+    cf::get_col_update_time_delta_histogram.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         //auto id = get_uuid(req->param["name"], ctx.db.local());
@@ -870,7 +870,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return !cf.is_auto_compaction_disabled_by_user();
     });
 
-    cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return ctx.db.invoke_on(0, [&ctx, req = std::move(req)] (replica::database& db) {
             auto g = replica::database::autocompaction_toggle_guard(db);
             return foreach_column_family(ctx, req->param["name"], [](replica::column_family &cf) {
@@ -881,7 +881,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return ctx.db.invoke_on(0, [&ctx, req = std::move(req)] (replica::database& db) {
             auto g = replica::database::autocompaction_toggle_guard(db);
             return foreach_column_family(ctx, req->param["name"], [](replica::column_family &cf) {
@@ -892,7 +892,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_built_indexes.set(r, [&ctx, &sys_ks](std::unique_ptr<request> req) {
+    cf::get_built_indexes.set(r, [&ctx, &sys_ks](std::unique_ptr<http::request> req) {
         auto ks_cf = parse_fully_qualified_cf_name(req->param["name"]);
         auto&& ks = std::get<0>(ks_cf);
         auto&& cf_name = std::get<1>(ks_cf);
@@ -930,7 +930,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return std::vector<sstring>();
     });
 
-    cf::get_compression_ratio.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::get_compression_ratio.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto uuid = get_uuid(req->param["name"], ctx.db.local());
 
         return ctx.db.map_reduce(sum_ratio<double>(), [uuid](replica::database& db) {
@@ -941,19 +941,19 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_read_latency_estimated_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::get_read_latency_estimated_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(ctx, req->param["name"], [](const replica::column_family& cf) {
             return cf.get_stats().reads.histogram();
         });
     });
 
-    cf::get_write_latency_estimated_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::get_write_latency_estimated_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(ctx, req->param["name"], [](const replica::column_family& cf) {
             return cf.get_stats().writes.histogram();
         });
     });
 
-    cf::set_compaction_strategy_class.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::set_compaction_strategy_class.set(r, [&ctx](std::unique_ptr<http::request> req) {
         sstring strategy = req->get_query_param("class_name");
         return foreach_column_family(ctx, req->param["name"], [strategy](replica::column_family& cf) {
             cf.set_compaction_strategy(sstables::compaction_strategy::type(strategy));
@@ -966,19 +966,19 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return ctx.db.local().find_column_family(get_uuid(req.param["name"], ctx.db.local())).get_compaction_strategy().name();
     });
 
-    cf::set_compression_parameters.set(r, [](std::unique_ptr<request> req) {
+    cf::set_compression_parameters.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cf::set_crc_check_chance.set(r, [](std::unique_ptr<request> req) {
+    cf::set_crc_check_chance.set(r, [](std::unique_ptr<http::request> req) {
         // TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cf::get_sstable_count_per_level.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::get_sstable_count_per_level.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return map_reduce_cf_raw(ctx, req->param["name"], std::vector<uint64_t>(), [](const replica::column_family& cf) {
             return cf.sstable_count_per_level();
         }, concat_sstable_count_per_level).then([](const std::vector<uint64_t>& res) {
@@ -986,7 +986,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::get_sstables_for_key.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::get_sstables_for_key.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto key = req->get_query_param("key");
         auto uuid = get_uuid(req->param["name"], ctx.db.local());
 
@@ -1002,7 +1002,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     });
 
 
-    cf::toppartitions.set(r, [&ctx] (std::unique_ptr<request> req) {
+    cf::toppartitions.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         auto name = req->param["name"];
         auto [ks, cf] = parse_fully_qualified_cf_name(name);
 
@@ -1018,7 +1018,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
     });
 
-    cf::force_major_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+    cf::force_major_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         if (req->get_query_param("split_output") != "") {
             fail(unimplemented::cause::API);
         }

--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 namespace api {
+using namespace seastar::httpd;
 
 template<typename T>
 static auto acquire_cl_metric(http_context& ctx, std::function<T (db::commitlog*)> func) {

--- a/api/config.cc
+++ b/api/config.cc
@@ -13,6 +13,7 @@
 #include <boost/algorithm/string/replace.hpp>
 
 namespace api {
+using namespace seastar::httpd;
 
 template<class T>
 json::json_return_type get_json_return_type(const T& val) {

--- a/api/endpoint_snitch.cc
+++ b/api/endpoint_snitch.cc
@@ -15,6 +15,7 @@
 #include "utils/fb_utilities.hh"
 
 namespace api {
+using namespace seastar::httpd;
 
 void set_endpoint_snitch(http_context& ctx, routes& r, sharded<locator::snitch_ptr>& snitch) {
     static auto host_or_broadcast = [](const_req req) {

--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/future-util.hh>
 
 namespace api {
+using namespace seastar::httpd;
 
 namespace hf = httpd::error_injection_json;
 

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -11,7 +11,9 @@
 #include "gms/failure_detector.hh"
 #include "gms/application_state.hh"
 #include "gms/gossiper.hh"
+
 namespace api {
+using namespace seastar::httpd;
 
 namespace fd = httpd::failure_detector_json;
 

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -29,21 +29,21 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
         return g.get_endpoint_downtime(ep);
     });
 
-    httpd::gossiper_json::get_current_generation_number.set(r, [&g] (std::unique_ptr<request> req) {
+    httpd::gossiper_json::get_current_generation_number.set(r, [&g] (std::unique_ptr<http::request> req) {
         gms::inet_address ep(req->param["addr"]);
         return g.get_current_generation_number(ep).then([] (int res) {
             return make_ready_future<json::json_return_type>(res);
         });
     });
 
-    httpd::gossiper_json::get_current_heart_beat_version.set(r, [&g] (std::unique_ptr<request> req) {
+    httpd::gossiper_json::get_current_heart_beat_version.set(r, [&g] (std::unique_ptr<http::request> req) {
         gms::inet_address ep(req->param["addr"]);
         return g.get_current_heart_beat_version(ep).then([] (int res) {
             return make_ready_future<json::json_return_type>(res);
         });
     });
 
-    httpd::gossiper_json::assassinate_endpoint.set(r, [&g](std::unique_ptr<request> req) {
+    httpd::gossiper_json::assassinate_endpoint.set(r, [&g](std::unique_ptr<http::request> req) {
         if (req->get_query_param("unsafe") != "True") {
             return g.assassinate_endpoint(req->param["addr"]).then([] {
                 return make_ready_future<json::json_return_type>(json_void());
@@ -54,7 +54,7 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
         });
     });
 
-    httpd::gossiper_json::force_remove_endpoint.set(r, [&g](std::unique_ptr<request> req) {
+    httpd::gossiper_json::force_remove_endpoint.set(r, [&g](std::unique_ptr<http::request> req) {
         gms::inet_address ep(req->param["addr"]);
         return g.force_remove_endpoint(ep).then([] {
             return make_ready_future<json::json_return_type>(json_void());

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -11,6 +11,7 @@
 #include "gms/gossiper.hh"
 
 namespace api {
+using namespace seastar::httpd;
 using namespace json;
 
 void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {

--- a/api/hinted_handoff.cc
+++ b/api/hinted_handoff.cc
@@ -22,7 +22,7 @@ using namespace json;
 namespace hh = httpd::hinted_handoff_json;
 
 void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {
-    hh::create_hints_sync_point.set(r, [&ctx, &g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    hh::create_hints_sync_point.set(r, [&ctx, &g] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto parse_hosts_list = [&g] (sstring arg) {
             std::vector<sstring> hosts_str = split(arg, ",");
             std::vector<gms::inet_address> hosts;
@@ -52,7 +52,7 @@ void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {
         });
     });
 
-    hh::get_hints_sync_point.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    hh::get_hints_sync_point.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         db::hints::sync_point sync_point;
         const sstring encoded = req->get_query_param("id");
         try {
@@ -93,42 +93,42 @@ void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {
         });
     });
 
-    hh::list_endpoints_pending_hints.set(r, [] (std::unique_ptr<request> req) {
+    hh::list_endpoints_pending_hints.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         std::vector<sstring> res;
         return make_ready_future<json::json_return_type>(res);
     });
 
-    hh::truncate_all_hints.set(r, [] (std::unique_ptr<request> req) {
+    hh::truncate_all_hints.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         sstring host = req->get_query_param("host");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    hh::schedule_hint_delivery.set(r, [] (std::unique_ptr<request> req) {
+    hh::schedule_hint_delivery.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         sstring host = req->get_query_param("host");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    hh::pause_hints_delivery.set(r, [] (std::unique_ptr<request> req) {
+    hh::pause_hints_delivery.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         sstring pause = req->get_query_param("pause");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    hh::get_create_hint_count.set(r, [] (std::unique_ptr<request> req) {
+    hh::get_create_hint_count.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         sstring host = req->get_query_param("host");
         return make_ready_future<json::json_return_type>(0);
     });
 
-    hh::get_not_stored_hints_count.set(r, [] (std::unique_ptr<request> req) {
+    hh::get_not_stored_hints_count.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
         sstring host = req->get_query_param("host");

--- a/api/hinted_handoff.cc
+++ b/api/hinted_handoff.cc
@@ -19,6 +19,7 @@
 namespace api {
 
 using namespace json;
+using namespace seastar::httpd;
 namespace hh = httpd::hinted_handoff_json;
 
 void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {

--- a/api/lsa.cc
+++ b/api/lsa.cc
@@ -16,6 +16,7 @@
 #include "replica/database.hh"
 
 namespace api {
+using namespace seastar::httpd;
 
 static logging::logger alogger("lsa-api");
 

--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 
+using namespace seastar::httpd;
 using namespace httpd::messaging_service_json;
 using namespace netw;
 

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -20,6 +20,7 @@ namespace api {
 
 namespace sp = httpd::storage_proxy_json;
 using proxy = service::storage_proxy;
+using namespace seastar::httpd;
 using namespace json;
 
 utils::time_estimated_histogram timed_rate_moving_average_summary_merge(utils::time_estimated_histogram a, const utils::timed_rate_moving_average_summary_and_histogram& b) {

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -184,18 +184,18 @@ sum_timer_stats_storage_proxy(distributed<proxy>& d,
 }
 
 void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_service>& ss) {
-    sp::get_total_hints.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_total_hints.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    sp::get_hinted_handoff_enabled.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_hinted_handoff_enabled.set(r, [](std::unique_ptr<http::request> req)  {
         const auto& filter = service::get_storage_proxy().local().get_hints_host_filter();
         return make_ready_future<json::json_return_type>(!filter.is_disabled_for_all());
     });
 
-    sp::set_hinted_handoff_enabled.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_hinted_handoff_enabled.set(r, [](std::unique_ptr<http::request> req)  {
         auto enable = req->get_query_param("enable");
         auto filter = (enable == "true" || enable == "1")
                 ? db::hints::host_filter(db::hints::host_filter::enabled_for_all_tag {})
@@ -207,7 +207,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         });
     });
 
-    sp::get_hinted_handoff_enabled_by_dc.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_hinted_handoff_enabled_by_dc.set(r, [](std::unique_ptr<http::request> req)  {
         std::vector<sstring> res;
         const auto& filter = service::get_storage_proxy().local().get_hints_host_filter();
         const auto& dcs = filter.get_dcs();
@@ -216,7 +216,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return make_ready_future<json::json_return_type>(res);
     });
 
-    sp::set_hinted_handoff_enabled_by_dc_list.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_hinted_handoff_enabled_by_dc_list.set(r, [](std::unique_ptr<http::request> req)  {
         auto dcs = req->get_query_param("dcs");
         auto filter = db::hints::host_filter::parse_from_dc_list(std::move(dcs));
         return service::get_storage_proxy().invoke_on_all([filter = std::move(filter)] (service::storage_proxy& sp) {
@@ -226,33 +226,33 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         });
     });
 
-    sp::get_max_hint_window.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_max_hint_window.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
     });
 
-    sp::set_max_hint_window.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_max_hint_window.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("ms");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    sp::get_max_hints_in_progress.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_max_hints_in_progress.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(1);
     });
 
-    sp::set_max_hints_in_progress.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_max_hints_in_progress.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("qs");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    sp::get_hints_in_progress.set(r, [](std::unique_ptr<request> req)  {
+    sp::get_hints_in_progress.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(0);
@@ -262,7 +262,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -273,7 +273,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().read_request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_read_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_read_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -284,7 +284,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().write_request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_write_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -295,7 +295,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().counter_write_request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_counter_write_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_counter_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -306,7 +306,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().cas_contention_timeout_in_ms()/1000.0;
     });
 
-    sp::set_cas_contention_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_cas_contention_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -317,7 +317,7 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().range_request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_range_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_range_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
@@ -328,32 +328,32 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return ctx.db.local().get_config().truncate_request_timeout_in_ms()/1000.0;
     });
 
-    sp::set_truncate_rpc_timeout.set(r, [](std::unique_ptr<request> req)  {
+    sp::set_truncate_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         auto enable = req->get_query_param("timeout");
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    sp::reload_trigger_classes.set(r, [](std::unique_ptr<request> req)  {
+    sp::reload_trigger_classes.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    sp::get_read_repair_attempted.set(r, [&ctx](std::unique_ptr<request> req)  {
+    sp::get_read_repair_attempted.set(r, [&ctx](std::unique_ptr<http::request> req)  {
         return sum_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read_repair_attempts);
     });
 
-    sp::get_read_repair_repaired_blocking.set(r, [&ctx](std::unique_ptr<request> req)  {
+    sp::get_read_repair_repaired_blocking.set(r, [&ctx](std::unique_ptr<http::request> req)  {
         return sum_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read_repair_repaired_blocking);
     });
 
-    sp::get_read_repair_repaired_background.set(r, [&ctx](std::unique_ptr<request> req)  {
+    sp::get_read_repair_repaired_background.set(r, [&ctx](std::unique_ptr<http::request> req)  {
         return sum_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read_repair_repaired_background);
     });
 
-    sp::get_schema_versions.set(r, [&ss](std::unique_ptr<request> req)  {
+    sp::get_schema_versions.set(r, [&ss](std::unique_ptr<http::request> req)  {
         return ss.local().describe_schema_versions().then([] (auto result) {
             std::vector<sp::mapper_list> res;
             for (auto e : result) {
@@ -366,122 +366,122 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         });
     });
 
-    sp::get_cas_read_timeouts.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_read_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &proxy::stats::cas_read_timeouts);
     });
 
-    sp::get_cas_read_unavailables.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_read_unavailables.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &proxy::stats::cas_read_unavailables);
     });
 
-    sp::get_cas_write_timeouts.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &proxy::stats::cas_write_timeouts);
     });
 
-    sp::get_cas_write_unavailables.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_unavailables.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &proxy::stats::cas_write_unavailables);
     });
 
-    sp::get_cas_write_metrics_unfinished_commit.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_metrics_unfinished_commit.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_stats(ctx.sp, &proxy::stats::cas_write_unfinished_commit);
     });
 
-    sp::get_cas_write_metrics_contention.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_metrics_contention.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_estimated_histogram(ctx, &proxy::stats::cas_write_contention);
     });
 
-    sp::get_cas_write_metrics_condition_not_met.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_metrics_condition_not_met.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_stats(ctx.sp, &proxy::stats::cas_write_condition_not_met);
     });
 
-    sp::get_cas_write_metrics_failed_read_round_optimization.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_metrics_failed_read_round_optimization.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_stats(ctx.sp, &proxy::stats::cas_failed_read_round_optimization);
     });
 
-    sp::get_cas_read_metrics_unfinished_commit.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_read_metrics_unfinished_commit.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_stats(ctx.sp, &proxy::stats::cas_read_unfinished_commit);
     });
 
-    sp::get_cas_read_metrics_contention.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_read_metrics_contention.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_estimated_histogram(ctx, &proxy::stats::cas_read_contention);
     });
 
-    sp::get_read_metrics_timeouts.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::read_timeouts);
     });
 
-    sp::get_read_metrics_unavailables.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_unavailables.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::read_unavailables);
     });
 
-    sp::get_range_metrics_timeouts.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::range_slice_timeouts);
     });
 
-    sp::get_range_metrics_unavailables.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_unavailables.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::range_slice_unavailables);
     });
 
-    sp::get_write_metrics_timeouts.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::write_timeouts);
     });
 
-    sp::get_write_metrics_unavailables.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_unavailables.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &service::storage_proxy_stats::stats::write_unavailables);
     });
 
-    sp::get_read_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::read_timeouts);
     });
 
-    sp::get_read_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::read_unavailables);
     });
 
-    sp::get_range_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::range_slice_timeouts);
     });
 
-    sp::get_range_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::range_slice_unavailables);
     });
 
-    sp::get_write_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_timeouts_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::write_timeouts);
     });
 
-    sp::get_write_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_unavailables_rates.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_obj(ctx.sp, &service::storage_proxy_stats::stats::write_unavailables);
     });
 
-    sp::get_range_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_histogram_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::range);
     });
 
-    sp::get_write_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_histogram_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::write);
     });
 
-    sp::get_read_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_latency_histogram_depricated.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_histogram_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read);
     });
 
-    sp::get_range_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::range);
     });
 
-    sp::get_write_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::write);
     });
-    sp::get_cas_write_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_write_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats(ctx.sp, &proxy::stats::cas_write);
     });
 
-    sp::get_cas_read_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_cas_read_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats(ctx.sp, &proxy::stats::cas_read);
     });
 
-    sp::get_view_write_metrics_latency_histogram.set(r, [](std::unique_ptr<request> req) {
+    sp::get_view_write_metrics_latency_histogram.set(r, [](std::unique_ptr<http::request> req) {
         //TBD
         // FIXME
         // No View metrics are available, so just return empty moving average
@@ -489,30 +489,30 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return make_ready_future<json::json_return_type>(get_empty_moving_average());
     });
 
-    sp::get_read_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_metrics_latency_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read);
     });
 
-    sp::get_read_estimated_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_estimated_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_estimated_histogram(ctx, &service::storage_proxy_stats::stats::read);
     });
 
-    sp::get_read_latency.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_read_latency.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return total_latency(ctx, &service::storage_proxy_stats::stats::read);
     });
-    sp::get_write_estimated_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_estimated_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_estimated_histogram(ctx, &service::storage_proxy_stats::stats::write);
     });
 
-    sp::get_write_latency.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_write_latency.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return total_latency(ctx, &service::storage_proxy_stats::stats::write);
     });
 
-    sp::get_range_estimated_histogram.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_estimated_histogram.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timer_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::range);
     });
 
-    sp::get_range_latency.set(r, [&ctx](std::unique_ptr<request> req) {
+    sp::get_range_latency.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return total_latency(ctx, &service::storage_proxy_stats::stats::range);
     });
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -47,6 +47,9 @@
 #include "sstables_loader.hh"
 #include "db/view/view_builder.hh"
 
+using namespace seastar::httpd;
+using namespace std::chrono_literals;
+
 extern logging::logger apilog;
 
 namespace std {

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -14,6 +14,7 @@
 #include "gms/gossiper.hh"
 
 namespace api {
+using namespace seastar::httpd;
 
 namespace hs = httpd::stream_manager_json;
 

--- a/api/system.cc
+++ b/api/system.cc
@@ -17,6 +17,7 @@
 extern logging::logger apilog;
 
 namespace api {
+using namespace seastar::httpd;
 
 namespace hs = httpd::system_json;
 

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -22,6 +22,7 @@ namespace api {
 
 namespace tm = httpd::task_manager_json;
 using namespace json;
+using namespace seastar::httpd;
 
 inline bool filter_tasks(tasks::task_manager::task_ptr task, std::unordered_map<sstring, sstring>& query_params) {
     return (!query_params.contains("keyspace") || query_params["keyspace"] == task->get_status().keyspace) &&

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -108,12 +108,12 @@ future<full_task_status> retrieve_status(const tasks::task_manager::foreign_task
 }
 
 void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
-    tm::get_modules.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::get_modules.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         std::vector<std::string> v = boost::copy_range<std::vector<std::string>>(ctx.tm.local().get_modules() | boost::adaptors::map_keys);
         co_return v;
     });
 
-    tm::get_tasks.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::get_tasks.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         using chunked_stats = utils::chunked_vector<task_stats>;
         auto internal = tasks::is_internal{req_param<bool>(*req, "internal", false)};
         std::vector<chunked_stats> res = co_await ctx.tm.map([&req, internal] (tasks::task_manager& tm) {
@@ -147,7 +147,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         co_return std::move(f);
     });
 
-    tm::get_task_status.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::get_task_status.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         auto task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
             auto state = task->get_status().state;
@@ -160,7 +160,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         co_return make_status(s);
     });
 
-    tm::abort_task.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::abort_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         co_await tasks::task_manager::invoke_on_task(ctx.tm, id, [] (tasks::task_manager::task_ptr task) -> future<> {
             if (!task->is_abortable()) {
@@ -171,7 +171,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         co_return json_void();
     });
 
-    tm::wait_task.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::wait_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         auto task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) {
             return task->done().then_wrapped([task] (auto f) {
@@ -184,7 +184,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         co_return make_status(s);
     });
 
-    tm::get_task_status_recursively.set(r, [&ctx] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::get_task_status_recursively.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& _ctx = ctx;
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         std::queue<tasks::task_manager::foreign_task_ptr> q;
@@ -225,7 +225,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         co_return f;
     });
 
-    tm::get_and_update_ttl.set(r, [&cfg] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+    tm::get_and_update_ttl.set(r, [&cfg] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         uint32_t ttl = cfg.task_ttl_seconds();
         co_await cfg.task_ttl_seconds.set_value_on_all_shards(req->query_parameters["ttl"], utils::config_file::config_source::API);
         co_return json::json_return_type(ttl);

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -18,6 +18,7 @@ namespace api {
 
 namespace tmt = httpd::task_manager_test_json;
 using namespace json;
+using namespace seastar::httpd;
 
 void set_task_manager_test(http_context& ctx, routes& r) {
     tmt::register_test_module.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {


### PR DESCRIPTION
- api: reference httpd::* symbols like 'httpd::*'
- alternator: using chrono_literals before using it
- api: s/request/http::request/

the last two commits were inspired Pavel's comment of

> It looks like api/ code was caught by some using namespace seastar::httpd shortcut.

they should be landed before we merge and include https://github.com/scylladb/seastar/pull/1536 in Scylla.