### PR TITLE
Debloat system_keyspace.hh (and a bit of .cc)

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -41,7 +41,7 @@
 #include "release.hh"
 #include "log.hh"
 #include <seastar/core/enum.hh>
-#include <seastar/net/inet_address.hh>
+#include "gms/inet_address.hh"
 #include "index/secondary_index.hh"
 #include "message/messaging_service.hh"
 #include "mutation_query.hh"
@@ -63,6 +63,7 @@
 #include "idl/frozen_mutation.dist.impl.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include "client_data.hh"
+#include "service/topology_state_machine.hh"
 
 using days = std::chrono::duration<int, std::ratio<24 * 3600>>;
 
@@ -3416,7 +3417,7 @@ future<> system_keyspace::save_group0_upgrade_state(sstring value) {
     return set_scylla_local_param(GROUP0_UPGRADE_STATE_KEY, value);
 }
 
-future<service::topology_state_machine::topology_type> system_keyspace::load_topology_state() {
+future<service::topology> system_keyspace::load_topology_state() {
     auto rs = co_await qctx->execute_cql(
         format("SELECT * FROM system.{} WHERE key = '{}'", TOPOLOGY, TOPOLOGY));
     assert(rs);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -470,8 +470,8 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<mutation> get_group0_history(distributed<service::storage_proxy>&);
 
-    future<service::group0_upgrade_state> load_group0_upgrade_state();
-    future<> save_group0_upgrade_state(service::group0_upgrade_state);
+    future<std::optional<sstring>> load_group0_upgrade_state();
+    future<> save_group0_upgrade_state(sstring);
 
     system_keyspace(sharded<cql3::query_processor>& qp, sharded<replica::database>& db) noexcept;
     ~system_keyspace();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -15,19 +15,14 @@
 #include <vector>
 #include "schema/schema_fwd.hh"
 #include "utils/UUID.hh"
-#include "gms/inet_address.hh"
 #include "query-result-set.hh"
 #include "db_clock.hh"
-#include "db/commitlog/replay_position.hh"
 #include "mutation_query.hh"
 #include "system_keyspace_view_types.hh"
 #include <map>
 #include <seastar/core/distributed.hh>
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
-#include "service/raft/group0_fwd.hh"
-#include "tasks/task_manager.hh"
-#include "service/topology_state_machine.hh"
 #include "mutation/canonical_mutation.hh"
 
 namespace service {
@@ -35,6 +30,7 @@ namespace service {
 class storage_proxy;
 class storage_service;
 class raft_group_registry;
+struct topology;
 
 namespace paxos {
     class paxos_state;
@@ -53,6 +49,7 @@ namespace cql3 {
 }
 
 namespace gms {
+    class inet_address;
     class feature;
     class feature_service;
 }
@@ -79,6 +76,7 @@ using system_keyspace_view_name = std::pair<sstring, sstring>;
 class system_keyspace_view_build_progress;
 
 struct truncation_record;
+struct replay_position;
 typedef std::vector<db::replay_position> replay_positions;
 
 
@@ -436,7 +434,7 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<bool> group0_history_contains(utils::UUID state_id);
 
-    static future<service::topology_state_machine::topology_type> load_topology_state();
+    static future<service::topology> load_topology_state();
 
     // The mutation appends the given state ID to the group 0 history table, with the given description if non-empty.
     //

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -436,24 +436,6 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<bool> group0_history_contains(utils::UUID state_id);
 
-    class topology_mutation_builder {
-        schema_ptr _s;
-        mutation _m;
-        api::timestamp_type _ts;
-        deletable_row& _r;
-    public:
-        topology_mutation_builder(api::timestamp_type ts, raft::server_id);
-        template<typename T>
-        topology_mutation_builder& set(const char* cell, const T& value) {
-            return set(cell, sstring{fmt::format("{}", value)});
-        }
-        topology_mutation_builder& set(const char* cell, const sstring& value);
-        topology_mutation_builder& set(const char* cell, const raft::server_id& value);
-        topology_mutation_builder& set(const char* cell, const std::unordered_set<dht::token>& value);
-        topology_mutation_builder& set(const char* cell, const uint32_t& value);
-        topology_mutation_builder& del(const char* cell);
-        canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
-    };
     static future<service::topology_state_machine::topology_type> load_topology_state();
 
     // The mutation appends the given state ID to the group 0 history table, with the given description if non-empty.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -328,7 +328,28 @@ raft_group0_client::raft_group0_client(service::raft_group_registry& raft_gr, db
 }
 
 future<> raft_group0_client::init() {
-    _upgrade_state = co_await _sys_ks.load_group0_upgrade_state();
+    auto value = [] (std::optional<sstring> s) {
+        if (!s || *s == "use_pre_raft_procedures") {
+            return service::group0_upgrade_state::use_pre_raft_procedures;
+        } else if (*s == "synchronize") {
+            return service::group0_upgrade_state::synchronize;
+        } else if (*s == "use_post_raft_procedures") {
+            return service::group0_upgrade_state::use_post_raft_procedures;
+        } else if (*s == "recovery") {
+            return service::group0_upgrade_state::recovery;
+        }
+
+        logger.error(
+                "load_group0_upgrade_state(): unknown value '{}' for key 'group0_upgrade_state' in Scylla local table."
+                " Did you change the value manually?"
+                " Correct values are: 'use_pre_raft_procedures', 'synchronize', 'use_post_raft_procedures', 'recovery'."
+                " Assuming 'recovery'.", *s);
+        // We don't call `on_internal_error` which would probably prevent the node from starting, but enter `recovery`
+        // allowing the user to fix their cluster.
+        return service::group0_upgrade_state::recovery;
+    };
+
+    _upgrade_state = value(co_await _sys_ks.load_group0_upgrade_state());
     if (_upgrade_state == group0_upgrade_state::recovery) {
         logger.warn("RECOVERY mode.");
     }
@@ -349,7 +370,28 @@ future<> raft_group0_client::set_group0_upgrade_state(group0_upgrade_state state
     // they will eventually finish (say, due to abort) and release it.
     auto holder = co_await _upgrade_lock.hold_write_lock();
 
-    co_await _sys_ks.save_group0_upgrade_state(state);
+    auto value = [] (group0_upgrade_state s) constexpr {
+        switch (s) {
+            case service::group0_upgrade_state::use_post_raft_procedures:
+                return "use_post_raft_procedures";
+            case service::group0_upgrade_state::synchronize:
+                return "synchronize";
+            case service::group0_upgrade_state::recovery:
+                // It should not be necessary to ever save this state internally - the user sets it manually
+                // (e.g. from cqlsh) if recovery is needed - but handle the case anyway.
+                return "recovery";
+            case service::group0_upgrade_state::use_pre_raft_procedures:
+                // It should not be necessary to ever save this state, but handle the case anyway.
+                return "use_pre_raft_procedures";
+        }
+
+        on_internal_error(logger, format(
+                "save_group0_upgrade_state: given value is outside the set of possible values (integer value: {})."
+                " This may have been caused by undefined behavior; best restart your system.",
+                static_cast<uint8_t>(s)));
+    };
+
+    co_await _sys_ks.save_group0_upgrade_state(value(state));
     _upgrade_state = state;
     if (_upgrade_state == group0_upgrade_state::use_post_raft_procedures) {
         _upgraded.broadcast();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -73,6 +73,7 @@
 #include "idl/storage_service.dist.hh"
 #include "service/storage_proxy.hh"
 #include "service/raft/raft_address_map.hh"
+#include "types/set.hh"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -437,6 +438,87 @@ future<> storage_service::merge_topology_snapshot(raft_topology_snapshot snp) {
    co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
 
+class topology_mutation_builder {
+    schema_ptr _s;
+    mutation _m;
+    api::timestamp_type _ts;
+    deletable_row& _r;
+public:
+    topology_mutation_builder(api::timestamp_type ts, raft::server_id);
+    template<typename T>
+    topology_mutation_builder& set(const char* cell, const T& value) {
+        return set(cell, sstring{fmt::format("{}", value)});
+    }
+    topology_mutation_builder& set(const char* cell, const sstring& value);
+    topology_mutation_builder& set(const char* cell, const raft::server_id& value);
+    topology_mutation_builder& set(const char* cell, const std::unordered_set<dht::token>& value);
+    topology_mutation_builder& set(const char* cell, const uint32_t& value);
+    topology_mutation_builder& del(const char* cell);
+    canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
+};
+
+topology_mutation_builder::topology_mutation_builder(api::timestamp_type ts, raft::server_id id) :
+        _s(db::system_keyspace::topology()),
+        _m(_s, partition_key::from_singular(*_s, db::system_keyspace::TOPOLOGY)),
+        _ts(ts),
+        _r(_m.partition().clustered_row(*_s, clustering_key::from_singular(*_s, id.uuid()))) {
+            _r.apply(row_marker(_ts));
+}
+
+topology_mutation_builder& topology_mutation_builder::set(const char* cell, const sstring& value) {
+    auto cdef = _s->get_column_definition(cell);
+    assert(cdef);
+    _r.cells().apply(*cdef, atomic_cell::make_live(*cdef->type, _ts, cdef->type->decompose(value)));
+    return *this;
+}
+
+topology_mutation_builder& topology_mutation_builder::set(const char* cell, const raft::server_id& value) {
+    auto cdef = _s->get_column_definition(cell);
+    assert(cdef);
+    _r.cells().apply(*cdef, atomic_cell::make_live(*cdef->type, _ts, cdef->type->decompose(value.uuid())));
+    return *this;
+}
+
+topology_mutation_builder& topology_mutation_builder::set(const char* cell, const uint32_t& value) {
+    auto cdef = _s->get_column_definition(cell);
+    assert(cdef);
+    _r.cells().apply(*cdef, atomic_cell::make_live(*cdef->type, _ts, cdef->type->decompose(int32_t(value))));
+    return *this;
+}
+
+topology_mutation_builder& topology_mutation_builder::del(const char* cell) {
+    auto cdef = _s->get_column_definition(cell);
+    assert(cdef);
+    if (!cdef->type->is_multi_cell()) {
+        _r.cells().apply(*cdef, atomic_cell::make_dead(_ts, gc_clock::now()));
+    } else {
+        collection_mutation_description cm;
+        cm.tomb = tombstone{_ts, gc_clock::now()};
+        _r.cells().apply(*cdef, cm.serialize(*cdef->type));
+    }
+    return *this;
+}
+
+topology_mutation_builder& topology_mutation_builder::set(const char* cell, const std::unordered_set<dht::token>& tokens) {
+    auto cdef = _s->get_column_definition(cell);
+    assert(cdef);
+    collection_mutation_description cm;
+    if (tokens.size()) {
+        auto vtype = static_pointer_cast<const set_type_impl>(cdef->type)->get_elements_type();
+
+        cm.cells.reserve(tokens.size());
+
+        for (auto&& value : tokens) {
+            cm.cells.emplace_back(vtype->decompose(value.to_sstring()), atomic_cell::make_live(*bytes_type, _ts, bytes_view()));
+        }
+
+        _r.cells().apply(*cdef, cm.serialize(*cdef->type));
+    } else {
+        del(cell);
+    }
+    return *this;
+}
+
 future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, raft::term_t term, sharded<db::system_distributed_keyspace>& sys_dist_ks, abort_source& as) {
     slogger.info("raft topology: start topology coordinator fiber");
 
@@ -585,7 +667,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                     }
                 }
                 // Streaming completed. We can now move tokens state to ring_slice::ring_slice::replication_state::write_both_read_new
-                db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                 builder.set("replication_state", ring_slice::replication_state::write_both_read_new);
                 auto str = fmt::format("{}: streaming completed for node {}", node.rs->state, node.id);
                 co_await update_replica_state(std::move(node), {builder.build()}, std::move(str));
@@ -600,7 +682,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                 }
                 switch(node.rs->state) {
                 case node_state::bootstrapping: {
-                    db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                    topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                     builder.set("replication_state", ring_slice::replication_state::owner)
                            .set("node_state", node_state::normal);
                     co_await update_replica_state(std::move(node), {builder.build()}, "bootstrap: read fence completed");
@@ -608,7 +690,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                     break;
                 case node_state::decommissioning:
                 case node_state::removing: {
-                    db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                    topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                     builder.del("replication_state")
                            .del("tokens")
                            .set("node_state", node_state::left);
@@ -617,13 +699,13 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                     }
                     break;
                 case node_state::replacing: {
-                    db::system_keyspace::topology_mutation_builder builder1(node.guard.write_timestamp(), node.id);
+                    topology_mutation_builder builder1(node.guard.write_timestamp(), node.id);
                     // Move new node to 'normal'
                     builder1.set("replication_state", ring_slice::replication_state::owner)
                             .set("node_state", node_state::normal);
 
                     // Move old node to 'left'
-                    db::system_keyspace::topology_mutation_builder builder2(node.guard.write_timestamp(), replaced_node);
+                    topology_mutation_builder builder2(node.guard.write_timestamp(), replaced_node);
                     builder2.del("replication_state")
                             .del("tokens")
                             .set("node_state", node_state::left);
@@ -650,7 +732,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
             case node_state::none: {
                 // if the state is none there have to be either 'join' or 'replace' request
                 // if the state is normal there have to be either 'leave', 'remove' or 'rebuild' request
-                db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                 switch (node.request.value()) {
                     case topology_request::join: {
                         assert(!node.rs->ring);
@@ -702,7 +784,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                         break;
                         }
                     case topology_request::rebuild: {
-                        db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                        topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                         builder.set("node_state", node_state::rebuilding)
                                 .del("topology_request");
                         co_await update_replica_state(std::move(node), {builder.build()}, "start rebuilding");
@@ -719,7 +801,7 @@ future<> storage_service::topology_change_coordinator_fiber(raft::server& raft, 
                 break;
             case node_state::rebuilding: {
                 node = co_await exec_direct_command(std::move(node), raft_topology_cmd{raft_topology_cmd::command::stream_ranges});
-                db::system_keyspace::topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
+                topology_mutation_builder builder(node.guard.write_timestamp(), node.id);
                 builder.set("node_state", node_state::normal)
                        .del("rebuild_option");
                 co_await update_replica_state(std::move(node), {builder.build()}, "rebuilding completed");
@@ -870,7 +952,7 @@ future<> storage_service::raft_replace(raft::server& raft_server, raft::server_i
         }
 
         auto& rs = it->second;
-        db::system_keyspace::topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
+        topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
         builder.set("node_state", node_state::none)
                .set("datacenter", rs.datacenter)
                .set("rack", rs.rack)
@@ -904,7 +986,7 @@ future<> storage_service::raft_bootstrap(raft::server& raft_server) {
         slogger.info("raft topology: adding myself to topology: {}", raft_server.id());
         // Current topology does not contains this node. Bootstrap is needed!
         auto guard = co_await _group0->client().start_operation(&_abort_source);
-        db::system_keyspace::topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
+        topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
         builder.set("node_state", node_state::none)
                .set("datacenter", _snitch.local()->get_datacenter())
                .set("rack", _snitch.local()->get_rack())
@@ -2862,7 +2944,7 @@ future<> storage_service::raft_decomission() {
         }
 
         slogger.info("raft topology: request decomission for: {}", raft_server.id());
-        db::system_keyspace::topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
+        topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
         builder.set("topology_request", topology_request::leave);
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, fmt::format("decomission: request decomission for {}", raft_server.id()));
@@ -3208,7 +3290,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id) {
         }
 
         slogger.info("raft topology: request removenode for: {}", id);
-        db::system_keyspace::topology_mutation_builder builder(guard.write_timestamp(), id);
+        topology_mutation_builder builder(guard.write_timestamp(), id);
         builder.set("topology_request", topology_request::remove);
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, fmt::format("removenode: request remove for {}", id));
@@ -3729,7 +3811,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
         }
 
         slogger.info("raft topology: request rebuild for: {}", raft_server.id());
-        db::system_keyspace::topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
+        topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
         builder.set("topology_request", topology_request::rebuild)
                .set("rebuild_option", source_dc);
         topology_change change{{builder.build()}};


### PR DESCRIPTION
The system_keyspace.hh now includes raft stuff, topology changes stuff, task_manager stuff, etc. It's going to include tablets.hh (but maybe not). Anything that deals with system keyspace, and includes system_keyspace.hh, would transitively pull these too. This header is becoming a central hub for all the features.

This PR removes all the headers from system_keyspace.hh that correspond to other "subsystems" keeping only generic mutations/querying and seastar ones.