### PR TITLE
bytes, gms: replace operator<<(..) with fmt formatter

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -27,7 +27,7 @@ template<class T>
 std::vector<sstring> container_to_vec(const T& container) {
     std::vector<sstring> res;
     for (auto i : container) {
-        res.push_back(boost::lexical_cast<std::string>(i));
+        res.push_back(fmt::to_string(i));
     }
     return res;
 }

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -22,7 +22,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
         std::vector<fd::endpoint_state> res;
         for (auto i : g.get_endpoint_states()) {
             fd::endpoint_state val;
-            val.addrs = boost::lexical_cast<std::string>(i.first);
+            val.addrs = fmt::to_string(i.first);
             val.is_alive = i.second.is_alive();
             val.generation = i.second.get_heart_beat_state().get_generation();
             val.version = i.second.get_heart_beat_state().get_heart_beat_version();

--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -29,7 +29,7 @@ std::vector<message_counter> map_to_message_counters(
     std::vector<message_counter> res;
     for (auto i : map) {
         res.push_back(message_counter());
-        res.back().key = boost::lexical_cast<sstring>(i.first);
+        res.back().key = fmt::to_string(i.first);
         res.back().value = i.second;
     }
     return res;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -169,7 +169,7 @@ static ss::token_range token_range_endpoints_to_json(const dht::token_range_endp
     r.rpc_endpoints = d._rpc_endpoints;
     for (auto det : d._endpoint_details) {
         ss::endpoint_detail ed;
-        ed.host = boost::lexical_cast<std::string>(det._host);
+        ed.host = fmt::to_string(det._host);
         ed.datacenter = det._datacenter;
         if (det._rack != "") {
             ed.rack = det._rack;
@@ -485,8 +485,8 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::get_token_endpoint.set(r, [&ss] (std::unique_ptr<http::request> req) {
         return make_ready_future<json::json_return_type>(stream_range_as_array(ss.local().get_token_to_endpoint_map(), [](const auto& i) {
             storage_service_json::mapper val;
-            val.key = boost::lexical_cast<std::string>(i.first);
-            val.value = boost::lexical_cast<std::string>(i.second);
+            val.key = fmt::to_string(i.first);
+            val.value = fmt::to_string(i.second);
             return val;
         }));
     });
@@ -554,7 +554,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         auto points = ctx.get_token_metadata().get_bootstrap_tokens();
         std::unordered_set<sstring> addr;
         for (auto i: points) {
-            addr.insert(boost::lexical_cast<std::string>(i.second));
+            addr.insert(fmt::to_string(i.second));
         }
         return container_to_vec(addr);
     });

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -39,7 +39,7 @@ static hs::progress_info get_progress_info(const streaming::progress_info& info)
     res.current_bytes = info.current_bytes;
     res.direction = info.dir;
     res.file_name = info.file_name;
-    res.peer = boost::lexical_cast<std::string>(info.peer);
+    res.peer = fmt::to_string(info.peer);
     res.session_index = 0;
     res.total_bytes = info.total_bytes;
     return res;
@@ -62,7 +62,7 @@ static hs::stream_state get_state(
     state.plan_id = result_future.plan_id.to_sstring();
     for (auto info : result_future.get_coordinator().get()->get_all_session_info()) {
         hs::stream_info si;
-        si.peer = boost::lexical_cast<std::string>(info.peer);
+        si.peer = fmt::to_string(info.peer);
         si.session_index = 0;
         si.state = info.state;
         si.connecting = si.peer;

--- a/bytes.cc
+++ b/bytes.cc
@@ -50,15 +50,7 @@ bytes from_hex(sstring_view s) {
 }
 
 sstring to_hex(bytes_view b) {
-    static char digits[] = "0123456789abcdef";
-    sstring out = uninitialized_string(b.size() * 2);
-    unsigned end = b.size();
-    for (unsigned i = 0; i != end; ++i) {
-        uint8_t x = b[i];
-        out[2*i] = digits[x >> 4];
-        out[2*i+1] = digits[x & 0xf];
-    }
-    return out;
+    return fmt::to_string(fmt_hex(b));
 }
 
 sstring to_hex(const bytes& b) {
@@ -70,12 +62,14 @@ sstring to_hex(const bytes_opt& b) {
 }
 
 std::ostream& operator<<(std::ostream& os, const bytes& b) {
-    return os << to_hex(b);
+    fmt::print(os, "{}", b);
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
     if (b) {
-        return os << *b;
+        fmt::print(os, "{}", *b);
+        return os;
     }
     return os << "null";
 }
@@ -83,11 +77,13 @@ std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
 namespace std {
 
 std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
-    return os << to_hex(b);
+    fmt::print(os, "{}", fmt_hex(b));
+    return os;
 }
 
 }
 
 std::ostream& operator<<(std::ostream& os, const fmt_hex& b) {
-    return os << to_hex(b.v);
+    fmt::print(os, "{}", b);
+    return os;
 }

--- a/bytes.hh
+++ b/bytes.hh
@@ -127,6 +127,14 @@ public:
     }
 };
 
+template <>
+struct fmt::formatter<bytes> : fmt::formatter<fmt_hex> {
+    template <typename FormatContext>
+    auto format(const ::bytes& s, FormatContext& ctx) const {
+        return fmt::formatter<::fmt_hex>::format(::fmt_hex(bytes_view(s)), ctx);
+    }
+};
+
 namespace std {
 
 // Must be in std:: namespace, or ADL fails

--- a/bytes.hh
+++ b/bytes.hh
@@ -37,8 +37,8 @@ inline bytes_view to_bytes_view(sstring_view view) {
 }
 
 struct fmt_hex {
-    bytes_view& v;
-    fmt_hex(bytes_view& v) noexcept : v(v) {}
+    const bytes_view& v;
+    fmt_hex(const bytes_view& v) noexcept : v(v) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const fmt_hex& hex);

--- a/gms/gossip_digest.hh
+++ b/gms/gossip_digest.hh
@@ -66,7 +66,8 @@ public:
     }
 
     friend inline std::ostream& operator<<(std::ostream& os, const gossip_digest& d) {
-        return os << d._endpoint << ":" << d._generation << ":" << d._max_version;
+        fmt::print(os, "{}:{}:{}", d._endpoint, d._generation, d._max_version);
+        return os;
     }
 }; // class gossip_digest
 

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -35,31 +35,7 @@ future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family fam
 }
 
 std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
-    if (x.addr().is_ipv4()) {
-        return os << x.addr();
-    }
-
-    boost::io::ios_flags_saver fs(os);
-
-    os << std::hex;
-    auto&& bytes = x.bytes();
-    auto i = 0u;
-    auto acc = 0u;
-    // extra paranoid sign extension evasion - #5808
-    for (uint8_t b : bytes) {
-        acc <<= 8;
-        acc |= b;
-        if ((++i & 1) == 0) {
-            os << (std::exchange(acc, 0u) & 0xffff);
-            if (i != bytes.size()) {
-                os << ":";
-            }
-        }
-    }    
-    os << std::dec;
-    if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
-        os << '%' << x.addr().scope();
-    }
+    fmt::print(os, "{}", x);
     return os;
 }
 

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -89,3 +89,19 @@ struct hash<gms::inet_address> {
     size_t operator()(gms::inet_address a) const noexcept { return std::hash<net::inet_address>()(a._addr); }
 };
 }
