### PR TITLE
Treewide use-after-move bug fixes

### DIFF
--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -197,7 +197,7 @@ public:
             streamed_mutation::forwarding fwd,
             mutation_reader::forwarding fwd_mr) {
         return flat_mutation_reader_v2(std::make_unique<build_progress_reader>(
-                std::move(s),
+                s,
                 std::move(permit),
                 _db.find_column_family(s->ks_name(), system_keyspace::v3::SCYLLA_VIEWS_BUILDS_IN_PROGRESS),
                 range,

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -223,7 +223,7 @@ public:
             mutation_reader::forwarding fwd_mr) {
         return make_flat_mutation_reader_v2<built_indexes_reader>(
                 _db,
-                std::move(s),
+                s,
                 std::move(permit),
                 _db.find_column_family(s->ks_name(), system_keyspace::v3::BUILT_VIEWS),
                 range,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -703,7 +703,7 @@ public:
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no) const;
 
     flat_mutation_reader_v2 make_streaming_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range) {
-        return make_streaming_reader(std::move(schema), std::move(permit), range, schema->full_slice());
+        return make_streaming_reader(schema, std::move(permit), range, schema->full_slice());
     }
 
     // Stream reader from the given sstables

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1701,7 +1701,7 @@ static flat_mutation_reader_v2 make_reader(
     // in 'native-reversed' format (if ever).
     if (slice.get().is_reversed()) {
         return make_flat_mutation_reader_v2<mx_sstable_mutation_reader>(
-            std::move(sstable), std::move(schema), std::move(permit), range,
+            std::move(sstable), schema, std::move(permit), range,
             legacy_reverse_slice_to_native_reverse_slice(*schema, slice.get()), pc, std::move(trace_state), fwd, fwd_mr, monitor);
     }
 


### PR DESCRIPTION
That's courtersy of https://github.com/raphaelsc/seastar/commit/153813d3b88f284fe135c8ac3c00d6777faad276, which annotates Seastar smart pointer classes with Clang's consumed attributes, to help Clang to statically spot use-after-move bugs.

