### PR TITLE
service levels: update `client_state` when SL is altered

### DIFF
--- a/generic_server.hh
+++ b/generic_server.hh
@@ -52,7 +52,7 @@ public:
 
     virtual future<> process_request() = 0;
 
-    virtual void on_connection_close();
+    virtual future<> on_connection_close();
 
     virtual future<> shutdown();
 };

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -244,11 +244,8 @@ future<> service::client_state::maybe_update_per_service_level_params() {
         auto& role_manager = _auth_service->underlying_role_manager();
         auto role_set = co_await role_manager.query_granted(_user->name.value(), auth::recursive_role_query::yes);
         auto slo_opt = co_await _sl_controller->find_service_level(role_set);
-        if (!slo_opt) {
-            co_return;
-        }
         auto slo_timeout_or = [&] (const lowres_clock::duration& default_timeout) {
-            return std::visit(overloaded_functor{
+            return (!slo_opt) ? default_timeout : std::visit(overloaded_functor{
                 [&] (const qos::service_level_options::unset_marker&) -> lowres_clock::duration {
                     return default_timeout;
                 },

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -271,3 +271,34 @@ future<> service::client_state::maybe_update_per_service_level_params() {
         _workload_type = slo_opt->workload;
     }
 }
+
+void service::client_state::register_service_level_subscriber() {
+    if (_sl_controller && _user && _user->name) {
+        _sl_controller->register_subscriber(this);
+    }
+}
+
+future<> service::client_state::on_client_leave() {
+    if (_sl_controller && _user && _user->name) {
+        return _sl_controller->unregister_subscriber(this);
+    }
+
+    return make_ready_future<>();
+}
+
+future<> service::client_state::on_before_service_level_add(qos::service_level_options slo, qos::service_level_info sl_info) {
+    return make_ready_future<>();
+}
+
+future<> service::client_state::on_after_service_level_add(qos::service_level_options slo, qos::service_level_info sl_info) {
+    return make_ready_future<>();
+}
+future<> service::client_state::on_after_service_level_remove(qos::service_level_info sl_info) {
+    return maybe_update_per_service_level_params();
+}
+future<> service::client_state::on_before_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) {
+    return make_ready_future<>();
+}
+future<> service::client_state::on_after_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) {
+    return maybe_update_per_service_level_params();
+}

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -40,7 +40,7 @@ namespace service {
 /**
  * State related to a client connection.
  */
-class client_state {
+class client_state : private qos::qos_configuration_change_subscriber {
 public:
     enum class auth_state : uint8_t {
         UNINITIALIZED, AUTHENTICATION, READY
@@ -347,6 +347,15 @@ public:
     future<> has_functions_access(auth::permission p) const;
     future<> has_functions_access(const sstring& ks, auth::permission p) const;
     future<> has_function_access(const sstring& ks, const sstring& function_signature, auth::permission p) const;
+
+public:
+    void register_service_level_subscriber();
+private:
+    virtual future<> on_before_service_level_add(qos::service_level_options slo, qos::service_level_info sl_info) override;
+    virtual future<> on_after_service_level_add(qos::service_level_options slo, qos::service_level_info sl_info) override;
+    virtual future<> on_after_service_level_remove(qos::service_level_info sl_info) override;
+    virtual future<> on_before_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) override;
+    virtual future<> on_after_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) override;
 private:
     future<> has_access(const sstring& keyspace, auth::command_desc) const;
 
@@ -421,6 +430,9 @@ public:
     void set_protocol_extensions(cql_transport::cql_protocol_extension_enum_set exts) {
         _enabled_protocol_extensions = std::move(exts);
     }
+
+public:
+    future<> on_client_leave();
 };
 
 }

--- a/service/qos/qos_configuration_change_subscriber.hh
+++ b/service/qos/qos_configuration_change_subscriber.hh
@@ -16,14 +16,19 @@ namespace qos {
     struct service_level_info {
         sstring name;
     };
+
     class qos_configuration_change_subscriber {
     public:
         /** This callback is going to be called just before the service level is available **/
         virtual future<> on_before_service_level_add(service_level_options slo, service_level_info sl_info) = 0;
-        /** This callback is going to be called just after the service level is removed **/
+        /** This callback is going to be called just after the service level is available **/
+        virtual future<> on_after_service_level_add(service_level_options slo, service_level_info sl_info) = 0;
+        /** This callback is going to be called just before the service level is available **/
         virtual future<> on_after_service_level_remove(service_level_info sl_info) = 0;
-        /** This callback is going to be called just before the service level is changed **/
+        /** This callback is going to be called just before the service level is available **/
         virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) = 0;
+        /** This callback is going to be called just after the service level is available **/
+        virtual future<> on_after_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) = 0;
 
         virtual ~qos_configuration_change_subscriber() {};
     };

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -52,6 +52,10 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
         return make_ready_future<>();
     }
 
+    virtual future<> on_after_service_level_add(service_level_options slo, service_level_info sl_info) override {
+        return make_ready_future<>();
+    }
+
     virtual future<> on_after_service_level_remove(service_level_info sl_info) override {
         ops.push_back(remove_op{sl_info.name});
         return make_ready_future<>();
@@ -59,6 +63,10 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
 
     virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
         ops.push_back(change_op{sl_info.name, slo_before, slo_after});
+        return make_ready_future<>();
+    }
+
+    virtual future<> on_after_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
         return make_ready_future<>();
     }
 };

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -7,11 +7,17 @@
  */
 
 
