### PR TITLE
Raft, use schema commit log

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -95,6 +95,7 @@ namespace {
     const auto set_use_schema_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
         if (ks_name == schema_tables::NAME) {
             props.use_schema_commitlog = true;
+            props.load_phase = system_table_load_phase::phase2;
         }
     });
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -97,6 +97,19 @@ namespace {
             props.wait_for_sync_to_commitlog = true;
         }
     });
+    const auto set_use_schema_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
+        static const std::unordered_set<sstring> raft_tables = {
+            system_keyspace::RAFT,
+            system_keyspace::RAFT_SNAPSHOTS,
+            system_keyspace::RAFT_SNAPSHOT_CONFIG,
+            system_keyspace::GROUP0_HISTORY,
+            system_keyspace::DISCOVERY
+        };
+        if (ks_name == system_keyspace::NAME && raft_tables.contains(cf_name)) {
+            props.use_schema_commitlog = true;
+            props.load_phase = system_table_load_phase::phase2;
+        }
+    });
 }
 
 std::unique_ptr<query_context> qctx = {};

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1589,7 +1589,7 @@ future<> set_scylla_local_param_as(const sstring& key, const T& value) {
     auto type = data_type_for<T>();
     co_await qctx->execute_cql(req, type->to_string_impl(data_value(value)), key).discard_result();
     // Flush the table so that the value is available on boot before commitlog replay.
-    // database::before_schema_keyspace_init() depends on it.
+    // database::maybe_init_schema_commitlog() depends on it.
     co_await smp::invoke_on_all([] () -> future<> {
         co_await qctx->qp().db().real_database().flush(db::system_keyspace::NAME, system_keyspace::SCYLLA_LOCAL);
     });

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -79,15 +79,6 @@ class system_keyspace_view_build_progress;
 struct truncation_record;
 typedef std::vector<db::replay_position> replay_positions;
 
-class table_selector {
-public:
-    static table_selector& all();
-    static std::unique_ptr<table_selector> all_in_keyspace(sstring);
-public:
-    virtual ~table_selector() = default;
-    virtual bool contains(const schema_ptr&) = 0;
-    virtual bool contains_keyspace(std::string_view) = 0;
-};
 
 struct compaction_history_entry {
     utils::UUID id;
@@ -267,7 +258,7 @@ public:
                          sharded<gms::gossiper>& g,
                          sharded<service::raft_group_registry>& raft_gr,
                          db::config& cfg,
-                         table_selector& = table_selector::all());
+                         system_table_load_phase phase);
 
     /// overloads
 

--- a/main.cc
+++ b/main.cc
@@ -1194,6 +1194,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, system_table_load_phase::phase2).get();
 
             if (raft_gr.local().is_enabled()) {
+                if (!db.local().uses_schema_commitlog()) {
+                    startlog.error("Bad configuration: consistent_cluster_management requires schema commit log to be enabled");
+                    throw bad_configuration_error();
+                }
                 auto my_raft_id = raft::server_id{cfg->host_id.uuid()};
                 supervisor::notify("starting Raft Group Registry service");
                 raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {

--- a/main.cc
+++ b/main.cc
@@ -1201,7 +1201,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // since some features affect storage.
             db::system_keyspace::enable_features_on_startup(feature_service).get();
 
-            db.local().before_schema_keyspace_init();
+            db.local().maybe_init_schema_commitlog();
 
             // Init schema tables only after enable_features_on_startup()
             // because table construction consults enabled features.

--- a/main.cc
+++ b/main.cc
@@ -1071,8 +1071,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // done only by shard 0, so we'll no longer face race conditions as
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
-            auto system_keyspace_sel = db::table_selector::all_in_keyspace(db::system_keyspace::NAME);
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, *system_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, system_table_load_phase::phase1).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
@@ -1208,8 +1207,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // because table construction consults enabled features.
             // Needs to be before system_keyspace::setup(), which writes to schema tables.
             supervisor::notify("loading system_schema sstables");
-            auto schema_keyspace_sel = db::table_selector::all_in_keyspace(db::schema_tables::NAME);
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, *schema_keyspace_sel).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, system_table_load_phase::phase2).get();
 
             // schema migration, if needed, is also done on shard 0
             db::legacy_schema_migrator::migrate(proxy, db, qp.local()).get();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -900,7 +900,7 @@ static bool is_system_table(const schema& s) {
         || s.ks_name() == db::system_distributed_keyspace::NAME_EVERYWHERE;
 }
 
