### PR TITLE
sstables: filesystem_storage::change_state: quote destination in log message

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2342,7 +2342,7 @@ future<> sstable::filesystem_storage::change_state(const sstable& sst, sstring t
         co_return; // Already there
     }
 
-    sstlog.info("Moving sstable {} to {} in {}", sst.get_filename(), to, path);
+    sstlog.info("Moving sstable {} to {}", sst.get_filename(), path);
     co_await move(sst, path.native(), std::move(new_generation), delay_commit);
 }
 


### PR DESCRIPTION
When moving to the base directory, the printout currently looks broken:
```
INFO  2023-04-16 09:15:58,631 [shard 0] sstable - Moving sstable .../data/ks/cf-4c1bb670dc3711ed96733daf102e4aab/upload/md-1-big-Data.db to  in ".../data/ks/cf-4c1bb670dc3711ed96733daf102e4aab/"
```