### PR TITLE
Discard SSTable bloom filter on load-and-stream

### DIFF
--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -99,7 +99,7 @@ public:
     // Each entry contains a vector of sstables for this shard.
     // The table UUID is returned too.
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-            get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf);
+            get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
     static future<> process_upload_dir(distributed<replica::database>& db, distributed<db::system_distributed_keyspace>& sys_dist_ks,
             distributed<db::view::view_update_generator>& view_update_generator, sstring ks_name, sstring cf_name);
 };

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -55,4 +55,15 @@ struct foreign_sstable_open_info {
     uint64_t uncompressed_data_size;
 };
 
+struct sstable_open_config {
+    // Load the first and last position in partition, populating the
+    // `_first_partition_first_position` and `_last_partition_last_position`
+    // fields respectively. Problematic sstables might fail to load. Set to
+    // false if you want to disable this, to be able to read such sstables.
+    // Should only be disabled for diagnostics purposes.
+    // FIXME: Enable it by default once the root cause of large allocation when reading sstable in reverse is fixed.
+    //  Ref: https://github.com/scylladb/scylladb/issues/11642
+    bool load_first_and_last_position_metadata = false;
+};
+
 }

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -64,6 +64,10 @@ struct sstable_open_config {
     // FIXME: Enable it by default once the root cause of large allocation when reading sstable in reverse is fixed.
     //  Ref: https://github.com/scylladb/scylladb/issues/11642
     bool load_first_and_last_position_metadata = false;
+    // If the bloom filter is not loaded, the SSTable will use an always-present
+    // filter, meaning that the SSTable will be opened on every single-partition
+    // read.
+    bool load_bloom_filter = true;
 };
 
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -119,14 +119,14 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
     }
 }
 
-future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc) const {
+future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg) const {
     auto sst = _manager.make_sstable(_schema, *_storage_opts, _sstable_dir.native(), desc.generation, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
-    co_await sst->load(_io_priority);
+    co_await sst->load(_io_priority, cfg);
     co_return sst;
 }
 
 future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc, process_flags flags) const {
-    auto sst = co_await load_sstable(std::move(desc));
+    auto sst = co_await load_sstable(std::move(desc), flags.sstable_open_config);
     validate(sst, flags);
     if (flags.need_mutate_level) {
         dirlog.trace("Mutating {} to level 0\n", sst->get_filename());

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -65,6 +65,7 @@ public:
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
         bool allow_loading_materialized_view = false;
         bool sort_sstables_according_to_owner = true;
+        sstables::sstable_open_config sstable_open_config;
     };
 
     class components_lister {
@@ -155,7 +156,7 @@ private:
 private:
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
-    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc) const;
+    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg = {}) const;
     future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, process_flags flags) const;
 
     template <typename Container, typename Func>

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1526,8 +1526,8 @@ future<> sstable::drop_caches() {
     });
 }
 
-future<> sstable::read_filter(const io_priority_class& pc) {
-    if (!has_component(component_type::Filter)) {
+future<> sstable::read_filter(const io_priority_class& pc, sstable_open_config cfg) {
+    if (!cfg.load_bloom_filter || !has_component(component_type::Filter)) {
         _components->filter = std::make_unique<utils::filter::always_present_filter>();
         return make_ready_future<>();
     }
@@ -1568,7 +1568,7 @@ future<> sstable::load(const io_priority_class& pc, sstable_open_config cfg) noe
     co_await read_statistics(pc);
     co_await coroutine::all(
             [&] { return read_compression(pc); },
-            [&] { return read_filter(pc); },
+            [&] { return read_filter(pc, cfg); },
             [&] { return read_summary(pc); });
     validate_min_max_metadata();
     validate_max_local_deletion_time();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -11,6 +11,7 @@
 
 #include "version.hh"
 #include "shared_sstable.hh"
+#include "open_info.hh"
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
@@ -128,17 +129,6 @@ constexpr auto table_subdirectories = std::to_array({
 });
 
 constexpr const char* repair_origin = "repair";
-
-struct sstable_open_config {
-    // Load the first and last position in partition, populating the
-    // `_first_partition_first_position` and `_last_partition_last_position`
-    // fields respectively. Problematic sstables might fail to load. Set to
-    // false if you want to disable this, to be able to read such sstables.
-    // Should only be disabled for diagnostics purposes.
-    // FIXME: Enable it by default once the root cause of large allocation when reading sstable in reverse is fixed.
-    //  Ref: https://github.com/scylladb/scylladb/issues/11642
-    bool load_first_and_last_position_metadata = false;
-};
 
 class sstable : public enable_lw_shared_from_this<sstable> {
     friend ::sstable_assertions;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -624,7 +624,7 @@ private:
     void write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, run_identifier identifier,
             std::optional<scylla_metadata::large_data_stats> ld_stats, sstring origin);
 
-    future<> read_filter(const io_priority_class& pc);
+    future<> read_filter(const io_priority_class& pc, sstable_open_config cfg = {});
 
     void write_filter(const io_priority_class& pc);
 


### PR DESCRIPTION
Load-and-stream reads the entire content from SSTables, therefore it can
afford to discard the bloom filter that might otherwise consume a significant
amount of memory. Bloom filters are only needed by compaction and other
replica::table operations that might want to check the presence of keys
in the SSTable files, like single-partition reads.

It's not uncommon to see Data:Filter ratio of less than 100:1, meaning
that for ~300G of data, filters will take ~3G.

In addition to saving memory footprint, it also reduces operation time
as load-and-stream no longer have to read, parse and build the filters
from disk into memory.
