### PR TITLE
test: network_topology_strategy_test: silence warning

### DIFF
--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -126,7 +126,8 @@ auto d2t = [](double d) -> int64_t {
     // Double to unsigned long conversion will overflow if the
     // input is greater than numeric_limits<long>::max(), so divide by two and
     // multiply again later.
-    return static_cast<unsigned long>(d*(std::numeric_limits<unsigned long>::max() >> 1)) << 1;
+    auto scale = std::numeric_limits<unsigned long>::max();
+    return static_cast<unsigned long>(d * static_cast<double>(scale >> 1)) << 1;
 };
 
 /**


### PR DESCRIPTION
clang warns when the implicit conversion changes the precision of the converted number. in this case, the before being multiplied, `std::numeric_limits<unsigned long>::max() >> 1` is implicitly promoted to double so it can obtain the common type of double and unsigned long. and the compiler warns:

```
/home/kefu/dev/scylladb/test/boost/network_topology_strategy_test.cc:129:84: error: implicit conversion from 'unsigned long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
    return static_cast<unsigned long>(d*(std::numeric_limits<unsigned long>::max() >> 1)) << 1;
                                       ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```
but

1. we don't really care about the precision here, we just want to map a double to an token represented by an int64_t
2. the maximum possible number being converted is less than 9223372036854775807, which is the maximum number of int64_t, which is in general an alias of `long long`, not to mention that LONG_MAX is always 2147483647, after shifting right, the result would be 1073741823

so this is a false alarm. in order to silence it, we explicitly cast the RHS of `*` operator to double.