### PR TITLE
test/cql-pytest: mark test_tools.TestScyllaSsstableSchemaLoading.test_table_dir_data_dir as xfail

### DIFF
--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -652,6 +652,7 @@ class TestScyllaSsstableSchemaLoading:
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
+    @pytest.mark.xfail(reason="issue 13553")
     def test_table_dir_data_dir(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_data_dir):
         self.check(
                 scylla_path,


### PR DESCRIPTION
This test fails from time-to-time. Until the investigation is ongoing, mark it as xfail so it doesn't affext our workflows.

Refs: #13553