### PR TITLE
Mark counters with skip when empty

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -138,7 +138,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT);
-                            }),
+                            }).set_skip_when_empty(),
 
                     sm::make_counter(
                             "updates",
@@ -159,7 +159,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE);
-                            }),
+                            }).set_skip_when_empty(),
 
                     sm::make_counter(
                             "deletes",
@@ -180,7 +180,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE);
-                            }),
+                            }).set_skip_when_empty(),
 
                     sm::make_counter(
                             "reads_per_ks",
@@ -213,13 +213,13 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT),
                             sm::description("Counts the number of CQL INSERT requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)."),
-                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "inserts_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT),
                             sm::description("Counts the number of CQL INSERT requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)."),
-                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "updates_per_ks",
@@ -238,13 +238,13 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE),
                             sm::description("Counts the number of CQL UPDATE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "updates_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE),
                             sm::description("Counts the number of CQL UPDATE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "deletes_per_ks",
@@ -263,13 +263,13 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE),
                             sm::description("Counts the number of CQL DELETE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "deletes_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE),
                             sm::description("Counts the number of CQL DELETE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "batches",

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2558,11 +2558,11 @@ void storage_proxy_stats::stats::register_stats() {
 
         sm::make_queue_length("foreground_reads", foreground_reads,
                 sm::description("number of currently pending foreground read requests"),
-                {storage_proxy_stats::current_scheduling_group_label()}),
+                {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
         sm::make_queue_length("background_reads", [this] { return reads - foreground_reads; },
                        sm::description("number of currently pending background read requests"),
-                       {storage_proxy_stats::current_scheduling_group_label()}),
+                       {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
         sm::make_total_operations("read_retries", read_retries,
                        sm::description("number of read retry attempts"),
@@ -2752,7 +2752,7 @@ void storage_proxy_stats::split_stats::register_metrics_local() {
     auto new_metrics = sm::metric_groups();
     new_metrics.add_group(_category, {
         sm::make_counter(_short_description_prefix + sstring("_local_node"), [this] { return _local.val; },
-                       sm::description(_long_description_prefix + "on a local Node"), {storage_proxy_stats::make_scheduling_group_label(_sg), op_type_label(_op_type)})
+                       sm::description(_long_description_prefix + "on a local Node"), {storage_proxy_stats::make_scheduling_group_label(_sg), op_type_label(_op_type)}).set_skip_when_empty()
     });
     _metrics = std::exchange(new_metrics, {});
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -289,7 +289,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         transport_metrics.emplace_back(
             sm::make_counter("cql_errors_total", sm::description("Counts the total number of returned CQL errors."),
                         {label_instance},
-                        [this, code = e.first] { auto it = _stats.errors.find(code); return it != _stats.errors.end() ? it->second : 0; })
+                        [this, code = e.first] { auto it = _stats.errors.find(code); return it != _stats.errors.end() ? it->second : 0; }).set_skip_when_empty()
         );
     }
 


### PR DESCRIPTION
This series mark multiple high cardinality counters with skip_when_empty flag.
After this patch the following counters will not be reported if they were never used:
```
scylla_transport_cql_errors_total
scylla_storage_proxy_coordinator_reads_local_node
scylla_storage_proxy_coordinator_completed_reads_local_node
scylla_transport_cql_errors_total
```
Also marked, the CAS related CQL operations.
Fixes #12751