### PR TITLE
Remove explicit flush() from sstable component writer

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1061,25 +1061,9 @@ void sstable::do_write_simple(component_type type, const io_priority_class& pc,
     options.io_priority_class = pc;
     auto w = make_component_file_writer(type, std::move(options)).get0();
     std::exception_ptr eptr;
-    try {
-        write_component(_version, w);
-        w.flush();
-    } catch (...) {
-        eptr = std::current_exception();
-    }
-    try {
-        w.close();
-    } catch (...) {
-        std::exception_ptr close_eptr = std::current_exception();
-        sstlog.warn("failed to close file_writer: {}", close_eptr);
-        // If write succeeded but close failed, we rethrow close's exception.
-        if (!eptr) {
-            eptr = close_eptr;
-        }
-    }
-    if (eptr) {
-        std::rethrow_exception(eptr);
-    }
+    write_component(_version, w);
+    w.flush();
+    w.close();
 }
 
 template <component_type Type, typename T>

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -71,10 +71,6 @@ public:
         _out.write(reinterpret_cast<const char*>(s.begin()), s.size()).get();
     }
     // Must be called in a seastar thread.
-    void flush() {
-        _out.flush().get();
-    }
-    // Must be called in a seastar thread.
     void close();
 
     uint64_t offset() const {
@@ -131,7 +127,6 @@ serialized_size(sstable_version_types v, const T& object) {
     uint64_t size = 0;
     auto writer = file_writer(make_sizing_output_stream(size));
     write(v, writer, object);
-    writer.flush();
     writer.close();
     return size;
 }


### PR DESCRIPTION
Writing into sstable component output stream should be done with care. In particular -- flushing can happen only once right before closing the  stream. Flushing the stream in between several writes is not going to work, because file stream would step on unaligned IO and S3 upload stream would send completion message to the server and would lose any  subsequent write.

Most of the file_writer users already obey that and flush the writer once right before closing it. The do_write_simple() is extra careful about exceptions handling, but it's an overkill (see first patch).

It's better to make file_writer API explicitly lack the ability to flush itself by flushing the stream when closing the writer.