### PR TITLE
cql3/expr: remove expr::token

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1773,7 +1773,12 @@ relation returns [expression e]
     : name=cident type=relationType t=term { $e = binary_operator(unresolved_identifier{std::move(name)}, type, std::move(t)); }
 
     | K_TOKEN l=tupleOfIdentifiers type=relationType t=term
-        { $e = binary_operator(token{std::move(l.elements)}, type, std::move(t)); }
+        {
+          $e = binary_operator(
+            function_call{functions::function_name::native_function("token"), std::move(l.elements)},
+            type,
+            std::move(t));
+        }
     | name=cident K_IS K_NOT K_NULL {
           $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, make_untyped_null()); }
     | name=cident K_IN marker1=marker

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -66,24 +66,6 @@ expression::operator=(const expression& o) {
     return *this;
 }
 
-token::token(std::vector<expression> args_in)
-    : args(std::move(args_in)) {
-}
-
-token::token(const std::vector<const column_definition*>& col_defs) {
-    args.reserve(col_defs.size());
-    for (const column_definition* col_def : col_defs) {
-        args.push_back(column_value(col_def));
-    }
-}
-
-token::token(const std::vector<::shared_ptr<column_identifier_raw>>& cols) {
-    args.reserve(cols.size());
-    for(const ::shared_ptr<column_identifier_raw>& col : cols) {
-        args.push_back(unresolved_identifier{col});
-    }
-}
-
 binary_operator::binary_operator(expression lhs, oper_t op, expression rhs, comparison_order order)
             : lhs(std::move(lhs))
             , op(op)
@@ -789,7 +771,11 @@ static value_set possible_lhs_values(const column_definition* cdef,
                             }
                             return unbounded_value_set;
                         },
