### PR TITLE
locator: topology: Fix abort when removing local node which is not at index 0

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -363,8 +363,7 @@ node_holder topology::pop_node(const node* node) {
 
     unindex_node(node);
 
-    // this node?
-    if (node->idx() == 0) {
+    if (node->is_this_node()) {
         on_internal_error(tlogger, format("topology[{}]: {}: cannot pop this_node", fmt::ptr(this), debug_format(node)));
     }
 


### PR DESCRIPTION
The abort happens in topology::pop_node(), called from here:

```
  void topology::remove_node(const node* node) {
      // never delete this node
      if (node->is_this_node()) {
          unindex_node(node);
      } else {
          pop_node(node);
      }
  }
```

pop_node() is supposed to be called only when !is_this_node(), and pop_node() checks for this using a different condition, by checking if the index is 0. In tests, apparently, is_this_node() can be true for a node which is not at index 0:

Fix pop_node() to look at is_this_node() rather than the index.