### PR TITLE
Manage CDC generations when bootstrapping nodes using Raft Group 0 topology coordinator

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -266,8 +266,8 @@ future<utils::chunked_vector<mutation>> get_cdc_generation_mutations(
         schema_ptr s,
         utils::UUID id,
         const cdc::topology_description& desc,
-        size_t mutation_size_threshold) {
-    auto ts = api::new_timestamp();
+        size_t mutation_size_threshold,
+        api::timestamp_type ts) {
     utils::chunked_vector<mutation> res;
     res.emplace_back(s, partition_key::from_singular(*s, id));
     res.back().set_static_cell(to_bytes("num_ranges"), int32_t(desc.entries().size()), ts);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -782,6 +782,7 @@ future<> generation_service::on_change(gms::inet_address ep, gms::application_st
 }
 
 future<> generation_service::check_and_repair_cdc_streams() {
+    // FIXME: support Raft group 0-based topology changes
     if (!_joined) {
         throw std::runtime_error("check_and_repair_cdc_streams: node not initialized yet");
     }

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -133,6 +133,13 @@ public:
  */
 bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper&);
 
+std::pair<utils::UUID, cdc::topology_description> make_new_generation_data(
+    const std::unordered_set<dht::token>& bootstrap_tokens,
+    const noncopyable_function<std::pair<size_t, uint8_t> (dht::token)>& get_sharding_info,
+    const locator::token_metadata_ptr);
+
+db_clock::time_point new_generation_timestamp(bool add_delay, std::chrono::milliseconds ring_delay);
+
 // Translates the CDC generation data given by a `cdc::topology_description` into a vector of mutations,
 // using `mutation_size_threshold` to decide on the mutation sizes. The partition key of each mutation
 // is given by `gen_uuid`. The timestamp of each cell in each mutation is given by `mutation_timestamp`.

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -135,10 +135,11 @@ bool should_propose_first_generation(const gms::inet_address& me, const gms::gos
 
 // Translates the CDC generation data given by a `cdc::topology_description` into a vector of mutations,
 // using `mutation_size_threshold` to decide on the mutation sizes. The partition key of each mutation
-// is given by `gen_uuid`.
+// is given by `gen_uuid`. The timestamp of each cell in each mutation is given by `mutation_timestamp`.
 //
 // Works for only specific schemas: CDC_GENERATIONS_V2 (in system_distributed_keyspace).
 future<utils::chunked_vector<mutation>> get_cdc_generation_mutations(
-    schema_ptr, utils::UUID gen_uuid, const cdc::topology_description&, size_t mutation_size_threshold);
+    schema_ptr, utils::UUID gen_uuid, const cdc::topology_description&,
+    size_t mutation_size_threshold, api::timestamp_type mutation_timestamp);
 
 } // namespace cdc

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -137,7 +137,8 @@ bool should_propose_first_generation(const gms::inet_address& me, const gms::gos
 // using `mutation_size_threshold` to decide on the mutation sizes. The partition key of each mutation
 // is given by `gen_uuid`. The timestamp of each cell in each mutation is given by `mutation_timestamp`.
 //
-// Works for only specific schemas: CDC_GENERATIONS_V2 (in system_distributed_keyspace).
+// Works for only specific schemas: CDC_GENERATIONS_V2 (in system_distributed_keyspace)
+// and CDC_GENERATIONS_V3 (in system_keyspace).
 future<utils::chunked_vector<mutation>> get_cdc_generation_mutations(
     schema_ptr, utils::UUID gen_uuid, const cdc::topology_description&,
     size_t mutation_size_threshold, api::timestamp_type mutation_timestamp);

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -133,4 +133,12 @@ public:
  */
 bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper&);
 
