### PR TITLE
Unit tests cleanup for sstable generation changes

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -128,6 +128,7 @@ future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::
 class mutation_reordered_with_truncate_exception : public std::exception {};
 
 class column_family_test;
+class table_for_tests;
 class database_test;
 
 namespace replica {
@@ -1091,7 +1092,9 @@ public:
 
     friend std::ostream& operator<<(std::ostream& out, const column_family& cf);
     // Testing purposes.
+    // to let test classes access calculate_generation_for_new_table
     friend class ::column_family_test;
+    friend class ::table_for_tests;
 
     friend class distributed_loader;
     friend class table_populator;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -507,6 +507,10 @@ public:
         sstring prefix() const { return dir; }
     };
 
+    const filesystem_storage& get_storage() const {
+        return _storage;
+    }
+
 private:
     sstring filename(component_type f) const {
         return filename(_storage.prefix(), f);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -79,8 +79,8 @@ public:
     shared_sstable make_sstable(schema_ptr schema,
             sstring dir,
             generation_type generation,
-            sstable_version_types v,
-            sstable_format_types f,
+            sstable_version_types v = get_highest_sstable_version(),
+            sstable_format_types f = sstable_format_types::big,
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -330,20 +330,20 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
     auto temp_sst_dir_3 = sst_dir + "/" + sst::sst_dir_basename(generation_from_value(3));
     touch_dir(temp_sst_dir_3);
 
-    auto temp_file_name = sst::filename(temp_sst_dir_3, ks, cf, sst::version_types::mc, generation_from_value(3), sst::format_types::big, component_type::TemporaryTOC);
+    auto temp_file_name = sst::filename(temp_sst_dir_3, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(3), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
 
-    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC);
+    temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
-    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data);
+    temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
     do_with_cql_env_and_compaction_groups([&sst_dir, &ks, &cf, &require_exist, &temp_sst_dir_2, &temp_sst_dir_3] (cql_test_env& e) {
         require_exist(temp_sst_dir_2, false);
         require_exist(temp_sst_dir_3, false);
 
-        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
-        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data), false);
+        require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
+        require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data), false);
     }, db_cfg_ptr).get();
 }
 
