### PR TITLE
Refactor schema, introduce schema_static_props and move several properties into it

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -92,6 +92,11 @@ namespace {
             props.use_null_sharder = true;
         }
     });
+    const auto set_use_schema_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
+        if (ks_name == schema_tables::NAME) {
+            props.use_schema_commitlog = true;
+        }
+    });
 }
 
 schema_ctxt::schema_ctxt(const db::config& cfg, std::shared_ptr<data_dictionary::user_types_storage> uts)

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -83,12 +83,6 @@ using namespace std::chrono_literals;
 
 static logging::logger diff_logger("schema_diff");
 
-static bool is_extra_durable(const sstring& ks_name, const sstring& cf_name) {
-    return (is_system_keyspace(ks_name) && db::system_keyspace::is_extra_durable(cf_name))
-        || ((ks_name == db::system_distributed_keyspace::NAME || ks_name == db::system_distributed_keyspace::NAME_EVERYWHERE)
-                && db::system_distributed_keyspace::is_extra_durable(cf_name));
-}
-
 
 /** system.schema_* tables used to store keyspace/table/type attributes prior to C* 3.0 */
 namespace db {
@@ -3091,10 +3085,6 @@ schema_ptr create_table_from_mutations(const schema_ctxt& ctxt, schema_mutations
     if (auto partitioner = sm.partitioner()) {
         builder.with_partitioner(*partitioner);
         builder.with_sharder(smp::count, ctxt.murmur3_partitioner_ignore_msb_bits());
-    }
-
-    if (is_extra_durable(ks_name, cf_name)) {
-        builder.set_wait_for_sync_to_commitlog(true);
     }
 
     return builder.build();

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -77,10 +77,6 @@ private:
     bool _forced_cdc_timestamps_schema_sync = false;
 
 public:
-    /* Should writes to the given table always be synchronized by commitlog (flushed to disk)
-     * before being acknowledged? */
-    static bool is_extra_durable(const sstring& cf_name);
-
     static std::vector<schema_ptr> all_distributed_tables();
     static std::vector<schema_ptr> all_everywhere_tables();
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -83,16 +83,26 @@ namespace {
             props.use_null_sharder = true;
         }
     });
+    const auto set_wait_for_sync_to_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
+        static const std::unordered_set<sstring> extra_durable_tables = {
+            system_keyspace::PAXOS,
+            system_keyspace::SCYLLA_LOCAL,
+            system_keyspace::RAFT,
+            system_keyspace::RAFT_SNAPSHOTS,
+            system_keyspace::RAFT_SNAPSHOT_CONFIG,
+            system_keyspace::DISCOVERY,
+            system_keyspace::BROADCAST_KV_STORE
+        };
+        if (ks_name == system_keyspace::NAME && extra_durable_tables.contains(cf_name)) {
+            props.wait_for_sync_to_commitlog = true;
+        }
+    });
 }
 
 std::unique_ptr<query_context> qctx = {};
 
 static logging::logger slogger("system_keyspace");
 static const api::timestamp_type creation_timestamp = api::new_timestamp();
-
-bool system_keyspace::is_extra_durable(const sstring& name) {
-    return boost::algorithm::any_of(extra_durable_tables, [name] (const char* table) { return name == table; });
-}
 
 api::timestamp_type system_keyspace::schema_creation_timestamp() {
     return creation_timestamp;
@@ -198,7 +208,6 @@ schema_ptr system_keyspace::batchlog() {
        );
        builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
-       builder.set_wait_for_sync_to_commitlog(true);
        return builder.build(schema_builder::compact_storage::no);
     }();
     return paxos;
@@ -222,7 +231,6 @@ schema_ptr system_keyspace::raft() {
 
             .set_comment("Persisted RAFT log, votes and snapshot info")
             .with_version(generate_schema_version(id))
-            .set_wait_for_sync_to_commitlog(true)
             .build();
     }();
     return schema;
