### PR TITLE
test/pylib: RandomTables.add_column with value column

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -173,10 +173,11 @@ class RandomTable():
         return await self.manager.cql.run_async(cql_stmt)
 
     async def add_column(self, name: str = None, ctype: Type[ValueType] = None, column: Column = None):
+        """Add a value column to the table"""
         if column is not None:
             assert type(column) is Column, "Wrong column type to add_column"
         else:
-            name = name if name is not None else f"c_{self.next_clustering_id():02}"
+            name = name if name is not None else f"v_{self.next_value_id():02}"
             ctype = ctype if ctype is not None else TextType
             column = Column(name, ctype=ctype)
         self.columns.append(column)


### PR DESCRIPTION
When adding extra columns in a test, make them value column. Name them with the "v_" prefix and use the value column number counter.