### PR TITLE
cmake: sync with `configure.py` (11/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ target_link_libraries(scylla PRIVATE
     utils)
 target_link_libraries(Boost::regex
   INTERFACE
-    ICU::i18n)
+    ICU::i18n
+    ICU::uc)
 
 target_link_libraries(scylla PRIVATE
     seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Boost REQUIRED
 find_package(Lua REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
-find_package(absl REQUIRED)
+find_package(absl COMPONENTS hash raw_hash_set REQUIRED)
 find_package(libdeflate REQUIRED)
 find_package(libxcrypt REQUIRED)
 find_package(RapidJSON REQUIRED)
@@ -44,7 +44,9 @@ set(scylla_gen_build_dir "${CMAKE_BINARY_DIR}/gen")
 file(MAKE_DIRECTORY "${scylla_gen_build_dir}")
 
 
-set(scylla_sources
+add_library(scylla-main STATIC)
+target_sources(scylla-main
+  PRIVATE
     absl-flat_hash_map.cc
     bytes.cc
     client_data.cc
@@ -84,7 +86,14 @@ set(scylla_sources
     validation.cc
     vint-serialization.cc
     zstd.cc)
-
+target_link_libraries(scylla-main
+  PRIVATE
+    db
+    absl::hash
+    absl::raw_hash_set
+    Seastar::seastar
+    systemd
+    ZLIB::ZLIB)
 add_subdirectory(api)
 add_subdirectory(alternator)
 add_subdirectory(db)
@@ -122,10 +131,11 @@ add_subdirectory(utils)
 include(add_version_library)
 add_version_library(scylla_version
     release.cc)
-add_executable(scylla
-    ${scylla_sources})
 
+add_executable(scylla
+  main.cc)
 target_link_libraries(scylla PRIVATE
+    scylla-main
     api
     auth
     alternator
@@ -172,33 +182,10 @@ target_link_libraries(scylla PRIVATE
     Boost::thread
     Boost::regex
     Boost::headers
-    # Abseil libs
-    absl::hashtablez_sampler
-    absl::raw_hash_set
-    absl::synchronization
-    absl::graphcycles_internal
-    absl::stacktrace
-    absl::symbolize
-    absl::debugging_internal
-    absl::demangle_internal
-    absl::time
-    absl::time_zone
-    absl::int128
-    absl::city
-    absl::hash
-    absl::malloc_internal
-    absl::spinlock_wait
-    absl::base
-    absl::dynamic_annotations
-    absl::raw_logging_internal
-    absl::exponential_biased
-    absl::throw_delegate
     # System libs
     libxcrypt::libxcrypt
     libdeflate::libdeflate
-    ZLIB::ZLIB
     ICU::uc
-    systemd
     zstd
     snappy
     xxHash::xxhash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,6 @@ target_link_libraries(scylla PRIVATE
     Boost::headers
     # System libs
     libxcrypt::libxcrypt
-    libdeflate::libdeflate
     ICU::uc
     zstd
     xxHash::xxhash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(absl COMPONENTS hash raw_hash_set REQUIRED)
 find_package(libdeflate REQUIRED)
 find_package(libxcrypt REQUIRED)
+find_package(Snappy REQUIRED)
 find_package(RapidJSON REQUIRED)
 find_package(Thrift REQUIRED)
 find_package(xxHash REQUIRED)
@@ -92,6 +93,7 @@ target_link_libraries(scylla-main
     absl::hash
     absl::raw_hash_set
     Seastar::seastar
+    Snappy::snappy
     systemd
     ZLIB::ZLIB)
 add_subdirectory(api)
@@ -187,7 +189,6 @@ target_link_libraries(scylla PRIVATE
     libdeflate::libdeflate
     ICU::uc
     zstd
-    snappy
     xxHash::xxhash)
 
 # Force SHA1 build-id generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,15 +53,12 @@ set(scylla_sources
     compress.cc
     converting_mutation_partition_applier.cc
     counters.cc
-    data_dictionary/data_dictionary.cc
     direct_failure_detector/failure_detector.cc
     duration.cc
     exceptions/exceptions.cc
     frozen_schema.cc
     generic_server.cc
     debug.cc
-    index/secondary_index.cc
-    index/secondary_index_manager.cc
     init.cc
     keys.cc
     main.cc
@@ -76,8 +73,6 @@ set(scylla_sources
     tombstone_gc_options.cc
     tombstone_gc.cc
     reader_concurrency_semaphore.cc
-    repair/repair.cc
-    repair/row_level.cc
     row_cache.cc
     schema_mutations.cc
     serializer.cc
@@ -97,9 +92,11 @@ add_subdirectory(auth)
 add_subdirectory(cdc)
 add_subdirectory(compaction)
 add_subdirectory(cql3)
+add_subdirectory(data_dictionary)
 add_subdirectory(dht)
 add_subdirectory(gms)
 add_subdirectory(idl)
+add_subdirectory(index)
 add_subdirectory(interface)
 add_subdirectory(lang)
 add_subdirectory(locator)
@@ -109,6 +106,7 @@ add_subdirectory(readers)
 add_subdirectory(redis)
 add_subdirectory(replica)
 add_subdirectory(raft)
+add_subdirectory(repair)
 add_subdirectory(rust)
 add_subdirectory(schema)
 add_subdirectory(service)
@@ -135,9 +133,11 @@ target_link_libraries(scylla PRIVATE
     cdc
     compaction
     cql3
+    data_dictionary
     dht
     gms
     idl
+    index
     lang
     locator
     mutation
@@ -145,6 +145,7 @@ target_link_libraries(scylla PRIVATE
     raft
     readers
     redis
+    repair
     replica
     schema
     scylla_version

--- a/compaction/CMakeLists.txt
+++ b/compaction/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(compaction
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    mutation_writer
     replica)

--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -119,4 +119,7 @@ target_link_libraries(cql3
     wasmtime_bindings
     Seastar::seastar
     xxHash::xxhash
-    ANTLR3::antlr3)
+    ANTLR3::antlr3
+  PRIVATE
+    lang
+    transport)

--- a/data_dictionary/CMakeLists.txt
+++ b/data_dictionary/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(data_dictionary STATIC)
+target_sources(data_dictionary
+  PRIVATE
+    data_dictionary.cc)
+target_include_directories(data_dictionary
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(data_dictionary
+  PRIVATE
+    cql3
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash)

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -40,4 +40,5 @@ target_link_libraries(db
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    data_dictionary
     cql3)

--- a/index/CMakeLists.txt
+++ b/index/CMakeLists.txt
@@ -1,0 +1,16 @@
+find_package(cryptopp REQUIRED)
+
+add_library(index STATIC)
+target_sources(index
+  PRIVATE
+    secondary_index.cc
+    secondary_index_manager.cc)
+target_include_directories(index
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(index
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    cql3)

--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(repair STATIC)
+target_sources(repair
+  PRIVATE
+    repair.cc
+    row_level.cc)
+target_include_directories(repair
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(repair
+  PUBLIC
+    idl
+    Seastar::seastar
+    xxHash::xxhash)

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -16,4 +16,6 @@ target_link_libraries(replica
     db
     wasmtime_bindings
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    absl::raw_hash_set)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -34,4 +34,8 @@ target_link_libraries(service
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
-    mutation)
+    mutation
+    raft
+    repair
+    streaming
+    systemd)

--- a/sstables/CMakeLists.txt
+++ b/sstables/CMakeLists.txt
@@ -30,4 +30,5 @@ target_link_libraries(sstables
   PRIVATE
     readers
     tracing
+    libdeflate::libdeflate
     ZLIB::ZLIB)

--- a/sstables/CMakeLists.txt
+++ b/sstables/CMakeLists.txt
@@ -26,4 +26,8 @@ target_link_libraries(sstables
     idl
     wasmtime_bindings
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    readers
+    tracing
+    ZLIB::ZLIB)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -126,7 +126,9 @@ add_scylla_test(types_test
   KIND BOOST)
 add_scylla_test(vint_serialization_test
   KIND BOOST
-  LIBRARIES utils)
+  LIBRARIES
+    scylla-main
+    utils)
 add_scylla_test(bptree_test
   KIND BOOST
   LIBRARIES utils)
@@ -134,7 +136,8 @@ add_scylla_test(utf8_test
   KIND BOOST
   LIBRARIES utils)
 add_scylla_test(user_function_test
-  KIND BOOST)
+  KIND SEASTAR
+  LIBRARIES idl)
 add_scylla_test(user_types_test
   KIND BOOST)
 add_scylla_test(expr_test

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -106,12 +106,6 @@ add_scylla_test(top_k_test
   KIND BOOST)
 add_scylla_test(transport_test
   KIND BOOST)
-add_scylla_test(type_json_test
-  KIND BOOST
-  LIBRARIES
-    cql3
-    types
-    utils)
 add_scylla_test(types_test
   KIND BOOST)
 add_scylla_test(vint_serialization_test

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -1,4 +1,20 @@
-function(add_scylla_test name)
+#
+ # Add a scylla unit test
+ #
+ # add_scylla_test(<test_name>
+ #   [KIND <kind>]
+ #   [SOUCES <src>...])
+ #
+ # kind can be:
+ # * SEASTAR - a unit test that depends on the scylla sources and the
+ #   seastar test framework.
+ # * BOOST - a unit test that only depends on the listed sources and the
+ #   Boost test framework
+ # test_name should map to a source file, such that ${test_name}.cc
+ # is a valid source file. If this isn't the case, please use the SOURCE
+ # param.
+ #
+ function(add_scylla_test name)
   cmake_parse_arguments(parsed_args
     ""
     "KIND"

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(test-lib)
 target_sources(test-lib
   PRIVATE
+    cql_assertions.cc
+    exception_utils.cc
     log.cc
     test_utils.cc
     tmpdir.cc

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -16,7 +16,23 @@ target_include_directories(test-lib
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(test-lib
   PUBLIC
+    scylla-main
+    replica
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
-    idl)
+    auth
+    cdc
+    compaction
+    dht   # used by cql3
+    gms
+    types
+    idl
+    index # used by cql3
+    locator
+    schema
+    scylla_version
+    service
+    sstables
+    utils
+    Boost::regex)

--- a/transport/CMakeLists.txt
+++ b/transport/CMakeLists.txt
@@ -15,4 +15,5 @@ target_link_libraries(transport
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
-    cql3)
+    cql3
+    Snappy::snappy)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(utils
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    Boost::regex
     cryptopp)


### PR DESCRIPTION
- build: cmake: remove test which does not exist yet
- build: cmake: document add_scylla_test()
- build: cmake: extract index, repair and data_dictionary out
- build: cmake: extract scylla-main out
- build: cmake: find Snappy before using it
- build: cmake: add missing linkages
- build: cmake: add missing sources to test-lib
- build: cmake: link sstables against libdeflate
- build: cmake: link Boost::regex against ICU::uc