### PR TITLE
code: Remove some headers from query_processor.hh

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -13,6 +13,8 @@
 #include <seastar/core/metrics.hh>
 
 #include "service/storage_proxy.hh"
+#include "service/forward_service.hh"
+#include "service/raft/raft_group0_client.hh"
 #include "cql3/CqlParser.hpp"
 #include "cql3/error_collector.hh"
 #include "cql3/statements/batch_statement.hh"

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -23,11 +23,9 @@
 #include "exceptions/exceptions.hh"
 #include "lang/wasm_instance_cache.hh"
 #include "service/migration_listener.hh"
-#include "service/raft/raft_group0_client.hh"
 #include "transport/messages/result_message.hh"
 #include "service/qos/service_level_controller.hh"
 #include "service/client_state.hh"
-#include "service/forward_service.hh"
 #include "utils/observable.hh"
 #include "lang/wasm_alien_thread_runner.hh"
 
@@ -35,6 +33,8 @@
 namespace service {
 class migration_manager;
 class query_state;
+class forward_service;
+class raft_group0_client;
 }
 
 namespace cql3 {

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -45,6 +45,7 @@
 #include "cql3/functions/user_aggregate.hh"
 #include "utils/overloaded_functor.hh"
 #include "data_dictionary/keyspace_element.hh"
+#include "db/system_keyspace.hh"
 
 static logging::logger dlogger("describe");
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -45,6 +45,7 @@
 #include "utils/result.hh"
 #include "utils/result_combinators.hh"
 #include "utils/result_loop.hh"
+#include "service/forward_service.hh"
 
 template<typename T = void>
 using coordinator_result = cql3::statements::select_statement::coordinator_result<T>;

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -25,6 +25,7 @@
 #include "cql3/values.hh"
 #include "timeout_config.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
+#include "db/system_keyspace.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/strongly_consistent_select_statement.cc
+++ b/cql3/statements/strongly_consistent_select_statement.cc
@@ -17,6 +17,7 @@
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/query_processor.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
+#include "db/system_keyspace.hh"
 
 namespace cql3 {
 

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -12,6 +12,7 @@
 #include "partition_slice_builder.hh"
 #include "serializer_impl.hh"
 #include "query-result-set.hh"
+#include "mutation_query.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/eventually.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include "querier.hh"
+#include "mutation_query.hh"
 #include "service/priority_manager.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/cql_test_env.hh"

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -32,6 +32,7 @@
 #include "gms/feature_service.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "tools/schema_loader.hh"
+#include "utils/fb_utilities.hh"
 
 namespace {
 


### PR DESCRIPTION
The forward_service.hh and raft_group0_client.hh can be replaced with forward declarations. Few other files need their previously indirectly included headers back.