### PR TITLE
test/pylib: topology: support clusters of initial size 0

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -81,7 +81,8 @@ class ManagerClient():
             logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
         except aiohttp.ClientError as exc:
             raise RuntimeError(f"Failed before test check {exc}") from exc
-        if self.cql is None:
+        servers = await self.running_servers()
+        if self.cql is None and servers:
             # TODO: if cluster is not up yet due to taking long and HTTP timeout, wait for it
             # await self._wait_for_cluster()
             await self.driver_connect()  # Connect driver to new cluster
@@ -168,7 +169,10 @@ class ManagerClient():
         except Exception as exc:
             raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
         logger.debug("ManagerClient added %s", s_info)
-        self._driver_update()
+        if self.cql:
+            self._driver_update()
+        else:
+            await self.driver_connect()
         return s_info
 
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -587,7 +587,8 @@ class ScyllaCluster:
         try:
             for _ in range(self.replicas):
                 await self.add_server()
-            self.keyspace_count = self._get_keyspace_count()
+            if self.replicas > 0:
+                self.keyspace_count = self._get_keyspace_count()
         except Exception as exc:
             # If start fails, swallow the error to throw later,
             # at test time.
@@ -769,7 +770,7 @@ class ScyllaCluster:
             self.logger.info(f"The cluster {self.name} is dirty, not checking"
                              f" keyspace count post-condition")
         else:
-            if self._get_keyspace_count() != self.keyspace_count:
+            if self.running and self._get_keyspace_count() != self.keyspace_count:
                 raise RuntimeError(f"Test post-condition on cluster {self.name} failed, "
                                    f"the test must drop all keyspaces it creates.")
         for server in itertools.chain(self.running.values(), self.stopped.values()):

--- a/test/topology_custom/conftest.py
+++ b/test/topology_custom/conftest.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file configures pytest for all tests in this directory, and also
+# defines common test fixtures for all of them to use
+
+from test.topology.conftest import *

--- a/test/topology_custom/pytest.ini
+++ b/test/topology_custom/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+asyncio_mode = auto
+
+log_cli = true
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S
+
+markers =
+    slow: tests that take more than 30 seconds to run

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -1,0 +1,6 @@
+type: Topology
+pool_size: 4
+cluster_size: 0
+extra_scylla_config_options:
+    authenticator: AllowAllAuthenticator
+    authorizer: AllowAllAuthorizer

--- a/test/topology_custom/test_custom.py
+++ b/test/topology_custom/test_custom.py
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+from test.pylib.random_tables import RandomTables
+from test.pylib.util import unique_name
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_custom(request, manager: ManagerClient):
+    servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
+    tables = RandomTables(request.node.name, manager, unique_name())
+    table = await tables.add_table(ncolumns=5)
+    await table.insert_seq()
+    await table.add_index(2)
+    await tables.verify_schema(table)


### PR DESCRIPTION
To allow tests with custom clusters, allow configuration of initial cluster size of 0.

Add a proof-of-concept test to be removed later.