### PR TITLE
[branch-5.0] - minimal fix for crash caused by empty primary key range in LWT update

### DIFF
--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -83,3 +83,77 @@ def test_insert_unset_regular_col(cql, table4):
     # INSERT (p, 1, 5, UNSET)
     insert(c=1, s=5, r=UNSET_VALUE)
     assert select_rows() == [(p, 1, 5, 3)]
+
+# Test INSERT with UNSET_VALUE for the clustering column value, using IF NOT EXISTS
+def test_insert_unset_clustering_col_if_not_exists(cql, table4):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?) IF NOT EXISTS"), [c, s, r])
+    def select_rows():
+        return sorted(list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}")))
+
+    # INSERT (p, UNSET, 2, 3)
+    with pytest.raises(InvalidRequest, match='unset'):
+        insert(c=UNSET_VALUE, s=2, r=3)
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, UNSET, 2, 3)
+    with pytest.raises(InvalidRequest, match='unset'):
+        insert(c=UNSET_VALUE, s=2, r=3)
+
+    # INSERT (p, UNSET, 5, 6)
+    with pytest.raises(InvalidRequest, match='unset'):
+        insert(c=UNSET_VALUE, s=5, r=6)
+
+    assert select_rows() == [(p, 1, 2, 3)]
+
+# Test INSERT with UNSET_VALUE for the static column value, using IF NOT EXISTS
+def test_insert_unset_static_col_if_not_exists(cql, table4):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?) IF NOT EXISTS"), [c, s, r])
+    def select_rows():
+        return sorted(list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}")))
+
+    # INSERT (p, 1, UNSET, 3)
+    insert(c=1, s=UNSET_VALUE, r=3)
+    assert select_rows() == [(p, 1, None, 3)]
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, None, 3)]
+
+    # INSERT (p, 1, UNSET, 3)
+    insert(c=1, s=UNSET_VALUE, r=3)
+    assert select_rows() == [(p, 1, None, 3)]
+
+    # INSERT (p, 1, UNSET, 4)
+    insert(c=1, s=UNSET_VALUE, r=4)
+    assert select_rows() == [(p, 1, None, 3)]
+
+# Test INSERT with UNSET_VALUE for the regular column value, using IF NOT EXISTS
+def test_insert_unset_regular_col_if_not_exists(cql, table4):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?) IF NOT EXISTS"), [c, s, r])
+    def select_rows():
+        return list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}"))
+
+    # INSERT (p, 1, 2, UNSET)
+    insert(c=1, s=2, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 2, None)]
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, None)]
+
+    # INSERT (p, 1, 2, UNSET)
+    insert(c=1, s=2, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 2, None)]
+
+    # INSERT (p, 1, 5, UNSET)
+    insert(c=1, s=5, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 2, None)]

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -1,0 +1,85 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+from util import new_test_table, unique_key_int
+from cassandra.query import UNSET_VALUE
+from cassandra.protocol import InvalidRequest
+
+@pytest.fixture(scope="module")
+def table4(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, s int, r int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+# Test INSERT with UNSET_VALUE for the clustering column value
+def test_insert_unset_clustering_col(cql, table4, scylla_only):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?)"), [c, s, r])
+    def select_rows():
+        return sorted(list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}")))
+
+    # INSERT (p, UNSET, 2, 3)
+    insert(c=UNSET_VALUE, s=2, r=3)
+    assert select_rows() == []
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, UNSET, 2, 3)
+    insert(c=UNSET_VALUE, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, UNSET, 5, 6)
+    insert(c=UNSET_VALUE, s=5, r=6)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+# Test INSERT with UNSET_VALUE for the static column value
+def test_insert_unset_static_col(cql, table4):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?)"), [c, s, r])
+    def select_rows():
+        return sorted(list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}")))
+
+    # INSERT (p, 1, UNSET, 3)
+    insert(c=1, s=UNSET_VALUE, r=3)
+    assert select_rows() == [(p, 1, None, 3)]
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, 1, UNSET, 3)
+    insert(c=1, s=UNSET_VALUE, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, 1, UNSET, 4)
+    insert(c=1, s=UNSET_VALUE, r=4)
+    assert select_rows() == [(p, 1, 2, 4)]
+
+# Test INSERT with UNSET_VALUE for the regular column value
+def test_insert_unset_regular_col(cql, table4):
+    p = unique_key_int()
+    def insert(c, s, r):
+        cql.execute(cql.prepare(f"INSERT INTO {table4} (p, c, s, r) VALUES ({p}, ?, ?, ?)"), [c, s, r])
+    def select_rows():
+        return list(cql.execute(f"SELECT p, c, s, r FROM {table4} WHERE p = {p}"))
+
+    # INSERT (p, 1, 2, UNSET)
+    insert(c=1, s=2, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 2, None)]
+
+    # INSERT (p, 1, 2, 3)
+    insert(c=1, s=2, r=3)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, 1, 2, UNSET)
+    insert(c=1, s=2, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 2, 3)]
+
+    # INSERT (p, 1, 5, UNSET)
+    insert(c=1, s=5, r=UNSET_VALUE)
+    assert select_rows() == [(p, 1, 5, 3)]

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -8,6 +8,21 @@ from cassandra.query import UNSET_VALUE
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int, li list<int>") as table:
+        yield table
+
+@pytest.fixture(scope="module")
+def table2(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+@pytest.fixture(scope="module")
+def table3(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, r int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+@pytest.fixture(scope="module")
 def table4(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c int, s int, r int, PRIMARY KEY (p, c)") as table:
         yield table
@@ -433,3 +448,151 @@ def test_update_unset_regular_column_with_lwt(cql, table4):
     # Setting everything to UNSET generates an error
     with pytest.raises(InvalidRequest):
         cql.execute(update1, [UNSET_VALUE, UNSET_VALUE, UNSET_VALUE, UNSET_VALUE])
+
+
+# A basic test that in a prepared statement with three assignments, one
+# bound by an UNSET_VALUE is simply not done, but the other ones are.
+# Try all 2^3 combinations of a 3 column updates with each one set to either
+# a real value or an UNSET_VALUE.
+def test_update_unset_value_basic(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET a=?, b=?, c=? WHERE p={p}')
+    a = 1
+    b = 2
+    c = 3
+    cql.execute(stmt, [a, b, c])
+    assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+    i = 4
+    for unset_a in [False, True]:
+        for unset_b in [False, True]:
+            for unset_c in [False, True]:
+                if unset_a:
+                    newa = UNSET_VALUE
+                else:
+                    newa = i
+                    a = i
+                    i += 1
+                if unset_b:
+                    newb = UNSET_VALUE
+                else:
+                    newb = i
+                    b = i
+                    i += 1
+                if unset_c:
+                    newc = UNSET_VALUE
+                else:
+                    newc = i
+                    c = i
+                    i += 1
+                cql.execute(stmt, [newa, newb, newc])
+                assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+
+# The expression "SET a=?" is skipped if the bound value is UNSET_VALUE.
+# But what if it is part of a more complex expression like "SET a=(int)?+1"
+# (arithmetic expression on the bind variable)? Does the SET also get
+# skipped? Cassandra, and Scylla, decided that the answer will be no:
+# We refuse to evaluate expressions involving an UNSET_VALUE, and in
+# such case the whole write request will fail instead of parts of it being
+# skipped. See discussion in pull request #12517.
+
+@pytest.mark.xfail(reason="issue #2693 - Scylla doesn't yet support arithmetic expressions")
+def test_update_unset_value_expr_arithmetic(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET a=(int)?+1 WHERE p={p}')
+    cql.execute(stmt, [7])
+    assert [(8,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+    with pytest.raises(InvalidRequest):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Despite the decision that expressions will not allow UNSET_VALUE, Cassandra
+# decided that (quoting its NEWS.txt) "an unset bind counter operation does
+# not change the counter value.".  So "c = c + ?" for a counter, when given
+# an UNSET_VALUE, will causes the write to be skipped, without error.
+# The rationale is that "c = c + ?" is not an expression - it doesn't actually
+# calculate c + ?, but rather it is a primitive increment operation, and
+# passing ?=UNSET_VALUE should be able to skip this primitive operation.
+def test_unset_counter_increment(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table:
+        p = unique_key_int()
+        stmt = cql.prepare(f'UPDATE {table} SET c=c+? WHERE p={p}')
+        cql.execute(stmt, [3])
+        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+        cql.execute(stmt, [UNSET_VALUE])
+        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+
+# Like the counter increment, a list append operation (li=li+?) is a primitive
+# operation and not expression, so we believe UNSET_VALUE should be able
+# to skip it, and Scylla indeed does as this test shows. Cassandra fails
+# this test - it produces an internal error on a bad cast, and we consider
+# this a Cassandra bug and hence the cassandra_bug tag.
+def test_unset_list_append(cql, table1, cassandra_bug):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} SET li=li+? WHERE p={p}')
+    cql.execute(stmt, [[7]])
+    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+    cql.execute(stmt, [UNSET_VALUE])
+    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+
+# According to Cassandra's NEWS.txt, "an unset bind ttl is treated as
+# 'unlimited'". It shouldn't skip the write.
+# Note that the NEWS.txt is not accurate: An unset ttl isn't really treated
+# as unlimited, but rather as the default ttl set on the table. The default
+# ttl is usually unlimited, but not always. We test that case in
+# test_ttl.py::test_default_ttl_unset()
+def test_unset_ttl(cql, table1):
+    p = unique_key_int()
+    # First write using a normal TTL:
+    stmt = cql.prepare(f'UPDATE {table1} USING TTL ? SET a=? WHERE p={p}')
+    cql.execute(stmt, [20000, 3])
+    res = list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+    assert res[0].a == 3
+    assert res[0].ttl_a > 10000
+    # Check that an UNSET_VALUE ttl didn't skip the write but reset the TTL
+    # to unlimited (None)
+    cql.execute(stmt, [UNSET_VALUE, 4])
+    assert [(4, None)] == list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+
+# According to Cassadra's NEWS.txt, "an unset bind timestamp is treated
+# as 'now'". It shouldn't skip the write.
+def test_unset_timestamp(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f'UPDATE {table1} USING TIMESTAMP ? SET a=? WHERE p={p}')
+    cql.execute(stmt, [UNSET_VALUE, 3])
+    assert [(3,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+
+# According to Cassandra's NEWS.txt, "In a QUERY request an unset limit
+# is treated as 'unlimited'.". It mustn't cause the query to fail (let alone
+# be skipped somehow).
+def test_unset_limit(cql, table2):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 1)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 2)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 3)')
+    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 4)')
+    stmt = cql.prepare(f'SELECT c FROM {table2} WHERE p={p} limit ?')
+    assert [(1,),(2,)] == list(cql.execute(stmt, [2]))
+    assert [(1,),(2,),(3,),(4,)] == list(cql.execute(stmt, [UNSET_VALUE]))
+
+# TODO: check that (according to NEWS.txt documentation): "Unset tuple field,
+# UDT field and map key are not allowed.".
+
+# Similar to test_unset_insert_where() above, just use an LWT write ("IF
+# NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condtion causes
+# a clear error, not silent skip and not a crash as in issue #13001.
+def test_unset_insert_where_lwt(cql, table2):
+    p = unique_key_int()
+    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE])
+
+# Like test_unset_insert_where_lwt, but using UPDATE
+# Python driver doesn't allow sending an UNSET_VALUE for the partition key,
+# so only the clustering key is tested.
+def test_unset_update_where_lwt(cql, table3):
+    stmt = cql.prepare(f"UPDATE {table3} SET r = 42 WHERE p = 0 AND c = ? IF r = ?")
+
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [UNSET_VALUE, 2])
+
+    with pytest.raises(InvalidRequest, match="unset"):
+        cql.execute(stmt, [1, UNSET_VALUE])


### PR DESCRIPTION
In #13001 we found a test case which causes a crash because it didn't handle `UNSET_VALUE` properly:

```python3
def test_unset_insert_where(cql, table2):
    p = unique_key_int()
    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
    with pytest.raises(InvalidRequest, match="unset"):
        cql.execute(stmt, [UNSET_VALUE])

def test_unset_insert_where_lwt(cql, table2):
    p = unique_key_int()
    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
    with pytest.raises(InvalidRequest, match="unset"):
        cql.execute(stmt, [UNSET_VALUE])
```

This PR does an absolutely minimal change to fix the crash.
It adds a check the moment before the crash would happen.

To make sure that everything works correctly, and to detect any possible breaking changes, I wrote a bunch of tests that validate the current behavior.
I also ported some tests from the `master` branch, at least the ones that were in line with the behavior on `branch-5.0`.

The changes are the same as in #13133, just cherry-picked to `branch-5.0`