### PR TITLE
doc: update the metrics between 5.2 and 2023.1

### DIFF
--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/metric-update-5.2-to-2023.1.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/metric-update-5.2-to-2023.1.rst
@@ -2,4 +2,4 @@
 ScyllaDB Metric Update - Scylla 5.2 to Scylla Enterprise 2023.1
 =================================================================
 
-
+There are no metric updates in ScyllaDB Enterprise 2023.1 compared to ScyllaDB 5.2.


### PR DESCRIPTION
Related: https://github.com/scylladb/scylla-enterprise/issues/2794

This commit adds information about the metric changes in version 2023.1 compared to version 5.2.

This commit is part of the 5.2-to-2023.1 upgrade guide and must be backported to branch-5.2.

The information was provided by @amnonh in https://github.com/scylladb/scylla-enterprise/issues/2794.