### PR TITLE
storage_proxy: rename metrics after service level rename

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1095,6 +1095,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_stats();
                 reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_split_metrics_local();
             };
+            storage_proxy_stats_cfg.rename = [] (void* ptr) {
+                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_stats();
+                reinterpret_cast<service::storage_proxy_stats::stats*>(ptr)->register_split_metrics_local();
+            };
             proxy.start(std::ref(db), std::ref(gossiper), spcfg, std::ref(node_backlog),
                     scheduling_group_key_create(storage_proxy_stats_cfg).get0(),
                     std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory), std::ref(messaging)).get();


### PR DESCRIPTION
Under some circumstances, service_level_controller renames service levels for internal purposes. However, the per-service-level metrics registered by storage_proxy keep the name seen at first registration time. This sometimes leads to mislabeled metrics.

Fix that by re-registering the metrics after scheduling groups are renamed.

Fixes scylladb/scylla-enterprise#2755