### PR TITLE
token_metadata: read remapping for write_both_read_new

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -435,6 +435,7 @@ scylla_tests = set([
     'test/boost/mutation_writer_test',
     'test/boost/mvcc_test',
     'test/boost/network_topology_strategy_test',
+    'test/boost/token_metadata_test',
     'test/boost/tablets_test',
     'test/boost/nonwrapping_range_test',
     'test/boost/observable_test',

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -329,7 +329,7 @@ filter_for_query(consistency_level cl,
         }));
 
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
-            // local node is always first if present (see storage_proxy::get_live_sorted_endpoints)
+            // local node is always first if present (see storage_proxy::get_endpoints_for_reading)
             unsigned local_idx = epi[0].first == utils::fb_utilities::get_broadcast_address() ? 0 : epi.size() + 1;
             live_endpoints = boost::copy_range<inet_address_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
         }

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -203,14 +203,14 @@ public:
      * @return new token metadata
      */
     future<std::unique_ptr<token_metadata_impl>> clone_after_all_left() const noexcept {
-      return clone_only_token_map(false).then([this] (std::unique_ptr<token_metadata_impl> all_left_metadata) {
-        for (auto endpoint : _leaving_endpoints) {
-            all_left_metadata->remove_endpoint(endpoint);
-        }
-        all_left_metadata->sort_tokens();
+        return clone_only_token_map(false).then([this] (std::unique_ptr<token_metadata_impl> all_left_metadata) {
+            for (auto endpoint : _leaving_endpoints) {
+                all_left_metadata->remove_endpoint(endpoint);
+            }
+            all_left_metadata->sort_tokens();
 
-        return all_left_metadata;
-      });
+            return all_left_metadata;
+        });
     }
 
     /**

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -245,27 +245,14 @@ public:
 
     bool has_pending_ranges(sstring keyspace_name, inet_address endpoint) const;
      /**
-     * Calculate pending ranges according to bootsrapping and leaving nodes. Reasoning is:
+     * Calculate pending ranges according to bootstrapping, leaving and replacing nodes.
      *
-     * (1) When in doubt, it is better to write too much to a node than too little. That is, if
-     * there are multiple nodes moving, calculate the biggest ranges a node could have. Cleaning
-     * up unneeded data afterwards is better than missing writes during movement.
-     * (2) When a node leaves, ranges for other nodes can only grow (a node might get additional
-     * ranges, but it will not lose any of its current ranges as a result of a leave). Therefore
-     * we will first remove _all_ leaving tokens for the sake of calculation and then check what
-     * ranges would go where if all nodes are to leave. This way we get the biggest possible
-     * ranges with regard current leave operations, covering all subsets of possible final range
-     * values.
-     * (3) When a node bootstraps, ranges of other nodes can only get smaller. Without doing
-     * complex calculations to see if multiple bootstraps overlap, we simply base calculations
-     * on the same token ring used before (reflecting situation after all leave operations have
-     * completed). Bootstrapping nodes will be added and removed one by one to that metadata and
-     * checked what their ranges would be. This will give us the biggest possible ranges the
-     * node could have. It might be that other bootstraps make our actual final ranges smaller,
-     * but it does not matter as we can clean up the data afterwards.
-     *
-     * NOTE: This is heavy and ineffective operation. This will be done only once when a node
-     * changes state in the cluster, so it should be manageable.
+     * We construct an updated version of the token_metadata by incorporating
+     * all proposed modifications (join, bootstrap, and replace operations).
+     * Subsequently, for each token range, we compare the outcomes of the calculate_natural_endpoints
+     * function applied to both the previous and the new token_metadata.
+     * Endpoints present in the updated version but absent in the original one
+     * ought to be appended to the pending_ranges.
      */
     future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name, dc_rack_fn& get_dc_rack);
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -28,6 +28,7 @@
 
 #include "locator/types.hh"
 #include "locator/topology.hh"
