### PR TITLE
reloc: silence warning from readelf

### DIFF
--- a/scripts/strip.sh
+++ b/scripts/strip.sh
@@ -17,7 +17,8 @@ dynsyms="$orig.dynsyms"
 funcsyms="$orig.funcsyms"
 keep_symbols="$orig.keep_symbols"
 mini_debuginfo="$orig.minidebug"
-remove_sections=`readelf -W -S "$debuginfo" | awk '{ if (index($2,".debug_") != 1 && ($3 == "PROGBITS" || $3 == "NOTE" || $3 == "NOBITS") && index($8,"A") == 0) printf "--remove-section "$2" " }'`
+# silence "Error: Unable to find program interpreter name" warning from readelf, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012107
+remove_sections=`readelf -W -S "$debuginfo" 2> /dev/null | awk '{ if (index($2,".debug_") != 1 && ($3 == "PROGBITS" || $3 == "NOTE" || $3 == "NOBITS") && index($8,"A") == 0) printf "--remove-section "$2" " }'`
 nm -D "$stripped" --format=posix --defined-only | awk '{ print $1 }' | sort > "$dynsyms"
 nm "$debuginfo" --format=sysv --defined-only | awk -F \| '{ if ($4 ~ "FUNC") print $1 }' | sort > "$funcsyms"
 comm -13 "$dynsyms" "$funcsyms" > "$keep_symbols"


### PR DESCRIPTION
we've been seeing errors like

```
10:39:36  gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:39:36  readelf: /jenkins/workspace/scylla-master/next/scylla/build/dist/debug/redhat/BUILDROOT/scylla-5.3.0~dev-0.20230321.0f97d464d32b.x86_64/usr/lib/debug/opt/scylladb/libreloc/libc.so.6-5.3.0~dev-0.20230321.0f97d464d32b.x86_64.debug: Error: Unable to find program interpreter name
```

when strip.sh is processing *.debug elf images. this is caused by a known issue, see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012107 . and this error is not fatal. but it is very distracting when we are trying to find errors in jenkins logging messages.

so, in this change, the stderr output from readelf is muted for higher signal-noise ratio in the build logging message.