### PR TITLE
Sanitize {format_types|version_types} to/from string converters

### DIFF
--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -41,7 +41,7 @@ future<> sstables_format_selector::maybe_select_format(sstables::sstable_version
     auto units = co_await get_units(_sem, 1);
 
     if (new_format > _selected_format) {
-        co_await db::system_keyspace::set_scylla_local_param(SSTABLE_FORMAT_PARAM_NAME, to_string(new_format));
+        co_await db::system_keyspace::set_scylla_local_param(SSTABLE_FORMAT_PARAM_NAME, fmt::to_string(new_format));
         co_await select_format(new_format);
         // FIXME discarded future
         (void)_gossiper.add_local_application_state(gms::application_state::SUPPORTED_FEATURES,
@@ -69,7 +69,7 @@ future<> sstables_format_selector::read_sstables_format() {
 }
 
 future<> sstables_format_selector::select_format(sstables::sstable_version_types format) {
-    logger.info("Selected {} sstables format", to_string(format));
+    logger.info("Selected {} sstables format", format);
     _selected_format = format;
     co_await _db.invoke_on_all([this] (replica::database& db) {
         db.set_format(_selected_format);

--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -63,7 +63,7 @@ future<> sstables_format_selector::stop() {
 future<> sstables_format_selector::read_sstables_format() {
     std::optional<sstring> format_opt = co_await db::system_keyspace::get_scylla_local_param(SSTABLE_FORMAT_PARAM_NAME);
     if (format_opt) {
-        sstables::sstable_version_types format = sstables::from_string(*format_opt);
+        sstables::sstable_version_types format = sstables::version_from_string(*format_opt);
         co_await select_format(format);
     }
 }

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -34,7 +34,7 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
 
     fcfg._disabled_features = std::move(disabled);
 
-    switch (sstables::from_string(cfg.sstable_format())) {
+    switch (sstables::version_from_string(cfg.sstable_format())) {
     case sstables::sstable_version_types::ka:
     case sstables::sstable_version_types::la:
     case sstables::sstable_version_types::mc:

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2040,7 +2040,7 @@ sstring sstable::component_basename(const sstring& ks, const sstring& cf, versio
                                     format_types format, sstring component) {
     sstring v = fmt::to_string(version);
     sstring g = to_sstring(generation);
-    sstring f = format_string.at(format);
+    sstring f = fmt::to_string(format);
     switch (version) {
     case sstable::version_types::ka:
         return ks + "-" + cf + "-" + v + "-" + g + "-" + component;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2398,7 +2398,7 @@ static entry_descriptor make_entry_descriptor(sstring sstdir, sstring fname, sst
                 throw malformed_sstable_exception(seastar::format("invalid path for file {}: {}. Path doesn't match known pattern.", fname, sstdir));
             }
         }
-        version = from_string(match[1].str());
+        version = version_from_string(match[1].str());
         generation = match[2].str();
         format = sstring(match[3].str());
         component = sstring(match[4].str());

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -187,16 +187,16 @@ future<file> sstable::new_sstable_component_file(const io_error_handler& error_h
   }
 }
 
-const std::unordered_map<sstable::version_types, sstring, enum_hash<sstable::version_types>> sstable::_version_string = {
-    { sstable::version_types::ka , "ka" },
-    { sstable::version_types::la , "la" },
-    { sstable::version_types::mc , "mc" },
-    { sstable::version_types::md , "md" },
-    { sstable::version_types::me , "me" },
+const std::unordered_map<sstable_version_types, sstring, enum_hash<sstable_version_types>> version_string = {
+    { sstable_version_types::ka , "ka" },
+    { sstable_version_types::la , "la" },
+    { sstable_version_types::mc , "mc" },
+    { sstable_version_types::md , "md" },
+    { sstable_version_types::me , "me" },
 };
 
-const std::unordered_map<sstable::format_types, sstring, enum_hash<sstable::format_types>> sstable::_format_string = {
-    { sstable::format_types::big , "big" }
+const std::unordered_map<sstable_format_types, sstring, enum_hash<sstable_format_types>> format_string = {
+    { sstable_format_types::big , "big" }
 };
 
 // This assumes that the mappings are small enough, and called unfrequent
@@ -2038,9 +2038,9 @@ bool sstable::is_uploaded() const noexcept {
 
 sstring sstable::component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                     format_types format, sstring component) {
-    sstring v = _version_string.at(version);
+    sstring v = version_string.at(version);
     sstring g = to_sstring(generation);
-    sstring f = _format_string.at(format);
+    sstring f = format_string.at(format);
     switch (version) {
     case sstable::version_types::ka:
         return ks + "-" + cf + "-" + v + "-" + g + "-" + component;
@@ -2426,7 +2426,7 @@ entry_descriptor entry_descriptor::make_descriptor(sstring sstdir, sstring fname
 
 sstable::version_types sstable::version_from_sstring(const sstring &s) {
     try {
-        return reverse_map(s, _version_string);
+        return reverse_map(s, version_string);
     } catch (std::out_of_range&) {
         throw std::out_of_range(seastar::format("Unknown sstable version: {}", s.c_str()));
     }
@@ -2434,7 +2434,7 @@ sstable::version_types sstable::version_from_sstring(const sstring &s) {
 
 sstable::format_types sstable::format_from_sstring(const sstring &s) {
     try {
-        return reverse_map(s, _format_string);
+        return reverse_map(s, format_string);
     } catch (std::out_of_range&) {
         throw std::out_of_range(seastar::format("Unknown sstable format: {}", s.c_str()));
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2038,7 +2038,7 @@ bool sstable::is_uploaded() const noexcept {
 
 sstring sstable::component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                     format_types format, sstring component) {
-    sstring v = version_string.at(version);
+    sstring v = fmt::to_string(version);
     sstring g = to_sstring(generation);
     sstring f = format_string.at(format);
     switch (version) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -176,8 +176,6 @@ public:
     };
 
     static component_type component_from_sstring(version_types version, const sstring& s);
-    static version_types version_from_sstring(const sstring& s);
-    static format_types format_from_sstring(const sstring& s);
     static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                       format_types format, component_type component);
     static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -528,9 +528,6 @@ private:
 
     size_t sstable_buffer_size;
 
-    static const std::unordered_map<version_types, sstring, enum_hash<version_types>> _version_string;
-    static const std::unordered_map<format_types, sstring, enum_hash<format_types>> _format_string;
-
     std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
     std::vector<sstring> _unrecognized_components;
 

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/enum.hh>
 
 namespace sstables {
 
@@ -74,6 +75,10 @@ inline sstable_version_types from_string(const seastar::sstring& format) {
     }
     throw std::invalid_argument("Wrong sstable format name: " + format);
 }
+
+extern const std::unordered_map<sstable_version_types, seastar::sstring, seastar::enum_hash<sstable_version_types>> version_string;
+extern const std::unordered_map<sstable_format_types, seastar::sstring, seastar::enum_hash<sstable_format_types>> format_string;
+
 
 inline seastar::sstring to_string(sstable_version_types format) {
     switch (format) {

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -80,17 +80,6 @@ extern const std::unordered_map<sstable_version_types, seastar::sstring, seastar
 extern const std::unordered_map<sstable_format_types, seastar::sstring, seastar::enum_hash<sstable_format_types>> format_string;
 
 
-inline seastar::sstring to_string(sstable_version_types format) {
-    switch (format) {
-        case sstable_version_types::ka: return "ka";
-        case sstable_version_types::la: return "la";
-        case sstable_version_types::mc: return "mc";
-        case sstable_version_types::md: return "md";
-        case sstable_version_types::me: return "me";
-    }
-    throw std::runtime_error("Wrong sstable format");
-}
-
 inline int operator<=>(sstable_version_types a, sstable_version_types b) {
     auto to_int = [] (sstable_version_types x) {
         return static_cast<std::underlying_type_t<sstable_version_types>>(x);
@@ -99,3 +88,11 @@ inline int operator<=>(sstable_version_types a, sstable_version_types b) {
 }
 
 }
+
+template <>
+struct fmt::formatter<sstables::sstable_version_types> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::sstable_version_types& version, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", sstables::version_string.at(version));
+    }
+};

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -96,3 +96,11 @@ struct fmt::formatter<sstables::sstable_version_types> : fmt::formatter<std::str
         return fmt::format_to(ctx.out(), "{}", sstables::version_string.at(version));
     }
 };
+
+template <>
+struct fmt::formatter<sstables::sstable_format_types> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::sstable_format_types& format, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", sstables::format_string.at(format));
+    }
+};

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -76,6 +76,9 @@ inline sstable_version_types from_string(const seastar::sstring& format) {
     throw std::invalid_argument("Wrong sstable format name: " + format);
 }
 
+sstable_version_types version_from_string(std::string_view s);
+sstable_format_types format_from_string(std::string_view s);
+
 extern const std::unordered_map<sstable_version_types, seastar::sstring, seastar::enum_hash<sstable_version_types>> version_string;
 extern const std::unordered_map<sstable_format_types, seastar::sstring, seastar::enum_hash<sstable_format_types>> format_string;
 

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -57,25 +57,6 @@ inline auto get_highest_sstable_version() {
     return all_sstable_versions[all_sstable_versions.size() - 1];
 }
 
-inline sstable_version_types from_string(const seastar::sstring& format) {
-    if (format == "ka") {
-        return sstable_version_types::ka;
-    }
-    if (format == "la") {
-        return sstable_version_types::la;
-    }
-    if (format == "mc") {
-        return sstable_version_types::mc;
-    }
-    if (format == "md") {
-        return sstable_version_types::md;
-    }
-    if (format == "me") {
-        return sstable_version_types::me;
-    }
-    throw std::invalid_argument("Wrong sstable format name: " + format);
-}
-
 sstable_version_types version_from_string(std::string_view s);
 sstable_format_types format_from_string(std::string_view s);
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1015,7 +1015,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                         .with_column("ck2", utf8_type, column_kind::clustering_key)
                         .with_column("r1", int32_type)
                         .build();
-                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: min={{\"a\", \"c\"}} max={{\"b\", \"a\"}} version={}", to_string(version)));
+                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: min={{\"a\", \"c\"}} max={{\"b\", \"a\"}} version={}", version));
                 auto sst_gen = env.make_sst_factory(s, version);
                 test_min_max_clustering_key(env, s, sst_gen, {"key1"}, {{"b", "a"}, {"a", "c"}}, {"a", "c"}, {"b", "a"}, version);
             }
@@ -1027,7 +1027,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                         .with_column("ck2", utf8_type, column_kind::clustering_key)
                         .with_column("r1", int32_type)
                         .build();
-                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: min={{\"a\", \"c\"}} max={{\"b\", \"a\"}} with compact storage version={}", to_string(version)));
+                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: min={{\"a\", \"c\"}} max={{\"b\", \"a\"}} with compact storage version={}", version));
                 auto sst_gen = env.make_sst_factory(s, version);
                 test_min_max_clustering_key(env, s, sst_gen, {"key1"}, {{"b", "a"}, {"a", "c"}}, {"a", "c"}, {"b", "a"}, version);
             }
@@ -1038,7 +1038,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                         .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
                         .with_column("r1", int32_type)
                         .build();
-                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\", \"z\"}} max={{\"a\", \"a\"}} version={}", to_string(version)));
+                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\", \"z\"}} max={{\"a\", \"a\"}} version={}", version));
                 auto sst_gen = env.make_sst_factory(s, version);
                 test_min_max_clustering_key(env, s, sst_gen, {"key1"}, {{"a", "a"}, {"a", "z"}}, {"a", "z"}, {"a", "a"}, version);
             }
@@ -1049,7 +1049,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                         .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
                         .with_column("r1", int32_type)
                         .build();
-                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\", \"a\"}} max={{\"b\", \"z\"}} version={}", to_string(version)));
+                BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\", \"a\"}} max={{\"b\", \"z\"}} version={}", version));
                 auto sst_gen = env.make_sst_factory(s, version);
                 test_min_max_clustering_key(env, s, sst_gen, {"key1"}, {{"b", "z"}, {"a", "a"}}, {"a", "a"}, {"b", "z"}, version);
             }
@@ -1090,7 +1090,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                             .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
                             .with_column("r1", int32_type)
                             .build();
-                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\"}} max={{\"a\"}} with compact storage version={}", to_string(version)));
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\"}} max={{\"a\"}} with compact storage version={}", version));
                 auto sst_gen = env.make_sst_factory(s, version);
                     test_min_max_clustering_key(env, s, sst_gen, {"key1"}, {{"a", "z"}, {"a"}}, {"a"}, {"a"}, version);
                 }
