### PR TITLE
db: view: use deferred_close for closing staging_sstable_reader

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -158,11 +158,11 @@ future<> view_update_generator::start() {
                             service::get_local_streaming_priority(),
                             nullptr,
                             ::mutation_reader::forwarding::no);
+                    auto close_sr = deferred_close(staging_sstable_reader);
 
                     inject_failure("view_update_generator_consume_staging_sstable");
                     auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(s, std::move(permit), *t, sstables, _as, staging_sstable_reader_handle),
                         dht::incremental_owned_ranges_checker::make_partition_filter(_db.get_keyspace_local_ranges(s->ks_name())));
-                    staging_sstable_reader.close().get();
                     if (result == stop_iteration::yes) {
                         break;
                     }


### PR DESCRIPTION
When consume_in_thread throws the reader should still be closed.

Related: https://github.com/scylladb/scylla-enterprise/issues/2661
Fixes: https://github.com/scylladb/scylladb/issues/13413