### PR TITLE
cmake: sync with `configure.py` (13/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,18 +177,7 @@ target_link_libraries(Boost::regex
 
 target_link_libraries(scylla PRIVATE
     seastar
-    # Boost dependencies
-    Boost::filesystem
-    Boost::program_options
-    Boost::system
-    Boost::thread
-    Boost::regex
-    Boost::headers
-    # System libs
-    libxcrypt::libxcrypt
-    ICU::uc
-    zstd
-    xxHash::xxhash)
+    Boost::program_options)
 
 # Force SHA1 build-id generation
 set(default_linker_flags "-Wl,--build-id=sha1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
   "Debug" "Release" "Dev" "Sanitize")
 string(TOUPPER "${CMAKE_BUILD_TYPE}" build_mode)
-include("mode.common")
-include("mode.${build_mode}")
+include(mode.common)
+include(mode.${build_mode})
 add_compile_definitions(
     ${Seastar_DEFINITIONS_${build_mode}}
     FMT_DEPRECATED_OSTREAM)
-include("limit_jobs")
+include(limit_jobs)
 # Configure Seastar compile options to align with Scylla
 set(CMAKE_CXX_STANDARD "20" CACHE INTERNAL "")
 set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")

--- a/cmake/limit_jobs.cmake
+++ b/cmake/limit_jobs.cmake
@@ -1,4 +1,4 @@
-set(LINK_MEM_PER_JOB 1024 CACHE INTERNAL "Maximum memory used by each link job in (in MiB)")
+set(LINK_MEM_PER_JOB 4096 CACHE INTERNAL "Maximum memory used by each link job in (in MiB)")
 
 cmake_host_system_information(
   RESULT _total_mem

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -61,14 +61,27 @@ endfunction()
 
 add_scylla_test(anchorless_list_test
   KIND BOOST)
+add_scylla_test(alternator_unit_test
+  KIND BOOST)
 add_scylla_test(auth_passwords_test
   KIND BOOST
   LIBRARIES auth)
 add_scylla_test(auth_resource_test
   KIND BOOST)
+add_scylla_test(batchlog_manager_test
+  KIND SEASTAR)
 add_scylla_test(big_decimal_test
   KIND BOOST
   LIBRARIES utils)
+add_scylla_test(bptree_test
+  KIND BOOST
+  LIBRARIES utils)
+add_scylla_test(broken_sstable_test
+  KIND SEASTAR)
+add_scylla_test(btree_test
+  KIND SEASTAR)
+add_scylla_test(bytes_ostream_test
+  KIND SEASTAR)
 add_scylla_test(caching_options_test
   KIND BOOST)
 add_scylla_test(cartesian_product_test
@@ -84,6 +97,14 @@ add_scylla_test(cql_auth_syntax_test
   LIBRARIES cql3)
 add_scylla_test(crc_test
   KIND BOOST)
+add_scylla_test(data_listeners_test
+  KIND SEASTAR)
+add_scylla_test(database_test
+  KIND SEASTAR)
+add_scylla_test(dirty_memory_manager_test
+  KIND SEASTAR)
+add_scylla_test(double_decker_test
+  KIND SEASTAR)
 add_scylla_test(duration_test
   KIND BOOST)
 add_scylla_test(dynamic_bitset_test
@@ -93,9 +114,36 @@ add_scylla_test(enum_option_test
   KIND BOOST)
 add_scylla_test(enum_set_test
   KIND BOOST)
+add_scylla_test(error_injection_test
+  KIND SEASTAR)
+add_scylla_test(estimated_histogram_test
+  KIND BOOST)
+add_scylla_test(exception_container_test
+  KIND SEASTAR)
+add_scylla_test(exceptions_fallback_test
+  KIND SEASTAR)
+add_scylla_test(exceptions_optimized_test
+  KIND SEASTAR)
+add_scylla_test(expr_test
+  KIND BOOST
+  LIBRARIES cql3)
+add_scylla_test(gossiping_property_file_snitch_test
+  KIND SEASTAR)
+add_scylla_test(group0_test
+  KIND SEASTAR)
+add_scylla_test(hash_test
+  KIND SEASTAR)
+add_scylla_test(hashers_test
+  KIND SEASTAR)
+add_scylla_test(hint_test
+  KIND SEASTAR)
 add_scylla_test(idl_test
   KIND BOOST
   LIBRARIES idl)
+add_scylla_test(index_with_paging_test
+  KIND SEASTAR)
+add_scylla_test(intrusive_array_test
+  KIND SEASTAR)
 add_scylla_test(json_test
   KIND BOOST
   LIBRARIES cql3)
@@ -189,9 +237,42 @@ add_scylla_test(row_cache_test
 add_scylla_test(rust_test
   KIND BOOST
   LIBRARIES inc)
+add_scylla_test(secondary_index_test
+  KIND SEASTAR)
 add_scylla_test(serialization_test
   KIND BOOST)
+add_scylla_test(serialized_action_test
+  KIND SEASTAR)
 add_scylla_test(small_vector_test
+  KIND SEASTAR)
+add_scylla_test(snitch_reset_test
+  KIND SEASTAR)
+add_scylla_test(sstable_3_x_test
+  KIND SEASTAR)
+add_scylla_test(sstable_datafile_test
+  KIND SEASTAR)
+add_scylla_test(sstable_mutation_test
+  KIND SEASTAR)
+add_scylla_test(sstable_partition_index_cache_test
+  KIND SEASTAR)
+add_scylla_test(schema_changes_test
+  KIND SEASTAR)
+add_scylla_test(sstable_conforms_to_mutation_source_test
+  KIND SEASTAR)
+add_scylla_test(sstable_compaction_test
+  KIND SEASTAR)
+add_scylla_test(sstable_resharding_test
+  KIND SEASTAR)
+add_scylla_test(sstable_directory_test
+  KIND SEASTAR)
+add_scylla_test(sstable_test
+  KIND SEASTAR)
+add_scylla_test(sstable_move_test
+  KIND SEASTAR)
+add_scylla_test(statement_restrictions_test
+  KIND SEASTAR
+  LIBRARIES cql3)
+add_scylla_test(storage_proxy_test
   KIND SEASTAR)
 add_scylla_test(summary_test
   KIND BOOST)
@@ -201,18 +282,8 @@ add_scylla_test(tracing_test
   KIND SEASTAR)
 add_scylla_test(transport_test
   KIND SEASTAR)
-add_scylla_test(type_json_test
-  KIND BOOST)
 add_scylla_test(types_test
   KIND SEASTAR)
-add_scylla_test(vint_serialization_test
-  KIND BOOST
-  LIBRARIES
-    scylla-main
-    utils)
-add_scylla_test(bptree_test
-  KIND BOOST
-  LIBRARIES utils)
 add_scylla_test(utf8_test
   KIND BOOST
   LIBRARIES utils)
@@ -221,6 +292,26 @@ add_scylla_test(user_function_test
   LIBRARIES idl)
 add_scylla_test(user_types_test
   KIND SEASTAR)
-add_scylla_test(expr_test
+add_scylla_test(UUID_test
+  KIND BOOST)
+add_scylla_test(view_build_test
+  KIND SEASTAR)
+add_scylla_test(view_complex_test
+  KIND SEASTAR)
+add_scylla_test(view_schema_test
+  KIND SEASTAR)
+add_scylla_test(view_schema_pkey_test
+  KIND SEASTAR)
+add_scylla_test(view_schema_ckey_test
+  KIND SEASTAR)
+add_scylla_test(vint_serialization_test
   KIND BOOST
-  LIBRARIES cql3)
+  LIBRARIES
+    scylla-main
+    utils)
+add_scylla_test(virtual_reader_test
+  KIND SEASTAR)
+add_scylla_test(virtual_table_mutation_source_test
+  KIND SEASTAR)
+add_scylla_test(virtual_table_test
+  KIND SEASTAR)

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(test-lib)
 target_sources(test-lib
   PRIVATE
     cql_assertions.cc
+    dummy_sharder.cc
     exception_utils.cc
     log.cc
     test_utils.cc
@@ -14,6 +15,7 @@ target_sources(test-lib
     mutation_source_test.cc
     random_schema.cc
     result_set_assertions.cc
+    sstable_run_based_compaction_strategy_for_tests.cc
     sstable_utils.cc
     data_model.cc)
 target_include_directories(test-lib


### PR DESCRIPTION
this is the 13rd changeset of a series which tries to give an overhaul to the CMake building system. this series has two goals:

- to enable developer to use CMake for building scylla. so they can use tools (CLion for instance) with CMake integration for better developer experience
- to enable us to tweak the dependencies in a simpler way. a well-defined cross module / subsystem dependency is a prerequisite for building this project with the C++20 modules.

this changeset includes following changes:

- build: cmake: increase per link job mem to 4GiB
- build: cmake: add missing sources to test-lib
- build: cmake: add more tests
- build: cmake: remote quotes in "include()" commands
- build: cmake: drop unnecessary linkages