-                        [&] (token) -> value_set {
+                        [&] (const function_call& token_fun_call) -> value_set {
+                            if (!is_partition_token_for_schema(token_fun_call, *table_schema_opt)) {
+                                on_internal_error(expr_logger, "possible_lhs_values: function calls are not supported as the LHS of a binary expression");
+                            }
+
                             if (cdef) {
                                 return unbounded_value_set;
                             }
@@ -831,9 +817,6 @@ static value_set possible_lhs_values(const column_definition* cdef,
                         [] (const column_mutation_attribute&) -> value_set {
                             on_internal_error(expr_logger, "possible_lhs_values: writetime/ttl are not supported as the LHS of a binary expression");
                         },
-                        [] (const function_call&) -> value_set {
-                            on_internal_error(expr_logger, "possible_lhs_values: function calls are not supported as the LHS of a binary expression");
-                        },
                         [] (const cast&) -> value_set {
                             on_internal_error(expr_logger, "possible_lhs_values: typecasts are not supported as the LHS of a binary expression");
                         },
@@ -859,9 +842,6 @@ static value_set possible_lhs_values(const column_definition* cdef,
             },
             [] (const subscript&) -> value_set {
                 on_internal_error(expr_logger, "possible_lhs_values: a subscript cannot serve as a restriction by itself");
-            },
-            [] (const token&) -> value_set {
-                on_internal_error(expr_logger, "possible_lhs_values: the token function cannot serve as a restriction by itself");
             },
             [] (const unresolved_identifier&) -> value_set {
                 on_internal_error(expr_logger, "possible_lhs_values: an unresolved identifier cannot serve as a restriction");
@@ -951,7 +931,7 @@ secondary_index::index::supports_expression_v is_supported_by_helper(const expre
                             // We don't use index table for multi-column restrictions, as it cannot avoid filtering.
                             return index::supports_expression_v::from_bool(false);
                         },
-                        [&] (const token&) { return index::supports_expression_v::from_bool(false); },
+                        [&] (const function_call&) { return index::supports_expression_v::from_bool(false); },
                         [&] (const subscript& s) -> ret_t {
                             const column_value& col = get_subscripted_column(s);
                             return idx.supports_subscript_expression(*col.col, oper.op);
@@ -970,9 +950,6 @@ secondary_index::index::supports_expression_v is_supported_by_helper(const expre
                         },
                         [&] (const column_mutation_attribute&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: writetime/ttl are not supported as the LHS of a binary expression");
-                        },
-                        [&] (const function_call&) -> ret_t {
-                            on_internal_error(expr_logger, "is_supported_by: function calls are not supported as the LHS of a binary expression");
                         },
                         [&] (const cast&) -> ret_t {
                             on_internal_error(expr_logger, "is_supported_by: typecasts are not supported as the LHS of a binary expression");
@@ -1096,9 +1073,6 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
                         os << to_printer(opr.lhs) << ' ' << opr.op << ' ' << to_printer(opr.rhs);
                     }
                 }
-            },
-            [&] (const token& t) {
-                fmt::print(os, "token({})", fmt::join(t.args | transformed(to_printer), ", "));
             },
             [&] (const column_value& col) {
                 fmt::print(os, "{}", cql3::util::maybe_quote(col.col->name_as_text()));
@@ -1307,7 +1281,7 @@ expression replace_column_def(const expression& expr, const column_definition* n
 
 expression replace_partition_token(const expression& expr, const column_definition* new_cdef, const schema& table_schema) {
     return search_and_replace(expr, [&] (const expression& expr) -> std::optional<expression> {
-        if (expr::is<token>(expr)) {
+        if (is_partition_token_for_schema(expr, table_schema)) {
             return column_value{new_cdef};
         } else {
             return std::nullopt;
@@ -1376,14 +1350,6 @@ bool recurse_until(const expression& e, const noncopyable_function<bool (const e
             [&] (const usertype_constructor& c) {
                 for (auto& [k, v] : c.elements) {
                     if (auto found = recurse_until(v, predicate_fun)) {
-                        return found;
-                    }
-                }
-                return false;
-            },
-            [&] (const token& tok) {
-                for (auto& a : tok.args) {
-                    if (auto found = recurse_until(a, predicate_fun)) {
                         return found;
                     }
                 }
@@ -1464,13 +1430,6 @@ expression search_and_replace(const expression& e,
                         .type = s.type,
                     };
                 },
-                [&](const token& tok) -> expression {
-                    return token {
-                        boost::copy_range<std::vector<expression>>(
-                            tok.args | boost::adaptors::transformed(recurse)
-                        )
-                    };
-                },
                 [&] (LeafExpression auto const& e) -> expression {
                     return e;
                 },
@@ -1545,7 +1504,6 @@ std::vector<expression> extract_single_column_restrictions_for_column(const expr
             }
         }
 
-        void operator()(const token&) {}
         void operator()(const unresolved_identifier&) {}
         void operator()(const column_mutation_attribute&) {}
         void operator()(const function_call&) {}
@@ -1708,9 +1666,6 @@ cql3::raw_value evaluate(const expression& e, const evaluation_inputs& inputs) {
         },
         [&](const conjunction& conj) -> cql3::raw_value {
             return evaluate(conj, inputs);
-        },
-        [](const token&) -> cql3::raw_value {
-            on_internal_error(expr_logger, "Can't evaluate token");
         },
         [](const unresolved_identifier&) -> cql3::raw_value {
             on_internal_error(expr_logger, "Can't evaluate unresolved_identifier");
@@ -2251,11 +2206,6 @@ void fill_prepare_context(expression& e, prepare_context& ctx) {
                 fill_prepare_context(child, ctx);
             }
         },
-        [&](token& tok) {
-            for (expression& arg : tok.args) {
-                fill_prepare_context(arg, ctx);
-            }
-        },
         [](unresolved_identifier&) {},
         [&](column_mutation_attribute& a) {
             fill_prepare_context(a.column, ctx);
@@ -2304,9 +2254,6 @@ type_of(const expression& e) {
         },
         [] (const column_value& e) {
             return e.col->type;
-        },
-        [] (const token& e) {
-            return long_type;
         },
         [] (const unresolved_identifier& e) -> data_type {
             on_internal_error(expr_logger, "evaluating type of unresolved_identifier");

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -856,7 +856,7 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                 on_internal_error(expr_logger, "possible_lhs_values: the token function cannot serve as a restriction by itself");
             },
             [] (const unresolved_identifier&) -> value_set {
-                on_internal_error(expr_logger, "is_satisfied_by: an unresolved identifier cannot serve as a restriction");
+                on_internal_error(expr_logger, "possible_lhs_values: an unresolved identifier cannot serve as a restriction");
             },
             [] (const column_mutation_attribute&) -> value_set {
                 on_internal_error(expr_logger, "possible_lhs_values: the writetime/ttl functions cannot serve as a restriction by itself");

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2711,5 +2711,48 @@ bool is_token_function(const expression& e) {
 
     return is_token_function(*fun_call);
 }
+
+bool is_partition_token_for_schema(const function_call& fun_call, const schema& table_schema) {
+    if (!is_token_function(fun_call)) {
+        return false;
+    }
+
+    if (fun_call.args.size() != table_schema.partition_key_size()) {
+        return false;
+    }
+
+    auto arguments_iter = fun_call.args.begin();
+    for (const column_definition& partition_key_col : table_schema.partition_key_columns()) {
+        const expression& cur_argument = *arguments_iter;
+
+        const column_value* cur_col = as_if<column_value>(&cur_argument);
+        if (cur_col == nullptr) {
+            // A sanity check that we didn't call the function on an unprepared expression.
+            if (is<unresolved_identifier>(cur_argument)) {
+                on_internal_error(expr_logger,
+                                  format("called is_partition_token with unprepared expression: {}", fun_call));
+            }
+
+            return false;
+        }
+
+        if (cur_col->col != &partition_key_col) {
+            return false;
+        }
+
+        arguments_iter++;
+    }
+
+    return true;
+}
+
+bool is_partition_token_for_schema(const expression& maybe_token, const schema& table_schema) {
+    const function_call* fun_call = as_if<function_call>(&maybe_token);
+    if (fun_call == nullptr) {
+        return false;
+    }
+
+    return is_partition_token_for_schema(*fun_call, table_schema);
+}
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1119,14 +1119,18 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
                         to_printer(cma.column));
             },
             [&] (const function_call& fc)  {
-                std::visit(overloaded_functor{
-                    [&] (const functions::function_name& named) {
-                        fmt::print(os, "{}({})", named, fmt::join(fc.args | transformed(to_printer), ", "));
-                    },
-                    [&] (const shared_ptr<functions::function>& anon) {
-                        fmt::print(os, "<anonymous function>({})", fmt::join(fc.args | transformed(to_printer), ", "));
-                    },
-                }, fc.func);
+                if (is_token_function(fc)) {
+                    fmt::print(os, "token({})", fmt::join(fc.args | transformed(to_printer), ", "));
+                } else {
+                    std::visit(overloaded_functor{
+                        [&] (const functions::function_name& named) {
+                            fmt::print(os, "{}({})", named, fmt::join(fc.args | transformed(to_printer), ", "));
+                        },
+                        [&] (const shared_ptr<functions::function>& anon) {
+                            fmt::print(os, "<anonymous function>({})", fmt::join(fc.args | transformed(to_printer), ", "));
+                        },
+                    }, fc.func);
+                }
             },
             [&] (const cast& c)  {
                 std::visit(overloaded_functor{

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1363,7 +1363,7 @@ expression replace_column_def(const expression& expr, const column_definition* n
     });
 }
 
-expression replace_token(const expression& expr, const column_definition* new_cdef) {
+expression replace_partition_token(const expression& expr, const column_definition* new_cdef, const schema& table_schema) {
     return search_and_replace(expr, [&] (const expression& expr) -> std::optional<expression> {
         if (expr::is<token>(expr)) {
             return column_value{new_cdef};

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2690,5 +2690,26 @@ adjust_for_collection_as_maps(const expression& e) {
     });
 }
 
+bool is_token_function(const function_call& fun_call) {
+    static thread_local const functions::function_name token_function_name =
+        functions::function_name::native_function("token");
+
+    // Check that function name is "token"
+    const functions::function_name& fun_name =
+        std::visit(overloaded_functor{[](const functions::function_name& fname) { return fname; },
+                                      [](const shared_ptr<functions::function>& fun) { return fun->name(); }},
+                   fun_call.func);
+
+    return fun_name.has_keyspace() ? fun_name == token_function_name : fun_name.name == token_function_name.name;
+}
+
+bool is_token_function(const expression& e) {
+    const function_call* fun_call = as_if<function_call>(&e);
+    if (fun_call == nullptr) {
+        return false;
+    }
+
+    return is_token_function(*fun_call);
+}
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -694,7 +694,8 @@ extern expression replace_column_def(const expression&, const column_definition*
 
 // Replaces all occurences of token(p1, p2) on the left hand side with the given colum.
 // For example this changes token(p1, p2) < token(1, 2) to my_column_name < token(1, 2).
-extern expression replace_token(const expression&, const column_definition*);
+// Schema is needed to find out which calls to token() describe the partition token.
+extern expression replace_partition_token(const expression&, const column_definition*, const schema&);
 
 // Recursively copies e and returns it. Calls replace_candidate() on all nodes. If it returns nullopt,
 // continue with the copying. If it returns an expression, that expression replaces the current node.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -642,6 +642,11 @@ inline bool is_multi_column(const binary_operator& op) {
     return expr::is<tuple_constructor>(op.lhs);
 }
 
+/// Check whether the expression contains a binary_operator whose LHS is a call to the token
+/// function representing a partition key token.
+/// Examples:
+/// For expression: "token(p1, p2, p3) < 123 AND c = 2" returns true
+/// For expression: "p1 = token(1, 2, 3) AND c = 2" return false
 inline bool has_partition_token(const expression& e, const schema& table_schema) {
     return find_binop(e, [] (const binary_operator& o) { return expr::is<token>(o.lhs); });
 }

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -830,6 +830,8 @@ bool has_only_eq_binops(const expression&);
 bool is_token_function(const function_call&);
 bool is_token_function(const expression&);
 
+bool is_partition_token_for_schema(const function_call&, const schema&);
+bool is_partition_token_for_schema(const expression&, const schema&);
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -642,7 +642,7 @@ inline bool is_multi_column(const binary_operator& op) {
     return expr::is<tuple_constructor>(op.lhs);
 }
 
-inline bool has_token(const expression& e) {
+inline bool has_partition_token(const expression& e, const schema& table_schema) {
     return find_binop(e, [] (const binary_operator& o) { return expr::is<token>(o.lhs); });
 }
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -824,6 +824,12 @@ bytes_opt value_for(const column_definition&, const expression&, const query_opt
 bool contains_multi_column_restriction(const expression&);
 
 bool has_only_eq_binops(const expression&);
+
+// Check whether the given expression represents
+// a call to the token() function.
+bool is_token_function(const function_call&);
+bool is_token_function(const expression&);
+
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -510,8 +510,8 @@ using value_list = std::vector<managed_bytes>; // Sorted and deduped using value
 /// never singular and never has start > end.  Universal set is a nonwrapping_range with both bounds null.
 using value_set = std::variant<value_list, nonwrapping_range<managed_bytes>>;
 
-/// A set of all column values that would satisfy an expression.  If column is null, a set of all token values
-/// that satisfy.
+/// A set of all column values that would satisfy an expression. The _token_values variant finds
+/// matching values for the partition token function call instead of the column.
 ///
 /// An expression restricts possible values of a column or token:
 /// - `A>5` restricts A from below
@@ -521,7 +521,8 @@ using value_set = std::variant<value_list, nonwrapping_range<managed_bytes>>;
 /// - `A=1 AND A<=0` restricts A to an empty list; no value is able to satisfy the expression
 /// - `A>=NULL` also restricts A to an empty list; all comparisons to NULL are false
 /// - an expression without A "restricts" A to unbounded range
-extern value_set possible_lhs_values(const column_definition*, const expression&, const query_options&);
+extern value_set possible_column_values(const column_definition*, const expression&, const query_options&);
+extern value_set possible_partition_token_values(const expression&, const query_options&, const schema& table_schema);
 
 /// Turns value_set into a range, unless it's a multi-valued list (in which case this throws).
 extern nonwrapping_range<managed_bytes> to_range(const value_set&);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -817,17 +817,38 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
 
 std::optional<expression>
 prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    if (!receiver) {
-        // TODO: It is possible to infer the type of a function call if there is only one overload, or if all overloads return the same type
-        return std::nullopt;
+    // Try to extract a column family name from the available information.
+    // Most functions can be prepared without information about the column family, usually just the keyspace is enough.
+    // One exception is the token() function - in order to prepare system.token() we have to know the partition key of the table,
+    // which can only be known when the column family is known.
+    // In cases when someone calls prepare_function_call on a token() function without a known column_family, an exception is thrown by functions::get.
+    std::optional<std::string_view> cf_name;
+    if (schema_opt != nullptr) {
+        cf_name = std::string_view(schema_opt->cf_name());
+    } else if (receiver.get() != nullptr) {
+        cf_name = receiver->cf_name;
     }
+
+    // Prepare the arguments that can be prepared without a receiver.
+    // Prepared expressions have a known type, which helps with finding the right function.
+    std::vector<expression> partially_prepared_args;
+    for (const expression& argument : fc.args) {
+        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr);
+        if (prepared_arg_opt.has_value()) {
+            partially_prepared_args.emplace_back(*prepared_arg_opt);
+        } else {
+            partially_prepared_args.push_back(argument);
+        }
+    }
+
     auto&& fun = std::visit(overloaded_functor{
         [] (const shared_ptr<functions::function>& func) {
             return func;
         },
         [&] (const functions::function_name& name) {
-            auto args = boost::copy_range<std::vector<::shared_ptr<assignment_testable>>>(fc.args | boost::adaptors::transformed(expr::as_assignment_testable));
-            auto fun = functions::functions::get(db, keyspace, name, args, receiver->ks_name, receiver->cf_name, receiver.get());
+            auto args = boost::copy_range<std::vector<::shared_ptr<assignment_testable>>>(
+                    partially_prepared_args | boost::adaptors::transformed(expr::as_assignment_testable));
+            auto fun = functions::functions::get(db, keyspace, name, args, keyspace, cf_name, receiver.get());
             if (!fun) {
                 throw exceptions::invalid_request_exception(format("Unknown function {} called", name));
             }
@@ -843,7 +864,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
 
     // Functions.get() will complain if no function "name" type check with the provided arguments.
     // We still have to validate that the return type matches however
-    if (!receiver->type->is_value_compatible_with(*scalar_fun->return_type())) {
+    if (receiver && !receiver->type->is_value_compatible_with(*scalar_fun->return_type())) {
         throw exceptions::invalid_request_exception(format("Type error: cannot assign result of function {} (type {}) to {} (type {})",
                                                     fun->name(), fun->return_type()->as_cql3_type(),
                                                     receiver->name, receiver->type->as_cql3_type()));
@@ -855,11 +876,11 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     }
 
     std::vector<expr::expression> parameters;
-    parameters.reserve(fc.args.size());
+    parameters.reserve(partially_prepared_args.size());
     bool all_terminal = true;
-    for (size_t i = 0; i < fc.args.size(); ++i) {
-        expr::expression e = prepare_expression(fc.args[i], db, keyspace, schema_opt,
-                                                functions::functions::make_arg_spec(receiver->ks_name, receiver->cf_name, *scalar_fun, i));
+    for (size_t i = 0; i < partially_prepared_args.size(); ++i) {
+        expr::expression e = prepare_expression(partially_prepared_args[i], db, keyspace, schema_opt,
+                                                functions::functions::make_arg_spec(keyspace, cf_name, *scalar_fun, i));
         if (!expr::is<expr::constant>(e)) {
             all_terminal = false;
         }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1096,8 +1096,8 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
         [&] (const conjunction&) -> test_result {
             on_internal_error(expr_logger, "conjunctions are not yet reachable via test_assignment()");
         },
-        [&] (const column_value&) -> test_result {
-            on_internal_error(expr_logger, "column_values are not yet reachable via test_assignment()");
+        [&] (const column_value& col_val) -> test_result {
+            return expression_test_assignment(col_val.col->type, receiver);
         },
         [&] (const subscript&) -> test_result {
             on_internal_error(expr_logger, "subscripts are not yet reachable via test_assignment()");

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -40,7 +40,7 @@ class functions {
 private:
     static std::unordered_multimap<function_name, shared_ptr<function>> init() noexcept;
 public:
-    static lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, const sstring& receiver_cf,
+    static lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
             const function& fun, size_t i);
 public:
     static shared_ptr<function> get(data_dictionary::database db,
@@ -48,7 +48,7 @@ public:
                                     const function_name& name,
                                     const std::vector<shared_ptr<assignment_testable>>& provided_args,
                                     const sstring& receiver_ks,
-                                    const sstring& receiver_cf,
+                                    std::optional<const std::string_view> receiver_cf,
                                     const column_specification* receiver = nullptr);
     template <typename AssignmentTestablePtrRange>
     static shared_ptr<function> get(data_dictionary::database db,
@@ -56,7 +56,7 @@ public:
                                     const function_name& name,
                                     AssignmentTestablePtrRange&& provided_args,
                                     const sstring& receiver_ks,
-                                    const sstring& receiver_cf,
+                                    std::optional<const std::string_view> receiver_cf,
                                     const column_specification* receiver = nullptr) {
         const std::vector<shared_ptr<assignment_testable>> args(std::begin(provided_args), std::end(provided_args));
         return get(db, keyspace, name, args, receiver_ks, receiver_cf, receiver);
@@ -87,12 +87,12 @@ private:
                               shared_ptr<function> fun,
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
-                              const sstring& receiver_cf);
+                              std::optional<const std::string_view> receiver_cf);
     static assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
             shared_ptr<function> fun,
             const std::vector<shared_ptr<assignment_testable>>& provided_args,
             const sstring& receiver_ks,
-            const sstring& receiver_cf);
+            std::optional<const std::string_view> receiver_cf);
 
     static bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1791,7 +1791,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
         // When there is a token(p1, p2) >/</= ? restriction, it is not allowed to have restrictions on p1 or p2.
         // This means that p1 and p2 can have many different values (token is a hash, can have collisions).
         // Clustering prefix ends after token_restriction, all further restrictions have to be filtered.
-        expr::expression token_restriction = replace_token(_partition_key_restrictions, token_column);
+        expr::expression token_restriction = replace_partition_token(_partition_key_restrictions, token_column, *_schema);
         _idx_tbl_ck_prefix = std::vector{std::move(token_restriction)};
 
         return;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -213,6 +213,7 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
     /// Collects all clustering-column restrictions from an expression.  Presumes the expression only uses
     /// conjunction to combine subexpressions.
     struct visitor {
+        schema_ptr table_schema;
         std::vector<expression> multi; ///< All multi-column restrictions.
         /// All single-clustering-column restrictions, grouped by column.  Each value is either an atom or a
         /// conjunction of atoms.
@@ -313,7 +314,11 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
         void operator()(const usertype_constructor&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(usertype_constructor)");
         }
-    } v;
+    };
+    visitor v {
+        .table_schema = schema
+    };
+
     expr::visit(v, where_clause);
 
     if (!v.multi.empty()) {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -181,7 +181,7 @@ public:
     }
 
     bool has_token_restrictions() const {
-        return has_token(_partition_key_restrictions);
+        return has_partition_token(_partition_key_restrictions, *_schema);
     }
 
     // Checks whether the given column has an EQ restriction.

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -478,7 +478,7 @@ public:
         // If token restrictions are present in an indexed query, then all other restrictions need to be filtered.
         // A single token restriction can have multiple matching partition key values.
         // Because of this we can't create a clustering prefix with more than token restriction.
-        || (_uses_secondary_indexing && has_token(_partition_key_restrictions));
+        || (_uses_secondary_indexing && has_token_restrictions());
     }
 
     bool clustering_key_restrictions_need_filtering() const;

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -393,7 +393,7 @@ modification_statement::process_where_clause(data_dictionary::database db, expr:
             _has_regular_column_conditions = true;
         }
     }
-    if (has_token(_restrictions->get_partition_key_restrictions())) {
+    if (_restrictions->has_token_restrictions()) {
         throw exceptions::invalid_request_exception(format("The token function cannot be used in WHERE clauses for UPDATE and DELETE statements: {}",
                 to_string(_restrictions->get_partition_key_restrictions())));
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -876,7 +876,7 @@ primary_key_select_statement::primary_key_select_statement(schema_ptr schema, ui
     if (_ks_sel == ks_selector::NONSYSTEM) {
         if (_restrictions->need_filtering() ||
                 _restrictions->partition_key_restrictions_is_empty() ||
-                (has_token(_restrictions->get_partition_key_restrictions()) &&
+                (_restrictions->has_token_restrictions() &&
                  !find(_restrictions->get_partition_key_restrictions(), expr::oper_t::EQ))) {
             _range_scan = true;
             if (!_parameters->bypass_cache())
@@ -1211,7 +1211,7 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_g
     partition_slice_builder partition_slice_builder{*_view_schema};
 
     if (!_restrictions->has_partition_key_unrestricted_components()) {
-        bool pk_restrictions_is_single = !has_token(_restrictions->get_partition_key_restrictions());
+        bool pk_restrictions_is_single = !_restrictions->has_token_restrictions();
         // Only EQ restrictions on base partition key can be used in an index view query
         if (pk_restrictions_is_single && _restrictions->partition_key_restrictions_is_all_eq()) {
             partition_slice_builder.with_ranges(
@@ -2027,7 +2027,7 @@ static bool needs_allow_filtering_anyway(
     const auto& pk_restrictions = restrictions.get_partition_key_restrictions();
     // Even if no filtering happens on the coordinator, we still warn about poor performance when partition
     // slice is defined but in potentially unlimited number of partitions (see #7608).
-    if ((expr::is_empty_restriction(pk_restrictions) || has_token(pk_restrictions)) // Potentially unlimited partitions.
+    if ((expr::is_empty_restriction(pk_restrictions) || restrictions.has_token_restrictions()) // Potentially unlimited partitions.
         && !expr::is_empty_restriction(ck_restrictions) // Slice defined.
         && !restrictions.uses_secondary_indexing()) { // Base-table is used. (Index-table use always limits partitions.)
         if (strict_allow_filtering == flag_t::WARN) {

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1332,9 +1332,9 @@ BOOST_AUTO_TEST_CASE(prepare_token) {
                                   .build();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression tok =
-        token({::make_shared<column_identifier_raw>("p1", true), ::make_shared<column_identifier_raw>("p2", true),
-               ::make_shared<column_identifier_raw>("p3", true)});
+    expression tok = token({unresolved_identifier{::make_shared<column_identifier_raw>("p1", true)},
+                            unresolved_identifier{::make_shared<column_identifier_raw>("p2", true)},
+                            unresolved_identifier{::make_shared<column_identifier_raw>("p3", true)}});
 
     expression prepared = prepare_expression(tok, db, "test_ks", table_schema.get(), nullptr);
 

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -449,7 +449,10 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     expression ck1_ck2_restriction = make_multi_column_restriction({&col_ck1, &col_ck2}, oper_t::LT);
     expression conjunction_expr = conjunction{std::vector{ck1_ck2_restriction, r1_restriction2}};
 
-    token token_expr(std::vector<const column_definition*>{&col_pk1, &col_pk2});
+    function_call token_expr = function_call {
+        .func = functions::function_name::native_function("token"),
+        .args = {column_value(&col_pk1), column_value(&col_pk2)}
+    };
     expression token_lt_restriction = binary_operator(token_expr, oper_t::LT, zero_value);
     expression token_gt_restriction = binary_operator(token_expr, oper_t::GT, zero_value);
 

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -399,12 +399,14 @@ def test_filter_and_fetch_size(cql, test_keyspace, use_index, driver_bug_1):
 # Reproduces #13468
 def test_filter_token(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY (pk, ck)') as table:
-        with pytest.raises(InvalidRequest, match='duplicate partition key'):
+        with pytest.raises(InvalidRequest, match='Invalid number of arguments'):
             cql.execute(f'SELECT pk FROM {table} WHERE token(pk, pk) = 0')
     with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY ((pk, ck))') as table:
-        with pytest.raises(InvalidRequest, match='all partition key components'):
+        with pytest.raises(InvalidRequest, match='duplicate partition key'):
+            cql.execute(f'SELECT pk FROM {table} WHERE token(pk, pk) = 0')
+        with pytest.raises(InvalidRequest, match='Invalid number of arguments'):
             cql.execute(f'SELECT pk FROM {table} WHERE token(x) = 0')
-        with pytest.raises(InvalidRequest, match='all partition key components'):
+        with pytest.raises(InvalidRequest, match='Invalid number of arguments'):
             cql.execute(f'SELECT pk FROM {table} WHERE token(pk) = 0')
         with pytest.raises(InvalidRequest, match='partition key order'):
             cql.execute(f'SELECT pk FROM {table} WHERE token(ck, pk) = 0')


### PR DESCRIPTION
Let's remove `expr::token` and replace all of its functionality with `expr::function_call`.

`expr::token` is a struct whose job is to represent a partition key token.
The idea is that when the user types in `token(p1, p2) < 1234`, this will be internally represented as an expression which uses `expr::token` to represent the `token(p1, p2)` part.

The situation with `expr::token` is a bit complicated.
On one hand side it's supposed to represent the partition token, but sometimes it's also assumed that it can represent a generic call to the `token()` function, for example `token(1, 2, 3)` could be a `function_call`, but it could also be `expr::token`.

The query planning code assumes that each occurence of expr::token
represents the partition token without checking the arguments.
Because of this allowing `token(1, 2, 3)` to be represented as `expr::token` is dangerous - the query planning might think that it is `token(p1, p2, p3)` and plan the query based on this, which would be wrong.

Currently `expr::token` is created only in one specific case.
When the parser detects that the user typed in a restriction which has a call to `token` on the LHS it generates `expr::token`.
In all other cases it generates an `expr::function_call`.
Even when the `function_call` represents a valid partition token, it stays a `function_call`. During preparation there is no check to see if a `function_call` to `token` could be turned into `expr::token`. This is a bit inconsistent - sometimes `token(p1, p2, p3)` is represented as `expr::token` and the query planner handles that, but sometimes it might be represented as `function_call`, which the query planner doesn't handle.

There is also a problem because there's a lot of code duplication between a `function_call` and `expr::token`.
All of the evaluation and preparation is the same for `expr::token` as it's for a `function_call` to the token function.
Currently it's impossible to evaluate `expr::token` and preparation has some flaws, but implementing it would basically consist of copy-pasting the corresponding code from token `function_call`.

One more aspect is multi-table queries.
With `expr::token` we turn a call to the `token()` function into a struct that is schema-specific.
What happens when a single expression is used to make queries to multiple tables? The schema is different, so something that is represented as `expr::token` for one schema would be represented as `function_call` in the context of a different schema.
Translating expressions to different tables would require careful manipulation to convert `expr::token` to `function_call` and vice versa. This could cause trouble for index queries.

Overall I think it would be best to remove `expr::token`.

Although having a clear marker for the partition token is sometimes nice for query planning, in my opinion the pros are outweighted by the cons.
I'm a big fan of having a single way to represent things, having two separate representations of the same thing without clear boundaries between them causes trouble.

Instead of having both `expr::token` and `function_call` we can just have the `function_call` and check if it represents a partition token when needed.

Refs: #12906
Refs: #12677
Closes: #12905