### PR TITLE
treewide: stop using 'using namespace std' in namespace scope

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -24,7 +24,6 @@ extern logging::logger apilog;
 namespace api {
 using namespace httpd;
 
-using namespace std;
 using namespace json;
 namespace cf = httpd::column_family_json;
 
@@ -56,7 +55,7 @@ const table_id& get_uuid(const sstring& name, const replica::database& db) {
     return get_uuid(ks, cf, db);
 }
 
-future<> foreach_column_family(http_context& ctx, const sstring& name, function<void(replica::column_family&)> f) {
+future<> foreach_column_family(http_context& ctx, const sstring& name, std::function<void(replica::column_family&)> f) {
     auto uuid = get_uuid(name, ctx.db.local());
 
     return ctx.db.invoke_on_all([f, uuid](replica::database& db) {
@@ -305,7 +304,7 @@ ratio_holder filter_recent_false_positive_as_ratio_holder(const sstables::shared
 
 void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace>& sys_ks) {
     cf::get_column_family_name.set(r, [&ctx] (const_req req){
-        vector<sstring> res;
+        std::vector<sstring> res;
         for (auto i: ctx.db.local().get_column_families_mapping()) {
             res.push_back(i.first.first + ":" + i.first.second);
         }
@@ -325,7 +324,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
 
     cf::get_column_family_name_keyspace.set(r, [&ctx] (const_req req){
-        vector<sstring> res;
+        std::vector<sstring> res;
         for (auto i = ctx.db.local().get_keyspaces().cbegin(); i!=  ctx.db.local().get_keyspaces().cend(); i++) {
             res.push_back(i->first);
         }

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -17,7 +17,6 @@
 
 #include "db/data_listeners.hh"
 
-using namespace std;
 using namespace std::chrono_literals;
 
 class table_listener : public db::data_listener {

--- a/test/boost/map_difference_test.cc
+++ b/test/boost/map_difference_test.cc
@@ -15,7 +15,8 @@
 #include <map>
 #include <set>
 
-using namespace std;
+using std::map;
+using std::set;
 
 BOOST_AUTO_TEST_CASE(both_empty) {
     map<int, int> left;

--- a/test/boost/top_k_test.cc
+++ b/test/boost/top_k_test.cc
@@ -13,18 +13,16 @@
 #include <vector>
 #include <algorithm>
 
-using namespace std;
-
 //---------------------------------------------------------------------------------------------
 
 using top_k_t = utils::space_saving_top_k<unsigned>;
 using results_t = top_k_t::results;
 
 // a permutation of 1..17
-vector<unsigned> freq{13, 8, 12, 4, 11, 2, 15, 1, 5, 3, 16, 7, 6, 9, 14, 10, 17};
+std::vector<unsigned> freq{13, 8, 12, 4, 11, 2, 15, 1, 5, 3, 16, 7, 6, 9, 14, 10, 17};
 
 // expected results
-vector<unsigned> exp_results(unsigned k = 10) {
+std::vector<unsigned> exp_results(unsigned k = 10) {
     auto v = freq;
     std::sort(v.begin(), v.end(), std::greater<unsigned>());
     v.resize(k);
@@ -32,8 +30,8 @@ vector<unsigned> exp_results(unsigned k = 10) {
 }
 
 
-vector<unsigned> count(const utils::space_saving_top_k<unsigned>::results& res) {
-    vector<unsigned> v;
+std::vector<unsigned> count(const utils::space_saving_top_k<unsigned>::results& res) {
+    std::vector<unsigned> v;
     for (auto& c : res) {
         v.push_back(c.count);
     }
@@ -52,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_top_k_straight_insertion) {
         }
     }
 
-    vector<unsigned> res = count(top.top(10));
+    std::vector<unsigned> res = count(top.top(10));
     BOOST_REQUIRE_EQUAL(res, exp_results());
 }
 
@@ -103,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_top_k_single_value) {
     }
 
     auto res{count(top.top(10))};
-    BOOST_REQUIRE_EQUAL(res, (vector<unsigned>{100}));
+    BOOST_REQUIRE_EQUAL(res, (std::vector<unsigned>{100}));
 }
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Such namespace-wide imports can create conflicts between names that are the same in seastar and std, such as {std,seastar}::future and {std,seastar}::format, since we also have 'using namespace seastar'.

Replace the namespace imports with explicit qualification, or with specific name imports.