### PR TITLE
reader_concurrency_semaphore: execution_loop(): trigger admission check when _ready_list is empty

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -907,6 +907,8 @@ future<> reader_concurrency_semaphore::execution_loop() noexcept {
                 co_await coroutine::maybe_yield();
             }
         }
+
+        maybe_admit_waiters();
     }
 }
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1896,3 +1896,43 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         semaphore.set_resources(initial_resources);
     }
 }
+
+// Check that a waiter permit which was queued due to the _ready_list not being
+// empty, will be executed right after the previous read in _ready_list is
+// executed, even if said read doesn't trigger admission checks via releasing
+// resources.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_execution_stage_wakeup) {
+    const auto initial_resources = reader_concurrency_semaphore::resources{2, 4 * 1024};
+    const auto serialize_multiplier = std::numeric_limits<uint32_t>::max();
+    const auto kill_multiplier = std::numeric_limits<uint32_t>::max();
+    reader_concurrency_semaphore semaphore(initial_resources.count, initial_resources.memory, get_name(), 100,
+            utils::updateable_value<uint32_t>(serialize_multiplier), utils::updateable_value<uint32_t>(kill_multiplier));
+    auto stop_sem = deferred_stop(semaphore);
+
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
+
+    bool func_called = false;
+    auto func_fut = semaphore.with_ready_permit(permit1, [&] (reader_permit permit) {
+        func_called = true;
+        return sleep(std::chrono::milliseconds(1));
+    });
+    // permit1 should be on the ready list, not executed yet
+    BOOST_REQUIRE(!func_called);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
+
+    // trying to obtain a second permit should block on the _ready_list
+    auto permit2_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_ready_list, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+
+    // After func runs, the _ready_list becomes empty and the waiting permit should be admitted
+    func_fut.get();
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 2);
+
+    permit2_fut.get();
+}


### PR DESCRIPTION
The execution loop consumes permits from the _ready_list and executes them. The _ready_list usually contains a single permit. When the _ready_list is not empty, new permits are queued until it becomes empty. The execution loops relies on admission checks triggered by the read releasing resouces, to bring in any queued read into the _ready_list, while it is executing the current read. But in some cases the current read might not free any resorces and thus fail to trigger an admission check and the currently queued permits will sit in the queue until another source triggers an admission check.
I don't yet know how this situation can occur, if at all, but it is reproducible with a simple unit test, so it is best to cover this corner-case in the off-chance it happens in the wild. Add an explicit admission check to the execution loop, after the _ready_list is exhausted, to make sure any waiters that can be admitted with an empty _ready_list are admitted immediately and execution continues.

Fixes: #13540