@@ -392,11 +392,11 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
     };
 
     auto component_basename = [&ks, &cf] (int64_t gen, component_type ctype) {
-        return sst::component_basename(ks, cf, sst::version_types::mc, generation_from_value(gen), sst::format_types::big, ctype);
+        return sst::component_basename(ks, cf, sstables::get_highest_sstable_version(), generation_from_value(gen), sst::format_types::big, ctype);
     };
 
     auto gen_filename = [&sst_dir, &ks, &cf] (int64_t gen, component_type ctype) {
-        return sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(gen), sst::format_types::big, ctype);
+        return sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(gen), sst::format_types::big, ctype);
     };
 
     touch_dir(pending_delete_dir);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -979,9 +979,8 @@ SEASTAR_TEST_CASE(reader_selector_fast_forwarding_test) {
 
 static
 sstables::shared_sstable create_sstable(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations) {
-    static int gen = 0;
     return make_sstable_containing([&] {
-        return env.make_sstable(s, gen++);
+        return env.make_sstable(s);
     }, mutations);
 }
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3883,8 +3883,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
         int64_t gen = 0;
         for (auto& mb: scenario.readers_data) {
             auto sst_factory = [table_schema, &env, &tmp, gen = ++gen] () {
-                return env.make_sstable(std::move(table_schema), tmp.path().string(), gen,
-                    sstables::sstable::version_types::md, sstables::sstable::format_types::big);
+                return env.make_sstable(std::move(table_schema), tmp.path().string(), gen);
             };
 
             if (mb.m) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3856,9 +3856,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
         time_series_sstable_set sst_set(table_schema);
         mutation merged(table_schema, g._pk);
         std::unordered_set<int64_t> included_gens;
-        auto sst_factory = [&env, table_schema] () {
-            return env.make_sstable(std::move(table_schema));
-        };
+        auto sst_factory = env.make_sst_factory(table_schema);
         for (auto& mb: scenario.readers_data) {
             sstables::shared_sstable sst;
             if (mb.m) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1368,7 +1368,7 @@ memory_limit_table create_memory_limit_table(cql_test_env& env, uint64_t target_
         return seastar::async([&] {
             while (num_sstables != target_num_sstables) {
                 ++num_sstables;
-                auto sst = sst_man.make_sstable(s, sstables_dir.path().string(), sstables::generation_type{num_sstables}, sst_man.get_highest_supported_format(), sstables::sstable_format_types::big);
+                auto sst = sst_man.make_sstable(s, sstables_dir.path().string(), sstables::generation_type{num_sstables});
                 auto writer_cfg = sst_man.configure_writer("test");
                 sst->write_components(
                     make_flat_mutation_reader_from_mutations_v2(s, semaphore.make_tracking_only_permit(s.get(), "test", db::no_timeout), mut, s->full_slice()),

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -41,7 +41,7 @@ SEASTAR_TEST_CASE(test_schema_changes) {
 
                 created_with_base_schema = make_sstable_easy(env, mt, env.manager().configure_writer(), gen, version, base_mutations.size());
 
-                created_with_changed_schema = env.make_sstable(changed, env.tempdir().path().string(), gen, version, sstables::sstable::format_types::big);
+                created_with_changed_schema = env.make_sstable(changed, gen, version);
                 created_with_changed_schema->load().get();
 
                 cache.emplace(std::tuple { version, base }, std::tuple { created_with_base_schema, gen });
@@ -49,7 +49,7 @@ SEASTAR_TEST_CASE(test_schema_changes) {
             } else {
                 created_with_base_schema = std::get<shared_sstable>(it->second);
 
-                created_with_changed_schema = env.make_sstable(changed, env.tempdir().path().string(), std::get<int>(it->second), version, sstables::sstable::format_types::big);
+                created_with_changed_schema = env.make_sstable(changed, std::get<int>(it->second), version);
                 created_with_changed_schema->load().get();
             }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3244,9 +3244,8 @@ static sstables::shared_sstable write_and_compare_sstables(test_env& env, schema
 }
 
 static sstables::shared_sstable write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<replica::memtable> mt, sstable_version_types version) {
-    auto sst = env.make_sstable(s, version);
+    auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
     BOOST_TEST_MESSAGE(format("write_sstable from memtable: {}", sst->get_filename()));
-    write_memtable_to_sstable_for_test(*mt, sst).get();
     return sst;
 }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3035,8 +3035,7 @@ static flat_mutation_reader_v2 compacted_sstable_reader(test_env& env, schema_pt
 
     auto desc = sstables::compaction_descriptor(std::move(sstables), default_priority_class());
     desc.creator = [&] (shard_id dummy) {
-        compacted_sst = env.make_sstable(s, tmp.path().string(), new_generation,
-                         sstables::sstable_version_types::mc, sstable::format_types::big, 4096);
+        compacted_sst = env.make_sstable(s, new_generation);
         return compacted_sst;
     };
     desc.replacer = replacer_fn_no_op();
@@ -4588,7 +4587,7 @@ static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader
 }
 
 shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name, int64_t gen = 1) {
-    return env.reusable_sst(schema, get_read_index_test_path(table_name), gen, sstable_version_types::mc).get0();
+    return env.reusable_sst(schema, get_read_index_test_path(table_name), gen).get0();
 }
 
 /*

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4312,7 +4312,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
 }
 
 SEASTAR_TEST_CASE(compound_sstable_set_incremental_selector_test) {
-    return test_env::do_with([] (test_env& env) {
+    return test_env::do_with_async([] (test_env& env) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
                                     {{"p1", utf8_type}}, {}, {}, {}, utf8_type);
         auto cs = sstables::make_compaction_strategy(sstables::compaction_strategy_type::leveled, s->compaction_strategy_options());
@@ -4403,8 +4403,6 @@ SEASTAR_TEST_CASE(compound_sstable_set_incremental_selector_test) {
             incremental_selection_test(strategy_param::ICS);
             incremental_selection_test(strategy_param::LCS);
         }
-
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -165,7 +165,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf), sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
 
         write_memtable_to_sstable_for_test(*mt, sst).get();
         sst->load().get();
@@ -332,7 +332,7 @@ static future<std::vector<unsigned long>> compact_sstables(test_env& env, std::v
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(min_sstable_size, 'a')));
                 mt->apply(std::move(m));
 
-                auto sst = env.make_sstable(s, generation, sstables::get_highest_sstable_version(), big);
+                auto sst = env.make_sstable(s, generation);
 
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst->load().get();
@@ -342,7 +342,7 @@ static future<std::vector<unsigned long>> compact_sstables(test_env& env, std::v
         auto new_sstable = [&] {
             auto gen = new_generation++;
             created.push_back(gen);
-            return env.make_sstable(s, gen, sstables::get_highest_sstable_version(), sstables::sstable::format_types::big);
+            return env.make_sstable(s, gen);
         };
         // We must have opened at least all original candidates.
         BOOST_REQUIRE(generations.size() == sstables.size());
@@ -462,7 +462,7 @@ SEASTAR_TEST_CASE(compact_02) {
 // NOTE: must run in a thread.
 static void add_sstable_for_leveled_test(test_env& env, lw_shared_ptr<replica::column_family> cf, int64_t gen, uint64_t fake_data_size,
                                          uint32_t sstable_level, const partition_key& first_key, const partition_key& last_key, int64_t max_timestamp = 0) {
-    auto sst = env.make_sstable(cf->schema(), "", gen, la, big);
+    auto sst = env.make_sstable(cf->schema(), "", gen);
     sstables::test(sst).set_values_for_leveled_strategy(fake_data_size, sstable_level, max_timestamp, first_key, last_key);
     assert(sst->data_size() == fake_data_size);
     assert(sst->get_sstable_level() == sstable_level);
@@ -474,14 +474,14 @@ static void add_sstable_for_leveled_test(test_env& env, lw_shared_ptr<replica::c
 // NOTE: must run in a thread.
 static shared_sstable add_sstable_for_overlapping_test(test_env& env, lw_shared_ptr<replica::column_family> cf, int64_t gen,
         const partition_key& first_key, const partition_key& last_key, stats_metadata stats = {}) {
-    auto sst = env.make_sstable(cf->schema(), "", gen, la, big);
+    auto sst = env.make_sstable(cf->schema(), "", gen);
     sstables::test(sst).set_values(std::move(first_key), std::move(last_key), std::move(stats));
     column_family_test(cf).add_sstable(sst).get();
     return sst;
 }
 static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_ptr& schema, int64_t gen,
         const partition_key& first_key, const partition_key& last_key, uint32_t level = 0) {
-    auto sst = env.make_sstable(schema, "", gen, la, big);
+    auto sst = env.make_sstable(schema, "", gen);
     sstables::test(sst).set_values_for_leveled_strategy(0, level, 0, first_key, last_key);
     return sst;
 }
@@ -949,7 +949,7 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto compact = [&, s] (std::vector<shared_sstable> all, std::vector<shared_sstable> to_compact) -> std::vector<shared_sstable> {
@@ -1154,13 +1154,13 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
         };
         apply_key(key_for_this_shard[0]);
 
-        auto sst = env.make_sstable(s, 51, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 51);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 51).get();
         auto key = key_for_this_shard[0];
         std::vector<sstables::shared_sstable> new_tables;
         auto creator = [&] {
-            auto sst = env.make_sstable(s, 52, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, 52);
             new_tables.emplace_back(sst);
             return sst;
         };
@@ -1302,7 +1302,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto c_key = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto mt = make_lw_shared<replica::memtable>(s);
@@ -1461,7 +1461,7 @@ SEASTAR_TEST_CASE(time_window_strategy_ts_resolution_check) {
         std::map<sstring, sstring> opts = { { time_window_compaction_strategy_options::TIMESTAMP_RESOLUTION_KEY, "MILLISECONDS" }, };
         time_window_compaction_strategy_options options(opts);
 
-        auto sst = env.make_sstable(s, "", 1, la, big);
+        auto sst = env.make_sstable(s, "", 1);
         sstables::test(sst).set_values(key.key(), key.key(), build_stats(ts_in_ms.count(), ts_in_ms.count(), std::numeric_limits<int32_t>::max()));
 
         auto ret = time_window_compaction_strategy::get_buckets({ sst }, options);
@@ -1474,7 +1474,7 @@ SEASTAR_TEST_CASE(time_window_strategy_ts_resolution_check) {
         std::map<sstring, sstring> opts = { { time_window_compaction_strategy_options::TIMESTAMP_RESOLUTION_KEY, "MICROSECONDS" }, };
         time_window_compaction_strategy_options options(opts);
 
-        auto sst = env.make_sstable(s, "", 1, la, big);
+        auto sst = env.make_sstable(s, "", 1);
         sstables::test(sst).set_values(key.key(), key.key(), build_stats(ts_in_us.count(), ts_in_us.count(), std::numeric_limits<int32_t>::max()));
 
         auto ret = time_window_compaction_strategy::get_buckets({ sst }, options);
@@ -1592,7 +1592,7 @@ SEASTAR_TEST_CASE(time_window_strategy_size_tiered_behavior_correctness) {
                 .with_column("value", int32_type).build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto make_insert = [&] (partition_key key, api::timestamp_type t) {
@@ -1736,7 +1736,7 @@ SEASTAR_TEST_CASE(size_tiered_beyond_max_threshold_test) {
     int max_threshold = cf->schema()->max_compaction_threshold();
     candidates.reserve(max_threshold+1);
     for (auto i = 0; i < (max_threshold+1); i++) { // (max_threshold+1) sstables of similar size
-        auto sst = env.make_sstable(cf.schema(), "", i, la, big);
+        auto sst = env.make_sstable(cf.schema(), "", i);
         sstables::test(sst).set_data_file_size(1);
         candidates.push_back(std::move(sst));
     }
@@ -1778,7 +1778,7 @@ SEASTAR_TEST_CASE(sstable_expired_data_ratio) {
         for (auto i = 0; i < remaining; i++) {
             insert_key(to_bytes("key" + to_sstring(i)), 3600, expiration_time);
         }
-        auto sst = env.make_sstable(s, 1, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 1);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         sst = env.reusable_sst(s, 1).get0();
         const auto& stats = sst->get_stats_metadata();
@@ -1794,7 +1794,7 @@ SEASTAR_TEST_CASE(sstable_expired_data_ratio) {
         table_for_tests cf(env.manager(), s);
         auto close_cf = deferred_stop(cf);
         auto creator = [&, gen = make_lw_shared<unsigned>(2)] {
-            auto sst = env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, (*gen)++);
             return sst;
         };
         auto info = compact_sstables(sstables::compaction_descriptor({ sst }, default_priority_class()), cf, creator).get0();
@@ -1860,7 +1860,7 @@ SEASTAR_TEST_CASE(compaction_correctness_with_partitioned_sstable_set) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            auto sst = env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, (*gen)++);
             return sst;
         };
 
@@ -1967,7 +1967,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
                     .with_column("value", int32_type).build();
 
             auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-                return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+                return env.make_sstable(s, (*gen)++);
             };
 
             auto make_insert = [&] (dht::decorated_key key) {
@@ -2845,7 +2845,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            auto sst = env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, (*gen)++);
             return sst;
         };
 
@@ -3015,7 +3015,7 @@ SEASTAR_TEST_CASE(backlog_tracker_correctness_after_changing_compaction_strategy
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            auto sst = env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, (*gen)++);
             return sst;
         };
 
@@ -3268,7 +3268,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto next_timestamp = [] {
@@ -3386,7 +3386,7 @@ SEASTAR_TEST_CASE(twcs_major_compaction_test) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto next_timestamp = [] (auto step) {
@@ -3507,7 +3507,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto next_timestamp = [] (auto step) {
@@ -3615,7 +3615,7 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
         const auto rows_per_partition = 200;
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto next_timestamp = [] (int sstable_idx, int ck_idx) {
@@ -3798,7 +3798,7 @@ SEASTAR_TEST_CASE(test_twcs_compaction_across_buckets) {
             return (gc_clock::now().time_since_epoch() - std::chrono::duration_cast<std::chrono::microseconds>(step)).count();
         };
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
         auto pkey = tests::generate_partition_key(s);
 
@@ -3927,7 +3927,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
         };
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)]() {
-            return env.make_sstable(s, (*gen)++, sstables::sstable::version_types::md, big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         {
@@ -4062,7 +4062,7 @@ SEASTAR_TEST_CASE(stcs_reshape_overlapping_test) {
         };
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)]() {
-            return env.make_sstable(s, (*gen)++, sstables::sstable::version_types::md, big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         {
@@ -4104,7 +4104,7 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         auto s = builder.build();
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)]() {
-            return env.make_sstable(s, (*gen)++, sstables::sstable::version_types::md, big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         auto make_row = [&] (int32_t pk, int32_t ck) {
@@ -4228,7 +4228,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
         auto sst_gen = [&, gen = make_lw_shared<unsigned>(1)] (size_t idx) mutable {
             auto s = schemas[idx];
             auto t = tables[idx];
-            return env.make_sstable(s, t->dir(), (*gen)++, sstables::sstable::version_types::md, big);
+            return env.make_sstable(s, t->dir(), (*gen)++);
         };
 
         auto add_single_fully_expired_sstable_to_table = [&] (auto idx) {
@@ -4433,7 +4433,7 @@ SEASTAR_TEST_CASE(twcs_single_key_reader_through_compound_set_test) {
         auto set2 = make_lw_shared<sstable_set>(cs.make_sstable_set(s));
 
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)]() {
-            return env.make_sstable(s, (*gen)++, sstables::sstable::version_types::md, big);
+            return env.make_sstable(s, (*gen)++);
         };
 
         // sstables with same key but belonging to different windows
@@ -4475,8 +4475,7 @@ SEASTAR_TEST_CASE(test_major_does_not_miss_data_in_memtable) {
         table_for_tests cf(env.manager(), s, env.tempdir().path().string());
         auto close_cf = deferred_stop(cf);
         auto sst_gen = [&env, &cf, s] () mutable {
-            return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf),
-                sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
         };
 
         auto row_mut = [&] () {
@@ -4532,7 +4531,7 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
         auto manager = compaction_manager(std::move(cfg), as, task_manager);
 
         auto add_sstable = [&env, gen = make_lw_shared<unsigned>(1)] (table_for_tests& t, uint64_t data_size, int level) {
-            auto sst = env.make_sstable(t.schema(), env.tempdir().path().native(), (*gen)++, la, big);
+            auto sst = env.make_sstable(t.schema(), env.tempdir().path().native(), (*gen)++);
             auto key = tests::generate_partition_key(t.schema()).key();
             sstables::test(sst).set_values_for_leveled_strategy(data_size, level, 0 /*max ts*/, key, key);
             assert(sst->data_size() == data_size);
@@ -4647,8 +4646,7 @@ SEASTAR_TEST_CASE(test_compaction_strategy_cleanup_method) {
             table_for_tests cf(env.manager(), s, env.tempdir().path().string());
             auto close_cf = deferred_stop(cf);
             auto sst_gen = [&env, &cf, s]() mutable {
-                return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf),
-                                        sstables::get_highest_sstable_version(), big);
+                return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
             };
 
             using namespace std::chrono;
@@ -4732,7 +4730,7 @@ SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
             return (gc_clock::now().time_since_epoch() + duration_cast<microseconds>(step)).count();
         };
         auto sst_gen = [&env, s, gen = make_lw_shared<unsigned>(1)] () mutable {
-            return env.make_sstable(s, (*gen)++, sstables::get_highest_sstable_version(), big);
+            return env.make_sstable(s, (*gen)++);
         };
         auto pkey = tests::generate_partition_key(s);
         table_for_tests cf(env.manager(), s);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1210,7 +1210,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time_2) {
                     mt->apply(std::move(m));
                 };
                 auto get_usable_sst = [&env, s, version](replica::memtable &mt, int64_t gen) -> future<sstable_ptr> {
-                    auto sst = env.make_sstable(s, gen, version, big);
+                    auto sst = env.make_sstable(s, gen, version);
                     return write_memtable_to_sstable_for_test(mt, sst).then([&env, sst, gen, s, version] {
                         return env.reusable_sst(s, gen, version);
                     });
@@ -1232,7 +1232,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time_2) {
                 auto sst2 = get_usable_sst(*mt, 55).get0();
                 BOOST_REQUIRE(now.time_since_epoch().count() == sst2->get_stats_metadata().max_local_deletion_time);
 
-                auto creator = [&env, s, version, gen = make_lw_shared<unsigned>(56)] { return env.make_sstable(s, (*gen)++, version, big); };
+                auto creator = [&env, s, version, gen = make_lw_shared<unsigned>(56)] { return env.make_sstable(s, (*gen)++, version); };
                 auto info = compact_sstables(sstables::compaction_descriptor({sst1, sst2}, default_priority_class()), cf, creator).get0();
                 BOOST_REQUIRE(info.new_sstables.size() == 1);
                 BOOST_REQUIRE(((now + gc_clock::duration(100)).time_since_epoch().count()) ==
@@ -1700,7 +1700,7 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test_2) {
                 }
                 mt->apply(std::move(m));
             }
-            auto sst = env.make_sstable(s, 1, version, big);
+            auto sst = env.make_sstable(s, 1, version);
             write_memtable_to_sstable_for_test(*mt, sst).get();
             sst = env.reusable_sst(s, 1, version).get0();
             check_min_max_column_names(sst, {"0ck100"}, {"7ck149"});
@@ -1713,12 +1713,12 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test_2) {
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
             }
             mt->apply(std::move(m));
-            auto sst2 = env.make_sstable(s, 2, version, big);
+            auto sst2 = env.make_sstable(s, 2, version);
             write_memtable_to_sstable_for_test(*mt, sst2).get();
             sst2 = env.reusable_sst(s, 2, version).get0();
             check_min_max_column_names(sst2, {"9ck101"}, {"9ck298"});
 
-            auto creator = [&env, s, version] { return env.make_sstable(s, 3, version, big); };
+            auto creator = [&env, s, version] { return env.make_sstable(s, 3, version); };
             auto info = compact_sstables(sstables::compaction_descriptor({sst, sst2}, default_priority_class()), cf, creator).get0();
             BOOST_REQUIRE(info.new_sstables.size() == 1);
             check_min_max_column_names(info.new_sstables.front(), {"0ck100"}, {"9ck298"});
@@ -3854,7 +3854,7 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
             table_for_tests cf(env.manager(), s, tmp.path().string());
             auto close_cf = deferred_stop(cf);
             auto sst_gen = [&env, s, cf, path = tmp.path().string(), version] () mutable {
-                return env.make_sstable(s, path, column_family_test::calculate_generation_for_new_table(*cf), version, big);
+                return env.make_sstable(s, path, column_family_test::calculate_generation_for_new_table(*cf), version);
             };
 
             cf->mark_ready_for_writes();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1191,29 +1191,29 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 51).get();
         auto key = key_for_this_shard[0];
-        auto new_tables = make_lw_shared<std::vector<sstables::shared_sstable>>();
-        auto creator = [&env, new_tables, s] {
+        std::vector<sstables::shared_sstable> new_tables;
+        auto creator = [&] {
             auto sst = env.make_sstable(s, 52, sstables::get_highest_sstable_version(), big);
-            new_tables->emplace_back(sst);
+            new_tables.emplace_back(sst);
             return sst;
         };
-        auto cf = make_lw_shared<table_for_tests>(env.manager(), s);
-        auto stop_cf = deferred_stop(*cf);
+        auto cf = table_for_tests(env.manager(), s);
+        auto stop_cf = deferred_stop(cf);
         std::vector<shared_sstable> sstables;
         sstables.push_back(std::move(sstp));
 
-        compact_sstables(sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, creator).get();
-        BOOST_REQUIRE(new_tables->size() == 1);
-        auto newsst = (*new_tables)[0];
+        compact_sstables(sstables::compaction_descriptor(std::move(sstables), default_priority_class()), cf, creator).get();
+        BOOST_REQUIRE(new_tables.size() == 1);
+        auto newsst = new_tables[0];
         BOOST_REQUIRE(generation_value(newsst->generation()) == 52);
-        auto reader = make_lw_shared<flat_mutation_reader_v2>(sstable_reader(newsst, s, env.make_reader_permit()));
-        auto close_reader = deferred_close(*reader);
-        auto m = (*reader)().get();
+        auto reader = sstable_reader(newsst, s, env.make_reader_permit());
+        auto close_reader = deferred_close(reader);
+        auto m = reader().get();
         BOOST_REQUIRE(m);
         BOOST_REQUIRE(m->is_partition_start());
         BOOST_REQUIRE(m->as_partition_start().key().equal(*s, key));
-        reader->next_partition().get();
-        m = (*reader)().get();
+        reader.next_partition().get();
+        m = reader().get();
         BOOST_REQUIRE(!m);
     });
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -165,7 +165,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
+        auto sst = cf.make_sstable();
 
         write_memtable_to_sstable_for_test(*mt, sst).get();
         sst->load().get();
