### PR TITLE
doc: update the Ubuntu version used in the image

### DIFF
--- a/docs/upgrade/ami-upgrade.rst
+++ b/docs/upgrade/ami-upgrade.rst
@@ -8,8 +8,8 @@ Upgrading ScyllaDB images requires updating:
 * Underlying OS packages. Starting with ScyllaDB 4.6, each ScyllaDB version includes a list of 3rd party and 
   OS packages tested with the ScyllaDB release. The list depends on the base OS:
   
-  * ScyllaDB Open Source **4.4** and ScyllaDB Enterprise **2020.1** or earlier are based on **CentOS 7**.
-  * ScyllaDB Open Source **4.5** and ScyllaDB Enterprise **2021.1** or later are based on **Ubuntu 20.04**.
+  * ScyllaDB Open Source **5.0 and 5.1** and ScyllaDB Enterprise **2021.1, 2022.1, and 2022.2** are based on **Ubuntu 20.04**.
+  * ScyllaDB Open Source **5.2** and ScyllaDB Enterprise **2023.1** are based on **Ubuntu 22.04**.
 
 If you're running ScyllaDB Open Source 5.0 or later or ScyllaDB Enterprise 2021.1.10 or later, you can 
 automatically update 3rd party and OS packages together with the ScyllaDB packages - by running one command. 


### PR DESCRIPTION
Starting from 5.2 and 2023.1 our images are based on Ubuntu:22.04. See https://github.com/scylladb/scylladb/issues/13138#issuecomment-1467737084

This commit adds that information to the docs.

It should be merged and backported to branch-5.2.