### PR TITLE
topology: node: update_node: do not override internal changed flag by state option

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -220,7 +220,7 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
         }
     }
     if (opt_st) {
-        changed = node->get_state() != *opt_st;
+        changed |= node->get_state() != *opt_st;
     }
 
     if (!changed) {


### PR DESCRIPTION
Currently, opt_st overrides the internal `changed` flag by setting it with the opt_st changed status.
Instead, it should use `|=` to keep it true if it is already so.