### PR TITLE
test/alternator: increase CQL connection timeout

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -274,7 +274,14 @@ def get_cql_cluster(ip, ssl_context=None):
     auth_provider = cassandra.auth.PlainTextAuthProvider(username='cassandra', password='cassandra')
     return cassandra.cluster.Cluster([ip],
         auth_provider=auth_provider,
-        ssl_context=ssl_context)
+        ssl_context=ssl_context,
+        # The default timeout for new connections is 5 seconds, and for
+        # requests made by the control connection is 2 seconds. These should
+        # have been more than enough, but in some extreme cases with a very
+        # slow debug build running on a very busy machine, they may not be.
+        # so let's increase them to 60 seconds. See issue #13239.
+        connect_timeout = 60,
+        control_connection_timeout = 60)
 
 ## Test that CQL is serving, for wait_for_services() below.
 def check_cql(ip, ssl_context=None):


### PR DESCRIPTION
This patch increases the connection timeout in the get_cql_cluster() function in test/cql-pytest/run.py. This function is used to test that Scylla came up, and also test/alternator/run uses it to set up the authentication - which can only be done through CQL.

The Python driver has 2-second and 5-second default timeouts that should have been more than enough for everybody (TM), but in #13239 we saw that in one case it apparently wasn't enough. So to be extra safe, let's increase the default connection-related timeouts to 60 seconds.

Note this change only affects the Scylla *boot* in the test/*/run scripts, and it does not affect the actual tests - those have different code to connect to Scylla (see cql_session() in test/cql-pytest/util.py), and we already increased the timeouts there in #11289.

Fixes #13239