### PR TITLE
cql:  allow SUM() aggregations which result in a NaN

### DIFF
--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -147,8 +147,14 @@ template<typename NarrowT, typename WideT>
 NarrowT
 narrow(WideT acc) {
     NarrowT ret = static_cast<NarrowT>(acc);
-    if (static_cast<WideT>(ret) != acc) {
-        throw exceptions::overflow_error_exception("Sum overflow. Values should be casted to a wider type.");
+    // The following check only makes sense when NarrowT and WideT are two
+    // different integeral types and we want to check that NarrowT isn't too
+    // narrow. Let's avoid the check when they are the same type - it is
+    // useless, and worse - wrong for the floating-point case (issue #13564).
+    if constexpr (!std::is_same<WideT, NarrowT>::value) {
+        if (static_cast<WideT>(ret) != acc) {
+            throw exceptions::overflow_error_exception("Sum overflow. Values should be casted to a wider type.");
+        }
     }
     return ret;
 }

--- a/test/cql-pytest/test_aggregate.py
+++ b/test/cql-pytest/test_aggregate.py
@@ -131,7 +131,6 @@ def test_timeuuid(cql, test_keyspace):
 # Check floating-point aggregations with non-finite results - inf and nan.
 # Reproduces issue #13551: sum of +inf and -inf produced an error instead
 # of a NaN as in Cassandra (and in older Scylla).
-@pytest.mark.xfail(reason="issue #13551")
 def test_aggregation_inf_nan(cql, table1):
     p = unique_key_int()
     # Add a single infinity value, see we can read it back as infinity,

--- a/test/cql-pytest/test_aggregate.py
+++ b/test/cql-pytest/test_aggregate.py
@@ -7,12 +7,13 @@
 #############################################################################
 
 import pytest
+import math
 from util import new_test_table, unique_key_int, project
 from cassandra.util import Date
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, d double, PRIMARY KEY (p, c)") as table:
         yield table
 
 # When there is no row matching the selection, the count should be 0.
@@ -21,10 +22,11 @@ def test_count_empty_eq(cql, table1):
     p = unique_key_int()
     assert [(0,)] == list(cql.execute(f"select count(*) from {table1} where p = {p}"))
     # The aggregation "0" for no results is true for count(), but not all
-    # aggregators - min() returns null for no results, while sum() returns
-    # 0 for no results (see issue #13027):
+    # aggregators - min() returns null for no results, while sum() and
+    # avg() return 0 for no results (see discussion in issue #13027):
     assert [(None,)] == list(cql.execute(f"select min(v) from {table1} where p = {p}"))
     assert [(0,)] == list(cql.execute(f"select sum(v) from {table1} where p = {p}"))
+    assert [(0,)] == list(cql.execute(f"select avg(v) from {table1} where p = {p}"))
 
 # Above in test_count_empty_eq() we tested that aggregates return some value -
 # sometimes 0 and sometimes null - when aggregating no data. If we select
@@ -125,3 +127,22 @@ def test_timeuuid(cql, test_keyspace):
                        cql.execute(f'select todate(min(b)) from {table} where a = 0')) == [Date('2020-12-01')]
         assert project('system_todate_system_max_b',
                        cql.execute(f'select todate(max(b)) from {table} where a = 0')) == [Date('2038-09-06')]
+
+# Check floating-point aggregations with non-finite results - inf and nan.
+# Reproduces issue #13551: sum of +inf and -inf produced an error instead
+# of a NaN as in Cassandra (and in older Scylla).
+@pytest.mark.xfail(reason="issue #13551")
+def test_aggregation_inf_nan(cql, table1):
+    p = unique_key_int()
+    # Add a single infinity value, see we can read it back as infinity,
+    # and its sum() is also infinity of course.
+    cql.execute(f"insert into {table1} (p, c, d) values ({p}, 1, infinity)")
+    assert [(math.inf,)] == list(cql.execute(f"select d from {table1} where p = {p} and c = 1"))
+    assert [(math.inf,)] == list(cql.execute(f"select sum(d) from {table1} where p = {p}"))
+    # Add a second value, a negative infinity. See we can read it back, and
+    # now the sum of +Inf and -Inf should be a NaN.
+    # Note that we have to use isnan() to check that the result is a NaN,
+    # because equality check doesn't work on NaN:
+    cql.execute(f"insert into {table1} (p, c, d) values ({p}, 2, -infinity)")
+    assert [(-math.inf,)] == list(cql.execute(f"select d from {table1} where p = {p} and c = 2"))
+    assert math.isnan(list(cql.execute(f"select sum(d) from {table1} where p = {p}"))[0][0])

