### PR TITLE
utils: big_decimal: specialize fmt::formatter<big_decimal>

### DIFF
--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -53,6 +53,10 @@ public:
     friend bool operator>(const big_decimal& x, const big_decimal& y) { return x.compare(y) > 0; }
 };
 
-inline std::ostream& operator<<(std::ostream& s, const big_decimal& v) {
-    return s << v.to_string();
-}
+template <>
+struct fmt::formatter<big_decimal> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const big_decimal& v, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", v.to_string());
+    }
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `big_decimal` without the help of `operator<<`. this operator is droppe in this change, as all its callers are now using fmtlib for formatting now. we might need to use fmtlib to implement `big_decimal::to_string()`, and use `fmt::to_string()` instead, but let's leave it for a follow-up change.

Refs scylladb#13245