### PR TITLE
doc: mark --load-and-stream as Open Source-only

### DIFF
--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -22,22 +22,24 @@ For example:
 ``nodetool refresh nba player_stats``
 
 
-Load and Stream
----------------
+.. only:: opensource
 
-.. versionadded:: 4.6
+  Load and Stream
+  ---------------
 
-.. code::
+  .. versionadded:: 4.6
 
-   nodetool refresh <my_keyspace> <my_table> [--load-and-stream | -las]
+  .. code::
 
-The Load and Stream feature extends nodetool refresh. The new ``-las`` option loads arbitrary sstables that do not belong to a node into the cluster. It loads the sstables from the disk and calculates the data's owning nodes, and streams automatically.
-For example, say the old cluster has 6 nodes and the new cluster has 3 nodes. We can copy the sstables from the old cluster to any of the new nodes and trigger the load and stream process.
+     nodetool refresh <my_keyspace> <my_table> [--load-and-stream | -las]
 
-Load and Stream make restores and migrations much easier:
+  The Load and Stream feature extends nodetool refresh. The new ``-las`` option loads arbitrary sstables that do not belong to a node into the cluster. It loads the sstables from the disk and calculates the data's owning nodes, and streams automatically.
+  For example, say the old cluster has 6 nodes and the new cluster has 3 nodes. We can copy the sstables from the old cluster to any of the new nodes and trigger the load and stream process.
 
-* You can place sstable from every node to every node
-* No need to run nodetool cleanup to remove unused data
+  Load and Stream make restores and migrations much easier:
+
+  * You can place sstable from every node to every node
+  * No need to run nodetool cleanup to remove unused data
 
 
 .. include:: nodetool-index.rst


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-enterprise/issues/2807

The `--load-and-stream` option is included in both Open Source and Enterprise documentation, while it is only avalilable in Open Source.
This commit excludes the Load and Stream section from the Enterprise documentation by marking it as Open Source-only.

This commit must be backported to branch-5.2 and branch-5.1.avalilable