### PR TITLE
s3/client: Explicitly set _upload_id empty when completing

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -344,7 +344,7 @@ future<> client::upload_sink::upload_part(unsigned part_number, memory_data_sink
 future<> client::upload_sink::abort_upload() {
     s3l.trace("DELETE upload {}", _upload_id);
     auto req = http::request::make("DELETE", _client->_host, _object_name);
-    req.query_parameters["uploadId"] = std::move(_upload_id);
+    req.query_parameters["uploadId"] = std::exchange(_upload_id, ""); // now upload_started() returns false
     co_await _http.make_request(std::move(req), ignore_reply, http::reply::status_type::no_content);
 }
 
@@ -366,7 +366,7 @@ future<> client::upload_sink::finalize_upload() {
 
     s3l.trace("POST upload completion {} parts (upload id {})", _part_etags.size(), _upload_id);
     auto req = http::request::make("POST", _client->_host, _object_name);
-    req.query_parameters["uploadId"] = std::move(_upload_id);
+    req.query_parameters["uploadId"] = std::exchange(_upload_id, ""); // now upload_started() returns false
     req.write_body("xml", parts_xml_len, [this] (output_stream<char>&& out) -> future<> {
         return dump_multipart_upload_parts(std::move(out), _part_etags);
     });


### PR DESCRIPTION
The upload_sink::_upload_id remains empty until upload starts, remains non-empty while it proceeds, then becomes empty again after it completes. The upload_started() method cheks that and on .close() started upload is aborted.

The final switch to empty is done by std::move()ing the upload id into completion requrest, but it's better to use std::exchange() to emphasize the fact the the _upload_id becomes empty at that point for a reason.