### PR TITLE
create-relocatable-package.py: error out if pigz fails

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -180,3 +180,6 @@ ar.reloc_add('fix_system_distributed_tables.py')
 # Complete the tar output, and wait for the gzip process to complete
 ar.close()
 gzip_process.communicate()
+if gzip_process.returncode != 0:
+    print('pigz returned {gzip_process.returncode}!', file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
before this change, we don't error out even if pigz fails. but there is chance that pigz fails to create the gzip'ed relocatable tarball either due to environmental issues or some other problems, and we are not aware of this until packaging scripts like `reloc/build_rpm.sh` tries to ungzip this corrupted gzip file.

in this change, if pigz's status code is not 0, the status code is printed, and create-relocatable-package.py will return 1.