### PR TITLE
compaction: repair: rename shard_* task manager task to local_*

### DIFF
--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -71,12 +71,12 @@ protected:
     virtual future<> run() override;
 };
 
-class shard_major_keyspace_compaction_task_impl : public major_compaction_task_impl {
+class local_major_keyspace_compaction_task_impl : public major_compaction_task_impl {
 private:
     replica::database& _db;
     std::vector<table_id> _local_tables;
 public:
-    shard_major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
+    local_major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
@@ -129,12 +129,12 @@ protected:
     virtual future<> run() override;
 };
 
-class shard_cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
+class local_cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
 private:
     replica::database& _db;
     std::vector<table_id> _local_tables;
 public:
-    shard_cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
+    local_cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2372,7 +2372,7 @@ static void add_to_repair_meta_for_followers(repair_meta& rm) {
 }
 
 class row_level_repair {
-    repair::shard_repair_task_impl& _shard_task;
+    repair::local_repair_task_impl& _shard_task;
     sstring _cf_name;
     table_id _table_id;
     dht::token_range _range;
@@ -2421,7 +2421,7 @@ class row_level_repair {
     gc_clock::time_point _start_time;
 
 public:
-    row_level_repair(repair::shard_repair_task_impl& shard_task,
+    row_level_repair(repair::local_repair_task_impl& shard_task,
             sstring cf_name,
             table_id table_id,
             dht::token_range range,
@@ -2842,7 +2842,7 @@ public:
     }
 };
 
-future<> repair_cf_range_row_level(repair::shard_repair_task_impl& shard_task,
+future<> repair_cf_range_row_level(repair::local_repair_task_impl& shard_task,
         sstring cf_name, table_id table_id, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes) {
     return seastar::futurize_invoke([&shard_task, cf_name = std::move(cf_name), table_id = std::move(table_id), range = std::move(range), &all_peer_nodes] () mutable {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -240,7 +240,7 @@ class repair_row;
 class repair_hasher;
 class repair_writer;
 
-future<> repair_cf_range_row_level(repair::shard_repair_task_impl& shard_task,
+future<> repair_cf_range_row_level(repair::local_repair_task_impl& shard_task,
         sstring cf_name, table_id table_id, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes);
 future<std::list<repair_row>> to_repair_rows_list(repair_rows_on_wire rows,

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -92,7 +92,7 @@ protected:
     // TODO: implement progress for data-sync repairs
 };
 
-class shard_repair_task_impl : public repair_task_impl {
+class local_repair_task_impl : public repair_task_impl {
 public:
     repair_service& rs;
     seastar::sharded<replica::database>& db;
@@ -121,7 +121,7 @@ public:
     std::unordered_set<sstring> dropped_tables;
     bool _hints_batchlog_flushed = false;
 public:
-    shard_repair_task_impl(tasks::task_manager::module_ptr module,
+    local_repair_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             const sstring& keyspace,
             repair_service& repair,


### PR DESCRIPTION
Task manager tasks covering operations performed on single shard have their names changed from shard_* to local_* to make them more meaningful.