### PR TITLE
Cluster features on raft

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -256,6 +256,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("num_tokens", int32_type)
             .with_column("shard_count", int32_type)
             .with_column("ignore_msb", int32_type)
+            .with_column("supported_features", utf8_type)
             .with_column("new_cdc_generation_data_uuid", uuid_type, column_kind::static_column)
             .with_column("transition_state", utf8_type, column_kind::static_column)
             .with_column("current_cdc_generation_uuid", uuid_type, column_kind::static_column)

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3521,6 +3521,11 @@ future<service::topology> system_keyspace::load_topology_state() {
             rebuild_option = row.get_as<sstring>("rebuild_option");
         }
 
+        std::set<sstring> supported_features;
+        if (row.has("supported_features")) {
+            supported_features = gms::feature_service::to_feature_set(row.get_as<sstring>("supported_features"));
+        }
+
         if (row.has("topology_request")) {
             auto req = service::topology_request_from_string(row.get_as<sstring>("topology_request"));
             ret.requests.emplace(host_id, req);
@@ -3587,7 +3592,7 @@ future<service::topology> system_keyspace::load_topology_state() {
         if (map) {
             map->emplace(host_id, service::replica_state{
                 nstate, std::move(datacenter), std::move(rack), std::move(release_version),
-                ring_slice, shard_count, ignore_msb});
+                ring_slice, shard_count, ignore_msb, std::move(supported_features)});
         }
     }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3361,7 +3361,7 @@ future<std::set<sstring>> system_keyspace::load_local_enabled_features() {
 }
 
 future<> system_keyspace::save_local_enabled_features(std::set<sstring> features) {
-    auto features_str = fmt::to_string(fmt::join(features, ","));
+    auto features_str = gms::feature_service::from_feature_set(features);
     co_await set_scylla_local_param(gms::feature_service::ENABLED_FEATURES_KEY, features_str);
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -183,6 +183,14 @@ std::set<sstring> feature_service::to_feature_set(sstring features_string) {
     return features;
 }
 
+sstring feature_service::from_feature_set(const std::set<sstring>& feature_set) {
+    return fmt::to_string(fmt::join(feature_set, ","));
+}
+
+sstring feature_service::from_feature_set(const std::set<std::string_view>& feature_set) {
+    return fmt::to_string(fmt::join(feature_set, ","));
+}
+
 class persistent_feature_enabler : public i_endpoint_state_change_subscriber {
     gossiper& _g;
     feature_service& _feat;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -20,6 +20,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include "gms/gossiper.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
+#include "utils/error_injection.hh"
 
 namespace gms {
 
@@ -70,6 +71,10 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     }
     if (!cfg.check_experimental(db::experimental_features_t::feature::TABLETS)) {
         fcfg._disabled_features.insert("TABLETS"s);
+    }
+
+    if (!utils::get_local_injector().enter("features_enable_test_feature")) {
+        fcfg._disabled_features.insert("TEST_ONLY_FEATURE"s);
     }
 
     return fcfg;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -250,7 +250,7 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     }
 
     std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
-    co_await enable(std::move(feat));
+    co_await enable(std::move(feat), feature_service::without_persisting{});
 }
 
 future<> persistent_feature_enabler::enable_features() {
@@ -269,10 +269,10 @@ future<> persistent_feature_enabler::enable_features() {
     co_await _sys_ks.save_local_enabled_features(std::move(feats_set));
 
     std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);
-    co_await _feat.enable(std::move(features_v));
+    co_await _feat.enable(std::move(features_v), feature_service::without_persisting{});
 }
 
