### PR TITLE
mvcc: make schema upgrades gentle, old version of the PR

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -483,7 +483,7 @@ mutation_partition& view_updates::partition_for(partition_key&& key) {
     if (it != _updates.end()) {
         return it->second;
     }
-    return _updates.emplace(std::move(key), mutation_partition(_view)).first->second;
+    return _updates.emplace(std::move(key), mutation_partition(*_view)).first->second;
 }
 
 size_t view_updates::op_count() const {

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -13,13 +13,13 @@
 mutation::data::data(dht::decorated_key&& key, schema_ptr&& schema)
     : _schema(std::move(schema))
     , _dk(std::move(key))
-    , _p(_schema)
+    , _p(*_schema)
 { }
 
 mutation::data::data(partition_key&& key_, schema_ptr&& schema)
     : _schema(std::move(schema))
     , _dk(dht::decorate_key(*_schema, std::move(key_)))
-    , _p(_schema)
+    , _p(*_schema)
 { }
 
 mutation::data::data(schema_ptr&& schema, dht::decorated_key&& key, const mutation_partition& mp)

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -90,6 +90,9 @@ public:
     void apply(const schema& s, const deletable_row& r) {
         _row.apply(s, r);
     }
+    void apply(const schema& our_schema, const schema& their_schema, const deletable_row& r) {
+        _row.apply(our_schema, their_schema, r);
+    }
 
     position_in_partition_view position() const;
 

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -67,10 +67,10 @@ public:
     }
 
     void apply(const schema& s, clustering_row&& cr) {
-        _row.apply(s, std::move(cr._row));
+        _row.apply_monotonically(s, std::move(cr._row));
     }
     void apply(const schema& s, const clustering_row& cr) {
-        _row.apply(s, deletable_row(s, cr._row));
+        _row.apply_monotonically(s, deletable_row(s, cr._row));
     }
     void set_cell(const column_definition& def, atomic_cell_or_collection&& value) {
         _row.cells().apply(def, std::move(value));
@@ -85,7 +85,7 @@ public:
         _row.apply(std::move(t));
     }
     void apply(const schema& s, const rows_entry& r) {
-        _row.apply(s, deletable_row(s, r.row()));
+        _row.apply(s, r.row());
     }
     void apply(const schema& s, const deletable_row& r) {
         _row.apply(s, r);
@@ -149,7 +149,7 @@ public:
         _cells.apply(s, column_kind::static_column, r);
     }
     void apply(const schema& s, static_row&& sr) {
-        _cells.apply(s, column_kind::static_column, std::move(sr._cells));
+        _cells.apply_monotonically(s, column_kind::static_column, std::move(sr._cells));
     }
     void set_cell(const column_definition& def, atomic_cell_or_collection&& value) {
         _cells.apply(def, std::move(value));

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -243,21 +243,6 @@ void mutation_partition::ensure_last_dummy(const schema& s) {
     }
 }
 
-void mutation_partition::apply(const schema& s, const mutation_partition& p, const schema& p_schema,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, p, p_schema, app_stats);
-}
-
-void mutation_partition::apply(const schema& s, mutation_partition&& p,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, std::move(p), app_stats);
-}
-
-void mutation_partition::apply(const schema& s, mutation_partition_view p, const schema& p_schema,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, p, p_schema, app_stats);
-}
-
 struct mutation_fragment_applier {
     const schema& _s;
     mutation_partition& _mp;
@@ -508,7 +493,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
 }
 
 void
-mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
+mutation_partition::apply(const schema& s, mutation_partition_view p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
     mutation_partition p2(*this, copy_comparators_only{});
@@ -517,13 +502,13 @@ mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
     apply_monotonically(s, std::move(p2), p_schema, app_stats);
 }
 
-void mutation_partition::apply_weak(const schema& s, const mutation_partition& p,
+void mutation_partition::apply(const schema& s, const mutation_partition& p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
     apply_monotonically(s, mutation_partition(p_schema, p), p_schema, app_stats);
 }
 
-void mutation_partition::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
+void mutation_partition::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
     apply_monotonically(s, std::move(p), no_cache_tracker, app_stats);
 }
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -489,7 +489,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
     if (s.version() == p_schema.version()) {
         return apply_monotonically(s, std::move(p), no_cache_tracker, app_stats, preemptible, res);
     } else {
-        mutation_partition p2(s, p);
+        mutation_partition p2(p_schema, p);
         p2.upgrade(p_schema, s);
         return apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::no, res); // FIXME: make preemptible
     }
@@ -520,7 +520,7 @@ mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
 void mutation_partition::apply_weak(const schema& s, const mutation_partition& p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
-    apply_monotonically(s, mutation_partition(s, p), p_schema, app_stats);
+    apply_monotonically(s, mutation_partition(p_schema, p), p_schema, app_stats);
 }
 
 void mutation_partition::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1559,6 +1559,16 @@ row::row(const schema& s, column_kind kind, const row& o) : _size(o._size)
     _cells.clone_from(o._cells, clone_cell_and_hash);
 }
 
+row row::construct_row(const schema& our_schema, const schema& their_schema, column_kind kind, const row& o) {
+    if (our_schema.version() == their_schema.version()) {
+        return row(our_schema, kind, o);
+    } else {
+        row r;
+        r.apply(our_schema, their_schema, kind, o);
+        return r;
+    }
+}
+
 row::~row() {
 }
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1865,19 +1865,19 @@ bool row_marker::compact_and_expire(tombstone tomb, gc_clock::time_point now,
     return !is_missing() && _ttl != dead;
 }
 
