### PR TITLE
Initialize Wasm together with query_processor

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -56,7 +56,7 @@ public:
     }
 };
 
-query_processor::query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client)
+query_processor::query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client, std::shared_ptr<rust::Box<wasmtime::Engine>> wasm_engine)
         : _migration_subscriber{std::make_unique<migration_subscriber>(this)}
         , _proxy(proxy)
         , _forwarder(forwarder)
@@ -73,6 +73,7 @@ query_processor::query_processor(service::storage_proxy& proxy, service::forward
         , _authorized_prepared_cache_config_action([this] { update_authorized_prepared_cache_config(); return make_ready_future<>(); })
         , _authorized_prepared_cache_update_interval_in_ms_observer(_db.get_config().permissions_update_interval_in_ms.observe(_auth_prepared_cache_cfg_cb))
         , _authorized_prepared_cache_validity_in_ms_observer(_db.get_config().permissions_validity_in_ms.observe(_auth_prepared_cache_cfg_cb))
+        , _wasm_engine(std::move(wasm_engine))
         {
     namespace sm = seastar::metrics;
     namespace stm = statements;

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -127,7 +127,7 @@ private:
     std::unordered_map<sstring, std::unique_ptr<statements::prepared_statement>> _internal_statements;
 
     std::shared_ptr<rust::Box<wasmtime::Engine>> _wasm_engine;
-    wasm::instance_cache* _wasm_instance_cache;
+    std::optional<wasm::instance_cache> _wasm_instance_cache;
     std::shared_ptr<wasm::alien_thread_runner> _alien_runner;
 public:
     static const sstring CQL_VERSION;
@@ -143,7 +143,7 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries);
 
-    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client, std::shared_ptr<rust::Box<wasmtime::Engine>> wasm_engine);
+    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client, std::optional<wasm::startup_context> wasm_ctx);
 
     ~query_processor();
 
@@ -180,14 +180,6 @@ public:
 
     wasm::alien_thread_runner& alien_runner() {
         return *_alien_runner;
-    }
-
-    void set_wasm_instance_cache(wasm::instance_cache* cache) {
-        _wasm_instance_cache = cache;
-    }
-
-    void set_alien_runner(std::shared_ptr<wasm::alien_thread_runner> alien_runner) {
-        _alien_runner = std::move(alien_runner);
     }
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const std::optional<auth::authenticated_user>& user, const prepared_cache_key_type& key) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -174,8 +174,8 @@ public:
         return **_wasm_engine;
     }
 
-    wasm::instance_cache* get_wasm_instance_cache() {
-        return _wasm_instance_cache;
+    wasm::instance_cache& wasm_instance_cache() {
+        return *_wasm_instance_cache;
     }
 
     wasm::alien_thread_runner& alien_runner() {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -126,6 +126,7 @@ private:
     // don't bother with expiration on those.
     std::unordered_map<sstring, std::unique_ptr<statements::prepared_statement>> _internal_statements;
 
+    std::shared_ptr<rust::Box<wasmtime::Engine>> _wasm_engine;
     wasm::instance_cache* _wasm_instance_cache;
     std::shared_ptr<wasm::alien_thread_runner> _alien_runner;
 public:
@@ -142,7 +143,7 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries);
 
-    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client);
+    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client, std::shared_ptr<rust::Box<wasmtime::Engine>> wasm_engine);
 
     ~query_processor();
 
