### PR TITLE
Improve database shutdown verbosity

### DIFF
--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -58,6 +58,7 @@ void large_data_handler::start() {
 future<> large_data_handler::stop() {
     if (running()) {
         _running = false;
+        large_data_logger.info("Waiting for {} background handlers", max_concurrency - _sem.available_units());
         co_await _sem.wait(max_concurrency);
     }
 }

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/print.hh>
+#include <seastar/core/coroutine.hh>
 #include "db/system_keyspace.hh"
 #include "db/large_data_handler.hh"
 #include "sstables/sstables.hh"
@@ -55,11 +56,10 @@ void large_data_handler::start() {
 }
 
 future<> large_data_handler::stop() {
-    if (!running()) {
-        return make_ready_future<>();
+    if (running()) {
+        _running = false;
+        co_await _sem.wait(max_concurrency);
     }
-    _running = false;
-    return _sem.wait(max_concurrency);
 }
 
 void large_data_handler::plug_system_keyspace(db::system_keyspace& sys_ks) noexcept {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2245,16 +2245,24 @@ future<> database::stop() {
     if (_schema_commitlog) {
         co_await _schema_commitlog->release();
     }
+    dblog.info("Shutting down system dirty memory manager");
     co_await _system_dirty_memory_manager.shutdown();
+    dblog.info("Shutting down dirty memory manager");
     co_await _dirty_memory_manager.shutdown();
+    dblog.info("Shutting down memtable controller");
     co_await _memtable_controller.shutdown();
+    dblog.info("Closing user sstables manager");
     co_await _user_sstables_manager->close();
+    dblog.info("Closing system sstables manager");
     co_await _system_sstables_manager->close();
+    dblog.info("Stopping querier cache");
     co_await _querier_cache.stop();
+    dblog.info("Stopping concurrency semaphores");
     co_await _read_concurrency_sem.stop();
     co_await _streaming_concurrency_sem.stop();
     co_await _compaction_concurrency_sem.stop();
     co_await _system_read_concurrency_sem.stop();
+    dblog.info("Joining memtable update action");
     co_await _update_memtable_flush_static_shares_action.join();
 }
 


### PR DESCRIPTION
The `database::stop` method is sometimes hanging and it's always hard to spot where exactly it sleeps. Few more logging messages would make this much simpler.

refs: #13100
refs: #10941