### PR TITLE
docs: Separate conf.py files for opensource and enterprise versions

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -2,10 +2,14 @@ name: "Docs / Publish"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+env:
+  FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
+
 on:
   push:
     branches:
-      - master
+      - 'master'
+      - 'enterprise'
     paths:
       - "docs/**"
   workflow_dispatch:
@@ -24,12 +28,13 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up env
-        run: make -C docs setupenv
+        run: make -C docs FLAG="${{ env.FLAG }}" setupenv
       - name: Build docs
-        run: make -C docs multiversion
+        run: make -C docs FLAG="${{ env.FLAG }}" multiversion
       - name: Build redirects
-        run: make -C docs redirects
+        run: make -C docs FLAG="${{ env.FLAG }}" redirects
       - name: Deploy docs to GitHub Pages
         run: ./docs/_utils/deploy.sh
+        if: (github.ref_name == 'master' && env.FLAG == 'opensource') || (github.ref_name == 'enterprise' && env.FLAG == 'enterprise')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -2,6 +2,9 @@ name: "Docs / Build PR"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+env:
+  FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
+
 on:
   pull_request:
     branches:
@@ -23,6 +26,6 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up env
-        run: make -C docs setupenv
+        run: make -C docs FLAG="${{ env.FLAG }}" setupenv
       - name: Build docs
-        run: make -C docs test
+        run: make -C docs FLAG="${{ env.FLAG }}" test

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - enterprise
     paths:
       - "docs/**"
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,13 +7,20 @@ PAPER         :=
 BUILDDIR      := _build
 SOURCEDIR     := .
 PREVIEW_HOST  := 127.0.0.1
+FLAG 	  	  := opensource
+CONF_PATH 	  := ./
 
 # Internal variables
+ifeq ($(FLAG), enterprise)
+	CONF_PATH = ./enterprise
+endif
+
 PAPEROPT_a4     := -D latex_paper_size=a4
 PAPEROPT_letter := -D latex_paper_size=letter
-ALLSPHINXOPTS   := -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
+ALLSPHINXOPTS   := -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR) -t $(FLAG) -c $(CONF_PATH)
 TESTSPHINXOPTS  := $(ALLSPHINXOPTS) -W --keep-going
-PROD_OPTS       := -D html_theme_options.collapse_navigation='false' -D html_theme_options.navigation_depth=3
+PROD_OPTS       := -D html_theme_options.collapse_navigation='false' -D html_theme_options.navigation_depth=3 -t $(FLAG) -c $(CONF_PATH)
+
 
 # Windows variables
 ifeq ($(OS),Windows_NT)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ CONF_PATH     := ./
 
 # Internal variables
 ifeq ($(FLAG), enterprise)
-    CONF_PATH = ./enterprise
+    CONF_PATH = ./_enterprise
 endif
 
 PAPEROPT_a4     := -D latex_paper_size=a4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,12 +7,12 @@ PAPER         :=
 BUILDDIR      := _build
 SOURCEDIR     := .
 PREVIEW_HOST  := 127.0.0.1
-FLAG 	  	  := opensource
-CONF_PATH 	  := ./
+FLAG          := opensource
+CONF_PATH     := ./
 
 # Internal variables
 ifeq ($(FLAG), enterprise)
-	CONF_PATH = ./enterprise
+    CONF_PATH = ./enterprise
 endif
 
 PAPEROPT_a4     := -D latex_paper_size=a4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,6 @@ LATEST_VERSION = "branch-5.1"
 UNSTABLE_VERSIONS = ["master", "branch-5.2"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
-# Set to enterprise or opensource.
-FLAGS = ["opensource"]
 
 # -- General configuration ------------------------------------------------
 
@@ -141,13 +139,7 @@ html_context = {"html_baseurl": html_baseurl}
 
 
 # -- Initialize Sphinx ----------------------------------------------
-def builder_inited(app):
-    # Add custom flags
-    for flag in FLAGS:
-        app.tags.add(flag)
-
 def setup(sphinx):
-    sphinx.connect('builder-inited', builder_inited)
     warnings.filterwarnings(
         action="ignore",
         category=UserWarning,


### PR DESCRIPTION
# Motivation

This PR modifies the docs workflows to prevent merge conflicts in configuration files when backporting pull requests to the enterprise repository.

Specifically, the changes are:

- The GitHub workflows now pass a flag to the `Makefile` command, indicating whether we are building docs for the enterprise or open-source repository.
- The Makefile then selects the appropriate `conf.py` file based on the flag provided.

As a result, we will have identical files for building docs for enterprise and open-source repos, except for the `conf.py` file and custom enteprise docs pages. These will have unique names to prevent conflicts when backporting changes.

# How to test this pull request

- Clone this pull request, go to the docs folder, run `make preview`, and ensure it executes without errors. In this case, you should be able to preview the open-source version of the site.
- Testing the workflows can be more tricky, but you should see that the workflow "Docs / Build PR" passes without errors.
