### PR TITLE
alternator/rest api tests: Remove name assumption and rely on actual …

### DIFF
--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -26,7 +26,8 @@ def test_storage_service_keyspaces(cql, this_dc, rest_api):
         resp_user.raise_for_status()
         keyspaces_user = resp_user.json()
         assert keyspace in keyspaces_user
-        assert all(not ks.startswith("system") for ks in keyspaces_user)
+        # don't assume all that starts with system is non-user, but "system" certainly is not.
+        assert not "system" in keyspaces_user
 
         resp_nls = rest_api.send("GET", "storage_service/keyspaces", { "type": "non_local_strategy" })
         resp_nls.raise_for_status()


### PR DESCRIPTION
…scylla info

Fixes #13332
The tests user the discriminator "system" as prefix to assume keyspaces are marked "internal" inside scylla. This is not true in enterprise universe (replicated key provider). It maybe/probably should, but that train is sailing right now.

Fix by removing one assert (not correct) and use actual API info in the alternator test.