### PR TITLE
Add S3 support to sstables::test_env

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -495,6 +495,7 @@ public:
         virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) = 0;
         virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) = 0;
         virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
+        virtual future<> destroy(const sstable& sst) = 0;
 
         virtual sstring prefix() const  = 0;
     };

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -274,7 +274,7 @@ SEASTAR_TEST_CASE(datafile_generation_15) {
     return sstable_compression_test(compressor::deflate);
 }
 
-SEASTAR_TEST_CASE(datafile_generation_16) {
+future<> test_datafile_generation_16(test_env_config cfg) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = uncompressed_schema();
 
@@ -293,7 +293,16 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
         auto sst = make_sstable_containing(env.make_sstable(s), mtp);
         // Not crashing is enough
         BOOST_REQUIRE(sst);
-    });
+        sst->destroy().get();
+    }, std::move(cfg));
+}
+
+SEASTAR_TEST_CASE(datafile_generation_16) {
+    return test_datafile_generation_16({});
+}
+
+SEASTAR_TEST_CASE(datafile_generation_16_s3) {
+    return test_datafile_generation_16(test_env_config{ .storage = make_test_object_storage_options() });
 }
 
 // mutation_reader for sstable keeping all the required objects alive.

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -46,9 +46,7 @@ static future<> assert_sstable_computes_correct_owners(test_env& env, const ssta
 }
 
 // Must be called in a seastar thread.
-void run_sstable_resharding_test() {
-    test_env env;
-    auto close_env = defer([&] { env.stop().get(); });
+void run_sstable_resharding_test(sstables::test_env& env) {
   for (const auto version : writable_sstable_versions) {
     auto s = get_schema();
     auto cf = env.make_table_for_tests(s);
@@ -129,8 +127,8 @@ void run_sstable_resharding_test() {
 }
 
 SEASTAR_TEST_CASE(sstable_resharding_test) {
-    return seastar::async([] {
-        run_sstable_resharding_test();
+    return sstables::test_env::do_with_async([] (auto& env) {
+        run_sstable_resharding_test(env);
     });
 }
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -49,6 +49,8 @@ struct test_env_config {
     data_dictionary::storage_options storage; // will be local by default
 };
 
+data_dictionary::storage_options make_test_object_storage_options();
+
 class test_env {
     struct impl {
         tmpdir dir;
@@ -176,6 +178,7 @@ public:
     reader_concurrency_semaphore& semaphore() { return _impl->semaphore; }
     db::config& db_config() { return *_impl->db_config; }
     tmpdir& tempdir() noexcept { return _impl->dir; }
+    data_dictionary::storage_options get_storage_options() const noexcept { return _impl->storage; }
 
     reader_permit make_reader_permit(const schema* const s, const char* n, db::timeout_clock::time_point timeout) {
         return _impl->semaphore.make_tracking_only_permit(s, n, timeout, {});

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -221,11 +221,11 @@ public:
     }
 
     table_for_tests make_table_for_tests(schema_ptr s, sstring dir) {
-        return table_for_tests(manager(), s, std::move(dir));
+        return table_for_tests(manager(), s, std::move(dir), _impl->storage);
     }
 
     table_for_tests make_table_for_tests(schema_ptr s = nullptr) {
-        return table_for_tests(manager(), s, tempdir().path().native());
+        return table_for_tests(manager(), s, tempdir().path().native(), _impl->storage);
     }
 };
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -197,13 +197,7 @@ public:
         });
     }
 
-    static inline future<> do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg = {}) {
-        return seastar::async([func = std::move(func), cfg = std::move(cfg)] () mutable {
-            test_env env(std::move(cfg));
-            auto close_env = defer([&] { env.stop().get(); });
-            func(env);
-        });
-    }
+    static future<> do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg = {});
 
     static inline future<> do_with_sharded_async(noncopyable_function<void (sharded<test_env>&)> func) {
         return seastar::async([func = std::move(func)] {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -46,6 +46,7 @@ public:
 
 struct test_env_config {
     db::large_data_handler* large_data_handler = nullptr;
+    data_dictionary::storage_options storage; // will be local by default
 };
 
 class test_env {
@@ -59,6 +60,7 @@ class test_env {
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
         sstables::sstable_generation_generator gen{0};
+        data_dictionary::storage_options storage;
 
         impl(test_env_config cfg);
         impl(impl&&) = delete;
@@ -86,8 +88,7 @@ public:
     shared_sstable make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
-        data_dictionary::storage_options local;
-        return _impl->mgr.make_sstable(std::move(schema), local, dir, generation, v, f, now, default_io_error_handler_gen(), buffer_size);
+        return _impl->mgr.make_sstable(std::move(schema), _impl->storage, dir, generation, v, f, now, default_io_error_handler_gen(), buffer_size);
     }
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, sstable::version_types v = sstables::get_highest_sstable_version()) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -125,7 +125,7 @@ public:
     }
 };
 
-table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir)
+table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir, data_dictionary::storage_options storage)
     : _data(make_lw_shared<data>())
 {
     _data->s = s ? s : make_default_schema();
@@ -139,6 +139,7 @@ table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, s
     _data->cf->mark_ready_for_writes();
     _data->table_s = std::make_unique<table_state>(*_data, sstables_manager);
     _data->cm.add(*_data->table_s);
+    _data->storage = std::move(storage);
 }
 
 compaction::table_state& table_for_tests::as_table_state() noexcept {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -165,6 +165,7 @@ test_env::impl::impl(test_env_config cfg)
     , feature_service(gms::feature_config_from_db_config(*db_config))
     , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
+    , storage(std::move(cfg.storage))
 { }
 
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -168,6 +168,14 @@ test_env::impl::impl(test_env_config cfg)
     , storage(std::move(cfg.storage))
 { }
 
+future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg) {
+    return seastar::async([func = std::move(func), cfg = std::move(cfg)] () mutable {
+        test_env env(std::move(cfg));
+        auto close_env = defer([&] { env.stop().get(); });
+        func(env);
+    });
+}
+
 }
 
 static std::pair<int, char**> rebuild_arg_list_without(int argc, char** argv, const char* filter_out, bool exclude_positional_arg = false) {

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -47,6 +47,7 @@ struct table_for_tests {
         compaction_manager cm{tm, compaction_manager::for_testing_tag{}};
         lw_shared_ptr<replica::column_family> cf;
         std::unique_ptr<table_state> table_s;
+        data_dictionary::storage_options storage;
         data();
         ~data();
     };
@@ -56,7 +57,7 @@ struct table_for_tests {
 
     explicit table_for_tests(sstables::sstables_manager& sstables_manager);
 
-    explicit table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir = {});
+    explicit table_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s, std::optional<sstring> datadir = {}, data_dictionary::storage_options storage = {});
 
     schema_ptr schema() { return _data->s; }
 
