### PR TITLE
utils: big_decimal: optimize big_decimal::compare() and use <=> operator

### DIFF
--- a/types/types.cc
+++ b/types/types.cc
@@ -2346,7 +2346,7 @@ struct compare_visitor {
       return with_empty_checks([&] {
         auto a = deserialize_value(d, v1);
         auto b = deserialize_value(d, v2);
-        return a.compare(b);
+        return a <=> b;
       });
     }
     std::strong_ordering operator()(const varint_type_impl& v) {

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -135,7 +135,7 @@ sstring big_decimal::to_string() const
     return str;
 }
 
-std::strong_ordering big_decimal::compare(const big_decimal& other) const
+std::strong_ordering big_decimal::operator<=>(const big_decimal& other) const
 {
     auto max_scale = std::max(_scale, other._scale);
     boost::multiprecision::cpp_int rescale(10);

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -141,7 +141,7 @@ std::strong_ordering big_decimal::compare(const big_decimal& other) const
     boost::multiprecision::cpp_int rescale(10);
     boost::multiprecision::cpp_int x = _unscaled_value * boost::multiprecision::pow(rescale, max_scale - _scale);
     boost::multiprecision::cpp_int y = other._unscaled_value * boost::multiprecision::pow(rescale, max_scale - other._scale);
-    return x == y ? std::strong_ordering::equal : x < y ? std::strong_ordering::less : std::strong_ordering::greater;
+    return x.compare(y) <=> 0;
 }
 
 big_decimal& big_decimal::operator+=(const big_decimal& other)

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -38,19 +38,13 @@ public:
 
     sstring to_string() const;
 
-    std::strong_ordering compare(const big_decimal& other) const;
+    std::strong_ordering operator<=>(const big_decimal& other) const;
 
     big_decimal& operator+=(const big_decimal& other);
     big_decimal& operator-=(const big_decimal& other);
     big_decimal operator+(const big_decimal& other) const;
     big_decimal operator-(const big_decimal& other) const;
     big_decimal div(const ::uint64_t y, const rounding_mode mode) const;
-    friend bool operator<(const big_decimal& x, const big_decimal& y) { return x.compare(y) < 0; }
-    friend bool operator<=(const big_decimal& x, const big_decimal& y) { return x.compare(y) <= 0; }
-    friend bool operator==(const big_decimal& x, const big_decimal& y) { return x.compare(y) == 0; }
-    friend bool operator!=(const big_decimal& x, const big_decimal& y) { return x.compare(y) != 0; }
-    friend bool operator>=(const big_decimal& x, const big_decimal& y) { return x.compare(y) >= 0; }
-    friend bool operator>(const big_decimal& x, const big_decimal& y) { return x.compare(y) > 0; }
 };
 
 template <>


### PR DESCRIPTION
in this series, we use <=> operator to replace `big_decimal::compare()` for better readability. also, we trade the chained ternary expression with a more verbose if-else statement for better performance and readability.