### PR TITLE
test: Update boost.suite.run_first list

### DIFF
--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -5,11 +5,11 @@ run_first:
     - schema_changes_test
     - sstable_conforms_to_mutation_source_test
     - secondary_index_test
-    - cql_query_test
     - mutation_reader_test
-    - view_schema_test
     - multishard_combining_reader_as_mutation_source_test
     - database_test
+    - cql_function_test
+    - memtable_test
 # These test cannot work in case-by-case mode because
 # some test-cases depend on each other
 no_parallel_cases:


### PR DESCRIPTION
In debug mode the timings are:

view_schema_test:        90 sec
cql_query_test:         170 sec
memtable_test:         2090 sec
cql_functions_test:    2591 sec

other tests that are in/out of this list are not that obvious, but the former two apparently deserve being replaced with the latter two.

Timings for dev/release modes are not that horrible, but the "first pair is notably smaller than the latter" relation also exists.