### PR TITLE
s3/client: Don't use designated initialization of sys stat struct

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -441,13 +441,12 @@ public:
 
     virtual future<struct stat> stat(void) override {
         auto size = co_await _client->get_object_size(_object_name);
-        struct stat ret {
-            .st_nlink = 1,
-            .st_mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH,
-            .st_size = size,
-            .st_blksize = 1 << 10, // huh?
-            .st_blocks = size >> 9,
-        };
+        struct stat ret;
+        ret.st_nlink = 1;
+        ret.st_mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
+        ret.st_size = size;
+        ret.st_blksize = 1 << 10; // huh?
+        ret.st_blocks = size >> 9;
         co_return ret;
     }
 


### PR DESCRIPTION
It makes compiler complan about mis-ordered initialization of st_nlink vs st_mode on different arches. Current code (st_nlink before st_mode) compiled fine on x86, but fails on ARM which wants st_mode to come before st_nlink. Changing the order would, apparently, break x86 build with similar message.