### PR TITLE
raft topology: store `shard_count` and `ignore_msb` in topology

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -467,6 +467,9 @@ public:
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);
 
+    future<bool> get_must_synchronize_topology();
+    future<> set_must_synchronize_topology(bool);
+
     system_keyspace(sharded<cql3::query_processor>& qp, sharded<replica::database>& db) noexcept;
     ~system_keyspace();
     future<> start(const locator::snitch_ptr&);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -992,7 +992,9 @@ future<> storage_service::raft_bootstrap(raft::server& raft_server) {
                .set("rack", _snitch.local()->get_rack())
                .set("release_version", version::release())
                .set("topology_request", topology_request::join)
-               .set("num_tokens", _db.local().get_config().num_tokens());
+               .set("num_tokens", _db.local().get_config().num_tokens())
+               .set("shard_count", smp::count)
+               .set("ignore_msb", _db.local().get_config().murmur3_partitioner_ignore_msb_bits());
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, "bootstrap: add myself to topology");
         try {
@@ -1001,6 +1003,70 @@ future<> storage_service::raft_bootstrap(raft::server& raft_server) {
             slogger.info("raft topology: bootstrap: concurrent operation is detected, retrying.");
         }
     }
+}
+
+future<> storage_service::update_topology_with_local_metadata(raft::server& raft_server) {
+    // TODO: include more metadata here
+    auto local_shard_count = smp::count;
+    auto local_ignore_msb = _db.local().get_config().murmur3_partitioner_ignore_msb_bits();
+
+    auto synchronized = [&] () {
+        auto it = _topology_state_machine._topology.find(raft_server.id());
+        if (!it) {
+            throw std::runtime_error{"Removed from topology while performing metadata update"};
+        }
+
+        auto& replica_state = it->second;
+
+        return replica_state.shard_count == local_shard_count
+            && replica_state.ignore_msb == local_ignore_msb;
+    };
+
+    // We avoid performing a read barrier if we're sure that our metadata stored in topology
+    // is the same as local metadata. Note that only we can update our metadata, other nodes cannot.
+    //
+    // We use a persisted flag `must_update_topology` to avoid the following scenario:
+    // 1. the node restarts and its metadata changes
+    // 2. the node commits the new metadata to topology, but before the update is applied
+    //    to the local state machine, the node crashes
+    // 3. then the metadata changes back to old values and node restarts again
+    // 4. the local state machine tells us that we're in sync, which is wrong
+    // If the persisted flag is true, it tells us that we attempted a metadata change earlier,
+    // forcing us to perform a read barrier even when the local state machine tells us we're in sync.
+
+    if (synchronized() && !(co_await _sys_ks.local().get_must_synchronize_topology())) {
+        co_return;
+    }
+
+    while (true) {
+        slogger.info("raft topology: refreshing topology to check if it's synchronized with local metadata");
+
+        auto guard = co_await _group0->client().start_operation(&_abort_source);
+
+        if (synchronized()) {
+            break;
+        }
+
+        slogger.info("raft topology: updating topology with local metadata");
+
+        co_await _sys_ks.local().set_must_synchronize_topology(true);
+
+        topology_mutation_builder builder(guard.write_timestamp(), raft_server.id());
+        builder.set("shard_count", local_shard_count)
+               .set("ignore_msb", local_ignore_msb);
+        topology_change change{{builder.build()}};
+        group0_command g0_cmd = _group0->client().prepare_command(
+                std::move(change), guard, format("{}: update topology with local metadata", raft_server.id()));
+
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_abort_source);
+        } catch (group0_concurrent_modification&) {
+            slogger.info("raft topology: update topology with local metadata:"
+                         " concurrent operation is detected, retrying.");
+        }
+    }
+
+    co_await _sys_ks.local().set_must_synchronize_topology(false);
 }
 
 future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_service,
@@ -1231,6 +1297,8 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         if (_topology_state_machine._topology.left_nodes.contains(raft_server->id())) {
             throw std::runtime_error("A node that already left the cluster cannot be restarted");
         }
+
+        co_await update_topology_with_local_metadata(*raft_server);
 
         // Node state is enough to know that bootstrap has completed, but to make legacy code happy
         // let it know that the bootstrap is completed as well

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -789,6 +789,7 @@ private:
     future<> raft_removenode(locator::host_id host_id);
     future<> raft_replace(raft::server&, raft::server_id, gms::inet_address);
     future<> raft_rebuild(sstring source_dc);
+    future<> update_topology_with_local_metadata(raft::server&);
 
     // This is called on all nodes for each new command received through raft
     future<> topology_transition(storage_proxy& proxy, gms::inet_address, std::vector<canonical_mutation>);

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -63,6 +63,8 @@ struct replica_state {
     seastar::sstring rack;
     seastar::sstring release_version;
     std::optional<ring_slice> ring; // if engaged contain the set of tokens the node owns together with their state
+    size_t shard_count;
+    uint8_t ignore_msb;
 };
 
 struct topology {


### PR DESCRIPTION
Add new columns to the `system.topology` table: `shard_count` and `ignore_msb`. When a node bootstraps or restarts and observes that the values stored in `topology` are different than the local values, it updates them. This is done in the `update_topology_with_local_metadata` function (the 'metadata' here being the two values).

Additional flag persisted in `system.scylla_local` is used to safely avoid performing read barriers when the values didn't change on node restart. A comment in `update_topology_with_local_metadata` explains why this flag is needed.

An example use case where `shard_count` and `ignore_msb` are needed is creating CDC generations.

Fixes: #13508