### PR TITLE
scripts/open-coredump.sh: allow user to plug in scylla package

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -97,6 +97,20 @@ function log {
     fi
 }
 
+function get_json_field {
+    local json_obj=$1
+    local field_name=$2
+    local field_val=$(jq -r ".${field_name}" <<< "$json_obj")
+
+    if [[ -z $field_val ]]
+    then
+        echo "error: failed to get field '$field_name' from: $json_obj" >&2
+        exit 1
+    fi
+
+    echo $field_val
+}
+
 for required in eu-unstrip jq curl git; do
     if ! type $required >& /dev/null; then
         echo "error: missing required program $required, please install first" >&2
@@ -197,13 +211,13 @@ then
     exit 1
 fi
 
-RESPONSE_BUILD_ID=$(jq -r .build_id <<< $BUILD)
-VERSION=$(jq -r .version <<< $BUILD)
-PRODUCT=$(jq -r .product <<< $BUILD)
-RELEASE=$(jq -r .release <<< $BUILD)
-ARCH=$(jq -r .arch <<< $BUILD)
-BUILD_MODE=$(jq -r .build_mode <<< $BUILD)
-PACKAGE_URL=$(jq -r .package_url <<< $BUILD)
+RESPONSE_BUILD_ID=$(get_json_field "$BUILD" "build_id")
+VERSION=$(get_json_field "$BUILD" "version")
+PRODUCT=$(get_json_field "$BUILD" "product")
+RELEASE=$(get_json_field "$BUILD" "release")
+ARCH=$(get_json_field "$BUILD" "arch")
+BUILD_MODE=$(get_json_field "$BUILD" "build_mode")
+PACKAGE_URL=$(get_json_field "$BUILD" "package_url")
 
 if [[ "$RESPONSE_BUILD_ID" != "$BUILD_ID" ]]
 then

--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -99,7 +99,7 @@ function log {
 
 for required in eu-unstrip jq curl git; do
     if ! type $required >& /dev/null; then
-        echo "error: missing required program $required, please install first"
+        echo "error: missing required program $required, please install first" >&2
         exit 1
     fi
 done
@@ -142,7 +142,7 @@ do
             shift 2
             ;;
         *)
-            echo "unrecognized option: $1, see $0 -h for usage"
+            echo "error: unrecognized option: $1, see $0 -h for usage" >&2
             exit 1
             ;;
     esac
@@ -152,7 +152,7 @@ COREFILE=$1
 shift 1
 if ! [[ -f $COREFILE ]]
 then
-    echo "error: ${COREFILE} is not a valid path to a core file"
+    echo "error: ${COREFILE} is not a valid path to a core file" >&2
     exit 1
 fi
 COREDIR=$(dirname ${COREFILE})
@@ -180,7 +180,7 @@ case "${SCYLLA_GDB_PY_SOURCE}" in
     ("repo"|"package"|"none")
         ;;
     *)
-        echo "error: invalid value for option SCYLLA_GDB_PY_SOURCE, has to be one of repo, package or none, got: ${SCYLLA_GDB_PY_SOURCE}"
+        echo "error: invalid value for option SCYLLA_GDB_PY_SOURCE, has to be one of repo, package or none, got: ${SCYLLA_GDB_PY_SOURCE}" >&2
         exit 1
         ;;
 esac
@@ -193,7 +193,7 @@ BUILD=$(curl -s -X GET "${SCYLLA_S3_RELOC_SERVER_URL}/build.json?build_id=${BUIL
 
 if [[ -z "$BUILD" ]]
 then
-    echo "Failed to retrieve build information from ${SCYLLA_S3_RELOC_SERVER_URL}"
+    echo "error: failed to retrieve build information from ${SCYLLA_S3_RELOC_SERVER_URL}" >&2
     exit 1
 fi
 
@@ -207,7 +207,7 @@ PACKAGE_URL=$(jq -r .package_url <<< $BUILD)
 
 if [[ "$RESPONSE_BUILD_ID" != "$BUILD_ID" ]]
 then
-    echo "Mismatching build id: requested ${BUILD_ID} but got ${RESPONSE_BUILD_ID}";
+    echo "error: mismatching build id: requested ${BUILD_ID} but got ${RESPONSE_BUILD_ID}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Lately we have observed that some builds are missing the package_url in the build metadata. This is usually caused by changes in how build metadata is stored on the servers and the s3 reloc server failing to dig them out of the metadata files. A user can usually still obtain the package url but currently there is no way to plug in user-obtained scylla package into the script's workflow.
This PR fixes this by allowing the user to provide the package as `$ARTIFACT_DIR/scylla.package` (in unpacked form).