### PR TITLE
tree: migrate from std::regex to boost::regex

### DIFF
--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -8,7 +8,7 @@
 
 #include <iostream>
 #include <iterator>
-#include <regex>
+#include <boost/regex.hpp>
 
 #include "cql3_type.hh"
 #include "cql3/util.hh"
@@ -464,11 +464,11 @@ sstring maybe_quote(const sstring& identifier) {
     if (num_quotes == 0) {
         return make_sstring("\"", identifier, "\"");
     }
-    static const std::regex double_quote_re("\"");
+    static const boost::regex double_quote_re("\"");
     std::string result;
     result.reserve(2 + identifier.size() + num_quotes);
     result.push_back('"');
-    std::regex_replace(std::back_inserter(result), identifier.begin(), identifier.end(), double_quote_re, "\"\"");
+    boost::regex_replace(std::back_inserter(result), identifier.begin(), identifier.end(), double_quote_re, "\"\"");
     result.push_back('"');
     return result;
 }
@@ -490,11 +490,11 @@ static sstring quote_with(const sstring& str) {
     }
 
     static const std::string double_quote_str{C, C};
-    static const std::regex quote_re(std::string{C});
+    static const boost::regex quote_re(std::string{C});
     std::string result;
     result.reserve(2 + str.size() + num_quotes);
     result.push_back(C);
-    std::regex_replace(std::back_inserter(result), str.begin(), str.end(), quote_re, double_quote_str);
+    boost::regex_replace(std::back_inserter(result), str.begin(), str.end(), quote_re, double_quote_str);
     result.push_back(C);
     return result;
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -22,7 +22,7 @@
 #include "db/config.hh"
 #include "gms/feature_service.hh"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <stdexcept>
 
 bool is_system_keyspace(std::string_view keyspace);
@@ -59,8 +59,8 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
         throw exceptions::invalid_request_exception("system keyspace is not user-modifiable");
     }
     // keyspace name
