### PR TITLE
tree: finish the reader_permit state renames

### DIFF
--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -241,7 +241,7 @@ future<> size_estimates_mutation_reader::get_next_partition() {
         _end_of_stream = true;
         return make_ready_future<>();
     }
-    return do_with(reader_permit::blocked_guard(_permit), [this] (reader_permit::blocked_guard&) {
+    return do_with(reader_permit::awaits_guard(_permit), [this] (reader_permit::awaits_guard&) {
         return get_local_ranges(_db, _sys_ks);
     }).then([this] (auto&& ranges) {
         auto estimates = this->estimates_for_current_keyspace(std::move(ranges));

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1246,7 +1246,7 @@ reader_concurrency_semaphore::can_admit_read(const reader_permit::impl& permit) 
     }
 
     if (!all_need_cpu_permits_are_awaiting()) {
-        return {can_admit::no, reason::used_permits};
+        return {can_admit::no, reason::need_cpu_permits};
     }
 
     if (!has_available_units(permit.base_resources())) {

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -251,7 +251,7 @@ public:
         }
 
         if (_need_cpu_branches) {
-            on_internal_error_noexcept(rcslog, format("reader_permit::impl::~impl(): permit {}.{}:{} destroyed with {} used branches",
+            on_internal_error_noexcept(rcslog, format("reader_permit::impl::~impl(): permit {}.{}:{} destroyed with {} need_cpu branches",
                         _schema ? _schema->ks_name() : "*",
                         _schema ? _schema->cf_name() : "*",
                         _op_name_view,
@@ -260,7 +260,7 @@ public:
         }
 
         if (_awaits_branches) {
-            on_internal_error_noexcept(rcslog, format("reader_permit::impl::~impl(): permit {}.{}:{} destroyed with {} blocked branches",
+            on_internal_error_noexcept(rcslog, format("reader_permit::impl::~impl(): permit {}.{}:{} destroyed with {} awaits branches",
                         _schema ? _schema->ks_name() : "*",
                         _schema ? _schema->cf_name() : "*",
                         _op_name_view,
@@ -400,9 +400,9 @@ public:
         assert(_need_cpu_branches);
         --_need_cpu_branches;
         if (_marked_as_need_cpu && !_need_cpu_branches) {
-            // When an exception is thrown, blocked and used guards might be
-            // destroyed out-of-order. Force an unblock here so that we maintain
-            // used >= blocked.
+            // When an exception is thrown, need_cpu and awaits guards might be
+            // destroyed out-of-order. Force the state out of awaits state here
+            // so that we maintain awaits >= need_cpu.
             if (_marked_as_awaits) {
                 on_permit_not_awaits();
             }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -201,7 +201,7 @@ private:
 
     bool has_available_units(const resources& r) const;
 
-    bool all_used_permits_are_stalled() const;
+    bool all_need_cpu_permits_are_awaiting() const;
 
     [[nodiscard]] std::exception_ptr check_queue_size(std::string_view queue_name);
 
@@ -241,11 +241,11 @@ private:
     void on_permit_created(reader_permit::impl&);
     void on_permit_destroyed(reader_permit::impl&) noexcept;
 
-    void on_permit_used() noexcept;
-    void on_permit_unused() noexcept;
+    void on_permit_need_cpu() noexcept;
+    void on_permit_not_need_cpu() noexcept;
 
-    void on_permit_blocked() noexcept;
-    void on_permit_unblocked() noexcept;
+    void on_permit_awaits() noexcept;
+    void on_permit_not_awaits() noexcept;
 
     std::runtime_error stopped_exception();
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -100,8 +100,8 @@ public:
         uint64_t reads_admitted_immediately = 0;
         // Total number of reads enqueued because ready_list wasn't empty
         uint64_t reads_queued_because_ready_list = 0;
-        // Total number of reads enqueued because there are used but unblocked permits
-        uint64_t reads_queued_because_used_permits = 0;
+        // Total number of reads enqueued because there are permits who need CPU to make progress
+        uint64_t reads_queued_because_need_cpu_permits = 0;
         // Total number of reads enqueued because there weren't enough memory resources
         uint64_t reads_queued_because_memory_resources = 0;
         // Total number of reads enqueued because there weren't enough count resources
@@ -112,10 +112,10 @@ public:
         uint64_t total_permits = 0;
         // Current number of permits.
         uint64_t current_permits = 0;
-        // Current number of used permits.
-        uint64_t used_permits = 0;
-        // Current number of blocked permits.
-        uint64_t blocked_permits = 0;
+        // Current number permits needing CPU to make progress.
+        uint64_t need_cpu_permits = 0;
+        // Current number of permits awaiting I/O or an operation running on a remote shard.
+        uint64_t awaits_permits = 0;
         // Current number of reads reading from the disk.
         uint64_t disk_reads = 0;
         // The number of sstables read currently.

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -218,7 +218,7 @@ private:
     // A return value of can_admit::maybe means admission might be possible if
     // some of the inactive readers are evicted.
     enum class can_admit { no, maybe, yes };
-    enum class reason { all_ok = 0, ready_list, used_permits, memory_resources, count_resources };
+    enum class reason { all_ok = 0, ready_list, need_cpu_permits, memory_resources, count_resources };
     struct admit_result { can_admit decision; reason why; };
     admit_result can_admit_read(const reader_permit::impl& permit) const noexcept;
 

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -76,8 +76,8 @@ class reader_permit {
 
 public:
     class resource_units;
-    class used_guard;
-    class blocked_guard;
+    class need_cpu_guard;
+    class awaits_guard;
 
     enum class state {
         waiting_for_admission,
@@ -207,53 +207,53 @@ public:
 
 std::ostream& operator<<(std::ostream& os, reader_permit::state s);
 
-/// Mark a permit as used.
+/// Mark a permit as needing CPU.
 ///
-/// Conceptually, a permit is considered used, when at least one reader
+/// Conceptually, a permit is considered as needing CPU, when at least one reader
 /// associated with it has an ongoing foreground operation initiated by
 /// its consumer. E.g. a pending `fill_buffer()` call.
-/// This class is an RAII used marker meant to be used by keeping it alive
-/// until the reader is used.
-class reader_permit::used_guard {
+/// This class is an RAII need_cpu marker meant to be used by keeping it alive
+/// while the reader is in need of CPU.
+class reader_permit::need_cpu_guard {
     reader_permit_opt _permit;
 public:
-    explicit used_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
+    explicit need_cpu_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
         _permit->mark_need_cpu();
     }
-    used_guard(used_guard&&) noexcept = default;
-    used_guard(const used_guard&) = delete;
-    ~used_guard() {
+    need_cpu_guard(need_cpu_guard&&) noexcept = default;
+    need_cpu_guard(const need_cpu_guard&) = delete;
+    ~need_cpu_guard() {
         if (_permit) {
             _permit->mark_not_need_cpu();
         }
     }
-    used_guard& operator=(used_guard&&) = delete;
-    used_guard& operator=(const used_guard&) = delete;
+    need_cpu_guard& operator=(need_cpu_guard&&) = delete;
+    need_cpu_guard& operator=(const need_cpu_guard&) = delete;
 };
 
-/// Mark a permit as blocked.
+/// Mark a permit as awaiting I/O or an operation running on a remote shard.
 ///
-/// Conceptually, a permit is considered blocked, when at least one reader
+/// Conceptually, a permit is considered awaiting, when at least one reader
 /// associated with it is waiting on I/O or a remote shard as part of a
 /// foreground operation initiated by its consumer. E.g. an sstable reader
 /// waiting on a disk read as part of its `fill_buffer()` call.
-/// This class is an RAII block marker meant to be used by keeping it alive
-/// until said block resolves.
-class reader_permit::blocked_guard {
+/// This class is an RAII awaits marker meant to be used by keeping it alive
+/// until said awaited event completes.
+class reader_permit::awaits_guard {
     reader_permit_opt _permit;
 public:
-    explicit blocked_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
+    explicit awaits_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
         _permit->mark_awaits();
     }
-    blocked_guard(blocked_guard&&) noexcept = default;
-    blocked_guard(const blocked_guard&) = delete;
-    ~blocked_guard() {
+    awaits_guard(awaits_guard&&) noexcept = default;
+    awaits_guard(const awaits_guard&) = delete;
+    ~awaits_guard() {
         if (_permit) {
             _permit->mark_not_awaits();
         }
     }
-    blocked_guard& operator=(blocked_guard&&) = delete;
-    blocked_guard& operator=(const blocked_guard&) = delete;
+    awaits_guard& operator=(awaits_guard&&) = delete;
+    awaits_guard& operator=(const awaits_guard&) = delete;
 };
 
 template <typename Char>

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -106,13 +106,13 @@ private:
     reader_permit::impl& operator*() { return *_impl; }
     reader_permit::impl* operator->() { return _impl.get(); }
 
-    void mark_used() noexcept;
+    void mark_need_cpu() noexcept;
 
-    void mark_unused() noexcept;
+    void mark_not_need_cpu() noexcept;
 
-    void mark_blocked() noexcept;
+    void mark_awaits() noexcept;
 
-    void mark_unblocked() noexcept;
+    void mark_not_awaits() noexcept;
 
     operator bool() const { return bool(_impl); }
 
@@ -218,13 +218,13 @@ class reader_permit::used_guard {
     reader_permit_opt _permit;
 public:
     explicit used_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
-        _permit->mark_used();
+        _permit->mark_need_cpu();
     }
     used_guard(used_guard&&) noexcept = default;
     used_guard(const used_guard&) = delete;
     ~used_guard() {
         if (_permit) {
-            _permit->mark_unused();
+            _permit->mark_not_need_cpu();
         }
     }
     used_guard& operator=(used_guard&&) = delete;
@@ -243,13 +243,13 @@ class reader_permit::blocked_guard {
     reader_permit_opt _permit;
 public:
     explicit blocked_guard(reader_permit permit) noexcept : _permit(std::move(permit)) {
-        _permit->mark_blocked();
+        _permit->mark_awaits();
     }
     blocked_guard(blocked_guard&&) noexcept = default;
     blocked_guard(const blocked_guard&) = delete;
     ~blocked_guard() {
         if (_permit) {
-            _permit->mark_unblocked();
+            _permit->mark_not_awaits();
         }
     }
     blocked_guard& operator=(blocked_guard&&) = delete;

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -58,7 +58,7 @@ class foreign_reader : public flat_mutation_reader_v2::impl {
     // we don't have to wait on the remote reader filling its buffer.
     template <typename Operation, typename Result = futurize_t<std::result_of_t<Operation()>>>
     Result forward_operation(Operation op) {
-        reader_permit::blocked_guard bg{_permit};
+        reader_permit::awaits_guard awaits_guard{_permit};
         return smp::submit_to(_reader.get_owner_shard(), [reader = _reader.get(),
                 read_ahead_future = std::exchange(_read_ahead_future, nullptr),
                 op = std::move(op)] () mutable {
@@ -84,7 +84,7 @@ class foreign_reader : public flat_mutation_reader_v2::impl {
                 auto result = std::get<1>(std::move(fut_and_result));
                 return make_ready_future<decltype(result)>(std::move(result));
             }
-        }).finally([bg = std::move(bg)] { });
+        }).finally([awaits_guard = std::move(awaits_guard)] { });
     }
 public:
     foreign_reader(schema_ptr schema,
@@ -853,7 +853,7 @@ future<> shard_reader_v2::do_fill_buffer() {
 
                 try {
                     tracing::trace(_trace_state, "Creating shard reader on shard: {}", this_shard_id());
-                    reader_permit::used_guard ug{rreader->permit()};
+                    reader_permit::need_cpu_guard ncpu_guard{rreader->permit()};
                     co_await rreader->fill_buffer();
                     auto res = remote_fill_buffer_result_v2(rreader->detach_buffer(), rreader->is_end_of_stream());
                     co_return reader_and_buffer_fill_result{std::move(rreader), std::move(res)};
@@ -867,7 +867,7 @@ future<> shard_reader_v2::do_fill_buffer() {
             co_return std::move(res.result);
         } else {
             co_return co_await smp::submit_to(_shard, coroutine::lambda([this] () -> future<remote_fill_buffer_result_v2>  {
-                reader_permit::used_guard ug{_reader->permit()};
+                reader_permit::need_cpu_guard ncpu_guard{_reader->permit()};
                 co_await _reader->fill_buffer();
                 co_return remote_fill_buffer_result_v2(_reader->detach_buffer(), _reader->is_end_of_stream());
             }));
@@ -884,7 +884,7 @@ future<> shard_reader_v2::do_fill_buffer() {
 
 future<> shard_reader_v2::fill_buffer() {
     // FIXME: want to move this to the inner scopes but it makes clang miscompile the code.
-    reader_permit::blocked_guard guard(_permit);
+    reader_permit::awaits_guard guard(_permit);
     if (_read_ahead) {
         co_await *std::exchange(_read_ahead, std::nullopt);
         co_return;
@@ -901,7 +901,7 @@ future<> shard_reader_v2::next_partition() {
     }
 
     // FIXME: want to move this to the inner scopes but it makes clang miscompile the code.
-    reader_permit::blocked_guard guard(_permit);
+    reader_permit::awaits_guard guard(_permit);
 
     if (_read_ahead) {
         co_await *std::exchange(_read_ahead, std::nullopt);
@@ -923,7 +923,7 @@ future<> shard_reader_v2::fast_forward_to(const dht::partition_range& pr) {
         co_return;
     }
 
-    reader_permit::blocked_guard guard(_permit);
+    reader_permit::awaits_guard guard(_permit);
 
     if (_read_ahead) {
         co_await *std::exchange(_read_ahead, std::nullopt);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1507,10 +1507,10 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
     }
 
     auto read_func = [&, this] (reader_permit permit) {
-        reader_permit::used_guard ug{permit};
+        reader_permit::need_cpu_guard ncpu_guard{permit};
         permit.set_max_result_size(max_result_size);
         return cf.query(std::move(s), std::move(permit), cmd, opts, ranges, trace_state, get_result_memory_limiter(),
-                timeout, &querier_opt).then([&result, ug = std::move(ug)] (lw_shared_ptr<query::result> res) {
+                timeout, &querier_opt).then([&result, ncpu_guard = std::move(ncpu_guard)] (lw_shared_ptr<query::result> res) {
             result = std::move(res);
         });
     };
@@ -1574,10 +1574,10 @@ database::query_mutations(schema_ptr s, const query::read_command& cmd, const dh
     }
 
     auto read_func = [&] (reader_permit permit) {
-        reader_permit::used_guard ug{permit};
+        reader_permit::need_cpu_guard ncpu_guard{permit};
         permit.set_max_result_size(max_result_size);
         return cf.mutation_query(std::move(s), std::move(permit), cmd, range,
-                std::move(trace_state), std::move(accounter), timeout, &querier_opt).then([&result, ug = std::move(ug)] (reconcilable_result res) {
+                std::move(trace_state), std::move(accounter), timeout, &querier_opt).then([&result, ncpu_guard = std::move(ncpu_guard)] (reconcilable_result res) {
             result = std::move(res);
         });
     };

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -477,7 +477,7 @@ protected:
     sstables::reader_position_tracker _stream_position;
     // remaining length of input to read (if <0, continue until end of file).
     uint64_t _remain;
-    std::optional<reader_permit::blocked_guard> _blocked_guard;
+    std::optional<reader_permit::awaits_guard> _awaits_guard;
     bool _first_invoke = true;
 public:
     using read_status = data_consumer::read_status;
@@ -507,11 +507,11 @@ public:
     }
 
     void mark_blocked() {
-        _blocked_guard.emplace(_permit);
+        _awaits_guard.emplace(_permit);
     }
 
     void mark_unblocked() {
-        _blocked_guard.reset();
+        _awaits_guard.reset();
     }
 
     data_consumer::processing_result skip(temporary_buffer<char>& data, uint32_t len) {
@@ -616,7 +616,7 @@ public:
         _remain = end - _stream_position.position;
 
         primitive_consumer::reset();
-        reader_permit::blocked_guard _{_permit};
+        reader_permit::awaits_guard _{_permit};
         co_await _input.skip(n);
     }
 

--- a/test/boost/continuous_data_consumer_test.cc
+++ b/test/boost/continuous_data_consumer_test.cc
@@ -30,7 +30,7 @@ class test_consumer final : public data_consumer::continuous_data_consumer<test_
     uint64_t _tested_value;
     int _state = 0;
     int _count = 0;
-    reader_permit::used_guard _used_guard;
+    reader_permit::need_cpu_guard _need_cpu_guard;
 
     void check(uint64_t got) {
         BOOST_REQUIRE_EQUAL(_tested_value, got);
@@ -54,7 +54,7 @@ public:
     test_consumer(reader_permit permit, uint64_t tested_value)
         : continuous_data_consumer(std::move(permit), prepare_stream(tested_value), 0, calculate_length(tested_value))
         , _tested_value(tested_value)
-        , _used_guard(_permit)
+        , _need_cpu_guard(_permit)
     { }
 
     bool non_consuming() { return false; }

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -203,7 +203,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_forward_progress) {
             skeleton_reader(schema_ptr s, reader_permit permit)
                 : impl(std::move(s), std::move(permit)) { }
             virtual future<> fill_buffer() override {
-                reader_permit::blocked_guard _{_permit};
+                reader_permit::awaits_guard _{_permit};
                 _resources.emplace(_permit.consume_resources(reader_resources(0, tests::random::get_int(1024, 2048))));
                 co_await sleep(std::chrono::milliseconds(1));
             }
@@ -682,11 +682,11 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
         require_can_admit(true, "!used");
         {
-            reader_permit::used_guard ug{permit};
+            reader_permit::need_cpu_guard ncpu_guard{permit};
 
             require_can_admit(false, "used > blocked");
             {
-                reader_permit::blocked_guard bg{permit};
+                reader_permit::awaits_guard awaits_guard{permit};
                 require_can_admit(true, "used == blocked");
             }
             require_can_admit(false, "used > blocked");
@@ -713,7 +713,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
         BOOST_REQUIRE(semaphore.try_evict_one_inactive_read());
         BOOST_REQUIRE(!irh);
 
-        reader_permit::used_guard _{permit};
+        reader_permit::need_cpu_guard _{permit};
 
         const auto stats_before = semaphore.get_stats();
 
@@ -740,7 +740,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
             auto irh = semaphore.register_inactive_read(make_empty_flat_reader_v2(s.schema(), permit));
             require_can_admit(true, "inactive");
 
-            reader_permit::used_guard ug{permit};
+            reader_permit::need_cpu_guard ncpu_guard{permit};
 
             require_can_admit(true, "inactive (used)");
 
@@ -831,9 +831,9 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
             [&] {
                 auto permit = semaphore.obtain_permit(schema_ptr, get_name(), 1024, db::timeout_clock::now(), {}).get();
                 require_can_admit(true, "enough resources");
-                return std::pair(permit, std::optional<reader_permit::used_guard>{permit});
-            }, [&] (std::pair<reader_permit, std::optional<reader_permit::used_guard>>& permit_and_used_guard) {
-                permit_and_used_guard.second.reset();
+                return std::pair(permit, std::optional<reader_permit::need_cpu_guard>{permit});
+            }, [&] (std::pair<reader_permit, std::optional<reader_permit::need_cpu_guard>>& permit_and_need_cpu_guard) {
+                permit_and_need_cpu_guard.second.reset();
                 return 0;
             }
         );
@@ -847,9 +847,9 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
             [&] {
                 auto permit = semaphore.obtain_permit(schema_ptr, get_name(), 1024, db::timeout_clock::now(), {}).get();
                 require_can_admit(true, "enough resources");
-                return std::pair(permit, reader_permit::used_guard{permit});
-            }, [&] (std::pair<reader_permit, reader_permit::used_guard>& permit_and_used_guard) {
-                return reader_permit::blocked_guard{permit_and_used_guard.first};
+                return std::pair(permit, reader_permit::need_cpu_guard{permit});
+            }, [&] (std::pair<reader_permit, reader_permit::need_cpu_guard>& permit_and_need_cpu_guard) {
+                return reader_permit::awaits_guard{permit_and_need_cpu_guard.first};
             }
         );
     }
@@ -871,8 +871,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_used_blocked) {
     for (auto scenario = 0; scenario < 5; ++scenario) {
         testlog.info("Running scenario {}", scenario);
 
-        std::vector<reader_permit::used_guard> used;
-        std::vector<reader_permit::blocked_guard> blocked;
+        std::vector<reader_permit::need_cpu_guard> used;
+        std::vector<reader_permit::awaits_guard> blocked;
         unsigned count;
 
         switch (scenario) {
@@ -991,15 +991,15 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
         promise<> _read_started_pr;
         future<> _read_started_fut;
         promise<> _read_done_pr;
-        reader_permit::used_guard _ug;
-        std::optional<reader_permit::blocked_guard> _bg;
+        reader_permit::need_cpu_guard _ncpu_guard;
+        std::optional<reader_permit::awaits_guard> _awaits_guard;
 
     public:
-        explicit read(reader_permit p) : _permit(std::move(p)), _read_started_fut(_read_started_pr.get_future()), _ug(_permit) { }
+        explicit read(reader_permit p) : _permit(std::move(p)), _read_started_fut(_read_started_pr.get_future()), _ncpu_guard(_permit) { }
         future<> wait_read_started() { return std::move(_read_started_fut); }
         void set_read_done() { _read_done_pr.set_value(); }
-        void mark_as_blocked() { _bg.emplace(_permit); }
-        void mark_as_unblocked() { _bg.reset(); }
+        void mark_as_blocked() { _awaits_guard.emplace(_permit); }
+        void mark_as_unblocked() { _awaits_guard.reset(); }
         reader_concurrency_semaphore::read_func get_read_func() {
             return [this] (reader_permit permit) -> future<> {
                 _read_started_pr.set_value();
@@ -1536,15 +1536,15 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
     // used
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get0();
-        reader_permit::used_guard ug{permit};
+        reader_permit::need_cpu_guard ncpu_guard{permit};
         do_check(permit, 1, 0, std::source_location::current());
     }
 
     // blocked
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get0();
-        reader_permit::used_guard ug{permit};
-        reader_permit::blocked_guard bg{permit};
+        reader_permit::need_cpu_guard ncpu_guard{permit};
+        reader_permit::awaits_guard awaits_guard{permit};
         do_check(permit, 1, 1, std::source_location::current());
     }
 }
@@ -1718,8 +1718,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicti
         auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
         auto permit3 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
 
-        std::optional<reader_permit::used_guard> ug1{permit1};
-        std::optional<reader_permit::used_guard> ug2{permit2};
+        std::optional<reader_permit::need_cpu_guard> ncpu_guard1{permit1};
+        std::optional<reader_permit::need_cpu_guard> ncpu_guard2{permit2};
 
         auto permit4_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
@@ -1734,7 +1734,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicti
         BOOST_REQUIRE_EQUAL(permit3.get_state(), reader_permit::state::inactive);
 
         // Now check the callback admission path (admission check on resources being freed).
-        ug2.reset();
+        ncpu_guard2.reset();
         BOOST_REQUIRE(handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
@@ -1847,7 +1847,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
 
-        std::optional<reader_permit::used_guard> ug{permit2};
+        std::optional<reader_permit::need_cpu_guard> ncpu_guard{permit2};
 
         auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
@@ -1856,7 +1856,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE(handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
-        ug.reset();
+        ncpu_guard.reset();
         BOOST_REQUIRE(!handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
@@ -1876,7 +1876,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
 
-        std::optional<reader_permit::used_guard> ug{permit2};
+        std::optional<reader_permit::need_cpu_guard> ncpu_guard{permit2};
 
         auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
@@ -1885,7 +1885,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE(handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
-        ug.reset();
+        ncpu_guard.reset();
         thread::yield(); // allow debug builds to schedule the fiber evicting the reads again
         BOOST_REQUIRE(!handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -676,22 +676,22 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
     require_can_admit(true, "semaphore in initial state");
 
-    // used and blocked
+    // need_cpu and awaits
     {
         auto permit = semaphore.obtain_permit(schema_ptr, get_name(), 1024, db::timeout_clock::now(), {}).get();
 
-        require_can_admit(true, "!used");
+        require_can_admit(true, "!need_cpu");
         {
             reader_permit::need_cpu_guard ncpu_guard{permit};
 
-            require_can_admit(false, "used > blocked");
+            require_can_admit(false, "need_cpu > awaits");
             {
                 reader_permit::awaits_guard awaits_guard{permit};
-                require_can_admit(true, "used == blocked");
+                require_can_admit(true, "need_cpu == awaits");
             }
-            require_can_admit(false, "used > blocked");
+            require_can_admit(false, "need_cpu > awaits");
         }
-        require_can_admit(true, "!used");
+        require_can_admit(true, "!need_cpu");
     }
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
     require_can_admit(true, "semaphore in initial state");
@@ -735,26 +735,26 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     {
         auto permit = semaphore.obtain_permit(schema_ptr, get_name(), 1024, db::timeout_clock::now(), {}).get();
 
-        require_can_admit(true, "!used");
+        require_can_admit(true, "!need_cpu");
         {
             auto irh = semaphore.register_inactive_read(make_empty_flat_reader_v2(s.schema(), permit));
             require_can_admit(true, "inactive");
 
             reader_permit::need_cpu_guard ncpu_guard{permit};
 
-            require_can_admit(true, "inactive (used)");
+            require_can_admit(true, "inactive (need_cpu)");
 
             {
                 auto rd = semaphore.unregister_inactive_read(std::move(irh));
                 rd->close().get();
             }
 
-            require_can_admit(false, "used > blocked");
+            require_can_admit(false, "need_cpu > awaits");
 
             irh = semaphore.register_inactive_read(make_empty_flat_reader_v2(s.schema(), permit));
-            require_can_admit(true, "inactive (used)");
+            require_can_admit(true, "inactive (need_cpu)");
         }
-        require_can_admit(true, "!used");
+        require_can_admit(true, "!need_cpu");
     }
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
     require_can_admit(true, "semaphore in initial state");
@@ -775,7 +775,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     auto check_admitting_enqueued_read = [&] (auto pre_admission_hook, auto post_enqueue_hook) {
         auto cookie1 = pre_admission_hook();
 
-        require_can_admit(false, "admission blocked");
+        require_can_admit(false, "admission awaits");
 
         const auto stats_before = semaphore.get_stats();
 
@@ -825,7 +825,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
     require_can_admit(true, "semaphore in initial state");
 
-    // admitting enqueued reads -- permit becomes unused
+    // admitting enqueued reads -- permit becomes active
     {
         check_admitting_enqueued_read(
             [&] {
@@ -841,7 +841,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
     require_can_admit(true, "semaphore in initial state");
 
-    // admitting enqueued reads -- permit becomes blocked
+    // admitting enqueued reads -- permit becomes awaits
     {
         check_admitting_enqueued_read(
             [&] {
@@ -857,7 +857,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     require_can_admit(true, "semaphore in initial state");
 }
 
-SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_used_blocked) {
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_need_cpu_awaits) {
     const auto initial_resources = reader_concurrency_semaphore::resources{2, 2 * 1024};
     reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(), initial_resources.count, initial_resources.memory);
     auto stop_sem = deferred_stop(semaphore);
@@ -871,36 +871,36 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_used_blocked) {
     for (auto scenario = 0; scenario < 5; ++scenario) {
         testlog.info("Running scenario {}", scenario);
 
-        std::vector<reader_permit::need_cpu_guard> used;
-        std::vector<reader_permit::awaits_guard> blocked;
+        std::vector<reader_permit::need_cpu_guard> need_cpu;
+        std::vector<reader_permit::awaits_guard> awaits;
         unsigned count;
 
         switch (scenario) {
             case 0:
-                used.emplace_back(permit);
+                need_cpu.emplace_back(permit);
 
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 0);
                 break;
             case 1:
-                used.emplace_back(permit);
-                blocked.emplace_back(permit);
+                need_cpu.emplace_back(permit);
+                awaits.emplace_back(permit);
 
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 1);
                 break;
             case 2:
-                blocked.emplace_back(permit);
+                awaits.emplace_back(permit);
 
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 0);
                 break;
             case 3:
-                blocked.emplace_back(permit);
-                used.emplace_back(permit);
+                awaits.emplace_back(permit);
+                need_cpu.emplace_back(permit);
 
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 1);
                 BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 1);
@@ -910,25 +910,25 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_used_blocked) {
                 count = tests::random::get_int<unsigned>(3, 100);
                 for (unsigned i = 0; i < count; ++i) {
                     if (tests::random::get_bool()) {
-                        used.emplace_back(permit);
+                        need_cpu.emplace_back(permit);
                     } else {
-                        blocked.emplace_back(permit);
+                        awaits.emplace_back(permit);
                     }
                 }
                 break;
         }
 
-        while (!used.empty() && !blocked.empty()) {
-            const bool pop_used = !used.empty() && tests::random::get_bool();
+        while (!need_cpu.empty() && !awaits.empty()) {
+            const bool pop_need_cpu = !need_cpu.empty() && tests::random::get_bool();
 
-            if (pop_used) {
-                used.pop_back();
-                if (used.empty()) {
+            if (pop_need_cpu) {
+                need_cpu.pop_back();
+                if (need_cpu.empty()) {
                     BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0);
                 }
             } else {
-                blocked.pop_back();
-                if (blocked.empty()) {
+                awaits.pop_back();
+                if (awaits.empty()) {
                     BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 0);
                 }
             }
@@ -978,7 +978,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
 }
 
 // Reproduces https://github.com/scylladb/scylladb/issues/11770
-SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_when_all_is_blocked) {
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_when_all_is_awaits) {
     simple_schema ss;
     const auto& s = *ss.schema();
 
@@ -998,8 +998,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
         explicit read(reader_permit p) : _permit(std::move(p)), _read_started_fut(_read_started_pr.get_future()), _ncpu_guard(_permit) { }
         future<> wait_read_started() { return std::move(_read_started_fut); }
         void set_read_done() { _read_done_pr.set_value(); }
-        void mark_as_blocked() { _awaits_guard.emplace(_permit); }
-        void mark_as_unblocked() { _awaits_guard.reset(); }
+        void mark_as_awaits() { _awaits_guard.emplace(_permit); }
+        void mark_as_not_awaits() { _awaits_guard.reset(); }
         reader_concurrency_semaphore::read_func get_read_func() {
             return [this] (reader_permit permit) -> future<> {
                 _read_started_pr.set_value();
@@ -1017,13 +1017,13 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
 
     // At this point we expect to have:
     // * 1 inactive read (not evicted)
-    // * 1 used (but not blocked) read on the ready list
+    // * 1 need_cpu (but not awaiting) read on the ready list
     // * 1 waiter
     // * no more count resources left
     auto p3_fut = semaphore.obtain_permit(&s, get_name(), 1024, db::no_timeout, {});
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2); // (waiters includes _ready_list entries)
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
-    BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0); // permit looses used status while waiting for execution
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0); // permit looses need_cpu status while waiting for execution
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 0);
@@ -1040,8 +1040,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
     BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
     BOOST_REQUIRE(irh1);
 
-    // Marking p2 as blocked should now allow p3 to be admitted by evicting p1
-    rd2.mark_as_blocked();
+    // Marking p2 as awaits should now allow p3 to be admitted by evicting p1
+    rd2.mark_as_awaits();
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 1);
@@ -1051,7 +1051,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
     BOOST_REQUIRE(!irh1);
 
     p3_fut.get();
-    rd2.mark_as_unblocked();
+    rd2.mark_as_not_awaits();
     rd2.set_read_done();
     fut2.get();
 }
@@ -1498,18 +1498,18 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
 
     uint64_t reads_enqueued_for_memory = 0;
 
-    auto do_check = [&] (reader_permit& permit, uint64_t used, uint64_t blocked, std::source_location sl) {
+    auto do_check = [&] (reader_permit& permit, uint64_t need_cpu, uint64_t awaits, std::source_location sl) {
         testlog.info("do_check() {}:{}", sl.file_name(), sl.line());
 
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 2);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, used);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, blocked);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, need_cpu);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, awaits);
 
         auto units1 = permit.request_memory(1024).get();
 
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 2);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, used);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, blocked);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, need_cpu);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, awaits);
 
         auto sponge_units = sponge_permit.request_memory(8 * 1024).get();
 
@@ -1523,24 +1523,24 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
         auto units2 = units2_fut.get();
 
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 2);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, used);
-        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, blocked);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, need_cpu);
+        BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, awaits);
     };
 
-    // unused
+    // active
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get0();
         do_check(permit, 0, 0, std::source_location::current());
     }
 
-    // used
+    // need_cpu
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get0();
         reader_permit::need_cpu_guard ncpu_guard{permit};
         do_check(permit, 1, 0, std::source_location::current());
     }
 
-    // blocked
+    // awaits
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get0();
         reader_permit::need_cpu_guard ncpu_guard{permit};


### PR DESCRIPTION
In https://github.com/scylladb/scylladb/pull/13482 we renamed the reader permit states to more descriptive names. That PR however only covered only the states themselves and their usages, as well as the documentation in `docs/dev`.
This PR is a followup to said PR, completing the name changes: renaming all symbols, names, comments etc, so all is consistent and up-to-date.