### PR TITLE
[DRAFT] dist: introduce docker-minimal container image

### DIFF
--- a/dist/docker-minimal/build_jmx.sh
+++ b/dist/docker-minimal/build_jmx.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+
+print_usage() {
+    echo "build_docker.sh --mode release --unified-pkg build/release/scylla-unified.tar.gz"
+    echo "  --mode scylla build mode"
+    echo "  --unified-pkg specify package path"
+    echo "  --with-busybox build container with busybox"
+    exit 1
+}
+
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+VERSION=`sed 's/-/~/' build/SCYLLA-VERSION-FILE`
+RELEASE=`cat build/SCYLLA-RELEASE-FILE`
+
+BASE_IMAGE="gcr.io/distroless/java-debian11:nonroot"
+MODE="release"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "--mode")
+            MODE="$2"
+            shift 2
+            ;;
+        "--unified-pkg")
+            UNIFIED_PKG="$2"
+            shift 2
+            ;;
+        "--with-busybox")
+            BASE_IMAGE="gcr.io/distroless/java-debian11:debug-nonroot"
+            shift 1
+            ;;
+        *)
+            print_usage
+            ;;
+    esac
+done
+
+if [ -z "$UNIFIED_PKG" ]; then
+    UNIFIED_PKG="build/$MODE/dist/tar/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
+fi
+BUILDDIR=build/"$MODE"/dist/docker-minimal/scylla-jmx
+
+if [ ! -e $UNIFIED_PKG ]; then
+    echo "unified package is not specified."
+    exit 1
+fi
+
+rm -rf "$BUILDDIR"
+mkdir -p "$BUILDDIR"
+tar xpf "$UNIFIED_PKG" -C "$BUILDDIR"
+TOPDIR=`pwd`
+cd "$BUILDDIR"
+cd scylla-*/scylla-jmx
+./install.sh --packaging --root ../../scylla-root --sysconfdir /etc/default
+cd -
+
+# XXX: these fixup should be move to install.sh
+rm -rf scylla-root/{etc,usr} scylla-root/opt/scylladb/jmx/{scylla-jmx,symlinks} scylla-root/opt/scylladb/scripts
+
+CONTAINER="$(buildah from $BASE_IMAGE)"
+IMAGE="$PRODUCT-minimal-jmx-$VERSION-$RELEASE"
+buildah copy "$CONTAINER" scylla-root/opt/ /opt/
+
+buildah config --entrypoint '["/usr/bin/java", "-Xmx256m", "-XX:+UseSerialGC", "-XX:+HeapDumpOnOutOfMemoryError", "-Dcom.sun.management.jmxremote.authenticate=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.host=localhost", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.port=7199", "-Djava.rmi.server.hostname=localhost", "-Dcom.sun.management.jmxremote.rmi.port=7199", "-Djavax.management.builder.initial=com.scylladb.jmx.utils.APIBuilder", "-jar", "/opt/scylladb/jmx/scylla-jmx-1.0.jar"]' "$CONTAINER"
+buildah config --cmd "" "$CONTAINER"
+buildah config --port 7199 "$CONTAINER"
+buildah commit "$CONTAINER" "oci-archive:$IMAGE"
+echo "Image is now available in $BUILDDIR/$IMAGE."

