### PR TITLE
view: view_builder: start: demote sleep_aborted log error

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1831,6 +1831,8 @@ future<> view_builder::start(service::migration_manager& mm) {
             (void)_build_step.trigger();
             return make_ready_future<>();
         });
+    }).handle_exception_type([] (const seastar::sleep_aborted& e) {
+        vlogger.debug("start aborted: {}", e.what());
     }).handle_exception([] (std::exception_ptr eptr) {
         vlogger.error("start failed: {}", eptr);
         return make_ready_future<>();


### PR DESCRIPTION
This is not really an error, so print it in debug log_level rather than error log_level.

Fixes #13374