@@ -3822,8 +3822,8 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
 
             auto cf = env.make_table_for_tests(s, tmp.path().string());
             auto close_cf = deferred_stop(cf);
-            auto sst_gen = [&env, s, cf, path = tmp.path().string(), version] () mutable {
-                return env.make_sstable(s, path, column_family_test::calculate_generation_for_new_table(*cf), version);
+            auto sst_gen = [&] () mutable {
+                return cf.make_sstable(version);
             };
 
             cf->mark_ready_for_writes();
@@ -4452,8 +4452,8 @@ SEASTAR_TEST_CASE(test_major_does_not_miss_data_in_memtable) {
 
         auto cf = env.make_table_for_tests(s);
         auto close_cf = deferred_stop(cf);
-        auto sst_gen = [&env, &cf, s] () mutable {
-            return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
+        auto sst_gen = [&] () mutable {
+            return cf.make_sstable();
         };
 
         auto row_mut = [&] () {
@@ -4623,8 +4623,8 @@ SEASTAR_TEST_CASE(test_compaction_strategy_cleanup_method) {
 
             auto cf = env.make_table_for_tests(s);
             auto close_cf = deferred_stop(cf);
-            auto sst_gen = [&env, &cf, s]() mutable {
-                return env.make_sstable(s, column_family_test::calculate_generation_for_new_table(*cf));
+            auto sst_gen = [&]() mutable {
+                return cf.make_sstable();
             };
 
             using namespace std::chrono;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -734,15 +734,14 @@ SEASTAR_TEST_CASE(leveled_05) {
     return test_env::do_with_async([] (test_env& env) {
         // Check compaction code with leveled strategy. In this test, two sstables of level 0 will be created.
         auto generations = compact_sstables(env, { 48, 49 }, 50, true, 1024*1024, compaction_strategy_type::leveled).get();
-            // FIXME: indentation
-            BOOST_REQUIRE(generations.size() == 2);
-            BOOST_REQUIRE(generations[0] == 50);
-            BOOST_REQUIRE(generations[1] == 51);
+        BOOST_REQUIRE(generations.size() == 2);
+        BOOST_REQUIRE(generations[0] == 50);
+        BOOST_REQUIRE(generations[1] == 51);
 
-                for (auto gen : generations) {
-                    auto fname = sstable::filename(env.tempdir().path().native(), "ks", "cf", sstables::get_highest_sstable_version(), generation_from_value(gen), big, component_type::Data);
-                    BOOST_REQUIRE(file_size(fname).get0() >= 1024*1024);
-                }
+        for (auto gen : generations) {
+            auto fname = sstable::filename(env.tempdir().path().native(), "ks", "cf", sstables::get_highest_sstable_version(), generation_from_value(gen), big, component_type::Data);
+            BOOST_REQUIRE(file_size(fname).get0() >= 1024*1024);
+        }
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3572,7 +3572,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
 }
 
 SEASTAR_TEST_CASE(sstable_needs_cleanup_test) {
-  return test_env::do_with([] (test_env& env) {
+  return test_env::do_with_async([] (test_env& env) {
     auto s = make_shared_schema({}, some_keyspace, some_column_family,
         {{"p1", utf8_type}}, {}, {}, {}, utf8_type);
 
@@ -3606,8 +3606,6 @@ SEASTAR_TEST_CASE(sstable_needs_cleanup_test) {
         auto sst5 = sst_gen(keys[7], keys[7]);
         BOOST_REQUIRE(needs_cleanup(sst5, local_ranges, s));
     }
-
-    return make_ready_future<>();
   });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -940,9 +940,7 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
         builder.set_gc_grace_seconds(0);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto compact = [&, s] (std::vector<shared_sstable> all, std::vector<shared_sstable> to_compact) -> std::vector<shared_sstable> {
             auto cf = env.make_table_for_tests(s);
@@ -1292,9 +1290,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
 
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto c_key = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto mt = make_lw_shared<replica::memtable>(s);
         mutation m(s, key);
@@ -1586,9 +1582,7 @@ SEASTAR_TEST_CASE(time_window_strategy_size_tiered_behavior_correctness) {
                 .with_column("id", utf8_type, column_kind::partition_key)
                 .with_column("value", int32_type).build();
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto make_insert = [&] (partition_key key, api::timestamp_type t) {
             mutation m(s, key);
@@ -1854,10 +1848,7 @@ SEASTAR_TEST_CASE(compaction_correctness_with_partitioned_sstable_set) {
         builder.set_compaction_strategy(sstables::compaction_strategy_type::leveled);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            auto sst = env.make_sstable(s);
-            return sst;
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto compact = [&, s] (std::vector<shared_sstable> all) -> std::vector<shared_sstable> {
             // NEEDED for partitioned_sstable_set to actually have an effect
@@ -1961,9 +1952,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
                     .with_column("id", utf8_type, column_kind::partition_key)
                     .with_column("value", int32_type).build();
 
-            auto sst_gen = [&env, s] () mutable {
-                return env.make_sstable(s);
-            };
+            auto sst_gen = env.make_sst_factory(s);
 
             auto make_insert = [&] (dht::decorated_key key) {
                 mutation m(s, std::move(key));
@@ -2839,10 +2828,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
                 .with_column("value", int32_type);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            auto sst = env.make_sstable(s);
-            return sst;
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto tracker = make_lw_shared<cache_tracker>();
         auto cf = env.make_table_for_tests(s);
@@ -3009,10 +2995,7 @@ SEASTAR_TEST_CASE(backlog_tracker_correctness_after_changing_compaction_strategy
                 .with_column("value", int32_type);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            auto sst = env.make_sstable(s);
-            return sst;
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto cf = env.make_table_for_tests(s);
         auto close_cf = deferred_stop(cf);
@@ -3262,9 +3245,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         builder.set_gc_grace_seconds(0);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto next_timestamp = [] {
             static thread_local api::timestamp_type next = 1;
@@ -3380,9 +3361,7 @@ SEASTAR_TEST_CASE(twcs_major_compaction_test) {
                 .with_column("value", int32_type);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto next_timestamp = [] (auto step) {
             using namespace std::chrono;
@@ -3501,9 +3480,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
         builder.set_gc_grace_seconds(0);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto next_timestamp = [] (auto step) {
             using namespace std::chrono;
@@ -3609,9 +3586,7 @@ SEASTAR_TEST_CASE(test_twcs_partition_estimate) {
 
         const auto rows_per_partition = 200;
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto next_timestamp = [] (int sstable_idx, int ck_idx) {
             using namespace std::chrono;
@@ -3793,9 +3768,7 @@ SEASTAR_TEST_CASE(test_twcs_compaction_across_buckets) {
             return (gc_clock::now().time_since_epoch() - std::chrono::duration_cast<std::chrono::microseconds>(step)).count();
         };
 
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
         auto pkey = tests::generate_partition_key(s);
 
         auto make_row = [&] (std::chrono::hours step) {
@@ -3922,9 +3895,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
             return m;
         };
 
-        auto sst_gen = [&env, s]() {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         {
             // create set of 256 disjoint ssts that belong to the same time window and expect that twcs reshape allows them all to be compacted at once
@@ -4057,9 +4028,7 @@ SEASTAR_TEST_CASE(stcs_reshape_overlapping_test) {
             return m;
         };
 
-        auto sst_gen = [&env, s]() {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         {
             // create set of 256 disjoint ssts and expect that stcs reshape allows them all to be compacted at once
@@ -4099,9 +4068,7 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         builder.set_compaction_strategy(sstables::compaction_strategy_type::time_window);
         auto s = builder.build();
 
-        auto sst_gen = [&env, s]() {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         auto make_row = [&] (int32_t pk, int32_t ck) {
             mutation m(s, partition_key::from_single_value(*s, int32_type->decompose(pk)));
@@ -4445,9 +4412,7 @@ SEASTAR_TEST_CASE(twcs_single_key_reader_through_compound_set_test) {
         auto set1 = make_lw_shared<sstable_set>(cs.make_sstable_set(s));
         auto set2 = make_lw_shared<sstable_set>(cs.make_sstable_set(s));
 
-        auto sst_gen = [&env, s]() {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
 
         // sstables with same key but belonging to different windows
         auto sst1 = make_sstable_containing(sst_gen, {make_row(std::chrono::hours(1))});
@@ -4742,9 +4707,7 @@ SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
         auto next_timestamp = [] (std::chrono::seconds step = 0s) {
             return (gc_clock::now().time_since_epoch() + duration_cast<microseconds>(step)).count();
         };
-        auto sst_gen = [&env, s] () mutable {
-            return env.make_sstable(s);
-        };
+        auto sst_gen = env.make_sst_factory(s);
         auto pkey = tests::generate_partition_key(s);
         auto cf = env.make_table_for_tests(s);
         auto close_cf = deferred_stop(cf);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -438,32 +438,22 @@ SEASTAR_TEST_CASE(compact_02) {
     // By the way, automatic compaction isn't tested here, instead the
     // strategy algorithm that selects candidates for compaction.
 
-    return test_env::do_with([] (test_env& env) {
+    return test_env::do_with_async([] (test_env& env) {
         // Compact 4 sstables into 1 using size-tiered strategy to select sstables.
         // E.g.: generations 18, 19, 20 and 21 will be compacted into generation 22.
-        return compact_sstables(env, { 18, 19, 20, 21 }, 22).then([&env] {
-            // Check that generation 22 contains all keys of generations 18, 19, 20 and 21.
-            return check_compacted_sstables(env, 22, { 18, 19, 20, 21 });
-        }).then([&env] {
-            return compact_sstables(env, { 23, 24, 25, 26 }, 27).then([&env] {
-                return check_compacted_sstables(env, 27, { 23, 24, 25, 26 });
-            });
-        }).then([&env] {
-            return compact_sstables(env, { 28, 29, 30, 31 }, 32).then([&env] {
-                return check_compacted_sstables(env, 32, { 28, 29, 30, 31 });
-            });
-        }).then([&env] {
-            return compact_sstables(env, { 33, 34, 35, 36 }, 37).then([&env] {
-                return check_compacted_sstables(env, 37, { 33, 34, 35, 36 });
-            });
-        }).then([&env] {
-            // In this step, we compact 4 compacted sstables.
-            return compact_sstables(env, { 22, 27, 32, 37 }, 38, false).then([&env] {
-                // Check that the compacted sstable contains all keys.
-                return check_compacted_sstables(env, 38,
-                    { 18, 19, 20, 21, 23, 24, 25, 26, 28, 29, 30, 31, 33, 34, 35, 36 });
-            });
-        });
+        compact_sstables(env, { 18, 19, 20, 21 }, 22).get();
+        // Check that generation 22 contains all keys of generations 18, 19, 20 and 21.
+        check_compacted_sstables(env, 22, { 18, 19, 20, 21 }).get();
+        compact_sstables(env, { 23, 24, 25, 26 }, 27).get();
+        check_compacted_sstables(env, 27, { 23, 24, 25, 26 }).get();
+        compact_sstables(env, { 28, 29, 30, 31 }, 32).get();
+        check_compacted_sstables(env, 32, { 28, 29, 30, 31 }).get();
+        compact_sstables(env, { 33, 34, 35, 36 }, 37).get();
+        check_compacted_sstables(env, 37, { 33, 34, 35, 36 }).get();
+        // In this step, we compact 4 compacted sstables.
+        compact_sstables(env, { 22, 27, 32, 37 }, 38, false).get();
+        // Check that the compacted sstable contains all keys.
+        check_compacted_sstables(env, 38, { 18, 19, 20, 21, 23, 24, 25, 26, 28, 29, 30, 31, 33, 34, 35, 36 }).get();
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1170,7 +1170,7 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
 
 SEASTAR_TEST_CASE(sstable_rewrite) {
     BOOST_REQUIRE(smp::count == 1);
-    return test_env::do_with([] (test_env& env) {
+    return test_env::do_with_async([] (test_env& env) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
 
@@ -1188,9 +1188,10 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
         apply_key(key_for_this_shard[0]);
 
         auto sst = env.make_sstable(s, 51, sstables::get_highest_sstable_version(), big);
-        return write_memtable_to_sstable_for_test(*mt, sst).then([&env, s, sst] {
-            return env.reusable_sst(s, 51);
-        }).then([&env, s, key = key_for_this_shard[0]] (auto sstp) mutable {
+        write_memtable_to_sstable_for_test(*mt, sst).get();
+        auto sstp = env.reusable_sst(s, 51).get();
+        auto key = key_for_this_shard[0];
+        // FIXME: indentation
             auto new_tables = make_lw_shared<std::vector<sstables::shared_sstable>>();
             auto creator = [&env, new_tables, s] {
                 auto sst = env.make_sstable(s, 52, sstables::get_highest_sstable_version(), big);
@@ -1198,28 +1199,23 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
                 return sst;
             };
             auto cf = make_lw_shared<table_for_tests>(env.manager(), s);
+            auto stop_cf = deferred_stop(*cf);
             std::vector<shared_sstable> sstables;
             sstables.push_back(std::move(sstp));
 
-            return compact_sstables(sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, creator).then([&env, s, key, new_tables] (auto) {
+            compact_sstables(sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, creator).get();
                 BOOST_REQUIRE(new_tables->size() == 1);
                 auto newsst = (*new_tables)[0];
                 BOOST_REQUIRE(generation_value(newsst->generation()) == 52);
                 auto reader = make_lw_shared<flat_mutation_reader_v2>(sstable_reader(newsst, s, env.make_reader_permit()));
-                return (*reader)().then([s, reader, key] (mutation_fragment_v2_opt m) {
+                auto close_reader = deferred_close(*reader);
+                auto m = (*reader)().get();
                     BOOST_REQUIRE(m);
                     BOOST_REQUIRE(m->is_partition_start());
                     BOOST_REQUIRE(m->as_partition_start().key().equal(*s, key));
-                    return reader->next_partition();
-                }).then([reader] {
-                    return (*reader)();
-                }).then([reader] (mutation_fragment_v2_opt m) {
+                    reader->next_partition().get();
+                m = (*reader)().get();
                     BOOST_REQUIRE(!m);
-                }).finally([reader] {
-                    return reader->close();
-                });
-            }).finally([cf] () mutable { return cf->stop_and_keep_alive(); });
-        }).then([sst, mt, s] {});
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -149,15 +149,15 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
     auto close_cf = deferred_stop(cf);
     cf->set_compaction_strategy(sstables::compaction_strategy_type::size_tiered);
 
-    auto generations = std::vector<unsigned long>({1, 2, 3, 4});
-    for (auto generation : generations) {
+    auto idx = std::vector<unsigned long>({1, 2, 3, 4});
+    for (auto i : idx) {
         // create 4 sstables of similar size to be compacted later on.
 
         auto mt = make_lw_shared<replica::memtable>(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
 
-        sstring k = "key" + to_sstring(generation);
+        sstring k = "key" + to_sstring(i);
         auto key = partition_key::from_exploded(*s, {to_bytes(k)});
         auto c_key = clustering_key::from_exploded(*s, {to_bytes("abc")});
 
@@ -172,7 +172,7 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
         column_family_test(cf).add_sstable(sst).get();
     }
 
-    BOOST_REQUIRE(cf->sstables_count() == generations.size());
+    BOOST_REQUIRE(cf->sstables_count() == idx.size());
     cf->trigger_compaction();
     BOOST_REQUIRE(cm.get_stats().pending_tasks == 1 || cm.get_stats().active_tasks == 1);
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -915,7 +915,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time) {
                                          make_atomic_cell(utf8_type, bytes("a"), 3600 + i, last_expiry));
                     mt->apply(std::move(m));
                 }
-                auto sst = env.make_sstable(s, 53, version, big);
+                auto sst = env.make_sstable(s, 53, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 auto sstp = env.reusable_sst(s, 53, version).get0();
                 BOOST_REQUIRE(last_expiry == sstp->get_stats_metadata().max_local_deletion_time);
@@ -1030,7 +1030,7 @@ static void test_min_max_clustering_key(test_env& env, schema_ptr s, std::vector
         }
     }
     auto tmp = env.tempdir().make_sweeper();
-    auto sst = env.make_sstable(s, 1, version, big);
+    auto sst = env.make_sstable(s, 1, version);
     write_memtable_to_sstable_for_test(*mt, sst).get();
     sst = env.reusable_sst(s, 1, version).get0();
     check_min_max_column_names(sst, std::move(min_components), std::move(max_components));
@@ -1164,7 +1164,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 1, version, big);
+                auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 1, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1176,7 +1176,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 2, version, big);
+                auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 2, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1188,7 +1188,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 3, version, big);
+                auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 3, version).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1208,7 +1208,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m2));
 
-                auto sst = env.make_sstable(s, 4, version, big);
+                auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 4, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1221,7 +1221,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 5, version, big);
+                auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 5, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1236,7 +1236,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 "a")), clustering_key_prefix::from_single_value(*s, bytes("a")), tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 6, version, big);
+                auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 6, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1256,7 +1256,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 7, version, big);
+                auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 7, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1276,7 +1276,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 8, version, big);
+                auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 8, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1296,7 +1296,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 9, version, big);
+                auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 9, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1317,7 +1317,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 10, version, big);
+                    auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 10, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1335,7 +1335,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 11, version, big);
+                    auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 11, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1349,7 +1349,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
                     m.partition().apply_delete(*s, clustering_key_prefix::make_empty(), tomb);
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 12, version, big);
+                    auto sst = env.make_sstable(s, 12, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 12, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1382,7 +1382,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 1, version, big);
+                auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 1, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1394,7 +1394,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 2, version, big);
+                auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 2, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1406,7 +1406,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 3, version, big);
+                auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 3, version).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1426,7 +1426,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m2));
 
-                auto sst = env.make_sstable(s, 4, version, big);
+                auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 4, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1439,7 +1439,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 5, version, big);
+                auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 5, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1456,7 +1456,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 6, version, big);
+                auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 6, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1476,7 +1476,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 7, version, big);
+                auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 7, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1496,7 +1496,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 8, version, big);
+                auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 8, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1516,7 +1516,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 9, version, big);
+                auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 9, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1537,7 +1537,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 10, version, big);
+                    auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 10, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1555,7 +1555,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 11, version, big);
+                    auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 11, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1588,7 +1588,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 1, version, big);
+                auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 1, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1600,7 +1600,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 2, version, big);
+                auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 2, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1612,7 +1612,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 3, version, big);
+                auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 3, version).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1632,7 +1632,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                 mt->apply(std::move(m2));
 
-                auto sst = env.make_sstable(s, 4, version, big);
+                auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 4, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1645,7 +1645,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 5, version, big);
+                auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 5, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1662,7 +1662,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 6, version, big);
+                auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 6, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1682,7 +1682,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 7, version, big);
+                auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 7, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1702,7 +1702,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 8, version, big);
+                auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 8, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1722,7 +1722,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
                 mt->apply(std::move(m));
-                auto sst = env.make_sstable(s, 9, version, big);
+                auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
                 sst = env.reusable_sst(s, 9, version).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1743,7 +1743,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 10, version, big);
+                    auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 10, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -1761,7 +1761,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
                     mt->apply(std::move(m));
-                    auto sst = env.make_sstable(s, 11, version, big);
+                    auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
                     sst = env.reusable_sst(s, 11, version).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
@@ -2416,7 +2416,7 @@ SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {
                 .with_column("v", int32_type)
                 .build(schema_builder::compact_storage::yes);
 
-        auto sst = env.make_sstable(s, get_test_dir("broken_non_compound_pi_and_range_tombstone", s), 1, version, big);
+        auto sst = env.make_sstable(s, get_test_dir("broken_non_compound_pi_and_range_tombstone", s), 1, version);
         try {
             sst->load().get();
         } catch (...) {
@@ -2850,7 +2850,7 @@ SEASTAR_TEST_CASE(test_missing_partition_end_fragment) {
             auto mr = make_flat_mutation_reader_from_fragments(s, env.make_reader_permit(), std::move(frags));
             auto close_mr = deferred_close(mr);
 
-            auto sst = env.make_sstable(s, 0, version, big);
+            auto sst = env.make_sstable(s, 0, version);
             sstable_writer_config cfg = env.manager().configure_writer();
 
             try {
@@ -3000,7 +3000,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 auto mr = make_flat_mutation_reader_from_mutations_v2(schema, permit, muts);
                 auto close_mr = deferred_close(mr);
 
-                auto sst = env.make_sstable(sst_schema, gen++, version, big);
+                auto sst = env.make_sstable(sst_schema, gen++, version);
                 sstable_writer_config cfg = env.manager().configure_writer();
 
                 auto wr = sst->get_writer(*sst_schema, 1, cfg, encoding_stats{}, default_priority_class());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -179,7 +179,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
 
         auto sst = env.make_sstable(s, 11);
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sstp = env.reusable_sst(s, 11).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         std::invoke([&] {
             auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
             auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
@@ -240,7 +240,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
 
         auto sst = env.make_sstable(s, 12);
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sstp = env.reusable_sst(s, 12).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -273,7 +273,7 @@ static future<> sstable_compression_test(compressor_ptr c, unsigned generation) 
 
         auto sst = env.make_sstable(s, generation);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
-        auto sstp = env.reusable_sst(s, generation).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -316,7 +316,7 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
 
         auto sst = env.make_sstable(s, 16);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
-        env.reusable_sst(s, 16).get();
+        env.reusable_sst(s, sst).get();
         // Not crashing is enough
     });
 }
@@ -348,7 +348,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
 
         auto sst = env.make_sstable(s, 37);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
-        auto sstp = env.reusable_sst(s, 37).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -379,7 +379,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
 
         auto sst = env.make_sstable(s, 38);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
-        auto sstp = env.reusable_sst(s, 38).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -411,7 +411,7 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
 
         auto sst = env.make_sstable(s, 39);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
-        auto sstp = env.reusable_sst(s, 39).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -440,7 +440,7 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
 
         auto sst = env.make_sstable(s, 41);
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sstp = env.reusable_sst(s, 41).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
         auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
         auto close_rd = deferred_close(rd);
@@ -470,7 +470,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
 
         auto sst = env.make_sstable(s, 47);
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sstp = env.reusable_sst(s, 47).get();
+        auto sstp = env.reusable_sst(s, sst).get();
         auto reader = sstable_reader_v2(sstp, s, env.make_reader_permit());
         auto close_reader = deferred_close(reader);
         while (reader().get()) {
@@ -520,7 +520,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
         auto sst = env.make_sstable(s, 900);
         write_memtable_to_sstable_for_test(*mt, sst).get();
 
-        auto sstp = env.reusable_sst(s, 900).get0();
+        auto sstp = env.reusable_sst(s, sst).get0();
         assert_that(sstable_reader_v2(sstp, s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
@@ -917,7 +917,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time) {
                 }
                 auto sst = env.make_sstable(s, 53, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                auto sstp = env.reusable_sst(s, 53, version).get0();
+                auto sstp = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(last_expiry == sstp->get_stats_metadata().max_local_deletion_time);
             }
     });
@@ -1032,7 +1032,7 @@ static void test_min_max_clustering_key(test_env& env, schema_ptr s, std::vector
     auto tmp = env.tempdir().make_sweeper();
     auto sst = env.make_sstable(s, 1, version);
     write_memtable_to_sstable_for_test(*mt, sst).get();
-    sst = env.reusable_sst(s, 1, version).get0();
+    sst = env.reusable_sst(sst).get0();
     check_min_max_column_names(sst, std::move(min_components), std::move(max_components));
 }
 
@@ -1166,7 +1166,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 1, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1178,7 +1178,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 2, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1190,7 +1190,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 3, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1210,7 +1210,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
 
                 auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 4, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1223,7 +1223,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 5, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1238,7 +1238,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 6, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"a"});
@@ -1258,7 +1258,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 7, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"c1"});
@@ -1278,7 +1278,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 8, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c"}, {"d"});
@@ -1298,7 +1298,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 9, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1"}, {"z"});
@@ -1319,7 +1319,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 10, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1337,7 +1337,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 11, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -1351,7 +1351,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 12, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 12, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {});
                 }
@@ -1384,7 +1384,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 1, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1396,7 +1396,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 2, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1408,7 +1408,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 3, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1428,7 +1428,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
 
                 auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 4, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1441,7 +1441,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 5, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1458,7 +1458,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 6, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "aa"}, {"z", "zz"});
