### PR TITLE
docs: edit landing page

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,17 +1,11 @@
 /* Override theme styles */
 
-.cloud-card img {
-    right: -30px !important;
+.topic-box--product p {
+    margin-bottom: 0;
 }
 
-.enterprise-card img {
-    right: -25px !important;
-}
-
-@media  screen and (min-width: 1024px) {
-    .cloud-card .card,
-    .enterprise-card .card,
-    .opensource-card .card {
-        padding: 20px 30px !important;
+@media screen and (min-width: 640px) {
+    .hero__title {
+        max-width: 550px;
     }
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,8 @@
 
 .. topic-box::
   :title: ScyllaDB Cloud
+  :icon: scylla-icon scylla-icon--cloud
   :link: https://cloud.docs.scylladb.com
-  :image: /_static/img/mascots/scylla-cloud.svg
   :class: large-4 cloud-card
   :anchor: ScyllaDB Cloud Documentation
 
@@ -36,8 +36,8 @@
 
 .. topic-box::
   :title: ScyllaDB Enterprise
+  :icon: scylla-icon scylla-icon--enterprise-m
   :link: https://enterprise.docs.scylladb.com
-  :image: /_static/img/mascots/scylla-enterprise.svg
   :class: large-4 enterprise-card
   :anchor: ScyllaDB Enterprise Documentation
 
@@ -45,8 +45,8 @@
 
 .. topic-box::
   :title: ScyllaDB Open Source
+  :icon: scylla-icon scylla-icon--about-us-m
   :link: https://docs.scylladb.com/stable/getting-started/
-  :image: /_static/img/mascots/scylla-opensource.svg
   :class: large-4 opensource-card
   :anchor: ScyllaDB Open Source Documentation
 
@@ -163,4 +163,3 @@
   faq
   Contribute to ScyllaDB <contribute>
   alternator/alternator
-


### PR DESCRIPTION
## Motivation

I was asked to remove the Scylla monster from the heading. After conducting some tests, I decided to revert part of the changes made in #13167 to maintain consistency with the original design and other documentation projects. Note that ScyllaDB Cloud and Care Pet projects also feature monsters in their headers. Beside, in responsive mode icons are not shown in responsive mode, makign the site 

## Changes

- Reverted partially changes from #13167

- The original design for product cards was intended for 4 column grids. The CSS has been edited to better support 3 column grids by removing a bit of bottom padding.

  **Before**:
  
  ![image](https://user-images.githubusercontent.com/9107969/232734936-cd13fecb-6b7c-4578-9ef6-b6b6ebb03bb9.png)
  
  **Now**:
  
  ![image](https://user-images.githubusercontent.com/9107969/232735047-b6dc5024-c869-4aa9-b494-32c970aede77.png)


- Prevent the site title from breaking into two lines on large screens.

   **Before**
   
    ![image](https://user-images.githubusercontent.com/9107969/232735275-52f290f1-041b-40ed-bb71-02d7ee2c3a0a.png)

  **Now**

    ![image](https://user-images.githubusercontent.com/9107969/232736024-c90e9460-31c5-4d10-a414-a507d33092c3.png)

## How to test the pull request

1. Clone this PR
2. Go to the docs folder and run `make preview`.
3. Open the site and check the new home page.