### PR TITLE
build: cmake: drop test_table.cc

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -118,9 +118,6 @@ add_scylla_test(managed_vector_test
 add_scylla_test(memtable_test
   KIND SEASTAR)
 add_scylla_test(multishard_mutation_query_test
-  SOURCES
-    multishard_mutation_query_test.cc
-    test_table.cc
   KIND SEASTAR)
 add_scylla_test(murmur_hash_test
   KIND BOOST)


### PR DESCRIPTION
this change mirrors the corresponding change in `configure.py` in 4b5b6a901013a1048b3c2859b3a2010bd1f87495 .