### PR TITLE
Prevent invalidation of iterators over database::_column_families

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -43,7 +43,7 @@ std::tuple<sstring, sstring> parse_fully_qualified_cf_name(sstring name) {
     return std::make_tuple(name.substr(0, pos), name.substr(end));
 }
 
-const table_id& get_uuid(const sstring& ks, const sstring& cf, const replica::database& db) {
+table_id get_uuid(const sstring& ks, const sstring& cf, const replica::database& db) {
     try {
         return db.find_uuid(ks, cf);
     } catch (replica::no_such_column_family& e) {
@@ -51,7 +51,7 @@ const table_id& get_uuid(const sstring& ks, const sstring& cf, const replica::da
     }
 }
 
-const table_id& get_uuid(const sstring& name, const replica::database& db) {
+table_id get_uuid(const sstring& name, const replica::database& db) {
     auto [ks, cf] = parse_fully_qualified_cf_name(name);
     return get_uuid(ks, cf, db);
 }

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -23,7 +23,7 @@ namespace api {
 void set_column_family(http_context& ctx, httpd::routes& r, sharded<db::system_keyspace>& sys_ks);
 void unset_column_family(http_context& ctx, httpd::routes& r);
 
-const table_id& get_uuid(const sstring& name, const replica::database& db);
+table_id get_uuid(const sstring& name, const replica::database& db);
 future<> foreach_column_family(http_context& ctx, const sstring& name, std::function<void(replica::column_family&)> f);
 
 

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -68,7 +68,7 @@ struct map_reduce_column_families_locally {
     std::function<std::unique_ptr<std::any>(std::unique_ptr<std::any>, std::unique_ptr<std::any>)> reducer;
     future<std::unique_ptr<std::any>> operator()(replica::database& db) const {
         auto res = seastar::make_lw_shared<std::unique_ptr<std::any>>(std::make_unique<std::any>(init));
-        return do_for_each(db.get_column_families(), [res, this](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) {
+        return do_for_each(db.get_tables_metadata()._column_families, [res, this](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) {
             *res = reducer(std::move(*res), mapper(*i.second.get()));
         }).then([res] {
             return std::move(*res);

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -68,7 +68,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
     cm::get_pending_tasks_by_table.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) {
             return do_with(std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>(), [&db](std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>& tasks) {
-                return do_for_each(db.get_column_families(), [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) -> future<> {
+                return do_for_each(db.get_tables_metadata()._column_families, [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) -> future<> {
                     replica::table& cf = *i.second.get();
                     tasks[std::make_pair(cf.schema()->ks_name(), cf.schema()->cf_name())] = cf.estimate_pending_compactions();
                     return make_ready_future<>();

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -68,8 +68,8 @@ void set_compaction_manager(http_context& ctx, routes& r) {
     cm::get_pending_tasks_by_table.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) {
             return do_with(std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>(), [&db](std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_hash>& tasks) {
-                return do_for_each(db.get_tables_metadata()._column_families, [&tasks](const std::pair<table_id, seastar::lw_shared_ptr<replica::table>>& i) -> future<> {
-                    replica::table& cf = *i.second.get();
+                return db.get_tables_metadata().for_each_table_gently([&tasks] (table_id, lw_shared_ptr<replica::table> table) {
+                    replica::table& cf = *table.get();
                     tasks[std::make_pair(cf.schema()->ks_name(), cf.schema()->cf_name())] = cf.estimate_pending_compactions();
                     return make_ready_future<>();
                 }).then([&tasks] {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -980,7 +980,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                 ks.set_incremental_backups(value);
             }
 
-            for (auto& pair: db.get_column_families()) {
+            for (auto& pair: db.get_tables_metadata()._column_families) {
                 auto cf_ptr = pair.second;
                 cf_ptr->set_incremental_backups(value);
             }
@@ -1258,7 +1258,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
                 auto& ext = db.get_config().extensions();
 
-                for (auto& t : db.get_column_families() | boost::adaptors::map_values) {
+                for (auto& t : db.get_tables_metadata()._column_families | boost::adaptors::map_values) {
                     auto& schema = t->schema();
                     if ((ks.empty() || ks == schema->ks_name()) && (cf.empty() || cf == schema->cf_name())) {
                         // at most Nsstables long

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -641,7 +641,7 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
 
     // For each CDC log table get the TTL setting (from CDC options) and the table's creation time
     std::vector<time_and_ttl> times_and_ttls;
-    for (auto& [_, cf] : _db.get_column_families()) {
+    for (auto& [_, cf] : _db.get_tables_metadata()._column_families) {
         auto& s = *cf->schema();
         auto base = cdc::get_base_table(_db, s.ks_name(), s.cf_name());
         if (!base) {

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -641,21 +641,21 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
 
     // For each CDC log table get the TTL setting (from CDC options) and the table's creation time
     std::vector<time_and_ttl> times_and_ttls;
-    for (auto& [_, cf] : _db.get_tables_metadata()._column_families) {
-        auto& s = *cf->schema();
+    _db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> t) {
+        auto& s = *t->schema();
         auto base = cdc::get_base_table(_db, s.ks_name(), s.cf_name());
         if (!base) {
             // Not a CDC log table.
-            continue;
+            return;
         }
         auto& cdc_opts = base->cdc_options();
         if (!cdc_opts.enabled()) {
             // This table is named like a CDC log table but it's not one.
-            continue;
+            return;
         }
 
         times_and_ttls.push_back(time_and_ttl{as_timepoint(s.id().uuid()), cdc_opts.ttl()});
-    }
+    });
 
     if (times_and_ttls.empty()) {
         // There's no point in rewriting old generations' streams (they don't contain any data).

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -126,8 +126,7 @@ future<> db::commitlog_replayer::impl::init() {
         }
     }, [this](replica::database& db) {
         return do_with(shard_rpm_map{}, [this, &db](shard_rpm_map& map) {
-            return parallel_for_each(db.get_tables_metadata()._column_families, [this, &map](auto& cfp) {
-                auto uuid = cfp.first;
+            return db.get_tables_metadata().parallel_for_each_table([this, &map] (table_id uuid, lw_shared_ptr<replica::table>) {
                 // We do this on each cpu, for each CF, which technically is a little wasteful, but the values are
                 // cached, this is only startup, and it makes the code easier.
                 // Get all truncation records for the CF and initialize max rps if
@@ -156,13 +155,13 @@ future<> db::commitlog_replayer::impl::init() {
         // existing sstables-per-shard.
         // So, go through all CF:s and check, if a shard mapping does not
         // have data for it, assume we must set global pos to zero.
-        for (auto&p : _db.local().get_tables_metadata()._column_families) {
+        _db.local().get_tables_metadata().for_each_table([&] (table_id id, lw_shared_ptr<replica::table>) {
             for (auto&p1 : _rpm) { // for each shard
-                if (!p1.second.contains(p.first)) {
+                if (!p1.second.contains(id)) {
                     _min_pos[p1.first] = replay_position();
                 }
             }
-        }
+        });
         for (auto&p : _min_pos) {
             rlogger.debug("minimum position for shard {}: {}", p.first, p.second);
         }

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -126,7 +126,7 @@ future<> db::commitlog_replayer::impl::init() {
         }
     }, [this](replica::database& db) {
         return do_with(shard_rpm_map{}, [this, &db](shard_rpm_map& map) {
-            return parallel_for_each(db.get_column_families(), [this, &map](auto& cfp) {
+            return parallel_for_each(db.get_tables_metadata()._column_families, [this, &map](auto& cfp) {
                 auto uuid = cfp.first;
                 // We do this on each cpu, for each CF, which technically is a little wasteful, but the values are
                 // cached, this is only startup, and it makes the code easier.
@@ -156,7 +156,7 @@ future<> db::commitlog_replayer::impl::init() {
         // existing sstables-per-shard.
         // So, go through all CF:s and check, if a shard mapping does not
         // have data for it, assume we must set global pos to zero.
-        for (auto&p : _db.local().get_column_families()) {
+        for (auto&p : _db.local().get_tables_metadata()._column_families) {
             for (auto&p1 : _rpm) { // for each shard
                 if (!p1.second.contains(p.first)) {
                     _min_pos[p1.first] = replay_position();

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -265,7 +265,7 @@ void view_update_generator::setup_metrics() {
 }
 
 void view_update_generator::discover_staging_sstables() {
-    for (auto& x : _db.get_column_families()) {
+    for (auto& x : _db.get_tables_metadata()._column_families) {
         auto t = x.second->shared_from_this();
         for (auto sstables = t->get_sstables(); sstables::shared_sstable sst : *sstables) {
             if (sst->requires_view_building()) {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -265,8 +265,8 @@ void view_update_generator::setup_metrics() {
 }
 
 void view_update_generator::discover_staging_sstables() {
-    for (auto& x : _db.get_tables_metadata()._column_families) {
-        auto t = x.second->shared_from_this();
+    _db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> table) {
+        auto t = table->shared_from_this();
         for (auto sstables = t->get_sstables(); sstables::shared_sstable sst : *sstables) {
             if (sst->requires_view_building()) {
                 _progress_tracker->on_sstable_registration(sst);
@@ -276,7 +276,7 @@ void view_update_generator::discover_staging_sstables() {
                 _registration_sem.consume(1);
             }
         }
-    }
+    });
 }
 
 }

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -283,13 +283,13 @@ public:
             const auto snapshots_by_tables = co_await _db.map_reduce(snapshot_reducer(), [ks_name_ = ks_data.name] (replica::database& db) mutable -> future<snapshots_by_tables_map> {
                 auto ks_name = std::move(ks_name_);
                 snapshots_by_tables_map snapshots_by_tables;
-                for (auto& [_, table] : db.get_tables_metadata()._column_families) {
+                co_await db.get_tables_metadata().for_each_table_gently(coroutine::lambda([&] (table_id, lw_shared_ptr<replica::table> table) -> future<> {
                     if (table->schema()->ks_name() != ks_name) {
-                        continue;
+                        co_return;
                     }
                     const auto unordered_snapshots = co_await table->get_snapshot_details();
                     snapshots_by_tables.emplace(table->schema()->cf_name(), std::map<sstring, replica::table::snapshot_details>(unordered_snapshots.begin(), unordered_snapshots.end()));
-                }
+                }));
                 co_return snapshots_by_tables;
             });
 
@@ -433,9 +433,9 @@ private:
         };
         co_return co_await _db.map_reduce(shard_reducer(reduce), [map, reduce] (replica::database& db) {
             T val = {};
-            for (auto& [_, table] : db.get_tables_metadata()._column_families) {
+            db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> table) {
                val = reduce(val, map(*table));
-            }
+            });
             return val;
         });
     }
@@ -560,13 +560,13 @@ public:
                 res.total = occupancy.total_space();
                 res.free = occupancy.free_space();
                 res.entries = db.row_cache_tracker().partitions();
-                for (const auto& [_, t] : db.get_tables_metadata()._column_families) {
+                db.get_tables_metadata().for_each_table([&] (table_id id, lw_shared_ptr<replica::table> t) {
                     auto& cache_stats = t->get_row_cache().stats();
                     res.hits += cache_stats.hits.count();
                     res.misses += cache_stats.misses.count();
                     res.hits_moving_average += cache_stats.hits.rate();
                     res.requests_moving_average += (cache_stats.hits.rate() + cache_stats.misses.rate());
-                }
+                });
                 return res;
             }, stats{}, stats::reduce).then([] (stats s) {
                 return std::vector<std::pair<sstring, sstring>>{

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -283,7 +283,7 @@ public:
             const auto snapshots_by_tables = co_await _db.map_reduce(snapshot_reducer(), [ks_name_ = ks_data.name] (replica::database& db) mutable -> future<snapshots_by_tables_map> {
                 auto ks_name = std::move(ks_name_);
                 snapshots_by_tables_map snapshots_by_tables;
-                for (auto& [_, table] : db.get_column_families()) {
+                for (auto& [_, table] : db.get_tables_metadata()._column_families) {
                     if (table->schema()->ks_name() != ks_name) {
                         continue;
                     }
@@ -433,7 +433,7 @@ private:
         };
         co_return co_await _db.map_reduce(shard_reducer(reduce), [map, reduce] (replica::database& db) {
             T val = {};
-            for (auto& [_, table] : db.get_column_families()) {
+            for (auto& [_, table] : db.get_tables_metadata()._column_families) {
                val = reduce(val, map(*table));
             }
             return val;
@@ -560,7 +560,7 @@ public:
                 res.total = occupancy.total_space();
                 res.free = occupancy.free_space();
                 res.entries = db.row_cache_tracker().partitions();
-                for (const auto& [_, t] : db.get_column_families()) {
+                for (const auto& [_, t] : db.get_tables_metadata()._column_families) {
                     auto& cache_stats = t->get_row_cache().stats();
                     res.hits += cache_stats.hits.count();
                     res.misses += cache_stats.misses.count();

--- a/main.cc
+++ b/main.cc
@@ -1346,7 +1346,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Needs to happen before replaying the schema commitlog, which interprets
             // replay position in the truncation record.
             // Needs to happen before system_keyspace::setup(), which reads truncation records.
-            for (auto&& e : db.local().get_column_families()) {
+            for (auto&& e : db.local().get_tables_metadata()._column_families) {
                 auto table_ptr = e.second;
                 if (table_ptr->schema()->ks_name() == db::schema_tables::NAME) {
                     if (table_ptr->get_truncation_record() != db_clock::time_point::min()) {
@@ -1405,7 +1405,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
 
             db.invoke_on_all([] (replica::database& db) {
-                for (auto& x : db.get_column_families()) {
+                for (auto& x : db.get_tables_metadata()._column_families) {
                     replica::table& t = *(x.second);
                     t.enable_auto_compaction();
                 }
@@ -1423,7 +1423,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // streaming
 
             db.invoke_on_all([] (replica::database& db) {
-                for (auto& x : db.get_column_families()) {
+                for (auto& x : db.get_tables_metadata()._column_families) {
                     replica::column_family& cf = *(x.second);
                     cf.trigger_compaction();
                 }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -127,19 +127,20 @@ std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo
 }
 
 static size_t get_nr_tables(const replica::database& db, const sstring& keyspace) {
-    auto& m = db.get_tables_metadata()._ks_cf_to_uuid;
-    return std::count_if(m.begin(), m.end(), [&keyspace] (auto& e) {
-        return e.first.first == keyspace;
+    size_t tables = 0;
+    db.get_tables_metadata().for_each_table_id([&keyspace, &tables] (const std::pair<sstring, sstring>& kscf, table_id) {
+        tables += kscf.first == keyspace;
     });
+    return tables;
 }
 
 static std::vector<sstring> list_column_families(const replica::database& db, const sstring& keyspace) {
     std::vector<sstring> ret;
-    for (auto &&e : db.get_tables_metadata()._ks_cf_to_uuid) {
-        if (e.first.first == keyspace) {
-            ret.push_back(e.first.second);
+    db.get_tables_metadata().for_each_table_id([&] (const std::pair<sstring, sstring>& kscf, table_id) {
+        if (kscf.first == keyspace) {
+            ret.push_back(kscf.second);
         }
-    }
+    });
     return ret;
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -127,7 +127,7 @@ std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo
 }
 
 static size_t get_nr_tables(const replica::database& db, const sstring& keyspace) {
-    auto& m = db.get_column_families_mapping();
+    auto& m = db.get_tables_metadata()._ks_cf_to_uuid;
     return std::count_if(m.begin(), m.end(), [&keyspace] (auto& e) {
         return e.first.first == keyspace;
     });
@@ -135,7 +135,7 @@ static size_t get_nr_tables(const replica::database& db, const sstring& keyspace
 
 static std::vector<sstring> list_column_families(const replica::database& db, const sstring& keyspace) {
     std::vector<sstring> ret;
-    for (auto &&e : db.get_column_families_mapping()) {
+    for (auto &&e : db.get_tables_metadata()._ks_cf_to_uuid) {
         if (e.first.first == keyspace) {
             ret.push_back(e.first.second);
         }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3050,7 +3050,7 @@ future<> repair_service::cleanup_history(tasks::task_id repair_id) {
 }
 
 future<> repair_service::load_history() {
-    auto tables = get_db().local().get_column_families();
+    auto tables = get_db().local().get_tables_metadata()._column_families;
     for (const auto& x : tables) {
         auto& table_uuid = x.first;
         auto& table = x.second;

--- a/replica/data_dictionary_impl.hh
+++ b/replica/data_dictionary_impl.hh
@@ -66,7 +66,7 @@ public:
     }
     virtual std::vector<data_dictionary::table> get_tables(data_dictionary::database db) const override {
         std::vector<data_dictionary::table> ret;
-        auto&& tables = unwrap(db).get_column_families();
+        auto&& tables = unwrap(db).get_tables_metadata()._column_families;
         ret.reserve(tables.size());
         for (auto&& [uuid, cf] : tables) {
             ret.push_back(wrap(*cf));

--- a/replica/data_dictionary_impl.hh
+++ b/replica/data_dictionary_impl.hh
@@ -66,11 +66,11 @@ public:
     }
     virtual std::vector<data_dictionary::table> get_tables(data_dictionary::database db) const override {
         std::vector<data_dictionary::table> ret;
-        auto&& tables = unwrap(db).get_tables_metadata()._column_families;
-        ret.reserve(tables.size());
-        for (auto&& [uuid, cf] : tables) {
-            ret.push_back(wrap(*cf));
-        }
+        auto& tmd = unwrap(db).get_tables_metadata();
+        ret.reserve(tmd.size());
+        tmd.for_each_table([&] (table_id, const lw_shared_ptr<table> table) {
+            ret.push_back(wrap(*table));
+        });
         return ret;
     }
     virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db, std::string_view ks, std::string_view table) const override {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1143,7 +1143,7 @@ future<> database::drop_table_on_all_shards(sharded<database>& sharded_db, sstri
     co_await table_shards->destroy_storage();
 }
 
-const table_id& database::find_uuid(std::string_view ks, std::string_view cf) const {
+table_id database::find_uuid(std::string_view ks, std::string_view cf) const {
     try {
         return _tables_metadata._ks_cf_to_uuid.at(std::make_pair(ks, cf));
     } catch (std::out_of_range&) {
@@ -1151,7 +1151,7 @@ const table_id& database::find_uuid(std::string_view ks, std::string_view cf) co
     }
 }
 
-const table_id& database::find_uuid(const schema_ptr& schema) const {
+table_id database::find_uuid(const schema_ptr& schema) const {
     return find_uuid(schema->ks_name(), schema->cf_name());
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1309,8 +1309,14 @@ public:
         std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;
         ks_cf_to_uuid_t _ks_cf_to_uuid;
 
+        size_t size() const noexcept;
+
         future<> add_table(schema_ptr schema);
         future<> remove_table(schema_ptr schema) noexcept;
+        void for_each_table(std::function<void(table_id, lw_shared_ptr<table>)> f) const;
+        void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
+        future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
+        future<> parallel_for_each_table(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
     };
 private:
     replica::cf_stats _cf_stats;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1551,8 +1551,8 @@ public:
     future<> add_column_family_and_make_directory(schema_ptr schema);
 
     /* throws no_such_column_family if missing */
-    const table_id& find_uuid(std::string_view ks, std::string_view cf) const;
-    const table_id& find_uuid(const schema_ptr&) const;
+    table_id find_uuid(std::string_view ks, std::string_view cf) const;
+    table_id find_uuid(const schema_ptr&) const;
 
     /**
      * Creates a keyspace for a given metadata if it still doesn't exist.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1449,7 +1449,7 @@ private:
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    void remove(table&) noexcept;
+    future<> remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(const keyspace_metadata& tmp_ksm);
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier);
@@ -1703,7 +1703,7 @@ public:
 public:
     bool update_column_family(schema_ptr s);
 private:
-    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg);
+    future<> add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg);
     future<> detach_column_family(table& cf);
 
     struct table_truncate_state;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1308,6 +1308,9 @@ public:
     public: // FIXME: change member access to private. 
         std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;
         ks_cf_to_uuid_t _ks_cf_to_uuid;
+
+        future<> add_table(schema_ptr schema);
+        future<> remove_table(schema_ptr schema) noexcept;
     };
 private:
     replica::cf_stats _cf_stats;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1305,10 +1305,9 @@ public:
         flat_hash_map<ks_cf_t, table_id, utils::tuple_hash, string_pair_eq>;
     class tables_metadata {
         rwlock _cf_lock;
-    public: // FIXME: change member access to private. 
         std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;
         ks_cf_to_uuid_t _ks_cf_to_uuid;
-
+    public:
         size_t size() const noexcept;
 
         future<> add_table(schema_ptr schema);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1323,6 +1323,11 @@ public:
         void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
         future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
         future<> parallel_for_each_table(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
+        const std::unordered_map<table_id, lw_shared_ptr<table>> get_column_families_copy() const;
+
+        const auto filter(std::function<bool(std::pair<table_id, lw_shared_ptr<table>>)> f) const {
+            return _column_families | boost::adaptors::filtered(std::move(f));
+        }
     };
 private:
     replica::cf_stats _cf_stats;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1317,6 +1317,8 @@ public:
         table_id get_table_id(const std::pair<std::string_view, std::string_view>& kscf) const;
         lw_shared_ptr<table> get_table_if_exists(table_id id) const;
         table_id get_table_id_if_exists(const std::pair<std::string_view, std::string_view>& kscf) const;
+        bool contains(table_id id) const;
+        bool contains(std::pair<std::string_view, std::string_view> kscf) const;
         void for_each_table(std::function<void(table_id, lw_shared_ptr<table>)> f) const;
         void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
         future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1313,6 +1313,10 @@ public:
 
         future<> add_table(schema_ptr schema);
         future<> remove_table(schema_ptr schema) noexcept;
+        table& get_table(table_id id) const;
+        table_id get_table_id(const std::pair<std::string_view, std::string_view>& kscf) const;
+        lw_shared_ptr<table> get_table_if_exists(table_id id) const;
+        table_id get_table_id_if_exists(const std::pair<std::string_view, std::string_view>& kscf) const;
         void for_each_table(std::function<void(table_id, lw_shared_ptr<table>)> f) const;
         void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
         future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -472,11 +472,11 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
 
     dblog.info("Populating Keyspace {}", ks_name);
     auto& ks = i->second;
-    auto& column_families = db.local().get_tables_metadata()._column_families;
+    auto& tables_metadata = db.local().get_tables_metadata();
 
     co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
         auto uuid = s->id();
-        lw_shared_ptr<replica::column_family> cf = column_families[uuid];
+        lw_shared_ptr<replica::column_family> cf = tables_metadata.get_table(uuid).shared_from_this();
 
         // System tables (from system and system_schema keyspaces) are loaded in two phases.
         // The populate_keyspace function can be called in the second phase for tables that

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -472,7 +472,7 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
 
     dblog.info("Populating Keyspace {}", ks_name);
     auto& ks = i->second;
-    auto& column_families = db.local().get_column_families();
+    auto& column_families = db.local().get_tables_metadata()._column_families;
 
     co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
         auto uuid = s->id();

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1209,7 +1209,7 @@ def find_dbs():
 def for_each_table(db=None):
     if not db:
         db = find_db()
-    cfs = db['_column_families']
+    cfs = db['_tables_metadata']['_column_families']
     for (key, value) in unordered_map(cfs):
         yield value['_p'].reinterpret_cast(lookup_type(['replica::table', 'column_family'])[1].pointer()).dereference()  # it's a lw_shared_ptr
 
@@ -1511,7 +1511,7 @@ class scylla_tables(gdb.Command):
 
         for shard in shards:
             db = find_db(shard)
-            cfs = db['_column_families']
+            cfs = db['_tables_metadata']['_column_families']
             for (key, value) in unordered_map(cfs):
                 value = seastar_lw_shared_ptr(value).get().dereference()
                 schema = schema_ptr(value['_schema'])
@@ -1533,7 +1533,7 @@ class scylla_table(gdb.Command):
 
     def _find_table(self, ks, cf):
         db = find_db()
-        cfs = db['_column_families']
+        cfs = db['_tables_metadata']['_column_families']
         for (key, value) in unordered_map(cfs):
             value = seastar_lw_shared_ptr(value).get().dereference()
             schema = schema_ptr(value['_schema'])
@@ -1900,7 +1900,7 @@ class seastar_lw_shared_ptr():
 def all_tables(db):
     """Returns pointers to table objects which exist on current shard"""
 
-    for (key, value) in unordered_map(db['_column_families']):
+    for (key, value) in unordered_map(db['_tables_metadata']['_column_families']):
         yield seastar_lw_shared_ptr(value).get()
 
 

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -78,9 +78,9 @@ void load_broadcaster::start_broadcasting() {
         llogger.debug("Disseminating load info ...");
         _done = _db.map_reduce0([](replica::database& db) {
             int64_t res = 0;
-            for (auto i : db.get_tables_metadata()._column_families) {
-                res += i.second->get_stats().live_disk_space_used;
-            }
+            db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> table) {
+                res += table->get_stats().live_disk_space_used;
+            });
             return res;
         }, int64_t(0), std::plus<int64_t>()).then([this] (int64_t size) {
             return _gossiper.add_local_application_state(gms::application_state::LOAD,

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -137,7 +137,7 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
     };
 
     auto cf_to_cache_hit_stats = [non_system_filter] (replica::database& db) {
-        return boost::copy_range<std::unordered_map<table_id, stat>>(db.get_tables_metadata()._column_families | boost::adaptors::filtered(non_system_filter) |
+        return boost::copy_range<std::unordered_map<table_id, stat>>(db.get_tables_metadata().filter(non_system_filter) |
                 boost::adaptors::transformed([]  (const std::pair<table_id, lw_shared_ptr<replica::column_family>>& cf) {
             auto& stats = cf.second->get_row_cache().stats();
             return std::make_pair(cf.first, stat{float(stats.reads_with_no_misses.rate().rates[0]), float(stats.reads_with_misses.rate().rates[0])});

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3093,7 +3093,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
         co_await container().invoke_on_all([&] (storage_service& ss) {
             auto& db = ss._db.local();
             auto tmptr = pending_token_metadata_ptr[this_shard_id()];
-            for (auto&& [id, cf] : db.get_column_families()) { // Safe because we iterate without preemption
+            for (auto&& [id, cf] : db.get_tables_metadata()._column_families) { // Safe because we iterate without preemption
                 auto rs = db.find_keyspace(cf->schema()->keypace_name()).get_replication_strategy_ptr();
                 locator::effective_replication_map_ptr erm;
                 if (auto pt_rs = rs->maybe_as_per_table()) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3093,16 +3093,16 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
         co_await container().invoke_on_all([&] (storage_service& ss) {
             auto& db = ss._db.local();
             auto tmptr = pending_token_metadata_ptr[this_shard_id()];
-            for (auto&& [id, cf] : db.get_tables_metadata()._column_families) { // Safe because we iterate without preemption
-                auto rs = db.find_keyspace(cf->schema()->keypace_name()).get_replication_strategy_ptr();
+            db.get_tables_metadata().for_each_table([&] (table_id id, lw_shared_ptr<replica::table> table) {
+                auto rs = db.find_keyspace(table->schema()->keypace_name()).get_replication_strategy_ptr();
                 locator::effective_replication_map_ptr erm;
                 if (auto pt_rs = rs->maybe_as_per_table()) {
                     erm = pt_rs->make_replication_map(id, tmptr);
                 } else {
-                    erm = pending_effective_replication_maps[this_shard_id()][cf->schema()->keypace_name()];
+                    erm = pending_effective_replication_maps[this_shard_id()][table->schema()->keypace_name()];
                 }
                 pending_table_erms[this_shard_id()].emplace(id, std::move(erm));
-            }
+            });
         });
     } catch (...) {
         ex = std::current_exception();

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -462,15 +462,15 @@ std::vector<replica::column_family*> stream_session::get_column_family_stores(co
     std::vector<replica::column_family*> stores;
     auto& db = manager().db();
     if (column_families.empty()) {
-        for (auto& x : db.get_tables_metadata()._column_families) {
-            replica::column_family& cf = *(x.second);
+        db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> tp) {
+            replica::column_family& cf = *tp;
             auto cf_name = cf.schema()->cf_name();
             auto ks_name = cf.schema()->ks_name();
             if (ks_name == keyspace) {
                 sslog.debug("Find ks={} cf={}", ks_name, cf_name);
                 stores.push_back(&cf);
             }
-        }
+        });
     } else {
         // TODO: We can move this to database class and use shared_ptr<column_family> instead
         for (auto& cf_name : column_families) {

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -462,7 +462,7 @@ std::vector<replica::column_family*> stream_session::get_column_family_stores(co
     std::vector<replica::column_family*> stores;
     auto& db = manager().db();
     if (column_families.empty()) {
-        for (auto& x : db.get_column_families()) {
+        for (auto& x : db.get_tables_metadata()._column_families) {
             replica::column_family& cf = *(x.second);
             auto cf_name = cf.schema()->cf_name();
             auto ks_name = cf.schema()->ks_name();

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -116,7 +116,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         //   and the old sstable is deleted.
         flush(e);
         e.db().invoke_on_all([] (replica::database& dbi) {
-            return parallel_for_each(dbi.get_column_families(), [&dbi] (auto& table) {
+            return parallel_for_each(dbi.get_tables_metadata()._column_families, [&dbi] (auto& table) {
                 return dbi.get_compaction_manager().perform_major_compaction((table.second)->as_table_state());
             });
         }).get();

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -116,8 +116,8 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         //   and the old sstable is deleted.
         flush(e);
         e.db().invoke_on_all([] (replica::database& dbi) {
-            return parallel_for_each(dbi.get_tables_metadata()._column_families, [&dbi] (auto& table) {
-                return dbi.get_compaction_manager().perform_major_compaction((table.second)->as_table_state());
+            return dbi.get_tables_metadata().parallel_for_each_table([&dbi] (table_id, lw_shared_ptr<replica::table> t) {
+                return dbi.get_compaction_manager().perform_major_compaction(t->as_table_state());
             });
         }).get();
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -860,10 +860,10 @@ public:
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
             db.invoke_on_all([] (replica::database& db) {
-                for (auto& x : db.get_tables_metadata()._column_families) {
-                    replica::table& t = *(x.second);
+                db.get_tables_metadata().for_each_table([] (table_id, lw_shared_ptr<replica::table> table) {
+                    replica::table& t = *table;
                     t.enable_auto_compaction();
-                }
+                });
             }).get();
 
             if (raft_gr.local().is_enabled()) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -860,7 +860,7 @@ public:
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
             db.invoke_on_all([] (replica::database& db) {
-                for (auto& x : db.get_column_families()) {
+                for (auto& x : db.get_tables_metadata()._column_families) {
                     replica::table& t = *(x.second);
                     t.enable_auto_compaction();
                 }


### PR DESCRIPTION
Maps related to column families in database are extracted
to a column_families_data class. Access to them is possible only 
through methods. All methods which may preempt hold rwlock 
in relevant mode, so that the iterators can't become invalid.

Fixes: #13290