### PR TITLE
Backport bugfixes regarding UDT, UDF, UDA interactions to branch-5.2

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -153,9 +153,9 @@ void functions::remove_function(const function_name& name, const std::vector<dat
 std::optional<function_name> functions::used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types) {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
-        if (aggregate && ((aggregate->sfunc().name() == name && aggregate->sfunc().arg_types() == arg_types)
-            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types)
-            || (aggregate->is_reducible() && aggregate->reducefunc().name() == name && aggregate->reducefunc().arg_types() == arg_types))) {
+        if (aggregate && ((aggregate->sfunc()->name() == name && aggregate->sfunc()->arg_types() == arg_types)
+            || (aggregate->has_finalfunc() && aggregate->finalfunc()->name() == name && aggregate->finalfunc()->arg_types() == arg_types)
+            || (aggregate->is_reducible() && aggregate->reducefunc()->name() == name && aggregate->reducefunc()->arg_types() == arg_types))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -150,10 +150,11 @@ void functions::remove_function(const function_name& name, const std::vector<dat
     with_udf_iter(name, arg_types, [] (functions::declared_t::iterator i) { _declared.erase(i); });
 }
 
-std::optional<function_name> functions::used_by_user_aggregate(const function_name& name) {
+std::optional<function_name> functions::used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types) {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
-        if (aggregate && (aggregate->sfunc().name() == name || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name))) {
+        if (aggregate && ((aggregate->sfunc().name() == name && aggregate->sfunc().arg_types() == arg_types)
+            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -154,7 +154,8 @@ std::optional<function_name> functions::used_by_user_aggregate(const function_na
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
         if (aggregate && ((aggregate->sfunc().name() == name && aggregate->sfunc().arg_types() == arg_types)
-            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types))) {
+            || (aggregate->has_finalfunc() && aggregate->finalfunc().name() == name && aggregate->finalfunc().arg_types() == arg_types)
+            || (aggregate->is_reducible() && aggregate->reducefunc().name() == name && aggregate->reducefunc().arg_types() == arg_types))) {
             return aggregate->name();
         }
     }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -72,6 +72,7 @@ public:
     static void replace_function(shared_ptr<function>);
     static void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
     static std::optional<function_name> used_by_user_aggregate(const function_name& name);
+    static std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
     template <typename F>
     static void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -71,7 +71,7 @@ public:
     static void add_function(shared_ptr<function>);
     static void replace_function(shared_ptr<function>);
     static void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    static std::optional<function_name> used_by_user_aggregate(const function_name& name);
+    static std::optional<function_name> used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types);
     static std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
     template <typename F>

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -71,7 +71,7 @@ public:
     static void add_function(shared_ptr<function>);
     static void replace_function(shared_ptr<function>);
     static void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    static std::optional<function_name> used_by_user_aggregate(const function_name& name, const std::vector<data_type>& arg_types);
+    static std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
     static std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
     template <typename F>

--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -37,14 +37,14 @@ public:
     virtual sstring element_type() const override { return "aggregate"; }
     virtual std::ostream& describe(std::ostream& os) const override;
 
-    const scalar_function& sfunc() const {
-        return *_sfunc;
+    seastar::shared_ptr<scalar_function> sfunc() const {
+        return _sfunc;
     }
-    const scalar_function& reducefunc() const {
-        return *_reducefunc;
+    seastar::shared_ptr<scalar_function> reducefunc() const {
+        return _reducefunc;
     }
-    const scalar_function& finalfunc() const {
-        return *_finalfunc;
+    seastar::shared_ptr<scalar_function> finalfunc() const {
+        return _finalfunc;
     }
     const bytes_opt& initcond() const {
         return _initcond;

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -35,7 +35,7 @@ drop_function_statement::prepare_schema_mutations(query_processor& qp, api::time
         if (!user_func) {
             throw exceptions::invalid_request_exception(format("'{}' is not a user defined function", func));
         }
-        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func->name(), user_func->arg_types())) {
+        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func)) {
             throw exceptions::invalid_request_exception(format("Cannot delete function {}, as it is used by user-defined aggregate {}", func, *aggregate));
         }
         m = co_await qp.get_migration_manager().prepare_function_drop_announcement(user_func, ts);

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -35,7 +35,7 @@ drop_function_statement::prepare_schema_mutations(query_processor& qp, api::time
         if (!user_func) {
             throw exceptions::invalid_request_exception(format("'{}' is not a user defined function", func));
         }
-        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func->name()); bool(aggregate)) {
+        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func->name(), user_func->arg_types())) {
             throw exceptions::invalid_request_exception(format("Cannot delete function {}, as it is used by user-defined aggregate {}", func, *aggregate));
         }
         m = co_await qp.get_migration_manager().prepare_function_drop_announcement(user_func, ts);

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -10,6 +10,7 @@
 #include "cql3/statements/drop_type_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/functions/functions.hh"
 
 #include "boost/range/adaptor/map.hpp"
 
@@ -109,6 +110,9 @@ void drop_type_statement::validate_while_executing(query_processor& qp) const {
             }
         }
 
+        if (auto&& fun_name = functions::functions::used_by_user_function(_name)) {
+            throw exceptions::invalid_request_exception(format("Cannot drop user type {}.{} as it is still used by function {}", keyspace, type->get_name_as_string(), *fun_name));
+        }
     } catch (data_dictionary::no_such_keyspace& e) {
         throw exceptions::invalid_request_exception(format("Cannot drop type in unknown keyspace {}", keyspace()));
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2216,15 +2216,15 @@ std::vector<mutation> make_create_aggregate_mutations(schema_features features, 
     mutation& m = p.first;
     clustering_key& ckey = p.second;
 
-    data_type state_type = aggregate->sfunc().arg_types()[0];
+    data_type state_type = aggregate->sfunc()->arg_types()[0];
     if (aggregate->has_finalfunc()) {
-        m.set_clustered_cell(ckey, "final_func", aggregate->finalfunc().name().name, timestamp);
+        m.set_clustered_cell(ckey, "final_func", aggregate->finalfunc()->name().name, timestamp);
     }
     if (aggregate->initcond()) {
         m.set_clustered_cell(ckey, "initcond", state_type->deserialize(*aggregate->initcond()).to_parsable_string(), timestamp);
     }
     m.set_clustered_cell(ckey, "return_type", aggregate->return_type()->as_cql3_type().to_string(), timestamp);
-    m.set_clustered_cell(ckey, "state_func", aggregate->sfunc().name().name, timestamp);
+    m.set_clustered_cell(ckey, "state_func", aggregate->sfunc()->name().name, timestamp);
     m.set_clustered_cell(ckey, "state_type", state_type->as_cql3_type().to_string(), timestamp);
     std::vector<mutation> muts = {m};
 
@@ -2233,7 +2233,7 @@ std::vector<mutation> make_create_aggregate_mutations(schema_features features, 
         auto sa_p = get_mutation(sa_schema, *aggregate);
         mutation& sa_mut = sa_p.first;
         clustering_key& sa_ckey = sa_p.second;
-        sa_mut.set_clustered_cell(sa_ckey, "reduce_func", aggregate->reducefunc().name().name, timestamp);
+        sa_mut.set_clustered_cell(sa_ckey, "reduce_func", aggregate->reducefunc()->name().name, timestamp);
         sa_mut.set_clustered_cell(sa_ckey, "state_type", state_type->as_cql3_type().to_string(), timestamp);
 
         muts.emplace_back(sa_mut);

--- a/test/cql-pytest/test_uda.py
+++ b/test/cql-pytest/test_uda.py
@@ -230,3 +230,39 @@ def test_drop_keyspace_with_uda(scylla_only, cql):
     assert aggregates_before.result - aggregates_after.result == 1
     with pytest.raises(ConfigurationException, match="Cannot drop non existing keyspace"):
         cql.execute(f"DROP KEYSPACE {ks}")
+
+# Test that replacing the state function, reduce function or the final function succesfully changes the function used by the aggregate.
+# When the state or final function is replaced, the new function should be used in following calls to the aggregate. Cassandra keeps using
+# the old function, which we consider a cassandra bug.
+def test_replace_sfunc_ffunc(cql, test_keyspace, cassandra_bug):
+    schema = "id bigint primary key"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"INSERT INTO {table} (id) VALUES (1)")
+        cql.execute(f"INSERT INTO {table} (id) VALUES (2)")
+        cql.execute(f"INSERT INTO {table} (id) VALUES (3)")
+        sum_partial_body = "(state bigint, val bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state + val'"
+        sum_partial_body2 = "(state bigint, val bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state + 2 * val'"
+        sum_final_body = "(state bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state'"
+        sum_final_body2 = "(state bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return 3 * state'"
+        try:
+            # Check if we can use lua, i.e. we're in Scylla
+            with new_function(cql, test_keyspace, sum_partial_body):
+                pass
+        except:
+            # We're in Cassandra, use java instead
+            sum_partial_body = "(state bigint, val bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return state + val'"
+            sum_partial_body2 = "(state bigint, val bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return state + 2 * val'"
+            sum_final_body = "(state bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return state'"
+            sum_final_body2 = "(state bigint) CALLED ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return 3 * state'"
+
+        with new_function(cql, test_keyspace, sum_partial_body) as sum_partial, new_function(cql, test_keyspace, sum_final_body) as sum_final:
+            custom_sum_body = f"(bigint) SFUNC {sum_partial} STYPE bigint FINALFUNC {sum_final} INITCOND 0"
+            with new_aggregate(cql, test_keyspace, custom_sum_body) as custom_sum:
+                result = cql.execute(f"SELECT {custom_sum}(id) AS result FROM {table}").one()
+                assert result.result == 6
+                cql.execute(f"CREATE OR REPLACE FUNCTION {test_keyspace}.{sum_partial} {sum_partial_body2}")
+                result = cql.execute(f"SELECT {custom_sum}(id) AS result FROM {table}").one()
+                assert result.result == 12
+                cql.execute(f"CREATE OR REPLACE FUNCTION {test_keyspace}.{sum_final} {sum_final_body2}")
+                result = cql.execute(f"SELECT {custom_sum}(id) AS result FROM {table}").one()
+                assert result.result == 36

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -101,13 +101,16 @@ def new_type(cql, keyspace, cmd):
 
 # A utility function for creating a new temporary user-defined function.
 @contextmanager
-def new_function(cql, keyspace, body, name=None):
+def new_function(cql, keyspace, body, name=None, args=None):
     fun = name if name else unique_name()
     cql.execute(f"CREATE FUNCTION {keyspace}.{fun} {body}")
     try:
         yield fun
     finally:
-        cql.execute(f"DROP FUNCTION {keyspace}.{fun}")
+        if args:
+            cql.execute(f"DROP FUNCTION {keyspace}.{fun}({args})")
+        else:
+            cql.execute(f"DROP FUNCTION {keyspace}.{fun}")
 
 # A utility function for creating a new temporary user-defined aggregate.
 @contextmanager


### PR DESCRIPTION
This patch backports https://github.com/scylladb/scylladb/pull/12710 to branch-5.2. To resolve the conflicts that it's causing, it also includes
* https://github.com/scylladb/scylladb/pull/12680
* https://github.com/scylladb/scylladb/pull/12681
