### PR TITLE
hinted-handoff: clear all hints on node startup

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -1362,8 +1362,8 @@ public:
         return with_semaphore(_lock, 1, [this] () {
             utils::directories::set dir_set;
             dir_set.add_sharded(_hints_directory);
+            manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
             return _dirs.create_and_verify(std::move(dir_set)).then([this] {
-                manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
                 _state = state::created_and_validated;
             });
         });

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -1359,13 +1359,12 @@ public:
             return make_ready_future<>();
         }
 
-        return with_semaphore(_lock, 1, [this] () {
+        return with_semaphore(_lock, 1, [this] () -> future<> {
             utils::directories::set dir_set;
             dir_set.add_sharded(_hints_directory);
             manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
-            return _dirs.create_and_verify(std::move(dir_set)).then([this] {
-                _state = state::created_and_validated;
-            });
+            co_await _dirs.create_and_verify(std::move(dir_set));
+            _state = state::created_and_validated;
         });
     }
 

--- a/main.cc
+++ b/main.cc
@@ -1351,12 +1351,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_stream_manager(ctx).get();
             });
 
-            supervisor::notify("starting hinted handoff manager");
-            if (!hinted_handoff_enabled.is_disabled_for_all()) {
-                hints_dir_initializer.ensure_rebalanced().get();
-            }
-            view_hints_dir_initializer.ensure_rebalanced().get();
-
             proxy.invoke_on_all([&lifecycle_notifier, &gossiper] (service::storage_proxy& local_proxy) {
                 lifecycle_notifier.local().register_subscriber(&local_proxy);
                 return local_proxy.start_hints_manager(gossiper.local().shared_from_this());


### PR DESCRIPTION
The purpose of hints is to bridge small, temporary gaps in node availability. Hints are not a  means to keep a cluster consistent, that is the job of repair. Therefore, keeping unsent hints for a long time serves no purpose. Keeping hints across node restarts is also problematic, because there is no way to verify whether the hints are stale or not. Worst still, while the current node was down, the topology might have changed and the node will start sending hints to the wrong endpoints (although AFAIK currently we don't handle online topology changes w.r.t. hints either).
This PR wipes the hint directory on startup, so we don't have to deal with these problems. This furthermore makes it much easier to transition HH to use of host-ids, as we no longer have to deal inheriting old IP based hints directories.