### PR TITLE
test: network_topology_strategy_test: use std::lerp

### DIFF
--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -16,6 +16,7 @@
 #include <seastar/core/sstring.hh>
 #include "log.hh"
 #include "gms/gossiper.hh"
+#include <cmath>
 #include <vector>
 #include <string>
 #include <map>
@@ -123,11 +124,8 @@ void endpoints_check(
 }
 
 auto d2t = [](double d) -> int64_t {
-    // Double to unsigned long conversion will overflow if the
-    // input is greater than numeric_limits<long>::max(), so divide by two and
-    // multiply again later.
     auto scale = std::numeric_limits<unsigned long>::max();
-    return static_cast<unsigned long>(d * static_cast<double>(scale >> 1)) << 1;
+    return static_cast<unsigned long>(std::lerp(0, scale, d));
 };
 
 /**


### PR DESCRIPTION
std::lerp() interpolate a value in the given range into another, and we don't need to worry about the overflow, so it is a perfect fit to our needs. as `d2t()` scales a float point number in the range of [0, 1] to the a token represented with an unsigned long. so, let's use `std::lerp()` to replace the shift dance.