+#include "service/topology_state_machine.hh"
 
 // forward declaration since replica/database.hh includes this file
 namespace replica {
@@ -266,6 +267,16 @@ public:
 
     // returns empty vector if keyspace_name not found.
     inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
+
+    // This function returns a list of nodes to which a read request should be directed.
+    // Returns not null only during topology changes, if _topology_change_stage == read_new and
+    // new set of replicas differs from the old one.
+    std::optional<inet_address_vector_replica_set> endpoints_for_reading(const token& token, const sstring& keyspace_name) const;
+
+    // updates the current topology_transition_state of this instance,
+    // this value is preserved in all clone functions,
+    // by default it's not set
+    void set_topology_transition_state(std::optional<service::topology::transition_state> state);
 
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
     std::multimap<inet_address, token> get_endpoint_to_token_map_for_reading() const;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5089,10 +5089,10 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     speculative_retry::type retry_type = schema->speculative_retry().get_type();
     std::optional<gms::inet_address> extra_replica;
 
-    inet_address_vector_replica_set all_replicas = get_live_sorted_endpoints(*erm, token);
+    inet_address_vector_replica_set all_replicas = get_endpoints_for_reading(schema->ks_name(), *erm, token);
     // Check for a non-local read before heat-weighted load balancing
     // reordering of endpoints happens. The local endpoint, if
-    // present, is always first in the list, as get_live_sorted_endpoints()
+    // present, is always first in the list, as get_endpoints_for_reading()
     // orders the list by proximity to the local endpoint.
     is_read_non_local |= !all_replicas.empty() && all_replicas.front() != utils::fb_utilities::get_broadcast_address();
 
@@ -5403,7 +5403,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
     auto& gossiper = _remote->gossiper();
     while (i != ranges.end()) {
         dht::partition_range& range = *i;
-        inet_address_vector_replica_set live_endpoints = get_live_sorted_endpoints(*erm, end_token(range));
+        inet_address_vector_replica_set live_endpoints = get_endpoints_for_reading(schema->ks_name(), *erm, end_token(range));
         inet_address_vector_replica_set merged_preferred_replicas = preferred_replicas_for_range(*i);
         inet_address_vector_replica_set filtered_endpoints = filter_for_query(cl, *erm, live_endpoints, merged_preferred_replicas, gossiper, pcf);
         std::vector<dht::token_range> merged_ranges{to_token_range(range)};
@@ -5416,7 +5416,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
         {
             const auto current_range_preferred_replicas = preferred_replicas_for_range(*i);
             dht::partition_range& next_range = *i;
-            inet_address_vector_replica_set next_endpoints = get_live_sorted_endpoints(*erm, end_token(next_range));
+            inet_address_vector_replica_set next_endpoints = get_endpoints_for_reading(schema->ks_name(), *erm, end_token(next_range));
             inet_address_vector_replica_set next_filtered_endpoints = filter_for_query(cl, *erm, next_endpoints, current_range_preferred_replicas, gossiper, pcf);
 
             // Origin has this to say here:
@@ -6005,7 +6005,7 @@ void storage_proxy::sort_endpoints_by_proximity(const locator::topology& topo, i
     }
 }
 
-inet_address_vector_replica_set storage_proxy::get_live_sorted_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const {
+inet_address_vector_replica_set storage_proxy::get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const {
     auto eps = get_live_endpoints(erm, token);
     sort_endpoints_by_proximity(erm.get_topology(), eps);
     return eps;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -327,7 +327,7 @@ private:
     bool hints_enabled(db::write_type type) const noexcept;
     db::hints::manager& hints_manager_for(db::write_type type);
     void sort_endpoints_by_proximity(const locator::topology& topo, inet_address_vector_replica_set& eps) const;
-    inet_address_vector_replica_set get_live_sorted_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
+    inet_address_vector_replica_set get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const;
     bool is_alive(const gms::inet_address&) const;
     db::read_repair_decision new_read_repair_decision(const schema& s);
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -354,6 +354,8 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
             co_await add_normal_node(id, rs);
         }
 
+        tmptr->set_topology_transition_state(_topology_state_machine._topology.tstate);
+
         for (const auto& [id, rs]: _topology_state_machine._topology.transition_nodes) {
             locator::host_id host_id{id.uuid()};
             auto ip = co_await id2ip(id);

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -201,6 +201,8 @@ add_scylla_test(map_difference_test
   KIND BOOST)
 add_scylla_test(network_topology_strategy_test
   KIND SEASTAR)
+add_scylla_test(token_metadata_test
+  KIND SEASTAR)
 add_scylla_test(nonwrapping_range_test
   KIND BOOST)
 add_scylla_test(observable_test

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/testing/thread_test_case.hh>
+#include "utils/fb_utilities.hh"
+#include "locator/token_metadata.hh"
+#include "locator/simple_strategy.hh"
+
+using namespace locator;
+
+namespace {
+    const auto ks_name = sstring("test-ks");
+
+    endpoint_dc_rack get_dc_rack(inet_address) {
+        return {
+            .dc = "unk-dc",
+            .rack = "unk-rack"
+        };
+    }
+
+    token_metadata create_token_metadata(inet_address this_endpoint) {
+        return token_metadata({
+            topology::config {
+                .this_host_id = host_id::create_random_id(),
+                .this_endpoint = this_endpoint,
+                .local_dc_rack = get_dc_rack(this_endpoint)
+            }
+        });
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_first_node) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto e1 = inet_address("192.168.0.1");
+    const auto t1 = dht::token::from_int64(1);
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "1"}
+    });
+    token_metadata.add_bootstrap_token(t1, e1);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(0), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+        inet_address_vector_topology_change{e1});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_second_node) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto e1 = inet_address("192.168.0.1");
+    const auto t1 = dht::token::from_int64(1);
+    const auto e2 = inet_address("192.168.0.2");
+    const auto t2 = dht::token::from_int64(100);
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    token_metadata.update_topology(e2, get_dc_rack(e2));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "1"}
+    });
+    token_metadata.update_normal_tokens({t1}, e1).get();
+    token_metadata.add_bootstrap_token(t2, e2);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(0), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+        inet_address_vector_topology_change{e2});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+        inet_address_vector_topology_change{e2});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+        inet_address_vector_topology_change{});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_with_replicas) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto t1 = dht::token::from_int64(1);
+    const auto t10 = dht::token::from_int64(10);
+    const auto t100 = dht::token::from_int64(100);
+    const auto t1000 = dht::token::from_int64(1000);
+    const auto e1 = inet_address("192.168.0.1");
+    const auto e2 = inet_address("192.168.0.2");
+    const auto e3 = inet_address("192.168.0.3");
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    token_metadata.update_topology(e2, get_dc_rack(e2));
+    token_metadata.update_topology(e3, get_dc_rack(e3));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "2"}
+    });
+    token_metadata.update_normal_tokens({t1, t1000}, e2).get();
+    token_metadata.update_normal_tokens({t10}, e3).get();
+    token_metadata.add_bootstrap_token(t100, e1);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+        inet_address_vector_topology_change{});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_leave_with_replicas) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto t1 = dht::token::from_int64(1);
+    const auto t10 = dht::token::from_int64(10);
+    const auto t100 = dht::token::from_int64(100);
+    const auto t1000 = dht::token::from_int64(1000);
+    const auto e1 = inet_address("192.168.0.1");
+    const auto e2 = inet_address("192.168.0.2");
+    const auto e3 = inet_address("192.168.0.3");
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    token_metadata.update_topology(e2, get_dc_rack(e2));
+    token_metadata.update_topology(e3, get_dc_rack(e3));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "2"}
+    });
+    token_metadata.update_normal_tokens({t1, t1000}, e2).get();
+    token_metadata.update_normal_tokens({t10}, e3).get();
+    token_metadata.update_normal_tokens({t100}, e1).get();
+    token_metadata.add_leaving_endpoint(e1);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+        inet_address_vector_topology_change{e2});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+        inet_address_vector_topology_change{e3});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+        inet_address_vector_topology_change{e3});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+        inet_address_vector_topology_change{});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_replace_with_replicas) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto t1 = dht::token::from_int64(1);
+    const auto t10 = dht::token::from_int64(10);
+    const auto t100 = dht::token::from_int64(100);
+    const auto t1000 = dht::token::from_int64(1000);
+    const auto e1 = inet_address("192.168.0.1");
+    const auto e2 = inet_address("192.168.0.2");
+    const auto e3 = inet_address("192.168.0.3");
+    const auto e4 = inet_address("192.168.0.4");
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    token_metadata.update_topology(e2, get_dc_rack(e2));
+    token_metadata.update_topology(e3, get_dc_rack(e3));
+    token_metadata.update_topology(e4, get_dc_rack(e4));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "2"}
+    });
+    token_metadata.update_normal_tokens({t1000}, e1).get();
+    token_metadata.update_normal_tokens({t1, t100}, e2).get();
+    token_metadata.update_normal_tokens({t10}, e3).get();
+    token_metadata.add_replacing_endpoint(e3, e4);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1000), ks_name),
+        inet_address_vector_topology_change{});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1001), ks_name),
+        inet_address_vector_topology_change{e4});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{e4});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+        inet_address_vector_topology_change{e4});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(10), ks_name),
+        inet_address_vector_topology_change{e4});
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+        inet_address_vector_topology_change{});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_replace_node_with_same_endpoint) {
+    dc_rack_fn get_dc_rack_fn = get_dc_rack;
+
+    const auto t1 = dht::token::from_int64(1);
+    const auto e1 = inet_address("192.168.0.1");
+    auto token_metadata = create_token_metadata(e1);
+    token_metadata.update_topology(e1, get_dc_rack(e1));
+    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+        {"replication_factor", "2"}
+    });
+    token_metadata.update_normal_tokens({t1}, e1).get();
+    token_metadata.add_replacing_endpoint(e1, e1);
+    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+        inet_address_vector_topology_change{e1});
+    BOOST_REQUIRE_EQUAL(token_metadata.get_endpoint(t1), e1);
+}

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -129,6 +129,10 @@ public:
         return _set;
     }
 
+    auto extract_set() && noexcept {
+        return std::move(_set);
+    }
+
     bool contains(const T& t) const noexcept {
         return _set.contains(t);
     }


### PR DESCRIPTION
When new nodes are added or existing nodes are deleted, the topology state machine needs to shunt reads from the old nodes to the new ones. This happens in the `write_both_read_new` state. The problem is that previously this state was not handled in any way in `token_metadata` and the read nodes were only changed when the topology sm reached the final 'owned' state.

To handle `write_both_read_new` an additional `interval_map` inside `token_metadata` is maintained similar to `pending_endpoints`.  It maps the ranges affected by the ongoing topology change operation to replicas which should be used for reading. When topology state sm reaches the point when it needs to switch reads to a new topology, it passes `request_read_new=true` in a call to `update_pending_ranges`. This forces `update_pending_ranges` to compute the ranges based on new topology and store them to the `interval_map`. On the data plane, when a read on coordinator needs to decide which endpoints to use, it first consults this `interval_map` in `token_metadata`, and only if it doesn't contain a range for current token it uses normal endpoints from `effective_replication_map`.
