### PR TITLE
install-dependencies: extract go_arch() out

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -174,21 +174,25 @@ arch_packages=(
     thrift
 )
 
+go_arch() {
+    declare -A local GO_ARCH=(
+        ["x86_64"]=amd64
+        ["aarch64"]=arm64
+        ["s390x"]=s390x
+    )
+    echo ${GO_ARCH["$(arch)"]}
+}
+
 NODE_EXPORTER_VERSION=1.5.0
 declare -A NODE_EXPORTER_CHECKSUM=(
     ["x86_64"]=af999fd31ab54ed3a34b9f0b10c28e9acee9ef5ac5a5d5edfdde85437db7acbb
     ["aarch64"]=e031a539af9a619c06774788b54c23fccc2a852d41437315725a086ccdb0ed16
     ["s390x"]=fc5be2c18cb5a13de56ae2b8e91d3fabb40bf1ece398be690df1cd5c43008747
 )
-declare -A NODE_EXPORTER_ARCH=(
-    ["x86_64"]=amd64
-    ["aarch64"]=arm64
-    ["s390x"]=s390x
-)
 NODE_EXPORTER_DIR=/opt/scylladb/dependencies
 
 node_exporter_filename() {
-    echo "node_exporter-$NODE_EXPORTER_VERSION.linux-${NODE_EXPORTER_ARCH["$(arch)"]}.tar.gz"
+    echo "node_exporter-$NODE_EXPORTER_VERSION.linux-$(go_arch).tar.gz"
 }
 
 node_exporter_fullpath() {
@@ -203,19 +207,14 @@ node_exporter_url() {
     echo "https://github.com/prometheus/node_exporter/releases/download/v$NODE_EXPORTER_VERSION/$(node_exporter_filename)"
 }
 
-declare -A MINIO_ARCH=(
-    ["x86_64"]=amd64
-    ["aarch64"]=arm64
-    ["s390x"]=s390x
-)
 MINIO_BINARIES_DIR=/usr/local/bin
 
 minio_server_url() {
-    echo "https://dl.minio.io/server/minio/release/linux-${MINIO_ARCH[$(arch)]}/minio"
+    echo "https://dl.minio.io/server/minio/release/linux-$(go_arch)/minio"
 }
 
 minio_client_url() {
-    echo "https://dl.min.io/client/mc/release/linux-${MINIO_ARCH[$(arch)]}/mc"
+    echo "https://dl.min.io/client/mc/release/linux-$(go_arch)/mc"
 }
 
 minio_download_jobs() {


### PR DESCRIPTION
for defining the mapping from the output of `arch` to the corresponding GO_ARCH. see https://github.com/golang/go/blob/b94dc384cabf75e7e8703265cd80f5324f84b642/src/go/build/syslist.go#L55