### PR TITLE
sstables_loader: Make non-concurrent loading more verbose

### DIFF
--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -42,7 +42,7 @@ class sstables_loader : public seastar::peering_sharded_service<sstables_loader>
     //
     // It shouldn't be impossible to actively serialize two callers if the need
     // ever arise.
-    bool _loading_new_sstables = false;
+    std::optional<std::pair<sstring, sstring>> _current = {};
 
     future<> load_and_stream(sstring ks_name, sstring cf_name,
             table_id, std::vector<sstables::shared_sstable> sstables,


### PR DESCRIPTION
Current load-new-sstables API allows limited parallelizm. If hashes table name and by that hash value identifies the shard that will govern the loading. One shard is allowed to serve at most one request.

To enforce that limitation, sstables_loader instance have bool flag on board that's set before loading and unset after it passes or fails, and if a new attempt is made on this shard an exception is thrown.

The patch extends the boolean to contain ks.cf pair from which sstables are being loaded on current shard, so that the API caller could get more info upon "try again later" exception.

Also, while at it, make the boolean reset more RAIIsh.