### PR TITLE
cmake: sync with `configure.py` (12/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ target_sources(scylla-main
     debug.cc
     init.cc
     keys.cc
-    main.cc
     message/messaging_service.cc
     multishard_mutation_query.cc
     mutation_query.cc

--- a/cmake/limit_jobs.cmake
+++ b/cmake/limit_jobs.cmake
@@ -1,9 +1,9 @@
-set(Seastar_LINK_MEM_PER_JOB 1024 CACHE INTERNAL "Maximum memory used by each link job in (in MiB)")
+set(LINK_MEM_PER_JOB 1024 CACHE INTERNAL "Maximum memory used by each link job in (in MiB)")
 
 cmake_host_system_information(
   RESULT _total_mem
   QUERY AVAILABLE_PHYSICAL_MEMORY)
-math(EXPR _link_pool_depth "${_total_mem} / ${Seastar_LINK_MEM_PER_JOB}")
+math(EXPR _link_pool_depth "${_total_mem} / ${LINK_MEM_PER_JOB}")
 if(_link_pool_depth EQUAL 0)
   set(_link_pool_depth 1)
 endif()

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -76,3 +76,21 @@ target_include_directories(wasmtime_bindings
     ${scylla_gen_build_dir})
 target_link_libraries(wasmtime_bindings
   INTERFACE Rust::rust_combined)
+
+# only for testing
+generate_cxxbridge(inc
+  INPUT inc/src/lib.rs
+  INCLUDE ${cxx_header}
+  OUTPUT_DIR "${binding_gen_build_dir}"
+  SOURCES inc_sources)
+
+add_library(inc)
+target_sources(inc
+  PRIVATE
+    ${cxx_header}
+    ${inc_sources})
+target_include_directories(inc
+  INTERFACE
+    ${scylla_gen_build_dir})
+target_link_libraries(inc
+  INTERFACE Rust::rust_combined)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -43,6 +43,9 @@
     target_link_libraries(${name}
       PRIVATE
         Seastar::seastar_testing)
+    target_compile_definitions(${name}
+      PRIVATE
+        SEASTAR_TESTING_MAIN)
   elseif(kind STREQUAL "BOOST")
     target_link_libraries(${name}
       PRIVATE

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -102,31 +102,109 @@ add_scylla_test(json_test
 add_scylla_test(keys_test
   KIND BOOST
   LIBRARIES idl schema)
+add_scylla_test(large_paging_state_test
+  KIND SEASTAR)
 add_scylla_test(like_matcher_test
   KIND BOOST
   LIBRARIES utils)
+add_scylla_test(limiting_data_source_test
+  KIND SEASTAR)
 add_scylla_test(linearizing_input_stream_test
   KIND BOOST)
+add_scylla_test(lister_test
+  KIND SEASTAR)
+add_scylla_test(loading_cache_test
+  KIND SEASTAR)
+add_scylla_test(log_heap_test
+  KIND BOOST)
+add_scylla_test(logalloc_test
+  KIND SEASTAR)
+add_scylla_test(logalloc_standard_allocator_segment_pool_backend_test
+  KIND SEASTAR)
+add_scylla_test(managed_bytes_test
+  KIND SEASTAR)
+add_scylla_test(managed_vector_test
+  KIND SEASTAR)
+add_scylla_test(memtable_test
+  KIND SEASTAR)
+add_scylla_test(multishard_mutation_query_test
+  SOURCES
+    multishard_mutation_query_test.cc
+    test_table.cc
+  KIND SEASTAR)
+add_scylla_test(murmur_hash_test
+  KIND BOOST)
+add_scylla_test(mutation_fragment_test
+  KIND SEASTAR)
+add_scylla_test(mutation_query_test
+  KIND SEASTAR)
+add_scylla_test(mutation_reader_test
+  KIND SEASTAR)
+add_scylla_test(multishard_combining_reader_as_mutation_source_test
+  KIND SEASTAR)
+add_scylla_test(mutation_test
+  KIND SEASTAR)
+add_scylla_test(mutation_writer_test
+  KIND SEASTAR)
+add_scylla_test(mvcc_test
+  KIND SEASTAR)
 add_scylla_test(map_difference_test
   KIND BOOST)
+add_scylla_test(network_topology_strategy_test
+  KIND SEASTAR)
 add_scylla_test(nonwrapping_range_test
   KIND BOOST)
 add_scylla_test(observable_test
   KIND BOOST)
+add_scylla_test(partitioner_test
+  KIND SEASTAR)
+add_scylla_test(per_partition_rate_limit_test
+  KIND SEASTAR)
+add_scylla_test(querier_cache_test
+  KIND SEASTAR)
+add_scylla_test(query_processor_test
+  KIND SEASTAR)
+add_scylla_test(radix_tree_test
+  KIND SEASTAR)
 add_scylla_test(range_test
   KIND BOOST)
 add_scylla_test(range_tombstone_list_test
   KIND BOOST)
+add_scylla_test(rate_limiter_test
+  KIND SEASTAR)
+add_scylla_test(reader_concurrency_semaphore_test
+  KIND SEASTAR)
+add_scylla_test(repair_test
+  KIND SEASTAR)
+add_scylla_test(restrictions_test
+  KIND SEASTAR)
+add_scylla_test(result_utils_test
+  KIND SEASTAR)
+add_scylla_test(reusable_buffer_test
+  KIND SEASTAR)
+add_scylla_test(role_manager_test
+  KIND SEASTAR)
+add_scylla_test(row_cache_test
+  KIND SEASTAR)
+add_scylla_test(rust_test
+  KIND BOOST
+  LIBRARIES inc)
 add_scylla_test(serialization_test
   KIND BOOST)
 add_scylla_test(small_vector_test
+  KIND SEASTAR)
+add_scylla_test(summary_test
   KIND BOOST)
 add_scylla_test(top_k_test
   KIND BOOST)
+add_scylla_test(tracing_test
+  KIND SEASTAR)
 add_scylla_test(transport_test
+  KIND SEASTAR)
+add_scylla_test(type_json_test
   KIND BOOST)
 add_scylla_test(types_test
-  KIND BOOST)
+  KIND SEASTAR)
 add_scylla_test(vint_serialization_test
   KIND BOOST
   LIBRARIES
@@ -142,7 +220,7 @@ add_scylla_test(user_function_test
   KIND SEASTAR
   LIBRARIES idl)
 add_scylla_test(user_types_test
-  KIND BOOST)
+  KIND SEASTAR)
 add_scylla_test(expr_test
   KIND BOOST
   LIBRARIES cql3)

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -11,7 +11,10 @@ target_sources(test-lib
     expr_test_utils.cc
     test_services.cc
     key_utils.cc
+    mutation_source_test.cc
     random_schema.cc
+    result_set_assertions.cc
+    sstable_utils.cc
     data_model.cc)
 target_include_directories(test-lib
   PUBLIC

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(utils
     rate_limiter.cc
     rjson.cc
     runtime.cc
+    to_string.cc
     updateable_value.cc
     utf8.cc
     uuid.cc)


### PR DESCRIPTION
this is the 12nd changeset of a series which tries to give an overhaul to the CMake building system. this series has two goals:

- to enable developer to use CMake for building scylla. so they can use tools (CLion for instance) with CMake integration for better developer experience
- to enable us to tweak the dependencies in a simpler way. a well-defined cross module / subsystem dependency is a prerequisite for building this project with the C++20 modules.

this changeset includes following changes:

- build: cmake: remove Seastar from the option name
- build: cmake: add missing sources in test-lib and utils
- build: cmake: do not include main.cc in scylla-main
- build: cmake: define SEASTAR_TESTING_MAIN for SEASTAR tests
- build: cmake: add more tests