### PR TITLE
memory_data_sink: Add move ctor

### DIFF
--- a/utils/memory_data_sink.hh
+++ b/utils/memory_data_sink.hh
@@ -35,6 +35,14 @@ public:
         _bufs.clear();
         _size = 0;
     }
+
+    memory_data_sink_buffers() = default;
+
+    memory_data_sink_buffers(memory_data_sink_buffers&& other)
+            : _bufs(std::move(other._bufs))
+            , _size(std::exchange(other._size, 0))
+    {
+    }
 };
 
 class memory_data_sink : public data_sink_impl {


### PR DESCRIPTION
To make it possible to move the class member away resetting to be be empty at the same time.

refs: #12523 (detached small change from large PR)