### PR TITLE
db/view: remove error message when a remote view update fails

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1720,9 +1720,7 @@ future<> mutate_MV(
                     stats.view_updates_failed_remote += updates_pushed_remote;
                     cf_stats.total_view_updates_failed_remote += updates_pushed_remote;
                     auto ep = f.get_exception();
-                    tracing::trace(tr_state, "Failed to apply view update for {} and {} remote endpoints",
-                            *target_endpoint, updates_pushed_remote);
-                    vlogger.error("Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
+                    tracing::trace(tr_state, "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
                             *target_endpoint, s->ks_name(), s->cf_name(), base_token, view_token, ep);
                     return apply_update_synchronously ? make_exception_future<>(std::move(ep)) : make_ready_future<>();
                 }


### PR DESCRIPTION
When using materialized views each update to the base table is propagated to the view tables of materialized views based on this table.

The materialized view might have a different partition key from the base table, and because of that a mutation that is applied locally for the base table has to be sent to a remote node that handles this partition in the view table.

When sending the message to a remote node fails we currently print an error message.

There are two issues with that:
1) The error message is printed on each mutation, which causes log spam.

2) It's expected that sending the mutation will sometimes fail. The remote node might be temporarily down because it's being updated or it just crashed for whatever reason. Scylla should be able to handle that gracefully. Printing an error message there makes it look like there was a completely unexpected failure that shouldn't happen.

Let's not scare the users with unimportant error messages, such failing updates are expected, and shouldn't be treated as hard errors.

This change removes printing the error using `logger.log`, but it's still printed using `tracing::trace`. I decided to do it this way because there are many similar calls to `trace` in this part of the code. It might be useful to know that a remote update failed, but it will only be visible when someone explicitly enables tracing.

Fixes: #12711
Fixes: #12321
Fixes: #13052
Fixes: #12977

Refs: #12693