### PR TITLE
bytes, gms: s/format_to/fmt::format_to/

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -113,14 +113,14 @@ public:
         if (_group_size_in_bytes > 0) {
             for (size_t i = 0, size = v.size(); i < size; i++) {
                 if (i != 0 && i % _group_size_in_bytes == 0) {
-                    format_to(out, "{}{:02x}", _delimiter, std::byte(v[i]));
+                    fmt::format_to(out, "{}{:02x}", _delimiter, std::byte(v[i]));
                 } else {
-                    format_to(out, "{:02x}", std::byte(v[i]));
+                    fmt::format_to(out, "{:02x}", std::byte(v[i]));
                 }
             }
         } else {
             for (auto b : v) {
-                format_to(out, "{:02x}", std::byte(b));
+                fmt::format_to(out, "{:02x}", std::byte(b));
             }
         }
         return out;

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -98,9 +98,9 @@ struct fmt::formatter<gms::inet_address> : fmt::formatter<std::string_view> {
             return fmt::format_to(ctx.out(), "{}", x.addr());
         }
         // print 2 bytes in a group, and use ':' as the delimeter
-        format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
+        fmt::format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
         if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
-            return format_to(ctx.out(), "%{}", x.addr().scope());
+            return fmt::format_to(ctx.out(), "%{}", x.addr().scope());
         }
         return ctx.out();
     }


### PR DESCRIPTION
to disambiguate `fmt::format_to()` from `std::format_to()`. turns out, we have `using namespace std` somewhere in the source tree, and with libstdc++ shipped by GCC-13, we have `std::format_to()`, so without exactly which one to use, compiler complains like

```
/optimized_clang/stage-1-X86/build/bin/clang++ -MD -MT build/dev/mutation/mutation.o -MF build/dev/mutation/mutation.o.d -I/optimized_clang/scylla-X86/seastar/include -I/optimized_clang/scylla-X86/build/dev/seastar/gen/include -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Werror=unused-result -fstack-clash-protection -DSEASTAR_API_LEVEL=6 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_TYPE_ERASE_MORE -DFMT_SHARED -I/usr/include/p11-kit-1   -ffile-prefix-map=/optimized_clang/scylla-X86=. -march=westmere -DDEVEL -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSCYLLA_ENABLE_ERROR_INJECTION -O2 -DSCYLLA_BUILD_MODE=dev -iquote. -iquote build/dev/gen --std=gnu++20  -ffile-prefix-map=/optimized_clang/scylla-X86=. -march=westmere  -DBOOST_TEST_DYN_LINK   -DNOMINMAX -DNOMINMAX -fvisibility=hidden  -Wall -Werror -Wno-mismatched-tags -Wno-tautological-compare -Wno-parentheses-equality -Wno-c++11-narrowing -Wno-missing-braces -Wno-ignored-attributes -Wno-overloaded-virtual -Wno-unused-command-line-argument -Wno-unsupported-friend -Wno-delete-non-abstract-non-virtual-dtor -Wno-braced-scalar-init -Wno-implicit-int-float-conversion -Wno-delete-abstract-non-virtual-dtor -Wno-psabi -Wno-narrowing -Wno-nonnull -Wno-uninitialized -Wno-error=deprecated-declarations -DXXH_PRIVATE_API -DSEASTAR_TESTING_MAIN -DFMT_DEPRECATED_OSTREAM  -c -o build/dev/mutation/mutation.o mutation/mutation.cc
In file included from mutation/mutation.cc:9:
In file included from mutation/mutation.hh:13:
In file included from mutation/mutation_partition.hh:21:
In file included from ./schema/schema_fwd.hh:13:
In file included from ./utils/UUID.hh:22:
./bytes.hh:116:21: error: call to 'format_to' is ambiguous
                    format_to(out, "{}{:02x}", _delimiter, std::byte(v[i]));
                    ^~~~~~~~~
./bytes.hh:134:43: note: in instantiation of function template specialization 'fmt::formatter<fmt_hex>::format<fmt::basic_format_context<fmt::appender, char>>' requested here
        return fmt::formatter<::fmt_hex>::format(::fmt_hex(bytes_view(s)), ctx);
                                          ^
/usr/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<seastar::basic_sstring<signed char, unsigned int, 31, false>>::format<fmt::basic_format_context<fmt::appender, char>>' requested here
    -> decltype(typename Context::template formatter_type<T>().format(
                                                               ^
/usr/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = seastar::basic_sstring<signed char, unsigned int, 31, false>]
  return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
```

to address this FTBFS, let's be more explicit by adding "fmt::" to specify which `format_to()` to use.