### PR TITLE
Backport to 5.2 per opcode cql metrics

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1609,7 +1609,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 db.revert_initial_system_read_concurrency_boost();
             }).get();
 
-            cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg);
+            scheduling_group_key_config cql_sg_stats_cfg = make_scheduling_group_key_config<cql_transport::cql_sg_stats>();
+            cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, scheduling_group_key_create(cql_sg_stats_cfg).get0());
 
             ss.local().register_protocol_server(cql_server_ctl);
 

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -45,6 +45,8 @@ class controller : public protocol_server {
     sharded<service::memory_limiter>& _mem_limiter;
     sharded<qos::service_level_controller>& _sl_controller;
     const db::config& _config;
+    scheduling_group_key _cql_opcode_stats_key;
+
 
     future<> set_cql_ready(bool ready);
     future<> do_start_server();
@@ -57,7 +59,7 @@ public:
     controller(sharded<auth::service>&, sharded<service::migration_notifier>&, sharded<gms::gossiper>&,
             sharded<cql3::query_processor>&, sharded<service::memory_limiter>&,
             sharded<qos::service_level_controller>&, sharded<service::endpoint_lifecycle_notifier>&,
-            const db::config& cfg);
+            const db::config& cfg, scheduling_group_key cql_opcode_stats_key);
     virtual sstring name() const override;
     virtual sstring protocol() const override;
     virtual sstring protocol_version() const override;

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -31,6 +31,7 @@ enum class cql_binary_opcode : uint8_t {
     AUTH_CHALLENGE = 14,
     AUTH_RESPONSE  = 15,
     AUTH_SUCCESS   = 16,
+    OPCODES_COUNT
 };
 
 class response {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -69,6 +69,22 @@ namespace cql_transport {
 
 static logging::logger clogger("cql_server");
 
+/**
+ * Skip registering CQL metrics for these SGs - these are internal scheduling groups that are not supposed to handle CQL
+ * requests.
+ */
+static const std::vector<sstring> non_cql_scheduling_classes_names = {
+        "atexit",
+        "background_reclaim",
+        "compaction",
+        "gossip",
+        "main",
+        "mem_compaction",
+        "memtable",
+        "memtable_to_cache",
+        "streaming"
+};
+
 struct cql_frame_error : std::exception {
     const char* what() const throw () override {
         return "bad cql binary frame";
@@ -168,9 +184,50 @@ event::event_type parse_event_type(const sstring& value)
     }
 }
 
+cql_sg_stats::cql_sg_stats()
+    : _cql_requests_stats(static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT))
+{
+    auto& vector_ref = non_cql_scheduling_classes_names;
+    if (std::find(vector_ref.begin(), vector_ref.end(), current_scheduling_group().name()) != vector_ref.end()) {
+        return;
+    }
+    register_metrics();
+}
+
+void cql_sg_stats::register_metrics()
+{
+    namespace sm = seastar::metrics;
+    std::vector<sm::metric_definition> transport_metrics;
+    auto& cur_sg_name = current_scheduling_group().name();
+
+    for (uint8_t i = 0; i < static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT); ++i) {
+        cql_binary_opcode opcode = cql_binary_opcode{i};
+
+        transport_metrics.emplace_back(
+                sm::make_counter("cql_requests_count", [this, opcode] { return get_cql_opcode_stats(opcode).count; },
+                                 sm::description("Counts the total number of CQL messages of a specific kind."),
+                                 {{"kind", to_string(opcode)}, {"scheduling_group_name", cur_sg_name}}).set_skip_when_empty()
+        );
+
+        transport_metrics.emplace_back(
+                sm::make_counter("cql_request_bytes", [this, opcode] { return get_cql_opcode_stats(opcode).request_size; },
+                                 sm::description("Counts the total number of received bytes in CQL messages of a specific kind."),
+                                 {{"kind", to_string(opcode)}, {"scheduling_group_name", cur_sg_name}}).set_skip_when_empty()
+        );
+
+        transport_metrics.emplace_back(
+                sm::make_counter("cql_response_bytes", [this, opcode] { return get_cql_opcode_stats(opcode).response_size; },
+                                 sm::description("Counts the total number of sent response bytes for CQL requests of a specific kind."),
+                                 {{"kind", to_string(opcode)}, {"scheduling_group_name", cur_sg_name}}).set_skip_when_empty()
+        );
+    }
+
+    _metrics.add_group("transport", std::move(transport_metrics));
+}
+
 cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& auth_service,
         service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
-        qos::service_level_controller& sl_controller, gms::gossiper& g)
+        qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key)
     : server("CQLServer", clogger)
     , _query_processor(qp)
     , _config(config)
@@ -178,10 +235,10 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     , _max_concurrent_requests(db_cfg.max_concurrent_requests_per_shard)
     , _memory_available(ml.get_semaphore())
     , _notifier(std::make_unique<event_notifier>(*this))
-    , _stats(static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT))
     , _auth_service(auth_service)
     , _sl_controller(sl_controller)
     , _gossiper(g)
+    , _stats_key(stats_key)
 {
     namespace sm = seastar::metrics;
 
@@ -218,28 +275,6 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     std::vector<sm::metric_definition> transport_metrics;
     for (auto& m : ls) {
         transport_metrics.emplace_back(std::move(m));
-    }
-
-    for (uint8_t i = 0; i < static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT); ++i) {
-        cql_binary_opcode opcode = cql_binary_opcode{i};
-
-        transport_metrics.emplace_back(
-            sm::make_counter("cql_requests_count", [this, opcode] { return _stats.get_cql_opcode_stats(opcode).count; },
-                         sm::description("Counts the total number of CQL messages of a specific kind."),
-                         {{"kind", to_string(opcode)}})
-        );
-
-        transport_metrics.emplace_back(
-            sm::make_counter("cql_request_bytes", [this, opcode] { return _stats.get_cql_opcode_stats(opcode).request_size; },
-                         sm::description("Counts the total number of received bytes in CQL messages of a specific kind."),
-                         {{"kind", to_string(opcode)}})
-        );
-
-        transport_metrics.emplace_back(
-            sm::make_counter("cql_response_bytes", [this, opcode] { return _stats.get_cql_opcode_stats(opcode).response_size; },
-                         sm::description("Counts the total number of sent response bytes for CQL requests of a specific kind."),
-                         {{"kind", to_string(opcode)}})
-        );
     }
 
     sm::label cql_error_label("type");
@@ -379,7 +414,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
         }
     }
 
-    request_kind_stats& cql_stats = _server._stats.get_cql_opcode_stats(cqlop);
+    cql_sg_stats::request_kind_stats& cql_stats = _server.get_cql_opcode_stats(cqlop);
     tracing::set_request_size(trace_state, fbuf.bytes_left());
     cql_stats.request_size += fbuf.bytes_left();
     ++cql_stats.count;


### PR DESCRIPTION
This PR contains two cherry picked patches that add new per CQL opcodes metrics that account their payload sizes, response sizes and count such requests.

Requests are accounted per opcode and per service level.

Fixes #13304 