### PR TITLE
doc: Add version 5.2 to the version selector

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,11 +15,11 @@ sys.path.insert(0, os.path.abspath(".."))
 BASE_URL = 'https://docs.scylladb.com'
 # Build documentation for the following tags and branches.
 TAGS = []
-BRANCHES = ["master", "branch-5.1"]
+BRANCHES = ["master", "branch-5.1", "branch-5.2"]
 # Set the latest version.
 LATEST_VERSION = "branch-5.1"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master"]
+UNSTABLE_VERSIONS = ["master", "branch-5.2"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 # Set to enterprise or opensource.


### PR DESCRIPTION
This commit adds branch-5.2 to the list of branches for which we want to build the docs. As a result,
version 5.2 will be added to the version selector.

NOTE: Version 5.2 will be marked as unstable, and an appropriate message will be shown to the user.
After 5.2 is released, branch-5.2 needs to be moved from UNSTABLE_VERSIONS to LATEST_VERSION
(where it should replace branch-5.1)