--- a/test/cql-pytest/test_cast_data.py
+++ b/test/cql-pytest/test_cast_data.py
@@ -1,0 +1,92 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+###############################################################################
+# Tests for data casts, e.g `SELECT CAST (... AS int) FROM tbl`
+#
+# Note that this is a different feature from the query casts `(int)123`
+# which are tested separately in test_cast.py. Whereas the query casts
+# can only reinterpret data losslessly (e.g., cast an integer to a wider
+# integer), the data casts tested here can actually convert data from one
+# type to another in sometimes surprising ways. For example, a very large
+# arbitrary-precision number (varint) can be cast into an integer and result
+# in a wraparound, or be cast into a float and result an infinity. In
+# this test file we'll check some of these surprising conversions, and
+# verify that they are the same in Scylla and Cassandra and don't regress.
+#
+# See also cql_cast_test.py in dtest.
+###############################################################################
+
+import pytest
+import math
+from util import new_test_table, unique_key_int
+from cassandra.protocol import InvalidRequest
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, cVarint varint") as table:
+        yield table
+
+# Utility function for emulating a wrapping cast of a big positive number
+# into a smaller signed integer of given number of bits. For example,
+# casting 511 to 8 bits results in -1.
+def signed(number, bits):
+    p = 2**bits
+    ret = number % p
+    if ret > p/2:
+        return ret - p
+    else:
+        return ret
+
+# Test casting a very large varint number to various other types, resulting
+# in various non-trivial conversions including truncation or wrap-around of
+# numbers.
+def test_cast_from_large_varint(cql, table1):
+    p = unique_key_int()
+    v = 32767456456456456456545678943512357658768763546575675
+    cql.execute(f'INSERT INTO {table1} (p, cVarint) VALUES ({p}, {v})')
+    # We can read back the original number without a cast, or with a cast
+    # to the same type. The "decimal" type can also hold a varint and return
+    # the same number.
+    assert [(v,)] == list(cql.execute(f"SELECT cVarint FROM {table1} WHERE p={p}"))
+    assert [(v,)] == list(cql.execute(f"SELECT CAST(cVarint AS varint) FROM {table1} WHERE p={p}"))
+    assert [(v,)] == list(cql.execute(f"SELECT CAST(cVarint AS decimal) FROM {table1} WHERE p={p}"))
+    # Casting into smaller integer types results in wraparound
+    assert [(signed(v,8),)] == list(cql.execute(f"SELECT CAST(cVarint AS tinyint) FROM {table1} WHERE p={p}"))
+    assert [(signed(v,16),)] == list(cql.execute(f"SELECT CAST(cVarint AS smallint) FROM {table1} WHERE p={p}"))
+    assert [(signed(v,32),)] == list(cql.execute(f"SELECT CAST(cVarint AS int) FROM {table1} WHERE p={p}"))
+    assert [(signed(v,64),)] == list(cql.execute(f"SELECT CAST(cVarint AS bigint) FROM {table1} WHERE p={p}"))
+    # Casting to a 32-bit floating point, which only supports numbers up
+    # to 1e38, results in infinity
+    assert [(math.inf,)] == list(cql.execute(f"SELECT CAST(cVarint AS float) FROM {table1} WHERE p={p}"))
+    # Casting to a 64-bit floating point, which supports the range of our
+    # given number (though not its full precision!) is allowed, and some
+    # precision is lost. Confusingly, Python's 64-bit floating point is
+    # called "float", and we can use Python's float() function to convert
+    # the large number into a 64-bit double to compare the expected result.
+    assert [(float(v),)] == list(cql.execute(f"SELECT CAST(cVarint AS double) FROM {table1} WHERE p={p}"))
+    # Casting the number to string types results in printing the string in
+    # decimal, as expected - same as Python's str() function:
+    assert [(str(v),)] == list(cql.execute(f"SELECT CAST(cVarint AS ascii) FROM {table1} WHERE p={p}"))
+    assert [(str(v),)] == list(cql.execute(f"SELECT CAST(cVarint AS text) FROM {table1} WHERE p={p}"))
+    # "varchar" is supposed to be an alias to "text" and worked just as well,
+    # but suprisingly casting to varchar doesn't work on Cassandra, so let's
+    # test it in a separate test below, test_cast_from_large_varint_to_varchar
+    # Casting a number to all other types is NOT allowed:
+    for t in ['blob', 'boolean', 'counter', 'date', 'duration', 'inet',
+              'timestamp', 'timeuuid', 'uuid']:
+        with pytest.raises(InvalidRequest, match='cast'):
+            cql.execute(f"SELECT CAST(cVarint AS {t}) FROM {table1} WHERE p={p}")
+
+# In test_cast_from_large_varint we checked that a varint can be cast
+# to the "text" type. Since "varchar" is just an alias for "text", casting
+# to varchar should work too, but in Cassandra it doesn't so this test
+# is marked a Cassandra bug.
+def test_cast_from_large_varint_to_varchar(cql, table1, cassandra_bug):
+    p = unique_key_int()
+    v = 32767456456456456456545678943512357658768763546575675
+    cql.execute(f'INSERT INTO {table1} (p, cVarint) VALUES ({p}, {v})')
+    assert [(str(v),)] == list(cql.execute(f"SELECT CAST(cVarint AS varchar) FROM {table1} WHERE p={p}"))
+
+# TODO: test casts from more types.


### PR DESCRIPTION
This short PR fixes a bug in SUM() aggregation where if the data contains +Inf and -Inf the returned sum should be NaN but we returned an error instead. This is a recent regression uncovered by a dtest (see issue #13551), but in the first patch we add additional tests in the cql-pytest framework which reproduce this bug and explore various other areas (wrongly) implicated by the failing dtest.

Fixes #13551
