### PR TITLE
cql: renice the wasm compilation alien thread

### DIFF
--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -23,7 +23,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "lang/wasm_alien_thread_runner.hh"
 
-static logging::logger wasm_logger("wasm");
+logging::logger wasm_logger("wasm");
 
 namespace wasm {
 context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache* cache, uint64_t yield_fuel, uint64_t total_fuel)


### PR DESCRIPTION
The Wasm compilation is a slow, low priority task, so it should not compete with reactor threads or the networking core. To achieve that, we increase the niceness of the thread by 10.

An alternative solution would be to set the priority using pthread_setschedparam, but it's not currently feasible, because as long as we're using the SCHED_OTHER policy for our threads, we cannot select any other priority than 0.