### PR TITLE
Add host_id to netw::msg_addr

### DIFF
--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -62,15 +62,11 @@ public:
         return addr().as_ipv4_address().ip;
     }
     sstring to_sstring() const;
-    friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept {
-        return x._addr == y._addr;
+    bool operator==(const inet_address& x) const noexcept {
+        return _addr == x._addr;
     }
-    friend inline bool operator!=(const inet_address& x, const inet_address& y) noexcept {
-        using namespace std::rel_ops;
-        return x._addr != y._addr;
-    }
-    friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
-        return x.bytes() < y.bytes();
+    auto operator<=>(const inet_address& x) const noexcept {
+        return bytes() <=> x.bytes();
     }
     friend struct std::hash<inet_address>;
 

--- a/main.cc
+++ b/main.cc
@@ -1159,6 +1159,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return sys_ks.start(snitch.local());
             }).get();
             cfg->host_id = sys_ks.local().load_local_host_id().get0();
+            utils::fb_utilities::set_host_id(cfg->host_id);
             shared_token_metadata::mutate_on_all_shards(token_metadata, [hostid = cfg->host_id, endpoint = utils::fb_utilities::get_broadcast_address()] (locator::token_metadata& tm) {
                 tm.get_topology().add_or_update_endpoint(endpoint, hostid);
                 return make_ready_future<>();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -167,11 +167,6 @@ std::ostream& operator<<(std::ostream& os, const msg_addr& x) {
     return os;
 }
 
-size_t msg_addr::hash::operator()(const msg_addr& id) const noexcept {
-    // Ignore cpu id for now since we do not really support // shard to shard connections
-    return std::hash<bytes_view>()(id.addr.bytes());
-}
-
 messaging_service::shard_info::shard_info(shared_ptr<rpc_protocol_client_wrapper>&& client, bool topo_ignored)
     : rpc_client(std::move(client))
     , topology_ignored(topo_ignored)

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -148,18 +148,9 @@ const size_t PER_SHARD_CONNECTION_COUNT = 2;
 // Counts per tenant connection types
 const size_t PER_TENANT_CONNECTION_COUNT = 3;
 
-bool operator==(const msg_addr& x, const msg_addr& y) noexcept {
+bool msg_addr::legacy_equal_to::operator()(const msg_addr& x, const msg_addr& y) const noexcept {
     // Ignore cpu id for now since we do not really support shard to shard connections
-    return x.addr == y.addr;
-}
-
-bool operator<(const msg_addr& x, const msg_addr& y) noexcept {
-    // Ignore cpu id for now since we do not really support shard to shard connections
-    if (x.addr < y.addr) {
-        return true;
-    } else {
-        return false;
-    }
+    return x.addr == y.addr && x.host_id == y.host_id;
 }
 
 std::ostream& operator<<(std::ostream& os, const msg_addr& x) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -163,7 +163,7 @@ bool operator<(const msg_addr& x, const msg_addr& y) noexcept {
 }
 
 std::ostream& operator<<(std::ostream& os, const msg_addr& x) {
-    fmt::print(os, "{}:{}", x.addr, x.cpu_id);
+    fmt::print(os, "{}", x);
     return os;
 }
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -219,7 +219,7 @@ public:
 
     using msg_addr = netw::msg_addr;
     using inet_address = gms::inet_address;
-    using clients_map = std::unordered_map<msg_addr, shard_info, msg_addr::hash>;
+    using clients_map = std::unordered_map<msg_addr, shard_info, std::hash<msg_addr>>;
 
     // This should change only if serialization format changes
     static constexpr int32_t current_version = 0;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -219,7 +219,7 @@ public:
 
     using msg_addr = netw::msg_addr;
     using inet_address = gms::inet_address;
-    using clients_map = std::unordered_map<msg_addr, shard_info, std::hash<msg_addr>>;
+    using clients_map = std::unordered_map<msg_addr, shard_info, std::hash<msg_addr>, msg_addr::legacy_equal_to>;
 
     // This should change only if serialization format changes
     static constexpr int32_t current_version = 0;

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -10,18 +10,42 @@
 
 #include "gms/inet_address.hh"
 #include <cstdint>
+#include "locator/host_id.hh"
 
 namespace netw {
 
 struct msg_addr {
     gms::inet_address addr;
     uint32_t cpu_id;
-    friend bool operator==(const msg_addr& x, const msg_addr& y) noexcept;
-    friend bool operator<(const msg_addr& x, const msg_addr& y) noexcept;
+    locator::host_id host_id;
+
+    msg_addr(gms::inet_address ip, uint32_t cpu = 0, locator::host_id host_id = locator::host_id::create_null_id()) noexcept
+        : addr(ip)
+        , cpu_id(cpu)
+        , host_id(host_id)
+    {}
+
+    msg_addr(gms::inet_address ip, locator::host_id host_id) noexcept : msg_addr(ip, 0, std::move(host_id)) {}
+
+    bool operator==(const msg_addr& x) const noexcept {
+        // Ignore cpu id for now since we do not really support shard to shard connections
+        return addr == x.addr && host_id == x.host_id;
+    }
+
+    auto operator<=>(const msg_addr& x) const noexcept {
+        // Ignore cpu id for now since we do not really support shard to shard connections
+        auto ret = addr <=> x.addr;
+        if (ret != 0) {
+            return ret;
+        }
+        return host_id <=> x.host_id;
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const msg_addr& x);
 
-    explicit msg_addr(gms::inet_address ip) noexcept : addr(ip), cpu_id(0) { }
-    msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
+    struct legacy_equal_to {
+        bool operator()(const msg_addr& x, const msg_addr& y) const noexcept;
+    };
 };
 
 std::ostream& operator<<(std::ostream& os, const netw::msg_addr& x);
@@ -34,7 +58,7 @@ template <>
 struct formatter<netw::msg_addr> : formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const netw::msg_addr& id, FormatContext& ctx) const {
-        return format_to(ctx.out(), "{}#{}", id.addr, id.cpu_id);
+        return format_to(ctx.out(), "{}/{}#{}", id.host_id, id.addr, id.cpu_id);
     }
 };
 
@@ -46,6 +70,7 @@ template <>
 struct hash<netw::msg_addr> {
     size_t operator()(const netw::msg_addr& id) const noexcept {
         // Ignore cpu id for now since we do not really support // shard to shard connections
+        // Ignore host_id for hashing since msg_addr with same address but different host_id should be rare.
         return std::hash<bytes_view>()(id.addr.bytes());
     }
 };

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -19,9 +19,7 @@ struct msg_addr {
     friend bool operator==(const msg_addr& x, const msg_addr& y) noexcept;
     friend bool operator<(const msg_addr& x, const msg_addr& y) noexcept;
     friend std::ostream& operator<<(std::ostream& os, const msg_addr& x);
-    struct hash {
-        size_t operator()(const msg_addr& id) const noexcept;
-    };
+
     explicit msg_addr(gms::inet_address ip) noexcept : addr(ip), cpu_id(0) { }
     msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
 };
@@ -41,3 +39,15 @@ struct formatter<netw::msg_addr> : formatter<std::string_view> {
 };
 
 } // namespace fmt
+
+namespace std {
+
+template <>
+struct hash<netw::msg_addr> {
+    size_t operator()(const netw::msg_addr& id) const noexcept {
+        // Ignore cpu id for now since we do not really support // shard to shard connections
+        return std::hash<bytes_view>()(id.addr.bytes());
+    }
+};
+
+} // namespace std

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -19,7 +19,13 @@ struct msg_addr {
     uint32_t cpu_id;
     locator::host_id host_id;
 
-    msg_addr(gms::inet_address ip, uint32_t cpu = 0, locator::host_id host_id = locator::host_id::create_null_id()) noexcept
+    explicit msg_addr(gms::inet_address ip) noexcept
+        : addr(ip)
+        , cpu_id(0)
+        , host_id(locator::host_id::create_null_id())
+    {}
+
+    msg_addr(gms::inet_address ip, uint32_t cpu, locator::host_id host_id = locator::host_id::create_null_id()) noexcept
         : addr(ip)
         , cpu_id(cpu)
         , host_id(host_id)

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -36,7 +36,7 @@ template <>
 struct formatter<netw::msg_addr> : formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const netw::msg_addr& id, FormatContext& ctx) const {
-        return format_to(ctx.out(), "{}.{}", id.addr, id.cpu_id);
+        return format_to(ctx.out(), "{}#{}", id.addr, id.cpu_id);
     }
 };
 

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -26,4 +26,18 @@ struct msg_addr {
     msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
 };
 