@@ -1478,7 +1478,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 7, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"c1", "c2"});
@@ -1498,7 +1498,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 8, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "aa"}, {"c1", "zz"});
@@ -1518,7 +1518,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 9, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "c2"}, {"z", "zz"});
@@ -1539,7 +1539,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 10, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1557,7 +1557,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 11, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -1590,7 +1590,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 1, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 1, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1602,7 +1602,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 2, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 2, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1614,7 +1614,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 3, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 3, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1634,7 +1634,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
 
                 auto sst = env.make_sstable(s, 4, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 4, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1647,7 +1647,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 5, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 5, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1664,7 +1664,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 6, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 6, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "zz"}, {"a", "aa"});
@@ -1684,7 +1684,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 7, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 7, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "zz"}, {"c1", "c2"});
@@ -1704,7 +1704,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 8, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 8, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "zz"}, {"c1"});
@@ -1724,7 +1724,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mt->apply(std::move(m));
                 auto sst = env.make_sstable(s, 9, version);
                 write_memtable_to_sstable_for_test(*mt, sst).get();
-                sst = env.reusable_sst(s, 9, version).get0();
+                sst = env.reusable_sst(sst).get0();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "zz"}, {"c1", "c2"});
@@ -1745,7 +1745,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 10, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 10, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1763,7 +1763,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                     mt->apply(std::move(m));
                     auto sst = env.make_sstable(s, 11, version);
                     write_memtable_to_sstable_for_test(*mt, sst).get();