+// Translates the CDC generation data given by a `cdc::topology_description` into a vector of mutations,
+// using `mutation_size_threshold` to decide on the mutation sizes. The partition key of each mutation
+// is given by `gen_uuid`.
+//
+// Works for only specific schemas: CDC_GENERATIONS_V2 (in system_distributed_keyspace).
+future<utils::chunked_vector<mutation>> get_cdc_generation_mutations(
+    schema_ptr, utils::UUID gen_uuid, const cdc::topology_description&, size_t mutation_size_threshold);
+
 } // namespace cdc

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -132,8 +132,11 @@ public:
      * so that other nodes learn about the generation before their clocks cross the generation's timestamp
      * (not guaranteed in the current implementation, but expected to be the common case;
      *  we assume that `ring_delay` is enough for other nodes to learn about the new generation).
+     *
+     * Legacy: used for gossiper-based topology changes.
      */
-    future<cdc::generation_id> make_new_generation(const std::unordered_set<dht::token>& bootstrap_tokens, bool add_delay);
+    future<cdc::generation_id> legacy_make_new_generation(
+        const std::unordered_set<dht::token>& bootstrap_tokens, bool add_delay);
 
     /* Retrieve the CDC generation with the given ID from local tables
      * and start using it for CDC log writes if it's not obsolete.
@@ -144,27 +147,39 @@ public:
 private:
     /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
      * and start using it for CDC log writes if it's not obsolete.
+     *
+     * Legacy: used for gossiper-based topology changes.
      */
-    future<> handle_cdc_generation(std::optional<cdc::generation_id>);
+    future<> legacy_handle_cdc_generation(std::optional<cdc::generation_id>);
 
-    /* If `handle_cdc_generation` fails, it schedules an asynchronous retry in the background
-     * using `async_handle_cdc_generation`.
+    /* If `legacy_handle_cdc_generation` fails, it schedules an asynchronous retry in the background
+     * using `legacy_async_handle_cdc_generation`.
+     *
+     * Legacy: used for gossiper-based topology changes.
      */
-    void async_handle_cdc_generation(cdc::generation_id);
+    void legacy_async_handle_cdc_generation(cdc::generation_id);
 
-    /* Wrapper around `do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
-     * Returns: do_handle_cdc_generation(ts). */
-    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(cdc::generation_id);
+    /* Wrapper around `legacy_do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
+     * Returns: legacy_do_handle_cdc_generation(ts).
+     *
+     * Legacy: used for gossiper-based topology changes.
+     */
+    future<bool> legacy_do_handle_cdc_generation_intercept_nonfatal_errors(cdc::generation_id);
 
     /* Returns `true` iff we started using the generation (it was not obsolete or already known),
-     * which means that this node might write some CDC log entries using streams from this generation. */
-    future<bool> do_handle_cdc_generation(cdc::generation_id);
+     * which means that this node might write some CDC log entries using streams from this generation.
+     *
+     * Legacy: used for gossiper-based topology changes.
+     */
+    future<bool> legacy_do_handle_cdc_generation(cdc::generation_id);
 
     /* Scan CDC generation timestamps gossiped by other nodes and retrieve the latest one.
      * This function should be called once at the end of the node startup procedure
      * (after the node is started and running normally, it will retrieve generations on gossip events instead).
+     *
+     * Legacy: used for gossiper-based topology changes.
      */
-    future<> scan_cdc_generations();
+    future<> legacy_scan_cdc_generations();
 
     /* generation_service code might be racing with system_distributed_keyspace deinitialization
      * (the deinitialization order is broken).

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -135,6 +135,12 @@ public:
      */
     future<cdc::generation_id> make_new_generation(const std::unordered_set<dht::token>& bootstrap_tokens, bool add_delay);
 
