### PR TITLE
utils, mutation: replace operator<<(..) with fmt formatter

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -30,7 +30,9 @@ operator<<(std::ostream& os, const static_row::printer& p) {
 
 std::ostream&
 operator<<(std::ostream& os, const partition_start& ph) {
-    return os << "{partition_start: pk "<< ph._key << " partition_tombstone " << ph._partition_tombstone << "}";
+    fmt::print(os, "{{partition_start: pk {} partition_tombstone {}}}",
+               ph._key, ph._partition_tombstone);
+    return os;
 }
 
 std::ostream&

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1055,7 +1055,7 @@ operator<<(std::ostream& os, const mutation_partition::printer& p) {
     auto& mp = p._mutation_partition;
     os << "mutation_partition: {\n";
     if (mp._tombstone) {
-        os << indent << "tombstone: " << mp._tombstone << ",\n";
+        fmt::print(os, "{}tombstone: {},\n", indent, mp._tombstone);
     }
     if (!mp._row_tombstones.empty()) {
         fmt::print(os, "{}range_tombstones: {{{}}},\n", indent, fmt::join(prefixed("\n    ", mp._row_tombstones), ","));

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -689,16 +689,21 @@ public:
     void apply(shadowable_tombstone t) noexcept {
         _tomb.apply(t._tomb);
     }
+};
 
-    friend std::ostream& operator<<(std::ostream& out, const shadowable_tombstone& t) {
+template <>
+struct fmt::formatter<shadowable_tombstone> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const shadowable_tombstone& t, FormatContext& ctx) const {
         if (t) {
-            return out << "{shadowable tombstone: timestamp=" << t.tomb().timestamp
-                   << ", deletion_time=" << t.tomb().deletion_time.time_since_epoch().count()
-                   << "}";
+            return fmt::format_to(ctx.out(),
+                                  "{{shadowable tombstone: timestamp={}, deletion_time={}}}",
+                                  t.tomb().timestamp, t.tomb(), t.tomb().deletion_time.time_since_epoch().count());
         } else {
-            return out << "{shadowable tombstone: none}";
+            return fmt::format_to(ctx.out(),
+                                  "{{shadowable tombstone: none}}");
         }
-    }
+     }
 };
 
 template<>
@@ -792,10 +797,11 @@ public:
 
     friend std::ostream& operator<<(std::ostream& out, const row_tombstone& t) {
         if (t) {
-            return out << "{row_tombstone: " << t._regular << (t.is_shadowable() ? t._shadowable : shadowable_tombstone()) << "}";
+            fmt::print(out, "{{row_tombstone: {}{}}}",  t._regular, t.is_shadowable() ? t._shadowable : shadowable_tombstone());
         } else {
-            return out << "{row_tombstone: none}";
+            fmt::print(out, "{{row_tombstone: none}}");
         }
+        return out;
     }
 };
 

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -792,7 +792,7 @@ operator<<(std::ostream& os, const mutation_partition_v2::printer& p) {
     auto& mp = p._mutation_partition;
     os << "mutation_partition_v2: {\n";
     if (mp._tombstone) {
-        os << indent << "tombstone: " << mp._tombstone << ",\n";
+        fmt::print(os, "{:2}tombstone: {},\n", "", mp._tombstone);
     }
 
     if (!mp.static_row().empty()) {
@@ -821,7 +821,7 @@ operator<<(std::ostream& os, const mutation_partition_v2::printer& p) {
             os << indent << indent << indent << "tombstone: " << row.deleted_at() << ",\n";
         }
         if (re.range_tombstone()) {
-            os << indent << indent << indent << "rt: " << re.range_tombstone() << ",\n";
+            fmt::print("{:6}rt: {},\n", "", re.range_tombstone());
         }
 
         position_in_partition pip(re.position());

--- a/mutation/tombstone.hh
+++ b/mutation/tombstone.hh
@@ -62,15 +62,27 @@ struct tombstone final {
         result.apply(t);
         return result;
     }
-
-    friend std::ostream& operator<<(std::ostream& out, const tombstone& t) {
-        if (t) {
-            return out << "{tombstone: timestamp=" << t.timestamp << ", deletion_time=" << t.deletion_time.time_since_epoch().count() << "}";
-        } else {
-            return out << "{tombstone: none}";
-        }
-    }
 };
+
+template <>
+struct fmt::formatter<tombstone> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const tombstone& t, FormatContext& ctx) const {
+        if (t) {
+            return fmt::format_to(ctx.out(),
+                                  "{{tombstone: timestamp={}, deletion_time={}}}",
+                                  t.timestamp, t.deletion_time.time_since_epoch().count());
+        } else {
+            return fmt::format_to(ctx.out(),
+                                  "{{tombstone: none}}");
+        }
+     }
+};
+
+static inline std::ostream& operator<<(std::ostream& out, const tombstone& t) {
+    fmt::print(out, "{}", t);
+    return out;
+}
 
 template<>
 struct appending_hash<tombstone> {

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -748,11 +748,10 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& out, const partition_snapshot_row_cursor& cur) {
-        out << "{cursor: position=" << cur._position
-            << ", cont=" << cur.continuous()
-            << ", rt=" << cur.range_tombstone();
+        fmt::print(out, "{{cursor: position={}, cont={}, rt={}}}",
+                   cur._position, cur.continuous(), cur.range_tombstone());
         if (cur.range_tombstone() != cur.range_tombstone_for_row()) {
-            out << ", row_rt=" << cur.range_tombstone_for_row();
+            fmt::print(out, ", row_rt={}", cur.range_tombstone_for_row());
         }
         out << ", ";
         if (cur._reversed) {

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -164,3 +164,15 @@ std::ostream& operator<<(std::ostream& os, const std::weak_ordering& order);
 std::ostream& operator<<(std::ostream& os, const std::partial_ordering& order);
 
 } // namespace std
+
+template<typename T>
+struct fmt::formatter<std::optional<T>> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const std::optional<T>& opt, FormatContext& ctx) const {
+        if (opt) {
+            return fmt::format_to(ctx.out(), "{}", *opt);
+        } else {
+            return fmt::format_to(ctx.out(), "{{}}");
+        }
+     }
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `tombstone` and `shadowable_tombstone` without the help of fmt::ostream. and their `operator<<(ostream,..)` are dropped, as there are no users of them anymore.

Refs #13245