@@ -76,15 +77,13 @@ struct table_for_tests {
     sstables::shared_sstable make_sstable() {
         auto& table = *_data->cf;
         auto& sstables_manager = table.get_sstables_manager();
-        data_dictionary::storage_options local;
-        return sstables_manager.make_sstable(_data->s, local, _data->cfg.datadir, table.calculate_generation_for_new_table());
+        return sstables_manager.make_sstable(_data->s, _data->storage, _data->cfg.datadir, table.calculate_generation_for_new_table());
     }
 
     sstables::shared_sstable make_sstable(sstables::sstable_version_types version) {
         auto& table = *_data->cf;
         auto& sstables_manager = table.get_sstables_manager();
-        data_dictionary::storage_options local;
-        return sstables_manager.make_sstable(_data->s, local, _data->cfg.datadir, table.calculate_generation_for_new_table(), version);
+        return sstables_manager.make_sstable(_data->s, _data->storage, _data->cfg.datadir, table.calculate_generation_for_new_table(), version);
     }
 
     std::function<sstables::shared_sstable()> make_sst_factory() {


### PR DESCRIPTION
Currently there are only 2 tests for S3 -- the pure client test and compound object_store test that launches scylla, creates s3-backed table and CQL-queries it. At the same time there's a whole lot of small unit test for sstables functionality, part of it can run over S3 storage too.

This PR adds this support and patches several test cases to use it. More test cases are to come later on demand.

fixes: #13015
