### PR TITLE
Tune up S3 unit tests environment usage (and a bit more)

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -26,7 +26,7 @@
  */
 
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
-    const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
+    const ipv4_addr s3_server(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), 9000);
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
@@ -59,7 +59,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
-    const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
+    const ipv4_addr s3_server(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), 9000);
     const sstring name(fmt::format("/{}/testlargeobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
@@ -110,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
-    const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
+    const ipv4_addr s3_server(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), 9000);
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -16,17 +16,18 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
 #include "utils/s3/client.hh"
 
 /*
  * Tests below expect minio server to be running on localhost
- * with the bucket named "testbucket" created with unrestricted
- * anonymous read-write access
+ * with the bucket named env['S3_PUBLIC_BUCKET_FOR_TEST'] created with
+ * unrestricted anonymous read-write access
  */
 
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
-    const sstring name(fmt::format("/testbucket/testobject-{}", ::getpid()));
+    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(s3_server);
@@ -59,7 +60,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
 
 SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
     const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
-    const sstring name(fmt::format("/testbucket/testlargeobject-{}", ::getpid()));
+    const sstring name(fmt::format("/{}/testlargeobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(s3_server);
@@ -110,7 +111,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
 
 SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
     const ipv4_addr s3_server(::getenv("MINIO_SERVER_ADDRESS"), 9000);
-    const sstring name(fmt::format("/testbucket/testroobject-{}", ::getpid()));
+    const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(s3_server);

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -47,4 +47,12 @@ void require_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std
 
 void fail(std::string_view msg, std::source_location sl = std::source_location::current());
 
+inline std::string getenv_safe(std::string_view name) {
+    auto v = ::getenv(name.data());
+    if (!v) {
+        throw std::logic_error(fmt::format("Environment variable {} not set", name));
+    }
+    return std::string(v);
+}
+
 }

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -31,13 +31,13 @@ print(f'Start scylla (dir={test_tempdir}')
 pid = run.run_with_generated_dir(cmd, get_tempdir)
 ip = run.pid_to_ip(pid)
 run.wait_for_services(pid, [ lambda: check_cql(ip) ])
-minio_server_address = os.environ['MINIO_SERVER_ADDRESS']
+s3_server_address = os.environ['S3_SERVER_ADDRESS_FOR_TEST']
 s3_public_bucket = os.environ['S3_PUBLIC_BUCKET_FOR_TEST']
 
-print(f'Create keyspace (minio listening at {minio_server_address})')
+print(f'Create keyspace (minio listening at {s3_server_address})')
 cluster = run.get_cql_cluster(ip)
 conn = cluster.connect()
-conn.execute("CREATE KEYSPACE test_ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': '1' } AND STORAGE = { 'type': 'S3', 'endpoint': '" + f'{minio_server_address}' + ":9000', 'bucket': '" + f'{s3_public_bucket}' + "' };")
+conn.execute("CREATE KEYSPACE test_ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': '1' } AND STORAGE = { 'type': 'S3', 'endpoint': '" + f'{s3_server_address}' + ":9000', 'bucket': '" + f'{s3_public_bucket}' + "' };")
 conn.execute("CREATE TABLE test_ks.test_cf ( name text primary key, value text );")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('0', 'zero');")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('1', 'one');")

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -32,11 +32,12 @@ pid = run.run_with_generated_dir(cmd, get_tempdir)
 ip = run.pid_to_ip(pid)
 run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 minio_server_address = os.environ['MINIO_SERVER_ADDRESS']
+s3_public_bucket = os.environ['S3_PUBLIC_BUCKET_FOR_TEST']
 
 print(f'Create keyspace (minio listening at {minio_server_address})')
 cluster = run.get_cql_cluster(ip)
 conn = cluster.connect()
-conn.execute("CREATE KEYSPACE test_ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': '1' } AND STORAGE = { 'type': 'S3', 'endpoint': '" + f'{minio_server_address}' + ":9000', 'bucket': 'testbucket' };")
+conn.execute("CREATE KEYSPACE test_ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': '1' } AND STORAGE = { 'type': 'S3', 'endpoint': '" + f'{minio_server_address}' + ":9000', 'bucket': '" + f'{s3_public_bucket}' + "' };")
 conn.execute("CREATE TABLE test_ks.test_cf ( name text primary key, value text );")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('0', 'zero');")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('1', 'one');")

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -52,7 +52,7 @@ class MinioServer:
 
         self.address = await self.hosts.lease_host()
         self.log_file = self.log_filename.open("wb")
-        os.environ['MINIO_SERVER_ADDRESS'] = f'{self.address}'
+        os.environ['S3_SERVER_ADDRESS_FOR_TEST'] = f'{self.address}'
         os.environ['S3_PUBLIC_BUCKET_FOR_TEST'] = f'{self.bucket_name}'
 
         self.logger.info(f'Starting minio server at {self.address}:{self.port}')

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -53,6 +53,7 @@ class MinioServer:
         self.address = await self.hosts.lease_host()
         self.log_file = self.log_filename.open("wb")
         os.environ['MINIO_SERVER_ADDRESS'] = f'{self.address}'
+        os.environ['S3_PUBLIC_BUCKET_FOR_TEST'] = f'{self.bucket_name}'
 
         self.logger.info(f'Starting minio server at {self.address}:{self.port}')
         os.mkdir(self.rootdir)


### PR DESCRIPTION
The tests in question are using MINIO_SERVER_ADDRESS environment variable to export minio server address from pylib to test cases. Also they use hard-coded public bucket name. Both plays badly with AWS S3, the former due to MINIO_... in its name and the latter because public bucket name can be any.

So this PR puts address and public bucket name into S3_..._FOR_TEST environment variables and fixes output stream closure on failure while at it.

Detached from #13493 