### PR TITLE
flat_mutation_reader_v2: use maybe_yield() when appropriate

### DIFF
--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -229,9 +229,7 @@ public:
         // entirely and never reach the consumer.
         void consume_pausable_in_thread(Consumer consumer, Filter filter) {
             while (true) {
-                if (need_preempt()) {
-                    seastar::thread::yield();
-                }
+                thread::maybe_yield();
                 if (is_buffer_empty()) {
                     if (is_end_of_stream()) {
                         return;


### PR DESCRIPTION
just came across this part of code, as `maybe_yield()` is a wrapper around "if should_yield(): yield()", so better off using it for more concise code.