### PR TITLE
doc: remove the sequential repair option from docs

### DIFF
--- a/docs/operating-scylla/nodetool-commands/repair.rst
+++ b/docs/operating-scylla/nodetool-commands/repair.rst
@@ -41,14 +41,6 @@ Scylla nodetool repair command supports the following options:
 
      nodetool repair -et 90874935784
      nodetool repair --end-token 90874935784
-
-- ``-seq``, ``--sequential`` Use *-seq* to carry out a sequential repair.
-
-  For example, a sequential repair of all keyspaces on a node:
-
-  ::
-
-     nodetool repair -seq
      
 - ``-hosts`` ``--in-hosts`` syncs the **repair master** data subset only between a list of nodes, using host ID or Address. The list *must* include the **repair master**.
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/12132

The sequential repair mode is not supported. This commit removes the incorrect information from the documentation.