### PR TITLE
auth: replace operator<<(..) with fmt formatter

### DIFF
--- a/auth/authenticated_user.cc
+++ b/auth/authenticated_user.cc
@@ -18,11 +18,6 @@ authenticated_user::authenticated_user(std::string_view name)
         : name(sstring(name)) {
 }
 
-std::ostream& operator<<(std::ostream& os, const authenticated_user& u) {
-    fmt::print(os, "{}", u);
-    return os;
-}
-
 static const authenticated_user the_anonymous_user{};
 
 const authenticated_user& anonymous_user() noexcept {

--- a/auth/authenticated_user.cc
+++ b/auth/authenticated_user.cc
@@ -19,12 +19,7 @@ authenticated_user::authenticated_user(std::string_view name)
 }
 
 std::ostream& operator<<(std::ostream& os, const authenticated_user& u) {
-    if (!u.name) {
-        os << "anonymous";
-    } else {
-        os << *u.name;
-    }
-
+    fmt::print(os, "{}", u);
     return os;
 }
 

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -38,9 +38,6 @@ public:
     explicit authenticated_user(std::string_view name);
 };
 
-///
-/// The user name, or "anonymous".
-///
 std::ostream& operator<<(std::ostream&, const authenticated_user&);
 
 inline bool operator==(const authenticated_user& u1, const authenticated_user& u2) noexcept {
@@ -58,6 +55,21 @@ inline bool is_anonymous(const authenticated_user& u) noexcept {
 }
 
 }
+
+///
+/// The user name, or "anonymous".
+///
+template <>
+struct fmt::formatter<auth::authenticated_user> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const auth::authenticated_user& u, FormatContext& ctx) const {
+        if (u.name) {
+            return fmt::format_to(ctx.out(), "{}", *u.name);
+        } else {
+            return fmt::format_to(ctx.out(), "{}", "anonymous");
+        }
+    }
+};
 
 namespace std {
 

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -38,8 +38,6 @@ public:
     explicit authenticated_user(std::string_view name);
 };
 
-std::ostream& operator<<(std::ostream&, const authenticated_user&);
-
 inline bool operator==(const authenticated_user& u1, const authenticated_user& u2) noexcept {
     return u1.name == u2.name;
 }

--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -187,6 +187,7 @@ struct hash<cql3::authorized_prepared_statements_cache_key> final {
 };
 
 inline std::ostream& operator<<(std::ostream& out, const cql3::authorized_prepared_statements_cache_key& k) {
-    return out << "{ " << k.key().first << ", " << k.key().second << " }";
+    fmt::print(out, "{{{}, {}}}", k.key().first, k.key().second);
+    return out;
 }
 }


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `authenticated_user` without using ostream<<. also, this change removes all existing callers of `operator<<(ostream, const authenticated_user&)`.

Refs #13245