### PR TITLE
install-dependencies: Add rapid XML dev package

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -47,6 +47,7 @@ debian_base_packages=(
     libzstd-dev
     libdeflate-dev
     libabsl-dev
+    librapidxml-dev
 )
 
 fedora_packages=(
@@ -104,6 +105,7 @@ fedora_packages=(
     curl
     rust
     cargo
+    rapidxml-devel
 )
 
 # lld is not available on s390x, see

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20230307
+docker.io/scylladb/scylla-toolchain:fedora-37-20230315


### PR DESCRIPTION
It will be needed by S3 driver to parse multipart-upload messages from server

refs: #12523

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>

Closes #13158

[avi: regenerate toolchain]