### PR TITLE
install-dependencies: Add rapid XML dev package

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -47,6 +47,7 @@ debian_base_packages=(
     libzstd-dev
     libdeflate-dev
     libabsl-dev
+    librapidxml-dev
 )
 
 fedora_packages=(
@@ -104,6 +105,7 @@ fedora_packages=(
     curl
     rust
     cargo
+    rapidxml-devel
 )
 
 # lld is not available on s390x, see


### PR DESCRIPTION
It will be needed by S3 driver to parse multipart-upload messages from server

refs: #12523