### PR TITLE
Update stop.rst

### DIFF
--- a/docs/operating-scylla/nodetool-commands/stop.rst
+++ b/docs/operating-scylla/nodetool-commands/stop.rst
@@ -7,7 +7,7 @@ Usage
 
 .. code:: sh
 
-          nodetool <options> stop -- <compaction_type>
+          nodetool <options> stop <compaction_type> 
 
 .. versionadded:: version 4.5 ``compaction type``
    
@@ -18,8 +18,8 @@ For example:
 
 .. code:: sh
 
-    nodetool stop compaction
+    nodetool stop COMPACTION
 
-    nodetool stop compaction RESHAPE
+    nodetool stop COMPACTION RESHAPE
 
 .. include:: nodetool-index.rst


### PR DESCRIPTION
In the example, compaction should be in the upper case to work. I tested with versions 5.1 and 4.4.8 and received the same output. 

```
root@d83c9d6dc140:/# nodetool stop compaction RESHAPE
nodetool: compaction_type: can not convert "compaction" to a OperationType
See 'nodetool help' or 'nodetool help <command>'.
root@d83c9d6dc140:/# nodetool stop COMPACTION RESHAPE
root@d83c9d6dc140:/# 
```