### PR TITLE
db: data_listener: mark data_listener's dtor virtual

### DIFF
--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -28,6 +28,7 @@ namespace db {
 
 class data_listener {
 public:
+    virtual ~data_listener() = default;
     // Invoked for each write, with partition granularity.
     // The schema_ptr passed is the one which corresponds to the incoming mutation, not the current schema of the table.
     virtual void on_write(const schema_ptr&, const frozen_mutation&) { }


### PR DESCRIPTION
Clang-17 warns when we try to delete a pointer to a class with virtual function(s) but without marking its dtor virtual. in this change, we mark the dtor of the base class of `table_listener` virtual to address the warning.

we have another solution though -- to mark `table_listener` `final`. as we don't destruct `table_listener` with a pointer to its base classes. but it'd be much simpler to just mark the dtor virtual of its base class with virtual method(s). it's much idiomatic this way, and less error-prune.

this change should silence the warning like:
```
In file included from /home/kefu/dev/scylladb/test/boost/data_listeners_test.cc:9:
In file included from /usr/include/boost/test/unit_test.hpp:18:
In file included from /usr/include/boost/test/test_tools.hpp:46:
In file included from /usr/include/boost/test/tools/old/impl.hpp:20:
In file included from /usr/include/boost/test/tools/assertion_result.hpp:21:
In file included from /usr/include/boost/shared_ptr.hpp:17:
In file included from /usr/include/boost/smart_ptr/shared_ptr.hpp:17:
In file included from /usr/include/boost/smart_ptr/detail/shared_count.hpp:27:
In file included from /usr/include/boost/smart_ptr/detail/sp_counted_impl.hpp:35:
In file included from /home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/memory:78:
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:100:2: error: delete called on non-final 'table_listener' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/unique_ptr.h:405:4: note: in instantiation of member function 'std::default_delete<table_listener>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/.local/bin/../lib/gcc/x86_64-pc-linux-gnu/13.0.1/../../../../include/c++/13.0.1/bits/stl_construct.h:88:15: note: in instantiation of member function 'std::unique_ptr<table_listener>::~unique_ptr' requested here
        __location->~_Tp();
                     ^
```