### PR TITLE
cql: enable setting permissions on resources with quoted UDT names

### DIFF
--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -205,10 +205,10 @@ class cql3_type::raw_ut : public raw {
 
     virtual sstring to_string() const override {
         if (is_frozen()) {
-            return format("frozen<{}>", _name.to_string());
+            return format("frozen<{}>", _name.to_cql_string());
         }
 
-        return _name.to_string();
+        return _name.to_cql_string();
     }
 public:
     raw_ut(ut_name name)

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -134,7 +134,7 @@ future<std::pair<::shared_ptr<cql_transport::event::schema_change>, std::vector<
                 _name.get_string_type_name());
         } else {
             if (!_if_not_exists) {
-                co_await coroutine::return_exception(exceptions::invalid_request_exception(format("A user type of name {} already exists", _name.to_string())));
+                co_await coroutine::return_exception(exceptions::invalid_request_exception(format("A user type of name {} already exists", _name.to_cql_string())));
             }
         }
     } catch (data_dictionary::no_such_keyspace& e) {

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -56,7 +56,7 @@ void drop_type_statement::validate_while_executing(query_processor& qp) const {
             if (_if_exists) {
                 return;
             } else {
-                throw exceptions::invalid_request_exception(format("No user type named {} exists.", _name.to_string()));
+                throw exceptions::invalid_request_exception(format("No user type named {} exists.", _name.to_cql_string()));
             }
         }
 

--- a/cql3/ut_name.cc
+++ b/cql3/ut_name.cc
@@ -39,8 +39,8 @@ sstring ut_name::get_string_type_name() const
     return _ut_name->to_string();
 }
 
-sstring ut_name::to_string() const {
-    return (has_keyspace() ? (_ks_name.value() + ".") : "") + _ut_name->to_string();
+sstring ut_name::to_cql_string() const {
+    return (has_keyspace() ? (_ks_name.value() + ".") : "") + _ut_name->to_cql_string();
 }
 
 }

--- a/cql3/ut_name.hh
+++ b/cql3/ut_name.hh
@@ -37,10 +37,10 @@ public:
 
     sstring get_string_type_name() const;
 
-    sstring to_string() const;
+    sstring to_cql_string() const;
 
     friend std::ostream& operator<<(std::ostream& os, const ut_name& n) {
-        return os << n.to_string();
+        return os << n.to_cql_string();
     }
 };
 

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -88,6 +88,11 @@ void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql
     ucontext_t uc;
     auto r = getcontext(&uc);
     assert(r == 0);
+    if (stack.get() <= (char*)&uc && (char*)&uc < stack.get() + stack_size) {
+        // We are already running on the large stack, so just call the
+        // parser directly.
+        return do_with_parser_impl_impl(cql, std::move(f));
+    }
     uc.uc_stack.ss_sp = stack.get();
     uc.uc_stack.ss_size = stack_size;
     uc.uc_link = nullptr;

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -91,8 +91,8 @@ def new_test_table(cql, keyspace, schema, extra=""):
 
 # A utility function for creating a new temporary user-defined type.
 @contextmanager
-def new_type(cql, keyspace, cmd):
-    type_name = keyspace + "." + unique_name()
+def new_type(cql, keyspace, cmd, name=None):
+    type_name = keyspace + "." + (name or unique_name())
     cql.execute("CREATE TYPE " + type_name + " " + cmd)
     try:
         yield type_name


### PR DESCRIPTION
This series fixes an issue with altering permissions on UDFs with
parameter types that are UDTs with quoted names and adds
a test for it.

The issue was caused by the format of the temporary string
that represented the UDT in `auth::resource`. After parsing the
user input to a raw type, we created a string representing the 
UDT using `ut_name::to_string()`. The segment of the resulting
string that represented the name of the UDT was not quoted,
making us unable to parse it again when the UDT was being
`prepare`d. Other than for this purpose, the `ut_name::to_string()`
is used only for logging, so the solution was modifying it to
maybe quote the UDT name.

Ref: https://github.com/scylladb/scylladb/pull/12869