### PR TITLE
create-relocatable-package.py: exclude tools/cqlsh

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -159,7 +159,8 @@ ar.reloc_add('api')
 def exclude_submodules(tarinfo):
     if tarinfo.name in ('scylla/tools/jmx',
                         'scylla/tools/java',
-                        'scylla/tools/python3'):
+                        'scylla/tools/python3',
+                        'scylla/tools/cqlsh'):
         return None
     return tarinfo
 ar.reloc_add('tools', filter=exclude_submodules)


### PR DESCRIPTION
We should exclude tools/cqlsh for relocatable package.

fixes #13181