### PR TITLE
Restrict logging of current_backtrace to log_level

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -909,19 +909,25 @@ read_keyspace_mutation(distributed<service::storage_proxy>& proxy, const sstring
 static thread_local semaphore the_merge_lock {1};
 
 future<> merge_lock() {
-    slogger.trace("merge_lock at {}", current_backtrace());
+    if (slogger.is_enabled(log_level::trace)) {
+        slogger.trace("merge_lock at {}", current_backtrace());
+    }
     return smp::submit_to(0, [] { return the_merge_lock.wait(); });
 }
 
 future<> merge_unlock() {
-    slogger.trace("merge_unlock at {}", current_backtrace());
+    if (slogger.is_enabled(log_level::trace)) {
+        slogger.trace("merge_unlock at {}", current_backtrace());
+    }
     return smp::submit_to(0, [] { the_merge_lock.signal(); });
 }
 
 future<semaphore_units<>> hold_merge_lock() noexcept {
     assert(this_shard_id() == 0);
 
-    slogger.trace("hold_merge_lock at {}", current_backtrace());
+    if (slogger.is_enabled(log_level::trace)) {
+        slogger.trace("hold_merge_lock at {}", current_backtrace());
+    }
     return get_units(the_merge_lock, 1);
 }
 

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -159,7 +159,9 @@ const node* topology::add_node(node_holder nptr) {
     nptr->set_idx(_nodes.size());
     _nodes.emplace_back(std::move(nptr));
 
-    tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    if (tlogger.is_enabled(log_level::debug)) {
+        tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    }
 
     try {
         index_node(node);
@@ -171,13 +173,15 @@ const node* topology::add_node(node_holder nptr) {
 }
 
 const node* topology::update_node(node* node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st) {
-    tlogger.debug("topology[{}]: update_node: {}: to: host_id={} endpoint={} dc={} rack={} state={}, at {}", fmt::ptr(this), debug_format(node),
+    if (tlogger.is_enabled(log_level::debug)) {
+        tlogger.debug("topology[{}]: update_node: {}: to: host_id={} endpoint={} dc={} rack={} state={}, at {}", fmt::ptr(this), debug_format(node),
             opt_id ? format("{}", *opt_id) : "unchanged",
             opt_ep ? format("{}", *opt_ep) : "unchanged",
             opt_dr ? format("{}", opt_dr->dc) : "unchanged",
             opt_dr ? format("{}", opt_dr->rack) : "unchanged",
             opt_st ? format("{}", *opt_st) : "unchanged",
             current_backtrace());
+    }
 
     bool changed = false;
     if (opt_id) {
@@ -270,7 +274,9 @@ void topology::remove_node(const node* node) {
 }
 
 void topology::index_node(const node* node) {
-    tlogger.trace("topology[{}]: index_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    if (tlogger.is_enabled(log_level::trace)) {
+        tlogger.trace("topology[{}]: index_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    }
 
     if (node->idx() < 0) {
         on_internal_error(tlogger, format("topology[{}]: {}: must already have a valid idx", fmt::ptr(this), debug_format(node)));
@@ -314,7 +320,9 @@ void topology::index_node(const node* node) {
 }
 
 void topology::unindex_node(const node* node) {
-    tlogger.trace("topology[{}]: unindex_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    if (tlogger.is_enabled(log_level::trace)) {
+        tlogger.trace("topology[{}]: unindex_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    }
 
     const auto& dc = node->dc_rack().dc;
     const auto& rack = node->dc_rack().rack;
@@ -359,7 +367,9 @@ void topology::unindex_node(const node* node) {
 }
 
 node_holder topology::pop_node(const node* node) {
-    tlogger.trace("topology[{}]: pop_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    if (tlogger.is_enabled(log_level::trace)) {
+        tlogger.trace("topology[{}]: pop_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+    }
 
     unindex_node(node);
 
@@ -410,9 +420,11 @@ const node* topology::find_node(node::idx_type idx) const noexcept {
 
 const node* topology::add_or_update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st)
 {
-    tlogger.trace("topology[{}]: add_or_update_endpoint: ep={} host_id={} dc={} rack={} state={}, at {}", fmt::ptr(this),
+    if (tlogger.is_enabled(log_level::trace)) {
+        tlogger.trace("topology[{}]: add_or_update_endpoint: ep={} host_id={} dc={} rack={} state={}, at {}", fmt::ptr(this),
             ep, opt_id.value_or(host_id::create_null_id()), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack, opt_st.value_or(node::state::none),
             current_backtrace());
+    }
     auto n = find_node(ep);
     if (n) {
         return update_node(make_mutable(n), opt_id, std::nullopt, std::move(opt_dr), std::move(opt_st));


### PR DESCRIPTION
`seastar::current_backtrace()` can be quite heavey.
When we pass it to a log message in relatively detailed log_level
(debug/trace), we pay the price of `current_backtrace` every time,
but we rarely print the message.