-                    sst = env.reusable_sst(s, 11, version).get0();
+                    sst = env.reusable_sst(sst).get0();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -2186,7 +2186,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_histogram_test) {
             }
             auto sst = make_sstable_containing(env.make_sstable(s, version), mutations);
             auto histogram = sst->get_stats_metadata().estimated_tombstone_drop_time;
-            sst = env.reusable_sst(s, generation_value(sst->generation()), version).get0();
+            sst = env.reusable_sst(sst).get0();
             auto histogram2 = sst->get_stats_metadata().estimated_tombstone_drop_time;
 
             // check that histogram respected limit
@@ -2238,7 +2238,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
             };
             auto sst = make_sstable_containing(sst_gen, std::move(muts));
             auto schema = schema_builder(s).with_sharder(smp_count, ignore_msb).build();
-            sst = env.reusable_sst(std::move(schema), generation_value(sst->generation())).get0();
+            sst = env.reusable_sst(std::move(schema), sst).get0();
             return sst;
         };
 
@@ -2291,7 +2291,6 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
         }
 
         auto sst = make_sstable_containing(env.make_sstable(s), mutations);
-        sst = env.reusable_sst(s, generation_value(sst->generation())).get0();
 
         summary& sum = sstables::test(sst).get_summary();
         BOOST_REQUIRE(sum.entries.size() == 1);
