### PR TITLE
token_metadata: use topology nodes for endpoint_to_host_id map

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2093,13 +2093,14 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
 future<std::unordered_map<sstring, sstring>>
 view_builder::view_build_statuses(sstring keyspace, sstring view_name) const {
     return _sys_dist_ks.view_status(std::move(keyspace), std::move(view_name)).then([] (std::unordered_map<locator::host_id, sstring> status) {
-        auto endpoint_to_host_id = service::get_local_storage_proxy().get_token_metadata_ptr()->get_endpoint_to_host_id_map_for_reading();
-        return boost::copy_range<std::unordered_map<sstring, sstring>>(endpoint_to_host_id
-                | boost::adaptors::transformed([&status] (const std::pair<gms::inet_address, locator::host_id>& p) {
-                    auto it = status.find(p.second);
-                    auto s = it != status.end() ? std::move(it->second) : "UNKNOWN";
-                    return std::pair(p.first.to_sstring(), std::move(s));
-                }));
+        std::unordered_map<sstring, sstring> status_map;
+        const auto& topo = service::get_local_storage_proxy().get_token_metadata_ptr()->get_topology();
+        topo.for_each_node([&] (const locator::node *node) {
+            auto it = status.find(node->host_id());
+            auto s = it != status.end() ? std::move(it->second) : "UNKNOWN";
+            status_map.emplace(node->endpoint().to_sstring(), std::move(s));
+        });
+        return status_map;
     });
 }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2093,7 +2093,7 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
 future<std::unordered_map<sstring, sstring>>
 view_builder::view_build_statuses(sstring keyspace, sstring view_name) const {
     return _sys_dist_ks.view_status(std::move(keyspace), std::move(view_name)).then([] (std::unordered_map<locator::host_id, sstring> status) {
-        auto& endpoint_to_host_id = service::get_local_storage_proxy().get_token_metadata_ptr()->get_endpoint_to_host_id_map_for_reading();
+        auto endpoint_to_host_id = service::get_local_storage_proxy().get_token_metadata_ptr()->get_endpoint_to_host_id_map_for_reading();
         return boost::copy_range<std::unordered_map<sstring, sstring>>(endpoint_to_host_id
                 | boost::adaptors::transformed([&status] (const std::pair<gms::inet_address, locator::host_id>& p) {
                     auto it = status.find(p.second);

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -161,7 +161,7 @@ public:
     host_id_or_endpoint parse_host_id_and_endpoint(const sstring& host_id_string) const;
 
     /** @return a copy of the endpoint-to-id map for read-only operations */
-    const std::unordered_map<inet_address, host_id>& get_endpoint_to_host_id_map_for_reading() const;
+    std::unordered_map<inet_address, host_id> get_endpoint_to_host_id_map_for_reading() const;
 
     void add_bootstrap_token(token t, inet_address endpoint);
 

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -495,6 +495,14 @@ std::weak_ordering topology::compare_endpoints(const inet_address& address, cons
     return d1 <=> d2;
 }
 
+void topology::for_each_node(std::function<void(const node*)> func) const {
+    for (const auto& np : _nodes) {
+        if (np) {
+            func(np.get());
+        }
+    }
+}
+
 } // namespace locator
 
 namespace std {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -250,6 +250,8 @@ public:
      */
     void sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const;
 
+    void for_each_node(std::function<void(const node*)> func) const;
+
 private:
     // default constructor for cloning purposes
     topology() noexcept;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -304,6 +304,11 @@ private:
 
     void calculate_datacenters();
 
+    const std::unordered_map<inet_address, const node*>& get_nodes_by_endpoint() const noexcept {
+        return _nodes_by_endpoint;
+    };
+
+    friend class token_metadata_impl;
 public:
     void test_compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
 };


### PR DESCRIPTION
Currently, token_metadata_impl maintains a "shadow" endpoint to host_id map on top of the maps in topology.
This series first reimplements the functions that currently use this map to use topology instead.
Then the important users of `get_endpoint_to_host_id_map_for_reading`: node_ops_ctl and view_builder
and converted to use a new `topology::for_each_node` function to process all nodes in topology directly, without going through `get_endpoint_to_host_id_map_for_reading`.
