### PR TITLE
utils: UUID: specialize fmt::formatter for UUID and tagged_uuid<>

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -47,8 +47,8 @@ template<class T, class MAP>
 std::vector<T>& map_to_key_value(const MAP& map, std::vector<T>& res) {
     for (auto i : map) {
         T val;
-        val.key = boost::lexical_cast<std::string>(i.first);
-        val.value = boost::lexical_cast<std::string>(i.second);
+        val.key = fmt::to_string(i.first);
+        val.value = fmt::to_string(i.second);
         res.push_back(val);
     }
     return res;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -55,7 +55,8 @@ extern logging::logger apilog;
 namespace std {
 
 std::ostream& operator<<(std::ostream& os, const api::table_info& ti) {
-    return os << "table{name=" << ti.name << ", id=" << ti.id << "}";
+    fmt::print(os, "table{{name={}, id={}}}", ti.name, ti.id);
+    return os;
 }
 
 } // namespace std

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -22,7 +22,7 @@ static void set_summaries(const std::vector<streaming::stream_summary>& from,
         json::json_list<hs::stream_summary>& to) {
     if (!from.empty()) {
         hs::stream_summary res;
-        res.cf_id = boost::lexical_cast<std::string>(from.front().cf_id);
+        res.cf_id = fmt::to_string(from.front().cf_id);
         // For each stream_session, we pretend we are sending/receiving one
         // file, to make it compatible with nodetool.
         res.files = 1;

--- a/counters.cc
+++ b/counters.cc
@@ -13,8 +13,9 @@
 #include <boost/range/algorithm/sort.hpp>
 
 std::ostream& operator<<(std::ostream& os, counter_shard_view csv) {
-    return os << "{global_shard id: " << csv.id() << " value: " << csv.value()
-              << " clock: " << csv.logical_clock() << "}";
+    fmt::print(os, "{{global_shard id: {} value: {}, clock: {}}}",
+               csv.id(), csv.value(), csv.logical_clock());
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, counter_cell_view ccv) {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1905,7 +1905,8 @@ std::ostream& operator<<(std::ostream& out, const db::commitlog::segment& s) {
 }
 
 std::ostream& operator<<(std::ostream& out, const db::commitlog::segment::cf_mark& m) {
-    return out << (m.s._cf_dirty | boost::adaptors::map_keys);
+    fmt::print(out, "{}", m.s._cf_dirty | boost::adaptors::map_keys);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const db::replay_position& p) {

--- a/query.cc
+++ b/query.cc
@@ -55,17 +55,9 @@ std::ostream& operator<<(std::ostream& out, const partition_slice& ps) {
 }
 
 std::ostream& operator<<(std::ostream& out, const read_command& r) {
-    return out << "read_command{"
-        << "cf_id=" << r.cf_id
-        << ", version=" << r.schema_version
-        << ", slice=" << r.slice << ""
-        << ", limit=" << r.get_row_limit()
-        << ", timestamp=" << r.timestamp.time_since_epoch().count()
-        << ", partition_limit=" << r.partition_limit
-        << ", query_uuid=" << r.query_uuid
-        << ", is_first_page=" << r.is_first_page
-        << ", read_timestamp=" << r.read_timestamp
-        << "}";
+    fmt::print(out, "read_command{{cf_id={}, version={}, slice={}, limit={}, timestamp={}, partition_limit={}, query_uuid={}, is_first_page={}, read_timestamp={}}}",
+               r.cf_id, r.schema_version, r.slice, r.get_row_limit(), r.timestamp.time_since_epoch().count(), r.partition_limit, r.query_uuid, r.is_first_page, r.read_timestamp);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const forward_request::reduction_type& r) {

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -1136,45 +1136,35 @@ void fsm::stop() {
 }
 
 std::ostream& operator<<(std::ostream& os, const fsm& f) {
-    os << "current term: " << f._current_term << ", ";
-    os << "current leader: " << f.current_leader() << ", ";
-    os << "len messages: " << f._messages.size() << ", ";
-    os << "voted for: " << f._voted_for << ", ";
-    os << "commit idx:" << f._commit_idx << ", ";
-    // os << "last applied: " << f._last_applied << ", ";
-    os << "log (" << f._log << "), ";
-    os << "observed (current term: " << f._observed._current_term << ", ";
-    os << "voted for: " << f._observed._voted_for << ", ";
-    os << "commit index: " << f._observed._commit_idx << "), ";
-    os << "current time: " << f._clock.now() << ", ";
-    os << "last election time: " << f._last_election_time << ", ";
+    fmt::print(os, "current term: {}, current leader: {}, len messages: {}, voted_for: {}, commit idx: {}, log ({}), ",
+               f._current_term, f.current_leader(), f._messages.size(), f._voted_for, f._commit_idx, f._log);
+    fmt::print(os, "observed (current term: {}, voted for {}, commit index: {}), ",
+               f._observed._current_term, f._observed._voted_for, f._observed._commit_idx);
+    fmt::print(os, "current time: {}, last election time: {}, ",
+               f._clock.now(), f._last_election_time);
     if (f.is_candidate()) {
-        os << "votes (" << f.candidate_state().votes << "), ";
+        fmt::print(os, "votes ({}), ", f.candidate_state().votes);
     }
-    os << "messages: " << f._messages.size() << ", ";
-
+    fmt::print(os, "messages: {}, ", f._messages.size());
     if (std::holds_alternative<leader>(f._state)) {
-        os << "leader, ";
+        fmt::print(os, "leader, ");
     } else if (std::holds_alternative<candidate>(f._state)) {
-        os << "candidate";
+        fmt::print(os, "candidate");
     } else if (std::holds_alternative<follower>(f._state)) {
-        os << "follower";
+        fmt::print(os, "follower");
     }
     if (f.is_leader()) {
-        os << "followers (";
+        fmt::print(os, "followers (");
         for (const auto& [server_id, follower_progress]: f.leader_state().tracker) {
-            os << server_id << ", ";
-            os << follower_progress.next_idx << ", ";
-            os << follower_progress.match_idx << ", ";
+            fmt::print(os, "{}, {}, {}, ", server_id, follower_progress.next_idx, follower_progress.match_idx);
             if (follower_progress.state == follower_progress::state::PROBE) {
-                os << "PROBE, ";
+                fmt::print(os, "PROBE, ");
             } else if (follower_progress.state == follower_progress::state::PIPELINE) {
-                os << "PIPELINE, ";
+                fmt::print(os, "PIPELINE, ");
             }
-            os << follower_progress.in_flight;
-            os << "; ";
+            fmt::print(os, "{}; ", follower_progress.in_flight);
         }
-        os << ")";
+        fmt::print(os, ")");
 
     }
     return os;

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -487,7 +487,8 @@ struct transient_error: public error {
     }
 
     friend std::ostream& operator<<(std::ostream& os, const transient_error& e) {
-        return os << "transient_error, message: " << e.what() << ", leader: " << e.leader;
+        fmt::print(os, "transient_error, message: {}, leader: {}", e.what(), e.leader);
+        return os;
     }
 };
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1638,7 +1638,7 @@ std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,
 }
 
 std::ostream& operator<<(std::ostream& os, const server_impl& s) {
-    os << "[id: " << s._id << ", fsm (" << s._fsm << ")]\n";
+    fmt::print(os, "[id: {}, fsm ()]\n", s._id, s._fsm);
     return os;
 }
 

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -34,7 +34,8 @@ make_random_uuid() noexcept {
 }
 
 std::ostream& operator<<(std::ostream& out, const UUID& uuid) {
-    return out << uuid.to_sstring();
+    fmt::print(out, "{}", uuid);
+    return out;
 }
 
 UUID::UUID(sstring_view uuid) {


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print UUID without using ostream<<. also, this change re-implements some formatting helpers using fmtlib for better performance and less dependencies on operator<<(), but we cannot drop it at this moment, as quite a few caller sites are still using operator<<(ostream&, const UUID&) and operator<<(ostream&, tagged_uuid<T>&). we will address them separately.

* add `fmt::formatter<UUID>`
* add `fmt::formatter<tagged_uuid<T>>`
* implement `UUID::to_string()` using `fmt::to_string()`
* implement `operator<<(std::ostream&, const UUID&)` with `fmt::print()`, this should help to improve the performance when printing uuid, as `fmt::print()` does not materialize a string when printing the uuid.
* treewide: use fmtlib when printing UUID

Refs #13245