@@ -2496,7 +2495,7 @@ SEASTAR_TEST_CASE(summary_rebuild_sanity) {
         BOOST_REQUIRE(s1.entries.size() > 1);
 
         sstables::test(sst).remove_component(component_type::Summary).get();
-        sst = env.reusable_sst(s, 1).get0();
+        sst = env.reusable_sst(sst).get0();
         summary& s2 = sstables::test(sst).get_summary();
 
         BOOST_REQUIRE(::memcmp(&s1.header, &s2.header, sizeof(summary::header)) == 0);
@@ -2959,7 +2958,7 @@ SEASTAR_TEST_CASE(sstable_reader_with_timeout) {
 
             auto sst = env.make_sstable(s, 12);
             write_memtable_to_sstable_for_test(*mt, sst).get();
-            auto sstp = env.reusable_sst(s, 12).get0();
+            auto sstp = env.reusable_sst(sst).get0();
             auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
             auto timeout = db::timeout_clock::now();
             auto rd = sstp->make_reader(s, env.make_reader_permit(timeout), pr, s->full_slice());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -106,10 +106,10 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 9, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 9);
 
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sst2 = env.make_sstable(s, 9, sstables::get_highest_sstable_version(), big);
+        auto sst2 = env.make_sstable(s, 9);
 
         sstables::test(sst2).read_summary().get();
         summary& sst1_s = sstables::test(sst).get_summary();
@@ -177,7 +177,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
             });
         };
 
