### PR TITLE
test: perf: add end-to-end benchmark for alternator

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1351,7 +1351,8 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc', 'utils/exceptions.cc']
 
 scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
-scylla_perfs = ['test/perf/perf_fast_forward.cc',
+scylla_perfs = ['test/perf/perf_alternator.cc',
+                'test/perf/perf_fast_forward.cc',
                 'test/perf/perf_row_cache_update.cc',
                 'test/perf/perf_simple_query.cc',
                 'test/perf/perf_sstable.cc',

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -26,6 +26,7 @@ endfunction()
 add_library(test-perf STATIC)
 target_sources(test-perf
   PRIVATE
+    perf_alternator.cc
     perf_fast_forward.cc
     perf_row_cache_update.cc
     perf_simple_query.cc

--- a/test/perf/entry_point.hh
+++ b/test/perf/entry_point.hh
@@ -6,6 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <functional>
+
+#include "db/config.hh"
+
 namespace perf {
 
 int scylla_fast_forward_main(int argc, char** argv);
@@ -13,5 +17,6 @@ int scylla_row_cache_update_main(int argc, char**argv);
 int scylla_simple_query_main(int argc, char** argv);
 int scylla_sstable_main(int argc, char** argv);
 int scylla_tablets_main(int argc, char**argv);
+std::function<int(int, char**)> alternator(std::function<int(int, char**)> scylla_main, std::function<void(lw_shared_ptr<db::config> cfg)>* after_init_func);
 
 } // namespace tools

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <iosfwd>
 #include <boost/range/irange.hpp>
+#include <vector>
 
 template <typename Func>
 static
@@ -163,6 +164,21 @@ struct perf_result {
     uint64_t errors;
 };
 
+
+struct aggregated_perf_results {
+    struct throughput_t {
+        double median;
+        double median_absolute_deviation;
+        double min;
+        double max;
+    };
+    throughput_t throughput;
+    perf_result median_by_throughput; // Simplification, median element is considered based on throughput value
+
+    aggregated_perf_results(std::vector<perf_result>& results);
+};
+
+std::ostream& operator<<(std::ostream& os, const aggregated_perf_results& result);
 // Use to make a perf_result with aio_writes added. Need to give "update" as
 // update-func to time_parallel_ex to make it work.
 struct aio_writes_result_mixin {

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <functional>
+#include <memory>
+#include <signal.h>
+#include <seastar/core/thread.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/http/client.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/short_streams.hh>
+#include <tuple>
+#include <boost/program_options.hpp>
+
+#include "db/config.hh"
+#include "seastar/core/future.hh"
+#include "test/perf/perf.hh"
+#include "test/lib/random_utils.hh"
+
+
+namespace perf {
+
+using namespace seastar;
+namespace bpo = boost::program_options;
+
+struct test_config {
+    std::string workload;
+    int port;
+    unsigned partitions;
+    unsigned duration_in_seconds;
+    unsigned concurrency;
+    bool flush;
+    std::string remote_host;
+};
+
+std::ostream& operator<<(std::ostream& os, const test_config& cfg) {
+    return os << "{workload=" << cfg.workload
+           << ", partitions=" << cfg.partitions
+           << ", concurrency=" << cfg.concurrency
+           << ", duration_in_seconds=" << cfg.duration_in_seconds
+           << ", flush=" << cfg.flush
+           << "}";
+}
+
+static http::experimental::client get_client(const test_config& c, int port = 0) {
+    std::string host = "127.0.0.1";
+    if (!c.remote_host.empty()) {
+        host = c.remote_host;
+    }
+    if (port == 0) {
+        port = c.port;
+    }
+    return http::experimental::client(socket_address(net::inet_address(host), port));
+}
+
+static future<> make_request(http::experimental::client& cli, sstring operation, sstring body) {
+    auto req = http::request::make("POST", "localhost", "/");
+    req._headers["X-Amz-Target:"] = "DynamoDB_20120810." + operation;
+    req.write_body("application/x-amz-json-1.0", std::move(body));
+    return cli.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in_) {
+        return do_with(std::move(in_), [] (auto& in) {
+            return util::skip_entire_stream(in).then([&in] () {
+                return in.close();
+            });
+        });
+    });
+}
+
+static void delete_alternator_table(http::experimental::client& cli) {
+    try {
+        make_request(cli, "DeleteTable", R"({"TableName": "workloads_test"})").get();
+    } catch(...) {
+        // table may exist or not
+    }
+}
+
+static void create_alternator_table(http::experimental::client& cli) {
+    delete_alternator_table(cli); // cleanup in case of leftovers
+    make_request(cli, "CreateTable", R"(
+        {
+            "AttributeDefinitions": [{
+                    "AttributeName": "p",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "c",
+                    "AttributeType": "S"
+                }
+            ],
+            "TableName": "workloads_test",
+            "BillingMode": "PAY_PER_REQUEST",
+            "KeySchema": [{
+                    "AttributeName": "p",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "c",
+                    "KeyType": "RANGE"
+                }
+            ]
+        }
+    )").get();
+}
+
+static future<> update_item(http::experimental::client& cli, uint64_t seq) {
+    // Exercise various types documented here: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html 
+    auto prefix = format(R"({{
+            "TableName": "workloads_test",
+            "Key": {{
+                "p": {{
+                    "S": "{}"
+                }},
+                "c": {{
+                    "S": "{}"
+                }}
+            }},)", seq, seq);
+    auto suffix = R"(
+            "UpdateExpression": "set C0 = :C0, C1 = :C1, C2 = :C2, C3 = :C3, C4 = :C4, C5 = :C5, C6 = :C6, C7 = :C7, C8 = :C8, C9 = :C9",
+            "ExpressionAttributeValues": {
+                ":C0": {
+                    "B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"
+                },
+                ":C1": {
+                   "BOOL": true
+                },
+                ":C2": {
+                    "BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
+                },
+                ":C3": {
+                    "L": [ {"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}]
+                },
+                ":C4": {
+                    "M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}
+                },
+                ":C5": {
+                    "N": "123.45"
+                },
+                ":C6": {
+                    "NS": ["42.2", "-19", "7.5", "3.14"]
+                },
+                ":C7": {
+                    "NULL": true
+                },
+                ":C8": {
+                    "S": "Hello"
+                },
+                ":C9": {
+                    "SS": ["Giraffe", "Hippo" ,"Zebra"]
+                }
+            },
+            "ReturnValues": "NONE"
+        }
+    )";
+    return make_request(cli, "UpdateItem", prefix+suffix);
+}
+
+static future<> get_item(http::experimental::client& cli, uint64_t seq) {
+    auto body = format(R"({{
+        "TableName": "workloads_test",
+        "Key": {{
+            "p": {{
+                "S": "{}"
+            }},
+            "c": {{
+                "S": "{}"
+            }}
+        }},
+        "ProjectionExpression": "C0, C1, C2, C3, C4, C5, C6, C7, C8, C9",
+        "ConsistentRead": false,
+        "ReturnConsumedCapacity": "TOTAL"
+    }})",seq, seq);
+    co_await make_request(cli, "GetItem", std::move(body));
+}
+
+static void flush_table(const test_config& c) {
+    auto cli = get_client(c, 10000);
+    auto req = http::request::make("POST", "localhost", "/storage_service/keyspace_flush/alternator_workloads_test");
+    cli.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
+        return make_ready_future<>();
+    }).get();
+    cli.close().get();
+}
+
+static void create_partitions(const test_config& c, http::experimental::client& cli) {
+    std::cout << "Creating " << c.partitions << " partitions..." << std::endl;
+    for (unsigned seq = 0; seq < c.partitions; ++seq) {
+        update_item(cli, seq).get();
+    }
+    if (c.flush) {
+        std::cout << "Flushing partitions..." << std::endl;
+        flush_table(c);
+    }
+}
+
+auto make_client_pool(const test_config& c) {
+    std::vector<http::experimental::client> res;
+    res.reserve(c.concurrency);
+    for (unsigned i = 0; i < c.concurrency; i++) {
+        res.push_back(get_client(c));
+    }
+    return res;
+}
+
+void workload_main(const test_config& c) {
+    std::cout << "Running test with config: " << c << std::endl;
+
+    auto cli = get_client(c);
+    auto finally = defer([&] {
+        delete_alternator_table(cli);
+        cli.close().get();
+    });
+
+    create_alternator_table(cli);
+    using fun_t = std::function<future<>(http::experimental::client&, uint64_t)>;
+    std::map<std::string, fun_t> workloads = {
+        {"read",  get_item},
+        {"write", update_item},
+    };
+
+    if (c.workload == "read") {
+        create_partitions(c, cli);
+    }
+
+    auto it = workloads.find(c.workload);
+    if (it == workloads.end()) {
+        throw std::runtime_error(format("unknown workload '{}'", c.workload));
+    }
+    fun_t fun = it->second;
+
+    auto results = time_parallel([&] {
+        static thread_local auto sharded_cli_pool = make_client_pool(c); // for simplicity never closed as it lives for the whole process runtime
+        static thread_local auto cli_iter = -1;
+        auto seq = tests::random::get_int<uint64_t>(c.partitions - 1);
+        return fun(sharded_cli_pool[++cli_iter % c.concurrency], seq);
+    }, c.concurrency, c.duration_in_seconds);
+
+    std::cout << aggregated_perf_results(results) << std::endl;
+}
+
+std::tuple<int,char**> cut_arg(int ac, char** av, std::string name, int num_args = 2) {
+    for (int i = 1 ; i < ac - 1; i++) {
+        if (std::string(av[i]) == name) {
+            std::shift_left(av + i, av + ac, num_args);
+            ac -= num_args;
+            break;
+        }
+    }
+    return std::make_tuple(ac, av);
+}
+
+std::function<int(int, char**)> alternator(std::function<int(int, char**)> scylla_main, std::function<void(lw_shared_ptr<db::config> cfg)>* after_init_func) {
+    return [=](int ac, char** av) -> int {
+        test_config c;
+       
+        bpo::options_description opts_desc;
+        opts_desc.add_options()
+            ("workload", bpo::value<std::string>()->default_value(""), "which workload type to run")
+            ("partitions", bpo::value<unsigned>()->default_value(10000), "number of partitions")
+            ("duration", bpo::value<unsigned>()->default_value(5), "test duration in seconds")
+            ("concurrency", bpo::value<unsigned>()->default_value(100), "workers per core")
+            ("flush", bpo::value<bool>()->default_value(true), "flush memtables before test")
+            ("remote-host", bpo::value<std::string>()->default_value(""), "address of remote alternator service, use localhost by default")
+        ;
+        bpo::variables_map opts;
+        bpo::store(bpo::command_line_parser(ac, av).options(opts_desc).allow_unregistered().run(), opts);
+
+        c.workload = opts["workload"].as<std::string>();
+        c.partitions = opts["partitions"].as<unsigned>();
+        c.duration_in_seconds = opts["duration"].as<unsigned>();
+        c.concurrency = opts["concurrency"].as<unsigned>();
+        c.flush = opts["flush"].as<bool>();
+        c.remote_host = opts["remote-host"].as<std::string>();
+
+        // Remove test options to not disturb scylla main app
+        for (auto& opt : opts_desc.options()) {
+            auto name = opt->canonical_display_name(bpo::command_line_style::allow_long);
+            std::tie(ac, av) = cut_arg(ac, av, name);
+        }
+
+        if (c.workload.empty()) {
+            std::cerr << "Missing --workload command-line value!" << std::endl;
+            return 1;
+        }
+        
+        if (!c.remote_host.empty()) {
+            c.port = 8000; // TODO: make configurable
+            app_template app;
+            return app.run(ac, av, [c = std::move(c)] () -> future<> {
+                return seastar::async([c = std::move(c)] () {
+                    workload_main(c);
+                });
+            });
+        }
+
+        *after_init_func = [c = std::move(c)] (lw_shared_ptr<db::config> cfg) mutable {
+            c.port = cfg->alternator_port();
+            (void)seastar::async([c = std::move(c)] {
+                try {
+                    workload_main(c);
+                } catch(...) {
+                    std::cerr << "Test failed: " << std::current_exception() << std::endl;
+                    raise(SIGKILL); // request abnormal shutdown
+                }
+                raise(SIGINT); // request shutdown
+            });
+        };
+        return scylla_main(ac, av);
+    };
+}
+
+} // namespace perf

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -34,6 +34,7 @@ struct test_config {
     std::string workload;
     int port;
     unsigned partitions;
+    bool prepopulate_partitions;
     unsigned duration_in_seconds;
     unsigned operations_per_shard;
     unsigned concurrency;
@@ -394,7 +395,7 @@ void workload_main(const test_config& c) {
         {"write_rmw", update_item_rmw},
     };
 
-    if (c.workload == "read" || c.workload == "scan") {
+    if (c.prepopulate_partitions && (c.workload == "read" || c.workload == "scan")) {
         create_partitions(c, cli);
     }
 
@@ -433,6 +434,7 @@ std::function<int(int, char**)> alternator(std::function<int(int, char**)> scyll
         opts_desc.add_options()
             ("workload", bpo::value<std::string>()->default_value(""), "which workload type to run")
             ("partitions", bpo::value<unsigned>()->default_value(10000), "number of partitions")
+            ("prepopulate-partitions", bpo::value<bool>()->default_value(true), "relevant for read workloads, can be disabled when data is prepopulated externally")
             ("duration", bpo::value<unsigned>()->default_value(5), "test duration in seconds")
             ("operations-per-shard", bpo::value<unsigned>()->default_value(0), "run this many operations per shard (overrides duration)")
             ("concurrency", bpo::value<unsigned>()->default_value(100), "workers per core")
@@ -446,6 +448,7 @@ std::function<int(int, char**)> alternator(std::function<int(int, char**)> scyll
 
         c.workload = opts["workload"].as<std::string>();
         c.partitions = opts["partitions"].as<unsigned>();
+        c.prepopulate_partitions = opts["prepopulate-partitions"].as<bool>();
         c.duration_in_seconds = opts["duration"].as<unsigned>();
         c.operations_per_shard = opts["operations-per-shard"].as<unsigned>();
         c.concurrency = opts["concurrency"].as<unsigned>();


### PR DESCRIPTION
  The code is based on similar idea as perf_simple_query. The main differences are:
  - it starts full scylla process
  - communicates with alternator via http (localhost)
  - uses richer table schema with all dynamoDB types instead of only strings
  
  Testing code runs in the same process as scylla so we can easily get various perf counters (tps, instr, allocation, etc).
  
  Results on my machine (with 1 vCPU):
  > ./build/release/scylla perf-alternator-workloads --workdir ~/tmp --smp 1 --developer-mode 1 --alternator-port 8000 --alternator-write-isolation forbid --workload read --duration 10 2> /dev/null
  ...
  median 23402.59616090321
  median absolute deviation: 598.77
  maximum: 24014.41
  minimum: 19990.34
  
  > ./build/release/scylla perf-alternator-workloads --workdir ~/tmp --smp 1 --developer-mode 1 --alternator-port 8000 --alternator-write-isolation forbid --workload write --duration 10 2> /dev/null
  ...
  median 16089.34211320635
  median absolute deviation: 552.65
  maximum: 16915.95
  minimum: 14781.97
  
  The above seem more realistic than results from perf_simple_query which are 96k and 49k tps (per core).

Related: https://github.com/scylladb/scylladb/issues/12518
