### PR TITLE
keys: specialize fmt::formatter<partition_key> and friends

### DIFF
--- a/db/data_listeners.cc
+++ b/db/data_listeners.cc
@@ -46,9 +46,7 @@ void data_listeners::on_write(const schema_ptr& s, const frozen_mutation& m) {
 }
 
 toppartitions_item_key::operator sstring() const {
-    std::ostringstream oss;
-    oss << key.key().with_schema(*schema);
-    return oss.str();
+    return fmt::to_string(key.key().with_schema(*schema));
 }
 
 toppartitions_data_listener::toppartitions_data_listener(replica::database& db, std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash> table_filters,

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -72,9 +72,7 @@ void large_data_handler::unplug_system_keyspace() noexcept {
 }
 
 template <typename T> static std::string key_to_str(const T& key, const schema& s) {
-    std::ostringstream oss;
-    oss << key.with_schema(s);
-    return oss.str();
+    return fmt::to_string(key.with_schema(s));
 }
 
 sstring large_data_handler::sst_filename(const sstables::sstable& sst) {

--- a/interval.hh
+++ b/interval.hh
@@ -16,6 +16,7 @@
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <compare>
+#include <fmt/format.h>
 
 template <typename Comparator, typename T>
 concept IntervalComparatorFor = requires (T a, T b, Comparator& cmp) {
@@ -410,7 +411,8 @@ private:
 template<typename U>
 std::ostream& operator<<(std::ostream& out, const wrapping_interval<U>& r) {
     if (r.is_singular()) {
-        return out << "{" << r.start()->value() << "}";
+        fmt::print(out, "{{{}}}", r.start()->value());
+        return out;
     }
 
     if (!r.start()) {
@@ -421,13 +423,13 @@ std::ostream& operator<<(std::ostream& out, const wrapping_interval<U>& r) {
         } else {
             out << "(";
         }
-        out << r.start()->value() << ", ";
+        fmt::print(out, "{},", r.start()->value());
     }
 
     if (!r.end()) {
         out << "+inf)";
     } else {
-        out << r.end()->value();
+        fmt::print(out, "{}", r.end()->value());
         if (r.end()->is_inclusive()) {
             out << "]";
         } else {

--- a/keys.cc
+++ b/keys.cc
@@ -12,61 +12,8 @@
 #include "dht/i_partitioner.hh"
 #include "clustering_bounds_comparator.hh"
 #include <boost/algorithm/string.hpp>
-#include "utils/utf8.hh"
 
 logging::logger klog("keys");
-
-std::ostream& operator<<(std::ostream& out, const partition_key& pk) {
-    fmt::print(out, "pk{{{}}}", managed_bytes_view(pk.representation()));
-    return out;
-}
-
-template<typename T>
-static std::ostream& print_key(std::ostream& out, const T& key_with_schema) {
-    const auto& [schema, key] = key_with_schema;
-    auto type_iterator = key.get_compound_type(schema)->types().begin();
-    bool first = true;
-    for (auto&& e : key.components(schema)) {
-        if (!first) {
-            out << ":";
-        }
-        first = false;
-        out << (*type_iterator)->to_string(to_bytes(e));
-        ++type_iterator;
-    }
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const partition_key::with_schema_wrapper& pk) {
-    const auto& [schema, key] = pk;
-    auto type_iterator = key.get_compound_type(schema)->types().begin();
-    bool first = true;
-    for (auto&& e : key.components(schema)) {
-        if (!first) {
-            out << ":";
-        }
-        first = false;
-        auto keystr = (*type_iterator)->to_string(to_bytes(e));
-        out << (utils::utf8::validate((const uint8_t *) keystr.data(), keystr.size()) ? keystr : "<non-utf8-key>");
-        ++type_iterator;
-    }
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const clustering_key_prefix::with_schema_wrapper& ck) {
-    return print_key(out, ck);
-}
-
-std::ostream& operator<<(std::ostream& out, const partition_key_view& pk) {
-    return with_linearized(pk.representation(), [&] (bytes_view v) {
-        return std::ref(out << "pk{" << to_hex(v) << "}");
-    });
-}
-
-std::ostream& operator<<(std::ostream& out, const clustering_key_prefix& ckp) {
-    fmt::print(out, "ckp{{{}}}", managed_bytes_view(ckp.representation()));
-    return out;
-}
 
 const legacy_compound_view<partition_key_view::c_type>
 partition_key_view::legacy_form(const schema& s) const {

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -85,9 +85,8 @@ public:
     };
 
     inline friend std::ostream& operator<<(std::ostream& o, const mp_row_consumer_m::range_tombstone_start& rt_start) {
-        o << "{ clustering: " << rt_start.ck
-          << ", kind: " << rt_start.kind
-          << ", tombstone: " << rt_start.tomb << " }";
+        fmt::print(o, "{{ clustering: {}, kind: {}, tombstone: {}}}",
+                   rt_start.ck, rt_start.kind, rt_start.tomb);
         return o;
     }
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -583,7 +583,7 @@ void test_sliced_read_row_presence(shared_sstable sst, schema_ptr s, reader_perm
                     return ck_eq(x, cr.key());
                 });
                 if (it == expected_cr.end()) {
-                    std::cout << "unexpected clustering row: " << cr.key() << "\n";
+                    fmt::print(std::cout, "unexpected clustering row: {}\n", cr.key());
                 }
                 BOOST_REQUIRE(it != expected_cr.end());
                 expected_cr.erase(it);


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print following classes without the help of `operator<<`.
    
- partition_key_view
- partition_key
- partition_key::with_schema_wrapper
- key_with_schema
- clustering_key_prefix
- clustering_key_prefix::with_schema_wrapper
    
the corresponding `operator<<()` are dropped dropped in this change,
as all its callers are now using fmtlib for formatting now. the helper
of `print_key()` is removed, as its only caller is
`operator<<(std::ostream&, const
clustering_key_prefix::with_schema_wrapper&)`.
    
the reason why all these operators are replaced in one go is that
we have a template function of `key_to_str()` in `db/large_data_handler.cc`.
this template function is actually the caller of operator<< of
`partition_key::with_schema_wrapper` and
`clustering_key_prefix::with_schema_wrapper`.
so, in order to drop either of these two operator<<, we need to remove
both of them, so that we can switch over to `fmt::to_string()` in this
template function.
    
Refs scylladb#13245
