### PR TITLE
Break the proxy -> database -> [views] -> proxy loop

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2295,7 +2295,6 @@ public:
         if (!step.current_key.key().is_empty(*_step.reader.schema())) {
             load_views_to_build();
         }
-        (void)_gen;
     }
 
     void load_views_to_build() {
@@ -2396,6 +2395,7 @@ public:
             auto close_reader = defer([&reader] { reader.close().get(); });
             reader.upgrade_schema(base_schema);
             _step.base->populate_views(
+                    _gen,
                     std::move(views),
                     _step.current_token(),
                     std::move(reader),

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2606,7 +2606,7 @@ view_updating_consumer::view_updating_consumer(view_update_generator& gen, schem
     : view_updating_consumer(std::move(schema), std::move(permit), as, staging_reader_handle,
             [table = table.shared_from_this(), excluded_sstables = std::move(excluded_sstables), gen = gen.shared_from_this()] (mutation m) mutable {
         auto s = m.schema();
-        return table->stream_view_replica_updates(std::move(s), std::move(m), db::no_timeout, excluded_sstables);
+        return table->stream_view_replica_updates(gen, std::move(s), std::move(m), db::no_timeout, excluded_sstables);
     })
 { }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -35,6 +35,7 @@
 #include "db/view/view.hh"
 #include "db/view/view_builder.hh"
 #include "db/view/view_updating_consumer.hh"
+#include "db/view/view_update_generator.hh"
 #include "db/system_keyspace_view_types.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
@@ -2597,10 +2598,10 @@ void view_updating_consumer::maybe_flush_buffer_mid_partition() {
     }
 }
 
-view_updating_consumer::view_updating_consumer(schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
+view_updating_consumer::view_updating_consumer(view_update_generator& gen, schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
         evictable_reader_handle_v2& staging_reader_handle)
     : view_updating_consumer(std::move(schema), std::move(permit), as, staging_reader_handle,
-            [table = table.shared_from_this(), excluded_sstables = std::move(excluded_sstables)] (mutation m) mutable {
+            [table = table.shared_from_this(), excluded_sstables = std::move(excluded_sstables), gen = gen.shared_from_this()] (mutation m) mutable {
         auto s = m.schema();
         return table->stream_view_replica_updates(std::move(s), std::move(m), db::no_timeout, excluded_sstables);
     })

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1746,11 +1746,12 @@ future<> mutate_MV(
     });
 }
 
-view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn)
+view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn, view_update_generator& vug)
         : _db(db)
         , _sys_ks(sys_ks)
         , _sys_dist_ks(sys_dist_ks)
         , _mnotifier(mn)
