### PR TITLE
docs: scylladb better php driver

### DIFF
--- a/docs/using-scylla/drivers/cql-drivers/index.rst
+++ b/docs/using-scylla/drivers/cql-drivers/index.rst
@@ -48,7 +48,7 @@ Scylla supports the CQL binary protocol version 3, so any Apache Cassandra/CQL d
   * `DataStax Ruby Driver <https://github.com/datastax/ruby-driver/>`_
   * `DataStax Node.js Driver <https://github.com/datastax/nodejs-driver/>`_
   * `DataStax C++ Driver <https://github.com/datastax/cpp-driver/>`_
-  * `DataStax PHP Driver  <https://github.com/datastax/php-driver/>`_
+  * `He4rt PHP Driver  <https://github.com/he4rt/scylladb-php-driver/>`_
   * `Rust <https://github.com/AlexPikalov/cdrs>`_
   * `Scala Phantom Project <https://github.com/outworkers/phantom>`_
 


### PR DESCRIPTION
Hey y'all! 

Me and @malusev998 are maintaining a updated version of the [PHP Driver ](https://github.com/he4rt/scylladb-php-driver) together with @he4rt community and it had a bunch of improvements on these last month.

Before it was working only at PHP 7.1 (DataStax branch), and at our branch we have it working at PHP 8.1 and 8.2.

We are also using the ScyllaDB C++ Driver on this project and I think that is a good idea to point new users for this project since it's the most updated PHP Driver maintained now.

What do y'all think about that?