### PR TITLE
thrift: initiaize _config first to avoid dangling reference

### DIFF
--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -60,12 +60,12 @@ thrift_server::thrift_server(data_dictionary::database db,
                              service::memory_limiter& ml,
                              thrift_server_config config)
         : _stats(new thrift_stats(*this))
-        , _handler_factory(create_handler_factory(db, qp, ss, proxy, auth_service, config.timeout_config, _current_permit).release())
+        , _config(std::move(config))
+        , _handler_factory(create_handler_factory(db, qp, ss, proxy, auth_service, _config.timeout_config, _current_permit).release())
         , _protocol_factory(new TBinaryProtocolFactoryT<TMemoryBuffer>())
         , _processor_factory(new CassandraAsyncProcessorFactory(_handler_factory))
         , _memory_available(ml.get_semaphore())
-        , _max_concurrent_requests(db.get_config().max_concurrent_requests_per_shard)
-        , _config(std::move(config)) {
+        , _max_concurrent_requests(db.get_config().max_concurrent_requests_per_shard) {
 }
 
 thrift_server::~thrift_server() {

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -104,6 +104,7 @@ private:
     std::vector<server_socket> _listeners;
     std::unique_ptr<thrift_stats> _stats;
     service_permit _current_permit = empty_service_permit();
+    thrift_server_config _config;
     thrift_std::shared_ptr<::cassandra::CassandraCobSvIfFactory> _handler_factory;
     std::unique_ptr<apache::thrift::protocol::TProtocolFactory> _protocol_factory;
     thrift_std::shared_ptr<apache::thrift::async::TAsyncProcessorFactory> _processor_factory;
@@ -115,7 +116,6 @@ private:
     semaphore& _memory_available;
     utils::updateable_value<uint32_t> _max_concurrent_requests;
     size_t _requests_shed;
-    thrift_server_config _config;
     boost::intrusive::list<connection> _connections_list;
     seastar::gate _stop_gate;
 public:


### PR DESCRIPTION
in c642ca9e73714db41c058005f9dfc7ca762492ef, a reference to the a parameter `config` passed to the `thrift_server` 's constructor is passed down to `create_handler_factory()`, which keeps it so it can create connection handler on demand. but unfortunately,

- the `config` parameter is a temporary variable
- the `config` parameter is moved away in the constructor after `create_handler_factory()` is called

hence we have a dangling reference when the factory created by `create_handler_factory()` tries to deference the reference when handling a new incoming connection.

in this change,

- the definitions of `_config` and `_handler_factory` member variables are transposed, so that the former is initialized first.
- `_handler_factory` now keeps a reference to `_config`'s member variable, so that the weak reference it holds is always valid.

Fixes #13455
Branches: none
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>