+        , _vug(vug)
         , _permit(_db.get_reader_concurrency_semaphore().make_tracking_only_permit(nullptr, "view_builder", db::no_timeout, {})) {
     setup_metrics();
 }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1614,7 +1614,7 @@ static bool should_update_synchronously(const schema& s) {
 // to a modification of a single base partition, and apply them to the
 // appropriate paired replicas. This is done asynchronously - we do not wait
 // for the writes to complete.
-future<> mutate_MV(
+future<> view_update_generator::mutate_MV(
         dht::token base_token,
         utils::chunked_vector<frozen_mutation_and_schema> view_updates,
         db::view::stats& stats,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1543,9 +1543,8 @@ bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_b
 // If the assumption that the given base token belongs to this replica
 // does not hold, we return an empty optional.
 static std::optional<gms::inet_address>
-get_view_natural_endpoint(const sstring& keyspace_name,
+get_view_natural_endpoint(replica::database& db, const sstring& keyspace_name,
         const dht::token& base_token, const dht::token& view_token) {
-    auto &db = service::get_local_storage_proxy().local_db();
     auto& ks = db.find_keyspace(keyspace_name);
     auto erm = ks.get_effective_replication_map();
     auto& topology = erm->get_token_metadata_ptr()->get_topology();
@@ -1586,13 +1585,13 @@ get_view_natural_endpoint(const sstring& keyspace_name,
     return view_endpoints[base_it - base_endpoints.begin()];
 }
 
-static future<> apply_to_remote_endpoints(gms::inet_address target, inet_address_vector_topology_change&& pending_endpoints,
+static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, gms::inet_address target, inet_address_vector_topology_change&& pending_endpoints,
         frozen_mutation_and_schema&& mut, const dht::token& base_token, const dht::token& view_token,
         service::allow_hints allow_hints, tracing::trace_state_ptr tr_state) {
 
     tracing::trace(tr_state, "Sending view update for {}.{} to {}, with pending endpoints = {}; base token = {}; view token = {}",
             mut.s->ks_name(), mut.s->cf_name(), target, pending_endpoints, base_token, view_token);
-    return service::get_local_storage_proxy().send_to_endpoint(
+    return proxy.send_to_endpoint(
             std::move(mut),
             target,
             std::move(pending_endpoints),
@@ -1626,11 +1625,11 @@ future<> view_update_generator::mutate_MV(
 {
     static constexpr size_t max_concurrent_updates = 128;
     co_await max_concurrent_for_each(view_updates, max_concurrent_updates,
-            [base_token, &stats, &cf_stats, tr_state, &pending_view_updates, allow_hints, wait_for_all] (frozen_mutation_and_schema mut) mutable -> future<> {
+            [this, base_token, &stats, &cf_stats, tr_state, &pending_view_updates, allow_hints, wait_for_all] (frozen_mutation_and_schema mut) mutable -> future<> {
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto& keyspace_name = mut.s->ks_name();
-        auto target_endpoint = get_view_natural_endpoint(keyspace_name, base_token, view_token);
-        auto remote_endpoints = service::get_local_storage_proxy().get_token_metadata_ptr()->pending_endpoints_for(view_token, keyspace_name);
+        auto target_endpoint = get_view_natural_endpoint(_proxy.local().local_db(), keyspace_name, base_token, view_token);
+        auto remote_endpoints = _proxy.local().get_token_metadata_ptr()->pending_endpoints_for(view_token, keyspace_name);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());
 
         const bool update_synchronously = should_update_synchronously(*mut.s);
@@ -1677,7 +1676,7 @@ future<> view_update_generator::mutate_MV(
             auto mut_ptr = remote_endpoints.empty() ? std::make_unique<frozen_mutation>(std::move(mut.fm)) : std::make_unique<frozen_mutation>(mut.fm);
             tracing::trace(tr_state, "Locally applying view update for {}.{}; base token = {}; view token = {}",
                     mut.s->ks_name(), mut.s->cf_name(), base_token, view_token);
-            local_view_update = service::get_local_storage_proxy().mutate_locally(mut.s, *mut_ptr, tr_state, db::commitlog::force_sync::no).then_wrapped(
+            local_view_update = _proxy.local().mutate_locally(mut.s, *mut_ptr, tr_state, db::commitlog::force_sync::no).then_wrapped(
                     [s = mut.s, &stats, &cf_stats, tr_state, base_token, view_token, my_address, mut_ptr = std::move(mut_ptr),
                             units = sem_units.split(sem_units.count())] (future<>&& f) {
                 --stats.writes;
@@ -1714,7 +1713,7 @@ future<> view_update_generator::mutate_MV(
             stats.view_updates_pushed_remote += updates_pushed_remote;
             cf_stats.total_view_updates_pushed_remote += updates_pushed_remote;
             schema_ptr s = mut.s;
-            future<> view_update = apply_to_remote_endpoints(*target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
+            future<> view_update = apply_to_remote_endpoints(_proxy.local(), *target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
                     [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote,
                             units = sem_units.split(sem_units.count()), apply_update_synchronously] (future<>&& f) mutable {
                 if (f.failed()) {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -21,11 +21,6 @@ namespace replica {
 struct cf_stats;
 }
 
-namespace service {
-struct allow_hints_tag;
-using allow_hints = bool_class<allow_hints_tag>;
-}
-
 namespace db {
 
 namespace view {
@@ -314,18 +309,6 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const std::vector<view_and_base>& views);
 
 bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views);
-
-struct wait_for_all_updates_tag {};
-using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
-future<> mutate_MV(
-        dht::token base_token,
-        utils::chunked_vector<frozen_mutation_and_schema> view_updates,
-        db::view::stats& stats,
-        replica::cf_stats& cf_stats,
-        tracing::trace_state_ptr tr_state,
-        db::timeout_semaphore_units pending_view_updates,
-        service::allow_hints allow_hints,
-        wait_for_all_updates wait_for_all);
 
 /**
  * create_virtual_column() adds a "virtual column" to a schema builder.

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -53,6 +53,8 @@ class exponential_backoff_retry;
 
 namespace db::view {
 
+class view_update_generator;
+
 /**
  * The view_builder is a sharded service responsible for building all defined materialized views.
  * This process entails walking over the existing data in a given base table, and using it to
@@ -151,6 +153,7 @@ class view_builder final : public service::migration_listener::only_view_notific
     db::system_keyspace& _sys_ks;
     db::system_distributed_keyspace& _sys_dist_ks;
     service::migration_notifier& _mnotifier;
+    view_update_generator&  _vug;
     reader_permit _permit;
     base_to_build_step_type _base_to_build_step;
     base_to_build_step_type::iterator _current_step = _base_to_build_step.end();
@@ -187,7 +190,7 @@ public:
     static constexpr size_t batch_memory_max = 1024*1024;
 
 public:
-    view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&);
+    view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&, view_update_generator& vug);
     view_builder(view_builder&&) = delete;
 
     /**

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -97,6 +97,7 @@ view_update_generator::view_update_generator(replica::database& db, sharded<serv
     setup_metrics();
     discover_staging_sstables();
     (void)_proxy;
+    _db.plug_view_update_generator(*this);
 }
 
 view_update_generator::~view_update_generator() {}
@@ -206,6 +207,7 @@ future<> view_update_generator::start() {
 }
 
 future<> view_update_generator::stop() {
+    _db.unplug_view_update_generator();
     _as.request_abort();
     _pending_sstables.signal();
     return std::move(_started).then([this] {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -90,9 +90,13 @@ public:
     }
 };
 
-view_update_generator::view_update_generator(replica::database& db) : _db(db), _progress_tracker(std::make_unique<progress_tracker>()) {
+view_update_generator::view_update_generator(replica::database& db, sharded<service::storage_proxy>& proxy)
+        : _db(db)
+        , _proxy(proxy)
+        , _progress_tracker(std::make_unique<progress_tracker>()) {
     setup_metrics();
     discover_staging_sstables();
+    (void)_proxy;
 }
 
 view_update_generator::~view_update_generator() {}

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -165,7 +165,7 @@ future<> view_update_generator::start() {
                             ::mutation_reader::forwarding::no);
 
                     inject_failure("view_update_generator_consume_staging_sstable");
-                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(s, std::move(permit), *t, sstables, _as, staging_sstable_reader_handle),
+                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(*this, s, std::move(permit), *t, sstables, _as, staging_sstable_reader_handle),
                         dht::incremental_owned_ranges_checker::make_partition_filter(_db.get_keyspace_local_ranges(s->ks_name())));
                     staging_sstable_reader.close().get();
                     if (result == stop_iteration::yes) {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -96,7 +96,6 @@ view_update_generator::view_update_generator(replica::database& db, sharded<serv
         , _progress_tracker(std::make_unique<progress_tracker>()) {
     setup_metrics();
     discover_staging_sstables();
-    (void)_proxy;
     _db.plug_view_update_generator(*this);
 }
 

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -9,7 +9,10 @@
 #pragma once
 
 #include "sstables/shared_sstable.hh"
+#include "db/timeout_clock.hh"
+#include "utils/chunked_vector.hh"
 
+#include <seastar/core/sharded.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
@@ -17,16 +20,33 @@
 
 using namespace seastar;
 
+struct frozen_mutation_and_schema;
+
+namespace dht {
+class token;
+}
+
+namespace tracing {
+class trace_state_ptr;
+}
+
 namespace replica {
 class database;
 class table;
+struct cf_stats;
 }
 
 namespace service {
 class storage_proxy;
+struct allow_hints_tag;
+using allow_hints = bool_class<allow_hints_tag>;
 }
 
 namespace db::view {
+
+class stats;
+struct wait_for_all_updates_tag {};
+using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 
 class view_update_generator : public async_sharded_service<view_update_generator> {
 public:
@@ -51,6 +71,16 @@ public:
     future<> start();
     future<> stop();
     future<> register_staging_sstable(sstables::shared_sstable sst, lw_shared_ptr<replica::table> table);
+
+    future<> mutate_MV(
+            dht::token base_token,
+            utils::chunked_vector<frozen_mutation_and_schema> view_updates,
+            db::view::stats& stats,
+            replica::cf_stats& cf_stats,
+            tracing::trace_state_ptr tr_state,
+            db::timeout_semaphore_units pending_view_updates,
+            service::allow_hints allow_hints,
+            wait_for_all_updates wait_for_all);
 
     ssize_t available_register_units() const { return _registration_sem.available_units(); }
 private:

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -22,6 +22,10 @@ class database;
 class table;
 }
 
+namespace service {
+class storage_proxy;
+}
+
 namespace db::view {
 
 class view_update_generator {
@@ -30,6 +34,7 @@ public:
 
 private:
     replica::database& _db;
+    sharded<service::storage_proxy>& _proxy;
     seastar::abort_source _as;
     future<> _started = make_ready_future<>();
     seastar::condition_variable _pending_sstables;
@@ -40,7 +45,7 @@ private:
     class progress_tracker;
     std::unique_ptr<progress_tracker> _progress_tracker;
 public:
-    view_update_generator(replica::database& db);
+    view_update_generator(replica::database& db, sharded<service::storage_proxy>& proxy);
     ~view_update_generator();
 
     future<> start();

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -28,7 +28,7 @@ class storage_proxy;
 
 namespace db::view {
 
-class view_update_generator {
+class view_update_generator : public async_sharded_service<view_update_generator> {
 public:
     static constexpr size_t registration_queue_size = 5;
 

--- a/db/view/view_updating_consumer.hh
+++ b/db/view/view_updating_consumer.hh
@@ -24,6 +24,8 @@ class evictable_reader_handle_v2;
 
 namespace db::view {
 
+class view_update_generator;
+
 /*
  * A consumer that pushes materialized view updates for each consumed mutation.
  * It is expected to be run in seastar::async threaded context through consume_in_thread()
@@ -62,7 +64,7 @@ public:
             , _view_update_pusher(std::move(view_update_pusher))
     { }
 
-    view_updating_consumer(schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
+    view_updating_consumer(view_update_generator& gen, schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
             evictable_reader_handle_v2& staging_reader_handle);
 
     view_updating_consumer(view_updating_consumer&&) = default;

--- a/main.cc
+++ b/main.cc
@@ -1603,7 +1603,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             static sharded<db::view::view_builder> view_builder;
             if (cfg->view_building()) {
                 supervisor::notify("starting the view builder");
-                view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier)).get();
+                view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator)).get();
                 view_builder.invoke_on_all([&mm] (db::view::view_builder& vb) { 
                     return vb.start(mm.local());
                 }).get();

--- a/main.cc
+++ b/main.cc
@@ -1269,7 +1269,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
             supervisor::notify("starting view update generator");
-            view_update_generator.start(std::ref(db)).get();
+            view_update_generator.start(std::ref(db), std::ref(proxy)).get();
 
             supervisor::notify("starting commit log");
             auto cl = db.local().commitlog();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -47,6 +47,7 @@
 #include "timeout_config.hh"
 #include "service/storage_proxy.hh"
 #include "db/operation_type.hh"
+#include "db/view/view_update_generator.hh"
 
 #include "utils/human_readable.hh"
 #include "utils/fb_utilities.hh"
@@ -2717,6 +2718,14 @@ void database::plug_system_keyspace(db::system_keyspace& sys_ks) noexcept {
 void database::unplug_system_keyspace() noexcept {
     _compaction_manager.unplug_system_keyspace();
     _large_data_handler->unplug_system_keyspace();
+}
+
+void database::plug_view_update_generator(db::view::view_update_generator& generator) noexcept {
+    _view_update_generator = generator.shared_from_this();
+}
+
+void database::unplug_view_update_generator() noexcept {
+    _view_update_generator = nullptr;
 }
 
 } // namespace replica

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1026,12 +1026,12 @@ public:
     void remove_view(view_ptr v);
     void clear_views();
     const std::vector<view_ptr>& views() const;
-    future<row_locker::lock_holder> push_view_replica_updates(const schema_ptr& s, const frozen_mutation& fm, db::timeout_clock::time_point timeout,
+    future<row_locker::lock_holder> push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, const frozen_mutation& fm, db::timeout_clock::time_point timeout,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const;
-    future<row_locker::lock_holder> push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
+    future<row_locker::lock_holder> push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const;
     future<row_locker::lock_holder>
-    stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
+    stream_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
             std::vector<sstables::shared_sstable>& excluded_sstables) const;
 
     void add_coordinator_read_latency(utils::estimated_histogram::duration latency);
@@ -1067,10 +1067,10 @@ public:
     size_t estimate_read_memory_cost() const;
 
 private:
-    future<row_locker::lock_holder> do_push_view_replica_updates(schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
+    future<row_locker::lock_holder> do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
     std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update) const;
-    future<> generate_and_propagate_view_updates(const schema_ptr& base,
+    future<> generate_and_propagate_view_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base,
             reader_permit permit,
             std::vector<db::view::view_and_base>&& views,
             mutation&& m,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1051,6 +1051,7 @@ public:
 
     // Reader's schema must be the same as the base schema of each of the views.
     future<> populate_views(
+            shared_ptr<db::view::view_update_generator> gen,
             std::vector<db::view::view_and_base>,
             dht::token base_token,
             flat_mutation_reader_v2&&,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -123,6 +123,10 @@ class table_selector;
 
 future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase);
 
+namespace view {
+class view_update_generator;
+}
+
 }
 
 class mutation_reordered_with_truncate_exception : public std::exception {};
@@ -1323,6 +1327,7 @@ private:
     db::timeout_semaphore _view_update_concurrency_sem{max_memory_pending_view_updates()};
 
     cache_tracker _row_cache_tracker;
+    seastar::shared_ptr<db::view::view_update_generator> _view_update_generator;
 
     inheriting_concrete_execution_stage<
             future<>,
@@ -1399,6 +1404,9 @@ public:
 
     void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
     void unplug_system_keyspace() noexcept;
+
+    void plug_view_update_generator(db::view::view_update_generator& generator) noexcept;
+    void unplug_view_update_generator() noexcept;
 
 private:
     future<> flush_non_system_column_families();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2107,6 +2107,7 @@ table::local_base_lock(
  * @return a future that resolves when the updates have been acknowledged by the view replicas
  */
 future<> table::populate_views(
+        shared_ptr<db::view::view_update_generator> gen,
         std::vector<db::view::view_and_base> views,
         dht::token base_token,
         flat_mutation_reader_v2&& reader,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1967,7 +1967,7 @@ static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_sc
  * but has simply some updated values.
  * @return a future resolving to the mutations to apply to the views, which can be empty.
  */
-future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
+future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base,
         reader_permit permit,
         std::vector<db::view::view_and_base>&& views,
         mutation&& m,
@@ -2572,14 +2572,14 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
  * Given an update for the base table, calculates the set of potentially affected views,
  * generates the relevant updates, and sends them to the paired view replicas.
  */
-future<row_locker::lock_holder> table::push_view_replica_updates(const schema_ptr& s, const frozen_mutation& fm,
+future<row_locker::lock_holder> table::push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, const frozen_mutation& fm,
         db::timeout_clock::time_point timeout, tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const {
     //FIXME: Avoid unfreezing here.
     auto m = fm.unfreeze(s);
-    return push_view_replica_updates(s, std::move(m), timeout, std::move(tr_state), sem);
+    return push_view_replica_updates(std::move(gen), s, std::move(m), timeout, std::move(tr_state), sem);
 }
 
-future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
+future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
         tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const {
     if (!_config.view_update_concurrency_semaphore->current()) {
         // We don't have resources to generate view updates for this write. If we reached this point, we failed to
@@ -2605,7 +2605,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
     const bool need_static = db::view::needs_static_row(m.partition(), views);
     if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
-        co_await generate_and_propagate_view_updates(base, sem.make_tracking_only_permit(s.get(), "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now);
+        co_await generate_and_propagate_view_updates(gen, base, sem.make_tracking_only_permit(s.get(), "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
@@ -2640,7 +2640,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = sem.make_tracking_only_permit(base.get(), "push-view-updates-2", timeout, tr_state);
     auto reader = source.make_reader_v2(base, permit, pk, slice, io_priority, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    co_await this->generate_and_propagate_view_updates(base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now);
+    co_await this->generate_and_propagate_view_updates(gen, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());
     // return the local partition/row lock we have taken so it
     // remains locked until the caller is done modifying this
@@ -2649,16 +2649,17 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
 
 }
 
-future<row_locker::lock_holder> table::push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
+future<row_locker::lock_holder> table::push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
         tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const {
-    return do_push_view_replica_updates(s, std::move(m), timeout, as_mutation_source(),
+    return do_push_view_replica_updates(std::move(gen), s, std::move(m), timeout, as_mutation_source(),
             std::move(tr_state), sem, service::get_local_sstable_query_read_priority(), {});
 }
 
 future<row_locker::lock_holder>
-table::stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
+table::stream_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
         std::vector<sstables::shared_sstable>& excluded_sstables) const {
     return do_push_view_replica_updates(
+            std::move(gen),
             s,
             std::move(m),
             timeout,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -34,7 +34,7 @@
 #include "db/system_keyspace.hh"
 #include "db/query_context.hh"
 #include "query-result-writer.hh"
-#include "db/view/view.hh"
+#include "db/view/view_update_generator.hh"
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include "utils/error_injection.hh"
@@ -1999,7 +1999,7 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
         tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
         auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(*updates));
         try {
-            co_await db::view::mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats, tr_state,
+            co_await gen->mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats, tr_state,
                 std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no);
         } catch (...) {
             // Ignore exceptions: any individual failure to propagate a view update will be reported
@@ -2132,7 +2132,7 @@ future<> table::populate_views(
             size_t units_to_wait_for = std::min(_config.view_update_concurrency_semaphore_limit, update_size);
             auto units = co_await seastar::get_units(*_config.view_update_concurrency_semaphore, units_to_wait_for);
             units.adopt(seastar::consume_units(*_config.view_update_concurrency_semaphore, update_size - units_to_wait_for));
-            co_await db::view::mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats,
+            co_await gen->mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats,
                     tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
         } catch (...) {
             if (!err) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -839,7 +839,7 @@ public:
                 raft_gr.invoke_on_all(&service::raft_group_registry::drain_on_shutdown).get();
             });
 
-            view_update_generator.start(std::ref(db)).get();
+            view_update_generator.start(std::ref(db), std::ref(proxy)).get();
             view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
             auto stop_view_update_generator = defer([&view_update_generator] {
                 view_update_generator.stop().get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -917,7 +917,7 @@ public:
             });
 
             sharded<db::view::view_builder> view_builder;
-            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notif)).get();
+            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notif), std::ref(view_update_generator)).get();
             view_builder.invoke_on_all([&mm] (db::view::view_builder& vb) {
                 return vb.start(mm.local());
             }).get();


### PR DESCRIPTION
... and drop usage of global storage proxy from several places of mutate_MV().

This is the last dependency loop around storage proxy left as long as the last user of the global storage proxy. The trouble is that while proxy naturally depends on database, the database SUDDENLY requires proxy to push view updates from the guts of database::do_apply().

Similar loop existed in a form of database -> { large_data_handler, compaction manager } -> system keyspace -> database and it was cut in 917fdb9e53 (Cut database-system_keyspace circular dependency) by introducing a soft dependency link from l. d. handler / compaction manager to system keyspace. The similar solution is proposed here.

The database instance gets a soft dependency (shared_ptr) to view_update_generator instance. On start the link is nullptr and pushing view updates is not possible until view_updates_generator starts and plugs itself to the database. The plugging happens naturally, because v.u.generator needs proxy as explicit dependency and, thus, can reach database via proxy. This (seems to) works because tables that need view updates don't start being mutated until late enough, as late as v.u.generator starts.

As a nice side effect this allows removing a bunch of global storage proxy usages from mutate_MV() which opens a pretty  short way towards de-globalizing proxy (after it only qctx, tracing and schema registry will be left).