-void database::before_schema_keyspace_init() {
+void database::maybe_init_schema_commitlog() {
     assert(this_shard_id() == 0);
 
     if (!_feat.schema_commitlog && !_cfg.force_schema_commit_log()) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -121,7 +121,7 @@ class large_data_handler;
 class system_keyspace;
 class table_selector;
 
-future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
+future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase);
 
 }
 
@@ -653,6 +653,10 @@ public:
     // to issue disk operations safely.
     void mark_ready_for_writes() {
         update_sstables_known_generation(sstables::generation_from_value(0));
+    }
+
+    bool is_ready_for_writes() const {
+        return _sstable_generation.has_value();
     }
 
     // Creates a mutation reader which covers all data sources for this column family.
@@ -1402,7 +1406,7 @@ private:
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
+    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1491,7 +1491,7 @@ public:
     const service::migration_notifier& get_notifier() const { return _mnotifier; }
 
     void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg);
-    void before_schema_keyspace_init();
+    void maybe_init_schema_commitlog();
     future<> add_column_family_and_make_directory(schema_ptr schema);
 
     /* throws no_such_column_family if missing */

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -80,7 +80,7 @@ class distributed_loader {
     static future<> handle_sstables_pending_delete(sstring pending_deletes_dir);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, db::table_selector&);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -559,10 +559,26 @@ public:
     }
 };
 
