### PR TITLE
raft: verify RPC destination ID

### DIFF
--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -39,6 +39,12 @@ struct raft_group_not_found: public raft::error {
     {}
 };
 
+struct raft_destination_id_not_correct: public raft::error {
+    raft_destination_id_not_correct(raft::server_id my_id, raft::server_id dst_id)
+            : raft::error(format("Got message for server {}, but my id is {}", dst_id, my_id))
+    {}
+};
+
 // An entry in the group registry
 struct raft_server_for_group {
     raft::group_id gid;


### PR DESCRIPTION
All Raft verbs include `dst_id`, the ID of the destination server, but it isn't checked. `append_entries` will work even if it arrives at completely the wrong server (but in the same group). It can cause problems, e.g. in the scenario of replacing a dead node.

This commit adds verifying if `dst_id` matches the server's ID and if it doesn't, the Raft verb is rejected.

Closes #12179

### Testing
Testcase and scylla's configuration: https://github.com/margdoc/scylla/commit/57d3ef14d848840b93346fdb9f86c7605d53bdcd

It artificially lengthens the duration of replacing the old node. It increases the chance of getting the RPC command sent to a replaced node, by the new node.

In the logs of the node that replaced the old one, we can see logs in the form:
```
DEBUG <time> [shard 0] raft_group_registry - Got message for server <dst_id>, but my id is <my_id>
```
It indicates that the Raft verb with the wrong `dst_id` was rejected.

This test isn't included in the pr because it doesn't catch any specific error.

