### PR TITLE
wasm: add noexcept specifier for alien::run_on()

### DIFF
--- a/lang/wasm_alien_thread_runner.cc
+++ b/lang/wasm_alien_thread_runner.cc
@@ -69,11 +69,11 @@ void alien_thread_runner::submit(seastar::promise<rust::Box<wasmtime::Module>>& 
     seastar::noncopyable_function<void()> packaged([f = std::move(f), &p, &alien = seastar::engine().alien(), shard = seastar::this_shard_id()] () mutable {
         try {
             rust::Box<wasmtime::Module> mod = f();
-            seastar::alien::run_on(alien, shard, [&p, mod = std::move(mod)] () mutable {
+            seastar::alien::run_on(alien, shard, [&p, mod = std::move(mod)] () mutable noexcept {
                 p.set_value(std::move(mod));
             });
         } catch (...) {
-            seastar::alien::run_on(alien, shard, [&, eptr = std::current_exception()] {
+            seastar::alien::run_on(alien, shard, [&, eptr = std::current_exception()]() noexcept {
                 p.set_exception(wasm::exception(format("Compilation failed: {}", eptr)));
             });
         }


### PR DESCRIPTION
as alien::run_on() requires the function to be noexcept, let's make this explicit. also, this paves the road to the type constraint added to `alien::run_on()`. the type contraint will enforce this requirement to the function passed to `alien::run_on()`.