### PR TITLE
docs: fix typos in wasm documentation

### DIFF
--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -270,7 +270,7 @@ The ``LANGUAGE`` clause specifies the language of the function, and the ``AS`` c
 
 * For Lua functions, the ``LANGUAGE`` is ``lua`` and the body is a string literal containing the Lua script.
 
-* For Wasm functions, the ``LANGUAGE`` is ``wasm`` and the body is a string literal containing a WebAssembly module in WebAssembly text format, which exports a function with the same name as specified in the ``CREATE FUNCTION`` statement. More details on generating the Wasm modules can be found `here </cql/wasm>`_.
+* For Wasm functions, the ``LANGUAGE`` is ``wasm`` and the body is a string literal containing a WebAssembly module in WebAssembly text format, which exports a function with the same name as specified in the ``CREATE FUNCTION`` statement. More details on generating the Wasm modules can be found :doc:`here </cql/wasm>`.
 
 If the function code contains single quotes, they must be escaped by doubling them, for example::
 

--- a/docs/cql/wasm.rst
+++ b/docs/cql/wasm.rst
@@ -33,7 +33,7 @@ As a short example, here's a sample Rust code which can be compiled to WebAssemb
         list.into_iter().flatten().collect()
     }
 
-The compilation instructions are described at <https://github.com/scylladb/scylla-rust-udf> but the commands will generally be:
+The compilation instructions are described at https://github.com/scylladb/scylla-rust-udf but the commands will generally be:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This patch fixes 2 small issues with the Wasm UDF documentation that recently got uploaded:
1. a link was unnecessarily wrapped in angle brackets
2. a link did not redirect to the correct page due to a missing ":doc:" tag