### PR TITLE
Backport "reader_concurrency_semaphore: don't evict inactive readers needlessly" to branch-5.0

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1030,6 +1030,13 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, r
     return fut;
 }
 
+void reader_concurrency_semaphore::set_resources(resources r) {
+    auto delta = r - _initial_resources;
+    _initial_resources = r;
+    _resources += delta;
+    maybe_admit_waiters();
+}
+
 void reader_concurrency_semaphore::broken(std::exception_ptr ex) {
     if (!ex) {
         ex = std::make_exception_ptr(broken_semaphore{});

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -910,7 +910,16 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, r
         _execution_loop_future.emplace(execution_loop());
     }
 
-    const auto admit = can_admit_read(permit).decision;
+    static uint64_t stats::*stats_table[] = {
+        &stats::reads_admitted_immediately,
+        &stats::reads_queued_because_ready_list,
+        &stats::reads_queued_because_used_permits,
+        &stats::reads_queued_because_memory_resources,
+        &stats::reads_queued_because_count_resources
+    };
+
+    const auto [admit, why] = can_admit_read(permit);
+    ++(_stats.*stats_table[static_cast<int>(why)]);
     if (admit != can_admit::yes || !_wait_list.empty()) {
         auto fut = enqueue_waiter(std::move(permit), std::move(func));
         if (admit == can_admit::yes && !_wait_list.empty()) {
@@ -921,6 +930,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, r
             maybe_dump_reader_permit_diagnostics(*this, _permit_list, "semaphore could admit new reads yet there are waiters");
             maybe_admit_waiters();
         } else if (admit == can_admit::maybe) {
+            ++_stats.reads_queued_with_eviction;
             evict_readers_in_background();
         }
         return fut;

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -883,25 +883,26 @@ void reader_concurrency_semaphore::evict_readers_in_background() {
     });
 }
 
-reader_concurrency_semaphore::can_admit
+reader_concurrency_semaphore::admit_result
 reader_concurrency_semaphore::can_admit_read(const reader_permit& permit) const noexcept {
     if (!_ready_list.empty()) {
-        return can_admit::no;
+        return {can_admit::no, reason::ready_list};
     }
 
     if (!all_used_permits_are_stalled()) {
-        return can_admit::no;
+        return {can_admit::no, reason::used_permits};
     }
 
     if (!has_available_units(permit.base_resources())) {
+        auto reason = _resources.memory >= permit.base_resources().memory ? reason::memory_resources : reason::count_resources;
         if (_inactive_reads.empty()) {
-            return can_admit::no;
+            return {can_admit::no, reason};
         } else {
-            return can_admit::maybe;
+            return {can_admit::maybe, reason};
         }
     }
 
-    return can_admit::yes;
+    return {can_admit::yes, reason::all_ok};
 }
 
 future<> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, read_func func) {
@@ -909,7 +910,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, r
         _execution_loop_future.emplace(execution_loop());
     }
 