@@ -243,7 +251,6 @@ schema_ptr system_keyspace::raft_snapshots() {
 
             .set_comment("Persisted RAFT snapshot descriptors info")
             .with_version(generate_schema_version(id))
-            .set_wait_for_sync_to_commitlog(true)
             .build();
     }();
     return schema;
@@ -260,7 +267,6 @@ schema_ptr system_keyspace::raft_snapshot_config() {
 
             .set_comment("RAFT configuration for the latest snapshot descriptor")
             .with_version(generate_schema_version(id))
-            .set_wait_for_sync_to_commitlog(true)
             .build();
     }();
     return schema;
@@ -654,8 +660,6 @@ schema_ptr system_keyspace::large_cells() {
         "Scylla specific information about the local node"
        );
        builder.set_gc_grace_seconds(0);
-       // Raft Group id and server id updates must be sync
-       builder.set_wait_for_sync_to_commitlog(true);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -956,7 +960,6 @@ schema_ptr system_keyspace::discovery() {
             .with_column("raft_server_id", uuid_type)
             .set_comment("State of cluster discovery algorithm: the set of discovered peers")
             .with_version(generate_schema_version(id))
-            .set_wait_for_sync_to_commitlog(true)
             .build();
     }();
     return schema;
@@ -969,7 +972,6 @@ schema_ptr system_keyspace::broadcast_kv_store() {
             .with_column("key", utf8_type, column_kind::partition_key)
             .with_column("value", utf8_type)
             .with_version(generate_schema_version(id))
-            .set_wait_for_sync_to_commitlog(true)
             .build();
     }();
     return schema;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -211,10 +211,6 @@ public:
         static schema_ptr batchlog();
     };
 
