### PR TITLE
mutation: replace operator<<(.., const range_tombstone&) with fmt formatter

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -310,7 +310,7 @@ std::ostream& operator<<(std::ostream& os, const mutation_fragment::printer& p) 
     mf.visit(make_visitor(
         [&] (const clustering_row& cr) { os << clustering_row::printer(p._schema, cr); },
         [&] (const static_row& sr) { os << static_row::printer(p._schema, sr); },
-        [&] (const auto& what) -> void { os << what; }
+        [&] (const auto& what) -> void { fmt::print(os, "{}", what); }
     ));
     os << "}";
     return os;
@@ -371,7 +371,7 @@ std::ostream& operator<<(std::ostream& os, const mutation_fragment_v2::printer& 
     mf.visit(make_visitor(
         [&] (const clustering_row& cr) { os << clustering_row::printer(p._schema, cr); },
         [&] (const static_row& sr) { os << static_row::printer(p._schema, sr); },
-        [&] (const auto& what) -> void { os << what; }
+        [&] (const auto& what) -> void { fmt::print(os, "{}", what); }
     ));
     os << "}";
     return os;

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -12,6 +12,7 @@
 #include "mutation_fragment.hh"
 #include "position_in_partition.hh"
 
+#include <fmt/core.h>
 #include <optional>
 #include <seastar/util/optimized_optional.hh>
 
@@ -75,6 +76,14 @@ public:
         return _tomb == other._tomb && eq(_pos, other._pos);
     }
     friend std::ostream& operator<<(std::ostream& out, const range_tombstone_change&);
+};
+
+template<>
+struct fmt::formatter<range_tombstone_change> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const range_tombstone_change& rt, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{range_tombstone_change: pos={}, {}}}", rt.position(), rt.tombstone());
+    }
 };
 
 template<typename T, typename ReturnType>

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -75,7 +75,6 @@ public:
         position_in_partition::equal_compare eq(s);
         return _tomb == other._tomb && eq(_pos, other._pos);
     }
-    friend std::ostream& operator<<(std::ostream& out, const range_tombstone_change&);
 };
 
 template<>

--- a/mutation/range_tombstone.cc
+++ b/mutation/range_tombstone.cc
@@ -12,19 +12,6 @@
 
 #include <boost/range/algorithm/upper_bound.hpp>
 
-std::ostream& operator<<(std::ostream& out, const range_tombstone& rt) {
-    if (rt) {
-        return out << "{range_tombstone: start=" << rt.position() << ", end=" << rt.end_position() << ", " << rt.tomb << "}";
-    } else {
-        return out << "{range_tombstone: none}";
-    }
-}
-
-std::ostream& operator<<(std::ostream& out, const range_tombstone_change& rt) {
-    fmt::print(out, "{{range_tombstone_change: pos={}, {}}}", rt.position(), rt.tombstone());
-    return out;
-}
-
 std::optional<range_tombstone> range_tombstone::apply(const schema& s, range_tombstone&& src)
 {
     bound_view::compare cmp(s);

--- a/mutation/range_tombstone.cc
+++ b/mutation/range_tombstone.cc
@@ -21,7 +21,8 @@ std::ostream& operator<<(std::ostream& out, const range_tombstone& rt) {
 }
 
 std::ostream& operator<<(std::ostream& out, const range_tombstone_change& rt) {
-    return out << "{range_tombstone_change: pos=" << rt.position() << ", " << rt.tombstone() << "}";
+    fmt::print(out, "{{range_tombstone_change: pos={}, {}}}", rt.position(), rt.tombstone());
+    return out;
 }
 
 std::optional<range_tombstone> range_tombstone::apply(const schema& s, range_tombstone&& src)

--- a/mutation/range_tombstone.hh
+++ b/mutation/range_tombstone.hh
@@ -102,7 +102,6 @@ public:
         rt2 = std::move(rt1);
         rt1 = std::move(tmp);
     }
-    friend std::ostream& operator<<(std::ostream& out, const range_tombstone& rt);
 
     static bool is_single_clustering_row_tombstone(const schema& s, const clustering_key_prefix& start,
         bound_kind start_kind, const clustering_key_prefix& end, bound_kind end_kind)

--- a/mutation/range_tombstone.hh
+++ b/mutation/range_tombstone.hh
@@ -286,3 +286,16 @@ public:
 
     void clear();
 };
+
+template<>
+struct fmt::formatter<range_tombstone> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const range_tombstone& rt, FormatContext& ctx) const {
+        if (rt) {
+            return fmt::format_to(ctx.out(), "{{range_tombstone: start={}, end={}, {}}}",
+                                  rt.position(), rt.end_position(), rt.tomb);
+        } else {
+            return fmt::format_to(ctx.out(), "{{range_tombstone: none}}");
+        }
+    }
+};

--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -430,7 +430,8 @@ std::ostream& operator<<(std::ostream& out, const range_tombstone_list& list) {
 }
 
 std::ostream& operator<<(std::ostream& out, const range_tombstone_entry& rt) {
-    return out << rt._tombstone;
+    fmt::print(out, "{}", rt._tombstone);
+    return out;
 }
 
 bool range_tombstone_list::equal(const schema& s, const range_tombstone_list& other) const {

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -519,11 +519,11 @@ BOOST_AUTO_TEST_CASE(test_random_list_is_not_overlapped) {
         if (!assert_valid(l)) {
             std::cout << "For input:" << std::endl;
             for (auto&& rt : input) {
-                std::cout << rt << std::endl;
+                fmt::print(std::cout, "{}\n", rt);
             }
             std::cout << "Produced:" << std::endl;
             for (auto&& rt : l) {
-                std::cout << rt << std::endl;
+                fmt::print(std::cout, "{}\n", rt);
             }
             BOOST_REQUIRE(false);
         }


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `range_tombstone` and `range_tombstone_change` without using ostream<<. also, this change removes all existing callers of `operator<<(ostream, const range_tombstone &)` and `operator<<(ostream, const range_tombstone_change &)`, and then removes these two `operator<<`s.

Refs #13245