+
+template <>
+struct fmt::formatter<gms::inet_address> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const ::gms::inet_address& x, FormatContext& ctx) const {
+        if (x.addr().is_ipv4()) {
+            return fmt::format_to(ctx.out(), "{}", x.addr());
+        }
+        // print 2 bytes in a group, and use ':' as the delimeter
+        format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
+        if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
+            return format_to(ctx.out(), "%{}", x.addr().scope());
+        }
+        return ctx.out();
+    }
+};

--- a/init.cc
+++ b/init.cc
@@ -45,8 +45,8 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg) {
         seeds.emplace(gms::inet_address("127.0.0.1"));
     }
     auto broadcast_address = utils::fb_utilities::get_broadcast_address();
-    startlog.info("seeds={}, listen_address={}, broadcast_address={}",
-            to_string(seeds), listen, broadcast_address);
+    startlog.info("seeds={{{}}}, listen_address={}, broadcast_address={}",
+            fmt::join(seeds, ", "), listen, broadcast_address);
     if (broadcast_address != listen && seeds.contains(listen)) {
         startlog.error("Use broadcast_address instead of listen_address for seeds list");
         throw std::runtime_error("Use broadcast_address for seeds list");

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -163,7 +163,8 @@ bool operator<(const msg_addr& x, const msg_addr& y) noexcept {
 }
 
 std::ostream& operator<<(std::ostream& os, const msg_addr& x) {
-    return os << x.addr << ":" << x.cpu_id;
+    fmt::print(os, "{}:{}", x.addr, x.cpu_id);
+    return os;
 }
 
 size_t msg_addr::hash::operator()(const msg_addr& id) const noexcept {


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `bytes` and `gms::inet_address` without using ostream<<. also, this change removes all existing callers of `operator<<(ostream, const bytes &)` and `operator<<(ostream, const gms::inet_address&)`.

`gms::inet_address` related changes are included here in hope to demonstrate the usage of delimiter specifier of `fmt_hex` 's formatter.

Refs #13245