### PR TITLE
Reduce memory footprint of SSTable index summary

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -554,7 +554,6 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
         // position is little-endian encoded
         auto position = seastar::read_le<uint64_t>(buf.get());
         auto token = schema.get_partitioner().get_token(key_view(key_data));
-        s.add_summary_data(token.data());
         s.entries.push_back({ token, key_data, position });
     }
     // Delete last element which isn't part of the on-disk format.
@@ -1689,7 +1688,6 @@ void maybe_add_summary_entry(summary& s, const dht::token& token, bytes_view key
     if (data_offset >= state.next_data_offset_to_write_summary) {
         auto entry_size = 8 + 2 + key.size();  // offset + key_size.size + key.size
         state.next_data_offset_to_write_summary += state.summary_byte_cost * entry_size;
-        s.add_summary_data(token.data());
         auto key_data = s.add_summary_data(key);
         s.entries.push_back({ token, key_data, index_offset });
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -554,7 +554,7 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
         // position is little-endian encoded
         auto position = seastar::read_le<uint64_t>(buf.get());
         auto token = schema.get_partitioner().get_token(key_view(key_data));
-        s.entries.push_back({ token, key_data, position });
+        s.entries.push_back(summary_entry{ token, key_data, position });
     }
     // Delete last element which isn't part of the on-disk format.
     s.positions.pop_back();
@@ -1689,7 +1689,7 @@ void maybe_add_summary_entry(summary& s, const dht::token& token, bytes_view key
         auto entry_size = 8 + 2 + key.size();  // offset + key_size.size + key.size
         state.next_data_offset_to_write_summary += state.summary_byte_cost * entry_size;
         auto key_data = s.add_summary_data(key);
-        s.entries.push_back({ token, key_data, index_offset });
+        s.entries.push_back(summary_entry{ token, key_data, index_offset });
     }
 }
 

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -126,16 +126,26 @@ inline std::ostream& operator<<(std::ostream& o, indexable_element e) {
 
 class summary_entry {
 public:
-    dht::token token;
+    int64_t raw_token;
     bytes_view key;
     uint64_t position;
+
+    explicit summary_entry(dht::token token, bytes_view key, uint64_t position)
+            : raw_token(dht::token::to_int64(token))
+            , key(key)
+            , position(position) {
+    }
 
     key_view get_key() const {
         return key_view{key};
     }
 
+    dht::token get_token() const {
+        return dht::token::from_int64(raw_token);
+    }
+
     decorated_key_view get_decorated_key() const {
-        return decorated_key_view(token, get_key());
+        return decorated_key_view(get_token(), get_key());
     }
 
     bool operator==(const summary_entry& x) const {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -980,7 +980,7 @@ void dump_summary_operation(schema_ptr schema, reader_permit permit, const std::
 
             auto pkey = e.get_key().to_partition_key(*schema);
             writer.Key("key");
-            writer.DataKey(*schema, pkey, e.token);
+            writer.DataKey(*schema, pkey, e.get_token());
             writer.Key("position");
             writer.Uint64(e.position);
 


### PR DESCRIPTION
SSTable summary is one of the components fully loaded into memory that may have a significant footprint.

This series reduces the summary footprint by reducing the amount of token information that we need to keep
in memory for each summary entry.

Of course, the benefit of this size optimization is proportional to the amount of summary entries, which
in turn is proportional to the number of partitions in a SSTable.

Therefore we can say that this optimization will benefit the most tables which have tons of small-sized
partitions, which will result in big summaries.

Results:

```
BEFORE

[1000000  pkeys]		 data size: 	4035888890,  summary -> memory footprint: 	5843232,  entries: 88158
[10000000 pkeys]		 data size: 	40368888890, summary -> memory footprint: 	55787128, entries: 844925

AFTER

[1000000  pkeys]		 data size: 	4035888890,  summary -> memory footprint: 	4351536,  entries: 88158
[10000000 pkeys]		 data size: 	40368888890, summary -> memory footprint: 	42211984, entries: 844925
```

That shows a 25% reduction in footprint, for both 1 and 10 million pkeys.