### PR TITLE
reader_concurrency_semaphore: improve diagnostics printout

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -725,7 +725,52 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             problem);
     total += do_dump_reader_permit_diagnostics(os, permits, max_lines);
     fmt::print(os, "\n");
-    fmt::print(os, "Total: {} permits with {} count and {} memory resources\n", total.permits, total.resources.count, utils::to_hr_size(total.resources.memory));
+    const auto& stats = semaphore.get_stats();
+    fmt::print(os, "Stats:\n"
+            "permit_based_evictions: {}\n"
+            "time_based_evictions: {}\n"
+            "inactive_reads: {}\n"
+            "total_successful_reads: {}\n"
+            "total_failed_reads: {}\n"
+            "total_reads_shed_due_to_overload: {}\n"
+            "total_reads_killed_due_to_kill_limit: {}\n"
+            "reads_admitted: {}\n"
+            "reads_enqueued_for_admission: {}\n"
+            "reads_enqueued_for_memory: {}\n"
+            "reads_admitted_immediately: {}\n"
+            "reads_queued_because_ready_list: {}\n"
+            "reads_queued_because_used_permits: {}\n"
+            "reads_queued_because_memory_resources: {}\n"
+            "reads_queued_because_count_resources: {}\n"
+            "reads_queued_with_eviction: {}\n"
+            "total_permits: {}\n"
+            "current_permits: {}\n"
+            "used_permits: {}\n"
+            "blocked_permits: {}\n"
+            "disk_reads: {}\n"
+            "sstables_read: {}",
+            stats.permit_based_evictions,
+            stats.time_based_evictions,
+            stats.inactive_reads,
+            stats.total_successful_reads,
+            stats.total_failed_reads,
+            stats.total_reads_shed_due_to_overload,
+            stats.total_reads_killed_due_to_kill_limit,
+            stats.reads_admitted,
+            stats.reads_enqueued_for_admission,
+            stats.reads_enqueued_for_memory,
+            stats.reads_admitted_immediately,
+            stats.reads_queued_because_ready_list,
+            stats.reads_queued_because_used_permits,
+            stats.reads_queued_because_memory_resources,
+            stats.reads_queued_because_count_resources,
+            stats.reads_queued_with_eviction,
+            stats.total_permits,
+            stats.current_permits,
+            stats.used_permits,
+            stats.blocked_permits,
+            stats.disk_reads,
+            stats.sstables_read);
 }
 
 void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem) noexcept {

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -205,7 +205,9 @@ private:
     // A return value of can_admit::maybe means admission might be possible if
     // some of the inactive readers are evicted.
     enum class can_admit { no, maybe, yes };
-    can_admit can_admit_read(const reader_permit::impl& permit) const noexcept;
+    enum class reason { all_ok = 0, ready_list, used_permits, memory_resources, count_resources };
+    struct admit_result { can_admit decision; reason why; };
+    admit_result can_admit_read(const reader_permit::impl& permit) const noexcept;
 
     void maybe_admit_waiters() noexcept;
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -96,6 +96,18 @@ public:
         uint64_t reads_enqueued_for_admission = 0;
         // Total number of reads enqueued to wait for memory.
         uint64_t reads_enqueued_for_memory = 0;
+        // Total number of reads admitted immediately, without queueing
+        uint64_t reads_admitted_immediately = 0;
+        // Total number of reads enqueued because ready_list wasn't empty
+        uint64_t reads_queued_because_ready_list = 0;
+        // Total number of reads enqueued because there are used but unblocked permits
+        uint64_t reads_queued_because_used_permits = 0;
+        // Total number of reads enqueued because there weren't enough memory resources
+        uint64_t reads_queued_because_memory_resources = 0;
+        // Total number of reads enqueued because there weren't enough count resources
+        uint64_t reads_queued_because_count_resources = 0;
+        // Total number of reads enqueued to be maybe admitted after evicting some inactive reads
+        uint64_t reads_queued_with_eviction = 0;
         // Total number of permits created so far.
         uint64_t total_permits = 0;
         // Current number of permits.


### PR DESCRIPTION
Remove redundant "Total: ..." line.
Include the entire `reader_concurrency_semaphore::stats` in the printout. This includes a lot of metrics not exported to monitoring. These metrics are very valuable when debugging timeouts but are otherwise uninteresting. To avoid bloating our monitoring with such niche metrics, we dump them when they are interesting: when timeouts happen. To be really helpful, we do need historic values too, but this shouldn't be a problem: timeouts come in bursts, we usually get at least a handful of diagnostics dumps at a time.
New stats are also added to record the reason why reads are queued on the semaphore.

Printout before:
```
INFO  2023-03-14 12:43:54,496 [shard 0] reader_concurrency_semaphore - Semaphore test_reader_concurrency_semaphore_memory_limit_no_leaks with 4/4 count and 7168/4096 memory resources: kill limit triggered, dumping permit diagnostics:
permits count   memory  table/description/state
4       4       7K      *.*/reader/active/unused
2       0       0B      *.*/reader/waiting_for_admission

6       4       7K      total

Total: 6 permits with 4 count and 7K memory resources
```

Printout after:
```
INFO  2023-03-16 04:23:41,791 [shard 0] reader_concurrency_semaphore - Semaphore test_reader_concurrency_semaphore_memory_limit_no_leaks with 3/4 count and 7168/4096 memory resources: kill limit triggered, dumping permit diagnostics:
permits count   memory  table/description/state
2       2       6K      *.*/reader/active/unused
1       1       1K      *.*/reader/waiting_for_memory
2       0       0B      *.*/reader/waiting_for_admission

5       3       7K      total
                                                               
Stats:  
permit_based_evictions: 0
time_based_evictions: 0
inactive_reads: 0
total_successful_reads: 0
total_failed_reads: 0
total_reads_shed_due_to_overload: 0
total_reads_killed_due_to_kill_limit: 1
reads_admitted: 4
reads_enqueued_for_admission: 4
reads_enqueued_for_memory: 5
reads_admitted_immediately: 2
reads_queued_because_ready_list: 0
reads_queued_because_used_permits: 0
reads_queued_because_memory_resources: 0
reads_queued_because_count_resources: 4
reads_queued_with_eviction: 0
total_permits: 6
current_permits: 5
used_permits: 0
blocked_permits: 0
disk_reads: 0
sstables_read: 0
```