### PR TITLE
config: add a space before parameter

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -861,7 +861,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
     , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 1,
         "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
-    , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard",liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
+    , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
         "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
     , cdc_dont_rewrite_streams(this, "cdc_dont_rewrite_streams", value_status::Used, false,
             "Disable rewriting streams from cdc_streams_descriptions to cdc_streams_descriptions_v2. Should not be necessary, but the procedure is expensive and prone to failures; this config option is left as a backdoor in case some user requires manual intervention.")


### PR DESCRIPTION
for better consistency in the code formatting.