### PR TITLE
storage_service: node_ops_ctl: send_to_all: print correct set of nodes in nodes_down error message

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2910,7 +2910,7 @@ public:
             }
         }
         if (!nodes_down.empty()) {
-            errors.emplace_back(format("The {} command failed for nodes={}: the needed nodes are down. It is highly recommended to fix the down nodes and try again", op_desc, nodes_failed));
+            errors.emplace_back(format("The {} command failed for nodes={}: the needed nodes are down. It is highly recommended to fix the down nodes and try again", op_desc, nodes_down));
         }
         if (!errors.empty()) {
             co_await coroutine::return_exception(std::runtime_error(fmt::to_string(fmt::join(errors, "; "))));


### PR DESCRIPTION
nodes_failed are printed by mistake, instead of nodes_down