### PR TITLE
cql-pytest/lwt_test: test LWT UPDATE when partition/clustering ranges are empty

### DIFF
--- a/test/cql-pytest/test_lwt.py
+++ b/test/cql-pytest/test_lwt.py
@@ -62,3 +62,10 @@ def test_lwt_static_condition(cql, table1):
     # respectively.
     with pytest.raises(InvalidRequest, match=re.compile('missing', re.IGNORECASE)):
         cql.execute(f'UPDATE {table1} SET s=2 WHERE p={p} IF r=1')
+
+# Generate an LWT update where there is no value for the partition key,
+# as the WHERE restricts it using `p = {p} AND p = {p+1}`.
+# Such quries are rejected.
+def test_lwt_empty_partition_range(cql, table1):
+    with pytest.raises(InvalidRequest):
+        cql.execute(f"UPDATE {table1} SET r = 9000 WHERE p = 1 AND p = 1000 AND c = 2 IF r = 3")

--- a/test/cql-pytest/test_lwt.py
+++ b/test/cql-pytest/test_lwt.py
@@ -69,3 +69,11 @@ def test_lwt_static_condition(cql, table1):
 def test_lwt_empty_partition_range(cql, table1):
     with pytest.raises(InvalidRequest):
         cql.execute(f"UPDATE {table1} SET r = 9000 WHERE p = 1 AND p = 1000 AND c = 2 IF r = 3")
+
+# Generate an LWT update where there is no value for the clustering key,
+# as the WHERE restricts it using `c = 2 AND c = 3`.
+# Such queries are rejected.
+@pytest.mark.skip(reason="crashes scylla, see issue #13129")
+def test_lwt_empty_clustering_range(cql, table1):
+    with pytest.raises(InvalidRequest):
+        cql.execute(f"UPDATE {table1} SET r = 9000 WHERE p = 1  AND c = 2 AND c = 2000 IF r = 3")


### PR DESCRIPTION
Adds two test cases which test what happens when we perform an LWT UPDATE, but the partition/clustering key has 0 possible values. This can happen e.g when a column is supposed to be equal to two different values (`c = 0 AND c = 1`).

Empty partition ranges work properly, empty clustering range currently causes a crash (#13129).
I added tests for both of these cases.
