### PR TITLE
doc: fix the service name from "scylla-enterprise-server" "to "scylla-server" - part 3

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-5.0-to-2022.1-ubuntu-and-debian.rst
@@ -114,7 +114,7 @@ New io.conf format was introduced in ScyllaDB 2.3 and 2019.1. If your io.conf do
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
@@ -154,7 +154,7 @@ Gracefully shutdown ScyllaDB
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the old release
 ------------------------------------

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.0-to-2022.1/upgrade-guide-from-5.0-to-2022.1-rpm.rst
@@ -104,7 +104,7 @@ A new io.conf format was introduced in ScyllaDB 2.3 and 2019.1. If your io.conf 
 
 .. code:: sh
 
-   sudo systemctl start scylla-enterprise-server
+   sudo systemctl start scylla-server
 
 Validate
 --------

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.1-to-2022.2/upgrade-guide-from-5.1-to-2022.2-generic.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.1-to-2022.2/upgrade-guide-from-5.1-to-2022.2-generic.rst
@@ -144,7 +144,7 @@ Download and install the new release
                sudo apt-get clean all
                sudo apt-get update
                sudo apt-get remove scylla\*
-               sudo apt-get install scylla-enterprise-server
+               sudo apt-get install scylla-enterprise
                sudo systemctl daemon-reload
 
         Answer ‘y’ to the first two questions.
@@ -163,7 +163,7 @@ Download and install the new release
                sudo yum clean all
                sudo rm -rf /var/cache/yum
                sudo yum remove scylla\*
-               sudo yum install scylla-enterprise-server
+               sudo yum install scylla-enterprise
 
    .. group-tab:: EC2/GCP/Azure Ubuntu Image
 
@@ -221,13 +221,13 @@ Start the node
 
 .. code:: sh
 
-   sudo service scylla-enterprise-server start
+   sudo service scylla-server start
 
 Validate
 --------
 #. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in ``UN`` status.
 #. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version. Validate that the version matches the one you upgraded to.
-#. Check scylla-enterprise-server log (using ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no new errors in the log.
+#. Check scylla-server log (using ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no new errors in the log.
 #. Check again after two minutes, to validate no new issues are introduced.
 
 Once you are sure the node upgrade was successful, move to the next node in the cluster.
@@ -269,7 +269,7 @@ Drain and gracefully stop the node
 .. code:: sh
 
    nodetool drain
-   sudo service scylla-enterprise-server stop
+   sudo service scylla-server stop
 
 Download and install the old release
 ------------------------------------


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13207

This PR fixes the service and package names in the upgrade guides 5.0-to-2022.1 and 5.1-to-2022.2. 
Service name: `scylla-server`
Package name: `scylla-enterprise`

Previous PRs to fix the same issue in other upgrade guides:
https://github.com/scylladb/scylladb/pull/12679
https://github.com/scylladb/scylladb/pull/12698

This PR must be backported to branch-5.1 and branch 5.2.