### PR TITLE
scylla-gdb: Parse and eval _all_threads without quotes

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3082,7 +3082,7 @@ def exit_thread_context():
 
 
 def seastar_threads_on_current_shard():
-    return intrusive_list(gdb.parse_and_eval('\'seastar::thread_context::_all_threads\''), link='_all_link')
+    return intrusive_list(gdb.parse_and_eval('seastar::thread_context::_all_threads'), link='_all_link')
 
 
 class scylla_thread(gdb.Command):


### PR DESCRIPTION
I've no idea why the quotes are there at all, it works even without them. However, with quotes gdb-13 fails to find the _all_threads static thread-local variable _unless_ it's printed with gdb "p" command beforehand.

fixes: #13125