### PR TITLE
Remove visible :orphan: in scylla.yaml documentation

### DIFF
--- a/docs/operating-scylla/scylla-yaml.inc
+++ b/docs/operating-scylla/scylla-yaml.inc
@@ -1,5 +1,3 @@
-:orphan:
-
 scylla.yaml
 ===========
 


### PR DESCRIPTION
The text `:orphan:` was showing up in the scylla.yaml documentation with no context.