### PR TITLE
validation: Avoid throwing schema lookup

### DIFF
--- a/validation.cc
+++ b/validation.cc
@@ -59,11 +59,12 @@ validate_column_family(data_dictionary::database db, const sstring& keyspace_nam
         throw exceptions::invalid_request_exception("non-empty table is required");
     }
 
-    try {
-        return db.find_schema(keyspace_name, cf_name);
-    } catch (...) {
+    auto t = db.try_find_table(keyspace_name, cf_name);
+    if (!t) {
         throw exceptions::invalid_request_exception(format("unconfigured table {}", cf_name));
     }
+
+    return t->schema();
 }
 
 void validate_keyspace(data_dictionary::database db, const sstring& keyspace_name) {


### PR DESCRIPTION
The validate_column_family() tries to find a schema and throws if it doesn't exist. The latter is determined by the exception thrown by the database::find_schema(), but there's a throw-less way of doing it.