### PR TITLE
install.sh: use scylla-jmx for detecting JRE

### DIFF
--- a/unified/install.sh
+++ b/unified/install.sh
@@ -107,14 +107,7 @@ if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     exit 1
 fi
 
-has_java=false
-if [ -x /usr/bin/java ]; then
-    javaver=$(/usr/bin/java -version 2>&1|head -n1|cut -f 3 -d " ")
-    if [[ "$javaver" =~ ^\"1.8.0 || "$javaver" =~ ^\"11.0. ]]; then
-        has_java=true
-    fi
-fi
-if ! $has_java; then
+if ! scylla-jmx/select-java --version > /dev/null; then
     echo "Please install openjdk-8 or openjdk-11 before running install.sh."
     exit 1
 fi


### PR DESCRIPTION
now that scylla-jmx has a dedicated script for detecting the existence of OpenJDK, and this script is included in the unified package, let's just leverage it instead of repeating it in `install.sh`.