### PR TITLE
Remove global proxy usage from view builder's value_getter

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -566,7 +566,6 @@ struct value_getter {
 private:
     // Schemas of base table and view.
     const schema& _base;
-    const view_ptr& _view;
 
     const partition_key& _base_key;
     const clustering_or_static_row& _update;
@@ -574,15 +573,13 @@ private:
     const bool _backing_secondary_index;
 
 public:
-    value_getter(const schema& base, const view_ptr& view, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, bool backing_secondary_index)
+    value_getter(const schema& base, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, bool backing_secondary_index)
         : _base(base)
-        , _view(view)
         , _base_key(base_key)
         , _update(update)
         , _existing(existing)
         , _backing_secondary_index(backing_secondary_index)
     {
-        (void)_view;
     }
 
     using vector_type = utils::small_vector<view_managed_key_view_and_action, 1>;
@@ -651,7 +648,7 @@ private:
 
 std::vector<view_updates::view_row_entry>
 view_updates::get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing) {
-    value_getter getter(*_base, _view, base_key, update, existing, _backing_secondary_index);
+    value_getter getter(*_base, base_key, update, existing, _backing_secondary_index);
     auto get_value = boost::adaptors::transformed(std::ref(getter));
 
 

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -209,13 +209,16 @@ class view_updates final {
     base_info_ptr _base_info;
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
     mutable size_t _op_count = 0;
+    const bool _backing_secondary_index;
 public:
-    explicit view_updates(view_and_base vab)
+    explicit view_updates(view_and_base vab, bool backing_secondary_index)
             : _view(std::move(vab.view))
             , _view_info(*_view->view_info())
             , _base(vab.base->base_schema())
             , _base_info(vab.base)
-            , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view)) {
+            , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view))
+            , _backing_secondary_index(backing_secondary_index)
+    {
     }
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1036,6 +1036,10 @@ public:
         return _index_manager;
     }
 
+    const secondary_index::secondary_index_manager& get_index_manager() const noexcept {
+        return _index_manager;
+    }
+
     sstables::sstables_manager& get_sstables_manager() noexcept {
         return _sstables_manager;
     }


### PR DESCRIPTION
There's a legacy safety check in view code that needs to find a base table from its schema ID. To do it it calls for global storage proxy instance. The comment says that this code can be removed once computes_column feature is known by everyone. I'm not sure if that's the case, so here's more complicated yet less incompatible way to stop using global proxy instance.