### PR TITLE
Revert "repair: Reduce repair reader eviction with diff shard count"

### DIFF
--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -104,8 +104,6 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
 
     size_t _max_repair_memory;
     seastar::semaphore _memory_sem;
-    seastar::semaphore _reader_sem;
-    seastar::semaphore _lock_sem{1};
 
     future<> init_ms_handlers();
     future<> uninit_ms_handlers();
@@ -174,8 +172,6 @@ public:
     gms::gossiper& get_gossiper() noexcept { return _gossiper.local(); }
     size_t max_repair_memory() const { return _max_repair_memory; }
     seastar::semaphore& memory_sem() { return _memory_sem; }
-    seastar::semaphore& reader_sem() { return _reader_sem; }
-    seastar::semaphore& lock_sem() { return _lock_sem; }
     repair_module& get_repair_module() noexcept {
         return *_repair_module;
     }


### PR DESCRIPTION
This reverts commit c6087cf3a05d2022555189b4d240dbc836a9c72c.

Said commit can cause a deadlock when 2 or more repairs compete for locks on 2 or more nodes. In this situation it can happen that one repair manages to get hold of the last permit on node A, while the other repair manages to get hold of the last permit on node B, causing a deadlock.
There is no simple solution to this so we have to revert this locking mechanism and look for another way to prevent reader trashing when repairing nodes with mismatching shard count.

Fixes: #12693