### PR TITLE
DOCS: rewording the raft Handling Failures and recovery procedure sections

### DIFF
--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -259,7 +259,7 @@ Handling Failures
 Raft requires a quorum of nodes in a cluster to proceed. As long as the majority of nodes are alive and connected, schema and topology updates proceed unaffected.
 When the node that was down is up again, it first contacts the cluster to fetch the latest schema and then starts serving queries.
 
-ScyllaDB data path, read and write requests, works with :term:`Consistency Level (CL)` , and are not dependent on Raft quorum.
+ScyllaDB data path read and write requests work with :term:Consistency Level (CL) and is not dependent on Raft quorum.
 
 The following examples show the recovery actions depending on your cluster's number of nodes and DCs.
 

--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -337,7 +337,7 @@ It's good practice to ensure that using firewall rules or otherwise isolates you
 Procedure
 ~~~~~~~~~
 
-During the recovery procedure, you'll enter a special ``RECOVERY`` mode, remove all faulty nodes (using the standard :doc:`node removal procedure </operating-scylla/procedures/cluster-management/remove-node/>`), delete the internal Raft data, and execute a rolling restart. This will cause the cluster to perform the internal Raft upgrade procedure again, initializing the Raft algorithm from scratch. The recovery procedure applies to clusters not running Raft in the past and then had Raft enabled and to clusters bootstrapped with Raft.
+During the recovery procedure, you'll enter a special ``RECOVERY`` mode, remove all faulty nodes (using the standard :doc:`node removal procedure </operating-scylla/procedures/cluster-management/remove-node/>`), delete the internal Raft data, and execute a rolling restart. This will cause the cluster to perform the internal Raft upgrade procedure again, initializing the Raft algorithm from scratch. The recovery procedure applies to clusters that were not running Raft in the past and then had Raft enabled.
 
 .. note::
 

--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -341,7 +341,7 @@ During the recovery procedure, you'll enter a special ``RECOVERY`` mode, remove 
 
 .. note::
 
-   Entering ``RECOVERY`` mode requires a node restart. Restarting an additional node while some nodes are already dead may lead to unavailability data queries. For example, if you're using the standard RF=3, CL=QUORUM setup, and you're recovering from a stuck of upgrade procedure because one of your nodes is dead, restarting another node will cause temporary data query unavailability (until the node finishes restarting). Prepare your service for downtime before proceeding.
+   Entering ``RECOVERY`` mode requires a node restart. Restarting an additional node while some nodes are already dead may lead to the unavailability of data queries. For example, if you're using the standard RF=3, CL=QUORUM setup, and you're recovering from a stuck of upgrade procedure because one of your nodes is dead, restarting another node will lead to unavailability of data queries (until the node finishes restarting). Prepare your service for downtime before proceeding.
 
 #. Perform the following query on **every alive node** in the cluster, using e.g. ``cqlsh``:
 


### PR DESCRIPTION
This PR reword sections in Raft Handling Failures and recovery procedure sections:

- reduce the number of Warnings by converting them to Prerequisite, notes, or procedure steps.
- adding topology updates when required; for example, one can not update topology when there is no quorum
- Remove  a failure in a use case of one DC cluster with one DC down (not interesting)
- Use shorter text when possible

The PR does **not** change the info or procedure documented.
