### PR TITLE
sstable: Remove unused friendship

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -56,10 +56,6 @@ namespace mc {
 class writer;
 }
 
-namespace mx {
-class partition_reversing_data_source_impl;
-}
-
 namespace fs = std::filesystem;
 
 extern logging::logger sstlog;
@@ -915,14 +911,10 @@ public:
     // will then re-export as public every method it needs.
     friend class test;
 
-    friend class components_writer;
-    friend class sstable_writer;
     friend class mc::writer;
     friend class index_reader;
     friend class promoted_index;
-    friend class compaction;
     friend class sstables_manager;
-    friend class mx::partition_reversing_data_source_impl;
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, uint64_t);


### PR DESCRIPTION
The components_writer class from this list doesn't even exist 
Also drop the forward declaration of mx::partition_reversing_data_source_impl