-    std::regex name_regex("\\w+");
-    if (!std::regex_match(name, name_regex)) {
+    boost::regex name_regex("\\w+");
+    if (!boost::regex_match(name, name_regex)) {
         throw exceptions::invalid_request_exception(format("\"{}\" is not a valid keyspace name", _name.c_str()));
     }
     if (name.length() > schema::NAME_LENGTH) {

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -10,7 +10,7 @@
 
 
 #include <inttypes.h>
-#include <regex>
+#include <boost/regex.hpp>
 
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/adjacent_find.hpp>
@@ -165,8 +165,8 @@ create_table_statement::raw_statement::raw_statement(cf_name name, bool if_not_e
 std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats) {
     // Column family name
     const sstring& cf_name = _cf_name->get_column_family();
-    std::regex name_regex("\\w+");
-    if (!std::regex_match(std::string(cf_name), name_regex)) {
+    boost::regex name_regex("\\w+");
+    if (!boost::regex_match(std::string(cf_name), name_regex)) {
         throw exceptions::invalid_request_exception(format("\"{}\" is not a valid table name (must be alphanumeric character only: [0-9A-Za-z]+)", cf_name.c_str()));
     }
     if (cf_name.size() > size_t(schema::NAME_LENGTH)) {

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <stdexcept>
 #include "index_target.hh"
 #include "index/secondary_index.hh"
@@ -22,7 +22,7 @@ using db::index::secondary_index;
 
 const sstring index_target::target_option_name = "target";
 const sstring index_target::custom_index_option_name = "class_name";
-const std::regex index_target::target_regex("^(keys|entries|values|full)\\((.+)\\)$");
+const boost::regex index_target::target_regex("^(keys|entries|values|full)\\((.+)\\)$");
 
 sstring index_target::column_name() const {
     struct as_string_visitor {
@@ -59,8 +59,8 @@ index_target::target_type index_target::from_sstring(const sstring& s)
 }
 
 index_target::target_type index_target::from_target_string(const sstring& target) {
-    std::cmatch match;
-    if (std::regex_match(target.data(), match, target_regex)) {
+    boost::cmatch match;
+    if (boost::regex_match(target.data(), match, target_regex)) {
         return index_target::from_sstring(match[1].str());
     }
     return target_type::regular_values;
@@ -86,15 +86,15 @@ sstring index_target::unescape_target_column(std::string_view str) {
         str.remove_suffix(1);
         // remove doubled quotes in the middle of the string, which to_cql_string()
         // adds. This code is inefficient but rarely called so it's fine.
-        static const std::regex double_quote_re("\"\"");
-        return std::regex_replace(std::string(str), double_quote_re, "\"");
+        static const boost::regex double_quote_re("\"\"");
+        return boost::regex_replace(std::string(str), double_quote_re, "\"");
     }
     return sstring(str);
 }
 
 sstring index_target::column_name_from_target_string(const sstring& target) {
-    std::cmatch match;
-    if (std::regex_match(target.data(), match, target_regex)) {
+    boost::cmatch match;
+    if (boost::regex_match(target.data(), match, target_regex)) {
         return unescape_target_column(match[2].str());
     }
     return unescape_target_column(target);

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -13,7 +13,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "cql3/column_identifier.hh"
 #include <variant>
-#include <regex>
+#include <boost/regex.hpp>
 
 namespace cql3 {
 
@@ -22,7 +22,7 @@ namespace statements {
 struct index_target {
     static const sstring target_option_name;
     static const sstring custom_index_option_name;
-    static const std::regex target_regex;
+    static const boost::regex target_regex;
 
     enum class target_type {
         regular_values, collection_values, keys, keys_and_values, full

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -11,7 +11,7 @@
 #include <string>
 #include <sys/stat.h>
 #include <malloc.h>
-#include <regex>
+#include <boost/regex.hpp>
 #include <filesystem>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/reversed.hpp>
@@ -128,19 +128,19 @@ const std::string db::commitlog::descriptor::SEPARATOR("-");
 const std::string db::commitlog::descriptor::FILENAME_PREFIX("CommitLog" + SEPARATOR);
 const std::string db::commitlog::descriptor::FILENAME_EXTENSION(".log");
 
-static const std::regex allowed_prefix("[a-zA-Z]+" + db::commitlog::descriptor::SEPARATOR);
-static const std::regex filename_match("(?:Recycled-)?([a-zA-Z]+" + db::commitlog::descriptor::SEPARATOR + ")(\\d+)(?:" + db::commitlog::descriptor::SEPARATOR + "(\\d+))?\\" + db::commitlog::descriptor::FILENAME_EXTENSION);
+static const boost::regex allowed_prefix("[a-zA-Z]+" + db::commitlog::descriptor::SEPARATOR);
+static const boost::regex filename_match("(?:Recycled-)?([a-zA-Z]+" + db::commitlog::descriptor::SEPARATOR + ")(\\d+)(?:" + db::commitlog::descriptor::SEPARATOR + "(\\d+))?\\" + db::commitlog::descriptor::FILENAME_EXTENSION);
 
 db::commitlog::descriptor::descriptor(const std::string& filename, const std::string& fname_prefix)
     : descriptor([&filename, &fname_prefix]() {
-        std::smatch m;
+        boost::smatch m;
         // match both legacy and new version of commitlogs Ex: CommitLog-12345.log and CommitLog-4-12345.log.
         auto cbegin = filename.cbegin();
         auto pos = filename.rfind('/');
         if (pos != std::string::npos) {
             cbegin += pos + 1;
         }
-        if (!std::regex_match(cbegin, filename.cend(), m, filename_match)) {
+        if (!boost::regex_match(cbegin, filename.cend(), m, filename_match)) {
             throw std::domain_error("Cannot parse the version of the file: " + filename);
         }
         if (m[1].str() != fname_prefix) {
@@ -1394,7 +1394,7 @@ db::commitlog::segment_manager::segment_manager(config c)
     if (!cfg.metrics_category_name.empty()) {
         create_counters(cfg.metrics_category_name);
     }
-    if (!std::regex_match(cfg.fname_prefix, allowed_prefix)) {
+    if (!boost::regex_match(cfg.fname_prefix, allowed_prefix)) {
         throw std::invalid_argument("Invalid filename prefix: " + cfg.fname_prefix);
     }
 }

--- a/duration.cc
+++ b/duration.cc
@@ -14,7 +14,7 @@
 #include <cctype>
 #include <optional>
 #include <limits>
-#include <regex>
+#include <boost/regex.hpp>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -260,15 +260,15 @@ std::optional<cql_duration> parse_duration_standard_format(std::string_view s) {
     //
 
     static const auto pattern =
-            std::regex("(\\d+)(y|Y|mo|MO|mO|Mo|w|W|d|D|h|H|s|S|ms|MS|mS|Ms|us|US|uS|Us|µs|µS|ns|NS|nS|Ns|m|M)");
+            boost::regex("(\\d+)(y|Y|mo|MO|mO|Mo|w|W|d|D|h|H|s|S|ms|MS|mS|Ms|us|US|uS|Us|µs|µS|ns|NS|nS|Ns|m|M)");
 
     auto iter = s.cbegin();
-    std::cmatch match;
+    boost::cmatch match;
 
     duration_builder b;
 
     // `match_continuous` ensures that the entire string must be included in a match.
-    while (std::regex_search(iter, s.end(), match, pattern, std::regex_constants::match_continuous)) {
+    while (boost::regex_search(iter, s.end(), match, pattern, boost::regex_constants::match_continuous)) {
         iter += match.length();
 
         auto symbol = match[2].str();
@@ -298,10 +298,10 @@ std::optional<cql_duration> parse_duration_standard_format(std::string_view s) {
 }
 
 std::optional<cql_duration> parse_duration_iso8601_format(std::string_view s) {
-    static const auto pattern = std::regex("P((\\d+)Y)?((\\d+)M)?((\\d+)D)?(T((\\d+)H)?((\\d+)M)?((\\d+)S)?)?");
+    static const auto pattern = boost::regex("P((\\d+)Y)?((\\d+)M)?((\\d+)D)?(T((\\d+)H)?((\\d+)M)?((\\d+)S)?)?");
 
-    std::cmatch match;
-    if (!std::regex_match(s.data(), match, pattern)) {
+    boost::cmatch match;
+    if (!boost::regex_match(s.data(), match, pattern)) {
         return {};
     }
 
@@ -338,10 +338,10 @@ std::optional<cql_duration> parse_duration_iso8601_format(std::string_view s) {
 }
 
 std::optional<cql_duration> parse_duration_iso8601_alternative_format(std::string_view s) {
-    static const auto pattern = std::regex("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
+    static const auto pattern = boost::regex("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
 
-    std::cmatch match;
-    if (!std::regex_match(s.data(), match, pattern)) {
+    boost::cmatch match;
+    if (!boost::regex_match(s.data(), match, pattern)) {
         return {};
     }
 
@@ -356,10 +356,10 @@ std::optional<cql_duration> parse_duration_iso8601_alternative_format(std::strin
 }
 
 std::optional<cql_duration> parse_duration_iso8601_week_format(std::string_view s) {
-    static const auto pattern = std::regex("P(\\d+)W");
+    static const auto pattern = boost::regex("P(\\d+)W");
 
-    std::cmatch match;
-    if (!std::regex_match(s.data(), match, pattern)) {
+    boost::cmatch match;
+    if (!boost::regex_match(s.data(), match, pattern)) {
         return {};
     }
 

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -12,7 +12,7 @@
 #include "index/target_parser.hh"
 #include "cql3/statements/index_target.hh"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptors.hpp>
@@ -27,7 +27,7 @@ namespace secondary_index {
 static constexpr auto PK_TARGET_KEY = "pk";
 static constexpr auto CK_TARGET_KEY = "ck";
 
-static const std::regex target_regex("^(keys|entries|values|full)\\((.+)\\)$");
+static const boost::regex target_regex("^(keys|entries|values|full)\\((.+)\\)$");
 
 target_parser::target_info target_parser::parse(schema_ptr schema, const index_metadata& im) {
     sstring target = im.options().at(cql3::statements::index_target::target_option_name);
@@ -50,8 +50,8 @@ target_parser::target_info target_parser::parse(schema_ptr schema, const sstring
         return cdef;
     };
 
-    std::cmatch match;
-    if (std::regex_match(target.data(), match, target_regex)) {
+    boost::cmatch match;
+    if (boost::regex_match(target.data(), match, target_regex)) {
         info.type = index_target::from_sstring(match[1].str());
         info.pk_columns.push_back(get_column(index_target::unescape_target_column(match[2].str())));
         return info;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -52,7 +52,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm_ext/is_sorted.hpp>
 #include <boost/range/algorithm/sort.hpp>
-#include <regex>
+#include <boost/regex.hpp>
 #include <seastar/core/align.hh>
 #include "mutation/range_tombstone_list.hh"
 #include "counters.hh"
@@ -2363,13 +2363,13 @@ sstable::make_crawling_reader(
 }
 
 static entry_descriptor make_entry_descriptor(sstring sstdir, sstring fname, sstring* const provided_ks, sstring* const provided_cf) {
-    static std::regex la_mx("(la|m[cde])-(\\d+)-(\\w+)-(.*)");
-    static std::regex ka("(\\w+)-(\\w+)-ka-(\\d+)-(.*)");
+    static boost::regex la_mx("(la|m[cde])-(\\d+)-(\\w+)-(.*)");
+    static boost::regex ka("(\\w+)-(\\w+)-ka-(\\d+)-(.*)");
 
-    static std::regex dir(format(".*/([^/]*)/([^/]+)-[\\da-fA-F]+(?:/({}|{}|{}|{})(?:/[^/]+)?)?/?",
+    static boost::regex dir(format(".*/([^/]*)/([^/]+)-[\\da-fA-F]+(?:/({}|{}|{}|{})(?:/[^/]+)?)?/?",
             sstables::staging_dir, sstables::quarantine_dir, sstables::upload_dir, sstables::snapshots_dir).c_str());
 
-    std::smatch match;
+    boost::smatch match;
 
     sstable::version_types version;
 
@@ -2387,11 +2387,11 @@ static entry_descriptor make_entry_descriptor(sstring sstdir, sstring fname, sst
 
     sstlog.debug("Make descriptor sstdir: {}; fname: {}", sstdir, fname);
     std::string s(fname);
-    if (std::regex_match(s, match, la_mx)) {
+    if (boost::regex_match(s, match, la_mx)) {
         std::string sdir(sstdir);
-        std::smatch dirmatch;
+        boost::smatch dirmatch;
         if (!ks_cf_provided) {
-            if (std::regex_match(sdir, dirmatch, dir)) {
+            if (boost::regex_match(sdir, dirmatch, dir)) {
                 ks = dirmatch[1].str();
                 cf = dirmatch[2].str();
             } else {
@@ -2402,7 +2402,7 @@ static entry_descriptor make_entry_descriptor(sstring sstdir, sstring fname, sst
         generation = match[2].str();
         format = sstring(match[3].str());
         component = sstring(match[4].str());
-    } else if (std::regex_match(s, match, ka)) {
+    } else if (boost::regex_match(s, match, ka)) {
         if (!ks_cf_provided) {
             ks = match[1].str();
             cf = match[2].str();

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -39,7 +39,7 @@
 #include "utils/fmt-compat.hh"
 #include "schema/schema_builder.hh"
 #include "service/migration_manager.hh"
-#include <regex>
+#include <boost/regex.hpp>
 #include "gms/feature.hh"
 #include "db/query_context.hh"
 #include "service/qos/qos_common.hh"
@@ -4124,7 +4124,7 @@ SEASTAR_TEST_CASE(test_view_with_two_regular_base_columns_in_key) {
  * a more robust testing.
  */
 std::string normalize_white_space(const std::string& str) {
-  return std::regex_replace(std::regex_replace(" " + str + " ", std::regex("\\s+"), " "), std::regex(", "), ",");
+  return boost::regex_replace(boost::regex_replace(" " + str + " ", boost::regex("\\s+"), " "), boost::regex(", "), ",");
 }
 
 SEASTAR_TEST_CASE(test_describe_simple_schema) {

--- a/thrift/thrift_validation.cc
+++ b/thrift/thrift_validation.cc
@@ -11,7 +11,7 @@
 #include "thrift_validation.hh"
 #include "thrift/utils.hh"
 #include "db/system_keyspace.hh"
-#include <regex>
+#include <boost/regex.hpp>
 #include "utils/fb_utilities.hh"
 
 using namespace thrift;
@@ -44,8 +44,8 @@ void validate_keyspace_not_system(const std::string& keyspace) {
 
 void validate_ks_def(const KsDef& ks_def) {
     validate_keyspace_not_system(ks_def.name);
-    std::regex name_regex("\\w+");
-    if (!std::regex_match(ks_def.name, name_regex)) {
+    boost::regex name_regex("\\w+");
+    if (!boost::regex_match(ks_def.name, name_regex)) {
         throw make_exception<InvalidRequestException>("\"{}\" is not a valid keyspace name", ks_def.name);
     }
     if (ks_def.name.length() > schema::NAME_LENGTH) {
@@ -54,8 +54,8 @@ void validate_ks_def(const KsDef& ks_def) {
 }
 
 void validate_cf_def(const CfDef& cf_def) {
-    std::regex name_regex("\\w+");
-    if (!std::regex_match(cf_def.name, name_regex)) {
+    boost::regex name_regex("\\w+");
+    if (!boost::regex_match(cf_def.name, name_regex)) {
         throw make_exception<InvalidRequestException>("\"{}\" is not a valid column family name", cf_def.name);
     }
     if (cf_def.name.length() > schema::NAME_LENGTH) {

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <iterator>
-#include <regex>
+#include <boost/regex.hpp>
 
 #include <yaml-cpp/yaml.h>
 #include <boost/any.hpp>
@@ -107,11 +107,11 @@ void validate(boost::any& out, const std::vector<std::string>& in, std::unordere
         out = boost::any(map_type());
     }
 
-    static const std::regex key(R"foo((?:^|\:)([^=:]+)=)foo");
+    static const boost::regex key(R"foo((?:^|\:)([^=:]+)=)foo");
 
     auto* p = boost::any_cast<map_type>(&out);
     for (const auto& s : in) {
-        std::sregex_iterator i(s.begin(), s.end(), key), e;
+        boost::sregex_iterator i(s.begin(), s.end(), key), e;
 
         if (i == e) {
             throw boost::program_options::invalid_option_value(s);


### PR DESCRIPTION
Except for where usage of `std::regex` is required by 3rd party library interfaces.
As demonstrated countless times, std::regex's practice of using recursion for pattern matching can result in stack overflow, especially on AARCH64. The most recent incident happened after merging https://github.com/scylladb/scylladb/pull/13075, which (indirectly) uses `sstables::make_entry_descriptor()` to test whether a certain path is a valid scylla table path in a trial-and-error manner. This resulted in stacks blowing up in AARCH64.
To prevent this, use the already tried and tested method of switching from `std::regex` to `boost::regex`. Don't wait until each of the `std::regex` sites explode, replace them all preemptively.

Refs: https://github.com/scylladb/scylladb/issues/13404