### PR TITLE
api: reference httpd::* symbols like 'httpd::*'

### DIFF
--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -490,7 +490,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_all_multi_range) {
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_with_partition_row_limits) {
-    do_with_cql_env_thread([this] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -574,7 +574,7 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_reversed) {
-    do_with_cql_env_thread([this] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
         using namespace std::chrono_literals;
 
         auto& db = env.db();

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -1001,7 +1001,7 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
 }
 
 SEASTAR_TEST_CASE(test_schema_get_reversed) {
-    return do_with_cql_env([this] (cql_test_env& e) {
+    return do_with_cql_env([] (cql_test_env& e) {
         auto schema = schema_builder("ks", get_name())
                 .with_column("pk", bytes_type, column_kind::partition_key)
                 .with_column("ck", bytes_type, column_kind::clustering_key)

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2075,8 +2075,8 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
     db_cfg.enable_cache(false);
     db_cfg.enable_commitlog(false);
 
-    return do_with_cql_env([this] (cql_test_env& cql_env) -> future<> {
-        return test_env::do_with_async([this] (test_env& env) {
+    return do_with_cql_env([] (cql_test_env& cql_env) -> future<> {
+        return test_env::do_with_async([] (test_env& env) {
             auto schema = schema_builder("ks", get_name())
                     .with_column("pk", utf8_type, column_kind::partition_key)
                     .with_column("ck", int32_type, column_kind::clustering_key)
@@ -2268,8 +2268,8 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
     db_cfg.enable_cache(false);
     db_cfg.enable_commitlog(false);
 
-    return do_with_cql_env([this] (cql_test_env& cql_env) -> future<> {
-        return test_env::do_with_async([this] (test_env& env) {
+    return do_with_cql_env([] (cql_test_env& cql_env) -> future<> {
+        return test_env::do_with_async([] (test_env& env) {
             auto schema = schema_builder("ks", get_name())
                     .with_column("pk", utf8_type, column_kind::partition_key)
                     .with_column("ck", int32_type, column_kind::clustering_key)
@@ -2357,8 +2357,8 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
     db_cfg.enable_cache(false);
     db_cfg.enable_commitlog(false);
 
-    return do_with_cql_env([this] (cql_test_env& cql_env) -> future<> {
-        return test_env::do_with_async([this] (test_env& env) {
+    return do_with_cql_env([] (cql_test_env& cql_env) -> future<> {
+        return test_env::do_with_async([] (test_env& env) {
             auto schema = schema_builder("ks", get_name())
                     .with_column("pk", utf8_type, column_kind::partition_key)
                     .with_column("ck", int32_type, column_kind::clustering_key)
@@ -2463,8 +2463,8 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
         sstables::compaction_type_options::scrub::quarantine_mode::only,
     };
     for (auto qmode : quarantine_modes) {
-        co_await do_with_cql_env([this, qmode] (cql_test_env& cql_env) {
-            return test_env::do_with_async([this, qmode] (test_env& env) {
+        co_await do_with_cql_env([qmode] (cql_test_env& cql_env) {
+            return test_env::do_with_async([qmode] (test_env& env) {
                 auto schema = schema_builder("ks", get_name())
                         .with_column("pk", utf8_type, column_kind::partition_key)
                         .with_column("ck", int32_type, column_kind::clustering_key)

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3021,7 +3021,7 @@ SEASTAR_TEST_CASE(test_crawling_reader_out_of_range_last_range_tombstone_change)
 }
 
 SEASTAR_TEST_CASE(test_crawling_reader_random_schema_random_mutations) {
-    return test_env::do_with_async([this] (test_env& env) {
+    return test_env::do_with_async([] (test_env& env) {
         auto random_spec = tests::make_random_schema_specification(
                 get_name(),
                 std::uniform_int_distribution<size_t>(1, 4),


### PR DESCRIPTION
this change is a leftover of 063b3be8a7340a12b9594b44f52cbb6fa60f58b3, which failed to include the changes in the header files.

it turns out we have `using namespace httpd;` in seastar's `request_parser.rl`, and we should not rely on this statement to expose the symbols in `seatar::httpd` to `seastar` namespace. in this change,

also, sine `get_name()` previously a non-static member function of `seastar_test` is now a static member function, so we need to update the tests which capture `this` for calling this function, so they don't capture `this` anymore.