+// To break some cyclic data dependencies in the early stages of a node boot process,
+// the system tables are loaded in two phases. This allows to use the tables
+// from the first phase to load the tables from the second phase.
+// For example, we need system.scylla_local table to load raft tables, since it
+// stores the enabled features, and SCHEMA_COMMITLOG feature is used to choose
+// what commitlog (regular or schema) will be used for raft tables.
+enum class system_table_load_phase {
+    phase1,
+    phase2
+};
+constexpr system_table_load_phase all_system_table_load_phases[] = {
+    system_table_load_phase::phase1,
+    system_table_load_phase::phase2
+};
+
 struct schema_static_props {
     bool use_null_sharder = false; // use a sharder that puts everything on shard 0
     bool wait_for_sync_to_commitlog = false; // true if all writes using this schema have to be synced immediately by commitlog
     bool use_schema_commitlog = false;
+    system_table_load_phase load_phase = system_table_load_phase::phase1;
 };
 
 /*

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -799,7 +799,9 @@ public:
                 std::ref(snitch)).get();
             auto stop_storage_service = defer([&ss] { ss.stop().get(); });
 
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, db::table_selector::all()).get();
+            for (const auto p: all_system_table_load_phases) {
+                replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, p).get();
+            }
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
             parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {

--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -18,6 +18,5 @@ class ServerInfo(NamedTuple):
     """Server id (test local) and IP address"""
     server_id: ServerNum
     ip_addr: IPAddress
-    host_id: HostID
     def __str__(self):
-        return f"Server({self.server_id}, {self.ip_addr}, {self.host_id})"
+        return f"Server({self.server_id}, {self.ip_addr})"

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -150,10 +150,10 @@ class ManagerClient():
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
-    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None) -> ServerInfo:
+    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None, start: bool = True) -> ServerInfo:
         """Add a new server"""
         try:
-            data: dict[str, Any] = {}
+            data: dict[str, Any] = {'start': start}
             if replace_cfg:
                 data['replace_cfg'] = replace_cfg._asdict()
             if cmdline:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -119,7 +119,7 @@ class ManagerClient():
         except RuntimeError as exc:
             raise Exception("Failed to get list of running servers") from exc
         assert isinstance(server_info_list, list), "running_servers got unknown data type"
-        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]), HostID(info[2]))
+        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]))
                 for info in server_info_list]
 
     async def mark_dirty(self) -> None:
@@ -166,8 +166,7 @@ class ManagerClient():
             raise Exception("Failed to add server") from exc
         try:
             s_info = ServerInfo(ServerNum(int(server_info["server_id"])),
-                                IPAddress(server_info["ip_addr"]),
-                                HostID(server_info["host_id"]))
+                                IPAddress(server_info["ip_addr"]))
         except Exception as exc:
             raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
         logger.debug("ManagerClient added %s", s_info)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -150,7 +150,7 @@ class ManagerClient():
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
         self._driver_update()
 
-    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None) -> ServerInfo:
+    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None) -> ServerInfo:
         """Add a new server"""
         try:
             data: dict[str, Any] = {}
@@ -158,6 +158,8 @@ class ManagerClient():
                 data['replace_cfg'] = replace_cfg._asdict()
             if cmdline:
                 data['cmdline'] = cmdline
+            if config:
+                data['config'] = config
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
                                                      timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except Exception as exc:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -137,10 +137,11 @@ class ManagerClient():
         logger.debug("ManagerClient stopping gracefully %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/stop_gracefully")
 
-    async def server_start(self, server_id: ServerNum) -> None:
+    async def server_start(self, server_id: ServerNum, expected_error: Optional[str] = None) -> None:
         """Start specified server"""
         logger.debug("ManagerClient starting %s", server_id)
-        await self.client.get_text(f"/cluster/server/{server_id}/start")
+        params = {'expected_error': expected_error} if expected_error is not None else None
+        await self.client.get_text(f"/cluster/server/{server_id}/start", params=params)
         self._driver_update()
 
     async def server_restart(self, server_id: ServerNum) -> None:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -400,6 +400,7 @@ class ScyllaServer:
 
         while time.time() < self.start_time + self.TOPOLOGY_TIMEOUT:
             if self.cmd.returncode:
+                self.cmd = None
                 with self.log_filename.open('r') as log_file:
                     self.logger.error("failed to start server at host %s in %s",
                                   self.ip_addr, self.workdir.name)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -699,7 +699,7 @@ class ScyllaCluster:
             raise
         self.running[server.server_id] = server
         self.logger.info("Cluster %s added %s", self, server)
-        return ServerInfo(server.server_id, server.ip_addr, server.host_id)
+        return ServerInfo(server.server_id, server.ip_addr)
 
     def endpoint(self) -> str:
         """Get a server id (IP) from running servers"""
@@ -731,9 +731,9 @@ class ScyllaCluster:
         stopped = ", ".join(str(server) for server in self.stopped.values())
         return f"ScyllaCluster(name: {self.name}, running: {running}, stopped: {stopped})"
 
-    def running_servers(self) -> List[Tuple[ServerNum, IPAddress, HostID]]:
+    def running_servers(self) -> List[Tuple[ServerNum, IPAddress]]:
         """Get a list of tuples of server id and IP address of running servers (and not removed)"""
-        return [(server.server_id, server.ip_addr, server.host_id) for server in self.running.values()
+        return [(server.server_id, server.ip_addr) for server in self.running.values()
                 if server.server_id not in self.removed]
 
     def _get_keyspace_count(self) -> int:
@@ -1098,8 +1098,7 @@ class ScyllaClusterManager:
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
         s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'))
         return aiohttp.web.json_response({"server_id" : s_info.server_id,
-                                          "ip_addr": s_info.ip_addr,
-                                          "host_id": s_info.host_id})
+                                          "ip_addr": s_info.ip_addr})
 
     async def _cluster_remove_node(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
         """Run remove node on Scylla REST API for a specified server"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -644,11 +644,11 @@ class ScyllaCluster:
     def _seeds(self) -> List[str]:
         return [server.ip_addr for server in self.running.values()]
 
-    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None) -> ServerInfo:
+    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
-        extra_config: dict[str, str] = {}
+        extra_config: dict[str, str] = config.copy() if config else {}
         if replace_cfg:
             replaced_id = replace_cfg.replaced_id
             assert replaced_id in self.servers, \
@@ -1096,7 +1096,7 @@ class ScyllaClusterManager:
         assert self.cluster
         data = await request.json()
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
-        s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'))
+        s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'))
         return aiohttp.web.json_response({"server_id" : s_info.server_id,
                                           "ip_addr": s_info.ip_addr,
                                           "host_id": s_info.host_id})

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -245,11 +245,7 @@ class ScyllaServer:
 
     async def install_and_start(self, api: ScyllaRESTAPIClient) -> None:
         """Setup and start this server"""
-        try:
-            await self.install()
-        except:
-            await self.uninstall()
-            raise
+        await self.install()
 
         self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
 
@@ -284,11 +280,19 @@ class ScyllaServer:
         # Cleanup any remains of the previously running server in this path
         shutil.rmtree(self.workdir, ignore_errors=True)
 
-        self.workdir.mkdir(parents=True, exist_ok=True)
-        self.config_filename.parent.mkdir(parents=True, exist_ok=True)
-        self._write_config_file()
+        try:
+            self.workdir.mkdir(parents=True, exist_ok=True)
+            self.config_filename.parent.mkdir(parents=True, exist_ok=True)
+            self._write_config_file()
 
-        self.log_file = self.log_filename.open("wb")
+            self.log_file = self.log_filename.open("wb")
+        except:
+            try:
+                shutil.rmtree(self.workdir)
+            except FileNotFoundError:
+                pass
+            self.log_filename.unlink(missing_ok=True)
+            raise
 
     def get_config(self) -> dict[str, object]:
         """Return the contents of conf/scylla.yaml as a dict."""
@@ -644,7 +648,7 @@ class ScyllaCluster:
     def _seeds(self) -> List[str]:
         return [server.ip_addr for server in self.running.values()]
 
-    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None) -> ServerInfo:
+    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None, start: bool = True) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
@@ -689,7 +693,10 @@ class ScyllaCluster:
         try:
             server = self.create_server(params)
             self.logger.info("Cluster %s adding server...", self)
-            await server.install_and_start(self.api)
+            if start:
+                await server.install_and_start(self.api)
+            else:
+                await server.install()
         except Exception as exc:
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
                           ip_addr, server.workdir.name, str(exc))
@@ -697,7 +704,10 @@ class ScyllaCluster:
                 self.leased_ips.remove(ip_addr)
                 await self.host_registry.release_host(Host(ip_addr))
             raise
-        self.running[server.server_id] = server
+        if start:
+            self.running[server.server_id] = server
+        else:
+            self.stopped[server.server_id] = server
         self.logger.info("Cluster %s added %s", self, server)
         return ServerInfo(server.server_id, server.ip_addr)
 
@@ -1096,7 +1106,7 @@ class ScyllaClusterManager:
         assert self.cluster
         data = await request.json()
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
-        s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'))
+        s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'), data.get('start', True))
         return aiohttp.web.json_response({"server_id" : s_info.server_id,
                                           "ip_addr": s_info.ip_addr})
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -398,24 +398,28 @@ class ScyllaServer:
         sleep_interval = 0.1
         cql_up_state = CqlUpState.NOT_CONNECTED
 
+        def report_error(message: str):
+            message += f", server_id {self.server_id}, IP {self.ip_addr}, workdir {self.workdir.name}"
+            message += f", host_id {self.host_id if hasattr(self, 'host_id') else '<missing>'}"
+            message += f", cql [{'connected' if cql_up_state == CqlUpState.CONNECTED else 'not connected'}]"
+            self.logger.error(message)
+            self.logger.error("last line of %s:", self.log_filename)
+            with self.log_filename.open('r') as log_file:
+                log_file.seek(0, 0)
+                self.logger.error(log_file.readlines()[-1].rstrip())
+            log_handler = logging.getLogger().handlers[0]
+            if hasattr(log_handler, 'baseFilename'):
+                logpath = log_handler.baseFilename   # type: ignore
+            else:
+                logpath = "?"
+            raise RuntimeError(message + "\nCheck the log files:\n"
+                                         f"{logpath}\n"
+                                         f"{self.log_filename}")
+
         while time.time() < self.start_time + self.TOPOLOGY_TIMEOUT:
             if self.cmd.returncode:
                 self.cmd = None
-                with self.log_filename.open('r') as log_file:
-                    self.logger.error("failed to start server at host %s in %s",
-                                  self.ip_addr, self.workdir.name)
-                    self.logger.error("last line of %s:", self.log_filename)
-                    log_file.seek(0, 0)
-                    self.logger.error(log_file.readlines()[-1].rstrip())
-                    log_handler = logging.getLogger().handlers[0]
-                    if hasattr(log_handler, 'baseFilename'):
-                        logpath = log_handler.baseFilename   # type: ignore
-                    else:
-                        logpath = "?"
-                    raise RuntimeError(f"Failed to start server with ID = {self.server_id}, IP = {self.ip_addr}.\n"
-                                       "Check the log files:\n"
-                                       f"{logpath}\n"
-                                       f"{self.log_filename}")
+                report_error("failed to start the node")
 
             if hasattr(self, "host_id") or await self.get_host_id(api):
                 cql_up_state = await self.cql_is_up()
@@ -425,17 +429,7 @@ class ScyllaServer:
             # Sleep and retry
             await asyncio.sleep(sleep_interval)
 
-        err = f"Failed to start server with ID = {self.server_id}, IP = {self.ip_addr}."
-        if hasattr(self, "host_id"):
-            err += f" Managed to obtain the server's Host ID ({self.host_id})"
-            if cql_up_state == CqlUpState.CONNECTED:
-                err += " and to connect the CQL driver, but failed to execute a query."
-            else:
-                err += " but failed to connect the CQL driver."
-        else:
-            err += " Failed to obtain the server's Host ID."
-        err += f"\nCheck server log at {self.log_filename}."
-        raise RuntimeError(err)
+        report_error('failed to start the node, timeout reached')
 
     async def force_schema_migration(self) -> None:
         """This is a hack to change schema hash on an existing cluster node

--- a/test/topology_raft_disabled/test_raft_upgrade.py
+++ b/test/topology_raft_disabled/test_raft_upgrade.py
@@ -108,6 +108,62 @@ def log_run_time(f):
     return wrapped
 
 
+# Wait for the given feature to be enabled.
+async def wait_for_feature(feature: str, cql: Session, host: Host, deadline: float) -> None:
+    async def feature_is_enabled():
+        rs = await cql.run_async("select value from system.scylla_local where key = 'enabled_features'", host=host)
+        if rs:
+            value = rs[0].value
+            if feature in value:
+                return True
+        return None
+    await wait_for(feature_is_enabled, deadline)
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_upgrade_with_no_schema_commitlog(manager: ManagerClient, random_tables: RandomTables):
+    # RAFT without schema_commit_log should produce error at node startup
+    # We can't test this on the already running nodes, since schema commitlog feature
+    # may have already been enabled on them
+    new_server_info = await manager.server_add(start=False, config={
+        'consistent_cluster_management': 'True',
+        'force_schema_commit_log': 'False'
+    })
+    await manager.server_start(new_server_info.server_id,
+                               "Bad configuration: consistent_cluster_management "
+                               "requires schema commit log to be enabled")
+
+    # Rollback RAFT and restart new node
+    # Now it's the same as initially running nodes, except with force_schema_commit_log = False
+    await manager.server_update_config(new_server_info.server_id, 'consistent_cluster_management', False)
+    await manager.server_stop_gracefully(new_server_info.server_id)
+    await manager.server_start(new_server_info.server_id)
+    cql = await reconnect_driver(manager)
+    servers = await manager.running_servers()
+
+    # Wait for schema commitlog feature on all nodes, including the new one.
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await asyncio.gather(*(wait_for_feature("SCHEMA_COMMITLOG", cql, h, time.time() + 60) for h in hosts))
+
+    # restart all the nodes with RAFT enabled
+    await asyncio.gather(*(enable_raft_and_restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    # wait until upgrade finishes
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+    # upgrade finished, try to create a new table
+    table = await random_tables.add_table(ncolumns=5)
+
+    # check group history
+    rs = await cql.run_async("select * from system.group0_history")
+    assert(rs)
+    logging.info(f"group0_history entry description: '{rs[0].description}'")
+    assert(table.full_name in rs[0].description)
+
+
 @pytest.mark.asyncio
 @log_run_time
 async def test_raft_upgrade_basic(manager: ManagerClient, random_tables: RandomTables):


### PR DESCRIPTION
We need this so that we can have multi-partition mutations which are applied atomically. If they live on different shards, we can't guarantee atomic write to the commitlog.

Fixes: #12642