-future<> feature_service::enable(std::set<std::string_view> list) {
+future<> feature_service::enable(std::set<std::string_view> list, feature_service::without_persisting) {
     // `gms::feature::enable` should be run within a seastar thread context
     co_await container().invoke_on_all([&list] (feature_service& fs) -> future<> {
         return seastar::async([&fs, &list] {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -126,6 +126,11 @@ public:
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
     gms::feature tablets { *this, "TABLETS"sv };
 
+    // A feature just for use in tests. It must not be advertised unless
+    // the "features_enable_test_feature" injection is enabled.
+    // This feature MUST NOT be advertised in release mode!
+    gms::feature test_only_feature { *this, "TEST_ONLY_FEATURE"sv };
+
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -64,6 +64,7 @@ public:
     explicit feature_service(feature_config cfg);
     ~feature_service() = default;
     future<> stop();
+    future<> enable(std::set<std::string_view> list, db::system_keyspace& sys_ks);
     future<> enable(std::set<std::string_view> list, without_persisting);
     db::schema_features cluster_schema_features() const;
     std::set<std::string_view> supported_feature_set() const;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -59,10 +59,12 @@ class feature_service final : public peering_sharded_service<feature_service> {
 
     feature_config _config;
 public:
+    struct without_persisting {};
+
     explicit feature_service(feature_config cfg);
     ~feature_service() = default;
     future<> stop();
-    future<> enable(std::set<std::string_view> list);
+    future<> enable(std::set<std::string_view> list, without_persisting);
     db::schema_features cluster_schema_features() const;
     std::set<std::string_view> supported_feature_set() const;
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -126,6 +126,9 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
+    static sstring from_feature_set(const std::set<sstring>& feature_set);
+    static sstring from_feature_set(const std::set<std::string_view>& feature_set);
+
     future<> enable_features_on_startup(db::system_keyspace&);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 };

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -44,6 +44,8 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
 
 using namespace std::literals;
 
+class persistent_feature_enabler;
+
 /**
  * A gossip feature tracks whether all the nodes the current one is
  * aware of support the specified feature.
@@ -58,6 +60,9 @@ class feature_service final : public peering_sharded_service<feature_service> {
     std::unordered_map<sstring, std::reference_wrapper<feature>> _registered_features;
 
     feature_config _config;
+
+    shared_ptr<persistent_feature_enabler> _enabler;
+    bool _connected_to_gossip = true;
 public:
     struct without_persisting {};
 
@@ -131,6 +136,10 @@ public:
 
     future<> enable_features_on_startup(db::system_keyspace&);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
+
+    // After calling this the feature service won't enable features
+    // based on what is happening in gossip.
+    future<> disconnect_from_gossip(gossiper&);
 };
 
 } // namespace gms

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -20,6 +20,7 @@
 #include "version.hh"
 #include "cdc/generation_id.hh"
 #include <unordered_set>
+#include "utils/error_injection.hh"
 
 namespace gms {
 
@@ -215,6 +216,11 @@ public:
     }
 
     static versioned_value supported_features(const std::set<std::string_view>& features) {
+        if (utils::get_local_injector().enter("gossiper_censor_test_only_feature")) {
+            std::set<std::string_view> censored_features = features;
+            censored_features.erase(std::string_view("TEST_ONLY_FEATURE"));
+            return versioned_value(fmt::to_string(fmt::join(censored_features, ",")));
+        }
         return versioned_value(fmt::to_string(fmt::join(features, ",")));
     }
 

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -27,6 +27,7 @@ namespace service {
   struct raft_topology_snapshot {
       std::vector<canonical_mutation> topology_mutations;
       std::optional<canonical_mutation> cdc_generation_mutation;
+      std::vector<sstring> enabled_features [[version 5.4]];
   };
 
   struct raft_topology_pull_params {};

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -13,8 +13,16 @@
 #include "mutation/canonical_mutation.hh"
 #include "service/raft/raft_state_machine.hh"
 
+namespace db {
+class system_keyspace;
+}
+
 namespace cdc {
 class generation_service;
+}
+
+namespace gms {
+class feature_service;
 }
 
 namespace service {
@@ -78,8 +86,10 @@ class group0_state_machine : public raft_state_machine {
     storage_proxy& _sp;
     storage_service& _ss;
     cdc::generation_service& _cdc_gen_svc;
+    gms::feature_service& _fs;
+    db::system_keyspace& _sys_ks;
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, cdc::generation_service& cdc_gen_svc) : _client(client), _mm(mm), _sp(sp), _ss(ss), _cdc_gen_svc(cdc_gen_svc) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, cdc::generation_service& cdc_gen_svc, gms::feature_service& fs, db::system_keyspace& sys_ks) : _client(client), _mm(mm), _sp(sp), _ss(ss), _cdc_gen_svc(cdc_gen_svc), _fs(fs), _sys_ks(sys_ks) {}
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -193,7 +193,7 @@ const raft::server_id& raft_group0::load_my_id() {
 
 raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
                                                             service::migration_manager& mm, cdc::generation_service& cdc_gen_svc) {
-    auto state_machine = std::make_unique<group0_state_machine>(_client, mm, qp.proxy(), ss, cdc_gen_svc);
+    auto state_machine = std::make_unique<group0_state_machine>(_client, mm, qp.proxy(), ss, cdc_gen_svc, _feat, _sys_ks);
     auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms.local(), _raft_gr.address_map(), gid, my_id);
     // Keep a reference to a specific RPC class.
     auto& rpc_ref = *rpc;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1635,7 +1635,9 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         auto local_features = _feature_service.supported_feature_set();
         slogger.info("Checking remote features with gossip, initial_contact_nodes={}", initial_contact_nodes);
         co_await _gossiper.do_shadow_round(initial_contact_nodes);
-        _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+        if (!_raft_topology_change_enabled) {
+            _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+        }
         _gossiper.check_snitch_name_matches(_snitch.local()->get_name());
         // Check if the node is already removed from the cluster
         auto local_host_id = _db.local().get_config().host_id;
@@ -2984,7 +2986,9 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
         do {
             slogger.info("Checking remote features with gossip");
             _gossiper.do_shadow_round(initial_contact_nodes).get();
-            _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+            if (!_raft_topology_change_enabled) {
+                _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+            }
             _gossiper.check_snitch_name_matches(_snitch.local()->get_name());
             auto addr = get_broadcast_address();
             if (!_gossiper.is_safe_for_bootstrap(addr)) {
@@ -3063,7 +3067,9 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
     slogger.info("Checking remote features with gossip");
     co_await _gossiper.do_shadow_round(initial_contact_nodes);
     auto local_features = _feature_service.supported_feature_set();
-    _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+    if (!_raft_topology_change_enabled) {
+        _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+    }
 
     // now that we've gossiped at least once, we should be able to find the node we're replacing
     if (replace_host_id) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -361,6 +361,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                 co_await _sys_ks.local().update_peer_info(ip, "rack", rs.rack);
                 co_await _sys_ks.local().update_peer_info(ip, "host_id", id.uuid());
                 co_await _sys_ks.local().update_peer_info(ip, "release_version", rs.release_version);
+                co_await _sys_ks.local().update_peer_info(ip, "supported_features", gms::feature_service::from_feature_set(rs.supported_features));
             } else {
                 co_await _sys_ks.local().update_tokens(rs.ring.value().tokens);
                 co_await _gossiper.add_local_application_state({{ gms::application_state::STATUS, gms::versioned_value::normal(rs.ring.value().tokens) }});

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1593,6 +1593,12 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         }
     }
 
+    if (_raft_topology_change_enabled) {
+        // Features are managed in group 0. We don't want to enable features
+        // based on gossip.
+        co_await _feature_service.disconnect_from_gossip(_gossiper);
+    }
+
     bool replacing_a_node_with_same_ip = false;
     bool replacing_a_node_with_diff_ip = false;
     std::optional<replacement_info> ri;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5258,9 +5258,12 @@ void storage_service::init_messaging_service(sharded<service::storage_proxy>& pr
                 cdc_generation_mutation.emplace(rs->partitions().begin()->mut().unfreeze(s));
             }
 
+            std::vector<sstring> enabled_features = boost::copy_range<std::vector<sstring>>(ss._topology_state_machine._topology.calculate_enabled_features());
+
             co_return raft_topology_snapshot{
                 .topology_mutations = std::move(topology_mutations),
                 .cdc_generation_mutation = std::move(cdc_generation_mutation),
+                .enabled_features = std::move(enabled_features),
             };
         });
     });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1421,7 +1421,8 @@ future<> storage_service::raft_replace(raft::server& raft_server, raft::server_i
                .set("replaced_id", replaced_id)
                .set("num_tokens", _db.local().get_config().num_tokens())
                .set("shard_count", smp::count)
-               .set("ignore_msb", _db.local().get_config().murmur3_partitioner_ignore_msb_bits());
+               .set("ignore_msb", _db.local().get_config().murmur3_partitioner_ignore_msb_bits())
+               .set("supported_features", gms::feature_service::from_feature_set(_feature_service.supported_feature_set()));
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("replace {}/{}: add myself ({}) to topology", replaced_id, replaced_ip, raft_server.id()));
         try {
@@ -1457,7 +1458,8 @@ future<> storage_service::raft_bootstrap(raft::server& raft_server) {
                .set("topology_request", topology_request::join)
                .set("num_tokens", _db.local().get_config().num_tokens())
                .set("shard_count", smp::count)
-               .set("ignore_msb", _db.local().get_config().murmur3_partitioner_ignore_msb_bits());
+               .set("ignore_msb", _db.local().get_config().murmur3_partitioner_ignore_msb_bits())
+               .set("supported_features", gms::feature_service::from_feature_set(_feature_service.supported_feature_set()));
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, "bootstrap: add myself to topology");
         try {
@@ -1473,6 +1475,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     auto local_shard_count = smp::count;
     auto local_ignore_msb = _db.local().get_config().murmur3_partitioner_ignore_msb_bits();
     auto local_release_version = version::release();
+    auto local_supported_features = boost::copy_range<std::set<sstring>>(_feature_service.supported_feature_set());
 
     auto synchronized = [&] () {
         auto it = _topology_state_machine._topology.find(raft_server.id());
@@ -1484,7 +1487,8 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
 
         return replica_state.shard_count == local_shard_count
             && replica_state.ignore_msb == local_ignore_msb
-            && replica_state.release_version == local_release_version;
+            && replica_state.release_version == local_release_version
+            && replica_state.supported_features == local_supported_features;
     };
 
     // We avoid performing a read barrier if we're sure that our metadata stored in topology
@@ -1520,7 +1524,8 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
         builder.with_node(raft_server.id())
                .set("shard_count", local_shard_count)
                .set("ignore_msb", local_ignore_msb)
-               .set("release_version", local_release_version);
+               .set("release_version", local_release_version)
+               .set("supported_features", gms::feature_service::from_feature_set(local_supported_features));
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(
                 std::move(change), guard, ::format("{}: update topology with local metadata", raft_server.id()));

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -65,6 +65,16 @@ std::set<sstring> topology::calculate_enabled_features() const {
     return common_features;
 }
 
+void topology::check_knows_enabled_features(const std::set<std::string_view>& local_features, const std::set<std::string_view>& enabled_features) {
+    std::vector<std::string_view> unknown_features;
+    std::ranges::set_difference(enabled_features, local_features, std::back_inserter(unknown_features));
+    if (!unknown_features.empty()) {
+        throw std::runtime_error(fmt::format("Feature check failed. The node doesn't support some of the features that are enabled in the cluster. "
+                "Unsupported features = {}, supported features = {}, enabled features in the cluster = {}",
+                unknown_features, local_features, enabled_features));
+    }
+}
+
 static std::unordered_map<topology::transition_state, sstring> transition_state_to_name_map = {
     {topology::transition_state::commit_cdc_generation, "commit cdc generation"},
     {topology::transition_state::publish_cdc_generation, "publish cdc generation"},

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -111,6 +111,11 @@ struct topology {
 
     // Returns the set of enabled features (common set of all features of non-left nodes).
     std::set<sstring> calculate_enabled_features() const;
+
+    // Checks whether the node described by `local_features` supports all
+    // enabled features described by `enabled_features`. Throws an exception
+    // if it doesn't.
+    static void check_knows_enabled_features(const std::set<std::string_view>& local_features, const std::set<std::string_view>& enabled_features);
 };
 
 struct raft_topology_snapshot {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -124,6 +124,11 @@ struct raft_topology_snapshot {
 
     // Mutation for system.cdc_generations_v3, contains the current CDC generation data.
     std::optional<canonical_mutation> cdc_generation_mutation;
+
+    // Features enabled by the cluster, based on the current system.topology table state.
+    // The receiving node must check whether it understands all of the features first
+    // before applying, because the format of the snapshot might depend on them.
+    std::vector<sstring> enabled_features;
 };
 
 struct raft_topology_pull_params {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -108,6 +108,9 @@ struct topology {
     const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;
     // Return true if node exists in any state including 'left' one
     bool contains(raft::server_id id);
+
+    // Returns the set of enabled features (common set of all features of non-left nodes).
+    std::set<sstring> calculate_enabled_features() const;
 };
 
 struct raft_topology_snapshot {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -63,6 +63,7 @@ struct replica_state {
     std::optional<ring_slice> ring; // if engaged contain the set of tokens the node owns together with their state
     size_t shard_count;
     uint8_t ignore_msb;
+    std::set<sstring> supported_features;
 };
 
 struct topology {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -751,7 +751,7 @@ public:
 
             db.invoke_on_all(&replica::database::start).get();
 
-            feature_service.local().enable(feature_service.local().supported_feature_set()).get();
+            feature_service.local().enable(feature_service.local().supported_feature_set(), gms::feature_service::without_persisting{}).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -751,9 +751,7 @@ public:
 
             db.invoke_on_all(&replica::database::start).get();
 
-            feature_service.invoke_on_all([] (auto& fs) {
-                return fs.enable(fs.supported_feature_set());
-            }).get();
+            feature_service.local().enable(feature_service.local().supported_feature_set()).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -121,4 +121,16 @@ async def read_barrier(cql: Session, host: Host):
     await cql.run_async("drop table if exists nosuchkeyspace.nosuchtable", host = host)
 
 
+# Wait for the given feature to be enabled.
+async def wait_for_feature(feature: str, cql: Session, host: Host, deadline: float) -> None:
+    async def feature_is_enabled():
+        rs = await cql.run_async("select value from system.scylla_local where key = 'enabled_features'", host=host)
+        if rs:
+            value = rs[0].value
+            if feature in value:
+                return True
+        return None
+    await wait_for(feature_is_enabled, deadline)
+
+
 unique_name.last_ms = 0

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -133,4 +133,16 @@ async def wait_for_feature(feature: str, cql: Session, host: Host, deadline: flo
     await wait_for(feature_is_enabled, deadline)
 
 
+async def get_supported_features(cql: Session, host: Host) -> set[str]:
+    """Returns a set of cluster features that a node advertises support for."""
+    rs = await cql.run_async(f"SELECT supported_features FROM system.local WHERE key = 'local'", host=host)
+    return set(rs[0].supported_features.split(","))
+
+
+async def get_enabled_features(cql: Session, host: Host) -> set[str]:
+    """Returns a set of cluster features that a node considers to be enabled."""
+    rs = await cql.run_async(f"SELECT value FROM system.scylla_local WHERE key = 'enabled_features'", host=host)
+    return set(rs[0].value.split(","))
+
+
 unique_name.last_ms = 0

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -11,3 +11,5 @@ run_first:
     - test_topology_remove_decom
     - test_mutation_schema_change
     - test_tablets
+skip_in_release:
+    - test_cluster_features

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Tests the cluster feature functionality.
+"""
+import logging
+import asyncio
+import time
+from typing import Set, Optional, List
+
+from cassandra.cluster import Session  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.pool import Host        # type: ignore # pylint: disable=no-name-in-module
+
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature, get_supported_features, get_enabled_features
+from test.topology.util import reconnect_driver
+import pytest
+
+
+logger = logging.getLogger(__name__)
+
+
+TEST_FEATURE_NAME = "TEST_ONLY_FEATURE"
+TEST_FEATURE_ENABLE_ERROR_INJECTION = "features_enable_test_feature"
+ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
+
+
+async def get_error_injections_enabled_at_startup(manager: ManagerClient, srv: ServerInfo) -> Set[str]:
+    # TODO: An "error injection enabled at startup" might not be a string, but a dictionary
+    #       with some options. The tests in this module only use strings, but it's worth
+    #       keeping that in mind here in case dicts start being used.
+    config = await manager.server_get_config(srv.server_id)
+    injections = config.get(ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY) or []
+    assert isinstance(injections, list)
+    assert all(isinstance(inj, str) for inj in injections)
+    return set(injections)
+
+
+async def turn_on_test_feature_and_restart(manager: ManagerClient, srv: ServerInfo) -> None:
+    logging.info(f"Reconfiguring and restarting node {srv} to support {TEST_FEATURE_NAME}")
+    await manager.server_stop_gracefully(srv.server_id)
+    injections = await get_error_injections_enabled_at_startup(manager, srv)
+    injections.add(TEST_FEATURE_ENABLE_ERROR_INJECTION)
+    await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, list(injections))
+    await manager.server_start(srv.server_id)
+
+
+async def turn_off_test_feature_and_restart(manager: ManagerClient, srv: ServerInfo, expected_error: Optional[str] = None) -> None:
+    logging.info(f"Reconfiguring and restarting node {srv} to disable support of {TEST_FEATURE_NAME}")
+    await manager.server_stop_gracefully(srv.server_id)
+    injections = await get_error_injections_enabled_at_startup(manager, srv)
+    injections.remove(TEST_FEATURE_ENABLE_ERROR_INJECTION)
+    await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, list(injections))
+    await manager.server_start(srv.server_id, expected_error)
+
+
+@pytest.mark.asyncio
+async def test_cluster_upgrade(manager: ManagerClient) -> None:
+    """Simulates an upgrade of a cluster by doing a rolling restart
+       and marking the test-only feature as supported on restarted nodes.
+    """
+    servers = await manager.running_servers()
+
+    cql = manager.cql
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    for srv in servers:
+        host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
+
+        # The feature should not be advertised as supported until we enable it
+        # via error injection.
+        assert TEST_FEATURE_NAME not in await get_supported_features(cql, host)
+
+        # Until all nodes are updated to support the test feature, that feature
+        # should not be considered enabled by any node.
+        for host in hosts:
+            assert TEST_FEATURE_NAME not in await get_enabled_features(cql, host)
+
+        await turn_on_test_feature_and_restart(manager, srv)
+        cql = await reconnect_driver(manager)
+
+        host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
+        assert TEST_FEATURE_NAME in await get_supported_features(cql, host)
+
+    # The feature should become enabled on all nodes soon.
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f"Waiting until {TEST_FEATURE_NAME} is enabled on all nodes")
+    await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
+
+
+@pytest.mark.asyncio
+async def test_partial_cluster_upgrade_then_downgrade(manager: ManagerClient) -> None:
+    """Simulates an partial of a cluster by enabling the test features in all
+       but one nodes, then downgrading them.
+    """
+    servers = await manager.running_servers()
+    upgrading_servers = servers[1:] if len(servers) > 0 else []
+
+    cql = manager.cql
+
+    # Upgrade
+    for srv in upgrading_servers:
+        await turn_on_test_feature_and_restart(manager, srv)
+        cql = await reconnect_driver(manager)
+        host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
+        assert TEST_FEATURE_NAME in await get_supported_features(cql, host)
+
+    # There is one node that is not upgraded. The feature should not be enabled.
+    for srv in servers:
+        cql = await reconnect_driver(manager)
+        host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
+        assert TEST_FEATURE_NAME not in await get_enabled_features(cql, host)
+
+    # Downgrade, in reverse order
+    for srv in upgrading_servers[::-1]:
+        await turn_off_test_feature_and_restart(manager, srv)
+        cql = await reconnect_driver(manager)
+        host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
+        assert TEST_FEATURE_NAME not in await get_supported_features(cql, host)
+
+
+@pytest.mark.asyncio
+async def test_reject_joining_node_without_support_for_enabled_features(manager: ManagerClient) -> None:
+    """Upgrades the cluster to enable a new feature, then tries to add
+       another node - which should fail because it doesn't support one
+       of the enabled features.
+    """
+    servers = await manager.running_servers()
+    await asyncio.gather(*(turn_on_test_feature_and_restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+
+    cql = manager.cql
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f"Waiting until {TEST_FEATURE_NAME} is enabled on all nodes")
+    await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
+
+    new_server_info = await manager.server_add(start=False)
+    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
+
+
+@pytest.mark.asyncio
+async def test_reject_replacing_node_without_support_for_enabled_features(manager: ManagerClient) -> None:
+    """Upgrades the cluster to enable a new feature, then tries to replace
+       an existing node with another node - which should fail because
+       it doesn't support one of the enabled features.
+    """
+    servers = await manager.running_servers()
+    await asyncio.gather(*(turn_on_test_feature_and_restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+
+    cql = manager.cql
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f"Waiting until {TEST_FEATURE_NAME} is enabled on all nodes")
+    await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
+
+    await manager.server_stop(servers[0].server_id)
+    replace_cfg = ReplaceConfig(replaced_id=servers[0].server_id, reuse_ip_addr=False, use_host_id=False)
+    new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg)
+    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -9,12 +9,27 @@ Test consistency of schema changes with topology changes.
 import logging
 import pytest
 import time
+
+from cassandra.cluster import Session  # type: ignore # pylint: disable=no-name-in-module
+
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier
 
 
 logger = logging.getLogger(__name__)
+
+
+async def reconnect_driver(manager: ManagerClient) -> Session:
+    """Workaround for scylladb/python-driver#170:
+       the existing driver session may not reconnect, create a new one.
+    """
+    logging.info(f"Reconnecting driver")
+    manager.driver_close()
+    await manager.driver_connect()
+    cql = manager.cql
+    assert(cql)
+    return cql
 
 
 async def get_token_ring_host_ids(manager: ManagerClient, srv: ServerInfo) -> set[str]:

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -6,3 +6,6 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
     experimental_features: ['raft']
+    error_injections_at_startup: ['gossiper_censor_test_only_feature']
+skip_in_release:
+    - test_raft_cluster_features

--- a/test/topology_experimental_raft/test_raft_cluster_features.py
+++ b/test/topology_experimental_raft/test_raft_cluster_features.py
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Tests the cluster feature functionality, with raft.
+"""
+from test.pylib.manager_client import ManagerClient
+import test.topology.test_cluster_features
+import pytest
+
+
+async def setup_cluster(manager: ManagerClient):
+    for i in range(3):
+        await manager.server_add()
+
+
+@pytest.mark.asyncio
+async def test_cluster_upgrade(manager: ManagerClient) -> None:
+    """Simulates an upgrade of a cluster by doing a rolling restart
+       and marking the test-only feature as supported on restarted nodes.
+    """
+    await setup_cluster(manager)
+    await test.topology.test_cluster_features.test_cluster_upgrade(manager)
+
+
+@pytest.mark.asyncio
+async def test_partial_cluster_upgrade_then_downgrade(manager: ManagerClient) -> None:
+    """Simulates an partial of a cluster by enabling the test features in all
+       but one nodes, then downgrading them.
+    """
+    await setup_cluster(manager)
+    await test.topology.test_cluster_features.test_partial_cluster_upgrade_then_downgrade(manager)
+
+
+@pytest.mark.asyncio
+async def test_reject_joining_node_without_support_for_enabled_features(manager: ManagerClient) -> None:
+    """Upgrades the cluster to enable a new feature, then tries to add
+       another node - which should fail because it doesn't support one
+       of the enabled features.
+    """
+    await setup_cluster(manager)
+    await test.topology.test_cluster_features.test_reject_joining_node_without_support_for_enabled_features(manager)
+
+
+@pytest.mark.asyncio
+async def test_reject_replacing_node_without_support_for_enabled_features(manager: ManagerClient) -> None:
+    """Upgrades the cluster to enable a new feature, then tries to replace
+       an existing node with another node - which should fail because
+       it doesn't support one of the enabled features.
+    """
+    await setup_cluster(manager)
+    await test.topology.test_cluster_features.test_reject_replacing_node_without_support_for_enabled_features(manager)

--- a/test/topology_raft_disabled/test_raft_upgrade_basic.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_basic.py
@@ -13,10 +13,10 @@ from typing import Callable, Awaitable, Optional, TypeVar, Generic
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import inject_error_one_shot
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_feature
 from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
-        delete_raft_data, log_run_time, wait_for_feature
+        delete_raft_data, log_run_time
 
 
 @pytest.mark.asyncio

--- a/test/topology_raft_disabled/test_raft_upgrade_basic.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_basic.py
@@ -14,7 +14,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import inject_error_one_shot
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_feature
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
         delete_raft_data, log_run_time
 

--- a/test/topology_raft_disabled/test_raft_upgrade_majority_loss.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_majority_loss.py
@@ -11,7 +11,8 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft_and_restart, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft_and_restart, \
         wait_until_upgrade_finishes, delete_raft_data, log_run_time
 
 

--- a/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
@@ -10,10 +10,10 @@ import logging
 import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
 from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
-        delete_raft_data, log_run_time, wait_for_feature
+        delete_raft_data, log_run_time
 
 @pytest.mark.asyncio
 @log_run_time

--- a/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
@@ -11,7 +11,8 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
         delete_raft_data, log_run_time
 

--- a/test/topology_raft_disabled/test_raft_upgrade_stuck.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_stuck.py
@@ -12,7 +12,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import inject_error_one_shot
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft_and_restart, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft_and_restart, \
         wait_for_upgrade_state, wait_until_upgrade_finishes, delete_raft_data, log_run_time
 
 

--- a/test/topology_raft_disabled/util.py
+++ b/test/topology_raft_disabled/util.py
@@ -103,15 +103,3 @@ def log_run_time(f):
         logging.info(f"{f.__name__} took {int(time.time() - start)} seconds.")
         return res
     return wrapped
-
-
-# Wait for the given feature to be enabled.
-async def wait_for_feature(feature: str, cql: Session, host: Host, deadline: float) -> None:
-    async def feature_is_enabled():
-        rs = await cql.run_async("select value from system.scylla_local where key = 'enabled_features'", host=host)
-        if rs:
-            value = rs[0].value
-            if feature in value:
-                return True
-        return None
-    await wait_for(feature_is_enabled, deadline)

--- a/test/topology_raft_disabled/util.py
+++ b/test/topology_raft_disabled/util.py
@@ -17,18 +17,6 @@ from test.pylib.manager_client import ManagerClient, IPAddress, ServerInfo
 from test.pylib.util import wait_for
 
 
-async def reconnect_driver(manager: ManagerClient) -> Session:
-    """Workaround for scylladb/python-driver#170:
-       the existing driver session may not reconnect, create a new one.
-    """
-    logging.info(f"Reconnecting driver")
-    manager.driver_close()
-    await manager.driver_connect()
-    cql = manager.cql
-    assert(cql)
-    return cql
-
-
 async def restart(manager: ManagerClient, server: ServerInfo) -> None:
     logging.info(f"Stopping {server} gracefully")
     await manager.server_stop_gracefully(server.server_id)

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -212,8 +212,11 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     cfg.enable_cache(false);
     cfg.volatile_system_keyspace_for_testing(true);
 
-    gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
-    feature_service.enable(feature_service.supported_feature_set()).get();
+    sharded<gms::feature_service> feature_service;
+    feature_service.start(gms::feature_config_from_db_config(cfg)).get();
+    auto stop_feature_service = deferred_stop(feature_service);
+
+    feature_service.local().enable(feature_service.local().supported_feature_set()).get();
     sharded<locator::shared_token_metadata> token_metadata;
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
@@ -221,7 +224,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     auto stop_token_metadata = deferred_stop(token_metadata);
 
     data_dictionary_impl dd_impl;
-    database real_db(cfg, feature_service);
+    database real_db(cfg, feature_service.local());
     auto db = dd_impl.wrap(real_db);
 
     // Mock system_schema keyspace to be able to parse modification statements

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -216,7 +216,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     feature_service.start(gms::feature_config_from_db_config(cfg)).get();
     auto stop_feature_service = deferred_stop(feature_service);
 
-    feature_service.local().enable(feature_service.local().supported_feature_set()).get();
+    feature_service.local().enable(feature_service.local().supported_feature_set(), gms::feature_service::without_persisting{}).get();
     sharded<locator::shared_token_metadata> token_metadata;
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));


### PR DESCRIPTION
This PR adds support for managing cluster features using raft. This new method is more safe than the existing one as it doesn't rely on gossip to propagate information about nodes' supported features in time. It is only enabled if raft is enabled and experimental raft feature is turned on.

A new column named `supported_features` is added to the group0-managed `system.topology` table. Every node is responsible for inserting and maintaining its features in that table: they are inserted when a node inserts its request to join the cluster or replace a node, and updated when a node restarts and notices that its supported feature set is different to what is in the table. The set of _enabled_ features in the cluster is implicitly defined as an intersection of all nodes' supported features persisted in the topology table.

Until a node puts or updates its features into the topology table on startup, it doesn't have a guarantee that it will understand all of the enabled features. Therefore, a feature check is performed every time a group 0 command that modifies the topology table is applied - further commands may depend on some features, so a node shouldn't attempt to process them if it might not understand them properly.

Similarly, features are also checked on snapshot transfer. A set of enabled features is sent in a simple format along the snapshot so that a node doesn't need to attempt to parse the rest of it, which it might be not prepared to understand.

When the new cluster feature management method is enabled, the node will still advertise its supported features in gossip but it won't use gossip to judge whether a feature should be enabled or not. This is left mostly for the purpose of some logic that reacts to features in gossip (it's mostly about updating `system.peers`) and for the sake of nodes that don't use cluster features on raft.

The implementation currently assumes that the cluster either always uses raft-based features or gossip-based features. There is no logic implemented yet that allows to transition from gossip features to raft features. Such a transition will have to happen when the cluster switches to managing topology over raft - which is also not implemented, but planned, so transitioning features to the new method will have to be a part of the solution.

Along with the implementation, a bunch of pylib tests for cluster features are added. A test-only feature is added which allows simulating node upgrade to a version which supports a new feature in the tests. The test suite is being run both for the gossip-based implementation as well as the new raft-based one.