-    const auto admit = can_admit_read(permit);
+    const auto admit = can_admit_read(permit).decision;
     if (admit != can_admit::yes || !_wait_list.empty()) {
         auto fut = enqueue_waiter(std::move(permit), std::move(func));
         if (admit == can_admit::yes && !_wait_list.empty()) {
@@ -935,7 +936,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, r
 
 void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
     auto admit = can_admit::no;
-    while (!_wait_list.empty() && (admit = can_admit_read(_wait_list.front().permit)) == can_admit::yes) {
+    while (!_wait_list.empty() && (admit = can_admit_read(_wait_list.front().permit).decision) == can_admit::yes) {
         auto& x = _wait_list.front();
         try {
             x.permit.on_admission();

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -74,6 +74,18 @@ public:
         uint64_t reads_admitted = 0;
         // Total number of reads enqueued to wait for admission.
         uint64_t reads_enqueued = 0;
+        // Total number of reads admitted immediately, without queueing
+        uint64_t reads_admitted_immediately = 0;
+        // Total number of reads enqueued because ready_list wasn't empty
+        uint64_t reads_queued_because_ready_list = 0;
+        // Total number of reads enqueued because there are used but unblocked permits
+        uint64_t reads_queued_because_used_permits = 0;
+        // Total number of reads enqueued because there weren't enough memory resources
+        uint64_t reads_queued_because_memory_resources = 0;
+        // Total number of reads enqueued because there weren't enough count resources
+        uint64_t reads_queued_because_count_resources = 0;
+        // Total number of reads enqueued to be maybe admitted after evicting some inactive reads
+        uint64_t reads_queued_with_eviction = 0;
         // Total number of permits created so far.
         uint64_t total_permits = 0;
         // Current number of permits.

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -169,7 +169,7 @@ public:
     };
 
 private:
-    const resources _initial_resources;
+    resources _initial_resources;
     resources _resources;
 
     expiring_fifo<entry, expiry_handler, db::timeout_clock> _wait_list;
@@ -399,6 +399,12 @@ public:
     /// \ref obtain_permit(), then \ref with_ready_permit() is less
     /// optimal then just using \ref with_permit().
     future<> with_ready_permit(reader_permit permit, read_func func);
+
+    /// Set the total resources of the semaphore to \p r.
+    ///
+    /// After this call, \ref initial_resources() will reflect the new value.
+    /// Available resources will be adjusted by the delta.
+    void set_resources(resources r);
 
     const resources initial_resources() const {
         return _initial_resources;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -225,6 +225,8 @@ private:
     struct admit_result { can_admit decision; reason why; };
     admit_result can_admit_read(const reader_permit& permit) const noexcept;
 
+    bool should_evict_inactive_read() const noexcept;
+
     void maybe_admit_waiters() noexcept;
 
     void on_permit_created(reader_permit::impl&);

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -209,7 +209,9 @@ private:
     // A return value of can_admit::maybe means admission might be possible if
     // some of the inactive readers are evicted.
     enum class can_admit { no, maybe, yes };
-    can_admit can_admit_read(const reader_permit& permit) const noexcept;
+    enum class reason { all_ok = 0, ready_list, used_permits, memory_resources, count_resources };
+    struct admit_result { can_admit decision; reason why; };
+    admit_result can_admit_read(const reader_permit& permit) const noexcept;
 
     void maybe_admit_waiters() noexcept;
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1109,3 +1109,247 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_set_resources) {
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(4, 4 * 1024));
     permit3_fut.get();
 }
+
+// Check that inactive reads are not needlessly evicted when admission is not
+// blocked on resources.
+// This test covers all the cases where eviction should **not** happen.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicting) {
+    const auto initial_resources = reader_concurrency_semaphore::resources{2, 4 * 1024};
+    reader_concurrency_semaphore semaphore(initial_resources.count, initial_resources.memory, get_name(), 100);
+    auto stop_sem = deferred_stop(semaphore);
+
+    simple_schema ss;
+    auto s = ss.schema();
+
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+    // There are available resources
+    {
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 3 * 1024);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        semaphore.set_resources(initial_resources);
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        BOOST_REQUIRE(semaphore.unregister_inactive_read(std::move(handle)));
+    }
+
+    // Count resources are on the limit but no one wants more
+    {
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        semaphore.set_resources(initial_resources);
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        BOOST_REQUIRE(semaphore.unregister_inactive_read(std::move(handle)));
+    }
+
+    // Memory resources are on the limit but no one wants more
+    {
+        auto units = permit1.consume_memory(3 * 1024);
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+        BOOST_REQUIRE(semaphore.unregister_inactive_read(std::move(handle)));
+    }
+
+    // Up the resource count, we need more permits to check the rest of the scenarios
+    semaphore.set_resources({4, 4 * 1024});
+
+    // There are waiters but they are not blocked on resources
+    {
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+        auto permit3 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+        std::optional<reader_permit::used_guard> ug1{permit1};
+        std::optional<reader_permit::used_guard> ug2{permit2};
+
+        auto permit4_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout);
+        BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_used_permits, 1);
+
+        // First check the register path.
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit3));
+
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+        BOOST_REQUIRE_EQUAL(permit3.get_state(), reader_permit::state::inactive);
+
+        // Now check the callback admission path (admission check on resources being freed).
+        ug2.reset();
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+        BOOST_REQUIRE_EQUAL(permit3.get_state(), reader_permit::state::inactive);
+    }
+}
+
+// Check that inactive reads are evicted when they are blocking admission
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
+    const auto initial_resources = reader_concurrency_semaphore::resources{2, 4 * 1024};
+    reader_concurrency_semaphore semaphore(initial_resources.count, initial_resources.memory, get_name(), 100);
+    auto stop_sem = deferred_stop(semaphore);
+
+    simple_schema ss;
+    auto s = ss.schema();
+
+    uint64_t evicted_reads = 0;
+
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+    // No count resources - obtaining new permit
+    {
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+    }
+
+    BOOST_REQUIRE(permit1.needs_readmission());
+    permit1.wait_readmission().get();
+
+    // No count resources - waiter
+    {
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
+
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout);
+        BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+
+        new_permit_fut.get();
+    }
+
+    BOOST_REQUIRE(permit1.needs_readmission());
+    permit1.wait_readmission().get();
+
+    // No memory resources
+    {
+        auto units = permit1.consume_memory(3 * 1024);
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+    }
+
+    BOOST_REQUIRE(permit1.needs_readmission());
+    permit1.wait_readmission().get();
+
+    // No memory resources - waiter
+    {
+        auto units = permit1.consume_memory(3 * 1024);
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
+
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout);
+        BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+
+        new_permit_fut.get();
+    }
+
+    BOOST_REQUIRE(permit1.needs_readmission());
+    permit1.wait_readmission().get();
+
+    // No count resources - waiter blocked on something else too
+    {
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
+
+        std::optional<reader_permit::used_guard> ug{permit2};
+
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout);
+        BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        ug.reset();
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+
+        new_permit_fut.get();
+    }
+
+    BOOST_REQUIRE(permit1.needs_readmission());
+    permit1.wait_readmission().get();
+
+    // No memory resources - waiter blocked on something else too
+    {
+        semaphore.set_resources({initial_resources.count + 1, initial_resources.memory});
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout).get();
+        auto units = permit1.consume_memory(2 * 1024);
+
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
+        BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
+
+        std::optional<reader_permit::used_guard> ug{permit2};
+
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout);
+        BOOST_REQUIRE_EQUAL(semaphore.waiters(), 1);
+
+        auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s, permit1));
+        BOOST_REQUIRE(handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
+
+        ug.reset();
+        thread::yield(); // allow debug builds to schedule the fiber evicting the reads again
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
+
+        new_permit_fut.get();
+
+        semaphore.set_resources(initial_resources);
+    }
+}


### PR DESCRIPTION
The patch doesn't apply cleanly, so a targeted backport PR was necessary.
I also needed to cherry-pick two patches from https://github.com/scylladb/scylladb/pull/13255 that the backported patch depends on. Decided against backporting the entire https://github.com/scylladb/scylladb/pull/13255 as it is quite an intrusive change.

Fixes: https://github.com/scylladb/scylladb/issues/11803