+#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdlib.h>
 #include <iostream>
 
+#include "auth/authentication_options.hh"
+#include "auth/password_authenticator.hh"
 #include "seastarx.hh"
+#include "service/qos/qos_common.hh"
+#include "test/lib/cql_assertions.hh"
+#include "test/lib/cql_test_env.hh"
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/future-util.hh>
@@ -20,12 +26,20 @@
 #include "service/qos/qos_configuration_change_subscriber.hh"
 #include "auth/service.hh"
 #include "utils/overloaded_functor.hh"
+#include "test/lib/make_random_string.hh"
+#include <seastar/core/sleep.hh>
 
 using namespace qos;
-struct add_op {
+struct before_add_op {
     sstring name;
     service_level_options slo;
-    bool operator==(const add_op& other) const = default;
+    bool operator==(const before_add_op& other) const = default;
+};
+
+struct after_add_op {
+    sstring name;
+    service_level_options slo;
+    bool operator==(const after_add_op& other) const = default;
 };
 
 struct remove_op {
@@ -33,14 +47,21 @@ struct remove_op {
     bool operator==(const remove_op& other) const = default;
 };
 
-struct change_op {
+struct before_change_op {
     sstring name;
     service_level_options slo_before;
     service_level_options slo_after;
-    bool operator==(const change_op& other) const = default;
+    bool operator==(const before_change_op& other) const = default;
 };
 
-using service_level_op =  std::variant<add_op, remove_op, change_op>;
+struct after_change_op {
+    sstring name;
+    service_level_options slo_before;
+    service_level_options slo_after;
+    bool operator==(const after_change_op& other) const = default;
+};
+
+using service_level_op =  std::variant<before_add_op, after_add_op, remove_op, before_change_op, after_change_op>;
 
 struct qos_configuration_change_suscriber_simple : public qos_configuration_change_subscriber {
 
@@ -48,11 +69,12 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
     std::vector<service_level_op> ops;
 
     virtual future<> on_before_service_level_add(service_level_options slo, service_level_info sl_info) override {
-        ops.push_back(add_op{sl_info.name, slo});
+        ops.push_back(before_add_op{sl_info.name, slo});
         return make_ready_future<>();
     }
 
     virtual future<> on_after_service_level_add(service_level_options slo, service_level_info sl_info) override {
+        ops.push_back(after_add_op{sl_info.name, slo});
         return make_ready_future<>();
     }
 
@@ -62,32 +84,43 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
     }
 
     virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
-        ops.push_back(change_op{sl_info.name, slo_before, slo_after});
+        ops.push_back(before_change_op{sl_info.name, slo_before, slo_after});
         return make_ready_future<>();
     }
 
     virtual future<> on_after_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
+        ops.push_back(after_change_op(sl_info.name, slo_before, slo_after));
         return make_ready_future<>();
     }
 };
 