-}
+std::ostream& operator<<(std::ostream& os, const netw::msg_addr& x);
+
+} // namespace netw
+
+namespace fmt {
+
+template <>
+struct formatter<netw::msg_addr> : formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const netw::msg_addr& id, FormatContext& ctx) const {
+        return format_to(ctx.out(), "{}.{}", id.addr, id.cpu_id);
+    }
+};
+
+} // namespace fmt

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -59,7 +59,7 @@ class migration_manager : public seastar::async_sharded_service<migration_manage
 private:
     migration_notifier& _notifier;
 
-    std::unordered_map<netw::msg_addr, serialized_action> _schema_pulls;
+    std::unordered_map<netw::msg_addr, serialized_action, std::hash<netw::msg_addr>, netw::msg_addr::legacy_equal_to> _schema_pulls;
     std::vector<gms::feature::listener_registration> _feature_listeners;
     seastar::gate _background_tasks;
     static const std::chrono::milliseconds migration_delay;

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -59,7 +59,7 @@ class migration_manager : public seastar::async_sharded_service<migration_manage
 private:
     migration_notifier& _notifier;
 
-    std::unordered_map<netw::msg_addr, serialized_action, netw::msg_addr::hash> _schema_pulls;
+    std::unordered_map<netw::msg_addr, serialized_action> _schema_pulls;
     std::vector<gms::feature::listener_registration> _feature_listeners;
     seastar::gate _background_tasks;
     static const std::chrono::milliseconds migration_delay;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -143,7 +143,7 @@ private:
     seastar::condition_variable _node_ops_abort_cond;
     named_semaphore _node_ops_abort_sem{1, named_semaphore_exception_factory{"node_ops_abort_sem"}};
     future<> _node_ops_abort_thread;
