### PR TITLE
cleanup: Move TWCS option from table into TWCS itself

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -71,6 +71,11 @@ time_window_compaction_strategy_options::time_window_compaction_strategy_options
             timestamp_resolution = valid_timestamp_resolutions.at(it->second);
         }
     }
+
+    it = options.find("enable_optimized_twcs_queries");
+    if (it != options.end() && it->second == "false") {
+        enable_optimized_twcs_queries = false;
+    }
 }
 
 time_window_compaction_strategy_options::time_window_compaction_strategy_options(time_window_compaction_strategy_options&&) = default;

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -51,6 +51,7 @@ private:
     std::chrono::seconds sstable_window_size = DEFAULT_COMPACTION_WINDOW_UNIT * DEFAULT_COMPACTION_WINDOW_SIZE;
     db_clock::duration expired_sstable_check_frequency = DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS();
     timestamp_resolutions timestamp_resolution = timestamp_resolutions::microsecond;
+    bool enable_optimized_twcs_queries{true};
 public:
     time_window_compaction_strategy_options(const time_window_compaction_strategy_options&);
     time_window_compaction_strategy_options(time_window_compaction_strategy_options&&);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -380,8 +380,6 @@ public:
         // for easy access from `table` member functions:
         utils::updateable_value<bool> reversed_reads_auto_bypass_cache{false};
         utils::updateable_value<bool> enable_optimized_reversed_reads{true};
-        // Can be updated by a schema change:
-        bool enable_optimized_twcs_queries{true};
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
     };
@@ -575,9 +573,6 @@ private:
     sstables::generation_type calculate_generation_for_new_table();
 private:
     void rebuild_statistics();
-
-    // Called on schema change.
-    void update_optimized_twcs_queries_flag();
 private:
     mutation_source_opt _virtual_reader;
     std::optional<noncopyable_function<future<>(const frozen_mutation&)>> _virtual_writer;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1552,8 +1552,6 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
         tlogger.warn("Writes disabled, column family no durable.");
     }
     set_metrics();
-
-    update_optimized_twcs_queries_flag();
 }
 
 partition_presence_checker
@@ -1943,18 +1941,7 @@ void table::set_schema(schema_ptr s) {
     }
 
     set_compaction_strategy(_schema->compaction_strategy());
-    update_optimized_twcs_queries_flag();
     trigger_compaction();
-}
-
-void table::update_optimized_twcs_queries_flag() {
-    auto& opts = _schema->compaction_strategy_options();
-    auto it = opts.find("enable_optimized_twcs_queries");
-    if (it != opts.end() && it->second == "false") {
-        _config.enable_optimized_twcs_queries = false;
-    } else {
-        _config.enable_optimized_twcs_queries = true;
-    }
 }
 
 static std::vector<view_ptr>::iterator find_view(std::vector<view_ptr>& views, const view_ptr& v) {

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -109,13 +109,14 @@ private:
 
     schema_ptr _schema;
     schema_ptr _reversed_schema; // == _schema->make_reversed();
+    bool _enable_optimized_twcs_queries;
     // s.min_position() -> s, ordered using _schema
     lw_shared_ptr<container_t> _sstables;
     // s.max_position().reversed() -> s, ordered using _reversed_schema; the set of values is the same as in _sstables
     lw_shared_ptr<container_t> _sstables_reversed;
 
 public:
-    time_series_sstable_set(schema_ptr schema);
+    time_series_sstable_set(schema_ptr schema, bool enable_optimized_twcs_queries);
     time_series_sstable_set(const time_series_sstable_set& s);
 
     virtual std::unique_ptr<sstable_set_impl> clone() const override;

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3854,7 +3854,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
             }
         }
 
-        time_series_sstable_set sst_set(table_schema);
+        time_series_sstable_set sst_set(table_schema, true);
         mutation merged(table_schema, g._pk);
         std::unordered_set<sstables::generation_type> included_gens;
         auto sst_factory = env.make_sst_factory(table_schema);

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -67,7 +67,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
 
-        auto ss1 = make_lw_shared<time_series_sstable_set>(ss.schema());
+        auto ss1 = make_lw_shared<time_series_sstable_set>(ss.schema(), true);
         ss1->insert(sst1);
         BOOST_REQUIRE_EQUAL(ss1->all()->size(), 1);
 


### PR DESCRIPTION
enable_optimized_twcs_queries is specific to TWCS, therefore it belongs to TWCS, not replica::table.