### PR TITLE
 mutation: replace operator<<(..) with fmt formatter

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3621,7 +3621,7 @@ static rjson::value encode_paging_state(const schema& schema, const service::pag
     // We conditionally include these fields when reading CQL tables through alternator.
     if (!is_alternator_keyspace(schema.ks_name()) && (!pos.has_key() || pos.get_bound_weight() != bound_weight::equal)) {
         rjson::add_with_string_name(last_evaluated_key, scylla_paging_region, rjson::empty_object());
-        rjson::add(last_evaluated_key[scylla_paging_region.data()], "S", rjson::from_string(to_string(pos.region())));
+        rjson::add(last_evaluated_key[scylla_paging_region.data()], "S", rjson::from_string(fmt::to_string(pos.region())));
         rjson::add_with_string_name(last_evaluated_key, scylla_paging_weight, rjson::empty_object());
         rjson::add(last_evaluated_key[scylla_paging_weight.data()], "N", static_cast<int>(pos.get_bound_weight()));
     }

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -52,16 +52,6 @@ partition_region parse_partition_region(std::string_view s) {
     }
 }
 
-std::ostream& operator<<(std::ostream& out, partition_region r) {
-    fmt::print(out, "{}", r);
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& os, position_in_partition_view::printer p) {
-    fmt::print(os, "{}", p);
-    return os;
-}
-
 std::ostream& operator<<(std::ostream& out, position_in_partition_view pos) {
     fmt::print(out, "{}", pos);
     return out;

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -58,29 +58,18 @@ std::ostream& operator<<(std::ostream& out, partition_region r) {
 }
 
 std::ostream& operator<<(std::ostream& os, position_in_partition_view::printer p) {
-    auto& pos = p._pipv;
-    fmt::print(os, "{{position: {},", pos._type);
-    if (pos._ck) {
-        fmt::print(os, "{}", clustering_key_prefix::with_schema_wrapper(p._schema, *pos._ck));
-    } else {
-        fmt::print(os, "null");
-    }
-    fmt::print(os, ", {}}}", int32_t(pos._bound_weight));
+    fmt::print(os, "{}", p);
     return os;
 }
 
 std::ostream& operator<<(std::ostream& out, position_in_partition_view pos) {
-    out << "{position: " << pos._type << ",";
-    if (pos._ck) {
-        out << *pos._ck;
-    } else {
-        out << "null";
-    }
-    return out << "," << int32_t(pos._bound_weight) << "}";
+    fmt::print(out, "{}", pos);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const position_in_partition& pos) {
-    return out << static_cast<position_in_partition_view>(pos);
+    fmt::print(out, "{}", pos);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const position_range& range) {

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -38,16 +38,6 @@ operator<<(std::ostream& os, const partition_end& eop) {
     return os << "{partition_end}";
 }
 
-std::string_view to_string(partition_region r) {
-    switch (r) {
-        case partition_region::partition_start: return "partition_start";
-        case partition_region::static_row: return "static_row";
-        case partition_region::clustered: return "clustered";
-        case partition_region::partition_end: return "partition_end";
-    }
-    std::abort(); // compiler will error before we reach here
-}
-
 partition_region parse_partition_region(std::string_view s) {
     if (s == "partition_start") {
         return partition_region::partition_start;
@@ -63,7 +53,8 @@ partition_region parse_partition_region(std::string_view s) {
 }
 
 std::ostream& operator<<(std::ostream& out, partition_region r) {
-    return out << to_string(r);
+    fmt::print(out, "{}", r);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& os, position_in_partition_view::printer p) {

--- a/mutation/position_in_partition.hh
+++ b/mutation/position_in_partition.hh
@@ -100,7 +100,6 @@ struct fmt::formatter<partition_region> : fmt::formatter<std::string_view> {
     }
 };
 
-std::ostream& operator<<(std::ostream&, partition_region);
 partition_region parse_partition_region(std::string_view);
 
 class position_in_partition_view {
@@ -254,7 +253,6 @@ public:
     public:
         printer(const schema& schema, const position_in_partition_view& pipv) : _schema(schema), _pipv(pipv) {}
         friend fmt::formatter<printer>;
-        friend std::ostream& operator<<(std::ostream& os, printer p);
     };
 
     // Create a position which is the same as this one but governed by a schema with reversed clustering key order.
@@ -264,8 +262,6 @@ public:
 
     friend fmt::formatter<printer>;
     friend fmt::formatter<position_in_partition_view>;
-    friend std::ostream& operator<<(std::ostream& os, printer p);
-    friend std::ostream& operator<<(std::ostream&, position_in_partition_view);
     friend bool no_clustering_row_between(const schema&, position_in_partition_view, position_in_partition_view);
 };
 

--- a/mutation/position_in_partition.hh
+++ b/mutation/position_in_partition.hh
@@ -82,8 +82,25 @@ enum class partition_region : uint8_t {
 
 struct view_and_holder;
 
+template <>
+struct fmt::formatter<partition_region> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const ::partition_region& r, FormatContext& ctx) const {
+        switch (r) {
+            case partition_region::partition_start:
+                return formatter<std::string_view>::format("partition_start", ctx);
+            case partition_region::static_row:
+                return formatter<std::string_view>::format("static_row", ctx);
+            case partition_region::clustered:
+                return formatter<std::string_view>::format("clustered", ctx);
+            case partition_region::partition_end:
+                return formatter<std::string_view>::format("partition_end", ctx);
+        }
+        std::abort(); // compiler will error before we reach here
+    }
+};
+
 std::ostream& operator<<(std::ostream&, partition_region);
-std::string_view to_string(partition_region);
 partition_region parse_partition_region(std::string_view);
 
 class position_in_partition_view {

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -768,12 +768,8 @@ public:
                 out << ", ";
             }
             first = false;
-            out << "{v=" << v.version_no
-                << ", pos=" << v.it->position()
-                << ", cont=" << v.continuous
-                << ", rt=" << v.rt
-                << ", row_rt=" << v.it->range_tombstone()
-                << "}";
+            fmt::print(out, "{{v={}, pos={}, cont={}, rt={}, row_rt={}}}",
+                       v.version_no, v.it->position(), v.continuous, v.rt, v.it->range_tombstone());
         }
         out << "], heap=[\n  ";
         first = true;
@@ -782,20 +778,16 @@ public:
                 out << ",\n  ";
             }
             first = false;
-            out << "{v=" << v.version_no
-                << ", pos=" << v.it->position()
-                << ", cont=" << v.continuous
-                << ", rt=" << v.rt
-                << ", row_rt=" << v.it->range_tombstone()
-                << "}";
+            fmt::print(out, "{{v={}, pos={}, cont={}, rt={}, row_rt={}}}",
+                       v.version_no, v.it->position(), v.continuous, v.rt, v.it->range_tombstone());
         }
         out << "], latest_iterator=[";
         if (cur._latest_it) {
             mutation_partition::rows_type::iterator i = *cur._latest_it;
             if (!i) {
-                out << "end";
+                fmt::print(out, "end");
             } else {
-                out << i->position();
+                fmt::print(out, "{}", i->position());
             }
         } else {
             out << "<none>";


### PR DESCRIPTION
this is a part of a series migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `position_in_partition` and `partition_region` without using ostream<<. also, this change removes `operator<<(ostream, const position_in_partition_view&)` ,  `operator<<(ostream, const partition_region&)` along with their callers.

Refs #13245