### PR TITLE
doc: add the Enterprise vs. OSS matrix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -154,6 +154,7 @@
   architecture/index
   troubleshooting/index
   kb/index
+  reference/index
   ScyllaDB University <https://university.scylladb.com/>
   faq
   Contribute to ScyllaDB <contribute>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,9 @@
+===============
+Reference 
+===============
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   /reference/*

--- a/docs/reference/versions-matrix-enterprise-oss.rst
+++ b/docs/reference/versions-matrix-enterprise-oss.rst
@@ -1,0 +1,29 @@
+=============================================
+ScyllaDB Enterprise vs. Open Source Matrix
+=============================================
+
+ScyllaDB Enterprise is based on ScyllaDB Open Source - it  provides the functionality of ScyllaDB Open Source, 
+with the addition of Enterprise-only features and 24/7 support.
+
+The following table shows ScyllaDB Enterprise versions and their corresponding ScyllaDB Open Source releases.
+
+
+.. list-table:: 
+   :widths: 50 50
+   :header-rows: 1
+
+   * - ScyllaDB Enterprise
+     - ScyllaDB Open Source
+   * - 2023.1
+     - 5.2
+   * - 2022.2
+     - 5.1
+   * - 2022.1
+     - 5.0
+   * - 2021.1
+     - 4.3
+   * - 2020.1
+     - 4.0
+   * - 2019.1
+     - 3.0
+


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12758

This commit adds a new page with a matrix that shows on which ScyllaDB Open Source versions we based given ScyllaDB Enterprise versions.

The new file is added to the newly created Reference section.