### PR TITLE
mutation_partition_v2: add sentinel to the tracker *after* adding to the tree

### DIFF
--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -237,10 +237,10 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutat
                 p_i->set_range_tombstone({});
             } else {
                 mplog.trace("{}: inserting sentinel at {}", fmt::ptr(&p), p_sentinel->position());
+                auto insert_result = p._rows.insert_before_hint(p_i, std::move(p_sentinel), cmp);
                 if (tracker) {
-                    tracker->insert(*p_i, *p_sentinel);
+                    tracker->insert(*p_i, *insert_result.first);
                 }
-                p._rows.insert_before_hint(p_i, std::move(p_sentinel), cmp);
             }
         }
     });


### PR DESCRIPTION
Every tracker insertion has to have a corresponding removal or eviction, (otherwise the number of rows in the tracker will be misaccounted).

If we add the row to the tracker before adding it to the tree, and the tree insertion fails (with bad_alloc), this contract will be violated. Fix that.

Note: the problem is currently irrelevant because an exception during sentinel insertion will abort the program anyway.