-mutation_partition mutation_partition::difference(schema_ptr s, const mutation_partition& other) const
+mutation_partition mutation_partition::difference(const schema& s, const mutation_partition& other) const
 {
-    check_schema(*s);
-    mutation_partition mp(*s);
+    check_schema(s);
+    mutation_partition mp(s);
     if (_tombstone > other._tombstone) {
         mp.apply(_tombstone);
     }
-    mp._static_row = _static_row.difference(*s, column_kind::static_column, other._static_row);
+    mp._static_row = _static_row.difference(s, column_kind::static_column, other._static_row);
 
-    mp._row_tombstones = _row_tombstones.difference(*s, other._row_tombstones);
+    mp._row_tombstones = _row_tombstones.difference(s, other._row_tombstones);
 
     auto it_r = other._rows.begin();
-    rows_entry::compare cmp_r(*s);
+    rows_entry::compare cmp_r(s);
     for (auto&& r : _rows) {
         if (r.dummy()) {
             continue;
@@ -1885,12 +1885,12 @@ mutation_partition mutation_partition::difference(schema_ptr s, const mutation_p
         while (it_r != other._rows.end() && (it_r->dummy() || cmp_r(*it_r, r))) {
             ++it_r;
         }
-        if (it_r == other._rows.end() || !it_r->key().equal(*s, r.key())) {
-            mp.insert_row(*s, r.key(), r.row());
+        if (it_r == other._rows.end() || !it_r->key().equal(s, r.key())) {
+            mp.insert_row(s, r.key(), r.row());
         } else {
-            auto dr = r.row().difference(*s, column_kind::regular_column, it_r->row());
+            auto dr = r.row().difference(s, column_kind::regular_column, it_r->row());
             if (!dr.empty()) {
-                mp.insert_row(*s, r.key(), std::move(dr));
+                mp.insert_row(s, r.key(), std::move(dr));
             }
         }
     }

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1868,7 +1868,7 @@ bool row_marker::compact_and_expire(tombstone tomb, gc_clock::time_point now,
 mutation_partition mutation_partition::difference(schema_ptr s, const mutation_partition& other) const
 {
     check_schema(*s);
-    mutation_partition mp(s);
+    mutation_partition mp(*s);
     if (_tombstone > other._tombstone) {
         mp.apply(_tombstone);
     }
@@ -1928,7 +1928,7 @@ void mutation_partition::accept(const schema& s, mutation_partition_visitor& v) 
 void
 mutation_partition::upgrade(const schema& old_schema, const schema& new_schema) {
     // We need to copy to provide strong exception guarantees.
-    mutation_partition tmp(new_schema.shared_from_this());
+    mutation_partition tmp(new_schema);
     tmp.set_static_row_continuous(_static_row_continuous);
     converting_mutation_partition_applier v(old_schema.get_column_mapping(), new_schema, tmp);
     accept(old_schema, v);

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -269,7 +269,7 @@ struct mutation_fragment_applier {
     void operator()(const clustering_row& cr) {
         auto temp = clustering_row(_s, cr);
         auto& dr = _mp.clustered_row(_s, std::move(temp.key()));
-        dr.apply(_s, std::move(temp).as_deletable_row());
+        dr.apply_monotonically(_s, std::move(temp).as_deletable_row());
     }
 };
 
@@ -1147,14 +1147,6 @@ deletable_row::equal(column_kind kind, const schema& s, const deletable_row& oth
 }
 
 void deletable_row::apply(const schema& s, const deletable_row& src) {
-    apply_monotonically(s, src);
-}
-
-void deletable_row::apply(const schema& s, deletable_row&& src) {
-    apply_monotonically(s, std::move(src));
-}
-
-void deletable_row::apply_monotonically(const schema& s, const deletable_row& src) {
     _cells.apply(s, column_kind::regular_column, src._cells);
     _marker.apply(src._marker);
     _deleted_at.apply(src._deleted_at, _marker);
@@ -1632,10 +1624,6 @@ void row::apply(const schema& s, column_kind kind, const row& other) {
     other.for_each_cell([&] (column_id id, const cell_and_hash& c_a_h) {
         apply(s.column_at(kind, id), c_a_h.cell, c_a_h.hash);
     });
-}
-
-void row::apply(const schema& s, column_kind kind, row&& other) {
-    apply_monotonically(s, kind, std::move(other));
 }
 
 void row::apply_monotonically(const schema& s, column_kind kind, row&& other) {

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1386,7 +1386,7 @@ public:
     // Returns the minimal mutation_partition that when applied to "other" will
     // create a mutation_partition equal to the sum of other and this one.
     // This and other must both be governed by the same schema s.
-    mutation_partition difference(schema_ptr s, const mutation_partition& other) const;
+    mutation_partition difference(const schema& s, const mutation_partition& other) const;
 
     // Returns a subset of this mutation holding only information relevant for given clustering ranges.
     // Range tombstones will be trimmed to the boundaries of the clustering ranges.

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -97,6 +97,7 @@ public:
     row();
     ~row();
     row(const schema&, column_kind, const row&);
+    static row construct_row(const schema& our_schema, const schema& their_schema, column_kind, const row&);
     row(row&& other) noexcept;
     row& operator=(row&& other) noexcept;
     size_t size() const { return _size; }
@@ -819,6 +820,11 @@ public:
         : _deleted_at(other._deleted_at)
         , _marker(other._marker)
         , _cells(s, column_kind::regular_column, other._cells)
+    { }
+    deletable_row(const schema& our_schema, const schema& their_schema, const deletable_row& other)
+        : _deleted_at(other._deleted_at)
+        , _marker(other._marker)
+        , _cells(row::construct_row(our_schema, their_schema, column_kind::regular_column, other._cells))
     { }
     deletable_row(row_tombstone&& tomb, row_marker&& marker, row&& cells)
         : _deleted_at(std::move(tomb)), _marker(std::move(marker)), _cells(std::move(cells))

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1191,11 +1191,11 @@ public:
     static mutation_partition make_incomplete(const schema& s, tombstone t = {}) {
         return mutation_partition(incomplete_tag(), s, t);
     }
-    mutation_partition(schema_ptr s)
+    mutation_partition(const schema& s)
         : _rows()
-        , _row_tombstones(*s)
+        , _row_tombstones(s)
 #ifdef SEASTAR_DEBUG
-        , _schema_version(s->version())
+        , _schema_version(s.version())
 #endif
     { }
     mutation_partition(mutation_partition& other, copy_comparators_only)

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -178,6 +178,7 @@ public:
 
     // Weak exception guarantees
     void apply(const schema&, column_kind, const row& src);
+    void apply(const schema& from, const schema& to, column_kind kind, const row& other);
     // Monotonic exception guarantees
     void apply_monotonically(const schema&, column_kind, row&& src);
 
@@ -851,6 +852,7 @@ public:
 
     // Weak exception guarantees.
     void apply(const schema& s, const deletable_row& src);
+    void apply(const schema& from, const schema& to, const deletable_row& src);
     void apply_monotonically(const schema& s, deletable_row&& src);
 public:
     row_tombstone deleted_at() const { return _deleted_at; }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -960,6 +960,12 @@ public:
         , _range_tombstone(e._range_tombstone)
         , _flags(e._flags)
     { }
+    rows_entry(const schema& our_schema, const schema& their_schema, const rows_entry& e)
+        : _key(e._key)
+        , _row(our_schema, their_schema, e._row)
+        , _range_tombstone(e._range_tombstone)
+        , _flags(e._flags)
+    { }
     // Valid only if !dummy()
     clustering_key& key() {
         return _key;

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -995,6 +995,9 @@ public:
     void apply_monotonically(const schema& s, rows_entry&& e) {
         _row.apply_monotonically(s, std::move(e._row));
     }
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, rows_entry&& e) {
+        _row.apply(our_schema, their_schema, e._row);
+    }
     bool empty() const {
         return _row.empty();
     }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1280,14 +1280,14 @@ public:
     // is not representable in this_schema is dropped, thus apply() loses commutativity.
     //
     // Weak exception guarantees.
+    // Assumes this and p are not owned by a cache_tracker.
     void apply(const schema& this_schema, const mutation_partition& p, const schema& p_schema,
             mutation_application_stats& app_stats);
-    // Use in case this instance and p share the same schema.
-    // Same guarantees as apply(const schema&, mutation_partition&&, const schema&);
-    void apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
-    // Same guarantees and constraints as for apply(const schema&, const mutation_partition&, const schema&).
     void apply(const schema& this_schema, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
+    // Use in case this instance and p share the same schema.
+    // Same guarantees and constraints as for other variants of apply().
+    void apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -1320,15 +1320,6 @@ public:
     stop_iteration apply_monotonically(const schema& s, mutation_partition&& p, cache_tracker* tracker,
             mutation_application_stats& app_stats);
     stop_iteration apply_monotonically(const schema& s, mutation_partition&& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-
-    // Weak exception guarantees.
-    // Assumes this and p are not owned by a cache_tracker.
-    void apply_weak(const schema& s, const mutation_partition& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition&&,
-            mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -178,8 +178,6 @@ public:
 
     // Weak exception guarantees
     void apply(const schema&, column_kind, const row& src);
-    // Weak exception guarantees
-    void apply(const schema&, column_kind, row&& src);
     // Monotonic exception guarantees
     void apply_monotonically(const schema&, column_kind, row&& src);
 
@@ -851,11 +849,8 @@ public:
         _deleted_at.maybe_shadow(_marker);
     }
 
-    // Weak exception guarantees. After exception, both src and this will commute to the same value as
-    // they would should the exception not happen.
+    // Weak exception guarantees.
     void apply(const schema& s, const deletable_row& src);
-    void apply(const schema& s, deletable_row&& src);
-    void apply_monotonically(const schema& s, const deletable_row& src);
     void apply_monotonically(const schema& s, deletable_row&& src);
 public:
     row_tombstone deleted_at() const { return _deleted_at; }
@@ -990,7 +985,7 @@ public:
         _row.apply(t);
     }
     void apply_monotonically(const schema& s, rows_entry&& e) {
-        _row.apply(s, std::move(e._row));
+        _row.apply_monotonically(s, std::move(e._row));
     }
     bool empty() const {
         return _row.empty();

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -389,6 +389,14 @@ public:
     }
 
     // Weak exception guarantees
+    void apply(const schema& our_schema, const schema& their_schema, column_kind kind, const lazy_row& src) {
+        if (src.empty()) {
+            return;
+        }
+        maybe_create().apply(our_schema, their_schema, kind, src.get_existing());
+    }
+
+    // Weak exception guarantees
     void apply(const schema& s, column_kind kind, row&& src) {
         if (src.empty()) {
             return;

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -66,7 +66,7 @@ mutation_partition_v2::mutation_partition_v2(const schema& s, mutation_partition
     auto&& tombstones = x.mutable_row_tombstones();
     if (!tombstones.empty()) {
         try {
-            mutation_partition_v2 p(s.shared_from_this());
+            mutation_partition_v2 p(s);
 
             for (auto&& t: tombstones) {
                 range_tombstone & rt = t.tombstone();

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -506,7 +506,7 @@ mutation_partition_v2::apply_row_tombstone(const schema& schema, clustering_key_
 void
 mutation_partition_v2::apply_row_tombstone(const schema& schema, range_tombstone rt) {
     check_schema(schema);
-    mutation_partition mp(schema.shared_from_this());
+    mutation_partition mp(schema);
     mp.apply_row_tombstone(schema, std::move(rt));
     apply_v1(schema, std::move(mp));
 }
@@ -915,7 +915,7 @@ void mutation_partition_v2::accept(const schema& s, mutation_partition_visitor& 
 void
 mutation_partition_v2::upgrade(const schema& old_schema, const schema& new_schema) {
     // We need to copy to provide strong exception guarantees.
-    mutation_partition tmp(new_schema.shared_from_this());
+    mutation_partition tmp(new_schema);
     tmp.set_static_row_continuous(_static_row_continuous);
     converting_mutation_partition_applier v(old_schema.get_column_mapping(), new_schema, tmp);
     accept(old_schema, v);
@@ -923,7 +923,7 @@ mutation_partition_v2::upgrade(const schema& old_schema, const schema& new_schem
 }
 
 mutation_partition mutation_partition_v2::as_mutation_partition(const schema& s) const {
-    mutation_partition tmp(s.shared_from_this());
+    mutation_partition tmp(s);
     tmp.set_static_row_continuous(_static_row_continuous);
     partition_builder v(s, tmp);
     accept(s, v);

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -211,7 +211,6 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutat
     alloc_strategy_unique_ptr<rows_entry> p_sentinel;
     alloc_strategy_unique_ptr<rows_entry> this_sentinel;
     auto insert_sentinel_back = defer([&] {
-        // Insert this_sentinel before sentinel so that the former lands before the latter in LRU.
         if (this_sentinel) {
             assert(p_i != p._rows.end());
             auto rt = this_sentinel->range_tombstone();

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -124,19 +124,17 @@ void mutation_partition_v2::apply_v2(const schema& s, mutation_partition_v2&& p,
 
 stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const schema& p_s, mutation_partition_v2&& p, cache_tracker* tracker,
         mutation_application_stats& app_stats, preemption_check need_preempt, apply_resume& res, is_evictable evictable) {
-    // FIXME: we want to merge versions with different schemas.
-    // As of now, apply_monotonically takes two schema arguments,
-    // but the functionality isn't implemented yet, and the two
-    // schemas must be equal.
-    // This comment and the below assert will be removed once cross-schema
-    // merging is implemented.
-    assert(s.version() == p_s.version());
 #ifdef SEASTAR_DEBUG
     assert(_schema_version == s.version());
     assert(p._schema_version == p_s.version());
 #endif
+    bool same_schema = s.version() == p_s.version();
     _tombstone.apply(p._tombstone);
-    _static_row.apply_monotonically(s, column_kind::static_column, std::move(p._static_row));
+    if (same_schema) [[likely]] {
+        _static_row.apply_monotonically(s, column_kind::static_column, std::move(p._static_row));
+    } else {
+        _static_row.apply(s, p_s, column_kind::static_column, p._static_row);
+    }
     _static_row_continuous |= p._static_row_continuous;
 
     rows_entry::tri_compare cmp(s);
@@ -355,7 +353,7 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
                         position_in_partition::after_key(s, src_e.position()), is_dummy::yes, is_continuous::no));
                 if (src_e.position().is_clustering_row()) {
                     s2 = alloc_strategy_unique_ptr<rows_entry>(
-                            current_allocator().construct<rows_entry>(s,
+                            current_allocator().construct<rows_entry>(p_s,
                                 s1->position(), is_dummy::yes, is_continuous::yes));
                     if (i != _rows.end() && i->continuous()) {
                         s2->set_range_tombstone(i->range_tombstone() + src_e.range_tombstone());
@@ -365,31 +363,40 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
                 }
             }
 
-            rows_type::key_grabber pi_kg(p_i);
-            lb_i = _rows.insert_before(i, std::move(pi_kg));
+            if (same_schema) [[likely]] {
+                rows_type::key_grabber pi_kg(p_i);
+                lb_i = _rows.insert_before(i, std::move(pi_kg));
+            } else {
+                auto new_e = alloc_strategy_unique_ptr<rows_entry>(current_allocator().construct<rows_entry>(s, p_s, src_e));
+                lb_i = _rows.insert_before(i, std::move(new_e));
+                // FIXME?: possible violation of "older versions are evicted first",
+                // especially when combined with sentinels?
+                lb_i->swap(src_e);
+                p_i = p._rows.erase_and_dispose(p_i, del);
+            }
             p_sentinel = std::move(s1);
             this_sentinel = std::move(s2);
 
-            // Check if src_e falls into a continuous range.
+            // Check if src_e (now: lb_i) fell into a continuous range.
             // The range past the last entry is also always implicitly continuous.
             if (i == _rows.end() || i->continuous()) {
                 tombstone i_rt = i != _rows.end() ? i->range_tombstone() : tombstone();
                 // Cannot apply only-row range tombstone falling into a continuous range without inserting extra entry.
                 // Should not occur in practice due to the "older versions are evicted first" rule.
                 // Never occurs in non-evictable snapshots because they are continuous.
-                if (!src_e.continuous() && src_e.range_tombstone() > i_rt) {
-                    if (src_e.dummy()) {
+                if (!lb_i->continuous() && lb_i->range_tombstone() > i_rt) {
+                    if (lb_i->dummy()) {
                         lb_i->set_range_tombstone(i_rt);
                     } else {
                         position_in_partition_view i_pos = i != _rows.end() ? i->position()
                                 : position_in_partition_view::after_all_clustered_rows();
                         // See the "no singular tombstones" rule.
                         mplog.error("Cannot merge entry {} with rt={}, cont=0 into continuous range before {} with rt={}",
-                                src_e.position(), src_e.range_tombstone(), i_pos, i_rt);
+                                lb_i->position(), lb_i->range_tombstone(), i_pos, i_rt);
                         abort();
                     }
                 } else {
-                    lb_i->set_range_tombstone(src_e.range_tombstone() + i_rt);
+                    lb_i->set_range_tombstone(lb_i->range_tombstone() + i_rt);
                 }
                 lb_i->set_continuous(true);
             }
@@ -440,18 +447,26 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
                 }
             }
             if (tracker) {
-                // Newer evictable versions store complete rows
-                i->row() = std::move(src_e.row());
-                // Need to preserve the LRU link of the later version in case it's
-                // the last dummy entry which holds the partition entry linked in LRU.
-                i->swap(src_e);
+                if (same_schema) [[likely]] {
+                    // Newer evictable versions store complete rows
+                    i->row() = std::move(src_e.row());
+                    // Need to preserve the LRU link of the later version in case it's
+                    // the last dummy entry which holds the partition entry linked in LRU.
+                    i->swap(src_e);
+                } else {
+                    i->apply_monotonically(s, p_s, std::move(src_e));
+                }
                 tracker->remove(src_e);
             } else {
                 // Avoid row compaction if no newer range tombstone.
                 do_compact = (src_e.range_tombstone() + src_e.row().deleted_at().regular()) >
                             (i->range_tombstone() + i->row().deleted_at().regular());
                 memory::on_alloc_point();
-                i->apply_monotonically(s, std::move(src_e));
+                if (same_schema) [[likely]] {
+                    i->apply_monotonically(s, std::move(src_e));
+                } else {
+                    i->apply_monotonically(s, p_s, std::move(src_e));
+                }
             }
             ++app_stats.row_hits;
             p_i = p._rows.erase_and_dispose(p_i, del);

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -75,8 +75,7 @@ mutation_partition_v2::mutation_partition_v2(const schema& s, mutation_partition
                         .set_range_tombstone(rt.tomb);
             }
 
-            mutation_application_stats app_stats;
-            apply_monotonically(s, std::move(p), s, app_stats);
+            apply_v2(s, std::move(p));
         } catch (...) {
             _rows.clear_and_dispose(current_deleter<rows_entry>());
             throw;
@@ -114,17 +113,27 @@ std::ostream& operator<<(std::ostream& out, const apply_resume& res) {
     return out << "{" << int(res._stage) << ", " << res._pos << "}";
 }
 
-stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker* tracker,
-        mutation_application_stats& app_stats, is_preemptible preemptible, apply_resume& res, is_evictable evictable) {
-    return apply_monotonically(s, std::move(p), tracker, app_stats,
-        preemptible ? default_preemption_check() : never_preempt(), res, evictable);
+void mutation_partition_v2::apply_v1(const schema& s, mutation_partition&& p) {
+    apply_v2(s, mutation_partition_v2(s, std::move(p)));
+}
+void mutation_partition_v2::apply_v2(const schema& s, mutation_partition_v2&& p, cache_tracker* tracker, is_evictable evictable) {
+    mutation_application_stats app_stats;
+    apply_resume res;
+    apply_monotonically(s, s, std::move(p), tracker, app_stats, never_preempt(), res, evictable);
 }
 
-stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker* tracker,
+stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const schema& p_s, mutation_partition_v2&& p, cache_tracker* tracker,
         mutation_application_stats& app_stats, preemption_check need_preempt, apply_resume& res, is_evictable evictable) {
+    // FIXME: we want to merge versions with different schemas.
+    // As of now, apply_monotonically takes two schema arguments,
+    // but the functionality isn't implemented yet, and the two
+    // schemas must be equal.
+    // This comment and the below assert will be removed once cross-schema
+    // merging is implemented.
+    assert(s.version() == p_s.version());
 #ifdef SEASTAR_DEBUG
-    assert(s.version() == _schema_version);
-    assert(p._schema_version == _schema_version);
+    assert(_schema_version == s.version());
+    assert(p._schema_version == p_s.version());
 #endif
     _tombstone.apply(p._tombstone);
     _static_row.apply_monotonically(s, column_kind::static_column, std::move(p._static_row));
@@ -486,43 +495,6 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutat
     return stop_iteration::yes;
 }
 
-stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-        mutation_application_stats& app_stats, is_preemptible preemptible, apply_resume& res, is_evictable evictable) {
-    if (s.version() == p_schema.version()) {
-        return apply_monotonically(s, std::move(p), no_cache_tracker, app_stats,
-                                   preemptible ? default_preemption_check() : never_preempt(), res, evictable);
-    } else {
-        mutation_partition_v2 p2(s, p);
-        p2.upgrade(p_schema, s);
-        return apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, never_preempt(), res, evictable); // FIXME: make preemptible
-    }
-}
-
-stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker *tracker,
-                                                       mutation_application_stats& app_stats, is_evictable evictable) {
-    apply_resume res;
-    return apply_monotonically(s, std::move(p), tracker, app_stats, is_preemptible::no, res, evictable);
-}
-
-stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-                                                       mutation_application_stats& app_stats) {
-    apply_resume res;
-    return apply_monotonically(s, std::move(p), p_schema, app_stats, is_preemptible::no, res, is_evictable::no);
-}
-
-void mutation_partition_v2::apply(const schema& s, const mutation_partition_v2& p, const schema& p_schema,
-                               mutation_application_stats& app_stats) {
-    apply_monotonically(s, mutation_partition_v2(p_schema, std::move(p)), p_schema, app_stats);
-}
-
-void mutation_partition_v2::apply(const schema& s, mutation_partition_v2&& p, mutation_application_stats& app_stats) {
-    apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
-}
-
-void mutation_partition_v2::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
-    apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
-}
-
 void
 mutation_partition_v2::apply_row_tombstone(const schema& schema, clustering_key_prefix prefix, tombstone t) {
     check_schema(schema);
@@ -536,8 +508,7 @@ mutation_partition_v2::apply_row_tombstone(const schema& schema, range_tombstone
     check_schema(schema);
     mutation_partition mp(schema.shared_from_this());
     mp.apply_row_tombstone(schema, std::move(rt));
-    mutation_application_stats stats;
-    apply(schema, std::move(mp), stats);
+    apply_v1(schema, std::move(mp));
 }
 
 void

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -519,23 +519,7 @@ void mutation_partition_v2::apply(const schema& s, mutation_partition_v2&& p, mu
     apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
 }
 
-void
-mutation_partition_v2::apply_weak(const schema& s, mutation_partition_view p,
-                                  const schema& p_schema, mutation_application_stats& app_stats) {
-    // FIXME: Optimize
-    mutation_partition p2(p_schema.shared_from_this());
-    partition_builder b(p_schema, p2);
-    p.accept(p_schema, b);
-    apply_monotonically(s, mutation_partition_v2(p_schema, std::move(p2)), p_schema, app_stats);
-}
-
-void mutation_partition_v2::apply_weak(const schema& s, const mutation_partition& p,
-                                       const schema& p_schema, mutation_application_stats& app_stats) {
-    // FIXME: Optimize
-    apply_monotonically(s, mutation_partition_v2(s, p), p_schema, app_stats);
-}
-
-void mutation_partition_v2::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
+void mutation_partition_v2::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
     apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
 }
 
@@ -553,7 +537,7 @@ mutation_partition_v2::apply_row_tombstone(const schema& schema, range_tombstone
     mutation_partition mp(schema.shared_from_this());
     mp.apply_row_tombstone(schema, std::move(rt));
     mutation_application_stats stats;
-    apply_weak(schema, std::move(mp), stats);
+    apply(schema, std::move(mp), stats);
 }
 
 void

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -178,7 +178,10 @@ public:
             mutation_application_stats& app_stats);
     // Use in case this instance and p share the same schema.
     // Same guarantees as apply(const schema&, mutation_partition_v2&&, const schema&);
+    // Weak exception guarantees.
+    // Assumes this and p are not owned by a cache_tracker and non-evictable.
     void apply(const schema& s, mutation_partition_v2&& p, mutation_application_stats& app_stats);
+    void apply(const schema& s, mutation_partition&&, mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -214,15 +217,6 @@ public:
             mutation_application_stats& app_stats);
     stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
             mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
-
-    // Weak exception guarantees.
-    // Assumes this and p are not owned by a cache_tracker and non-evictable.
-    void apply_weak(const schema& s, const mutation_partition& p, const schema& p_schema,
-                    mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition&&,
-                    mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition_view p, const schema& p_schema,
-                    mutation_application_stats& app_stats);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed
     // using the new schema.

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -89,10 +89,10 @@ public:
     static mutation_partition_v2 make_incomplete(const schema& s, tombstone t = {}) {
         return mutation_partition_v2(incomplete_tag(), s, t);
     }
-    mutation_partition_v2(schema_ptr s)
+    mutation_partition_v2(const schema& s)
         : _rows()
 #ifdef SEASTAR_DEBUG
-        , _schema_version(s->version())
+        , _schema_version(s.version())
 #endif
     { }
     mutation_partition_v2(mutation_partition_v2& other, copy_comparators_only)

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -167,21 +167,11 @@ public:
     // prefix must not be full
     void apply_row_tombstone(const schema& schema, clustering_key_prefix prefix, tombstone t);
     void apply_row_tombstone(const schema& schema, range_tombstone rt);
-    //
     // Applies p to current object.
-    //
-    // Commutative when this_schema == p_schema. If schemas differ, data in p which
-    // is not representable in this_schema is dropped, thus apply() loses commutativity.
-    //
-    // Weak exception guarantees.
-    void apply(const schema& this_schema, const mutation_partition_v2& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    // Use in case this instance and p share the same schema.
-    // Same guarantees as apply(const schema&, mutation_partition_v2&&, const schema&);
     // Weak exception guarantees.
     // Assumes this and p are not owned by a cache_tracker and non-evictable.
-    void apply(const schema& s, mutation_partition_v2&& p, mutation_application_stats& app_stats);
-    void apply(const schema& s, mutation_partition&&, mutation_application_stats& app_stats);
+    void apply_v1(const schema& s, mutation_partition&&);
+    void apply_v2(const schema& s, mutation_partition_v2&& p, cache_tracker* = nullptr, is_evictable evictable = is_evictable::no);
 
     // Applies p to this instance.
     //
@@ -207,16 +197,8 @@ public:
     //
     // If is_preemptible::yes is passed, apply_resume must also be passed,
     // same instance each time until stop_iteration::yes is returned.
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
-            mutation_application_stats& app_stats, is_preemptible, apply_resume&, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-            mutation_application_stats& app_stats, is_preemptible, apply_resume&, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker* tracker,
-            mutation_application_stats& app_stats, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
-            mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
+    stop_iteration apply_monotonically(const schema& this_schema, const schema& p_schema, mutation_partition_v2&& p,
+            cache_tracker*, mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed
     // using the new schema.

--- a/mutation/mutation_rebuilder.hh
+++ b/mutation/mutation_rebuilder.hh
@@ -46,7 +46,7 @@ public:
         auto& dr = _m->partition().clustered_row(*_s, std::move(cr.key()));
         dr.apply(cr.tomb());
         dr.apply(cr.marker());
-        dr.cells().apply(*_s, column_kind::regular_column, std::move(cr.cells()));
+        dr.cells().apply_monotonically(*_s, column_kind::regular_column, std::move(cr.cells()));
         return stop_iteration::no;
     }
 

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -329,7 +329,7 @@ partition_version& partition_entry::add_version(const schema& s, cache_tracker* 
     // Such versions must be fully discontinuous, and thus have a dummy at the end.
     auto new_version = tracker
                        ? current_allocator().construct<partition_version>(mutation_partition_v2::make_incomplete(s))
-                       : current_allocator().construct<partition_version>(mutation_partition_v2(s.shared_from_this()));
+                       : current_allocator().construct<partition_version>(mutation_partition_v2(s));
     new_version->partition().set_static_row_continuous(_version->partition().static_row_continuous());
     new_version->insert_before(*_version);
     set_version(new_version);
@@ -548,7 +548,7 @@ utils::coroutine partition_entry::apply_to_incomplete(const schema& s,
 
 mutation_partition_v2 partition_entry::squashed(schema_ptr from, schema_ptr to, is_evictable evictable)
 {
-    mutation_partition_v2 mp(to);
+    mutation_partition_v2 mp(*to);
     mp.set_static_row_continuous(_version->partition().static_row_continuous());
     for (auto&& v : _version->all_elements()) {
         auto older = mutation_partition_v2(*from, v.partition());

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -644,7 +644,7 @@ std::ostream& operator<<(std::ostream& out, const partition_entry::printer& p) {
                 }
                 out << ") ";
             }
-            out << fmt::ptr(v) << ": " << mutation_partition_v2::printer(p._schema, v->partition());
+            out << fmt::ptr(v) << ": " << mutation_partition_v2::printer(*v->get_schema(), v->partition());
             v = v->next();
             first = false;
         }

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -120,12 +120,12 @@ inline Result squashed(const partition_version_ref& v, Map&& map, Reduce&& reduc
     return ::static_row(::squashed<row>(version(),
                          [&] (const mutation_partition_v2& mp) -> const row& {
                             if (digest_requested) {
-                                mp.static_row().prepare_hash(*_schema, column_kind::static_column);
+                                mp.static_row().prepare_hash(*schema(), column_kind::static_column);
                             }
                             return mp.static_row().get();
                          },
-                         [this] (const row& r) { return row(*_schema, column_kind::static_column, r); },
-                         [this] (row& a, const row& b) { a.apply(*_schema, column_kind::static_column, b); }));
+                         [this] (const row& r) { return row(*schema(), column_kind::static_column, r); },
+                         [this] (row& a, const row& b) { a.apply(*schema(), column_kind::static_column, b); }));
 }
 
 bool partition_snapshot::static_row_continuous() const {
@@ -141,12 +141,12 @@ tombstone partition_snapshot::partition_tombstone() const {
 mutation_partition partition_snapshot::squashed() const {
     return ::squashed<mutation_partition>(version(),
                                [this] (const mutation_partition_v2& mp) -> mutation_partition {
-                                   return mp.as_mutation_partition(*_schema);
+                                   return mp.as_mutation_partition(*schema());
                                },
                                [] (mutation_partition&& mp) { return std::move(mp); },
                                [this] (mutation_partition& a, const mutation_partition& b) {
                                    mutation_application_stats app_stats;
-                                   a.apply(*_schema, b, *_schema, app_stats);
+                                   a.apply(*schema(), b, *schema(), app_stats);
                                });
 }
 
@@ -604,7 +604,7 @@ partition_snapshot_ptr partition_entry::read(logalloc::region& r,
         }
     }
 
-    auto snp = make_lw_shared<partition_snapshot>(entry_schema, r, cleaner, this, tracker, phase);
+    auto snp = make_lw_shared<partition_snapshot>(r, cleaner, this, tracker, phase);
     _snapshot = snp.get();
     return partition_snapshot_ptr(std::move(snp));
 }

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -571,30 +571,29 @@ utils::coroutine partition_entry::apply_to_incomplete(const schema& s,
     });
 }
 
-mutation_partition_v2 partition_entry::squashed(schema_ptr from, schema_ptr to, is_evictable evictable)
+mutation_partition_v2 partition_entry::squashed_v2(const schema& to, is_evictable evictable)
 {
-    mutation_partition_v2 mp(*to);
+    mutation_partition_v2 mp(to);
     mp.set_static_row_continuous(_version->partition().static_row_continuous());
     for (auto&& v : _version->all_elements()) {
-        auto older = mutation_partition_v2(*from, v.partition());
-        if (from->version() != to->version()) {
-            older.upgrade(*from, *to);
+        auto older = mutation_partition_v2(*v.get_schema(), v.partition());
+        if (v.get_schema()->version() != to.version()) {
+            older.upgrade(*v.get_schema(), to);
         }
-        merge_versions(*to, mp, std::move(older), no_cache_tracker, evictable);
+        merge_versions(to, mp, std::move(older), no_cache_tracker, evictable);
     }
     return mp;
 }
 
 mutation_partition partition_entry::squashed(const schema& s, is_evictable evictable)
 {
-    return squashed(s.shared_from_this(), s.shared_from_this(), evictable)
-        .as_mutation_partition(s);
+    return squashed_v2(s, evictable).as_mutation_partition(s);
 }
 
 void partition_entry::upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
 {
   with_allocator(r.allocator(), [&] {
-    auto new_version = r.allocator().construct<partition_version>(squashed(from, to, is_evictable(bool(tracker))), to);
+    auto new_version = r.allocator().construct<partition_version>(squashed_v2(*to, is_evictable(bool(tracker))), to);
     auto old_version = &*_version;
     set_version(new_version);
     if (tracker) {

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -590,7 +590,7 @@ mutation_partition partition_entry::squashed(const schema& s, is_evictable evict
     return squashed_v2(s, evictable).as_mutation_partition(s);
 }
 
-void partition_entry::upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
+void partition_entry::upgrade(logalloc::region& r, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
 {
   with_allocator(r.allocator(), [&] {
     auto new_version = r.allocator().construct<partition_version>(squashed_v2(*to, is_evictable(bool(tracker))), to);

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -117,15 +117,20 @@ inline Result squashed(const partition_version_ref& v, Map&& map, Reduce&& reduc
 }
 
 ::static_row partition_snapshot::static_row(bool digest_requested) const {
-    return ::static_row(::squashed<row>(version(),
-                         [&] (const mutation_partition_v2& mp) -> const row& {
-                            if (digest_requested) {
-                                mp.static_row().prepare_hash(*schema(), column_kind::static_column);
-                            }
-                            return mp.static_row().get();
-                         },
-                         [this] (const row& r) { return row(*schema(), column_kind::static_column, r); },
-                         [this] (row& a, const row& b) { a.apply(*schema(), column_kind::static_column, b); }));
+    const partition_version* this_v = &*version();
+    partition_version* it = this_v->last();
+    if (digest_requested) {
+        it->partition().static_row().prepare_hash(*it->get_schema(), column_kind::static_column);
+    }
+    row r = row::construct_row(*this_v->get_schema(), *it->get_schema(), column_kind::static_column, it->partition().static_row().get());
+    while (it != this_v) {
+        it = it->prev();
+        if (digest_requested) {
+            it->partition().static_row().prepare_hash(*it->get_schema(), column_kind::static_column);
+        }
+        r.apply(*this_v->get_schema(), *it->get_schema(), column_kind::static_column, it->partition().static_row().get());
+    }
+    return ::static_row(std::move(r));
 }
 
 bool partition_snapshot::static_row_continuous() const {

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -592,15 +592,16 @@ mutation_partition partition_entry::squashed(const schema& s, is_evictable evict
 
 void partition_entry::upgrade(logalloc::region& r, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
 {
-  with_allocator(r.allocator(), [&] {
-    auto new_version = r.allocator().construct<partition_version>(squashed_v2(*to, is_evictable(bool(tracker))), to);
-    auto old_version = &*_version;
-    set_version(new_version);
-    if (tracker) {
-        tracker->insert(*new_version);
-    }
-    remove_or_mark_as_unique_owner(old_version, &cleaner);
-  });
+    with_allocator(r.allocator(), [&] {
+        auto phase = partition_snapshot::max_phase;
+        if (_snapshot) {
+            phase = _snapshot->_phase;
+        }
+        // The destruction of this snapshot pointer will trigger a background merge
+        // of the old version into the new version.
+        partition_snapshot_ptr snp = read(r, cleaner, tracker, phase);
+        add_version(*to, tracker);
+    });
 }
 
 partition_snapshot_ptr partition_entry::read(logalloc::region& r,

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -166,8 +166,7 @@ partition_snapshot::~partition_snapshot() {
 }
 
 void merge_versions(const schema& s, mutation_partition_v2& newer, mutation_partition_v2&& older, cache_tracker* tracker, is_evictable evictable) {
-    mutation_application_stats app_stats;
-    older.apply_monotonically(s, std::move(newer), tracker, app_stats, evictable);
+    older.apply_v2(s, std::move(newer), tracker, evictable);
     newer = std::move(older);
 }
 
@@ -191,7 +190,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
                 _version_merging_state = apply_resume();
             }
             const auto do_stop_iteration = current->partition().apply_monotonically(*schema(),
-                std::move(prev->partition()), _tracker, local_app_stats, is_preemptible::yes, *_version_merging_state,
+                *schema(), std::move(prev->partition()), _tracker, local_app_stats, default_preemption_check(), *_version_merging_state,
                 is_evictable(bool(_tracker)));
             app_stats.row_hits += local_app_stats.row_hits;
             if (do_stop_iteration == stop_iteration::no) {
@@ -369,11 +368,11 @@ void partition_entry::apply(logalloc::region& r, mutation_cleaner& cleaner, cons
         try {
             apply_resume res;
             auto notify = cleaner.make_region_space_guard();
-            if (_version->partition().apply_monotonically(s,
+            if (_version->partition().apply_monotonically(s, s,
                       std::move(new_version->partition()),
                       no_cache_tracker,
                       app_stats,
-                      is_preemptible::yes,
+                      default_preemption_check(),
                       res,
                       is_evictable::no) == stop_iteration::yes) {
                 current_allocator().destroy(new_version);

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -120,7 +120,7 @@ public:
     }
 
     explicit partition_version(schema_ptr s) noexcept
-        : _partition(std::move(s)) { }
+        : _partition(*s) { }
     explicit partition_version(mutation_partition_v2 mp) noexcept
         : _partition(std::move(mp)) { }
     partition_version(partition_version&& pv) noexcept;

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -109,6 +109,7 @@ class partition_version_ref;
 
 class partition_version : public anchorless_list_base_hook<partition_version> {
     partition_version_ref* _backref = nullptr;
+    schema_ptr _schema;
     mutation_partition_v2 _partition;
 
     friend class partition_version_ref;
@@ -120,9 +121,18 @@ public:
     }
 
     explicit partition_version(schema_ptr s) noexcept
-        : _partition(*s) { }
-    explicit partition_version(mutation_partition_v2 mp) noexcept
-        : _partition(std::move(mp)) { }
+        : _schema(std::move(s))
+        , _partition(*_schema)
+    {
+        assert(_schema);
+    }
+    explicit partition_version(mutation_partition_v2 mp, schema_ptr s) noexcept
+        : _schema(std::move(s))
+        , _partition(std::move(mp))
+    {
+        assert(_schema);
+    }
+
     partition_version(partition_version&& pv) noexcept;
     partition_version& operator=(partition_version&& pv) noexcept;
     ~partition_version();
@@ -138,7 +148,9 @@ public:
     bool is_referenced_from_entry() const;
     partition_version_ref& back_reference() const { return *_backref; }
 
-    size_t size_in_allocator(const schema& s, allocation_strategy& allocator) const;
+    size_t size_in_allocator(allocation_strategy& allocator) const;
+
+    const schema_ptr& get_schema() const noexcept { return _schema; }
 };
 
 using partition_version_range = anchorless_list_base_hook<partition_version>::range;
@@ -442,7 +454,7 @@ public:
     // Constructs a non-evictable entry holding empty partition
     partition_entry() = default;
     // Constructs a non-evictable entry
-    explicit partition_entry(mutation_partition_v2);
+    partition_entry(const schema&, mutation_partition_v2);
     partition_entry(const schema&, mutation_partition);
     // Returns a reference to partition_entry containing given pv,
     // assuming pv.is_referenced_from_entry().
@@ -595,6 +607,8 @@ public:
     // needs to be called with reclaiming disabled
     // Must not be called when is_locked().
     void upgrade(schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
+
+    const schema_ptr& get_schema() const noexcept { return _version->get_schema(); }
 
     // Snapshots with different values of phase will point to different partition_version objects.
     // When is_locked(), read() can only be called with a phase which is <= the phase of the current snapshot.

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -616,10 +616,9 @@ public:
         partition_snapshot::phase_type phase = partition_snapshot::default_phase);
 
     class printer {
-        const schema& _schema;
         const partition_entry& _partition_entry;
     public:
-        printer(const schema& s, const partition_entry& pe) : _schema(s), _partition_entry(pe) { }
+        printer(const partition_entry& pe) : _partition_entry(pe) { }
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -526,24 +526,28 @@ public:
                const schema& mp_schema,
                mutation_application_stats& app_stats);
 
-    // Adds mutation_partition represented by "other" to the one represented
+    // Adds mutation_partition represented by "pe" to the one represented
     // by this entry.
     // This entry must be evictable.
+    // "pe" must be fully-continuous.
+    // (Alternatively: applies the "pe" memtable entry to "this" cache entry.)
     //
-    // The argument must be fully-continuous.
-    //
-    // The continuity of this entry remains unchanged. Information from "other"
+    // The continuity of this entry remains unchanged. Information from "pe"
     // which is incomplete in this instance is dropped. In other words, this
     // performs set intersection on continuity information, drops information
     // which falls outside of the continuity range, and applies regular merging
     // rules for the rest.
+    // (Rationale: updates from the memtable are only applied to intervals
+    // which were already in cache. The cache treats the entire sstable set as a
+    // single source -- it isn't able to store partial information only from a
+    // single sstable.)
     //
     // Weak exception guarantees.
-    // If an exception is thrown this and pe will be left in some valid states
+    // If an exception is thrown, "this" and "pe" will be left in some valid states
     // such that if the operation is retried (possibly many times) and eventually
     // succeeds the result will be as if the first attempt didn't fail.
     //
-    // The schema of pe must conform to s.
+    // The schema of "pe" must conform to "s".
     //
     // Returns a coroutine object representing the operation.
     // The coroutine must be resumed with the region being unlocked.

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -604,7 +604,7 @@ public:
 
     // needs to be called with reclaiming disabled
     // Must not be called when is_locked().
-    void upgrade(schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
+    void upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
 
     const schema_ptr& get_schema() const noexcept { return _version->get_schema(); }
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -271,7 +271,6 @@ public:
         }
     };
 private:
-    schema_ptr _schema;
     // Either _version or _entry is non-null.
     partition_version_ref _version;
     partition_entry* _entry;
@@ -285,13 +284,12 @@ private:
     friend class partition_entry;
     friend class mutation_cleaner_impl;
 public:
-    explicit partition_snapshot(schema_ptr s,
-                                logalloc::region& region,
+    explicit partition_snapshot(logalloc::region& region,
                                 mutation_cleaner& cleaner,
                                 partition_entry* entry,
                                 cache_tracker* tracker, // non-null for evictable snapshots
                                 phase_type phase = default_phase)
-        : _schema(std::move(s)), _entry(entry), _phase(phase), _region(&region), _cleaner(&cleaner), _tracker(tracker) { }
+        : _entry(entry), _phase(phase), _region(&region), _cleaner(&cleaner), _tracker(tracker) { }
     partition_snapshot(const partition_snapshot&) = delete;
     partition_snapshot(partition_snapshot&&) = delete;
     partition_snapshot& operator=(const partition_snapshot&) = delete;
@@ -373,7 +371,7 @@ public:
         return !version()->next();
     }
 
-    const schema_ptr& schema() const { return _schema; }
+    const schema_ptr& schema() const { return version()->get_schema(); }
     logalloc::region& region() const { return *_region; }
     cache_tracker* tracker() const { return _tracker; }
     mutation_cleaner& cleaner() { return *_cleaner; }

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -598,7 +598,7 @@ public:
         return *_version;
     }
 
-    mutation_partition_v2 squashed(schema_ptr from, schema_ptr to, is_evictable);
+    mutation_partition_v2 squashed_v2(const schema& to, is_evictable);
     mutation_partition squashed(const schema&, is_evictable);
     tombstone partition_tombstone() const;
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -604,7 +604,7 @@ public:
 
     // needs to be called with reclaiming disabled
     // Must not be called when is_locked().
-    void upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
+    void upgrade(logalloc::region& r, schema_ptr to, mutation_cleaner&, cache_tracker*);
 
     const schema_ptr& get_schema() const noexcept { return _version->get_schema(); }
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -612,7 +612,6 @@ public:
     // When is_locked(), read() can only be called with a phase which is <= the phase of the current snapshot.
     partition_snapshot_ptr read(logalloc::region& region,
         mutation_cleaner&,
-        schema_ptr entry_schema,
         cache_tracker*,
         partition_snapshot::phase_type phase = partition_snapshot::default_phase);
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -696,7 +696,7 @@ public:
 };
 
 partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
-    return _pe.read(mtbl.region(), mtbl.cleaner(), schema(), no_cache_tracker);
+    return _pe.read(mtbl.region(), mtbl.cleaner(), no_cache_tracker);
 }
 
 flat_mutation_reader_v2_opt

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -840,7 +840,7 @@ bool memtable::is_flushed() const noexcept {
 
 void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
-        partition().upgrade(r, schema(), s, cleaner, no_cache_tracker);
+        partition().upgrade(r, s, cleaner, no_cache_tracker);
     }
 }
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -840,16 +840,14 @@ bool memtable::is_flushed() const noexcept {
 
 void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
-        partition().upgrade(schema(), s, cleaner, no_cache_tracker);
+        partition().upgrade(r, schema(), s, cleaner, no_cache_tracker);
     }
 }
 
 void memtable::upgrade_entry(memtable_entry& e) {
     if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
-        with_allocator(allocator(), [this, &e] {
-            e.upgrade_schema(region(), _schema, cleaner());
-        });
+        e.upgrade_schema(region(), _schema, cleaner());
     }
 }
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -225,7 +225,7 @@ memtable::find_or_create_partition(const dht::decorated_key& key) {
     if (i == partitions.end() || !hint.match) {
         partitions_type::iterator entry = partitions.emplace_before(i,
                 key.token().raw(), hint,
-                _schema, dht::decorated_key(key), mutation_partition(_schema));
+                _schema, dht::decorated_key(key), mutation_partition(*_schema));
         ++nr_partitions;
         ++_table_stats.memtable_partition_insertions;
         if (!hint.emplace_keeps_iterators()) {
@@ -793,7 +793,7 @@ memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_han
     with_allocator(allocator(), [this, &m, &m_schema] {
         _allocating_section(*this, [&, this] {
             auto& p = find_or_create_partition_slow(m.key());
-            mutation_partition mp(m_schema);
+            mutation_partition mp(*m_schema);
             partition_builder pb(*m_schema, mp);
             m.partition().accept(*m_schema, pb);
             _stats_collector.update(*m_schema, mp);

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -838,7 +838,7 @@ bool memtable::is_flushed() const noexcept {
     return bool(_underlying);
 }
 
-void memtable_entry::upgrade_schema(const schema_ptr& s, mutation_cleaner& cleaner) {
+void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
         partition().upgrade(schema(), s, cleaner, no_cache_tracker);
     }
@@ -848,7 +848,7 @@ void memtable::upgrade_entry(memtable_entry& e) {
     if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
         with_allocator(allocator(), [this, &e] {
-            e.upgrade_schema(_schema, cleaner());
+            e.upgrade_schema(region(), _schema, cleaner());
         });
     }
 }

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -696,7 +696,7 @@ public:
 };
 
 partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
-    return _pe.read(mtbl.region(), mtbl.cleaner(), _schema, no_cache_tracker);
+    return _pe.read(mtbl.region(), mtbl.cleaner(), schema(), no_cache_tracker);
 }
 
 flat_mutation_reader_v2_opt
@@ -821,8 +821,7 @@ mutation_source memtable::as_data_source() {
 }
 
 memtable_entry::memtable_entry(memtable_entry&& o) noexcept
-    : _schema(std::move(o._schema))
-    , _key(std::move(o._key))
+    : _key(std::move(o._key))
     , _pe(std::move(o._pe))
     , _flags(o._flags)
 { }
@@ -840,14 +839,13 @@ bool memtable::is_flushed() const noexcept {
 }
 
 void memtable_entry::upgrade_schema(const schema_ptr& s, mutation_cleaner& cleaner) {
-    if (_schema != s) {
-        partition().upgrade(_schema, s, cleaner, no_cache_tracker);
-        _schema = s;
+    if (schema() != s) {
+        partition().upgrade(schema(), s, cleaner, no_cache_tracker);
     }
 }
 
 void memtable::upgrade_entry(memtable_entry& e) {
-    if (e._schema != _schema) {
+    if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
         with_allocator(allocator(), [this, &e] {
             e.upgrade_schema(_schema, cleaner());

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -867,7 +867,7 @@ std::ostream& operator<<(std::ostream& out, memtable& mt) {
 }
 
 std::ostream& operator<<(std::ostream& out, const memtable_entry& mt) {
-    return out << "{" << mt.key() << ": " << partition_entry::printer(*mt.schema(), mt.partition()) << "}";
+    return out << "{" << mt.key() << ": " << partition_entry::printer(mt.partition()) << "}";
 }
 
 }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -68,7 +68,7 @@ public:
 
     // Makes the entry conform to given schema.
     // Must be called under allocating section of the region which owns the entry.
-    void upgrade_schema(const schema_ptr&, mutation_cleaner&);
+    void upgrade_schema(logalloc::region&, const schema_ptr&, mutation_cleaner&);
 
     size_t external_memory_usage_without_rows() const {
         return _key.key().external_memory_usage();

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -86,7 +86,7 @@ public:
     size_t size_in_allocator(allocation_strategy& allocator) {
         auto size = size_in_allocator_without_rows(allocator);
         for (auto&& v : _pe.versions()) {
-            size += v.size_in_allocator(*_schema, allocator);
+            size += v.size_in_allocator(allocator);
         }
         return size;
     }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -33,7 +33,6 @@ namespace bi = boost::intrusive;
 namespace replica {
 
 class memtable_entry {
-    schema_ptr _schema;
     dht::decorated_key _key;
     partition_entry _pe;
     struct {
@@ -52,9 +51,8 @@ public:
     friend class memtable;
 
     memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p)
-        : _schema(std::move(s))
-        , _key(std::move(key))
-        , _pe(*_schema, std::move(p))
+        : _key(std::move(key))
+        , _pe(*s, std::move(p))
     { }
 
     memtable_entry(memtable_entry&& o) noexcept;
@@ -65,8 +63,7 @@ public:
     dht::decorated_key& key() { return _key; }
     const partition_entry& partition() const { return _pe; }
     partition_entry& partition() { return _pe; }
-    const schema_ptr& schema() const { return _schema; }
-    schema_ptr& schema() { return _schema; }
+    const schema_ptr& schema() const { return _pe.get_schema(); }
     partition_snapshot_ptr snapshot(memtable& mtbl);
 
     // Makes the entry conform to given schema.

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -846,7 +846,7 @@ cache_entry& row_cache::find_or_create_incomplete(const partition_start& ps, row
 
 cache_entry& row_cache::find_or_create_missing(const dht::decorated_key& key) {
     return do_find_or_create_entry(key, nullptr, [&] (auto i, const partitions_type::bound_hint& hint) {
-        mutation_partition mp(_schema);
+        mutation_partition mp(*_schema);
         bool cont = i->continuous();
         partitions_type::iterator entry = _partitions.emplace_before(i, key.token().raw(), hint,
                 _schema, key, std::move(mp));
@@ -1035,7 +1035,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
             // Partition is absent in underlying. First, insert a neutral partition entry.
             partitions_type::iterator entry = _partitions.emplace_before(cache_i, mem_e.key().token().raw(), hint,
                 cache_entry::evictable_tag(), _schema, dht::decorated_key(mem_e.key()),
-                partition_entry::make_evictable(*_schema, mutation_partition(_schema)));
+                partition_entry::make_evictable(*_schema, mutation_partition(*_schema)));
             entry->set_continuous(cache_i->continuous());
             _tracker.insert(*entry);
             mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1026,7 +1026,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
             upgrade_entry(entry);
             assert(entry.schema() == _schema);
             _tracker.on_partition_merge();
-            mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());
+            mem_e.upgrade_schema(_tracker.region(), _schema, _tracker.memtable_cleaner());
             return entry.partition().apply_to_incomplete(*_schema, std::move(mem_e.partition()), _tracker.memtable_cleaner(),
                 alloc, _tracker.region(), _tracker, _underlying_phase, acc);
         } else if (cache_i->continuous()
@@ -1038,7 +1038,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
                 partition_entry::make_evictable(*_schema, mutation_partition(*_schema)));
             entry->set_continuous(cache_i->continuous());
             _tracker.insert(*entry);
-            mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());
+            mem_e.upgrade_schema(_tracker.region(), _schema, _tracker.memtable_cleaner());
             return entry->partition().apply_to_incomplete(*_schema, std::move(mem_e.partition()), _tracker.memtable_cleaner(),
                 alloc, _tracker.region(), _tracker, _underlying_phase, acc);
         } else {

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1294,7 +1294,7 @@ flat_mutation_reader_v2 cache_entry::read(row_cache& rc, std::unique_ptr<read_co
 
 // Assumes reader is in the corresponding partition
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, reader.phase());
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, reader.phase());
     auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), reader.native_slice(), _key.key());
     schema_ptr entry_schema = to_query_domain(reader.slice(), schema());
     auto r = make_cache_flat_mutation_reader(entry_schema, _key, std::move(ckr), rc, reader, std::move(snp));
@@ -1304,7 +1304,7 @@ flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader
 }
 
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, std::unique_ptr<read_context> unique_ctx) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, unique_ctx->phase());
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, unique_ctx->phase());
     auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), unique_ctx->native_slice(), _key.key());
     schema_ptr reader_schema = unique_ctx->schema();
     schema_ptr entry_schema = to_query_domain(unique_ctx->slice(), schema());

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1368,6 +1368,6 @@ std::ostream& operator<<(std::ostream& out, cache_entry& e) {
     return out << "{cache_entry: " << e.position()
                << ", cont=" << e.continuous()
                << ", dummy=" << e.is_dummy_entry()
-               << ", " << partition_entry::printer(*e.schema(), e.partition())
+               << ", " << partition_entry::printer(e.partition())
                << "}";
 }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1323,9 +1323,7 @@ void row_cache::upgrade_entry(cache_entry& e) {
     if (e.schema() != _schema && !e.partition().is_locked()) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
-        with_allocator(r.allocator(), [this, &e] {
-            e.partition().upgrade(e.schema(), _schema, _tracker.cleaner(), &_tracker);
-        });
+        e.partition().upgrade(r, e.schema(), _schema, _tracker.cleaner(), &_tracker);
     }
 }
 

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1024,7 +1024,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
         if (cache_i != partitions_end() && hint.match) {
             cache_entry& entry = *cache_i;
             upgrade_entry(entry);
-            assert(entry._schema == _schema);
+            assert(entry.schema() == _schema);
             _tracker.on_partition_merge();
             mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());
             return entry.partition().apply_to_incomplete(*_schema, std::move(mem_e.partition()), _tracker.memtable_cleaner(),
@@ -1193,8 +1193,7 @@ row_cache::row_cache(schema_ptr s, snapshot_source src, cache_tracker& tracker, 
 }
 
 cache_entry::cache_entry(cache_entry&& o) noexcept
-    : _schema(std::move(o._schema))
-    , _key(std::move(o._key))
+    : _key(std::move(o._key))
     , _pe(std::move(o._pe))
     , _flags(o._flags)
 {
@@ -1295,9 +1294,9 @@ flat_mutation_reader_v2 cache_entry::read(row_cache& rc, std::unique_ptr<read_co
 
 // Assumes reader is in the corresponding partition
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), _schema, &rc._tracker, reader.phase());
-    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*_schema, reader.native_slice(), _key.key());
-    schema_ptr entry_schema = to_query_domain(reader.slice(), _schema);
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, reader.phase());
+    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), reader.native_slice(), _key.key());
+    schema_ptr entry_schema = to_query_domain(reader.slice(), schema());
     auto r = make_cache_flat_mutation_reader(entry_schema, _key, std::move(ckr), rc, reader, std::move(snp));
     r.upgrade_schema(to_query_domain(reader.slice(), rc.schema()));
     r.upgrade_schema(reader.schema());
@@ -1305,10 +1304,10 @@ flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader
 }
 
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, std::unique_ptr<read_context> unique_ctx) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), _schema, &rc._tracker, unique_ctx->phase());
-    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*_schema, unique_ctx->native_slice(), _key.key());
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, unique_ctx->phase());
+    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), unique_ctx->native_slice(), _key.key());
     schema_ptr reader_schema = unique_ctx->schema();
-    schema_ptr entry_schema = to_query_domain(unique_ctx->slice(), _schema);
+    schema_ptr entry_schema = to_query_domain(unique_ctx->slice(), schema());
     auto rc_schema = to_query_domain(unique_ctx->slice(), rc.schema());
     auto r = make_cache_flat_mutation_reader(entry_schema, _key, std::move(ckr), rc, std::move(unique_ctx), std::move(snp));
     r.upgrade_schema(rc_schema);
@@ -1321,12 +1320,11 @@ const schema_ptr& row_cache::schema() const {
 }
 
 void row_cache::upgrade_entry(cache_entry& e) {
-    if (e._schema != _schema && !e.partition().is_locked()) {
+    if (e.schema() != _schema && !e.partition().is_locked()) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
         with_allocator(r.allocator(), [this, &e] {
-            e.partition().upgrade(e._schema, _schema, _tracker.cleaner(), &_tracker);
-            e._schema = _schema;
+            e.partition().upgrade(e.schema(), _schema, _tracker.cleaner(), &_tracker);
         });
     }
 }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1323,7 +1323,7 @@ void row_cache::upgrade_entry(cache_entry& e) {
     if (e.schema() != _schema && !e.partition().is_locked()) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
-        e.partition().upgrade(r, e.schema(), _schema, _tracker.cleaner(), &_tracker);
+        e.partition().upgrade(r, _schema, _tracker.cleaner(), &_tracker);
     }
 }
 

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -50,7 +50,6 @@ class lsa_manager;
 //
 // TODO: Make memtables use this format too.
 class cache_entry {
-    schema_ptr _schema;
     dht::decorated_key _key;
     partition_entry _pe;
     // True when we know that there is nothing between this entry and the previous one in cache
@@ -86,9 +85,8 @@ public:
     }
 
     cache_entry(schema_ptr s, const dht::decorated_key& key, const mutation_partition& p)
-        : _schema(std::move(s))
-        , _key(key)
-        , _pe(partition_entry::make_evictable(*_schema, mutation_partition(*_schema, p)))
+        : _key(key)
+        , _pe(partition_entry::make_evictable(*s, mutation_partition(*s, p)))
     { }
 
     cache_entry(schema_ptr s, dht::decorated_key&& key, mutation_partition&& p)
@@ -99,8 +97,7 @@ public:
     // It is assumed that pe is fully continuous
     // pe must be evictable.
     cache_entry(evictable_tag, schema_ptr s, dht::decorated_key&& key, partition_entry&& pe) noexcept
-        : _schema(std::move(s))
-        , _key(std::move(key))
+        : _key(std::move(key))
         , _pe(std::move(pe))
     { }
 
@@ -130,8 +127,7 @@ public:
 
     const partition_entry& partition() const noexcept { return _pe; }
     partition_entry& partition() { return _pe; }
-    const schema_ptr& schema() const noexcept { return _schema; }
-    schema_ptr& schema() noexcept { return _schema; }
+    const schema_ptr& schema() const noexcept { return _pe.get_schema(); }
     flat_mutation_reader_v2 read(row_cache&, cache::read_context&);
     flat_mutation_reader_v2 read(row_cache&, std::unique_ptr<cache::read_context>);
     flat_mutation_reader_v2 read(row_cache&, cache::read_context&, utils::phased_barrier::phase_type);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4498,7 +4498,7 @@ public:
             const mutation& m = z.get<1>().mut;
             for (const version& v : z.get<0>()) {
                 auto diff = v.par
-                          ? m.partition().difference(schema, (co_await v.par->mut().unfreeze_gently(schema)).partition())
+                          ? m.partition().difference(*schema, (co_await v.par->mut().unfreeze_gently(schema)).partition())
                           : mutation_partition(*schema, m.partition());
                 std::optional<mutation> mdiff;
                 if (!diff.empty()) {

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -190,7 +190,7 @@ public:
     static partition_snapshot_ptr snapshot_for_key(row_cache& rc, const dht::decorated_key& dk) {
         return rc._read_section(rc._tracker.region(), [&] {
             cache_entry& e = rc.lookup(dk);
-            return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), e.schema(), &rc._tracker);
+            return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker);
         });
     }
 };

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -260,7 +260,7 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
 
         // Difference
 
-        m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m2.partition()));
+        m = mutation(s, m1.decorated_key(), m1.partition().difference(*s, m2.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
       {
@@ -277,7 +277,7 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         verify_shard_order(ccv);
       }
 
-        m = mutation(s, m1.decorated_key(), m2.partition().difference(s, m1.partition()));
+        m = mutation(s, m1.decorated_key(), m2.partition().difference(*s, m1.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
       {
@@ -294,11 +294,11 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         verify_shard_order(ccv);
       }
 
-        m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m3.partition()));
+        m = mutation(s, m1.decorated_key(), m1.partition().difference(*s, m3.partition()));
         BOOST_REQUIRE_EQUAL(m.partition().clustered_rows().calculate_size(), 0);
         BOOST_REQUIRE(m.partition().static_row().empty());
 
-        m = mutation(s, m1.decorated_key(), m3.partition().difference(s, m1.partition()));
+        m = mutation(s, m1.decorated_key(), m3.partition().difference(*s, m1.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(!ac.is_live());
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1920,9 +1920,9 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             auto m12_with_diff = m1;
             m12_with_diff.partition().apply(*s, m2.partition().difference(s, m1.partition()), app_stats);
             check_partitions_match(m12.partition(), m12_with_diff.partition(), *s);
-            check_partitions_match(mutation_partition{s}, m1.partition().difference(s, m1.partition()), *s);
-            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{s}), *s);
-            check_partitions_match(mutation_partition{s}, mutation_partition{s}.difference(s, m1.partition()), *s);
+            check_partitions_match(mutation_partition{*s}, m1.partition().difference(s, m1.partition()), *s);
+            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{*s}), *s);
+            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(s, m1.partition()), *s);
         });
     });
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1102,7 +1102,7 @@ SEASTAR_TEST_CASE(test_v2_apply_monotonically_is_monotonic_on_alloc_failures) {
                     m2 = mutation_partition_v2(s, second.partition());
                 });
                 auto check = defer([&] {
-                    m.apply_monotonically(s, std::move(m2), no_cache_tracker, app_stats, is_evictable::no);
+                    m.apply_v2(s, std::move(m2));
                     assert_that(target.schema(), m).is_equal_to_compacted(expected.partition());
                 });
                 auto continuity_check = defer([&] {
@@ -1119,7 +1119,7 @@ SEASTAR_TEST_CASE(test_v2_apply_monotonically_is_monotonic_on_alloc_failures) {
                     }
                 });
                 apply_resume res;
-                if (m.apply_monotonically(s, std::move(m2), no_cache_tracker, app_stats, preempt_check, res, is_evictable::yes) == stop_iteration::yes) {
+                if (m.apply_monotonically(s, s, std::move(m2), no_cache_tracker, app_stats, preempt_check, res, is_evictable::yes) == stop_iteration::yes) {
                     continuity_check.cancel();
                     seastar::memory::local_failure_injector().cancel();
                 }
@@ -2101,7 +2101,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_non_evictable_snapshot) {
             auto to_apply = mutation_partition_v2(s, m2_v2);
 
             apply_resume res;
-            while (result_v2.apply_monotonically(s, std::move(to_apply), no_cache_tracker, app_stats,
+            while (result_v2.apply_monotonically(s, s, std::move(to_apply), no_cache_tracker, app_stats,
                     [&] () noexcept { return preempt(); }, res, is_evictable::no) == stop_iteration::no) {
                 seastar::thread::maybe_yield();
             }
@@ -2199,7 +2199,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_evictable_snapshot) {
             clear(tracker, s, result_v2);
         });
         apply_resume res;
-        while (result_v2.apply_monotonically(s, std::move(m2_v2), &tracker, app_stats, is_preemptible::yes, res,
+        while (result_v2.apply_monotonically(s, s, std::move(m2_v2), &tracker, app_stats, default_preemption_check(), res,
                                              is_evictable::yes) == stop_iteration::no) {
             seastar::thread::maybe_yield();
         }
@@ -2284,7 +2284,7 @@ SEASTAR_TEST_CASE(test_continuity_merging_past_last_entry_in_evictable) {
 
             mutation_application_stats app_stats;
             apply_resume resume;
-            m1_v2.apply_monotonically(s, std::move(m2_v2), nullptr, app_stats, is_preemptible::no, resume,
+            m1_v2.apply_monotonically(s, s, std::move(m2_v2), nullptr, app_stats, never_preempt(), resume,
                                       is_evictable::yes);
 
             BOOST_REQUIRE(m1_v2.is_fully_continuous());
@@ -2305,7 +2305,7 @@ SEASTAR_TEST_CASE(test_continuity_merging_past_last_entry_in_evictable) {
             // m2_v2:  --------------- 5 ==(rt)== 7 [rt] ---
             // m1_v2:  === 1 === 3 =========================
 
-            m1_v2.apply_monotonically(s, std::move(m2_v2), nullptr, app_stats, is_preemptible::no, resume, is_evictable::yes);
+            m1_v2.apply_monotonically(s, s, std::move(m2_v2), nullptr, app_stats, never_preempt(), resume, is_evictable::yes);
 
             BOOST_REQUIRE(m1_v2.is_fully_continuous());
             assert_that(ss.schema(), m1_v2).is_equal_to_compacted(s, (m1 + m2).partition());

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1194,7 +1194,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12.apply(m1);
         m12.apply(m2);
 
-        auto m2_1 = m2.partition().difference(s, m1.partition());
+        auto m2_1 = m2.partition().difference(*s, m1.partition());
         BOOST_REQUIRE_EQUAL(m2_1.partition_tombstone(), tombstone());
         BOOST_REQUIRE(!m2_1.static_row().size());
         BOOST_REQUIRE(!m2_1.find_row(*s, ckey1));
@@ -1211,7 +1211,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12_1.partition().apply(*s, m2_1, *s, app_stats);
         BOOST_REQUIRE_EQUAL(m12, m12_1);
 
-        auto m1_2 = m1.partition().difference(s, m2.partition());
+        auto m1_2 = m1.partition().difference(*s, m2.partition());
         BOOST_REQUIRE_EQUAL(m1_2.partition_tombstone(), m12.partition().partition_tombstone());
         BOOST_REQUIRE(m1_2.find_row(*s, ckey1));
         BOOST_REQUIRE(m1_2.find_row(*s, ckey2));
@@ -1229,10 +1229,10 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12_2.partition().apply(*s, m1_2, *s, app_stats);
         BOOST_REQUIRE_EQUAL(m12, m12_2);
 
-        auto m3_12 = m3.partition().difference(s, m12.partition());
+        auto m3_12 = m3.partition().difference(*s, m12.partition());
         BOOST_REQUIRE(m3_12.empty());
 
-        auto m12_3 = m12.partition().difference(s, m3.partition());
+        auto m12_3 = m12.partition().difference(*s, m3.partition());
         BOOST_REQUIRE_EQUAL(m12_3.partition_tombstone(), m12.partition().partition_tombstone());
 
         mutation m123(s, partition_key::from_single_value(*s, "key1"));
@@ -1363,13 +1363,13 @@ SEASTAR_TEST_CASE(test_query_digest) {
 
                 auto m3 = m2;
                 {
-                    auto diff = m1.partition().difference(s, m2.partition());
+                    auto diff = m1.partition().difference(*s, m2.partition());
                     m3.partition().apply(*m3.schema(), std::move(diff), app_stats);
                 }
 
                 auto m4 = m1;
                 {
-                    auto diff = m2.partition().difference(s, m1.partition());
+                    auto diff = m2.partition().difference(*s, m1.partition());
                     m4.partition().apply(*m4.schema(), std::move(diff), app_stats);
                 }
 
@@ -1880,7 +1880,7 @@ SEASTAR_TEST_CASE(test_collection_cell_diff) {
         mutation m12 = m1;
         m12.apply(m2);
 
-        auto diff = m12.partition().difference(s, m1.partition());
+        auto diff = m12.partition().difference(*s, m1.partition());
         BOOST_REQUIRE(!diff.empty());
         BOOST_REQUIRE(m2.partition().equal(*s, diff));
     });
@@ -1918,11 +1918,11 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             auto m12 = m1;
             m12.apply(m2);
             auto m12_with_diff = m1;
-            m12_with_diff.partition().apply(*s, m2.partition().difference(s, m1.partition()), app_stats);
+            m12_with_diff.partition().apply(*s, m2.partition().difference(*s, m1.partition()), app_stats);
             check_partitions_match(m12.partition(), m12_with_diff.partition(), *s);
-            check_partitions_match(mutation_partition{*s}, m1.partition().difference(s, m1.partition()), *s);
-            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{*s}), *s);
-            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(s, m1.partition()), *s);
+            check_partitions_match(mutation_partition{*s}, m1.partition().difference(*s, m1.partition()), *s);
+            check_partitions_match(m1.partition(), m1.partition().difference(*s, mutation_partition{*s}), *s);
+            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(*s, m1.partition()), *s);
         });
     });
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2131,7 +2131,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_non_evictable_snapshot) {
 
 static void clear(cache_tracker& tracker, const schema& s, mutation_partition_v2& p) {
     while (p.clear_gently(&tracker) == stop_iteration::no) {}
-    p = mutation_partition_v2(s.shared_from_this());
+    p = mutation_partition_v2(s);
     tracker.insert(p);
 }
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -221,7 +221,7 @@ mvcc_partition& mvcc_partition::operator+=(const mutation& m) {
 void mvcc_partition::apply(const mutation_partition& mp, schema_ptr mp_s) {
     with_allocator(region().allocator(), [&] {
         if (_evictable) {
-            apply_to_evictable(partition_entry(mutation_partition_v2(*mp_s, mp)), mp_s);
+            apply_to_evictable(partition_entry(*mp_s, mutation_partition_v2(*mp_s, mp)), mp_s);
         } else {
             logalloc::allocating_section as;
             as(region(), [&] {
@@ -249,7 +249,7 @@ mvcc_partition mvcc_container::make_not_evictable(const mutation_partition& mp) 
     return with_allocator(region().allocator(), [&] {
         logalloc::allocating_section as;
         return as(region(), [&] {
-            return mvcc_partition(_schema, partition_entry(mutation_partition_v2(*_schema, mp)), *this, false);
+            return mvcc_partition(_schema, partition_entry(*_schema, mutation_partition_v2(*_schema, mp)), *this, false);
         });
     });
 }
@@ -592,7 +592,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging_for_nonevictab
             {
                 mutation_application_stats app_stats;
                 logalloc::reclaim_lock rl(r);
-                auto e = partition_entry(mutation_partition_v2(*s, m3.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m3.partition()));
                 auto snap1 = e.read(r, cleaner, s, no_cache_tracker);
                 e.apply(r, cleaner, *s, m2.partition(), *s, app_stats);
                 auto snap2 = e.read(r, cleaner, s, no_cache_tracker);
@@ -1173,7 +1173,7 @@ public:
             , _tracker(t)
             , _r(r)
             , _e(_tracker ? partition_entry::make_evictable(*_schema, mutation_partition::make_incomplete(*_schema))
-                          : partition_entry(mutation_partition_v2(*_schema)))
+                          : partition_entry(*_schema, mutation_partition_v2(*_schema)))
     {
         if (_tracker) {
             _tracker->insert(_e);
@@ -1654,7 +1654,7 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
             while (true) {
                 logalloc::reclaim_lock rl(r);
                 mutation_partition_v2 m2 = mutation_partition_v2(*second.schema(), second.partition());
-                auto e = partition_entry(mutation_partition_v2(*target.schema(), target.partition()));
+                auto e = partition_entry(*target.schema(), mutation_partition_v2(*target.schema(), target.partition()));
                 //auto snap1 = e.read(r, gen.schema());
 
                 alloc.fail_after(fail_offset++);
@@ -1703,7 +1703,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
             m3.partition().make_fully_continuous();
 
             {
-                auto e = partition_entry(mutation_partition_v2(*s, m1.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m1.partition()));
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {
@@ -1724,7 +1724,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
             }
 
             {
-                auto e = partition_entry(mutation_partition_v2(*s, m1.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m1.partition()));
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -41,7 +41,7 @@ static thread_local mutation_application_stats app_stats_for_tests;
 // The cursor must be pointing at a row and valid.
 // The cursor will not be pointing at a row after this.
 static mutation_partition read_partition_from(const schema& schema, partition_snapshot_row_cursor& cur) {
-    mutation_partition p(schema.shared_from_this());
+    mutation_partition p(schema);
     position_in_partition prev = position_in_partition::before_all_clustered_rows();
     do {
         testlog.trace("cur: {}", cur);
@@ -304,7 +304,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete) {
             assert_that(table.schema(), e.squashed()).is_equal_to((m2 + m3).partition());
 
             // Check that snapshot data is not stolen when its entry is applied
-            auto e2 = ms.make_evictable(mutation_partition(table.schema()));
+            auto e2 = ms.make_evictable(mutation_partition(s));
             e2 += std::move(e);
             assert_that(table.schema(), ms.squashed(snap1)).is_equal_to(m1.partition());
             assert_that(table.schema(), e2.squashed()).is_equal_to((m2 + m3).partition());
@@ -381,7 +381,7 @@ SEASTAR_TEST_CASE(test_eviction_with_active_reader) {
             auto ck1 = table.make_ckey(1);
             auto ck2 = table.make_ckey(2);
 
-            auto e = ms.make_evictable(mutation_partition(table.schema()));
+            auto e = ms.make_evictable(mutation_partition(s));
 
             mutation m1(table.schema(), pk);
             m1.partition().clustered_row(s, ck2);
@@ -670,7 +670,7 @@ SEASTAR_TEST_CASE(test_partition_snapshot_row_cursor) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {
@@ -841,7 +841,7 @@ SEASTAR_TEST_CASE(test_partition_snapshot_row_cursor_reversed) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             int ck_0 = 10;
@@ -1032,7 +1032,7 @@ SEASTAR_TEST_CASE(test_cursor_tracks_continuity_in_reversed_mode) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             tracker.insert(e);
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
@@ -1537,7 +1537,7 @@ SEASTAR_TEST_CASE(test_ensure_entry_in_latest_in_reversed_mode) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {
@@ -1593,7 +1593,7 @@ SEASTAR_TEST_CASE(test_ensure_entry_in_latest_does_not_set_continuity_in_reverse
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -170,7 +170,7 @@ public:
 
     void upgrade(schema_ptr new_schema) {
         _container.allocate_in_region([&] {
-            _e.upgrade(_container.region(), _s, new_schema, _container.cleaner(), _container.tracker());
+            _e.upgrade(_container.region(), new_schema, _container.cleaner(), _container.tracker());
             _s = new_schema;
         });
     }
@@ -194,7 +194,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
         mutation_cleaner src_cleaner(region(), no_cache_tracker, app_stats_for_tests);
         auto c = as(region(), [&] {
             if (_s != src_schema) {
-                src.upgrade(region(), src_schema, _s, src_cleaner, no_cache_tracker);
+                src.upgrade(region(), _s, src_cleaner, no_cache_tracker);
             }
             return _e.apply_to_incomplete(*schema(), std::move(src), src_cleaner, as, region(),
                 *_container.tracker(), _container.next_phase(), _container.accounter());

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -1173,7 +1173,7 @@ public:
             , _tracker(t)
             , _r(r)
             , _e(_tracker ? partition_entry::make_evictable(*_schema, mutation_partition::make_incomplete(*_schema))
-                          : partition_entry(mutation_partition_v2(_schema)))
+                          : partition_entry(mutation_partition_v2(*_schema)))
     {
         if (_tracker) {
             _tracker->insert(_e);

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -170,7 +170,7 @@ public:
 
     void upgrade(schema_ptr new_schema) {
         _container.allocate_in_region([&] {
-            _e.upgrade(_s, new_schema, _container.cleaner(), _container.tracker());
+            _e.upgrade(_container.region(), _s, new_schema, _container.cleaner(), _container.tracker());
             _s = new_schema;
         });
     }
@@ -194,7 +194,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
         mutation_cleaner src_cleaner(region(), no_cache_tracker, app_stats_for_tests);
         auto c = as(region(), [&] {
             if (_s != src_schema) {
-                src.upgrade(src_schema, _s, src_cleaner, no_cache_tracker);
+                src.upgrade(region(), src_schema, _s, src_cleaner, no_cache_tracker);
             }
             return _e.apply_to_incomplete(*schema(), std::move(src), src_cleaner, as, region(),
                 *_container.tracker(), _container.next_phase(), _container.accounter());

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -505,7 +505,7 @@ void evict_with_consistency_check(mvcc_container& ms, mvcc_partition& e, const m
         testlog.trace("evicting");
         auto ret = ms.tracker()->evict_from_lru_shallow();
 
-        testlog.trace("entry: {}", partition_entry::printer(s, e.entry()));
+        testlog.trace("entry: {}", partition_entry::printer(e.entry()));
 
         auto p = e.squashed();
         auto cont = p.get_continuity(s);
@@ -553,7 +553,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging) {
                 auto snap2 = e.read();
                 e += m3;
 
-                testlog.trace("e: {}", partition_entry::printer(*e.schema(), e.entry()));
+                testlog.trace("e: {}", partition_entry::printer(e.entry()));
 
                 auto expected = e.squashed();
                 auto snap = e.read();
@@ -2005,7 +2005,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_with_dummies) {
             }
         });
 
-        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(*s, e.entry()));
+        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(e.entry()));
 
         mutation m2(s, ss.make_pkey());
         // This one covers the dummy row for before(3) and before(2), marking the range [1, 3] as continuous.
@@ -2020,7 +2020,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_with_dummies) {
         e += m3;
         auto snp3 = e.read();
 
-        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(*s, e.entry()));
+        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(e.entry()));
 
         auto expected = m0 + m1 + m2 + m3;
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -452,7 +452,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_respects_continuity) {
                 }
 
                 auto expected = mutation_partition(*s, before);
-                expected.apply_weak(*s, std::move(expected_to_apply_slice), app_stats);
+                expected.apply(*s, std::move(expected_to_apply_slice), app_stats);
 
                 e += to_apply;
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -46,7 +46,7 @@ static mutation_partition read_partition_from(const schema& schema, partition_sn
     do {
         testlog.trace("cur: {}", cur);
         p.clustered_row(schema, cur.position(), is_dummy(cur.dummy()), is_continuous(cur.continuous()))
-            .apply(schema, cur.row().as_deletable_row());
+            .apply_monotonically(schema, cur.row().as_deletable_row());
         auto after_pos = position_in_partition::after_key(schema, cur.position());
         auto before_pos = position_in_partition::before_key(cur.position());
         if (cur.range_tombstone()) {

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -2033,3 +2033,104 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_with_dummies) {
         evict_with_consistency_check(ms, e, expected.partition());
     });
 }
+
+SEASTAR_TEST_CASE(test_gentle_schema_upgrades) {
+    return seastar::async([] {
+        auto ts1 = api::new_timestamp();
+        auto ts_drop = api::new_timestamp();
+        auto ts2 = api::new_timestamp();
+
+        auto s1 = schema_builder("ks", "cf")
+            .with_column("pk", utf8_type, column_kind::partition_key)
+            .with_column("ck", utf8_type, column_kind::clustering_key)
+            .with_column("s1", utf8_type, column_kind::static_column)
+            .with_column("s2", utf8_type, column_kind::static_column)
+            .with_column("v1", utf8_type, column_kind::regular_column)
+            .with_column("v2", utf8_type, column_kind::regular_column)
+            .with_column("v3", utf8_type, column_kind::regular_column)
+            .with_column("v4", utf8_type, column_kind::regular_column)
+            .build();
+        auto s2 = schema_builder(s1)
+            .remove_column("s1")
+            .remove_column("v3")
+            .without_column("v4", ts_drop).with_column("v4", utf8_type)
+            .with_column("v5", utf8_type)
+            .build();
+
+        auto m1 = std::invoke([s1, ts1] {
+            auto x = mutation(s1, partition_key::from_single_value(*s1, serialized(0)));
+            auto ck = clustering_key::from_single_value(*s1, serialized(0));
+            x.set_static_cell("s1", "s1_value", ts1);
+            x.set_static_cell("s2", "s2_value", ts1);
+            x.set_clustered_cell(ck, "v1", "v1_value", ts1);
+            x.set_clustered_cell(ck, "v2", "v2_value", ts1);
+            x.set_clustered_cell(ck, "v3", "v3_value", ts1);
+            x.set_clustered_cell(ck, "v4", "v4_value", ts1);
+            x.partition().set_static_row_continuous(false);
+            x.partition().ensure_last_dummy(*s1);
+            return x;
+        });
+
+        auto m2 = std::invoke([s2, ts2] {
+            auto x = mutation(s2, partition_key::from_single_value(*s2, serialized(0)));
+            auto ck = clustering_key::from_single_value(*s2, serialized(0));
+            x.set_clustered_cell(ck, "v2", "v2_value_new", ts2);
+            x.set_clustered_cell(ck, "v5", "v5_value_new", ts2);
+            x.partition().set_static_row_continuous(false);
+            x.partition().ensure_last_dummy(*s2);
+            return x;
+        });
+
+        auto expected = std::invoke([s2, ts1, ts2] {
+            auto x = mutation(s2, partition_key::from_single_value(*s2, serialized(0)));
+            auto ck = clustering_key::from_single_value(*s2, serialized(0));
+            x.set_static_cell("s2", "s2_value", ts1);
+            x.set_clustered_cell(ck, "v1", "v1_value", ts1);
+            x.set_clustered_cell(ck, "v2", "v2_value_new", ts2);
+            x.set_clustered_cell(ck, "v5", "v5_value_new", ts2);
+            x.partition().set_static_row_continuous(false);
+            x.partition().ensure_last_dummy(*s2);
+            return x;
+        });
+
+        {
+            // Test that the version merge is lazy.
+            // (This is not important and might be changed in the future.
+            // We often run some operations synchronously and only put them
+            // in the background after they preempt for the first time.)
+            mvcc_container ms(s1);
+            auto e = ms.make_evictable(m1.partition());
+            e.upgrade(s2);
+            BOOST_REQUIRE(e.entry().version()->next());
+            // Test that the upgrade initiated the merge.
+            ms.cleaner().drain().get();
+            BOOST_REQUIRE(!e.entry().version()->next());
+        }
+        {
+            // Test that the on-the-fly merge gives the expected result.
+            mvcc_container ms(s1);
+            auto e = ms.make_evictable(m1.partition());
+            auto rd1 = e.read();
+            e.upgrade(s2);
+            auto rd2 = e.read();
+            e += m2;
+            auto rd3 = e.read();
+
+            ASSERT_THAT_MP(s1, read_using_cursor(*rd1)).is_equal_to(*s1, m1.partition());
+
+            auto rd2_expected = mutation_partition(*s1, m1.partition());
+            rd2_expected.upgrade(*s1, *s2);
+            ASSERT_THAT_MP(s2, read_using_cursor(*rd2)).is_equal_to(rd2_expected);
+
+            ASSERT_THAT_MP(s2, read_using_cursor(*rd3)).is_equal_to(*s2, expected.partition());
+
+            rd1 = {};
+            rd2 = {};
+            // Merge versions.
+            ms.cleaner().drain().get();
+            BOOST_REQUIRE(!e.entry().version()->next());
+            // Test that the background merge gives the expected result.
+            ASSERT_THAT_MP(s2, read_using_cursor(*rd3)).is_equal_to(*s2, expected.partition());
+        }
+    });
+}

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -3448,6 +3448,16 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
             auto m2 = gen();
             m2.partition().make_fully_continuous();
 
+            bool upgrade_schema = tests::random::get_bool();
+            if (upgrade_schema) {
+                schema_ptr new_schema = schema_builder(s)
+                    .with_column(to_bytes("_phantom"), byte_type)
+                    .remove_column("_phantom")
+                    .build();
+                m2.upgrade(new_schema);
+                cache.set_schema(new_schema);
+            }
+
             auto mt = make_lw_shared<replica::memtable>(m2.schema());
             mt->apply(m2);
             cache.update(row_cache::external_updater([&] () noexcept {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -949,6 +949,7 @@ SEASTAR_TEST_CASE(test_eviction_after_schema_change) {
             rd.fill_buffer().get();
         }
 
+        tracker.cleaner().drain().get0();
         while (tracker.region().evict_some() == memory::reclaiming_result::reclaimed_something) ;
 
         // The partition should be evictable after schema change

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -504,7 +504,7 @@ public:
     mutation_assertion next_mutation() {
         auto mo = read_mutation_from_flat_mutation_reader(_reader).get0();
         BOOST_REQUIRE(bool(mo));
-        return mutation_assertion(std::move(*mo));
+        return assert_that(std::move(*mo));
     }
 
     future<> fill_buffer() {


### PR DESCRIPTION
After a schema change, memtable and cache have to be upgraded to the new schema. Currently, they are upgraded (on the first access after a schema change) atomically, i.e. all rows of the entry are upgraded with one non-preemptible call. This is a one of the last vestiges of the times when partition were treated atomically, and it is a well known source of numerous large stalls.

This series makes schema upgrades gentle (preemptible). This is done by co-opting the existing MVCC machinery.
Before the series, all partition_versions in the partition_entry chain have the same schema, and an entry upgrade replaces the entire chain with a single squashed and upgraded version.
After the series, each partition_version has its own schema. A partition entry upgrade happens simply by adding an empty version with the new schema to the head of the chain. Row entries are upgraded to the current schema on-the-fly by the cursor during reads, and upgraded permanently by the MVCC version merge ongoing in the background.

The series:
1. Does some code cleanup in the mutation_partition area.
2. Adds a schema field to partition_version and removes it from its containers (partition_snapshot, cache_entry, memtable_entry).
3. Adds upgrading variants of constructors and apply() for `row` and its wrappers. 
4. Prepares partition_snapshot_row_cursor, mutation_partition_v2::apply_monotonically and partition_snapshot::merge_partition_versions for dealing with heterogeneous version chains.
5. Modifies partition_entry::upgrade to perform upgrades by extending the version chain with a new schema instead of squashing it to a single upgraded version. 

I'm particularly worried about the correctness of the modifications to the version merging algorithm. It is already probably the trickiest and most complex piece of Scylla code, and these modifications make reasoning even harder.
Before the series, we always merge the newer version into the older version. After the series, we also merge in the other direction, because after the merge we want to end up with the newer schema, not the older schema. This changes some assumptions of apply_monotonically, especially these concerning eviction order and the "older versions are evicted first" rule.
Between preemption safety, exception safety, rows and dummies and last dummies, evictable and non-evictable entries, continuity, row tombstones, row compaction, and now also forward and backward merging, the complexity of this function is brain-melting. I have no idea how to cover it with trustworthy tests. The puny test I've added is barely more than a sanity check.

A possible performance problem with this method is that the same row entry might have to be upgraded many times by the cursor until its finally upgraded permanently by a version merge, whereas before the series they only need to be upgraded once. Note that problem is only relevant for big partition entries (the version merge starts eagerly and is only backgrounded on first preempt, so for small entries it will usually complete synchronously). I didn't do any performance tests, but schema upgrades currently (both before and after this series) seem to be implemented inefficiently: for *every cell* in the upgraded entry, a schema upgrade looks up its column name in a hashmap. If this is a performance problem, we can follow up with an optimization which avoids this by preparing an integer-based column mapping for the schema pair instead.

Fixes #2577