-    static constexpr const char* extra_durable_tables[] = { PAXOS, SCYLLA_LOCAL, RAFT, RAFT_SNAPSHOTS, RAFT_SNAPSHOT_CONFIG, DISCOVERY, BROADCAST_KV_STORE };
-
-    static bool is_extra_durable(const sstring& name);
-
     // Partition estimates for a given range of tokens.
     struct range_estimates {
         schema_ptr schema;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1226,16 +1226,6 @@ future<> keyspace::update_from(const locator::shared_token_metadata& stm, ::lw_s
    return create_replication_strategy(stm, _metadata->strategy_options());
 }
 
-future<> keyspace::ensure_populated() const {
-    return _populated.get_shared_future();
-}
-
-void keyspace::mark_as_populated() {
-    if (!_populated.available()) {
-        _populated.set_value();
-    }
-}
-
 column_family::config
 keyspace::make_column_family_config(const schema& s, const database& db) const {
     column_family::config cfg;
@@ -1368,12 +1358,6 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
     co_await create_in_memory_keyspace(ksm, erm_factory, system);
     auto& ks = _keyspaces.at(ksm->name());
     auto& datadir = ks.datadir();
-
-    // keyspace created by either cql or migration 
-    // is by definition populated
-    if (!is_bootstrap) {
-        ks.mark_as_populated();
-    }
 
     if (datadir != "") {
         co_await io_check([&datadir] { return touch_directory(datadir); });

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -946,7 +946,7 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
     auto& sst_manager = is_system_table(*schema) ? get_system_sstables_manager() : get_user_sstables_manager();
     lw_shared_ptr<column_family> cf;
     if (cfg.enable_commitlog && _commitlog) {
-        db::commitlog& cl = schema->ks_name() == db::schema_tables::NAME && _uses_schema_commitlog
+        db::commitlog& cl = schema->static_props().use_schema_commitlog && _uses_schema_commitlog
                 ? *_schema_commitlog
                 : *_commitlog;
         cf = make_lw_shared<column_family>(schema, std::move(cfg), cl, _compaction_manager, sst_manager, *_cl_stats, _row_cache_tracker);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1146,7 +1146,6 @@ private:
     locator::abstract_replication_strategy::ptr_type _replication_strategy;
     locator::effective_replication_map_ptr _effective_replication_map;
     lw_shared_ptr<keyspace_metadata> _metadata;
-    shared_promise<> _populated;
     config _config;
     locator::effective_replication_map_factory& _erm_factory;
 
@@ -1209,9 +1208,6 @@ public:
     }
 
     sstring column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const;
-
-    future<> ensure_populated() const;
-    void mark_as_populated();
 };
 
 using no_such_keyspace = data_dictionary::no_such_keyspace;

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -565,6 +565,7 @@ public:
 struct schema_static_props {
     bool use_null_sharder = false; // use a sharder that puts everything on shard 0
     bool wait_for_sync_to_commitlog = false; // true if all writes using this schema have to be synced immediately by commitlog
+    bool use_schema_commitlog = false;
 };
 
 /*

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -562,6 +562,10 @@ public:
     }
 };
 
+struct schema_static_props {
+    bool use_null_sharder = false; // use a sharder that puts everything on shard 0
+};
+
 /*
  * Effectively immutable.
  * Not safe to access across cores because of shared_ptr's.
@@ -630,6 +634,7 @@ private:
         std::reference_wrapper<const dht::sharder> _sharder;
     };
     raw_schema _raw;
+    schema_static_props _static_props;
     thrift_schema _thrift;
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
@@ -680,11 +685,14 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, std::optional<raw_view_info>);
+    schema(private_tag, const raw_schema&, std::optional<raw_view_info>, const schema_static_props& props);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);
     ~schema();
+    const schema_static_props& static_props() const {
+        return _static_props;
+    }
     table_schema_version version() const {
         return _raw._version;
     }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -564,6 +564,7 @@ public:
 
 struct schema_static_props {
     bool use_null_sharder = false; // use a sharder that puts everything on shard 0
+    bool wait_for_sync_to_commitlog = false; // true if all writes using this schema have to be synced immediately by commitlog
 };
 
 /*
@@ -625,9 +626,6 @@ private:
         std::unordered_map<sstring, dropped_column> _dropped_columns;
         std::map<bytes, data_type> _collections;
         std::unordered_map<sstring, index_metadata> _indices_by_name;
-        // The flag is not stored in the schema mutation and does not affects schema digest.
-        // It is set locally on a system tables that should be extra durable
-        bool _wait_for_sync = false; // true if all writes using this schema have to be synced immediately by commitlog
         std::reference_wrapper<const dht::i_partitioner> _partitioner;
         // Sharding info is not stored in the schema mutation and does not affect
         // schema digest. It is also not set locally on a schema tables.
@@ -962,7 +960,7 @@ public:
     bool is_synced() const;
     bool equal_columns(const schema&) const;
     bool wait_for_sync_to_commitlog() const {
-        return _raw._wait_for_sync;
+        return _static_props.wait_for_sync_to_commitlog;
     }
 public:
     const v3_columns& v3() const {

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -236,10 +236,6 @@ public:
         return *this;
     }
 
-    schema_builder& set_wait_for_sync_to_commitlog(bool sync) {
-        _raw._wait_for_sync = sync;
-        return *this;
-    }
     schema_builder& with_partitioner(sstring name);
     schema_builder& with_sharder(unsigned shard_count, unsigned sharding_ignore_msb_bits);
     class default_names {


### PR DESCRIPTION
Our end goal (#12642) is to mark raft tables to use
schema commitlog. There are two similar
cases in code right now - `with_null_sharder`
and `set_wait_for_sync_to_commitlog` `schema_builder`
methods. The problem is that if we need to
mark some new schema with one of these methods
we need to do this twice - first in
a method describing the schema
(e.g. `system_keyspace::raft()`) and second in the
function `create_table_from_mutations`, which is not
obvious and easy to forget.

`create_table_from_mutations` is called when schema object
is reconstructed from mutations, `with_null_sharder`
and `set_wait_for_sync_to_commitlog` must be called from it
since the schema properties they describe are
not included in the mutation representation of the schema.

This series proposes to distinguish between the schema
properties that get into mutations and those that do not.
The former are described with `schema_builder`, while for
the latter we introduce `schema_static_props` struct and
the `schema_builder::register_static_configurator` method.
This way we can formulate a rule once in the code about
which schemas should have a null sharder/be synced, and it will
be enforced in all cases.