### PR TITLE
test: sstables: do not compare a mutation with an optional<mutation>

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2842,7 +2842,8 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
             // this is only here as a sanity check.
             BOOST_REQUIRE(sst_mr.is_buffer_empty());
             BOOST_REQUIRE(sst_mr.is_end_of_stream());
-            BOOST_REQUIRE_EQUAL(mut, sst_mut);
+            BOOST_REQUIRE(sst_mut);
+            BOOST_REQUIRE_EQUAL(mut, *sst_mut);
         }
     });
 }


### PR DESCRIPTION
this change should address the FTBFS with Clang-17.

turns out we are comparing a mutation with an
optimized_optional<mutation>. and Clang-17 does not want to convert the LHS, which is a mutation to optimized_optional<mutation> for performing the comparison using operator==(const optimized_optional<mutation>&), desipte that optimized_optional(const T& obj) is not marked explicit. this is understandable.

so, in this change, instead of relying on the implicit conversion, we just

* check if the optional actually holds a value
* and compare the value by deferencing the optional.