### PR TITLE
Fix topology management when raft-based topology is enabled

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -182,7 +182,7 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
                 on_internal_error(tlogger, format("Updating node host_id to null is disallowed: {}: new host_id={}", debug_format(node), *opt_id));
             }
             if (node->is_this_node() && node->host_id()) {
-                on_internal_error(tlogger, format("This node host_id is alredy set: {}: new host_id={}", debug_format(node), *opt_id));
+                on_internal_error(tlogger, format("This node host_id is already set: {}: new host_id={}", debug_format(node), *opt_id));
             }
             if (_nodes_by_host_id.contains(*opt_id)) {
                 on_internal_error(tlogger, format("Cannot update node host_id: {}: new host_id already exists: {}", debug_format(node), debug_format(_nodes_by_host_id[*opt_id])));

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -443,11 +443,15 @@ bool topology::has_endpoint(inet_address ep) const
 }
 
 const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
-    if (ep == utils::fb_utilities::get_broadcast_address()) {
-        return get_location();
-    }
     if (auto node = find_node(ep)) {
         return node->dc_rack();
+    }
+    // We should do the following check after lookup in nodes.
+    // In tests, there may be no config for local node, so fall back to get_location()
+    // only if no mapping is found. Otherwise, get_location() will return empty location
+    // from config or random node, neither of which is correct.
+    if (ep == _cfg.this_endpoint) {
+        return get_location();
     }
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -65,14 +65,9 @@ future<> topology::clear_gently() noexcept {
     co_await utils::clear_gently(_nodes);
 }
 
-topology::topology() noexcept
-        : _shard(this_shard_id())
-{
-    tlogger.trace("topology[{}]: default-constructed", fmt::ptr(this));
-}
-
 topology::topology(config cfg)
         : _shard(this_shard_id())
