### PR TITLE
locator::ec2_snitch: change retry logic to exponential backoff

### DIFF
--- a/locator/ec2_snitch.hh
+++ b/locator/ec2_snitch.hh
@@ -9,6 +9,7 @@
 #include "locator/production_snitch_base.hh"
 #include <seastar/http/response_parser.hh>
 #include <seastar/net/api.hh>
+#include "utils/exponential_backoff_retry.hh"
 
 namespace locator {
 class ec2_snitch : public production_snitch_base {
@@ -17,8 +18,7 @@ public:
     static constexpr const char* ZONE_NAME_QUERY_REQ = "/latest/meta-data/placement/availability-zone";
     static constexpr const char* AWS_QUERY_SERVER_ADDR = "169.254.169.254";
     static constexpr uint16_t AWS_QUERY_SERVER_PORT = 80;
-    static constexpr int AWS_API_CALL_RETRIES = 5;
-    static constexpr auto AWS_API_CALL_RETRY_INTERVAL = std::chrono::seconds{5};
+    static constexpr int AWS_API_CALL_RETRIES = 10;
 
     ec2_snitch(const snitch_config&);
     virtual future<> start() override;
@@ -35,6 +35,7 @@ private:
     output_stream<char> _out;
     http_response_parser _parser;
     sstring _req;
+    exponential_backoff_retry _ec2_api_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(2560));
     future<sstring> aws_api_call_once(sstring addr, uint16_t port, const sstring cmd, std::optional<sstring> token);
 };
 } // namespace locator


### PR DESCRIPTION
Since Amazon recommended to use exponential backoff logic when retries to call AWS API, we should switch the logic on ec2_snitch.

see https://docs.aws.amazon.com/general/latest/gr/api-retries.html

Related with #12160