### PR TITLE
Put storage_service.hh on a diet

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -54,6 +54,7 @@
 #include "utils/generation-number.hh"
 #include "db/virtual_table.hh"
 #include "service/storage_service.hh"
+#include "protocol_server.hh"
 #include "gms/gossiper.hh"
 #include "service/paxos/paxos_state.hh"
 #include "service/raft/raft_group_registry.hh"

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -73,6 +73,7 @@
 #include "idl/storage_service.dist.hh"
 #include "service/storage_proxy.hh"
 #include "service/raft/raft_address_map.hh"
+#include "protocol_server.hh"
 #include "types/set.hh"
 
 #include <boost/algorithm/string/split.hpp>

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -11,13 +11,13 @@
 
 #pragma once
 
+#include <seastar/core/shared_future.hh>
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "inet_address_vectors.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/condition-variable.hh>
-#include "dht/i_partitioner.hh"
 #include "dht/token_range_endpoints.hh"
 #include <seastar/core/sleep.hh>
 #include "gms/application_state.hh"
@@ -25,21 +25,14 @@
 #include <seastar/core/gate.hh>
 #include "utils/fb_utilities.hh"
 #include "replica/database_fwd.hh"
-#include "db/schema_features.hh"
-#include "streaming/stream_state.hh"
 #include "streaming/stream_reason.hh"
 #include <seastar/core/distributed.hh>
 #include "utils/disk-error-handler.hh"
 #include "service/migration_listener.hh"
-#include "protocol_server.hh"
-#include "gms/feature_service.hh"
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/rwlock.hh>
-#include "sstables/version.hh"
-#include "sstables/shared_sstable.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/lowres_clock.hh>
-#include "locator/snitch_base.hh"
 #include "cdc/generation_id.hh"
 #include "raft/raft.hh"
 #include "repair/id.hh"
@@ -51,6 +44,7 @@ class node_ops_cmd_response;
 class node_ops_info;
 enum class node_ops_cmd : uint32_t;
 class repair_service;
+class protocol_server;
 
 namespace cql3 { class query_processor; }
 


### PR DESCRIPTION
By removing unneeded headers inclusions. At the cost of few more forward declarations and a couple of extra includes in other .cc files.