### PR TITLE
utils: fragment_range: specialize fmt::formatter<FragmentedView>

### DIFF
--- a/keys.cc
+++ b/keys.cc
@@ -17,7 +17,8 @@
 logging::logger klog("keys");
 
 std::ostream& operator<<(std::ostream& out, const partition_key& pk) {
-    return out << "pk{" << to_hex(managed_bytes_view(pk.representation())) << "}";
+    fmt::print(out, "pk{{{}}}", managed_bytes_view(pk.representation()));
+    return out;
 }
 
 template<typename T>
@@ -63,7 +64,8 @@ std::ostream& operator<<(std::ostream& out, const partition_key_view& pk) {
 }
 
 std::ostream& operator<<(std::ostream& out, const clustering_key_prefix& ckp) {
-    return out << "ckp{" << to_hex(managed_bytes_view(ckp.representation())) << "}";
+    fmt::print(out, "ckp{{{}}}", managed_bytes_view(ckp.representation()));
+    return out;
 }
 
 const legacy_compound_view<partition_key_view::c_type>

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2135,7 +2135,7 @@ std::ostream& operator<<(std::ostream& os, operation_type op_type) {
 std::ostream&
 operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
     // Can't pass to_hex() to transformed(), since it is overloaded, so wrap:
-    auto enhex = [] (auto&& x) { return to_hex(x); };
+    auto enhex = [] (auto&& x) { return fmt_hex(x); };
     fmt::print(os, "prefix{{{}}}", fmt::join(ecp._v | boost::adaptors::transformed(enhex), ":"));
     return os;
 }

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -412,22 +412,14 @@ void write_native(Out& out, std::type_identity_t<T> v) {
     }
 }
 
-inline sstring::iterator fragment_to_hex(sstring::iterator out, bytes_view frag) {
-    static constexpr char digits[] = "0123456789abcdef";
-    for (auto byte : frag) {
-        uint8_t x = static_cast<uint8_t>(byte);
-        *out++ = digits[x >> 4];
-        *out++ = digits[x & 0xf];
+template <FragmentedView View>
+struct fmt::formatter<View> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const View& b, FormatContext& ctx) const {
+        auto out = ctx.out();
+        for (auto frag : fragment_range(b)) {
+            fmt::format_to(out, "{}", fmt_hex(frag));
+        }
+        return out;
     }
-    return out;
-}
-
-template<FragmentedView View>
-sstring to_hex(const View& b) {
-    sstring out = uninitialized_string(b.size_bytes() * 2);
-    auto it = out.begin();
-    for (auto frag : fragment_range(b)) {
-        it = fragment_to_hex(it, frag);
-    }
-    return out;
-}
+};

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -23,7 +23,7 @@ managed_bytes::do_linearize_pure() const {
 }
 
 sstring to_hex(const managed_bytes& b) {
-    return to_hex(managed_bytes_view(b));
+    return fmt::to_string(managed_bytes_view(b));
 }
 
 sstring to_hex(const managed_bytes_opt& b) {


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print classes fulfill the requirement of `FragmentedView` concept without the help of template function of `to_hex()`, this function is dropped in this change, as all its callers are now using fmtlib for formatting now. the helper of `fragment_to_hex()` is dropped as well, its only caller is `to_hex()`.

Refs scylladb#13245