### PR TITLE
test: Fixie for test sstable chdir

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -486,6 +486,10 @@ public:
         future<> touch_temp_dir(const sstable& sst);
         future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay);
 
+        void change_dir_for_test(sstring nd) {
+            dir = std::move(nd);
+        }
+
     public:
         explicit filesystem_storage(sstring dir_) : dir(std::move(dir_)) {}
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -133,7 +133,7 @@ public:
     }
 
     void change_dir(sstring dir) {
-        _sst->_storage.dir = dir;
+        _sst->_storage.change_dir_for_test(dir);
     }
 
     void set_data_file_size(uint64_t size) {


### PR DESCRIPTION
Some unit tests want to change the sstable::_dir on the fly. However, the sstable::_dir is going away, so it needs a yet another virtual call on storage driver.

refs: #12523 (detached small change from large PR)