-    void node_ops_insert(node_ops_id, gms::inet_address coordinator, std::list<inet_address> ignore_nodes,
+    void node_ops_insert(node_ops_id, netw::msg_addr coordinator, std::list<inet_address> ignore_nodes,
                          std::function<future<>()> abort_func);
     future<> node_ops_update_heartbeat(node_ops_id ops_uuid);
     future<> node_ops_done(node_ops_id ops_uuid);
@@ -691,8 +691,8 @@ public:
      * @param hostIdString token for the node
      */
     future<> removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes);
-    future<node_ops_cmd_response> node_ops_cmd_handler(gms::inet_address coordinator, node_ops_cmd_request req);
-    void node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req);
+    future<node_ops_cmd_response> node_ops_cmd_handler(netw::msg_addr coordinator, node_ops_cmd_request req);
+    void node_ops_cmd_check(const netw::msg_addr&, const node_ops_cmd_request& req);
     future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
     void on_node_ops_registered(node_ops_id);
 

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -34,6 +34,7 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     engine().set_strict_dma(false);
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -190,6 +190,7 @@ locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
 void simple_test() {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     // Create the RackInferringSnitch
     snitch_config cfg;
@@ -200,7 +201,7 @@ void simple_test() {
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
-    tm_cfg.topo_cfg.this_host_id = host_id::create_random_id();
+    tm_cfg.topo_cfg.this_host_id = utils::fb_utilities::get_host_id();
     tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -273,6 +274,7 @@ void simple_test() {
 void heavy_origin_test() {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     // Create the RackInferringSnitch
     snitch_config cfg;
@@ -560,13 +562,15 @@ void generate_topology(topology& topo, const std::unordered_map<sstring, size_t>
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo.add_node(host_id::create_random_id(), node, {dc, to_sstring(r)}, locator::node::state::normal);
+        auto host_id = node == gms::inet_address("localhost") ? utils::fb_utilities::get_host_id() : host_id::create_random_id();
+        topo.add_node(host_id, node, {dc, to_sstring(r)}, locator::node::state::normal);
     }
 }
 
 SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     constexpr size_t NODES = 100;
     constexpr size_t VNODES = 64;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -522,6 +522,7 @@ public:
             if (!cfg->host_id) {
                 cfg->host_id = locator::host_id::create_random_id();
             }
+            utils::fb_utilities::set_host_id(cfg->host_id);
             create_directories((data_dir_path + "/system").c_str());
             create_directories(cfg->commitlog_directory().c_str());
             create_directories(cfg->schema_commitlog_directory().c_str());

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -59,6 +59,7 @@ int main(int ac, char ** av) {
             const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
             utils::fb_utilities::set_broadcast_address(listen);
             utils::fb_utilities::set_broadcast_rpc_address(listen);
+            utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
             auto cfg = std::make_unique<db::config>();
 
             sharded<gms::feature_service> feature_service;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -170,6 +170,7 @@ int main(int ac, char ** av) {
         bool stay_alive = config["stay-alive"].as<bool>();
         const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
         utils::fb_utilities::set_broadcast_address(listen);
+        utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
         seastar::sharded<netw::messaging_service> messaging;
         return messaging.start(listen).then([config, stay_alive, &messaging] () {
             auto testers = new distributed<tester>;

--- a/utils/fb_utilities.hh
+++ b/utils/fb_utilities.hh
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include "gms/inet_address.hh"
+#include "locator/host_id.hh"
 
 namespace utils {
 
@@ -29,6 +30,11 @@ private:
 
         return _broadcast_rpc_address;
     }
+    static locator::host_id& host_id() noexcept {
+        static locator::host_id _host_id;
+
+        return _host_id;
+    }
 public:
    static constexpr int32_t MAX_UNSIGNED_SHORT = 0xFFFF;
 
@@ -39,6 +45,10 @@ public:
    static void set_broadcast_rpc_address(inet_address addr) noexcept {
        broadcast_rpc_address() = addr;
    }
+
+    static void set_host_id(const locator::host_id& id) noexcept {
+        host_id() = id;
+    }
 
 
    static const inet_address get_broadcast_address() noexcept {
@@ -51,8 +61,15 @@ public:
        return *broadcast_rpc_address();
    }
 
+    static const locator::host_id& get_host_id() noexcept {
+        return host_id();
+    }
+
     static bool is_me(gms::inet_address addr) noexcept {
         return addr == get_broadcast_address();
+    }
+    static bool is_me(const locator::host_id id) noexcept {
+        return id == get_host_id();
     }
 };
 }


### PR DESCRIPTION
This series adds a host_id member to netw::msg_addr so it can be used to identify nodes by their host_id in addition to their ip address.

The CLIENT_ID rpc verb is extended here to optionally include the host_id.
And that is used in this series to pass the node operations coordinator as a `netw::msg_addr` rather than `gms::inet_address`.

To facilitate that, the local host_id is stored in fb_utilities.

Refs #6403