### PR TITLE
data_directory: Describe storage options of a keyspace

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -30,6 +30,7 @@ struct storage_options {
 
     storage_options() = default;
 
+    bool is_local_type() const noexcept;
     std::string_view type_string() const;
     std::map<sstring, sstring> to_map() const;
 

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -241,6 +241,16 @@ def test_storage_options_alter_type(cql, scylla_only):
         with pytest.raises(InvalidRequest):
             res = cql.execute(f"ALTER KEYSPACE {keyspace} {ksdef_local}")
 
+# Test that server-side desc statement is able to describe storage options, when not local.
+def test_storage_options_describe(cql, scylla_only):
+    ksdef = "WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : '1' } " \
+            "AND STORAGE = {'type': 'S3', 'bucket': '42', 'endpoint': 'localhost'}"
+
+    with new_test_keyspace(cql, ksdef) as keyspace:
+        desc_output = cql.execute(f"DESC KEYSPACE \"{keyspace}\"").one().create_statement
+
+        assert "{'type': 'S3', 'bucket': '42', 'endpoint': 'localhost'}" in desc_output
+
 # TODO: more tests for "WITH REPLICATION" syntax in CREATE TABLE.
 # TODO: check the "AND DURABLE_WRITES" option of CREATE TABLE.
 # TODO: confirm case insensitivity without quotes, and case sensitivity with them.


### PR DESCRIPTION
Description of storage options is important for S3, as one needs to know if underlying storage is either local or remote, and if the latter, details about it.

This relies on server-side desc statement.

```
$ ./bin/cqlsh.py -e "describe keyspace1;"

CREATE KEYSPACE keyspace1 WITH replication = { ... } AND
	storage = {'type': 'S3', 'bucket': 'sstables',
		   'endpoint': '127.0.0.1:9000'} AND
	durable_writes = true;
```

Fixes #13507.