### PR TITLE
Load SSTable at the shard that actually own it

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -144,7 +144,9 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc, process_f
 
 future<>
 sstable_directory::sort_sstable(sstables::shared_sstable sst) {
-    return sst->get_open_info().then([sst, this] (sstables::foreign_sstable_open_info info) {
+    sstables::foreign_sstable_open_info info = co_await sst->get_open_info();
+
+        // FIXME: indentation.
         auto shards = sst->get_shards_for_this_sstable();
         if (shards.size() == 1) {
             if (shards[0] == this_shard_id()) {
@@ -158,8 +160,6 @@ sstable_directory::sort_sstable(sstables::shared_sstable sst) {
             dirlog.trace("{} identified as a shared SSTable", sst->get_filename());
             _shared_sstable_info.push_back(std::move(info));
         }
-        return make_ready_future<>();
-    });
 }
 
 generation_type

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -290,7 +290,7 @@ future<shared_sstable> sstable_directory::load_foreign_sstable(foreign_sstable_o
 }
 
 future<>
-sstable_directory::load_foreign_sstables(sstable_info_vector info_vec) {
+sstable_directory::load_foreign_sstables(sstable_open_info_vector info_vec) {
     return parallel_for_each_restricted(info_vec, [this] (sstables::foreign_sstable_open_info& info) {
         return load_foreign_sstable(info).then([this] (auto sst) {
             _unshared_local_sstables.push_back(sst);
@@ -387,7 +387,7 @@ sstable_directory::store_phaser(utils::phased_barrier::operation op) {
     _operation_barrier.emplace(std::move(op));
 }
 
-sstable_directory::sstable_info_vector
+sstable_directory::sstable_open_info_vector
 sstable_directory::retrieve_shared_sstables() {
     return std::exchange(_shared_sstable_info, {});
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -146,20 +146,19 @@ future<>
 sstable_directory::sort_sstable(sstables::shared_sstable sst) {
     sstables::foreign_sstable_open_info info = co_await sst->get_open_info();
 
-        // FIXME: indentation.
-        auto shards = sst->get_shards_for_this_sstable();
-        if (shards.size() == 1) {
-            if (shards[0] == this_shard_id()) {
-                dirlog.trace("{} identified as a local unshared SSTable", sst->get_filename());
-                _unshared_local_sstables.push_back(sst);
-            } else {
-                dirlog.trace("{} identified as a remote unshared SSTable", sst->get_filename());
-                _unshared_remote_sstables[shards[0]].push_back(std::move(info));
-            }
+    auto shards = sst->get_shards_for_this_sstable();
+    if (shards.size() == 1) {
+        if (shards[0] == this_shard_id()) {
+            dirlog.trace("{} identified as a local unshared SSTable", sst->get_filename());
+            _unshared_local_sstables.push_back(sst);
         } else {
-            dirlog.trace("{} identified as a shared SSTable", sst->get_filename());
-            _shared_sstable_info.push_back(std::move(info));
+            dirlog.trace("{} identified as a remote unshared SSTable", sst->get_filename());
+            _unshared_remote_sstables[shards[0]].push_back(std::move(info));
         }
+    } else {
+        dirlog.trace("{} identified as a shared SSTable", sst->get_filename());
+        _shared_sstable_info.push_back(std::move(info));
+    }
 }
 
 generation_type

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -142,7 +142,10 @@ private:
     future<> load_foreign_sstables(sstable_info_vector info_vec);
 
     // Sort the sstable according to owner
-    future<> sort_sstable(sstables::shared_sstable sst);
+    future<> sort_sstable(sstables::entry_descriptor desc, process_flags flags);
+
+    // Returns filename for a SSTable from its entry_descriptor.
+    sstring sstable_filename(const sstables::entry_descriptor& desc) const;
 public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -133,6 +133,8 @@ private:
 private:
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
+    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc) const;
+    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, process_flags flags) const;
 
     template <typename Container, typename Func>
     requires std::is_invocable_r_v<future<>, Func, typename std::decay_t<Container>::value_type&>

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -129,6 +129,8 @@ private:
     // the amount of data resharded per shard, so a coordinator may redistribute this.
     sstable_info_vector _shared_sstable_info;
 
+    std::vector<sstables::shared_sstable> _unsorted_sstables;
+private:
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
 
@@ -136,8 +138,6 @@ private:
     requires std::is_invocable_r_v<future<>, Func, typename std::decay_t<Container>::value_type&>
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
     future<> load_foreign_sstables(sstable_info_vector info_vec);
-
-    std::vector<sstables::shared_sstable> _unsorted_sstables;
 public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -140,6 +140,9 @@ private:
     requires std::is_invocable_r_v<future<>, Func, typename std::decay_t<Container>::value_type&>
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
     future<> load_foreign_sstables(sstable_info_vector info_vec);
+
+    // Sort the sstable according to owner
+    future<> sort_sstable(sstables::shared_sstable sst);
 public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
@@ -175,9 +178,6 @@ public:
     // (commit_file_removals()) has to be issued. This is to make sure that all instances of this
     // class in a sharded service have the opportunity to validate its files.
     future<> process_sstable_dir(process_flags flags);
-
-    // Sort the sstable according to owner
-    future<> sort_sstable(sstables::shared_sstable sst);
 
     // If files were scheduled to be removed, they will be removed after this call.
     future<> commit_directory_changes();

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -53,7 +53,7 @@ class sstable_directory {
 public:
     // favor chunked vectors when dealing with file lists: they can grow to hundreds of thousands
     // of elements.
-    using sstable_info_vector = utils::chunked_vector<sstables::foreign_sstable_open_info>;
+    using sstable_open_info_vector = utils::chunked_vector<sstables::foreign_sstable_open_info>;
 
     // Flags below control how to behave when scanning new SSTables.
     struct process_flags {
@@ -122,12 +122,12 @@ private:
     //
     // The indexes of the outer vector represent the shards. Having anything in the index
     // representing this shard is illegal.
-    std::vector<sstable_info_vector> _unshared_remote_sstables;
+    std::vector<sstable_open_info_vector> _unshared_remote_sstables;
 
     // SSTables that are shared. Stored as foreign_sstable_open_info objects. Reason is those are
     // the SSTables that we found, and not necessarily the ones we will reshard. We want to balance
     // the amount of data resharded per shard, so a coordinator may redistribute this.
-    sstable_info_vector _shared_sstable_info;
+    sstable_open_info_vector _shared_sstable_info;
 
     std::vector<sstables::shared_sstable> _unsorted_sstables;
 private:
@@ -139,7 +139,7 @@ private:
     template <typename Container, typename Func>
     requires std::is_invocable_r_v<future<>, Func, typename std::decay_t<Container>::value_type&>
     future<> parallel_for_each_restricted(Container&& C, Func&& func);
-    future<> load_foreign_sstables(sstable_info_vector info_vec);
+    future<> load_foreign_sstables(sstable_open_info_vector info_vec);
 
     // Sort the sstable according to owner
     future<> sort_sstable(sstables::entry_descriptor desc, process_flags flags);
@@ -196,7 +196,7 @@ public:
 
     // Retrieves the list of shared SSTables in this object. The list will be reset once this
     // is called.
-    sstable_info_vector retrieve_shared_sstables();
+    sstable_open_info_vector retrieve_shared_sstables();
     std::vector<sstables::shared_sstable>& get_unshared_local_sstables() { return _unshared_local_sstables; }
 
     future<> remove_sstables(std::vector<sstables::shared_sstable> sstlist);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -196,6 +196,10 @@ public:
     future<> open_data(sstable_open_config cfg = {}) noexcept;
     future<> update_info_for_opened_data(sstable_open_config cfg = {});
 
+    // Load set of shards that own the SSTable, while reading the minimum
+    // from disk to achieve that.
+    future<> load_owner_shards(const io_priority_class& pc = default_priority_class());
+
     class delayed_commit_changes {
         std::unordered_set<sstring> _dirs;
         friend class sstable;


### PR DESCRIPTION
Today, the SSTable generation provides a hint on which shard owns a
particular SSTable. That hint determines which shard will load the
SSTable into memory.

With upcoming UUID generation, we will no longer have this hint
embedded into the SSTable generation, meaning that SSTables will be
loaded at random shards. This is not good because shards will have
to reference memory from other shards to access the SSTable
metadata that was allocated elsewhere.

This patch changes sstable_directory to:
1) Use generation value to only determine which shard will calculate
the owner shards for SSTables. Essentially works like a round-robin
distribution.
2) The shard assigned to compute the owners for a SSTable will do
so reading the minimum from disk, usually only Scylla file is
needed.
3) Once that shard finished computing the owners, it will forward
the SSTable to the shard that own it.
4) Shards will later load SSTables locally that were forwarded to
them.