### PR TITLE
Delete S3 sstables without the help of deletion log

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -461,7 +461,7 @@ bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, 
     return size_a == size_b && sstring::traits_type::compare(prefix_a.begin(), prefix_b.begin(), size_a) == 0;
 }
 
-future<> sstable_directory::delete_atomically(std::vector<shared_sstable> ssts) {
+future<> sstable_directory::delete_with_pending_deletion_log(std::vector<shared_sstable> ssts) {
     if (ssts.empty()) {
         return make_ready_future<>();
     }
@@ -536,8 +536,8 @@ future<> sstable_directory::delete_atomically(std::vector<shared_sstable> ssts) 
     });
 }
 
-// FIXME: Go through maybe_delete_large_partitions_entry on recovery
-// since this is an indication we crashed in the middle of delete_atomically
+// FIXME: Go through maybe_delete_large_partitions_entry on recovery since
+// this is an indication we crashed in the middle of delete_with_pending_deletion_log
 future<> sstable_directory::replay_pending_delete_log(fs::path pending_delete_log) {
     sstlog.debug("Reading pending_deletes log file {}", pending_delete_log);
     fs::path pending_delete_dir = pending_delete_log.parent_path();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -462,9 +462,6 @@ bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, 
 }
 
 future<> sstable_directory::delete_with_pending_deletion_log(std::vector<shared_sstable> ssts) {
-    if (ssts.empty()) {
-        return make_ready_future<>();
-    }
     return seastar::async([ssts = std::move(ssts)] {
         shared_sstable first = nullptr;
         min_max_tracker<generation_type> gen_tracker;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -257,7 +257,7 @@ public:
     // until all shards agree it can be deleted.
     //
     // This function only solves the second problem for now.
-    static future<> delete_atomically(std::vector<shared_sstable> ssts);
+    static future<> delete_with_pending_deletion_log(std::vector<shared_sstable> ssts);
     static future<> replay_pending_delete_log(std::filesystem::path log_file);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -109,7 +109,16 @@ void sstables_manager::maybe_done() {
 }
 
 future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
-    return sstable_directory::delete_with_pending_deletion_log(std::move(ssts));
+    if (ssts.empty()) {
+        co_return;
+    }
+
+    // All sstables here belong to the same table, thus they do live
+    // in the same storage so it's OK to get the deleter from the
+    // front element. The deleter implementation is welcome to check
+    // that sstables from the vector really live in it.
+    auto deleter = ssts.front()->get_storage().atomic_deleter();
+    co_await deleter(std::move(ssts));
 }
 
 future<> sstables_manager::close() {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -108,6 +108,10 @@ void sstables_manager::maybe_done() {
     }
 }
 
+future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
+    return sstable_directory::delete_with_pending_deletion_log(std::move(ssts));
+}
+
 future<> sstables_manager::close() {
     _closing = true;
     maybe_done();

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -130,6 +130,8 @@ public:
         return *_sys_ks;
     }
 
+    future<> delete_atomically(std::vector<shared_sstable> ssts);
+
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -65,6 +65,9 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) override;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
+    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
+        return sstable_directory::delete_with_pending_deletion_log;
+    }
 
     virtual sstring prefix() const override { return dir; }
 };
@@ -443,6 +446,9 @@ public:
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override {
         return _client->close();
+    }
+    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
+        return sstable_directory::delete_with_pending_deletion_log;
     }
 
     virtual sstring prefix() const override { return _location; }

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -16,6 +16,7 @@
 
 #include "data_dictionary/storage_options.hh"
 #include "seastarx.hh"
+#include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 
@@ -58,6 +59,7 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
+    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
 
     virtual sstring prefix() const  = 0;
 };

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1933,7 +1933,7 @@ SEASTAR_TEST_CASE(test_unknown_component) {
         BOOST_REQUIRE(file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get0());
 
         sstp = env.reusable_sst(uncompressed_schema(), generation_type{1}).get0();
-        sstables::sstable_directory::delete_atomically({sstp}).get();
+        env.manager().delete_atomically({sstp}).get();
         // assure unknown component is deleted
         BOOST_REQUIRE(!file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get0());
     });


### PR DESCRIPTION
There are two layers of stables deletion -- delete-atomically and wipe. The former is in fact the "API" method, it's called by table code when the specific sstable(s) are no longer needed. It's called "atomically" because it's expected to fail in the middle in a safe manner so that subsequent boot would pick the dangling parts and proceed. The latter is a low-level removal function that can fail in the middle, but it's not of _its_ care.

Currently the atomic deletion is implemented with the help of sstable_directory::delete_atomically() method that commits sstables files names into deletion log, then calls wipe (indirectly), then drops the deletion log. On boot all found deletion logs are replayed. The described functionality is used regardless of the sstable storage type, even for S3, though deletion log is an overkill for S3, it's better be implemented with the help of ownership table. In fact, S3 storage already implements atomic deletion in its wipe method thus being overly careful.

So this PR
- makes atomic deletion be storage-specific
- makes S3 wipe non-atomic

fixes: #13016
note: Replaying sstables deletion from ownership table on boot is not here, see #13024