### PR TITLE
database, reader_concurrency_semaphore: deduplicate reader_concurrency_semaphore metrics

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -13,6 +13,7 @@
 #include <seastar/util/log.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/metrics.hh>
 
 #include "reader_concurrency_semaphore.hh"
 #include "readers/flat_mutation_reader_v2.hh"
@@ -939,6 +940,8 @@ void reader_concurrency_semaphore::signal(const resources& r) noexcept {
     maybe_admit_waiters();
 }
 
+static const seastar::metrics::label class_label("class");
+
 reader_concurrency_semaphore::reader_concurrency_semaphore(int count, ssize_t memory, sstring name, size_t max_queue_length,
             utils::updateable_value<uint32_t> serialize_limit_multiplier, utils::updateable_value<uint32_t> kill_limit_multiplier)
     : _initial_resources(count, memory)
@@ -947,6 +950,53 @@ reader_concurrency_semaphore::reader_concurrency_semaphore(int count, ssize_t me
     , _max_queue_length(max_queue_length)
     , _serialize_limit_multiplier(std::move(serialize_limit_multiplier))
     , _kill_limit_multiplier(std::move(kill_limit_multiplier))
+    , _metrics({
+        {"database", {
+            seastar::metrics::make_gauge("reads_memory_consumption", [this] { return consumed_resources().memory; },
+                        seastar::metrics::description("Holds the amount of memory consumed by current read operations. "),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_gauge("queued_reads", _stats.waiters,
+                        seastar::metrics::description("Holds the number of currently queued read operations."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_gauge("paused_reads", _stats.inactive_reads,
+                        seastar::metrics::description("The number of currently active reads that are temporarily paused."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_counter("paused_reads_permit_based_evictions", _stats.permit_based_evictions,
+                        seastar::metrics::description("The number of paused reads evicted to free up permits."
+                                        " Permits are required for new reads to start, and the database will evict paused reads (if any)"
+                                        " to be able to admit new ones, if there is a shortage of permits."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_counter("reads_shed_due_to_overload", _stats.total_reads_shed_due_to_overload,
+                        seastar::metrics::description("The number of reads shed because the admission queue reached its max capacity."
+                                        " When the queue is full, excessive reads are shed to avoid overload."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_gauge("disk_reads", _stats.disk_reads,
+                        seastar::metrics::description("Holds the number of currently active disk read operations. "),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_gauge("sstables_read", _stats.sstables_read,
+                        seastar::metrics::description("Holds the number of currently read sstables. "),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_counter("total_reads", _stats.total_successful_reads,
+                        seastar::metrics::description("Counts the total number of successful user reads on this shard."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_counter("total_reads_failed", _stats.total_failed_reads,
+                        seastar::metrics::description("Counts the total number of failed user read operations. "
+                                        "Add the total_reads to this value to get the total amount of reads issued on this shard."),
+                        {class_label(_name)}),
+
+            seastar::metrics::make_gauge("active_reads", [this] { return active_reads(); },
+                        seastar::metrics::description("Holds the number of currently active read operations. "),
+                        {class_label(_name)}),
+        }}
+    })
 { }
 
 reader_concurrency_semaphore::reader_concurrency_semaphore(no_limits, sstring name)

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -12,6 +12,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/metrics_registration.hh>
 #include "reader_permit.hh"
 #include "utils/updateable_value.hh"
 
@@ -186,6 +187,7 @@ private:
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
     stats _stats;
+    seastar::metrics::metric_groups _metrics;
     bool _stopped = false;
     bool _evicting = false;
     gate _close_readers_gate;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -328,7 +328,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     }))
     , _read_concurrency_sem(max_count_concurrent_reads,
         max_memory_concurrent_reads(),
-        "_read_concurrency_sem",
+        "user",
         max_inactive_queue_length(),
         _cfg.reader_concurrency_semaphore_serialize_limit_multiplier,
         _cfg.reader_concurrency_semaphore_kill_limit_multiplier)
@@ -337,7 +337,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _streaming_concurrency_sem(
             max_count_streaming_concurrent_reads,
             max_memory_streaming_concurrent_reads(),
-            "_streaming_concurrency_sem",
+            "streaming",
             std::numeric_limits<size_t>::max(),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()))
@@ -347,7 +347,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             // Using higher initial concurrency, see revert_initial_system_read_concurrency_boost().
             max_count_concurrent_reads,
             max_memory_system_concurrent_reads(),
-            "_system_read_concurrency_sem",
+            "system",
             std::numeric_limits<size_t>::max(),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()))
@@ -468,10 +468,6 @@ database::setup_metrics() {
 
     namespace sm = seastar::metrics;
 
-    auto user_label_instance = class_label("user");
-    auto streaming_label_instance = class_label("streaming");
-    auto system_label_instance = class_label("system");
-
     _metrics.add_group("memory", {
         sm::make_gauge("dirty_bytes", [this] { return _dirty_memory_manager.real_dirty_memory() + _system_dirty_memory_manager.real_dirty_memory(); },
                        sm::description("Holds the current size of all (\"regular\", \"system\" and \"streaming\") non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. "
@@ -538,24 +534,6 @@ database::setup_metrics() {
         sm::make_counter("total_writes_rate_limited", _stats->total_writes_rate_limited,
                        sm::description("Counts write operations which were rejected on the replica side because the per-partition limit was reached.")),
 
-        sm::make_counter("total_reads", _read_concurrency_sem.get_stats().total_successful_reads,
-                       sm::description("Counts the total number of successful user reads on this shard."),
-                       {user_label_instance}),
-
-        sm::make_counter("total_reads_failed", _read_concurrency_sem.get_stats().total_failed_reads,
-                       sm::description("Counts the total number of failed user read operations. "
-                                       "Add the total_reads to this value to get the total amount of reads issued on this shard."),
-                       {user_label_instance}),
-
-        sm::make_counter("total_reads", _system_read_concurrency_sem.get_stats().total_successful_reads,
-                       sm::description("Counts the total number of successful system reads on this shard."),
-                       {system_label_instance}),
-
-        sm::make_counter("total_reads_failed", _system_read_concurrency_sem.get_stats().total_failed_reads,
-                       sm::description("Counts the total number of failed system read operations. "
-                                       "Add the total_reads to this value to get the total amount of reads issued on this shard."),
-                       {system_label_instance}),
-
         sm::make_counter("total_reads_rate_limited", _stats->total_reads_rate_limited,
                        sm::description("Counts read operations which were rejected on the replica side because the per-partition limit was reached.")),
 
@@ -585,114 +563,10 @@ database::setup_metrics() {
                        sm::description("Counts the number of times the sstable read queue was overloaded. "
                                        "A non-zero value indicates that we have to drop read requests because they arrive faster than we can serve them.")),
 
-        sm::make_gauge("active_reads", [this] { return _read_concurrency_sem.active_reads(); },
-                       sm::description("Holds the number of currently active read operations. "),
-                       {user_label_instance}),
     });
 
     // Registering all the metrics with a single call causes the stack size to blow up.
     _metrics.add_group("database", {
-        sm::make_gauge("reads_memory_consumption", [this] { return _read_concurrency_sem.consumed_resources().memory; },
-                       sm::description("Holds the amount of memory consumed by current read operations. "),
-                       {user_label_instance}),
-
-        sm::make_gauge("queued_reads", [this] { return _read_concurrency_sem.get_stats().waiters; },
-                       sm::description("Holds the number of currently queued read operations."),
-                       {user_label_instance}),
-
-        sm::make_gauge("paused_reads", _read_concurrency_sem.get_stats().inactive_reads,
-                       sm::description("The number of currently active reads that are temporarily paused."),
-                       {user_label_instance}),
-
-        sm::make_counter("paused_reads_permit_based_evictions", _read_concurrency_sem.get_stats().permit_based_evictions,
-                       sm::description("The number of paused reads evicted to free up permits."
-                                       " Permits are required for new reads to start, and the database will evict paused reads (if any)"
-                                       " to be able to admit new ones, if there is a shortage of permits."),
-                       {user_label_instance}),
-
-        sm::make_counter("reads_shed_due_to_overload", _read_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
-                       sm::description("The number of reads shed because the admission queue reached its max capacity."
-                                       " When the queue is full, excessive reads are shed to avoid overload."),
-                       {user_label_instance}),
-
-        sm::make_gauge("disk_reads", [this] { return _read_concurrency_sem.get_stats().disk_reads; },
-                       sm::description("Holds the number of currently active disk read operations. "),
-                       {user_label_instance}),
-
-        sm::make_gauge("sstables_read", [this] { return _read_concurrency_sem.get_stats().sstables_read; },
-                       sm::description("Holds the number of currently read sstables. "),
-                       {user_label_instance}),
-
-        sm::make_gauge("active_reads", [this] { return _streaming_concurrency_sem.active_reads(); },
-                       sm::description("Holds the number of currently active read operations issued on behalf of streaming "),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("reads_memory_consumption", [this] { return _streaming_concurrency_sem.consumed_resources().memory; },
-                       sm::description("Holds the amount of memory consumed by current read operations issued on behalf of streaming "),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("queued_reads", [this] { return _streaming_concurrency_sem.get_stats().waiters; },
-                       sm::description("Holds the number of currently queued read operations on behalf of streaming."),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("paused_reads", _streaming_concurrency_sem.get_stats().inactive_reads,
-                       sm::description("The number of currently ongoing streaming reads that are temporarily paused."),
-                       {streaming_label_instance}),
-
-        sm::make_counter("paused_reads_permit_based_evictions", _streaming_concurrency_sem.get_stats().permit_based_evictions,
-                       sm::description("The number of inactive streaming reads evicted to free up permits"
-                                       " Permits are required for new reads to start, and the database will evict paused reads (if any)"
-                                       " to be able to admit new ones, if there is a shortage of permits."),
-                       {streaming_label_instance}),
-
-        sm::make_counter("reads_shed_due_to_overload", _streaming_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
-                       sm::description("The number of reads shed because the admission queue reached its max capacity."
-                                       " When the queue is full, excessive reads are shed to avoid overload."),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("disk_reads", [this] { return _streaming_concurrency_sem.get_stats().disk_reads; },
-                       sm::description("Holds the number of currently active disk read operations. "),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("sstables_read", [this] { return _streaming_concurrency_sem.get_stats().sstables_read; },
-                       sm::description("Holds the number of currently read sstables. "),
-                       {streaming_label_instance}),
-
-        sm::make_gauge("active_reads", [this] { return _system_read_concurrency_sem.active_reads(); },
-                       sm::description("Holds the number of currently active read operations from \"system\" keyspace tables. "),
-                       {system_label_instance}),
-
-        sm::make_gauge("reads_memory_consumption", [this] { return max_memory_system_concurrent_reads() - _system_read_concurrency_sem.consumed_resources().memory; },
-                       sm::description("Holds the amount of memory consumed by all read operations from \"system\" keyspace tables. "),
-                       {system_label_instance}),
-
-        sm::make_gauge("queued_reads", [this] { return _system_read_concurrency_sem.get_stats().waiters; },
-                       sm::description("Holds the number of currently queued read operations from \"system\" keyspace tables."),
-                       {system_label_instance}),
-
-        sm::make_gauge("paused_reads", _system_read_concurrency_sem.get_stats().inactive_reads,
-                       sm::description("The number of currently ongoing system reads that are temporarily paused."),
-                       {system_label_instance}),
-
-        sm::make_counter("paused_reads_permit_based_evictions", _system_read_concurrency_sem.get_stats().permit_based_evictions,
-                       sm::description("The number of paused system reads evicted to free up permits"
-                                       " Permits are required for new reads to start, and the database will evict inactive reads (if any)"
-                                       " to be able to admit new ones, if there is a shortage of permits."),
-                       {system_label_instance}),
-
-        sm::make_counter("reads_shed_due_to_overload", _system_read_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
-                       sm::description("The number of reads shed because the admission queue reached its max capacity."
-                                       " When the queue is full, excessive reads are shed to avoid overload."),
-                       {system_label_instance}),
-
-        sm::make_gauge("disk_reads", [this] { return _system_read_concurrency_sem.get_stats().disk_reads; },
-                       sm::description("Holds the number of currently active disk read operations. "),
-                       {system_label_instance}),
-
-        sm::make_gauge("sstables_read", [this] { return _system_read_concurrency_sem.get_stats().sstables_read; },
-                       sm::description("Holds the number of currently read sstables. "),
-                       {system_label_instance}),
-
         sm::make_gauge("total_result_bytes", [this] { return get_result_memory_limiter().total_used_memory(); },
                        sm::description("Holds the current amount of memory used for results.")),
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -363,8 +363,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_rows_count_warning_threshold,
               _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
-    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>("user", *_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
+    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>("system", *_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2037,7 +2037,8 @@ class scylla_memory(gdb.Command):
 
     @staticmethod
     def format_semaphore_stats(semaphore):
-        semaphore_name = "{}:".format(str(semaphore['_name'])[1:-1].split("_")[1])
+        # older versions had names like "_user_concurrency_semaphore"
+        semaphore_name = "{}:".format(str(semaphore['_name']).removeprefix('_').removesuffix('_concurrency_semaphore'))
         initial_count = int(semaphore["_initial_resources"]["count"])
         initial_memory = int(semaphore["_initial_resources"]["memory"])
         used_count = initial_count - int(semaphore["_resources"]["count"])

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -19,12 +19,13 @@ namespace sstables {
 logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
+    sstring name,
     db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem)
     : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
     , _sstable_metadata_concurrency_sem(
         max_count_sstable_metadata_concurrent_reads,
         max_memory_sstable_metadata_concurrent_reads(available_memory),
-        "sstable_metadata_concurrency_sem",
+        fmt::format("sstables_manager_{}", name),
         std::numeric_limits<size_t>::max(),
         utils::updateable_value(std::numeric_limits<uint32_t>::max()),
         utils::updateable_value(std::numeric_limits<uint32_t>::max()))

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -72,7 +72,7 @@ private:
     reader_concurrency_semaphore _sstable_metadata_concurrency_sem;
     directory_semaphore& _dir_semaphore;
 public:
-    explicit sstables_manager(db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem);
+    explicit sstables_manager(sstring name, db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem);
     virtual ~sstables_manager();
 
     // Constructs a shared sstable

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -158,7 +158,7 @@ test_env::impl::impl(test_env_config cfg)
     , db_config(make_db_config(dir.path().native()))
     , dir_sem(1)
     , feature_service(gms::feature_config_from_db_config(*db_config))
-    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
+    , mgr("test", cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2843,7 +2843,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             cache_tracker tracker;
             dbcfg.host_id = locator::host_id::create_random_id();
             sstables::directory_semaphore dir_sem(1);
-            sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem);
+            sstables::sstables_manager sst_man("tools", large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem);
             auto close_sst_man = deferred_close(sst_man);
 
             std::vector<sstables::shared_sstable> sstables;


### PR DESCRIPTION
Reduce code duplication by defining each metric just once, instead of three times.