--- a/dist/docker-minimal/build_server.sh
+++ b/dist/docker-minimal/build_server.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+
+print_usage() {
+    echo "build_docker.sh --mode release --unified-pkg build/release/scylla-unified.tar.gz"
+    echo "  --mode scylla build mode"
+    echo "  --unified-pkg specify package path"
+    echo "  --with-busybox build container with busybox"
+    exit 1
+}
+
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+VERSION=`sed 's/-/~/' build/SCYLLA-VERSION-FILE`
+RELEASE=`cat build/SCYLLA-RELEASE-FILE`
+
+BASE_IMAGE="gcr.io/distroless/static-debian11"
+MODE="release"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "--mode")
+            MODE="$2"
+            shift 2
+            ;;
+        "--unified-pkg")
+            UNIFIED_PKG="$2"
+            shift 2
+            ;;
+        "--with-busybox")
+            BASE_IMAGE="gcr.io/distroless/static-debian11:debug"
+            shift 1
+            ;;
+        *)
+            print_usage
+            ;;
+    esac
+done
+
+if [ -z "$UNIFIED_PKG" ]; then
+    UNIFIED_PKG="build/$MODE/dist/tar/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
+fi
+BUILDDIR=build/"$MODE"/dist/docker-minimal/scylla-server
+
+if [ ! -e $UNIFIED_PKG ]; then
+    echo "unified package is not specified."
+    exit 1
+fi
+
+rm -rf "$BUILDDIR"
+mkdir -p "$BUILDDIR"
+tar xpf "$UNIFIED_PKG" -C "$BUILDDIR"
+TOPDIR=`pwd`
+cd "$BUILDDIR"
+cd scylla-*/scylla
+./install.sh --packaging --root ../../scylla-root --sysconfdir /etc/default
+cd -
+cd scylla-*/scylla-python3
+./install.sh --root ../../scylla-root
+cd -
+
+# XXX: these fixup should be move to install.sh
+rm -rf scylla-root/etc/systemd scylla-root/usr scylla-root/opt/scylladb/{api,bin,node_exporter,scyllatop,share,swagger-ui} scylla-root/opt/scylladb/libexec/{ethtool,gawk,gzip,hwloc-*,ifconfig,lsblk,lscpu,netstat,patchelf}
+mkdir scylla-root/opt/scylladb/docker-minimal
+install -m755 "$TOPDIR"/dist/docker/docker-entrypoint.py scylla-root/opt/scylladb/docker-minimal
+install -m644 "$TOPDIR"/dist/docker/commandlineparser.py "$TOPDIR"/dist/docker/scyllasetup.py "$TOPDIR"/dist/docker/minimalcontainer.py scylla-root/opt/scylladb/docker-minimal
+touch scylla-root/opt/scylladb/SCYLLA-MINIMAL-CONTAINER-FILE
+sed -i -e 's/^SCYLLA_ARGS=".*"$/SCYLLA_ARGS="--log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/' scylla-root/etc/default/scylla-server
+
+CONTAINER="$(buildah from $BASE_IMAGE)"
+IMAGE="$PRODUCT-minimal-server-$VERSION-$RELEASE"
+buildah copy "$CONTAINER" scylla-root/etc/ /etc/
+buildah copy "$CONTAINER" scylla-root/opt/ /opt/
+buildah copy --chown 65532:65532 "$CONTAINER" scylla-root/var/ /var/
+
+PYTHON_BIN=$(basename scylla-root/opt/scylladb/python3/libexec/python*.bin)
+buildah config --env LANG=C.UTF-8 "$CONTAINER"
+buildah config --env LANGUAGE= "$CONTAINER"
+buildah config --env LC_ALL=C.UTF-8 "$CONTAINER"
+buildah config --env PYTHONPATH=/opt/scylladb/docker-minimal/ "$CONTAINER"
+buildah config --entrypoint "[\"/opt/scylladb/python3/libexec/ld.so\", \"/opt/scylladb/python3/libexec/$PYTHON_BIN\", \"-s\", \"/opt/scylladb/docker-minimal/docker-entrypoint.py\"]" "$CONTAINER"
+buildah config --cmd "" "$CONTAINER"
+buildah config --port 10000 --port 9042 --port 9160 --port 9180 --port 7000 --port 7001 "$CONTAINER"
+buildah config --volume "/var/lib/scylla" "$CONTAINER"
+buildah commit "$CONTAINER" "oci-archive:$IMAGE"
+echo "Image is now available in $BUILDDIR/$IMAGE."

