### PR TITLE
tests: Mitigate flaky tests annoyance

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -505,6 +505,7 @@ scylla_tests = set([
     'test/boost/expr_test',
     'test/boost/exceptions_optimized_test',
     'test/boost/exceptions_fallback_test',
+    'test/boost/flaky_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/test/boost/flaky_test.cc
+++ b/test/boost/flaky_test.cc
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/testing/test_case.hh>
+#include "test/lib/random_utils.hh"
+#include <fmt/core.h>
+
+SEASTAR_TEST_CASE(flaky_test) {
+    BOOST_REQUIRE_EQUAL(tests::random::get_int(5), 0);
+    return make_ready_future<>();
+}

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -39,3 +39,5 @@ custom_args:
         - '-c1 -m256M'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
+flaky:
+    - flaky_test


### PR DESCRIPTION
The test.py has a facility to soften the impact from flaky tests -- if a test is marked as flaky in the suite.yaml file, it can be restarted several times if it fails. This functionalty has several drawbacks.

 First: flaky test can fail more than "several" times in a row
 Second: no tests are marked as flaky in current master
 Third: there still can be flaky tests we're unaware of

Having said that, here's an improvement -- the --run-until-it-pass option that keeps restarting any test (not only previously identified and marked as flaky) until it passes. This makes sure no flaky (both known and unknown) tests can break through the existing protection.

While at it, to make sure this new option works as long as the existing flaky test restart loop -- add a simple flaky test and mark it as such.