### PR TITLE
thrift: return address in listen_addresses() only after server is ready

### DIFF
--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -58,8 +58,7 @@ future<> thrift_controller::do_start_server() {
         return make_ready_future<>();
     }
     return seastar::async([this] {
-        _server = std::make_unique<distributed<thrift_server>>();
-        auto tserver = &*_server;
+        auto tserver = std::make_unique<distributed<thrift_server>>();
         _addr.reset();
 
         auto& cfg = _db.local().get_config();
@@ -81,6 +80,7 @@ future<> thrift_controller::do_start_server() {
         //});
         tserver->invoke_on_all(&thrift_server::listen, socket_address{ip, port}, keepalive).get();
         clogger.info("Thrift server listening on {}:{} ...", ip, port);
+        _server = std::move(tserver);
     });
 }
 

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -57,30 +57,30 @@ future<> thrift_controller::do_start_server() {
     if (_server) {
         return make_ready_future<>();
     }
+    return seastar::async([this] {
+        _server = std::make_unique<distributed<thrift_server>>();
+        auto tserver = &*_server;
+        _addr.reset();
 
-    _server = std::make_unique<distributed<thrift_server>>();
-    auto tserver = &*_server;
+        auto& cfg = _db.local().get_config();
+        auto preferred = cfg.rpc_interface_prefer_ipv6() ? std::make_optional(net::inet_address::family::INET6) : std::nullopt;
+        auto family = cfg.enable_ipv6_dns_lookup() || preferred ? std::nullopt : std::make_optional(net::inet_address::family::INET);
+        auto keepalive = cfg.rpc_keepalive();
+        thrift_server_config tsc;
+        tsc.timeout_config = make_timeout_config(cfg);
+        tsc.max_request_size = cfg.thrift_max_message_length_in_mb() * (uint64_t(1) << 20);
 
-    _addr.reset();
-
-    auto& cfg = _db.local().get_config();
-    auto preferred = cfg.rpc_interface_prefer_ipv6() ? std::make_optional(net::inet_address::family::INET6) : std::nullopt;
-    auto family = cfg.enable_ipv6_dns_lookup() || preferred ? std::nullopt : std::make_optional(net::inet_address::family::INET);
-    auto keepalive = cfg.rpc_keepalive();
-    thrift_server_config tsc;
-    tsc.timeout_config = make_timeout_config(cfg);
-    tsc.max_request_size = cfg.thrift_max_message_length_in_mb() * (uint64_t(1) << 20);
-    return utils::resolve(cfg.rpc_address, family, preferred).then([this, tserver, port = cfg.rpc_port(), keepalive, tsc] (gms::inet_address ip) {
+        auto ip = utils::resolve(cfg.rpc_address, family, preferred).get();
+        auto port = cfg.rpc_port();
         _addr.emplace(ip, port);
-        return tserver->start(sharded_parameter([this] { return _db.local().as_data_dictionary(); }), std::ref(_qp), std::ref(_ss), std::ref(_proxy), std::ref(_auth_service), std::ref(_mem_limiter), tsc).then([tserver, port, ip, keepalive] {
-            // #293 - do not stop anything
-            //engine().at_exit([tserver] {
-            //    return tserver->stop();
-            //});
-            return tserver->invoke_on_all(&thrift_server::listen, socket_address{ip, port}, keepalive);
-        }).then([ip, port] {
-            clogger.info("Thrift server listening on {}:{} ...", ip, port);
-        });
+
+        tserver->start(sharded_parameter([this] { return _db.local().as_data_dictionary(); }), std::ref(_qp), std::ref(_ss), std::ref(_proxy), std::ref(_auth_service), std::ref(_mem_limiter), tsc).get();
+        // #293 - do not stop anything
+        //engine().at_exit([tserver] {
+        //    return tserver->stop();
+        //});
+        tserver->invoke_on_all(&thrift_server::listen, socket_address{ip, port}, keepalive).get();
+        clogger.info("Thrift server listening on {}:{} ...", ip, port);
     });
 }
 


### PR DESCRIPTION
This is used for readiness API: /storage_service/rpc_server and the fix prevents from returning 'true' prematurely.

Some improvement for readiness was added in a51529dd1547fe029e8c259f8b03891106f6edc0 but thrift implementation wasn't fully done.

Fixes https://github.com/scylladb/scylladb/issues/12376