-        auto sst = env.make_sstable(s, 11, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 11);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 11).get();
         std::invoke([&] {
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
         m.partition().apply_delete(*s, cp, tomb);
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 12, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 12);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 12).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -271,7 +271,7 @@ static future<> sstable_compression_test(compressor_ptr c, unsigned generation) 
         m.partition().apply_delete(*s, cp, tomb);
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, generation, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, generation);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, generation).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -314,7 +314,7 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
             mtp->apply(std::move(m));
         }
 
-        auto sst = env.make_sstable(s, 16, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 16);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         env.reusable_sst(s, 16).get();
         // Not crashing is enough
@@ -346,7 +346,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 37, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 37);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, 37).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -377,7 +377,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
         m.set_clustered_cell(c_key, cl3, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl3")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 38, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 38);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, 38).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -409,7 +409,7 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 39, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 39);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, 39).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -438,7 +438,7 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
         m.partition().apply_delete(*s, std::move(c_key), tomb);
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 41, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 41);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 41).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -468,7 +468,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(512*1024, 'a')));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 47, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 47);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, 47).get();
         auto reader = sstable_reader_v2(sstp, s, env.make_reader_permit());
@@ -517,7 +517,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
 
         mt->apply(m);
 
-        auto sst = env.make_sstable(s, 900, sstables::get_highest_sstable_version(), big);
+        auto sst = env.make_sstable(s, 900);
         write_memtable_to_sstable_for_test(*mt, sst).get();
 
         auto sstp = env.reusable_sst(s, 900).get0();
@@ -529,7 +529,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
 
 static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_ptr& schema, int64_t gen,
         const partition_key& first_key, const partition_key& last_key, uint32_t level = 0) {
-    auto sst = env.make_sstable(schema, "", gen, la, big);
+    auto sst = env.make_sstable(schema, "", gen);
     sstables::test(sst).set_values_for_leveled_strategy(0, level, 0, first_key, last_key);
     return sst;
 }
@@ -2233,7 +2233,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
                 | boost::adaptors::transformed([&] (auto shard) { return mut(shard); }));
             auto sst_gen = [&env, s, gen, ignore_msb] () mutable {
                 auto schema = schema_builder(s).with_sharder(1, ignore_msb).build();
-                auto sst = env.make_sstable(std::move(schema), (*gen)++, sstables::get_highest_sstable_version(), big);
+                auto sst = env.make_sstable(std::move(schema), (*gen)++);
                 return sst;
             };
             auto sst = make_sstable_containing(sst_gen, std::move(muts));
@@ -2957,7 +2957,7 @@ SEASTAR_TEST_CASE(sstable_reader_with_timeout) {
             m.partition().apply_delete(*s, cp, tomb);
             mt->apply(std::move(m));
 
-            auto sst = env.make_sstable(s, 12, sstables::get_highest_sstable_version(), big);
+            auto sst = env.make_sstable(s, 12);
             write_memtable_to_sstable_for_test(*mt, sst).get();
             auto sstp = env.reusable_sst(s, 12).get0();
             auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -106,10 +106,10 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 9);
+        auto sst = env.make_sstable(s);
 
         write_memtable_to_sstable_for_test(*mt, sst).get();
-        auto sst2 = env.make_sstable(s, 9);
+        auto sst2 = env.make_sstable(s, sst->generation().value());
 
         sstables::test(sst2).read_summary().get();
         summary& sst1_s = sstables::test(sst).get_summary();
@@ -177,7 +177,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
             });
         };
 
-        auto sst = env.make_sstable(s, 11);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         std::invoke([&] {
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
         m.partition().apply_delete(*s, cp, tomb);
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 12);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -314,7 +314,7 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
             mtp->apply(std::move(m));
         }
 
-        auto sst = env.make_sstable(s, 16);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         env.reusable_sst(s, sst).get();
         // Not crashing is enough
@@ -346,7 +346,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 37);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -377,7 +377,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
         m.set_clustered_cell(c_key, cl3, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl3")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 38);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -409,7 +409,7 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
         mtp->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 39);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mtp, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -438,7 +438,7 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
         m.partition().apply_delete(*s, std::move(c_key), tomb);
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 41);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
@@ -468,7 +468,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(512*1024, 'a')));
         mt->apply(std::move(m));
 
-        auto sst = env.make_sstable(s, 47);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mt, sst).get();
         auto sstp = env.reusable_sst(s, sst).get();
         auto reader = sstable_reader_v2(sstp, s, env.make_reader_permit());
@@ -517,7 +517,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
 
         mt->apply(m);
 
-        auto sst = env.make_sstable(s, 900);
+        auto sst = env.make_sstable(s);
         write_memtable_to_sstable_for_test(*mt, sst).get();
 
         auto sstp = env.reusable_sst(s, sst).get0();

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -97,7 +97,7 @@ make_sstable_for_all_shards(replica::database& db, replica::table& table, fs::pa
 
 sstables::shared_sstable new_sstable(sstables::test_env& env, fs::path dir, int64_t gen) {
     return env.manager().make_sstable(test_table_schema(), dir.native(), generation_from_value(gen),
-                sstables::sstable_version_types::mc, sstables::sstable_format_types::big,
+                sstables::get_highest_sstable_version(), sstables::sstable_format_types::big,
                 gc_clock::now(), default_io_error_handler_gen(), default_sstable_buffer_size);
 }
 

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1459,11 +1459,11 @@ SEASTAR_TEST_CASE(test_reading_serialization_header) {
         // SSTable class has way too many responsibilities. In particular, it mixes the reading and
         // writting parts. Let's use a separate objects for writing and reading to ensure that nothing
         // carries over that wouldn't normally be read from disk.
-        auto sst = env.make_sstable(s, 1, sstable::version_types::mc, sstables::sstable::format_types::big);
+        auto sst = env.make_sstable(s, 1);
         sst->write_components(mt->make_flat_reader(s, env.make_reader_permit()), 2, s, env.manager().configure_writer(), mt->get_encoding_stats()).get();
     }
 
-    auto sst = env.make_sstable(s, 1, sstable::version_types::mc, sstables::sstable::format_types::big);
+    auto sst = env.make_sstable(s, 1);
     sst->load().get();
 
     auto hdr = sst->get_serialization_header();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -407,6 +407,7 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = make_shared_schema({}, "ks", "cf",
             {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
+        auto sst_gen = env.make_sst_factory(s);
 
         auto key = tests::generate_partition_key(s);
         auto c_key_start = clustering_key::from_exploded(*s, {int32_type->decompose(1)});
@@ -419,20 +420,19 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
         auto mt = make_lw_shared<replica::memtable>(s);
         mt->apply(std::move(m));
 
-        auto sst = make_sstable_containing(env.make_sstable(s), mt);
-        auto mut = with_closeable(sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice()), [] (auto& mr) {
-            return read_mutation_from_flat_mutation_reader(mr);
-        }).get0();
-        BOOST_REQUIRE(bool(mut));
-        auto rts = mut->partition().row_tombstones();
-        BOOST_REQUIRE(rts.size() == 1);
-        auto it = rts.begin();
-        BOOST_REQUIRE(it->tombstone().equal(*s, range_tombstone(
-                        c_key_start,
-                        bound_kind::excl_start,
-                        c_key_end,
-                        bound_kind::excl_end,
-                        tombstone(9, ttl))));
+        verify_mutation(env, env.make_sstable(s), mt, query::full_partition_range, [&] (mutation_opt& mut) {
+            BOOST_REQUIRE(bool(mut));
+            auto rts = mut->partition().row_tombstones();
+            BOOST_REQUIRE(rts.size() == 1);
+            auto it = rts.begin();
+            BOOST_REQUIRE(it->tombstone().equal(*s, range_tombstone(
+                          c_key_start,
+                          bound_kind::excl_start,
+                          c_key_end,
+                          bound_kind::excl_end,
+                          tombstone(9, ttl))));
+            return stop_iteration::yes;
+        }).get();
     });
 }
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -75,9 +75,7 @@ void run_sstable_resharding_test() {
                 mt->apply(std::move(m));
             }
         }