+    /* Retrieve the CDC generation with the given ID from local tables
+     * and start using it for CDC log writes if it's not obsolete.
+     * Precondition: the generation was committed using group 0 and locally applied.
+     */
+    future<> handle_cdc_generation(cdc::generation_id_v2);
+
 private:
     /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
      * and start using it for CDC log writes if it's not obsolete.

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -536,7 +536,7 @@ system_distributed_keyspace::insert_cdc_generation(
 
     auto s = _qp.db().real_database().find_schema(
         system_distributed_keyspace::NAME_EVERYWHERE, system_distributed_keyspace::CDC_GENERATIONS_V2);
-    auto ms = co_await cdc::get_cdc_generation_mutations(s, id, desc, mutation_size_threshold);
+    auto ms = co_await cdc::get_cdc_generation_mutations(s, id, desc, mutation_size_threshold, api::new_timestamp());
     co_await max_concurrent_for_each(ms, concurrency, [&] (mutation& m) -> future<> {
         co_await _sp.mutate(
             { std::move(m) },

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3538,9 +3538,16 @@ future<service::topology> system_keyspace::load_topology_state() {
                     host_id, repl_state));
             }
 
+            if (!row.has("new_cdc_generation_data_uuid")) {
+                on_fatal_internal_error(slogger, format(
+                    "load_topology_state: node {} has replication state ({}) but missing CDC generation data UUID",
+                    host_id, repl_state));
+            }
+
             ring_slice = service::ring_slice {
                 .state = repl_state,
                 .tokens = std::move(tokens),
+                .new_cdc_generation_data_uuid = row.get_as<utils::UUID>("new_cdc_generation_data_uuid"),
             };
         }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -151,6 +151,7 @@ public:
     static constexpr auto BROADCAST_KV_STORE = "broadcast_kv_store";
     static constexpr auto TOPOLOGY = "topology";
     static constexpr auto SSTABLES_REGISTRY = "sstables";
+    static constexpr auto CDC_GENERATIONS_V3 = "cdc_generations_v3";
 
     struct v3 {
         static constexpr auto BATCHES = "batches";
@@ -233,6 +234,7 @@ public:
     static schema_ptr broadcast_kv_store();
     static schema_ptr topology();
     static schema_ptr sstables_registry();
+    static schema_ptr cdc_generations_v3();
 
     static table_schema_version generate_schema_version(table_id table_id, uint16_t offset = 0);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -68,6 +68,10 @@ namespace gms {
     class gossiper;
 }
 
+namespace cdc {
+    class topology_description;
+}
+
 bool is_system_keyspace(std::string_view ks_name);
 
 namespace db {
@@ -444,6 +448,10 @@ public:
     static future<bool> group0_history_contains(utils::UUID state_id);
 
     static future<service::topology> load_topology_state();
+
+    // Read CDC generation data with the given UUID as key.
+    // Precondition: the data is known to be present in the table (because it was committed earlier through group 0).
+    future<cdc::topology_description> read_cdc_generation(utils::UUID id);
 
     // The mutation appends the given state ID to the group 0 history table, with the given description if non-empty.
     //

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -282,6 +282,13 @@ public:
                     const sstring& ks_name,
                     const sstring& cf_name);
 
+    future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
+    static query_mutations(distributed<service::storage_proxy>& proxy,
+                    const sstring& ks_name,
+                    const sstring& cf_name,
+                    const dht::partition_range& partition_range,
+                    query::clustering_range row_ranges = query::clustering_range::make_open_ended_both_sides());
+
     // Returns all data from given system table.
     // Intended to be used by code which is not performance critical.
     static future<lw_shared_ptr<query::result_set>> query(distributed<service::storage_proxy>& proxy,

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -25,7 +25,8 @@ namespace service {
   };
 
   struct raft_topology_snapshot {
-      std::vector<canonical_mutation> mutations;
+      std::vector<canonical_mutation> topology_mutations;
+      std::optional<canonical_mutation> cdc_generation_mutation;
   };
 
   struct raft_topology_pull_params {};

--- a/main.cc
+++ b/main.cc
@@ -1475,7 +1475,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,
-                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local()};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local(), cdc_generation_service.local()};
             group0_service.start().get();
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
                 group0_service.abort().get();

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -128,6 +128,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     // memory and thus needs to be protected with apply mutex
     auto read_apply_mutex_holder = co_await get_units(_client._read_apply_mutex, 1);
     co_await _ss.topology_state_load();
+    _ss._topology_state_machine.event.signal();
 }
 
 future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::snapshot_descriptor snp) {

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -156,7 +156,7 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
 
     co_await _mm.merge_schema_from(addr, std::move(*cm));
 
-    if (!topology_snp.mutations.empty()) {
+    if (!topology_snp.topology_mutations.empty()) {
         co_await _ss.merge_topology_snapshot(std::move(topology_snp));
     }
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -107,7 +107,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
             _client.set_query_result(cmd.new_state_id, std::move(result));
         },
         [&] (topology_change& chng) -> future<> {
-           return _ss.topology_transition(_sp, cmd.creator_addr, std::move(chng.mutations));
+           return _ss.topology_transition(_sp, _cdc_gen_svc, cmd.creator_addr, std::move(chng.mutations));
         }
         ), cmd.change);
 
