### PR TITLE
sstables: avoid a possible case of unclosed readers

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -696,12 +696,12 @@ private:
     // to be compacted together.
     future<> consume_without_gc_writer(gc_clock::time_point compaction_time) {
         auto consumer = make_interposer_consumer([this] (flat_mutation_reader_v2 reader) mutable {
-          return with_closeable(std::move(reader), [&] (auto& reader) {
-            return seastar::async([this, &reader] () {
-                auto cfc = compacted_fragments_writer(get_compacted_fragments_writer());
-                reader.consume_in_thread(std::move(cfc));
+            return with_closeable(std::move(reader), [&] (auto& reader) {
+                return seastar::async([this, &reader] () {
+                    auto cfc = compacted_fragments_writer(get_compacted_fragments_writer());
+                    reader.consume_in_thread(std::move(cfc));
+                });
             });
-          });
         });
         const auto& gc_state = _table_s.get_tombstone_gc_state();
         return consumer(make_compacting_reader(make_sstable_reader(), compaction_time, max_purgeable_func(), gc_state));
@@ -717,28 +717,28 @@ private:
         }
         auto consumer = make_interposer_consumer([this, now] (flat_mutation_reader_v2 reader) mutable
         {
-          return with_closeable(std::move(reader), [&] (auto& reader) {
-            return seastar::async([this, now, &reader] () {
-                if (enable_garbage_collected_sstable_writer()) {
-                    using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
+            return with_closeable(std::move(reader), [&] (auto& reader) {
+                return seastar::async([this, now, &reader] () {
+                    if (enable_garbage_collected_sstable_writer()) {
+                        using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
+                        auto cfc = compact_mutations(*schema(), now,
+                            max_purgeable_func(),
+                            _table_s.get_tombstone_gc_state(),
+                            get_compacted_fragments_writer(),
+                            get_gc_compacted_fragments_writer());
+
+                        reader.consume_in_thread(std::move(cfc));
+                        return;
+                    }
+                    using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
                     auto cfc = compact_mutations(*schema(), now,
                         max_purgeable_func(),
                         _table_s.get_tombstone_gc_state(),
                         get_compacted_fragments_writer(),
-                        get_gc_compacted_fragments_writer());
-
+                        noop_compacted_fragments_consumer());
                     reader.consume_in_thread(std::move(cfc));
-                    return;
-                }
-                using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
-                auto cfc = compact_mutations(*schema(), now,
-                    max_purgeable_func(),
-                    _table_s.get_tombstone_gc_state(),
-                    get_compacted_fragments_writer(),
-                    noop_compacted_fragments_consumer());
-                reader.consume_in_thread(std::move(cfc));
+                });
             });
-          });
         });
         return consumer(make_sstable_reader());
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1829,12 +1829,12 @@ future<> sstable::write_components(
         encoding_stats stats,
         const io_priority_class& pc) {
     assert_large_data_handler_is_running();
-  return with_closeable(std::move(mr), [&] (auto& mr) {
-    return seastar::async([this, &mr, estimated_partitions, schema = std::move(schema), cfg, stats, &pc] () {
-        auto wr = get_writer(*schema, estimated_partitions, cfg, stats, pc);
-        mr.consume_in_thread(std::move(wr));
-    });
-  }).finally([this] {
+    return with_closeable(std::move(mr), [&] (auto& mr) {
+        return seastar::async([this, &mr, estimated_partitions, schema = std::move(schema), cfg, stats, &pc] () {
+            auto wr = get_writer(*schema, estimated_partitions, cfg, stats, pc);
+            mr.consume_in_thread(std::move(wr));
+        });
+    }).finally([this] {
         assert_large_data_handler_is_running();
     });
 }


### PR DESCRIPTION
There are some cases of readers being moved into seastar::async, where they are
closed by deferred_close. However, seastar::async may fail with a bad_alloc, and
the deferred_close inside will never run, leaving the reader unclosed and
resulting in an assert violation.

This is not really a stability problem, because if bad_alloc is happening in a
seastar::async, a database failure is imminent anyway. But the assert violation
obscures the bad_alloc and causes confusion.

Fixes #13406