-        auto sst = cf.make_sstable(version);
-        write_memtable_to_sstable_for_test(*mt, sst).get();
-        return env.reusable_sst(s, sst->generation().value(), version).get();
+        return make_sstable_containing(cf.make_sstable(version), mt);
     });
 
     // FIXME: sstable write has a limitation in which it will generate sharding metadata only

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -52,7 +52,7 @@ void run_sstable_resharding_test() {
   for (const auto version : writable_sstable_versions) {
     auto tmp = tmpdir();
     auto s = get_schema();
-    table_for_tests cf(env.manager(), s);
+    auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -155,7 +155,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
         {
             auto s = get_schema();
             auto sst_gen = [&env, s, &tmp, gen, version]() mutable {
-                return env.make_sstable(s, tmp.path().string(), (*gen)++, version, big);
+                return env.make_sstable(s, tmp.path().string(), (*gen)++, version);
             };
 
             const auto keys = tests::generate_partition_keys(smp::count * 10, s);
@@ -175,7 +175,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
             auto key_s = get_schema();
             auto single_sharded_s = get_schema(1, cfg->murmur3_partitioner_ignore_msb_bits());
             auto sst_gen = [&env, single_sharded_s, &tmp, gen, version]() mutable {
-                return env.make_sstable(single_sharded_s, tmp.path().string(), (*gen)++, version, big);
+                return env.make_sstable(single_sharded_s, tmp.path().string(), (*gen)++, version);
             };
 
             std::vector<mutation> muts;

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -53,6 +53,7 @@ void run_sstable_resharding_test() {
     auto s = get_schema();
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
+    auto sst_gen = cf.make_sst_factory(version);
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -148,9 +148,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
         // created sstable owned only by this shard
         {
             auto s = get_schema();
-            auto sst_gen = [&env, s, version]() mutable {
-                return env.make_sstable(s, version);
-            };
+            auto sst_gen = env.make_sst_factory(s, version);
 
             const auto keys = tests::generate_partition_keys(smp::count * 10, s);
             std::vector<mutation> muts;
@@ -168,9 +166,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
         {
             auto key_s = get_schema();
             auto single_sharded_s = get_schema(1, cfg->murmur3_partitioner_ignore_msb_bits());
-            auto sst_gen = [&env, single_sharded_s, version]() mutable {
-                return env.make_sstable(single_sharded_s, version);
-            };
+            auto sst_gen = env.make_sst_factory(single_sharded_s, version);
 
             std::vector<mutation> muts;
             for (shard_id shard : boost::irange(0u, smp::count)) {

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -445,3 +445,16 @@ inline dht::decorated_key make_dkey(schema_ptr s, bytes b)
     auto sst_key = sstables::key::from_bytes(b);
     return dht::decorate_key(*s, sst_key.to_partition_key(*s));
 }
+
+// Must be called from a seastar thread.
+shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify);
+inline shared_sstable verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
+    return verify_mutation(env, sst_gen(), std::move(mt), std::move(key), std::move(verify));
+}
+shared_sstable verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify);
+
+shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);
+inline shared_sstable verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
+    return verify_mutation(env, sst_gen(), std::move(mt), std::move(pr), std::move(verify));
+}
+shared_sstable verify_mutation(test_env& env, shared_sstable sstp, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -216,8 +216,12 @@ public:
         });
     }
 
-    table_for_tests make_table_for_tests(schema_ptr s = nullptr, std::optional<sstring> dir = std::nullopt) {
-        return table_for_tests(manager(), s, dir.value_or(tempdir().path().native()));
+    table_for_tests make_table_for_tests(schema_ptr s, sstring dir) {
+        return table_for_tests(manager(), s, std::move(dir));
+    }
+
+    table_for_tests make_table_for_tests(schema_ptr s = nullptr) {
+        return table_for_tests(manager(), s, tempdir().path().native());
     }
 };
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -185,6 +185,10 @@ public:
             return func(env);
         });
     }
+
+    table_for_tests make_table_for_tests(schema_ptr s = nullptr, std::optional<sstring> dir = std::nullopt) {
+        return table_for_tests(manager(), s, dir.value_or(tempdir().path().native()));
+    }
 };
 
 }   // namespace sstables

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -72,10 +72,16 @@ public:
         });
     }
 
-    shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,
+    shared_sstable make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
-        return _impl->mgr.make_sstable(std::move(schema), dir, generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
+        return _impl->mgr.make_sstable(std::move(schema), dir, generation, v, f, now, default_io_error_handler_gen(), buffer_size);
+    }
+
+    shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long gen_value,
+            sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
+            size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
+        return make_sstable(std::move(schema), std::move(dir), generation_from_value(gen_value), v, f, buffer_size, now);
     }
 
     shared_sstable make_sstable(schema_ptr schema, unsigned long generation,

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -84,6 +84,10 @@ public:
         return make_sstable(std::move(schema), std::move(dir), generation_from_value(gen_value), v, f, buffer_size, now);
     }
 
+    shared_sstable make_sstable(schema_ptr schema, sstring dir, sstable::version_types v = sstables::get_highest_sstable_version()) {
+        return make_sstable(std::move(schema), std::move(dir), _impl->generation++, std::move(v));
+    }
+
     shared_sstable make_sstable(schema_ptr schema, unsigned long generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -127,6 +127,14 @@ public:
         return reusable_sst(std::move(schema), _impl->dir.path().native(), generation);
     }
 
+    future<shared_sstable> reusable_sst(schema_ptr schema, shared_sstable sst) {
+        return reusable_sst(std::move(schema), sst->get_storage().prefix(), sst->generation().value(), sst->get_version());
+    }
+
+    future<shared_sstable> reusable_sst(shared_sstable sst) {
+        return reusable_sst(sst->get_schema(), std::move(sst));
+    }
+
     test_env_sstables_manager& manager() { return _impl->mgr; }
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
     db::config& db_config() { return *_impl->db_config; }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -94,6 +94,11 @@ public:
         return make_sstable(std::move(schema), _impl->generation++, std::move(v));
     }
 
+    shared_sstable make_sstable(schema_ptr schema, unsigned long gen_value, sstable::version_types v, size_t buffer_size,
+            gc_clock::time_point now = gc_clock::now()) {
+        return make_sstable(std::move(schema), gen_value, v, sstable::format_types::big, buffer_size, now);
+    }
+
     struct sst_not_found : public std::runtime_error {
         sst_not_found(const sstring& dir, unsigned long generation)
             : std::runtime_error(format("no versions of sstable generation {} found in {}", generation, dir))

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -35,6 +35,11 @@ inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstabl
 shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now());
 
+inline shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
+        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
+    return make_sstable(env, std::move(s), env.tempdir().path().native(), std::move(mutations), std::move(cfg), version, query_time);
+}
+
 namespace sstables {
 
 using sstable_ptr = shared_sstable;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "sstables/sstables.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/index_reader.hh"

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -25,6 +25,9 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
+// Must be called in a seastar thread.
+sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt);
+sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt);
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts);
 sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts);
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -116,7 +116,7 @@ public:
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)
     : _data(make_lw_shared<data>())
 {
-    _data->s = s;
+    _data->s = s ? s : make_default_schema();
     _data->cfg = replica::table::config{.compaction_concurrency_semaphore = &_data->semaphore};
     _data->cfg.enable_disk_writes = bool(datadir);
     _data->cfg.datadir = datadir.value_or(sstring());

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -144,6 +144,7 @@ namespace sstables {
 std::unique_ptr<db::config> make_db_config(sstring temp_dir) {
     auto cfg = std::make_unique<db::config>();
     cfg->data_file_directories.set({ temp_dir });
+    cfg->host_id = locator::host_id::create_random_id();
     return cfg;
 }
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -72,4 +72,16 @@ struct table_for_tests {
     compaction::table_state& as_table_state() noexcept;
 
     future<> stop();
+
+    sstables::shared_sstable make_sstable() {
+        auto& table = *_data->cf;
+        auto& sstables_manager = table.get_sstables_manager();
+        return sstables_manager.make_sstable(_data->s, _data->cfg.datadir, table.calculate_generation_for_new_table());
+    }
+
+    sstables::shared_sstable make_sstable(sstables::sstable_version_types version) {
+        auto& table = *_data->cf;
+        auto& sstables_manager = table.get_sstables_manager();
+        return sstables_manager.make_sstable(_data->s, _data->cfg.datadir, table.calculate_generation_for_new_table(), version);
+    }
 };

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -72,8 +72,4 @@ struct table_for_tests {
     compaction::table_state& as_table_state() noexcept;
 
     future<> stop();
-
-    future<> stop_and_keep_alive() {
-        return stop().finally([cf = *this] {});
-    }
 };

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -84,4 +84,16 @@ struct table_for_tests {
         auto& sstables_manager = table.get_sstables_manager();
         return sstables_manager.make_sstable(_data->s, _data->cfg.datadir, table.calculate_generation_for_new_table(), version);
     }
+
+    std::function<sstables::shared_sstable()> make_sst_factory() {
+        return [this] {
+            return make_sstable();
+        };
+    }
+
+    std::function<sstables::shared_sstable()> make_sst_factory(sstables::sstable_version_types version) {
+        return [this, version] {
+            return make_sstable(version);
+        };
+    }
 };

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -179,7 +179,7 @@ public:
     }
 
     future<> load_sstables(unsigned iterations) {
-        _sst.push_back(_env.make_sstable(s, this->dir(), 0, sstables::get_highest_sstable_version(), sstable::format_types::big));
+        _sst.push_back(_env.make_sstable(s, this->dir(), 0));
         return _sst.back()->load();
     }
 


### PR DESCRIPTION
This series cleans up unit test in preparation for PR #12994.
Helpers are added (or reused) to not rely on specific sstable generation numbers where possible (other than loading reference sstables that are committed to the repo with given generation numbers), and to generate the sstables for tests easily, taking advantage of generation management in `sstable_test_env`, `table_for_tests`, or `replica::table` itself.
