### PR TITLE
gms, service: replicate live endpoints on shard 0

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -758,9 +758,12 @@ future<> gossiper::update_live_endpoints_version() {
 }
 
 future<std::set<inet_address>> gossiper::get_live_members_synchronized() {
-    auto live_members = gossiper::get_live_members();
-    co_await replicate_live_endpoints_on_change();
-    co_return live_members;
+    return container().invoke_on(0, [] (gms::gossiper& g) -> future<std::set<inet_address>> {
+        auto lock = co_await get_units(g._endpoint_update_semaphore, 1);
+        std::set<inet_address> live_members = g.get_live_members();
+        co_await g.replicate_live_endpoints_on_change();
+        co_return live_members;
+    });
 }
 
 future<> gossiper::failure_detector_loop_for_node(gms::inet_address node, int64_t gossip_generation, uint64_t live_endpoints_version) {
@@ -861,9 +864,9 @@ future<> gossiper::failure_detector_loop() {
     logger.info("failure_detector_loop: Finished main loop");
 }
 
+// This needs to be run with a lock
 future<> gossiper::replicate_live_endpoints_on_change() {
     assert(this_shard_id() == 0);
-    auto lock = co_await get_units(_endpoint_update_semaphore, 1);
     //
     // Gossiper task runs only on CPU0:
     //
@@ -982,7 +985,10 @@ void gossiper::run() {
                 do_status_check().get();
             }
 
-            replicate_live_endpoints_on_change().get();
+            {
+                auto lock = get_units(_endpoint_update_semaphore, 1).get();
+                replicate_live_endpoints_on_change().get();
+            }
 
     }).then_wrapped([this] (auto&& f) {
         try {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -227,7 +227,8 @@ private:
     std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
     utils::chunked_vector<inet_address> _shadow_live_endpoints;
 
-    // replicate live endpoints across all other shards.
+    // replicate shard 0 live endpoints across all other shards.
+    // _endpoint_update_semaphore must be held for the whole duration
     future<> replicate_live_endpoints_on_change();
 
     void run();


### PR DESCRIPTION
Call replicate_live_endpoints on shard 0 to copy from 0 to the rest of the shards.

Fixes https://github.com/scylladb/scylladb/issues/13235.