@@ -167,6 +168,10 @@ public:
 
     cql_stats& get_cql_stats() {
         return _cql_stats;
+    }
+
+    wasmtime::Engine& wasm_engine() {
+        return **_wasm_engine;
     }
 
     wasm::instance_cache* get_wasm_instance_cache() {

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -49,7 +49,7 @@ seastar::future<shared_ptr<functions::function>> create_function_statement::crea
             std::move(return_type), _called_on_null_input, std::move(ctx));
     } else if (_language == "wasm") {
        // FIXME: need better way to test wasm compilation without real_database()
-       wasm::context ctx{qp.wasm_engine(), _name.name, qp.get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+       wasm::context ctx{qp.wasm_engine(), _name.name, qp.wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
        try {
             co_await wasm::precompile(qp.alien_runner(), ctx, arg_names, _body);
             co_return ::make_shared<functions::user_function>(_name, _arg_types, std::move(arg_names), _body, _language,

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -49,7 +49,7 @@ seastar::future<shared_ptr<functions::function>> create_function_statement::crea
             std::move(return_type), _called_on_null_input, std::move(ctx));
     } else if (_language == "wasm") {
        // FIXME: need better way to test wasm compilation without real_database()
-       wasm::context ctx{db.real_database().wasm_engine(), _name.name, qp.get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+       wasm::context ctx{qp.wasm_engine(), _name.name, qp.get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
        try {
             co_await wasm::precompile(qp.alien_runner(), ctx, arg_names, _body);
             co_return ::make_shared<functions::user_function>(_name, _arg_types, std::move(arg_names), _body, _language,

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1866,7 +1866,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
     } else if (language == "wasm") {
-        wasm::context ctx{db.wasm_engine(), name.name, qctx->qp().get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+        wasm::context ctx{qctx->qp().wasm_engine(), name.name, qctx->qp().get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
         co_await wasm::precompile(qctx->qp().alien_runner(), ctx, arg_names, body);
         co_return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1866,7 +1866,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
     } else if (language == "wasm") {
-        wasm::context ctx{qctx->qp().wasm_engine(), name.name, qctx->qp().get_wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+        wasm::context ctx{qctx->qp().wasm_engine(), name.name, qctx->qp().wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
         co_await wasm::precompile(qctx->qp().alien_runner(), ctx, arg_names, body);
         co_return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),
@@ -1935,7 +1935,7 @@ static void drop_cached_func(replica::database& db, const query::result_set_row&
         cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("function_name")};
         auto arg_types = read_arg_types(db, row, name.keyspace);
-        qctx->qp().get_wasm_instance_cache()->remove(name, arg_types);
+        qctx->qp().wasm_instance_cache().remove(name, arg_types);
     }
 }
 

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -26,6 +26,15 @@
 static logging::logger wasm_logger("wasm");
 
 namespace wasm {
+
+startup_context::startup_context(db::config& cfg, replica::database_config& dbcfg)
+    : alien_runner(std::make_shared<wasm::alien_thread_runner>())
+    , engine(std::make_shared<rust::Box<wasmtime::Engine>>(wasmtime::create_engine(cfg.wasm_udf_memory_limit())))
+    , cache_size(dbcfg.available_memory * cfg.wasm_cache_memory_fraction())
+    , instance_size(cfg.wasm_cache_instance_size_limit())
+    , timer_period(std::chrono::milliseconds(cfg.wasm_cache_timeout_in_ms())) {
+}
+
 context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel)
     : engine_ptr(engine_ptr)
     , function_name(name)

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -26,7 +26,7 @@
 static logging::logger wasm_logger("wasm");
 
 namespace wasm {
-context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache* cache, uint64_t yield_fuel, uint64_t total_fuel)
+context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel)
     : engine_ptr(engine_ptr)
     , function_name(name)
     , cache(cache)
@@ -304,7 +304,7 @@ seastar::future<bytes_opt> run_script(const db::functions::function_name& name, 
     std::exception_ptr ex;
     bytes_opt ret;
     try {
-        func_inst = ctx.cache->get(name, arg_types, ctx).get0();
+        func_inst = ctx.cache.get(name, arg_types, ctx).get0();
         ret = wasm::run_script(ctx, *func_inst->instance->store, *func_inst->instance->instance, *func_inst->instance->func, arg_types, params, return_type, allow_null_input).get0();
     } catch (const wasm::instance_corrupting_exception& e) {
         func_inst->instance = std::nullopt;
@@ -314,7 +314,7 @@ seastar::future<bytes_opt> run_script(const db::functions::function_name& name, 
     }
     if (func_inst) {
         // The construction of func_inst may have failed due to a insufficient free memory for compiled modules.
-        ctx.cache->recycle(func_inst);
+        ctx.cache.recycle(func_inst);
     }
     if (ex) {
         std::rethrow_exception(std::move(ex));

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -13,6 +13,8 @@
 #include "db/functions/function_name.hh"
 #include "rust/wasmtime_bindings.hh"
 #include "lang/wasm_alien_thread_runner.hh"
+#include "db/config.hh"
+#include "replica/database.hh"
 
 namespace wasm {
 
@@ -29,6 +31,16 @@ public:
 
 struct instance_corrupting_exception : public exception {
     explicit instance_corrupting_exception(std::string_view msg) : exception(msg) {}
+};
+
+struct startup_context {
+    std::shared_ptr<alien_thread_runner> alien_runner;
+    std::shared_ptr<rust::Box<wasmtime::Engine>> engine;
+    size_t cache_size;
+    size_t instance_size;
+    seastar::lowres_clock::duration timer_period;
+
+    startup_context(db::config& cfg, replica::database_config& dbcfg);
 };
 
 struct context {

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -35,11 +35,11 @@ struct context {
     wasmtime::Engine& engine_ptr;
     std::optional<rust::Box<wasmtime::Module>> module;
     std::string function_name;
-    instance_cache* cache;
+    instance_cache& cache;
     uint64_t yield_fuel;
     uint64_t total_fuel;
 
-    context(wasmtime::Engine& engine_ptr, std::string name, instance_cache* cache, uint64_t yield_fuel, uint64_t total_fuel);
+    context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel);
 };
 
 seastar::future<> precompile(alien_thread_runner& alien_runner, context& ctx, const std::vector<sstring>& arg_names, std::string script);

--- a/main.cc
+++ b/main.cc
@@ -1005,20 +1005,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
             view_hints_dir_initializer.ensure_created_and_verified().get();
 
-            static sharded<wasm::instance_cache> wasm_instance_cache;
-            auto udf_enabled = cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF);
-            std::any stop_udf_cache_handlers;
-            std::shared_ptr<rust::Box<wasmtime::Engine>> wasm_engine;
-            std::shared_ptr<wasm::alien_thread_runner> alien_runner;
-            if (udf_enabled) {
-                supervisor::notify("starting wasm udf cache");
-                size_t max_cache_size = dbcfg.available_memory * cfg->wasm_cache_memory_fraction();
-                wasm_instance_cache.start(max_cache_size, cfg->wasm_cache_instance_size_limit(), std::chrono::milliseconds(cfg->wasm_cache_timeout_in_ms())).get();
-                stop_udf_cache_handlers = defer_verbose_shutdown("udf cache", [] {
-                    wasm_instance_cache.stop().get();
-                });
-                wasm_engine = std::make_shared<rust::Box<wasmtime::Engine>>(wasmtime::create_engine(cfg->wasm_udf_memory_limit()));
-                alien_runner = std::make_shared<wasm::alien_thread_runner>();
+            std::optional<wasm::startup_context> wasm_ctx;
+            if (cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF)) {
+                wasm_ctx.emplace(*cfg, dbcfg);
             }
 
             auto get_tm_cfg = sharded_parameter([&] {
@@ -1150,15 +1139,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                                                      std::chrono::duration_cast<std::chrono::milliseconds>(cql3::prepared_statements_cache::entry_expiry));
             auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
 
-            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notifier), std::ref(mm), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::ref(group0_client), wasm_engine).get();
+            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notifier), std::ref(mm), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::ref(group0_client), std::move(wasm_ctx)).get();
             // #293 - do not stop anything
             // engine().at_exit([&qp] { return qp.stop(); });
-            if (udf_enabled) {
-                qp.invoke_on_all([&] (cql3::query_processor& qp) {
-                    qp.set_wasm_instance_cache(&wasm_instance_cache.local());
-                    qp.set_alien_runner(alien_runner);
-                }).get();
-            }
             sstables::init_metrics().get();
 
             // FIXME -- this sys_ks start should really be up above, where its instance

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -370,7 +370,6 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _feat(feat)
     , _shared_token_metadata(stm)
     , _sst_dir_semaphore(sst_dir_sem)
-    , _wasm_engine(wasmtime::create_engine(cfg.wasm_udf_memory_limit()))
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })
     , _memtable_flush_static_shares_observer(cfg.memtable_flush_static_shares.observe(_update_memtable_flush_static_shares_action.make_observer()))

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1366,7 +1366,6 @@ private:
 
     sharded<sstables::directory_semaphore>& _sst_dir_semaphore;
 
-    rust::Box<wasmtime::Engine> _wasm_engine;
     utils::cross_shard_barrier _stop_barrier;
 
     db::rate_limiter _rate_limiter;
@@ -1382,10 +1381,6 @@ public:
     const gms::feature_service& features() const { return _feat; }
     future<> apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&&, db::timeout_clock::time_point timeout);
     future<> apply_in_memory(const mutation& m, column_family& cf, db::rp_handle&&, db::timeout_clock::time_point timeout);
-
-    wasmtime::Engine& wasm_engine() {
-        return *_wasm_engine;
-    }
 
     drain_progress get_drain_progress() const noexcept {
         return _drain_progress;

--- a/test/boost/wasm_alloc_test.cc
+++ b/test/boost/wasm_alloc_test.cc
@@ -63,7 +63,7 @@ SEASTAR_TEST_CASE(test_allocation_failures) {
     for (size_t fail_after = 0;;fail_after++) {
         auto wasm_engine = wasmtime::create_test_engine(1024 * 1024, fail_after);
         auto wasm_cache = std::make_unique<wasm::instance_cache>(100 * 1024 * 1024, 1024 * 1024, std::chrono::seconds(1));
-        auto wasm_ctx = wasm::context(*wasm_engine, "grow_return", wasm_cache.get(), 1000, 1000000000);
+        auto wasm_ctx = wasm::context(*wasm_engine, "grow_return", *wasm_cache, 1000, 1000000000);
         try {
             // Function that ignores the input, grows its memory by 1 page, and returns 10
             co_await wasm::precompile(alien_runner, wasm_ctx, {}, grow_return);

--- a/test/boost/wasm_test.cc
+++ b/test/boost/wasm_test.cc
@@ -19,7 +19,7 @@ SEASTAR_TEST_CASE(test_long_udf_yields) {
     auto wasm_engine = wasmtime::create_engine(1024 * 1024);
     wasm::alien_thread_runner alien_runner;
     auto wasm_cache = std::make_unique<wasm::instance_cache>(100 * 1024 * 1024, 1024 * 1024, std::chrono::seconds(1));
-    auto wasm_ctx = wasm::context(*wasm_engine, "fib", wasm_cache.get(), 100000, 100000000000);
+    auto wasm_ctx = wasm::context(*wasm_engine, "fib", *wasm_cache, 100000, 100000000000);
     // Recursive fibonacci function
     co_await wasm::precompile(alien_runner, wasm_ctx, {}, R"(
 (module

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -771,8 +771,13 @@ public:
                                                      std::chrono::duration_cast<std::chrono::milliseconds>(cql3::prepared_statements_cache::entry_expiry));
             auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
 
+            auto udf_enabled = cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF);
+            std::shared_ptr<rust::Box<wasmtime::Engine>> wasm_engine;
+            if (udf_enabled) {
+                wasm_engine = std::make_shared<rust::Box<wasmtime::Engine>>(wasmtime::create_engine(cfg->wasm_udf_memory_limit()));
+            }
 
-            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notif), std::ref(mm), qp_mcfg, std::ref(cql_config), auth_prep_cache_config, std::ref(group0_client)).get();
+            qp.start(std::ref(proxy), std::ref(forward_service), std::move(local_data_dict), std::ref(mm_notif), std::ref(mm), qp_mcfg, std::ref(cql_config), auth_prep_cache_config, std::ref(group0_client), wasm_engine).get();
             auto stop_qp = defer([&qp] { qp.stop().get(); });
 
             sys_ks.invoke_on_all([&snitch] (auto& sys_ks) {


### PR DESCRIPTION
The wasm engine is moved from replica::database to the query_processor.
The wasm instance cache and compilation thread runner were already there,
but now they're also initialized in the query_processor constructor.

By moving the initialization to the constructor, we can now
be certain that all wasm-related objects (wasm instance cache,
compilation thread runner, and wasm engine, which was already
passed in the constructor) are initialized when we try to use
them because we have to use the query processor to access them
anyway.

The change is also motivated by the fact that we're planning
to take Wasm UDFs out of experimental, after which they should
stop getting special treatment.