### PR TITLE
types: remove unused header

### DIFF
--- a/types/types.hh
+++ b/types/types.hh
@@ -12,7 +12,6 @@
 #include <boost/functional/hash.hpp>
 #include <iosfwd>
 #include <sstream>
-#include <iterator>
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>


### PR DESCRIPTION
<iterator> was introduced back in
1cf02cb9d843ea39f984872ef01af2088177274b, but lexicographical_compare.hh was extracted out in bdfc0aa7488af78d32e8fdc87bae9ddadf8f4fb3, since we don't have any users of <iterator> in types.hh anymore, let's remove it.