### PR TITLE
create-relocatable-package.py: use f-string

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -181,5 +181,5 @@ ar.reloc_add('fix_system_distributed_tables.py')
 ar.close()
 gzip_process.communicate()
 if gzip_process.returncode != 0:
-    print('pigz returned {gzip_process.returncode}!', file=sys.stderr)
+    print(f'pigz returned {gzip_process.returncode}!', file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
in dcce0c96a9a9babce3bd840f319e77f7c7a615a9, we should have used f-string for printing the return code of gzip subprocess. but the "f" prefix was missed. so, in this change, it is added.