### PR TITLE
Cut feature_service -> system_keyspace dependency

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1627,7 +1627,7 @@ future<std::vector<gms::inet_address>> system_keyspace::load_peers() {
 
 future<std::unordered_map<gms::inet_address, sstring>> system_keyspace::load_peer_features() {
     sstring req = format("SELECT peer, supported_features FROM system.{}", PEERS);
-    return qctx->execute_cql(req).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
+    return execute_cql(req).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
         std::unordered_map<gms::inet_address, sstring> ret;
         for (auto& row : *cql_result) {
             if (row.has("supported_features")) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1391,7 +1391,7 @@ future<> system_keyspace::setup_version(sharded<netw::messaging_service>& ms) {
 
 future<> system_keyspace::save_local_supported_features(const std::set<std::string_view>& feats) {
     static const auto req = format("INSERT INTO system.{} (key, supported_features) VALUES (?, ?)", LOCAL);
-    return qctx->execute_cql(req,
+    return execute_cql(req,
         sstring(db::system_keyspace::LOCAL),
         fmt::to_string(fmt::join(feats, ","))).discard_result();
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3364,46 +3364,6 @@ future<> system_keyspace::save_local_enabled_features(std::set<sstring> features
     co_await set_scylla_local_param(gms::feature_service::ENABLED_FEATURES_KEY, features_str);
 }
 
-} namespace gms {
-
-future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks) {
-    std::set<sstring> features_to_enable;
-    const auto persisted_features = co_await db::system_keyspace::load_local_enabled_features();
-    if (persisted_features.empty()) {
-        co_return;
-    }
-
-    const auto known_features = supported_feature_set();
-    for (auto&& f : persisted_features) {
-        db::slogger.debug("Enabling persisted feature '{}'", f);
-        const bool is_registered_feat = _registered_features.contains(sstring(f));
-        if (!is_registered_feat || !known_features.contains(f)) {
-            if (is_registered_feat) {
-                throw std::runtime_error(format(
-                    "Feature '{}' was previously enabled in the cluster but its support is disabled by this node. "
-                    "Set the corresponding configuration option to enable the support for the feature.", f));
-            } else {
-                throw std::runtime_error(format("Unknown feature '{}' was previously enabled in the cluster. "
-                    " That means this node is performing a prohibited downgrade procedure"
-                    " and should not be allowed to boot.", f));
-            }
-        }
-        if (is_registered_feat) {
-            features_to_enable.insert(std::move(f));
-        }
-        // If a feature is not in `registered_features` but still in `known_features` list
-        // that means the feature name is used for backward compatibility and should be implicitly
-        // enabled in the code by default, so just skip it.
-    }
-
-    co_await container().invoke_on_all([&features_to_enable] (auto& srv) -> future<> {
-        std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
-        co_await srv.enable(std::move(feat));
-    });
-}
-
-} namespace db {
-
 future<utils::UUID> system_keyspace::get_raft_group0_id() {
     auto opt = co_await get_scylla_local_param_as<utils::UUID>("raft_group0_id");
     co_return opt.value_or<utils::UUID>({});

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -371,8 +371,8 @@ public:
     future<std::unordered_set<dht::token>> get_local_tokens();
 
     future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
-    static future<std::set<sstring>> load_local_enabled_features();
-    static future<> save_local_enabled_features(std::set<sstring> features);
+    future<std::set<sstring>> load_local_enabled_features();
+    future<> save_local_enabled_features(std::set<sstring> features);
 
     future<int> increment_and_get_generation();
     bool bootstrap_needed() const;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -370,7 +370,7 @@ public:
      */
     future<std::unordered_set<dht::token>> get_local_tokens();
 
-    static future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
+    future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
     static future<std::set<sstring>> load_local_enabled_features();
     static future<> save_local_enabled_features(std::set<sstring> features);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -442,7 +442,7 @@ public:
     static future<> set_raft_group0_id(utils::UUID id);
 
     // Save advertised gossip feature set to system.local
-    static future<> save_local_supported_features(const std::set<std::string_view>& feats);
+    future<> save_local_supported_features(const std::set<std::string_view>& feats);
 
     // Get the last (the greatest in timeuuid order) state ID in the group 0 history table.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -435,8 +435,6 @@ public:
     future<bool> cdc_is_rewritten();
     future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);
 
-    static future<> enable_features_on_startup(sharded<gms::feature_service>& feat);
-
     // Load Raft Group 0 id from scylla.local
     static future<utils::UUID> get_raft_group0_id();
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -20,11 +20,15 @@
 #include "db/schema_features.hh"
 #include "gms/feature.hh"
 
-namespace db { class config; }
+namespace db {
+class config;
+class system_keyspace;
+}
 namespace service { class storage_service; }
 
 namespace gms {
 
+class gossiper;
 class feature_service;
 
 struct feature_config {
@@ -122,6 +126,7 @@ public:
     // The key itself is maintained as an `unordered_set<string>` and serialized via `to_string`
     // function to preserve readability.
     future<> persist_enabled_feature_info(std::set<std::string_view> extra) const;
+    future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 };
 
 } // namespace gms

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -11,6 +11,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_future.hh>
+#include <seastar/core/sharded.hh>
 #include <unordered_map>
 #include <functional>
 #include <set>
@@ -46,7 +47,7 @@ using namespace std::literals;
  * A pointer to `cql3::query_processor` can be optionally supplied
  * if the instance needs to persist enabled features in a system table.
  */
-class feature_service final {
+class feature_service final : public peering_sharded_service<feature_service> {
     void register_feature(feature& f);
     void unregister_feature(feature& f);
     friend class feature;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -122,6 +122,7 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
+    future<> enable_features_on_startup(db::system_keyspace&);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 };
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -122,10 +122,6 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
-    // Persist enabled feature in the `system.scylla_local` table under the "enabled_features" key.
-    // The key itself is maintained as an `unordered_set<string>` and serialized via `to_string`
-    // function to preserve readability.
-    future<> persist_enabled_feature_info(std::set<std::string_view> extra) const;
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 };
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -121,7 +121,7 @@ public:
     // Persist enabled feature in the `system.scylla_local` table under the "enabled_features" key.
     // The key itself is maintained as an `unordered_set<string>` and serialized via `to_string`
     // function to preserve readability.
-    void persist_enabled_feature_info(const gms::feature& f) const;
+    future<> persist_enabled_feature_info(const gms::feature& f) const;
 };
 
 } // namespace gms

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -121,7 +121,7 @@ public:
     // Persist enabled feature in the `system.scylla_local` table under the "enabled_features" key.
     // The key itself is maintained as an `unordered_set<string>` and serialized via `to_string`
     // function to preserve readability.
-    future<> persist_enabled_feature_info(const gms::feature& f) const;
+    future<> persist_enabled_feature_info(std::set<std::string_view> extra) const;
 };
 
 } // namespace gms

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -80,7 +80,6 @@ public:
             , _feat(f)
             , _sys_ks(s)
     {
-        (void)_sys_ks;
     }
     future<> on_join(inet_address ep, endpoint_state state) override {
         return enable_features();
@@ -2559,7 +2558,7 @@ future<> gossiper::enable_features() {
 }
 
 future<> persistent_feature_enabler::enable_features() {
-    auto loaded_peer_features = co_await db::system_keyspace::load_peer_features();
+    auto loaded_peer_features = co_await _sys_ks.load_peer_features();
     auto&& features = _g.get_supported_features(loaded_peer_features, gossiper::ignore_features_of_local_node::no);
     co_await _feat.container().invoke_on_all([&features] (feature_service& fs) -> future<> {
         std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2551,9 +2551,9 @@ void gossiper::append_endpoint_state(std::stringstream& ss, const endpoint_state
     }
 }
 
-future<> gossiper::enable_features() {
-    auto enabler = make_shared<persistent_feature_enabler>(*this, _feature_service, _sys_ks.local());
-    register_(enabler);
+future<> feature_service::enable_features_on_join(gossiper& g, db::system_keyspace& sys_ks) {
+    auto enabler = make_shared<persistent_feature_enabler>(g, *this, sys_ks);
+    g.register_(enabler);
     return enabler->enable_features();
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -70,35 +70,6 @@ std::chrono::milliseconds gossiper::quarantine_delay() const noexcept {
     return ring_delay * 2;
 }
 
-class persistent_feature_enabler : public i_endpoint_state_change_subscriber {
-    gossiper& _g;
-    feature_service& _feat;
-    db::system_keyspace& _sys_ks;
-public:
-    persistent_feature_enabler(gossiper& g, feature_service& f, db::system_keyspace& s)
-            : _g(g)
-            , _feat(f)
-            , _sys_ks(s)
-    {
-    }
-    future<> on_join(inet_address ep, endpoint_state state) override {
-        return enable_features();
-    }
-    future<> on_change(inet_address ep, application_state state, const versioned_value&) override {
-        if (state == application_state::SUPPORTED_FEATURES) {
-            return enable_features();
-        }
-        return make_ready_future();
-    }
-    future<> before_change(inet_address, endpoint_state, application_state, const versioned_value&) override { return make_ready_future(); }
-    future<> on_alive(inet_address, endpoint_state) override { return make_ready_future(); }
-    future<> on_dead(inet_address, endpoint_state) override { return make_ready_future(); }
-    future<> on_remove(inet_address) override { return make_ready_future(); }
-    future<> on_restart(inet_address, endpoint_state) override { return make_ready_future(); }
-
-    future<> enable_features();
-};
-
 gossiper::gossiper(abort_source& as, feature_service& features, const locator::shared_token_metadata& stm, netw::messaging_service& ms, sharded<db::system_keyspace>& sys_ks, const db::config& cfg, gossip_config gcfg)
         : _abort_source(as)
         , _feature_service(features)
@@ -2549,28 +2520,6 @@ void gossiper::append_endpoint_state(std::stringstream& ss, const endpoint_state
     } else {
         ss << "  TOKENS: not present" << "\n";
     }
-}
-
-future<> feature_service::enable_features_on_join(gossiper& g, db::system_keyspace& sys_ks) {
-    auto enabler = make_shared<persistent_feature_enabler>(g, *this, sys_ks);
-    g.register_(enabler);
-    return enabler->enable_features();
-}
-
-future<> persistent_feature_enabler::enable_features() {
-    auto loaded_peer_features = co_await _sys_ks.load_peer_features();
-    auto&& features = _g.get_supported_features(loaded_peer_features, gossiper::ignore_features_of_local_node::no);
-    std::set<std::string_view> persist;
-    for (feature& f : _feat.registered_features() | boost::adaptors::map_values) {
-        if (!f && features.contains(f.name())) {
-            persist.emplace(f.name());
-        }
-    }
-    co_await _feat.persist_enabled_feature_info(std::move(persist));
-    co_await _feat.container().invoke_on_all([&features] (feature_service& fs) -> future<> {
-        std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);
-        co_await fs.enable(std::move(features_v));
-    });
 }
 
 locator::token_metadata_ptr gossiper::get_token_metadata_ptr() const noexcept {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -70,12 +70,10 @@ std::chrono::milliseconds gossiper::quarantine_delay() const noexcept {
     return ring_delay * 2;
 }
 
-gossiper::gossiper(abort_source& as, feature_service& features, const locator::shared_token_metadata& stm, netw::messaging_service& ms, sharded<db::system_keyspace>& sys_ks, const db::config& cfg, gossip_config gcfg)
+gossiper::gossiper(abort_source& as, const locator::shared_token_metadata& stm, netw::messaging_service& ms, const db::config& cfg, gossip_config gcfg)
         : _abort_source(as)
-        , _feature_service(features)
         , _shared_token_metadata(stm)
         , _messaging(ms)
-        , _sys_ks(sys_ks)
         , _failure_detector_timeout_ms(cfg.failure_detector_timeout_in_ms)
         , _force_gossip_generation(cfg.force_gossip_generation)
         , _gcfg(std::move(gcfg)) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -42,7 +42,6 @@
 
 namespace db {
 class config;
-class system_keyspace;
 }
 
 namespace gms {
@@ -55,8 +54,6 @@ class inet_address;
 class i_endpoint_state_change_subscriber;
 class gossip_get_endpoint_states_request;
 class gossip_get_endpoint_states_response;
-
-class feature_service;
 
 using advertise_myself = bool_class<class advertise_myself_tag>;
 
@@ -242,7 +239,7 @@ private:
     // The value must be kept alive until completes and not change.
     future<> replicate(inet_address, application_state key, const versioned_value& value);
 public:
-    explicit gossiper(abort_source& as, feature_service& features, const locator::shared_token_metadata& stm, netw::messaging_service& ms, sharded<db::system_keyspace>& sys_ks, const db::config& cfg, gossip_config gcfg);
+    explicit gossiper(abort_source& as, const locator::shared_token_metadata& stm, netw::messaging_service& ms, const db::config& cfg, gossip_config gcfg);
 
     /**
      * Register for interesting state changes.
@@ -591,10 +588,8 @@ private:
     class msg_proc_guard;
 private:
     abort_source& _abort_source;
-    feature_service& _feature_service;
     const locator::shared_token_metadata& _shared_token_metadata;
     netw::messaging_service& _messaging;
-    sharded<db::system_keyspace>& _sys_ks;
     utils::updateable_value<uint32_t> _failure_detector_timeout_ms;
     utils::updateable_value<int32_t> _force_gossip_generation;
     gossip_config _gcfg;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -587,7 +587,6 @@ private:
 
     uint64_t _nr_run = 0;
     uint64_t _msg_processing = 0;
-    bool _gossip_settled = false;
 
     class msg_proc_guard;
 private:
@@ -606,7 +605,8 @@ private:
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
 public:
     void check_knows_remote_features(std::set<std::string_view>& local_features, const std::unordered_map<inet_address, sstring>& loaded_peer_features) const;
-    future<> maybe_enable_features();
+    future<> do_enable_features();
+    future<> enable_features();
 private:
     seastar::metrics::metric_groups _metrics;
 public:

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -600,12 +600,11 @@ private:
     gossip_config _gcfg;
     // Get features supported by a particular node
     std::set<sstring> get_supported_features(inet_address endpoint) const;
-    // Get features supported by all the nodes this node knows about
-    std::set<sstring> get_supported_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
 public:
     void check_knows_remote_features(std::set<std::string_view>& local_features, const std::unordered_map<inet_address, sstring>& loaded_peer_features) const;
-    future<> do_enable_features();
+    // Get features supported by all the nodes this node knows about
+    std::set<sstring> get_supported_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
     future<> enable_features();
 private:
     seastar::metrics::metric_groups _metrics;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -605,7 +605,6 @@ public:
     void check_knows_remote_features(std::set<std::string_view>& local_features, const std::unordered_map<inet_address, sstring>& loaded_peer_features) const;
     // Get features supported by all the nodes this node knows about
     std::set<sstring> get_supported_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
-    future<> enable_features();
 private:
     seastar::metrics::metric_groups _metrics;
 public:

--- a/main.cc
+++ b/main.cc
@@ -1184,7 +1184,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Re-enable previously enabled features on node startup.
             // This should be done before commitlog starts replaying
             // since some features affect storage.
-            db::system_keyspace::enable_features_on_startup(feature_service).get();
+            feature_service.local().enable_features_on_startup(sys_ks.local()).get();
 
             db.local().maybe_init_schema_commitlog();
 

--- a/main.cc
+++ b/main.cc
@@ -943,7 +943,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
 
             debug::the_gossiper = &gossiper;
-            gossiper.start(std::ref(stop_signal.as_sharded_abort_source()), std::ref(feature_service), std::ref(token_metadata), std::ref(messaging), std::ref(sys_ks), std::ref(*cfg), std::ref(gcfg)).get();
+            gossiper.start(std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(messaging), std::ref(*cfg), std::ref(gcfg)).get();
             auto stop_gossiper = defer_verbose_shutdown("gossiper", [&gossiper] {
                 // call stop on each instance, but leave the sharded<> pointers alive
                 gossiper.invoke_on_all(&gms::gossiper::stop).get();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2514,7 +2514,7 @@ future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,
         auto initial_contact_nodes = loaded_endpoints.empty() ?
             std::unordered_set<gms::inet_address>(seeds.begin(), seeds.end()) :
             loaded_endpoints;
-        auto loaded_peer_features = db::system_keyspace::load_peer_features().get0();
+        auto loaded_peer_features = _sys_ks.local().load_peer_features().get0();
         slogger.info("initial_contact_nodes={}, loaded_endpoints={}, loaded_peer_features={}",
                 initial_contact_nodes, loaded_endpoints, loaded_peer_features.size());
         for (auto& x : loaded_peer_features) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1435,7 +1435,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     });
     _listeners.emplace_back(make_lw_shared(std::move(schema_change_announce)));
     co_await _gossiper.wait_for_gossip_to_settle();
-    co_await _gossiper.enable_features();
+    co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local());
 
     set_mode(mode::JOINING);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1435,6 +1435,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     });
     _listeners.emplace_back(make_lw_shared(std::move(schema_change_announce)));
     co_await _gossiper.wait_for_gossip_to_settle();
+    co_await _gossiper.enable_features();
 
     set_mode(mode::JOINING);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1328,7 +1328,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     // Save the advertised feature set to system.local table after
     // all remote feature checks are complete and after gossip shadow rounds are done.
     // At this point, the final feature set is already determined before the node joins the ring.
-    co_await db::system_keyspace::save_local_supported_features(features);
+    co_await _sys_ks.local().save_local_supported_features(features);
 
     // If this is a restarting node, we should update tokens before gossip starts
     auto my_tokens = co_await _sys_ks.local().get_saved_tokens();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -641,7 +641,7 @@ public:
             gcfg.cluster_name = "Test Cluster";
             gcfg.seeds = std::move(seeds);
             gcfg.skip_wait_for_gossip_to_settle = 0;
-            gossiper.start(std::ref(abort_sources), std::ref(feature_service), std::ref(token_metadata), std::ref(ms), std::ref(sys_ks), std::ref(*cfg), std::move(gcfg)).get();
+            gossiper.start(std::ref(abort_sources), std::ref(token_metadata), std::ref(ms), std::ref(*cfg), std::move(gcfg)).get();
             auto stop_ms_fd_gossiper = defer([&gossiper] {
                 gossiper.stop().get();
             });


### PR DESCRIPTION
This implicit link it pretty bad, because feature service is a low-level one which lots of other services depend on. System keyspace is opposite -- a high-level one that needs e.g. query processor and database to operate. This inverse dependency is created by the feature service need to commit enabled features' names into system keyspace on cluster join. And it uses the qctx thing for that in a best-effort manner (not doing anything if it's null).

The dependency can be cut. The only place when enabled features are committed is when gossiper enables features on join or by receiving state changes from other nodes. By that time the sharded<system_keyspace> is up and running and can be used.

Despite gossiper already has system keyspace dependency, it's better not to overload it with the need to mess with enabling and persisting features. Instead, the feature_enabler instance is equipped with needed dependencies and takes care of it. Eventually the enabler is also moved to feature_service.cc where it naturally belongs.

fixes: #13837 