+        , _cfg(cfg)
         , _sort_by_proximity(!cfg.disable_proximity_sorting)
 {
     tlogger.trace("topology[{}]: constructing using config: host_id={} endpoint={} dc={} rack={}", fmt::ptr(this),
@@ -84,6 +79,7 @@ topology::topology(config cfg)
 
 topology::topology(topology&& o) noexcept
     : _shard(o._shard)
+    , _cfg(std::move(o._cfg))
     , _nodes(std::move(o._nodes))
     , _nodes_by_host_id(std::move(o._nodes_by_host_id))
     , _nodes_by_endpoint(std::move(o._nodes_by_endpoint))
@@ -105,7 +101,7 @@ topology::topology(topology&& o) noexcept
 }
 
 future<topology> topology::clone_gently() const {
-    topology ret;
+    topology ret(_cfg);
     tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);
     for (const auto& nptr : _nodes) {
         if (nptr) {

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -509,6 +509,18 @@ void topology::for_each_node(std::function<void(const node*)> func) const {
 
 namespace std {
 
+std::ostream& operator<<(std::ostream& out, const locator::topology& t) {
+    out << "{this_host_id: " << t._cfg.this_host_id
+        << ", this_endpoint: " << t._cfg.this_endpoint
+        << ", dc: " << t._cfg.local_dc_rack.dc
+        << ", rack: " << t._cfg.local_dc_rack.rack
+        << ", nodes:\n";
+    for (auto&& node : t._nodes) {
+        out << "  " << locator::topology::debug_format(&*node) << "\n";
+    }
+    return out << "}";
+}
+
 std::ostream& operator<<(std::ostream& out, const locator::node& node) {
     fmt::print(out, "{}", node);
     return out;

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -99,6 +99,14 @@ topology::topology(topology&& o) noexcept
     }
 }
 
+topology& topology::operator=(topology&& o) noexcept {
+    if (this != &o) {
+        this->~topology();
+        new (this) topology(std::move(o));
+    }
+    return *this;
+}
+
 future<topology> topology::clone_gently() const {
     topology ret(_cfg);
     tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -115,6 +115,8 @@ public:
     future<> clear_gently() noexcept;
 
 public:
+    const config& get_config() const noexcept { return _cfg; }
+
     const node* this_node() const noexcept {
         return _nodes.size() ? _nodes.front().get() : nullptr;
     }
@@ -253,9 +255,6 @@ public:
     void for_each_node(std::function<void(const node*)> func) const;
 
 private:
-    // default constructor for cloning purposes
-    topology() noexcept;
-
     const node* add_node(node_holder node);
     void remove_node(const node* node);
 
@@ -281,6 +280,7 @@ private:
     std::weak_ordering compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
 
     unsigned _shard;
+    config _cfg;
     std::vector<node_holder> _nodes;
     std::unordered_map<host_id, const node*> _nodes_by_host_id;
     std::unordered_map<inet_address, const node*> _nodes_by_endpoint;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -118,7 +118,7 @@ public:
     const config& get_config() const noexcept { return _cfg; }
 
     const node* this_node() const noexcept {
-        return _nodes.size() ? _nodes.front().get() : nullptr;
+        return _this_node;
     }
 
     // Adds a node with given host_id, endpoint, and DC/rack.
@@ -194,7 +194,7 @@ public:
 
     // Get dc/rack location of this node
     const endpoint_dc_rack& get_location() const noexcept {
-        return this_node()->dc_rack();
+        return _this_node ? _this_node->dc_rack() : _cfg.local_dc_rack;
     }
     // Get dc/rack location of a node identified by host_id
     // The specified node must exist.
@@ -255,6 +255,7 @@ public:
     void for_each_node(std::function<void(const node*)> func) const;
 
 private:
+    bool is_configured_this_node(const node&) const;
     const node* add_node(node_holder node);
     void remove_node(const node* node);
 
@@ -281,6 +282,7 @@ private:
 
     unsigned _shard;
     config _cfg;
+    const node* _this_node = nullptr;
     std::vector<node_holder> _nodes;
     std::unordered_map<host_id, const node*> _nodes_by_host_id;
     std::unordered_map<inet_address, const node*> _nodes_by_endpoint;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -111,11 +111,13 @@ public:
         inet_address this_endpoint;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;
+
+        bool operator==(const config&) const = default;
     };
     topology(config cfg);
     topology(topology&&) noexcept;
 
-    topology& operator=(topology&&) = default;
+    topology& operator=(topology&&) noexcept;
 
     future<topology> clone_gently() const;
     future<> clear_gently() noexcept;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -25,8 +25,14 @@
 using namespace seastar;
 
 namespace locator {
-
 class topology;
+}
+
+namespace std {
+std::ostream& operator<<(std::ostream& out, const locator::topology&);
+}
+
+namespace locator {
 
 class node;
 using node_holder = std::unique_ptr<node>;
@@ -315,6 +321,8 @@ private:
     friend class token_metadata_impl;
 public:
     void test_compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
+
+    friend std::ostream& std::operator<<(std::ostream& out, const topology&);
 };
 
 } // namespace locator

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -46,11 +46,10 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
     });
 
     std::unordered_set<const locator::node*> nodes;
-    nodes.insert(topo.this_node());
 
     nodes.insert(topo.add_node(id2, ep2, endpoint_dc_rack::default_location, node::state::normal));
+    nodes.insert(topo.add_node(id1, ep1, endpoint_dc_rack::default_location, node::state::normal));
 
-    BOOST_REQUIRE_THROW(topo.add_node(id1, ep1, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id1, ep2, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep1, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep2, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
@@ -88,6 +87,8 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     auto reset_on_internal_abort = seastar::defer([] {
         set_abort_on_internal_error(true);
     });
+
+    topo.add_or_update_endpoint(ep1, endpoint_dc_rack::default_location, node::state::normal);
 
     auto node = topo.this_node();
     auto mutable_node = const_cast<locator::node*>(node);


### PR DESCRIPTION
Fixes a problem when raft-based topology is enabled, which loads
topology from storage. It starts by clearing topology and then adding
nodes one by one. Before this patch, this violates internal invariant
of topology object which puts the local node as the first node. This
would manifest by triggering an assert in topology::pop_node() which
throws if popping the node at index 0 in order to keep the information
about local node around. This is normally prevented by a check in
topology::remove_node() which avoid calling pop_node() if removing the
local node. But since there is no node which is marked as local, this
check allows the first node to be popped.

To fix the problem I lift the invariant that local node is always in
_nodes. We still have information about local node in config. Instead
of keeping it in _nodes, we recognize it as part of indexing. We also
allow removing the local node like a regular node.

The path which reloads topology works correctly after this, the local
node will be recognized when (if) it is added to the topology.

Fixes #13495