-std::ostream& operator<<(std::ostream& os, const add_op& op) {
-    return os << "Service Level: added '" << op.name << "' with " << op.slo.workload;
+std::ostream& operator<<(std::ostream& os, const before_add_op& op) {
+    return os << "Service Level: before add '" << op.name << "' with " << op.slo.workload;
 }
 
-std::ostream& operator<<(std::ostream& os, const change_op& op) {
-    return os << "Service Level: changed '" << op.name << "' from " << op.slo_before.workload << " to " << op.slo_after.workload;
+std::ostream& operator<<(std::ostream& os, const after_add_op& op) {
+    return os << "Service Level: after add '" << op.name << "' with " << op.slo.workload;
+}
+
+std::ostream& operator<<(std::ostream& os, const before_change_op& op) {
+    return os << "Service Level: before change '" << op.name << "' from " << op.slo_before.workload << " to " << op.slo_after.workload;
+}
+
+std::ostream& operator<<(std::ostream& os, const after_change_op& op) {
+    return os << "Service Level: after change '" << op.name << "' from " << op.slo_before.workload << " to " << op.slo_after.workload;
 }
 
 std::ostream& operator<<(std::ostream& os, const remove_op& op) {
-    return os << "Service Level: removed '" << op.name << "'";
+    return os << "Service Level: remove '" << op.name << "'";
 }
 
 std::ostream& operator<<(std::ostream& os, const service_level_op& op) {
      std::visit(overloaded_functor {
-            [&os] (const add_op& op) { os << op; },
+            [&os] (const before_add_op& op) { os << op; },
+            [&os] (const after_add_op& op) { os << op; },
             [&os] (const remove_op& op) { os << op; },
-            [&os] (const change_op& op) { os << op; },
+            [&os] (const before_change_op& op) { os << op; },
+            [&os] (const after_change_op& op) { os << op; },
      }, op);
      return os;
 }
@@ -106,13 +139,66 @@ SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
     sl_controller.local().remove_service_level("sl2", false).get();
 
     std::vector<service_level_op> expected_result = {
-        add_op{"sl1", service_level_options{}},
-        add_op{"sl2", service_level_options{}},
-        change_op{"sl1", service_level_options{}, slo},
+        before_add_op{"sl1", service_level_options{}},
+        after_add_op{"sl1", service_level_options{}},
+        before_add_op{"sl2", service_level_options{}},
+        after_add_op{"sl2", service_level_options{}},
+        before_change_op{"sl1", service_level_options{}, slo},
+        after_change_op{"sl1", service_level_options{}, slo},
         remove_op{"sl2"},
     };
 
     sl_controller.local().unregister_subscriber(&ccss).get();
     BOOST_REQUIRE_EQUAL(ccss.ops, expected_result);
     sl_controller.stop().get();
+}
+
+static future<auth::authenticated_user>
+authenticate(cql_test_env& env, std::string_view username, std::string_view password) {
+    auto& c = env.local_client_state();
+    auto& a = env.local_auth_service().underlying_authenticator();
+
+    return do_with(
+            auth::authenticator::credentials_map{
+                    {auth::authenticator::USERNAME_KEY, sstring(username)},
+                    {auth::authenticator::PASSWORD_KEY, sstring(password)}},
+            [&a, &c](const auto& credentials) {
+        return a.authenticate(credentials).then([&c](auth::authenticated_user u) {
+            c.set_login(std::move(u));
+            return c.check_user_can_login().then([&c] { 
+                return c.maybe_update_per_service_level_params().then([&c] {
+                    return *c.user(); 
+                });
+            });
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(test_client_state_params_update_on_sl_alter) {
+    auto cfg = make_shared<db::config>();
+    cfg->authenticator(sstring(auth::password_authenticator_name));
+
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        env.local_client_state().register_service_level_subscriber();
+
+        sstring role_name = "user_" + make_random_numeric_string(8);
+        auth::role_config config {
+            .can_login = true,
+        };
+        auth::authentication_options opts {
+            .password = "pass",
+        };
+        auth::create_role(env.local_auth_service(), role_name, config, opts).get();
+        sstring sl_name = "sl_" + make_random_numeric_string(8);
+
+        cquery_nofail(env, "CREATE SERVICE LEVEL " + sl_name + " WITH timeout = 10s");
+        cquery_nofail(env, "ATTACH SERVICE LEVEL " + sl_name + " TO " + role_name);
+        authenticate(env, role_name, "pass").get();
+        BOOST_REQUIRE_EQUAL(env.local_client_state().get_timeout_config().read_timeout, std::chrono::seconds(10));
+        BOOST_REQUIRE_EQUAL(env.local_client_state().get_workload_type(), qos::service_level_options::workload_type::unspecified);
+
+        cquery_nofail(env, "ALTER SERVICE LEVEL " + sl_name + " WITH timeout = 2s AND workload_type = 'interactive'");
+        BOOST_REQUIRE_EQUAL(env.local_client_state().get_timeout_config().read_timeout, std::chrono::seconds(2));
+        BOOST_REQUIRE_EQUAL(env.local_client_state().get_workload_type(), qos::service_level_options::workload_type::interactive);
+    }, cfg);
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -16,6 +16,7 @@
 
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
+#include "seastar/core/future.hh"
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"
@@ -603,9 +604,9 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
 cql_server::connection::~connection() {
 }
 
-void cql_server::connection::on_connection_close()
-{
+future<> cql_server::connection::on_connection_close() {
     _server._notifier->unregister_connection(this);
+    return make_ready_future<>();
 }
 
 std::tuple<net::inet_address, int, client_type> cql_server::connection::make_client_key(const service::client_state& cli_state) {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -219,7 +219,7 @@ private:
         virtual ~connection();
         future<> process_request() override;
         void handle_error(future<>&& f) override;
-        void on_connection_close() override;
+        future<> on_connection_close() override;
         static std::tuple<net::inet_address, int, client_type> make_client_key(const service::client_state& cli_state);
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }


### PR DESCRIPTION
When any changes were made to service levels or roles, the client had to restart connection for the changes to take effect.

This PR makes the `client_state` params are updated when any service level is altered or dropped, by registering a subscriber on service level configuration change.
Update of `client_state` params isn't instant because service level configuration is updated in 10s interval.

This PR doesn't fix the need of restarting the connection when 
- a service level is attached to a role
- a service level is detached from a role
- one role is granted to another