### PR TITLE
replica: Make compaction_group responsible for deleting off-strategy compaction input

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1111,7 +1111,6 @@ private:
             return !sst->requires_view_building();
         }));
         std::vector<sstables::shared_sstable> reshape_candidates = old_sstables;
-        std::vector<sstables::shared_sstable> sstables_to_remove;
         std::unordered_set<sstables::shared_sstable> new_unused_sstables;
 
         auto cleanup_new_unused_sstables_on_failure = defer([&new_unused_sstables] {
@@ -1161,8 +1160,6 @@ private:
                 if (can_remove_now(sst)) {
                     co_await sst->unlink();
                     new_unused_sstables.erase(std::move(sst));
-                } else {
-                    sstables_to_remove.push_back(std::move(sst));
                 }
             }
         }
@@ -1175,7 +1172,6 @@ private:
         co_await t.on_compaction_completion(std::move(completion_desc), sstables::offstrategy::yes);
 
         cleanup_new_unused_sstables_on_failure.cancel();
-        co_await sstables::sstable_directory::delete_atomically(std::move(sstables_to_remove));
         if (err) {
             co_await coroutine::return_exception_ptr(std::move(err));
         }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -62,6 +62,8 @@ private:
     // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
     void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
     static uint64_t calculate_disk_space_used_for(const sstables::sstable_set& set);
+
+    future<> delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove);
 public:
     compaction_group(table& t, dht::token_range token_range);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1078,6 +1078,19 @@ table::sstable_list_builder::build_new_list(const sstables::sstable_set& current
 }
 
 future<>
+compaction_group::delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove) {
+    return seastar::try_with_gate(_t._sstable_deletion_gate, [this, sstables_to_remove = std::move(sstables_to_remove)] () mutable {
+        return with_semaphore(_t._sstable_deletion_sem, 1, [sstables_to_remove = std::move(sstables_to_remove)] () mutable {
+            return sstables::sstable_directory::delete_atomically(std::move(sstables_to_remove));
+        });
+    }).handle_exception([] (std::exception_ptr ex) {
+        // There is nothing more we can do here.
+        // Any remaining SSTables will eventually be re-compacted and re-deleted.
+        tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::move(ex));
+    });
+}
+
+future<>
 compaction_group::update_sstable_lists_on_off_strategy_completion(sstables::compaction_completion_desc desc) {
     class sstable_lists_updater : public row_cache::external_updater_impl {
         using sstables_t = std::vector<sstables::shared_sstable>;
@@ -1119,6 +1132,16 @@ compaction_group::update_sstable_lists_on_off_strategy_completion(sstables::comp
     co_await _t.get_row_cache().invalidate(std::move(updater), std::move(empty_ranges));
     _t.get_row_cache().refresh_snapshot();
     _t.rebuild_statistics();
+
+    std::unordered_set<sstables::shared_sstable> output(desc.new_sstables.begin(), desc.new_sstables.end());
+    // Input SSTables that weren't added to the main SSTable set, can be unlinked.
+    // An input SSTable remains linked if it hadn't gone through reshape compaction. Such a SSTable
+    // will only be moved from maintenance (source) to main (destination) set.
+    auto sstables_to_remove = boost::copy_range<std::vector<sstables::shared_sstable>>(desc.old_sstables
+            | boost::adaptors::filtered([&output] (const sstables::shared_sstable& input_sst) {
+                return !output.contains(input_sst);
+            }));
+    co_await delete_sstables_atomically(std::move(sstables_to_remove));
 }
 
 future<>
@@ -1197,19 +1220,7 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 
     _t.rebuild_statistics();
 
-    auto f = seastar::try_with_gate(_t._sstable_deletion_gate, [this, sstables_to_remove = desc.old_sstables] {
-       return with_semaphore(_t._sstable_deletion_sem, 1, [sstables_to_remove = std::move(sstables_to_remove)] {
-           return sstables::sstable_directory::delete_atomically(std::move(sstables_to_remove));
-       });
-    });
-
-    try {
-        co_await std::move(f);
-    } catch (...) {
-        // There is nothing more we can do here.
-        // Any remaining SSTables will eventually be re-compacted and re-deleted.
-        tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::current_exception());
-    }
+    co_await delete_sstables_atomically(std::move(desc.old_sstables));
 }
 
 future<>


### PR DESCRIPTION
Compaction group is responsible for deleting SSTables of "in-strategy" compactions, i.e. regular, major, cleanup, etc.

Both in-strategy and off-strategy compaction have their completion handled using the same compaction group interface, which is 
```
compaction_group::table_state::on_compaction_completion(...,
				sstables::offstrategy offstrategy)
```

So it's important to bring symmetry there, by moving the responsibility of deleting off-strategy input, from manager to group.

Another important advantage is that off-strategy deletion is now throttled and gated, allowing for better control, e.g. table waiting for deletion on shutdown.