### PR TITLE
Implement native reverse queries

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -545,6 +545,10 @@ murmur3_partitioner_ignore_msb_bits: 12
 # Set to `false` to fall-back to the old algorithm.
 # enable_optimized_reversed_reads: true
 
+# Coordinator-side option for optimizing reverse read queries using native reverse reads internally.
+# Set to `false` to fall-back to the legacy half-reversed internal reads.
+# enable_native_reversed_queries: true
+
 # Use on a new, parallel algorithm for performing aggregate queries.
 # Set to `false` to fall-back to the old algorithm.
 # enable_parallelized_aggregation: true

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -135,7 +135,7 @@ public:
 
     const sstring& column_family() const;
 
-    query::partition_slice make_partition_slice(const query_options& options) const;
+    query::partition_slice make_partition_slice(const query_options& options, bool native_reverse_query_supported = false) const;
 
     const ::shared_ptr<const restrictions::statement_restrictions> get_restrictions() const;
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -872,6 +872,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Bypass in-memory data cache (the row cache) when performing reversed queries.")
     , enable_optimized_reversed_reads(this, "enable_optimized_reversed_reads", liveness::LiveUpdate, value_status::Used, true,
             "Use a new optimized algorithm for performing reversed reads.")
+    , enable_native_reversed_queries(this, "enable_native_reversed_queries", liveness::LiveUpdate, value_status::Used, true,
+            "Optimize reverse read queries using native reverse reads internally.")
     , enable_cql_config_updates(this, "enable_cql_config_updates", liveness::LiveUpdate, value_status::Used, true,
             "Make the system.config table UPDATEable")
     , enable_parallelized_aggregation(this, "enable_parallelized_aggregation", liveness::LiveUpdate, value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -355,6 +355,7 @@ public:
     named_value<tri_mode_restriction> strict_allow_filtering;
     named_value<bool> reversed_reads_auto_bypass_cache;
     named_value<bool> enable_optimized_reversed_reads;
+    named_value<bool> enable_native_reversed_queries;
     named_value<bool> enable_cql_config_updates;
     named_value<bool> enable_parallelized_aggregation;
 

--- a/docs/dev/reverse-reads.md
+++ b/docs/dev/reverse-reads.md
@@ -120,3 +120,7 @@ partition that was used in the legacy format example, the native reverse
 version would look like this:
 
     ps{pk1}, sr{}, cr{ck5}, cr{ck4}, rt{(ck4, ck2]}, cr{ck3}, cr{ck2}, ck{ck1}, pe{}
+
+And with range_tombstone_change:
+
+    ps{pk1}, sr{}, cr{ck5}, cr{ck4}, rtc{after(ck4), t}, cr{ck3}, cr{ck2}, rtc{after(ck2), 0}, ck{ck1}, pe{}

--- a/docs/dev/reverse-reads.md
+++ b/docs/dev/reverse-reads.md
@@ -91,7 +91,10 @@ process the reverse stream as normal.
 ### Request
 
 The `query::partition_slice::options::reversed` flag is set as in the
-legacy format. Clustering ranges in both
+legacy format, and the `query::partition_slice::options::native_reversed` flag
+is set on top of it.
+
+Clustering ranges in both
 `query::partition_slice::_row_ranges` and
 `query::specific_ranges::_ranges`
 (`query::partition_slice::_specific_ranges`) are fully-reversed: they

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -111,6 +111,7 @@ public:
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
     gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
+    gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
 
 public:
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2212,7 +2212,14 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.is_legacy_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
+    auto reverse = consume_in_reverse::no;
+
+    if (slice.is_legacy_reversed()) {
+        reverse = consume_in_reverse::yes;
+        mplog.debug("to_data_query_result: legacy reversed");
+    } else if (slice.is_native_reversed()) {
+        mplog.debug("to_data_query_result: native reversed");
+    }
 
     // FIXME: frozen_mutation::consume supports only forward consumers
     if (reverse == consume_in_reverse::no) {
@@ -2244,7 +2251,15 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.is_legacy_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
+    auto reverse = consume_in_reverse::no;
+
+    if (slice.is_legacy_reversed()) {
+        reverse = consume_in_reverse::yes;
+        mplog.debug("query_mutation: legacy reversed");
+    } else if (slice.is_native_reversed()) {
+        mplog.debug("query_mutation: native reversed");
+    }
+
     std::move(m).consume(consumer, reverse);
     return builder.build(compaction_state->current_full_position());
 }

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2212,7 +2212,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
 
     // FIXME: frozen_mutation::consume supports only forward consumers
     if (reverse == consume_in_reverse::no) {
@@ -2244,7 +2244,7 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
     std::move(m).consume(consumer, reverse);
     return builder.build(compaction_state->current_full_position());
 }

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2212,7 +2212,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_legacy_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
 
     // FIXME: frozen_mutation::consume supports only forward consumers
     if (reverse == consume_in_reverse::no) {
@@ -2244,7 +2244,7 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_legacy_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
     std::move(m).consume(consumer, reverse);
     return builder.build(compaction_state->current_full_position());
 }

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -146,7 +146,7 @@ public:
     // Expects table schema (non-reversed) and half-reversed (legacy) slice when building results for reverse query.
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
-        : _schema(s), _slice(slice), _reversed(_slice.options.contains(query::partition_slice::option::reversed))
+        : _schema(s), _slice(slice), _reversed(_slice.is_reversed())
         , _memory_accounter(std::move(accounter))
     { }
 

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -156,6 +156,13 @@ partition_slice_builder::reversed() {
 }
 
 partition_slice_builder&
+partition_slice_builder::native_reversed() {
+    reversed();
+    _options.set<query::partition_slice::option::native_reversed>();
+    return *this;
+}
+
+partition_slice_builder&
 partition_slice_builder::without_partition_key_columns() {
     _options.remove<query::partition_slice::option::send_partition_key>();
     return *this;

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -48,6 +48,7 @@ public:
     partition_slice_builder& without_partition_key_columns();
     partition_slice_builder& without_clustering_key_columns();
     partition_slice_builder& reversed();
+    partition_slice_builder& native_reversed();
     template <query::partition_slice::option OPTION>
     partition_slice_builder& with_option() {
         _options.set<OPTION>();

--- a/querier.hh
+++ b/querier.hh
@@ -107,7 +107,7 @@ public:
     }
 
     bool is_reversed() const {
-        return _slice->options.contains(query::partition_slice::option::reversed);
+        return _slice->is_reversed();
     }
 
     virtual std::optional<full_position_view> current_position() const = 0;

--- a/query-request.hh
+++ b/query-request.hh
@@ -171,6 +171,10 @@ public:
         // directly, bypassing the intermediate reconcilable_result format used
         // in pre 4.5 range scans.
         range_scan_data_variant,
+        // native_reversed should be set on top of the `reversed` option
+        // to indicate that the query results are to be returned in native reverse order.
+        // the schema version sent over the wire indicates the native schema.
+        native_reversed,
     };
     using option_set = enum_set<super_enum<option,
         option::send_clustering_key,
@@ -185,7 +189,8 @@ public:
         option::with_digest,
         option::bypass_cache,
         option::always_return_static_content,
-        option::range_scan_data_variant>>;
+        option::range_scan_data_variant,
+        option::native_reversed>>;
     clustering_row_ranges _row_ranges;
 public:
     column_id_vector static_columns; // TODO: consider using bitmap
@@ -248,6 +253,16 @@ public:
     [[nodiscard]]
     bool is_reversed() const {
         return options.contains<query::partition_slice::option::reversed>();
+    }
+
+    [[nodiscard]]
+    bool is_native_reversed() const noexcept {
+        return is_reversed() && options.contains<query::partition_slice::option::native_reversed>();
+    }
+
+    [[nodiscard]]
+    bool is_legacy_reversed() const noexcept {
+        return is_reversed() && !options.contains<query::partition_slice::option::native_reversed>();
     }
 
     friend std::ostream& operator<<(std::ostream& out, const partition_slice& ps);

--- a/query.cc
+++ b/query.cc
@@ -49,8 +49,11 @@ std::ostream& operator<<(std::ostream& out, const partition_slice& ps) {
         fmt::print(out, ", specific=[{}]", *ps._specific_ranges);
     }
     // FIXME: pretty print options
-    fmt::print(out, ", options={:x}, , partition_row_limit={}}}",
-               ps.options.mask(), ps.partition_row_limit());
+    auto reverse_desc = ps.is_native_reversed() ? "native"
+            : ps.is_legacy_reversed() ? "legacy"
+            : "none";
+    fmt::print(out, ", options={:x}, reverse={}, partition_row_limit={}}}",
+               ps.options.mask(), reverse_desc, ps.partition_row_limit());
     return out;
 }
 

