### PR TITLE
Fix use-after-move when initializing row cache with dummy entry

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1188,7 +1188,8 @@ row_cache::row_cache(schema_ptr s, snapshot_source src, cache_tracker& tracker, 
     with_allocator(_tracker.allocator(), [this, cont] {
         cache_entry entry(cache_entry::dummy_entry_tag{});
         entry.set_continuous(bool(cont));
-        _partitions.insert(entry.position().token().raw(), std::move(entry), dht::ring_position_comparator{*_schema});
+        auto raw_token = entry.position().token().raw();
+        _partitions.insert(raw_token, std::move(entry), dht::ring_position_comparator{*_schema});
     });
 }
 


### PR DESCRIPTION
Courtersy of clang-tidy:
```
row_cache.cc:1191:28: warning: 'entry' used after it was moved [bugprone-use-after-move] _partitions.insert(entry.position().token().raw(), std::move(entry), dht::ring_position_comparator{_schema}); ^
row_cache.cc:1191:60: note: move occurred here
_partitions.insert(entry.position().token().raw(), std::move(entry), dht::ring_position_comparator{_schema}); ^
row_cache.cc:1191:28: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated _partitions.insert(entry.position().token().raw(), std::move(entry), dht::ring_position_comparator{*_schema});
```

The use-after-move is UB, as for it to happen, depends on evaluation order.

We haven't hit it yet as clang is left-to-right.

Fixes #13400.