### PR TITLE
docs/alternator: recommend to disable auto_snapshot

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -50,6 +50,13 @@ these default locations can overridden by specifying
 `--alternator-encryption-options keyfile="..."` and
 `--alternator-encryption-options certificate="..."`.
 
+By default, Scylla saves a snapshot of deleted tables. But Alternator does
+not offer an API to restore these snapshots, so these snapshots are not useful
+and waste disk space - deleting a table does not recover any disk space.
+It is therefore recommended to disable this automatic-snapshotting feature
+by configuring the **auto_snapshot** option to `false`.
+See also <https://github.com/scylladb/scylladb/issues/5283>.
+
 DynamoDB applications specify a single "endpoint" address, e.g.,
 `dynamodb.us-east-1.amazonaws.com`. Behind the scenes, a DNS server and/or
 load balancers distribute the connections to many different backend nodes.


### PR DESCRIPTION
In issue #5283 we noted that the auto_snapshot option is not useful in Alternator (as we don't offer any API to restore the snapshot...), and suggested that we should automatically disable this option for Alternator tables. However, this issue has been open for more than three years, and we never changed this default.

So until we solve that issue - if we ever do - let's add a paragraph in docs/alternator/alternator.md recommending to the user to disable this option in the configuration themselves. The text explains why, and also provides a link to the issue.

Refs #5283