### PR TITLE
test/pylib: ManagerClient helper to wait for server to see other servers after start/restart

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -48,7 +48,7 @@ class ManagerClient():
         """Close driver"""
         self.driver_close()
 
-    async def driver_connect(self, server=None) -> None:
+    async def driver_connect(self, server: Optional[ServerInfo] = None) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:
             targets = [server] if server else await self.running_servers()
@@ -139,17 +139,21 @@ class ManagerClient():
         logger.debug("ManagerClient stopping gracefully %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/stop_gracefully")
 
-    async def server_start(self, server_id: ServerNum, expected_error: Optional[str] = None) -> None:
-        """Start specified server"""
+    async def server_start(self, server_id: ServerNum, expected_error: Optional[str] = None,
+                           wait_others: int = 0, wait_interval: float = 45) -> None:
+        """Start specified server and optionally wait for it to learn of other servers"""
         logger.debug("ManagerClient starting %s", server_id)
         params = {'expected_error': expected_error} if expected_error is not None else None
         await self.client.get_text(f"/cluster/server/{server_id}/start", params=params)
+        await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         self._driver_update()
 
-    async def server_restart(self, server_id: ServerNum) -> None:
-        """Restart specified server"""
+    async def server_restart(self, server_id: ServerNum, wait_others: int = 0,
+                             wait_interval: float = 45) -> None:
+        """Restart specified server and optionally wait for it to learn of other servers"""
         logger.debug("ManagerClient restarting %s", server_id)
         await self.client.get_text(f"/cluster/server/{server_id}/restart")
+        await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         self._driver_update()
 
     async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None, start: bool = True) -> ServerInfo:
@@ -239,3 +243,32 @@ class ManagerClient():
         except Exception as exc:
             raise Exception(f"Failed to get local host id address for server {server_id}") from exc
         return HostID(host_id)
+
+    async def server_sees_others(self, server_id: ServerNum, count: int, interval: float = 45.):
+        """Wait till a server sees a minimum given count of other servers"""
+        if count < 1:
+            return
+        server_ip = await self.get_host_ip(server_id)
+        async def _sees_min_others():
+            alive_nodes = await self.api.get_alive_endpoints(server_ip)
+            if len(alive_nodes) > count:
+                return True
+        await wait_for(_sees_min_others, time() + interval, period=.1)
+
+    async def server_sees_other_server(self, server_ip: IPAddress, other_ip: IPAddress,
+                                       interval: float = 45.):
+        """Wait till a server sees another specific server IP as alive"""
+        async def _sees_another_server():
+            alive_nodes = await self.api.get_alive_endpoints(server_ip)
+            if other_ip in alive_nodes:
+                return True
+        await wait_for(_sees_another_server, time() + interval, period=.1)
+
+    async def server_not_sees_other_server(self, server_ip: IPAddress, other_ip: IPAddress,
+                                           interval: float = 45.):
+        """Wait till a server sees another specific server IP as dead"""
+        async def _not_sees_another_server():
+            alive_nodes = await self.api.get_alive_endpoints(server_ip)
+            if not other_ip in alive_nodes:
+                return True
+        await wait_for(_not_sees_another_server, time() + interval, period=.1)

--- a/test/topology/test_topology_remove_garbage_group0.py
+++ b/test/topology/test_topology_remove_garbage_group0.py
@@ -81,6 +81,8 @@ async def test_remove_garbage_group0_members(manager: ManagerClient):
     logging.info(f'stop {servers[1]}')
     await manager.server_stop_gracefully(servers[1].server_id)
 
+    logging.debug(f'waiting for {servers[2]} to see {servers[1]} is down')
+    await manager.server_not_sees_other_server(servers[2].ip_addr, servers[1].ip_addr)
     logging.info(f'removenode {servers[1]} using {servers[2]}')
     await manager.remove_node(servers[2].server_id, servers[1].server_id)
 


### PR DESCRIPTION
When starting/restarting a server, provide a way to wait for the server to see other servers.
    
Also leave the implementation methods available for manual use and update previous tests.

Fixes [#13147](https://github.com/scylladb/scylladb/issues/13147)
