### PR TITLE
raft: includes used header and use <path/to/header> for include boost headers

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -12,7 +12,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
-#include "boost/range/join.hpp"
+#include <boost/range/join.hpp>
 #include <map>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/future-util.hh>

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -25,6 +25,7 @@
 
 #include "fsm.hh"
 #include "log.hh"
+#include "raft.hh"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
at least, we need to access the declarations of exceptions, like`not_a_leader` and `dropped_entry`, so, instead of relying on other header to do this job for us, we should include the header which include the declaration. so, in this chance "raft.h" is include explicitly. also, include boost headers using "<path/to/header>` instead of "path/to/header` for more consistency.