--- a/read_context.hh
+++ b/read_context.hh
@@ -163,7 +163,7 @@ public:
         , _range_query(!query::is_single_partition(range))
         , _underlying(_cache, *this)
     {
-        if (_slice.options.contains(query::partition_slice::option::reversed)) {
+        if (_slice.is_reversed()) {
             _native_slice = query::legacy_reverse_slice_to_native_reverse_slice(*_schema, _slice);
         }
         ++_cache._tracker._stats.reads;
@@ -186,7 +186,7 @@ public:
     reader_permit permit() const { return _permit; }
     const dht::partition_range& range() const { return _range; }
     const query::partition_slice& slice() const { return _slice; }
-    bool is_reversed() const { return _slice.options.contains(query::partition_slice::option::reversed); }
+    bool is_reversed() const { return _slice.is_reversed(); }
     // Returns a slice in the native format (for reversed reads, in native-reversed format).
     const query::partition_slice& native_slice() const { return is_reversed() ? *_native_slice : _slice; }
     const io_priority_class& pc() const { return _pc; }

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -336,7 +336,7 @@ void evictable_reader_v2::update_next_position() {
 }
 
 void evictable_reader_v2::adjust_partition_slice() {
-    const auto reversed = _ps.options.contains(query::partition_slice::option::reversed);
+    const auto reversed = _ps.is_reversed();
     _slice_override = reversed ? query::legacy_reverse_slice_to_native_reverse_slice(*_schema, _ps) : _ps;
 
     auto ranges = _slice_override->default_row_ranges();
@@ -476,7 +476,7 @@ void evictable_reader_v2::validate_position_in_partition(position_in_partition_v
             pos);
 
     if (_slice_override && pos.region() == partition_region::clustered) {
-        const auto reversed = _ps.options.contains(query::partition_slice::option::reversed);
+        const auto reversed = _ps.is_reversed();
         std::optional<query::partition_slice> native_slice;
         if (reversed) {
             native_slice = query::legacy_reverse_slice_to_native_reverse_slice(*_schema, *_slice_override);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1554,7 +1554,7 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
 future<std::tuple<reconcilable_result, cache_temperature>>
 database::query_mutations(schema_ptr s, const query::read_command& cmd, const dht::partition_range& range,
                           tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout) {
-    const auto reversed = cmd.slice.options.contains(query::partition_slice::option::reversed);
+    const auto reversed = cmd.slice.is_reversed();
     if (reversed) {
         s = s->make_reversed();
     }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -35,7 +35,7 @@ using namespace std::chrono_literals;
 using namespace cache;
 
 static schema_ptr to_query_domain(const query::partition_slice& slice, schema_ptr table_domain_schema) {
-    if (slice.options.contains(query::partition_slice::option::reversed)) [[unlikely]] {
+    if (slice.is_reversed()) [[unlikely]] {
         return table_domain_schema->make_reversed();
     }
     return table_domain_schema;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -91,7 +91,7 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
         auto dpk = dht::decorate_key(*_schema, *_last_pkey);
         dht::ring_position lo(dpk);
 
-        auto reversed = _cmd->slice.options.contains<query::partition_slice::option::reversed>();
+        auto reversed = _cmd->slice.is_reversed();
 
         qlogger.trace("PKey={}, Pos={}, reversed={}", dpk, _last_pos, reversed);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2735,6 +2735,8 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, gms::gossiper& 
     slogger.trace("hinted DCs: {}", cfg.hinted_handoff_enabled.to_configuration_string());
     _hints_manager.register_metrics("hints_manager");
     _hints_for_views_manager.register_metrics("hints_for_views_manager");
+
+    _enable_native_reversed_queries = _db.local().get_config().enable_native_reversed_queries;
 }
 
 struct storage_proxy::remote& storage_proxy::remote() {
@@ -6277,6 +6279,10 @@ locator::token_metadata_ptr storage_proxy::get_token_metadata_ptr() const noexce
 
 future<std::vector<dht::token_range_endpoints>> storage_proxy::describe_ring(const sstring& keyspace, bool include_only_local_dc) const {
     return locator::describe_ring(_db.local(), _remote->gossiper(), keyspace, include_only_local_dc);
+}
+
+bool storage_proxy::enable_native_reversed_queries() const noexcept {
+    return features().native_reverse_queries && _enable_native_reversed_queries;
 }
 
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2199,7 +2199,7 @@ query::max_result_size storage_proxy::get_max_result_size(const query::partition
     // FIXME: Remove the code below once SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT
     //        cluster feature is released for more than 2 years and can be
     //        retired.
-    if (!slice.options.contains<query::partition_slice::option::allow_short_read>() || slice.options.contains<query::partition_slice::option::reversed>()) {
+    if (!slice.options.contains<query::partition_slice::option::allow_short_read>() || slice.is_reversed()) {
         return _db.local().get_unlimited_query_max_result_size();
     } else {
         return query::max_result_size(query::result_memory_limiter::maximum_result_size);
@@ -4336,7 +4336,7 @@ private:
         // and clustering keys of the last row that is going to be returned to the client and check if
         // it is in range of rows returned by each replicas that returned as many rows as they were
         // asked for (if a replica returned less rows it means it returned everything it has).
-        auto is_reversed = cmd.slice.options.contains(query::partition_slice::option::reversed);
+        auto is_reversed = cmd.slice.is_reversed();
 
         auto rows_left = original_row_limit;
         auto partitions_left = original_partition_limit;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -248,6 +248,7 @@ private:
     scheduling_group_key _stats_key;
     storage_proxy_stats::global_stats _global_stats;
     gms::feature_service& _features;
+    utils::updateable_value<bool> _enable_native_reversed_queries{true};
 
     class remote;
     std::unique_ptr<remote> _remote;
@@ -674,6 +675,8 @@ public:
     virtual void on_leave_cluster(const gms::inet_address& endpoint) override;
     virtual void on_up(const gms::inet_address& endpoint) override;
     virtual void on_down(const gms::inet_address& endpoint) override;
+
+    bool enable_native_reversed_queries() const noexcept;
 
     friend class abstract_read_executor;
     friend class abstract_write_response_handler;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -290,8 +290,12 @@ SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_sourc
     test_database(run_mutation_source_tests_plain);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse) {
-    test_database(run_mutation_source_tests_reverse);
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_legacy_reversed) {
+    test_database(run_mutation_source_tests_legacy_reversed);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_native_reversed) {
+    test_database(run_mutation_source_tests_native_reversed);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -1140,7 +1140,7 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_v2_is_mutation_source) {
             std::vector<mutation>* selected_muts;
 
             schema = schema->make_reversed();
-            const auto reversed = slice.options.contains(query::partition_slice::option::reversed);
+            const auto reversed = slice.is_reversed();
             if (reversed) {
                 reversed_slice = std::make_unique<query::partition_slice>(query::half_reverse_slice(*schema, slice));
                 selected_muts = &muts;

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -137,14 +137,26 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer) {
     }).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_reverse) {
+SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_legacy_reversed) {
     if (smp::count < 2) {
         std::cerr << "Cannot run test " << get_name() << " with smp::count < 2" << std::endl;
         return;
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests_reverse(make_populate(true, true), true);
+        run_mutation_source_tests_legacy_reversed(make_populate(true, true), true);
+        return make_ready_future<>();
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_native_reversed) {
+    if (smp::count < 2) {
+        std::cerr << "Cannot run test " << get_name() << " with smp::count < 2" << std::endl;
+        return;
+    }
+
+    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+        run_mutation_source_tests_native_reversed(make_populate(true, true), true);
         return make_ready_future<>();
     }).get();
 }

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -57,7 +57,7 @@ static mutation_source make_source(std::vector<mutation> mutations) {
             const io_priority_class& pc, tracing::trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         assert(range.is_full()); // slicing not implemented yet
         for (auto&& m : mutations) {
-            if (slice.options.contains(query::partition_slice::option::reversed)) {
+            if (slice.is_reversed()) {
                 assert(m.schema()->make_reversed()->version() == s->version());
             } else {
                 assert(m.schema() == s);
@@ -87,7 +87,7 @@ static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, co
 
     auto querier = query::querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
     auto close_querier = deferred_close(querier);
-    auto table_schema = slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
+    auto table_schema = slice.is_reversed() ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*table_schema, slice, make_accounter());
     return querier.consume_page(std::move(rrb), row_limit, partition_limit, query_time).get();
 }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3805,8 +3805,8 @@ SEASTAR_THREAD_TEST_CASE(test_clustering_order_merger_in_memory) {
 }
 
 
-static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
-  return sstables::test_env::do_with_async([reversed] (sstables::test_env& env) {
+static future<> do_test_clustering_order_merger_sstable_set(bool reversed, bool native_reversed = false) {
+  return sstables::test_env::do_with_async([reversed, native_reversed] (sstables::test_env& env) {
     auto pkeys = tests::generate_partition_keys(2, clustering_order_merger_test_generator::make_schema());
     clustering_order_merger_test_generator g(pkeys[0]);
     auto query_schema = g._s;
@@ -3816,6 +3816,9 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
     if (reversed) {
         table_schema = table_schema->make_reversed();
         query_slice.options.set(query::partition_slice::option::reversed);
+        if (native_reversed) {
+            query_slice.options.set(query::partition_slice::option::native_reversed);
+        }
         query_slice = query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, std::move(query_slice));
     }
 
@@ -3899,8 +3902,12 @@ SEASTAR_TEST_CASE(test_clustering_order_merger_sstable_set) {
     return do_test_clustering_order_merger_sstable_set(false);
 }
 
-SEASTAR_TEST_CASE(test_clustering_order_merger_sstable_set_reversed) {
+SEASTAR_TEST_CASE(test_clustering_order_merger_sstable_set_legacy_reversed) {
     return do_test_clustering_order_merger_sstable_set(true);
+}
+
+SEASTAR_TEST_CASE(test_clustering_order_merger_sstable_set_native_reversed) {
+    return do_test_clustering_order_merger_sstable_set(true, true);
 }
 
 SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -4097,7 +4097,7 @@ SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding fwd_sm,
                 mutation_reader::forwarding fwd_mr) {
-            auto reversed = slice.options.contains(query::partition_slice::option::reversed);
+            auto reversed = slice.is_reversed();
             std::map<dht::decorated_key, flat_mutation_reader_v2, dht::decorated_key::less_comparator>
                 good_readers{dht::decorated_key::less_comparator(s)};
             for (auto& [k, ms]: good) {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -3373,7 +3373,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
 
         auto pr = dht::partition_range::make_singular(m0.decorated_key());
         auto make_reader = [&] (const query::partition_slice& slice) {
-            auto reversed = slice.options.contains<query::partition_slice::option::reversed>();
+            auto reversed = slice.is_reversed();
             auto rd = cache.make_reader(reversed ? rev_s : s, semaphore.make_permit(), pr, slice);
             rd.set_max_buffer_size(3);
             rd.fill_buffer().get();

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1677,7 +1677,8 @@ void run_mutation_source_tests(populate_fn populate, bool with_partition_range_f
 
 void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding) {
     run_mutation_source_tests_plain(populate, with_partition_range_forwarding);
-    run_mutation_source_tests_reverse(populate, with_partition_range_forwarding);
+    run_mutation_source_tests_legacy_reversed(populate, with_partition_range_forwarding);
+    run_mutation_source_tests_native_reversed(populate, with_partition_range_forwarding);
     // Some tests call the sub-types individually, mind checking them
     // if adding new stuff here
 }
@@ -1687,7 +1688,7 @@ void run_mutation_source_tests_plain(populate_fn_ex populate, bool with_partitio
     run_mutation_reader_tests(populate, with_partition_range_forwarding);
 }
 
-void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding) {
+void run_mutation_source_tests_legacy_reversed(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
     // read in reverse
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
@@ -1710,7 +1711,37 @@ void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partit
                 streamed_mutation::forwarding fwd,
                 mutation_reader::forwarding mr_fwd) mutable {
             reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, slice))
-                    .with_option<query::partition_slice::option::reversed>()
+                    .reversed()
+                    .build());
+            return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), pc, tr, fwd, mr_fwd);
+        });
+    }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
+}
+
+void run_mutation_source_tests_native_reversed(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    // read in reverse
+    run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        auto table_schema = s->make_reversed();
+
+        std::vector<mutation> reversed_mutations;
+        reversed_mutations.reserve(m.size());
+        for (const auto& mut : m) {
+            reversed_mutations.emplace_back(reverse(mut));
+        }
+        auto ms = populate(table_schema, reversed_mutations, t);
+
+        return mutation_source([table_schema, ms = std::move(ms), reversed_slices = std::list<query::partition_slice>()] (
+                schema_ptr query_schema,
+                reader_permit permit,
+                const dht::partition_range& pr,
+                const query::partition_slice& slice,
+                const io_priority_class& pc,
+                tracing::trace_state_ptr tr,
+                streamed_mutation::forwarding fwd,
+                mutation_reader::forwarding mr_fwd) mutable {
+            reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::legacy_reverse_slice_to_native_reverse_slice(*table_schema, slice))
+                    .native_reversed()
                     .build());
             return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), pc, tr, fwd, mr_fwd);
         });

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -18,7 +18,8 @@ using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::ve
 void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
 void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 void run_mutation_source_tests_plain(populate_fn_ex populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_legacy_reversed(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_native_reversed(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 
 enum are_equal { no, yes };
 


### PR DESCRIPTION
This series extends `query::partition_slice` options with a native_reversed option.
When set on top of query::partition_slice::option::reversed, the coordinator indicates it would like to retrieve the results in native reverse order, rather than the legacy reversed order.

A cluster feature is added so to enable that option only when all replicas support it.
And a configuration option is added (enabled by default) to allow opting out in case a problem with this mechanism if found later in the field.

The select query marks the slice as native_reversed if it is a reverse query and native reverse queries are enabled by the cluster feature and by the configuration option.

Unit tests were added to test native_reverse in addition to the legacy reverse mode.

Fixes #12557