### PR TITLE
Get rid of global variable "load_prio_keyspaces" (step 1)

### DIFF
--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -54,3 +54,20 @@ void db::extensions::add_commitlog_file_extension(sstring n, commitlog_file_exte
 void db::extensions::add_extension_to_schema(schema_ptr s, const sstring& name, shared_ptr<schema_extension> ext) {
     const_cast<schema *>(s.get())->extensions()[name] = std::move(ext);
 }
+
+void db::extensions::add_extension_internal_keyspace(std::string ks) {
+    _extension_internal_keyspaces.emplace(std::move(ks));
+}
+
+// TODO: remove once this is backmerged to ent once, and relevant code is updated.
+extern bool is_load_prio_keyspace(std::string_view name);
+
+bool db::extensions::is_extension_internal_keyspace(const std::string& ks) const {
+    if (_extension_internal_keyspaces.count(ks)) {
+        return true;
+    }
+    if (::is_load_prio_keyspace(ks)) {
+        return true;
+    }
+    return false;
+}

--- a/db/extensions.hh
+++ b/db/extensions.hh
@@ -15,6 +15,7 @@
 #include <map>
 #include <variant>
 #include <vector>
+#include <unordered_set>
 
 #include <seastar/core/sstring.hh>
 
@@ -97,9 +98,27 @@ public:
      * config apply.
      */
     void add_extension_to_schema(schema_ptr, const sstring&, shared_ptr<schema_extension>);
+
+    /**
+     * Adds a keyspace to "extension internal" set.
+     *
+     * Such a keyspace must be loaded before/destroyed after any "normal" user keyspace.
+     * Thus a psuedo-system/internal keyspce.
+     * This has little to no use in open source version, and is temporarily bridged with
+     * the static version of same functionality in distributed loader. It is however (or will
+     * be), essential to enterprise code. Do not remove.
+     */
+    void add_extension_internal_keyspace(std::string);
+
+    /**
+     * Checks if a keyspace is a registered load priority one.
+     */
+    bool is_extension_internal_keyspace(const std::string&) const;
+
 private:
     std::map<sstring, schema_ext_create_func> _schema_extensions;
     std::map<sstring, sstable_file_io_extension> _sstable_file_io_extensions;
     std::map<sstring, commitlog_file_extension_ptr> _commitlog_file_extensions;
+    std::unordered_set<std::string> _extension_internal_keyspaces;
 };
 }

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -13,6 +13,7 @@
 #include "distributed_loader.hh"
 #include "replica/database.hh"
 #include "db/config.hh"
+#include "db/extensions.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/schema_tables.hh"
@@ -51,8 +52,8 @@ bool is_system_keyspace(std::string_view name) {
     return system_keyspaces.contains(name);
 }
 
-bool is_load_prio_keyspace(const sstring& name) {
-    return load_prio_keyspaces.contains(name);
+bool is_load_prio_keyspace(std::string_view name) {
+    return load_prio_keyspaces.contains(sstring(name));
 }
 
 static const std::unordered_set<std::string_view> internal_keyspaces = {
@@ -833,7 +834,7 @@ future<> distributed_loader::init_non_system_keyspaces(distributed<replica::data
                  * in open-source version. But essential for enterprise.
                  * Do _not_ remove or refactor away.
                  */
-                if (prio_only != is_load_prio_keyspace(ks_name)) {
+                if (prio_only != cfg.extensions().is_extension_internal_keyspace(ks_name)) {
                     continue;
                 }
 


### PR DESCRIPTION
The concept is needed by enterprise functionality, but in the hunt for globals this sticks out and should be removed.
This is also partially prompted by the need to handle the keyspaces in the above set special on shutdown as well as startup. I.e. we need to ensure all user keyspaces are flushed/closed earlier then these. I.e. treat as "system" keyspace for this purpose.

These changes adds a "extension internal" keyspace set instead, which for now (until enterprise branches are updated) also included the "load_prio" set. However, it changes distributed loader to use the extension API interface instead, as well as adds shutdown special treatment to replica::database.