### PR TITLE
build: add wasm compilation target for rust

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -106,6 +106,7 @@ fedora_packages=(
     rust
     cargo
     rapidxml-devel
+    rust-std-static-wasm32-wasi
 )
 
 # lld is not available on s390x, see

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20230315
+docker.io/scylladb/scylla-toolchain:fedora-37-20230320


### PR DESCRIPTION
In the future, when testing WASM UDFs, we will only store the Rust source codes of them, and compile them to WASM. To be able to do that, we need rust standard library for the wasm32-wasi target, which is available as an RPM called rust-std-static-wasm32-wasi.

Closes #12896

[avi: regenerate toolchain]