@@ -127,7 +127,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     // topology_state_load applies persisted state machine state into
     // memory and thus needs to be protected with apply mutex
     auto read_apply_mutex_holder = co_await get_units(_client._read_apply_mutex, 1);
-    co_await _ss.topology_state_load();
+    co_await _ss.topology_state_load(_cdc_gen_svc);
     _ss._topology_state_machine.event.signal();
 }
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -67,7 +67,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
                 cmd.prev_state_id, cmd.new_state_id, cmd.creator_addr, cmd.creator_id);
         slogger.trace("cmd.history_append: {}", cmd.history_append);
 
-        auto read_apply_mutex_holder = co_await get_units(_client._read_apply_mutex, 1);
+        auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
 
         if (cmd.prev_state_id) {
             auto last_group0_state_id = co_await db::system_keyspace::get_last_group0_state_id();
@@ -126,7 +126,7 @@ void group0_state_machine::drop_snapshot(raft::snapshot_id id) {
 future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     // topology_state_load applies persisted state machine state into
     // memory and thus needs to be protected with apply mutex
-    auto read_apply_mutex_holder = co_await get_units(_client._read_apply_mutex, 1);
+    auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
     co_await _ss.topology_state_load(_cdc_gen_svc);
     _ss._topology_state_machine.event.signal();
 }
@@ -152,7 +152,7 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
 
     // TODO ensure atomicity of snapshot application in presence of crashes (see TODO in `apply`)
 
-    auto read_apply_mutex_holder = co_await get_units(_client._read_apply_mutex, 1);
+    auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
 
     co_await _mm.merge_schema_from(addr, std::move(*cm));
 

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -13,6 +13,10 @@
 #include "mutation/canonical_mutation.hh"
 #include "service/raft/raft_state_machine.hh"
 
+namespace cdc {
+class generation_service;
+}
+
 namespace service {
 class raft_group0_client;
 class migration_manager;
@@ -73,8 +77,9 @@ class group0_state_machine : public raft_state_machine {
     migration_manager& _mm;
     storage_proxy& _sp;
     storage_service& _ss;
+    cdc::generation_service& _cdc_gen_svc;
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss) : _client(client), _mm(mm), _sp(sp), _ss(ss) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, cdc::generation_service& cdc_gen_svc) : _client(client), _mm(mm), _sp(sp), _ss(ss), _cdc_gen_svc(cdc_gen_svc) {}
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -16,6 +16,8 @@ namespace cql3 { class query_processor; }
 
 namespace db { class system_keyspace; }
 
+namespace cdc { class generation_service; }
+
 namespace gms { class gossiper; class feature_service; }
 
 namespace service {
@@ -76,6 +78,7 @@ class raft_group0 {
     db::system_keyspace& _sys_ks;
     raft_group0_client& _client;
     service::storage_service& _ss;
+    cdc::generation_service& _cdc_gen_svc;
 
     // Status of leader discovery. Initially there is no group 0,
     // and the variant contains no state. During initial cluster
@@ -114,7 +117,8 @@ public:
         gms::feature_service& feat,
         db::system_keyspace& sys_ks,
         raft_group0_client& client,
-        storage_service& ss);
+        storage_service& ss,
+        cdc::generation_service& cdc_gen_svc);
 
     // Initialises RPC verbs on all shards.
     // Call after construction but before using the object.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -64,7 +64,6 @@ public:
 
 // Singleton that exists only on shard zero. Used to post commands to group zero
 class raft_group0_client {
-    friend class group0_state_machine;
     service::raft_group_registry& _raft_gr;
     db::system_keyspace& _sys_ks;
 
@@ -165,6 +164,8 @@ public:
 
     // Wait until group 0 upgrade enters the `use_post_raft_procedures` state.
     future<> wait_until_group0_upgraded(abort_source&);
+
+    future<semaphore_units<>> hold_read_apply_mutex();
 
     db::system_keyspace& sys_ks();
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4822,6 +4822,9 @@ void storage_service::init_messaging_service(sharded<service::storage_proxy>& pr
             if (!ss._raft_topology_change_enabled) {
                co_return raft_topology_snapshot{};
             }
+            // FIXME: make it an rwlock, here we only need to lock for reads,
+            // might be useful if multiple nodes are trying to pull concurrently.
+            auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
             auto rs = co_await db::system_keyspace::query_mutations(proxy, db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
             auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
             std::vector<canonical_mutation> results;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -416,7 +416,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
 
     if (auto gen_id = _topology_state_machine._topology.current_cdc_generation_id) {
         slogger.debug("topology_state_load: current CDC generation ID: {}", *gen_id);
-        // TODO start using the generation for CDC writes
+        co_await cdc_gen_svc.handle_cdc_generation(*gen_id);
     }
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1607,7 +1607,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
                 && (!_sys_ks.local().bootstrap_complete()
                     || cdc::should_propose_first_generation(get_broadcast_address(), _gossiper))) {
             try {
-                cdc_gen_id = co_await cdc_gen_service.make_new_generation(bootstrap_tokens, !is_first_node());
+                cdc_gen_id = co_await cdc_gen_service.legacy_make_new_generation(bootstrap_tokens, !is_first_node());
             } catch (...) {
                 cdc_log.warn(
                     "Could not create a new CDC generation: {}. This may make it impossible to use CDC or cause performance problems."
@@ -1758,7 +1758,7 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
             // We don't do any other generation switches (unless we crash before complecting bootstrap).
             assert(!cdc_gen_id);
 
-            cdc_gen_id = cdc_gen_service.make_new_generation(bootstrap_tokens, !is_first_node()).get0();
+            cdc_gen_id = cdc_gen_service.legacy_make_new_generation(bootstrap_tokens, !is_first_node()).get0();
 
             if (!bootstrap_rbno) {
                 // When is_repair_based_node_ops_enabled is true, the bootstrap node

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -762,13 +762,13 @@ private:
     future<> _raft_state_monitor = make_ready_future<>();
     // This fibers monitors raft state and start/stops the topology change
     // coordinator fiber
-    future<> raft_state_monitor_fiber(raft::server&, sharded<db::system_distributed_keyspace>& sys_dist_ks);
+    future<> raft_state_monitor_fiber(raft::server&, cdc::generation_service&, sharded<db::system_distributed_keyspace>& sys_dist_ks);
 
      // State machine that is responsible for topology change
     topology_state_machine _topology_state_machine;
 
     future<> _topology_change_coordinator = make_ready_future<>();
-    future<> topology_change_coordinator_fiber(raft::server&, raft::term_t, sharded<db::system_distributed_keyspace>&, abort_source&);
+    future<> topology_change_coordinator_fiber(raft::server&, raft::term_t, cdc::generation_service&, sharded<db::system_distributed_keyspace>&, abort_source&);
 
     // Those futures hold results of streaming for various operations
     std::optional<shared_future<>> _bootstrap_result;
@@ -786,9 +786,9 @@ private:
     future<> update_topology_with_local_metadata(raft::server&);
 
     // This is called on all nodes for each new command received through raft
-    future<> topology_transition(storage_proxy& proxy, gms::inet_address, std::vector<canonical_mutation>);
+    future<> topology_transition(storage_proxy& proxy, cdc::generation_service&, gms::inet_address, std::vector<canonical_mutation>);
     // load topology state machine snapshot into memory
-    future<> topology_state_load();
+    future<> topology_state_load(cdc::generation_service&);
     // Applies received raft snapshot to local state machine persistent storage
     future<> merge_topology_snapshot(raft_topology_snapshot snp);
 };

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -786,10 +786,13 @@ private:
     future<> update_topology_with_local_metadata(raft::server&);
 
     // This is called on all nodes for each new command received through raft
+    // raft_group0_client::_read_apply_mutex must be held
     future<> topology_transition(storage_proxy& proxy, cdc::generation_service&, gms::inet_address, std::vector<canonical_mutation>);
     // load topology state machine snapshot into memory
+    // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load(cdc::generation_service&);
     // Applies received raft snapshot to local state machine persistent storage
+    // raft_group0_client::_read_apply_mutex must be held
     future<> merge_topology_snapshot(raft_topology_snapshot snp);
 };
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -37,6 +37,7 @@ bool topology::contains(raft::server_id id) {
 }
 
 static std::unordered_map<ring_slice::replication_state, sstring> replication_state_to_name_map = {
+    {ring_slice::replication_state::commit_cdc_generation, "commit cdc generation"},
     {ring_slice::replication_state::write_both_read_old, "write both read old"},
     {ring_slice::replication_state::write_both_read_new, "write both read new"},
     {ring_slice::replication_state::owner, "owner"},

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -13,7 +13,7 @@ namespace service {
 
 logging::logger tsmlogger("topology_state_machine");
 
-const std::pair<const raft::server_id, replica_state>* topology::find(raft::server_id id) {
+const std::pair<const raft::server_id, replica_state>* topology::find(raft::server_id id) const {
     auto it = normal_nodes.find(id);
     if (it != normal_nodes.end()) {
         return &*it;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -101,7 +101,11 @@ struct topology {
 };
 
 struct raft_topology_snapshot {
-    std::vector<canonical_mutation> mutations;
+    // Mutations for the system.topology table.
+    std::vector<canonical_mutation> topology_mutations;
+
+    // Mutation for system.cdc_generations_v3, contains the current CDC generation data.
+    std::optional<canonical_mutation> cdc_generation_mutation;
 };
 
 struct raft_topology_pull_params {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -55,6 +55,11 @@ struct ring_slice {
 
     replication_state state;
     std::unordered_set<dht::token> tokens;
+
+    // When a new node joins the cluster, always a new CDC generation is created.
+    // This is the UUID used to access the data of the CDC generation introduced
+    // when the node owning this ring_slice joined (it's the partition key in CDC_GENERATIONS_V3 table).
+    utils::UUID new_cdc_generation_data_uuid;
 };
 
 struct replica_state {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -17,6 +17,7 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
+#include "cdc/generation_id.hh"
 #include "dht/token.hh"
 #include "raft/raft.hh"
 #include "utils/UUID.hh"
@@ -48,6 +49,7 @@ using request_param = std::variant<raft::server_id, sstring, uint32_t>;
 
 struct ring_slice {
     enum class replication_state: uint8_t {
+        commit_cdc_generation,
         write_both_read_old,
         write_both_read_new,
         owner
@@ -89,6 +91,8 @@ struct topology {
     // Holds parameters for a request per node and valid during entire
     // operation untill the node becomes normal
     std::unordered_map<raft::server_id, request_param> req_param;
+
+    std::optional<cdc::generation_id_v2> current_cdc_generation_id;
 
     // Find only nodes in non 'left' state
     const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -86,7 +86,7 @@ struct topology {
     std::unordered_map<raft::server_id, request_param> req_param;
 
     // Find only nodes in non 'left' state
-    const std::pair<const raft::server_id, replica_state>* find(raft::server_id id);
+    const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;
     // Return true if node exists in any state including 'left' one
     bool contains(raft::server_id id);
 };

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -886,7 +886,7 @@ public:
 
             service::raft_group0 group0_service{
                     abort_sources.local(), raft_gr.local(), ms,
-                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local()};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local(), cdc_generation_service.local()};
             group0_service.start().get();
             auto stop_group0_service = defer([&group0_service] {
                 group0_service.abort().get();


### PR DESCRIPTION
Introduce a new table `CDC_GENERATIONS_V3` (`system.cdc_generations_v3`).
The table schema is a copy-paste of the `CDC_GENERATIONS_V2` schema. The
difference is that V2 lives in `system_distributed_keyspace` and writes to it
are distributed using regular `storage_proxy` replication mechanisms based on
the token ring.  The V3 table lives in `system_keyspace` and any mutations
written to it will go through group 0.

Extend the `TOPOLOGY` schema with new columns:
- `new_cdc_generation_data_uuid` will be stored as part of a bootstrapping
  node's `ring_slice`, it stores UUID of a newly introduced CDC
  generation which is used as partition key for the `CDC_GENERATIONS_V3`
  table to access this new generation's data. It's a regular column,
  meaning that every row (corresponding to a node) will have its own.
- `current_cdc_generation_uuid` and `current_cdc_generation_timestamp`
  together form the ID of the newest CDC generation in the cluster.
  (the uuid is the data key for `CDC_GENERATIONS_V3`, the timestamp is
  when the CDC generation starts operating). Those are static columns
  since there's a single newest CDC generation.

When topology coordinator handles a request for node to join, calculate a new
CDC generation using the bootstrapping node's tokens, translate it to mutation
format, and insert this mutation to the CDC_GENERATIONS_V3 table through group 0
at the same time we assign tokens to the node in Raft topology. The partition
key for this data is stored in the bootstrapping node's `ring_slice`.

After inserting new CDC generation data , we need to pick a timestamp for this
generation and commit it, telling all nodes in the cluster to start using the
generation for CDC log writes once their clocks cross that timestamp.

We introduce a separate step to the bootstrap saga, before
`write_both_read_old`, called `commit_cdc_generation`. In this step, the
coordinator takes the `new_cdc_generation_data_uuid` stored in a bootstrapping
node's `ring_slice` - which serves as the key to the table where the CDC
generation data is stored - and combines it with a timestamp which it generates
a bit into the future (as in old gossiper-based code, we use 2 * ring_delay, by
default 1 minute). This gives us a CDC generation ID which we commit into the
topology state as the `current_cdc_generation_id` while switching the saga to
the next step, `write_both_read_old`.

Once a new CDC generation is committed to the cluster by the topology
coordinator, we also need to publish it to the user-facing description tables so
CDC applications know which streams to read from.

This uses regular distributed table writes underneath (tables living in the
`system_distributed` keyspace) so it requires `token_metadata` to be nonempty.
We need a hack for the case of bootstrapping the first node in the cluster -
turning the tokens into normal tokens earlier in the procedure in
`token_metadata`, but this is fine for the single-node case since no streaming
is happening.

When a node notices that a new CDC generation was introduced in
`storage_service::topology_state_load`, it updates its internal data structures
that are used when coordinating writes to CDC log tables.

We include the current CDC generation data in topology snapshot transfers.

Some fixes and refactors included.
