### PR TITLE
compound_compat: replace operator<<(..) with fmt formatter 

### DIFF
--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -520,8 +520,6 @@ public:
         return os;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const composite& v);
-
     struct tri_compare {
         const std::vector<data_type>& _types;
         tri_compare(const std::vector<data_type>& types) : _types(types) {}
@@ -664,12 +662,6 @@ struct fmt::formatter<composite> : fmt::formatter<std::string_view> {
         return fmt::format_to(ctx.out(), "{}", composite_view(v));
     }
 };
-
-inline
-std::ostream& operator<<(std::ostream& os, const composite& v) {
-    fmt::print(os, "{}", v);
-    return os;
-}
 
 inline
 std::strong_ordering composite::tri_compare::operator()(const composite& v1, const composite& v2) const {

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -652,11 +652,6 @@ struct fmt::formatter<composite_view> : fmt::formatter<std::string_view> {
     }
 };
 
-inline std::ostream& operator<<(std::ostream& os, composite_view v) {
-    fmt::print(os, "{}", v);
-    return os;
-}
-
 inline
 composite::composite(const composite_view& v)
     : composite(bytes(v._bytes), v._is_compound)

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -662,9 +662,18 @@ composite::composite(const composite_view& v)
     : composite(bytes(v._bytes), v._is_compound)
 { }
 
+template <>
+struct fmt::formatter<composite> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const composite& v, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", composite_view(v));
+    }
+};
+
 inline
 std::ostream& operator<<(std::ostream& os, const composite& v) {
-    return os << composite_view(v);
+    fmt::print(os, "{}", v);
+    return os;
 }
 
 inline

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -516,7 +516,8 @@ public:
 
     template <typename Component>
     friend inline std::ostream& operator<<(std::ostream& os, const std::pair<Component, eoc>& c) {
-        return os << "{value=" << c.first << "; eoc=" << format("0x{:02x}", eoc_type(c.second) & 0xff) << "}";
+        fmt::print(os, "{}", c);
+        return os;
     }
 
     friend std::ostream& operator<<(std::ostream& os, const composite& v);
@@ -527,6 +528,20 @@ public:
         std::strong_ordering operator()(const composite&, const composite&) const;
         std::strong_ordering operator()(composite_view, composite_view) const;
     };
+};
+
+template <typename Component>
+struct fmt::formatter<std::pair<Component, composite::eoc>> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const std::pair<Component, composite::eoc>& c, FormatContext& ctx) const {
+        if constexpr (std::same_as<Component, bytes_view>) {
+            return fmt::format_to(ctx.out(), "{{value={}; eoc={:#02x}}}",
+                                  fmt_hex(c.first), composite::eoc_type(c.second) & 0xff);
+        } else {
+            return fmt::format_to(ctx.out(), "{{value={}; eoc={:#02x}}}",
+                                  c.first, composite::eoc_type(c.second) & 0xff);
+        }
+    }
 };
 
 class composite_view final {

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -640,11 +640,22 @@ public:
     bool operator==(const composite_view& k) const { return k._bytes == _bytes && k._is_compound == _is_compound; }
     bool operator!=(const composite_view& k) const { return !(k == *this); }
 
-    friend inline std::ostream& operator<<(std::ostream& os, composite_view v) {
-        fmt::print(os, "{{{}, compound={}, static={}}}", fmt::join(v.components(), ", "), v._is_compound, v.is_static());
-        return os;
+    friend fmt::formatter<composite_view>;
+};
+
+template <>
+struct fmt::formatter<composite_view> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const composite_view& v, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}, compound={}, static={}}}",
+                              fmt::join(v.components(), ", "), v._is_compound, v.is_static());
     }
 };
+
+inline std::ostream& operator<<(std::ostream& os, composite_view v) {
+    fmt::print(os, "{}", v);
+    return os;
+}
 
 inline
 composite::composite(const composite_view& v)

--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -310,11 +310,11 @@ using index_list = partition_index_page;
 }
 
 inline std::ostream& operator<<(std::ostream& out, const sstables::promoted_index_block_position_view& pos) {
-    std::visit([&out] (const auto& pos) mutable { out << pos; }, pos);
+    std::visit([&out] (const auto& pos) mutable { fmt::print(out, "{}", pos); }, pos);
     return out;
 }
 
 inline std::ostream& operator<<(std::ostream& out, const sstables::promoted_index_block_position& pos) {
-    std::visit([&out] (const auto& pos) mutable { out << pos; }, pos);
+    std::visit([&out] (const auto& pos) mutable { fmt::print(out, "{}", pos); }, pos);
     return out;
 }


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `composite` and `composite_view` without using ostream<<. also, this change removes `operator<<(ostream, const composite&)` ,  `operator<<(ostream, const composite_view&)` along with their callers.

Refs #13245