### PR TITLE
install-dependencies: Add minio server and client

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20230212
+docker.io/scylladb/scylla-toolchain:fedora-37-20230307


### PR DESCRIPTION
These two are static binaries, so no need in yum/apt-installing them with dependencies. Just download with curl and put them into /urs/local/bin with X-bit set.

This is needed for future object-storage work in order to run unit tests against minio.

refs: #12523

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>

[avi: regenerate frozen toolchain]

Closes #13064