### PR TITLE
test/cql-pytest: s/exit()/sys.exit()/

### DIFF
--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -165,10 +165,10 @@ run.wait_for_services(pid, [lambda: check_cql(ip)])
 success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
 if success:
     run.summary = 'Cassandra tests pass'
-    exit(1)
+    sys.exit(1)
 else:
     run.summary = 'Cassandra tests failure'
-    exit(0)
+    sys.exit(0)
 
 # Note that the run.cleanup_all() function runs now, just like on any exit
 # for any reason in this script. It will delete the temporary files and

--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -163,10 +163,12 @@ ip = run.pid_to_ip(pid)
 
 run.wait_for_services(pid, [lambda: check_cql(ip)])
 success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
-
-run.summary = 'Cassandra tests pass' if success else 'Cassandra tests failure'
-
-exit(0 if success else 1)
+if success:
+    run.summary = 'Cassandra tests pass'
+    exit(1)
+else:
+    run.summary = 'Cassandra tests failure'
+    exit(0)
 
 # Note that the run.cleanup_all() function runs now, just like on any exit
 # for any reason in this script. It will delete the temporary files and

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -174,11 +174,11 @@ def find_scylla():
         scyllas = glob.glob(os.path.join(source_path, 'build/*/scylla'))
         if not scyllas:
             print("Can't find a Scylla executable in {}.\nPlease build Scylla or set SCYLLA to the path of a Scylla executable.".format(source_path))
-            exit(1)
+            sys.exit(1)
         scylla = max(scyllas, key=os.path.getmtime)
     if not os.access(scylla, os.X_OK):
         print("Cannot execute '{}'.\nPlease set SCYLLA to the path of a Scylla executable.".format(scylla))
-        exit(1)
+        sys.exit(1)
     return scylla
 
 def run_scylla_cmd(pid, dir):
@@ -374,7 +374,7 @@ def run_pytest(pytest_dir, additional_parameters):
         os.setsid()
         os.execvp('pytest', ['pytest',
             '-o', 'junit_family=xunit2'] + additional_parameters)
-        exit(1)
+        sys.exit(1)
     # parent:
     run_pytest_pids.add(pid)
     if os.waitpid(pid, 0)[1]:


### PR DESCRIPTION
in addition to consolidating two conditions into a single one, this series replaces `exit()` call with `sys.exit()`. as the former is generally used by interactive shell, and the latter is used by an application.