### PR TITLE
main: Forget the --max-io-requests option

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -321,12 +321,8 @@ verify_seastar_io_scheduler(const boost::program_options::variables_map& opts, b
         }
     };
 
-    if (!opts.contains("max-io-requests") && !(opts.contains("io-properties") || opts.contains("io-properties-file"))) {
-        note_bad_conf("none of --max-io-requests, --io-properties and --io-properties-file are set.");
-    }
-    if (opts.contains("max-io-requests") && opts["max-io-requests"].as<unsigned>() < 4) {
-        auto cause = format("I/O Queue capacity for this shard is too low ({:d}, minimum 4 expected).", opts["max-io-requests"].as<unsigned>());
-        note_bad_conf(cause);
+    if (!(opts.contains("io-properties") || opts.contains("io-properties-file"))) {
+        note_bad_conf("none of --io-properties and --io-properties-file are set.");
     }
 }
 


### PR DESCRIPTION
On start scylla checks if the option is set. It's nowadays useless, as it had been removed from seastar (see 9e34779c update)