### PR TITLE
compaction: Don't bump compaction shares during major execution

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -454,8 +454,6 @@ protected:
         setup_new_compaction(descriptor.run_identifier);
 
         cmlog.info0("User initiated compaction started on behalf of {}.{}", t->schema()->ks_name(), t->schema()->cf_name());
-        compaction_backlog_tracker bt(std::make_unique<user_initiated_backlog_tracker>(_cm._compaction_controller.backlog_of_shares(200), _cm.available_memory()));
-        _cm.register_backlog_tracker(bt);
 
         // Now that the sstables for major compaction are registered
         // and the user_initiated_backlog_tracker is set up


### PR DESCRIPTION
Commit 49892a0, back in 2018, bumps the compaction shares by 200 to guarantee a minimum base line.

However, after commit e3f561d, major compaction runs in maintenance group meaning that bumping shares became completely irrelevant and only causes regular compaction to be unnecessarily more aggressive.

Fixes #13487.