### PR TITLE
cmake: sync with `configure.py` (15/n)

### DIFF
--- a/cmake/mode.RELEASE.cmake
+++ b/cmake/mode.RELEASE.cmake
@@ -7,6 +7,17 @@ set(CMAKE_CXX_FLAGS_RELEASE
 string(APPEND CMAKE_CXX_FLAGS_RELEASE
   " -O${Seastar_OptimizationLevel_RELEASE}")
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+  set(clang_inline_threshold 300)
+else()
+  set(clang_inline_threshold 2500)
+endif()
+string(APPEND CMAKE_CXX_FLAGS_RELEASE
+  " $<$<CXX_COMPILER_ID:GNU>:--param inline-unit-growth=300"
+  " $<$<CXX_COMPILER_ID:Clang>:-mllvm -inline-threshold=${clang_inline_threshold}>"
+  # clang generates 16-byte loads that break store-to-load forwarding
+  # gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
+  " -fno-slp-vectorize")
 set(Seastar_DEFINITIONS_DEBUG
   SCYLLA_BUILD_MODE=release)
 

--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -53,6 +53,7 @@ set(idl_headers
   group0.idl.hh
   hinted_handoff.idl.hh
   storage_proxy.idl.hh
+  storage_service.idl.hh
   group0_state_machine.idl.hh
   forward_request.idl.hh
   replica_exception.idl.hh

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -24,7 +24,8 @@ target_sources(service
     raft/raft_rpc.cc
     raft/raft_sys_table_storage.cc
     storage_proxy.cc
-    storage_service.cc)
+    storage_service.cc
+    topology_state_machine.cc)
 target_include_directories(service
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -257,3 +257,7 @@ add_scylla_test(virtual_table_mutation_source_test
   KIND SEASTAR)
 add_scylla_test(virtual_table_test
   KIND SEASTAR)
+add_scylla_test(wasm_alloc_test
+  KIND SEASTAR)
+add_scylla_test(wasm_test
+  KIND SEASTAR)

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -41,6 +41,9 @@ add_perf_test(perf_big_decimal
     schema)
 add_perf_test(perf_cache_eviction)
 add_perf_test(perf_checksum)
+add_perf_test(perf_commitlog
+  LIBRARIES
+    JsonCpp::JsonCpp)
 add_perf_test(perf_collection)
 add_perf_test(perf_cql_parser
   LIBRARIES


### PR DESCRIPTION
this is the 15th changeset of a series which tries to give an overhaul to the CMake building system. this series has two goals:
    - to enable developer to use CMake for building scylla. so they can use tools (CLion for instance) with CMake integration for better developer experience
    - to enable us to tweak the dependencies in a simpler way. a well-defined cross module / subsystem dependency is a prerequisite for building this project with the C++20 modules.

this changeset includes following changes:

 - build: cmake: add two missing tests
 - build: cmake: port more cxxflags from configure.py