@@ -1112,7 +1112,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             auto c_key = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
             const column_definition& r1_col = *s->get_column_definition("r1");
 
-            BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
 
             {
                 auto mt = make_lw_shared<replica::memtable>(s);
@@ -1306,7 +1306,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             auto c_key = clustering_key_prefix::from_exploded(*s, {to_bytes("c1"), to_bytes("c2")});
             const column_definition& r1_col = *s->get_column_definition("r1");
 
-            BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
 
             {
                 auto mt = make_lw_shared<replica::memtable>(s);
@@ -1490,7 +1490,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             auto c_key = clustering_key_prefix::from_exploded(*s, {to_bytes("c1"), to_bytes("c2")});
             const column_definition& r1_col = *s->get_column_definition("r1");
 
-            BOOST_TEST_MESSAGE(fmt::format("version {}", to_string(version)));
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
 
             {
                 auto mt = make_lw_shared<replica::memtable>(s);
@@ -2662,7 +2662,7 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
         ss.add_row(mut, ss.make_ckey(0), "val");
 
         for (const auto version : writable_sstable_versions) {
-            testlog.info("version={}", sstables::to_string(version));
+            testlog.info("version={}", version);
 
             auto mr = make_flat_mutation_reader_from_mutations_v2(ss.schema(), env.make_reader_permit(), {mut});
             sstable_writer_config cfg = env.manager().configure_writer();
@@ -2725,7 +2725,7 @@ SEASTAR_TEST_CASE(test_missing_partition_end_fragment) {
         auto enable_aborts = defer([] { set_abort_on_internal_error(true); }); // FIXME: restore to previous value
 
         for (const auto version : writable_sstable_versions) {
-            testlog.info("version={}", sstables::to_string(version));
+            testlog.info("version={}", version);
 
             std::deque<mutation_fragment_v2> frags;
             frags.push_back(mutation_fragment_v2(*s, env.make_reader_permit(), partition_start(pkeys[0], tombstone())));
@@ -2878,7 +2878,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
         int gen = 0;
 
         for (const auto version : writable_sstable_versions) {
-            testlog.info("version={}", sstables::to_string(version));
+            testlog.info("version={}", version);
             for (const auto& compression_params : {no_compression_params, lz4_compression_params}) {
                 testlog.info("compression={}", compression_params);
                 auto sst_schema = schema_builder(schema).set_compressor_params(compression_params).build();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -695,7 +695,7 @@ public:
             dbcfg.memtable_scheduling_group = scheduling_groups.memtable_scheduling_group;
             dbcfg.memtable_to_cache_scheduling_group = scheduling_groups.memtable_to_cache_scheduling_group;
             dbcfg.gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
-            dbcfg.sstables_format = sstables::from_string(cfg->sstable_format());
+            dbcfg.sstables_format = sstables::version_from_string(cfg->sstable_format());
 
             auto get_tm_cfg = sharded_parameter([&] {
                 return tasks::task_manager::config {

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -261,7 +261,7 @@ int main(int argc, char** argv) {
             std::cout << " - in memtable:  " << sizes.memtable << "\n";
             std::cout << " - in sstable:\n";
             for (auto v : sizes.sstable) {
-                std::cout << "   " << sstables::to_string(v.first) << ":   " << v.second << "\n";
+                std::cout << "   " << fmt::to_string(v.first) << ":   " << v.second << "\n";
             }
             std::cout << " - frozen:       " << sizes.frozen << "\n";
             std::cout << " - canonical:    " << sizes.canonical << "\n";


### PR DESCRIPTION
There's a need to convert both -- version and format -- to string and back. Currently, there's a disperse set of helpers in sstables/ code doing that and this PR brings some other to it

- adds fmt::formatter<> specialization for both types
- leaves one set of {format|version}_from_string() helpers converting any string-ish object into value

refs: #12523