### PR TITLE
Clean enabled features manipulations in system keyspace

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3311,11 +3311,8 @@ future<> system_keyspace::enable_features_on_startup(sharded<gms::feature_servic
     }
 
     co_await feat.invoke_on_all([&features_to_enable] (auto& srv) -> future<> {
-        // `gms::feature::enable` should be run within a seastar thread context
-        co_await seastar::async([&srv, &features_to_enable] {
-            std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
-            srv.enable(feat);
-        });
+        std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
+        co_await srv.enable(std::move(feat));
     });
 }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -358,6 +358,8 @@ public:
     future<std::unordered_set<dht::token>> get_local_tokens();
 
     static future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
+    static future<std::set<sstring>> load_local_enabled_features();
+    static future<> save_local_enabled_features(std::set<sstring> features);
 
     future<int> increment_and_get_generation();
     bool bootstrap_needed() const;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -84,7 +84,7 @@ void feature_service::unregister_feature(feature& f) {
 }
 
 
-std::set<std::string_view> feature_service::supported_feature_set() {
+std::set<std::string_view> feature_service::supported_feature_set() const {
     // Add features known by this local node. When a new feature is
     // introduced in scylla, update it here, e.g.,
     // return sstring("FEATURE1,FEATURE2")

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -84,17 +84,6 @@ void feature_service::unregister_feature(feature& f) {
 }
 
 
-void feature_service::enable(const sstring& name) {
-    if (auto it = _registered_features.find(name); it != _registered_features.end()) {
-        auto&& f = it->second;
-        auto& f_ref = f.get();
-        if (db::qctx && !f_ref) {
-            persist_enabled_feature_info(f_ref);
-        }
-        f_ref.enable();
-    }
-}
-
 std::set<std::string_view> feature_service::supported_feature_set() {
     // Add features known by this local node. When a new feature is
     // introduced in scylla, update it here, e.g.,

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -188,17 +188,17 @@ void feature_service::persist_enabled_feature_info(const gms::feature& f) const 
 }
 
 future<> feature_service::enable(std::set<std::string_view> list) {
-  // `gms::feature::enable` should be run within a seastar thread context
-  return seastar::async([this, list = std::move(list)] {
-    for (gms::feature& f : _registered_features | boost::adaptors::map_values) {
-        if (list.contains(f.name())) {
-            if (db::qctx && !f) {
-                persist_enabled_feature_info(f);
+    // `gms::feature::enable` should be run within a seastar thread context
+    return seastar::async([this, list = std::move(list)] {
+        for (gms::feature& f : _registered_features | boost::adaptors::map_values) {
+            if (list.contains(f.name())) {
+                if (db::qctx && !f) {
+                    persist_enabled_feature_info(f);
+                }
+                f.enable();
             }
-            f.enable();
         }
-    }
-  });
+    });
 }
 
 } // namespace gms

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -57,8 +57,7 @@ public:
     explicit feature_service(feature_config cfg);
     ~feature_service() = default;
     future<> stop();
-    // Has to run inside seastar::async context
-    void enable(const std::set<std::string_view>& list);
+    future<> enable(std::set<std::string_view> list);
     db::schema_features cluster_schema_features() const;
     std::set<std::string_view> supported_feature_set() const;
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -60,7 +60,7 @@ public:
     // Has to run inside seastar::async context
     void enable(const std::set<std::string_view>& list);
     db::schema_features cluster_schema_features() const;
-    std::set<std::string_view> supported_feature_set();
+    std::set<std::string_view> supported_feature_set() const;
 
     // Key in the 'system.scylla_local' table, that is used to
     // persist enabled features

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -58,7 +58,6 @@ public:
     ~feature_service() = default;
     future<> stop();
     // Has to run inside seastar::async context
-    void enable(const sstring& name);
     void enable(const std::set<std::string_view>& list);
     db::schema_features cluster_schema_features() const;
     std::set<std::string_view> supported_feature_set();

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2549,9 +2549,8 @@ future<> gossiper::maybe_enable_features() {
     co_await container().invoke_on_all([&features] (gossiper& g) {
         // gms::feature::enable should be run within seastar::async context
         return seastar::async([&features, &g] {
-            for (auto&& name : features) {
-                g._feature_service.enable(name);
-            }
+            std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);
+            g._feature_service.enable(features_v);
         });
     });
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -729,9 +729,7 @@ public:
             db.invoke_on_all(&replica::database::start).get();
 
             feature_service.invoke_on_all([] (auto& fs) {
-                return seastar::async([&fs] {
-                    fs.enable(fs.supported_feature_set());
-                });
+                return fs.enable(fs.supported_feature_set());
             }).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -206,7 +206,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     cfg.volatile_system_keyspace_for_testing(true);
 
     gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
-    feature_service.enable(feature_service.supported_feature_set());
+    feature_service.enable(feature_service.supported_feature_set()).get();
     sharded<locator::shared_token_metadata> token_metadata;
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));


### PR DESCRIPTION
There was an attempt to cut feature-service -> system-keyspace dependency (#13172) which turned out to require more changes. Here's a preparation squeezing from this future work.

This set 
- leaves only batch-enabling API in feature service
- keeps the need for async context in feature service
- narrows down system keyspace features API to only load and store records
- relaxes features updating logic in sys.ks.
- cosmetic