--- a/dist/docker-minimal/build_tools.sh
+++ b/dist/docker-minimal/build_tools.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -e
+
+print_usage() {
+    echo "build_docker.sh --mode release --unified-pkg build/release/scylla-unified.tar.gz"
+    echo "  --mode scylla build mode"
+    echo "  --unified-pkg specify package path"
+    exit 1
+}
+
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+VERSION=`sed 's/-/~/' build/SCYLLA-VERSION-FILE`
+RELEASE=`cat build/SCYLLA-RELEASE-FILE`
+
+BASE_IMAGE="gcr.io/distroless/java-debian11:debug-nonroot"
+MODE="release"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "--mode")
+            MODE="$2"
+            shift 2
+            ;;
+        "--unified-pkg")
+            UNIFIED_PKG="$2"
+            shift 2
+            ;;
+        *)
+            print_usage
+            ;;
+    esac
+done
+
+if [ -z "$UNIFIED_PKG" ]; then
+    UNIFIED_PKG="build/$MODE/dist/tar/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
+fi
+BUILDDIR=build/"$MODE"/dist/docker-minimal/scylla-tools
+
+if [ ! -e $UNIFIED_PKG ]; then
+    echo "unified package is not specified."
+    exit 1
+fi
+
+rm -rf "$BUILDDIR"
+mkdir -p "$BUILDDIR"
+tar xpf "$UNIFIED_PKG" -C "$BUILDDIR"
+TOPDIR=`pwd`
+cd "$BUILDDIR"
+cd scylla-*/scylla-tools
+./install.sh --root ../../scylla-root
+cd -
+
+# XXX: these fixup should be move to install.sh
+for i in scylla-root/usr/bin/*;do
+    if [ -f $i ]; then
+        sed -i -e '1 s#\#!/usr/bin/env bash#\#!/busybox/sh#' $i
+    fi
+done
+for i in scylla-root/opt/scylladb/share/cassandra/bin/*;do
+    if [ -f $i ]; then
+        sed -i -e '1 s#\#!/bin/sh#\#!/busybox/sh#' $i
+        sed -i -e '1 s#\#!/usr/bin/env bash#\#!/busybox/sh#' $i
+    fi
+done
+
+CONTAINER="$(buildah from $BASE_IMAGE)"
+IMAGE="$PRODUCT-minimal-tools-$VERSION-$RELEASE"
+buildah copy "$CONTAINER" scylla-root/etc/ /etc/
+buildah copy "$CONTAINER" scylla-root/usr/ /usr/
+buildah copy "$CONTAINER" scylla-root/opt/ /opt/
+
+buildah config --entrypoint '["/busybox/sh"]' "$CONTAINER"
+buildah config --cmd "" "$CONTAINER"
+buildah commit "$CONTAINER" "oci-archive:$IMAGE"
+echo "Image is now available in $BUILDDIR/$IMAGE."

--- a/dist/docker/docker-entrypoint.py
+++ b/dist/docker/docker-entrypoint.py
@@ -8,6 +8,7 @@ import subprocess
 import scyllasetup
 import logging
 import commandlineparser
+import minimalcontainer
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(message)s")
 
@@ -25,10 +26,13 @@ try:
     setup.developerMode()
     setup.cpuSet()
     setup.io()
-    setup.cqlshrc()
     setup.arguments()
-    setup.set_housekeeping()
-    supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
-    supervisord.wait()
+    if not minimalcontainer.is_minimal_container():
+        setup.cqlshrc()
+        setup.set_housekeeping()
+        supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
+        supervisord.wait()
+    else:
+        minimalcontainer.exec_scylla(arguments)
 except Exception:
     logging.exception('failed!')

--- a/dist/docker/minimalcontainer.py
+++ b/dist/docker/minimalcontainer.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import pwd
+import glob
+import subprocess
+from pathlib import Path
+sys.path.append('/opt/scylladb/scripts')
+from scylla_util import sysconfig_parser
+
+scylla_bin_env = {
+    'SCYLLA_HOME': '/var/lib/scylla',
+    'SCYLLA_CONF': '/etc/scylla',
+    'GNUTLS_SYSTEM_PRIORITY_FILE': '/opt/scylladb/libreloc/gnutls.config',
+    'LD_LIBRARY_PATH': '/opt/scylladb/libreloc',
+    'UBSAN_OPTIONS': 'suppressions=/opt/scylladb/libexec/ubsan-suppressions.supp'
+}
+
+def is_minimal_container():
+    return os.path.exists('/opt/scylladb/SCYLLA-MINIMAL-CONTAINER-FILE')
+
+def run_script(args, kwargs):
+    python_bin = glob.glob('/opt/scylladb/python3/libexec/python3.*.bin')[0]
+    cmdline = args[0]
+    exec_path = Path(cmdline[0]).absolute()
+    cmdline[0] = str(exec_path.parent / 'libexec' / exec_path.name)
+    cmdline = ['/opt/scylladb/python3/libexec/ld.so', python_bin, '-s'] + cmdline
+    kwargs['env'] = {'PYTHONPATH': '{}:{}'.format(str(exec_path.parent), str(exec_path.parent / 'libexec'))}
+    subprocess.check_call(*[cmdline], **kwargs)
+
+def io_setup():
+    cmdline = ['/opt/scylladb/libexec/iotune', '--format', 'envfile', '--options-file', '/etc/scylla.d/io.conf', '--properties-file', '/etc/scylla.d/io_properties.yaml', '--evaluation-directory', '/var/lib/scylla/data', '--evaluation-directory', '/var/lib/scylla/commitlog', '--evaluation-directory', '/var/lib/scylla/hints', '--evaluation-directory', '/var/lib/scylla/view_hints']
+    subprocess.run(cmdline, check=True, env=scylla_bin_env)
+
+def generate_cmdline(arguments):
+    cmdline = ['/opt/scylladb/libexec/scylla']
+    scylla_server_conf = sysconfig_parser('/etc/default/scylla-server')
+    scylla_args = scylla_server_conf.get('SCYLLA_ARGS')
+    cmdline += scylla_args.split()
+    if arguments.developerMode == '0' and arguments.io_setup == '1':
+        io_conf = sysconfig_parser('/etc/scylla.d/io.conf')
+        seastar_io = io_conf.get('SEASTAR_IO')
+        cmdline += seastar_io.split()
+    if arguments.developerMode == '1':
+        dev_mode_conf = sysconfig_parser('/etc/scylla.d/dev-mode.conf')
+        dev_mode = dev_mode_conf.get('DEV_MODE')
+        cmdline += dev_mode.split()
+    if arguments.cpuset:
+        cpuset_conf = sysconfig_parser('/etc/scylla.d/cpuset.conf')
+        cpuset = cpuset_conf.get('CPUSET')
+        cmdline += cpuset.split()
+    docker_conf = sysconfig_parser('/etc/scylla.d/docker.conf')
+    scylla_docker_args = docker_conf.get('SCYLLA_DOCKER_ARGS')
+    cmdline += scylla_docker_args.split()
+    return cmdline
+
+def execve_as(path, args, env, user):
+    pw_record = pwd.getpwnam(user)
+    os.setgid(pw_record.pw_uid)
+    os.setuid(pw_record.pw_gid)
+    env |= {'USER': user}
+    os.execve(path, args, env)
+
+def exec_scylla(arguments):
+    cmdline = generate_cmdline(arguments)
+    execve_as(cmdline[0], cmdline, scylla_bin_env, 'nonroot')


### PR DESCRIPTION
Introduce mimimal, barebone version of Docker image for k8s. It has separated container for each services, we have following:
 - scylla-server container
 - scylla-jmx container
 - scylla-tools container We use Google's 'distroless' image as a base container image.

To make scylla-server compatible with current all-in-one Docker container, we need to modify python scripts under dist/docker. It introduce 'minimalcontainer' module to handle minimal container image environment.
On the module, we do some hack to run relocatable binary without shell, since distroless does not have shell by default.
Also, replaced 'subprocess.check_output(['hostname', '-i'])' to 'socket.gethostbyname(socket.gethostname())', since we don't have hostname command on distroless and the result are same.

 Closes #5307