### PR TITLE
utils: add basic_xx_hasher

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -17,7 +17,7 @@
 #include <functional>
 #include <compare>
 #include "utils/mutable_view.hh"
-#include <xxhash.h>
+#include "utils/simple_hashers.hh"
 
 using bytes = basic_sstring<int8_t, uint32_t, 31, false>;
 using bytes_view = std::basic_string_view<int8_t>;
@@ -160,18 +160,7 @@ struct appending_hash<bytes_view> {
     }
 };
 
-struct bytes_view_hasher : public hasher {
-    XXH64_state_t _state;
-    bytes_view_hasher(uint64_t seed = 0) noexcept {
-        XXH64_reset(&_state, seed);
-    }
-    void update(const char* ptr, size_t length) noexcept {
-        XXH64_update(&_state, ptr, length);
-    }
-    size_t finalize() {
-        return static_cast<size_t>(XXH64_digest(&_state));
-    }
-};
+using bytes_view_hasher = simple_xx_hasher;
 
 namespace std {
 template <>

--- a/test/boost/hashers_test.cc
+++ b/test/boost/hashers_test.cc
@@ -13,6 +13,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "utils/hashers.hh"
 #include "utils/xx_hasher.hh"
+#include "utils/simple_hashers.hh"
 #include "gc_clock.hh"
 #include "test/lib/simple_schema.hh"
 #include "reader_concurrency_semaphore.hh"
@@ -101,4 +102,18 @@ SEASTAR_THREAD_TEST_CASE(mutation_fragment_sanity_check) {
         mutation_fragment f(*s.schema(), permit, s.make_range_tombstone(query::clustering_range::make(s.make_ckey(2), s.make_ckey(3)), ts));
         check_hash(f, 0x5092daca1b27ea26ull);
     }
+}
+
+BOOST_AUTO_TEST_CASE(basic_xx_hasher_sanity_check) {
+    simple_xx_hasher hasher1;
+    hasher1.update(reinterpret_cast<const char*>(std::data(text_part1)), std::size(text_part1));
+    hasher1.update(reinterpret_cast<const char*>(std::data(text_part2)), std::size(text_part2));
+    auto hash1 = hasher1.finalize();
+
+    bytes_view_hasher hasher2;
+    hasher2.update(reinterpret_cast<const char*>(std::data(text_part1)), std::size(text_part1));
+    hasher2.update(reinterpret_cast<const char*>(std::data(text_part2)), std::size(text_part2));
+    auto hash2 = hasher2.finalize();
+
+    BOOST_CHECK_EQUAL(hash1, hash2);
 }

--- a/utils/hashers.cc
+++ b/utils/hashers.cc
@@ -12,6 +12,8 @@
 #include <cryptopp/md5.h>
 #include <cryptopp/sha.h>
 
+static_assert(Hasher<hasher>);
+
 template <typename T> struct hasher_traits;
 template <> struct hasher_traits<md5_hasher> { using impl_type = CryptoPP::Weak::MD5; };
 template <> struct hasher_traits<sha256_hasher> { using impl_type = CryptoPP::SHA256; };

--- a/utils/hashers.cc
+++ b/utils/hashers.cc
@@ -8,6 +8,7 @@
 
 #include "utils/hashers.hh"
 #include "utils/xx_hasher.hh"
+#include "utils/simple_hashers.hh"
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
 #include <cryptopp/md5.h>
@@ -18,6 +19,8 @@ static_assert(Hasher<hasher>);
 static_assert(HasherReturningBytes<md5_hasher>);
 static_assert(HasherReturningBytes<sha256_hasher>);
 static_assert(HasherReturningBytes<xx_hasher>);
+
+static_assert(SimpleHasher<simple_xx_hasher>);
 
 template <typename T> struct hasher_traits;
 template <> struct hasher_traits<md5_hasher> { using impl_type = CryptoPP::Weak::MD5; };

--- a/utils/hashers.cc
+++ b/utils/hashers.cc
@@ -7,12 +7,17 @@
  */
 
 #include "utils/hashers.hh"
+#include "utils/xx_hasher.hh"
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
 #include <cryptopp/md5.h>
 #include <cryptopp/sha.h>
 
 static_assert(Hasher<hasher>);
+
+static_assert(HasherReturningBytes<md5_hasher>);
+static_assert(HasherReturningBytes<sha256_hasher>);
+static_assert(HasherReturningBytes<xx_hasher>);
 
 template <typename T> struct hasher_traits;
 template <> struct hasher_traits<md5_hasher> { using impl_type = CryptoPP::Weak::MD5; };

--- a/utils/hashers.hh
+++ b/utils/hashers.hh
@@ -11,6 +11,9 @@
 #include "bytes.hh"
 #include "utils/hashing.hh"
 
+template<typename H>
+concept HasherReturningBytes = HasherReturning<H, bytes>;
+
 class md5_hasher;
 
 template <typename T, size_t size> class cryptopp_hasher : public hasher {

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -41,8 +41,6 @@ public:
     virtual void update(const char* ptr, size_t size) noexcept = 0;
 };
 
-static_assert(Hasher<hasher>);
-
 template<typename T>
 struct appending_hash;
 

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -35,6 +35,12 @@ concept Hasher =
         { h.update(ptr, size) } noexcept -> std::same_as<void>;
     };
 
+template<typename H, typename ValueType>
+concept HasherReturning = Hasher<H> &&
+    requires (H& h) {
+        { h.finalize() } -> std::convertible_to<ValueType>;
+    };
+
 class hasher {
 public:
     virtual ~hasher() = default;

--- a/utils/simple_hashers.hh
+++ b/utils/simple_hashers.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include <xxhash.h>
+#pragma GCC diagnostic pop
+
+#include "utils/hashing.hh"
+
+template<typename H>
+concept SimpleHasher = HasherReturning<H, size_t>;
+
+struct simple_xx_hasher : public hasher {
+    XXH64_state_t _state;
+    simple_xx_hasher(uint64_t seed = 0) noexcept {
+        XXH64_reset(&_state, seed);
+    }
+    void update(const char* ptr, size_t length) noexcept override {
+        XXH64_update(&_state, ptr, length);
+    }
+    size_t finalize() {
+        return static_cast<size_t>(XXH64_digest(&_state));
+    }
+};


### PR DESCRIPTION
Consolidate `bytes_view_hasher` and abstract_replication_strategy `factory_key_hasher` which are the same into a reusable utils::basic_xx_hasher.

To be used in a followup series for netw:msg_addr.
