### PR TITLE
create-relocatable-package.py: stop using filter function on tools

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -164,14 +164,7 @@ ar.reloc_add('ORIGIN')
 ar.reloc_add('licenses')
 ar.reloc_add('swagger-ui')
 ar.reloc_add('api')
-def exclude_submodules(tarinfo):
-    if tarinfo.name in ('scylla/tools/jmx',
-                        'scylla/tools/java',
-                        'scylla/tools/python3',
-                        'scylla/tools/cqlsh'):
-        return None
-    return tarinfo
-ar.reloc_add('tools', filter=exclude_submodules)
+ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('build/debian/debian', arcname='debian')
 ar.reloc_add('build/node_exporter', arcname='node_exporter')


### PR DESCRIPTION
We introduced exclude_submodules at 19da4a5b8ff5a0ebdfa22bfe9b63b16f0267c120 to exclude tools/java and tools/jmx since they have their own relocatable packages, so we don't want to package same files twice.

However, most of the files under tools/ are not needed for installation, we just need tools/scyllatop.
So what we really need to do is "ar.reloc_add('tools/scyllatop')", not excluding files from tools/.

related with #13183