### PR TITLE
Break S3 upload 50Gb file limit

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -494,7 +494,8 @@ future<file> s3_storage::open_component(const sstable& sst, component_type type,
 future<data_sink> s3_storage::make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) {
     assert(type == component_type::Data || type == component_type::Index);
     co_await ensure_remote_prefix(sst);
-    co_return _client->make_upload_sink(make_s3_object_name(sst, type));
+    // FIXME: if we have file size upper bound upfront, it's better to use make_upload_sink() instead
+    co_return _client->make_upload_jumbo_sink(make_s3_object_name(sst, type));
 }
 
 future<data_sink> s3_storage::make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) {

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -97,14 +97,18 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     cln->close().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
-    const sstring name(fmt::format("/{}/testlargeobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
+void do_test_client_multipart_upload(bool with_copy_upload) {
+    const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
 
-    testlog.info("Upload object\n");
-    auto out = output_stream<char>(cln->make_upload_sink(name));
+    testlog.info("Upload object (with copy = {})\n", with_copy_upload);
+    auto out = output_stream<char>(
+        // Make it 3 parts per piece, so that 128Mb buffer below
+        // would be split into several 15Mb pieces
+        with_copy_upload ? cln->make_upload_jumbo_sink(name, 3) : cln->make_upload_sink(name)
+    );
     auto close = seastar::deferred_close(out);
 
     static constexpr unsigned chunk_size = 1024;
@@ -145,6 +149,14 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
     cln->delete_object(name).get();
 
     cln->close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload) {
+    do_test_client_multipart_upload(false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload) {
+    do_test_client_multipart_upload(true);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -111,7 +111,7 @@ void do_test_client_multipart_upload(bool with_copy_upload) {
     );
     auto close = seastar::deferred_close(out);
 
-    static constexpr unsigned chunk_size = 1024;
+    static constexpr unsigned chunk_size = 1000;
     auto rnd = tests::random::get_bytes(chunk_size);
     uint64_t object_size = 0;
     for (unsigned ch = 0; ch < 128 * 1024; ch++) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -299,6 +299,7 @@ future<> client::delete_object(sstring object_name) {
 class client::upload_sink_base : public data_sink_impl {
     static constexpr int flush_concurrency = 3;
 
+protected:
     shared_ptr<client> _client;
     http::experimental::client& _http;
     sstring _object_name;
@@ -306,10 +307,10 @@ class client::upload_sink_base : public data_sink_impl {
     utils::chunked_vector<sstring> _part_etags;
     semaphore _flush_sem{flush_concurrency};
 
-protected:
     future<> start_upload();
     future<> finalize_upload();
     future<> upload_part(memory_data_sink_buffers bufs);
+    future<> upload_part(std::unique_ptr<upload_sink> source);
     future<> abort_upload();
 
     bool upload_started() const noexcept {
@@ -333,6 +334,8 @@ public:
     virtual size_t buffer_size() const noexcept override {
         return 128 * 1024;
     }
+
+    unsigned parts_count() const noexcept { return _part_etags.size(); }
 };
 
 sstring parse_multipart_upload_id(sstring& body) {
@@ -348,6 +351,21 @@ sstring parse_multipart_upload_id(sstring& body) {
     auto root_node = doc->first_node("InitiateMultipartUploadResult");
     auto uploadid_node = root_node->first_node("UploadId");
     return uploadid_node->value();
+}
+
+sstring parse_multipart_copy_upload_etag(sstring& body) {
+    rapidxml::xml_document<> doc;
+    try {
+        doc.parse<0>(body.data());
+    } catch (const rapidxml::parse_error& e) {
+        s3l.warn("cannot parse multipart copy upload response: {}", e.what());
+        // The caller is supposed to check the etag to be empty
+        // and handle the error the way it prefers
+        return "";
+    }
+    auto root_node = doc.first_node("CopyPartResult");
+    auto etag_node = root_node->first_node("ETag");
+    return etag_node->value();
 }
 
 static constexpr std::string_view multipart_upload_complete_header =
@@ -542,8 +560,111 @@ public:
     }
 };
 
+future<> client::upload_sink_base::upload_part(std::unique_ptr<upload_sink> piece_ptr) {
+    if (!upload_started()) {
+        co_await start_upload();
+    }
+
+    auto& piece = *piece_ptr;
+    unsigned part_number = _part_etags.size();
+    _part_etags.emplace_back();
+    s3l.trace("PUT part {} from {} (upload id {})", part_number, piece._object_name, _upload_id);
+    auto req = http::request::make("PUT", _client->_host, _object_name);
+    req.query_parameters["partNumber"] = format("{}", part_number + 1);
+    req.query_parameters["uploadId"] = _upload_id;
+    req._headers["x-amz-copy-source"] = piece._object_name;
+
+    // See comment in upload_part(memory_data_sink_buffers) overload regarding the
+    // _flush_sem usage and _part_etags assignments
+    //
+    // Before the piece's object can be copied into the target one, it should be
+    // flushed and closed. After the object is copied, it can be removed. If copy
+    // goes wrong, the object should be removed anyway.
+    _client->authorize(req);
+    auto units = co_await get_units(_flush_sem, 1);
+    (void)piece.flush().then([&piece] () {
+        return piece.close();
+    }).then([this, part_number, req = std::move(req)] () mutable {
+        return _http.make_request(std::move(req), [this, part_number] (const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
+            return do_with(std::move(in_), [this, part_number] (auto& in) mutable {
+                return util::read_entire_stream_contiguous(in).then([this, part_number] (auto body) mutable {
+                    auto etag = parse_multipart_copy_upload_etag(body);
+                    if (etag.empty()) {
+                        return make_exception_future<>(std::runtime_error("cannot copy part upload"));
+                    }
+                    s3l.trace("copy-uploaded {} part data -> etag = {} (upload id {})", part_number, etag, _upload_id);
+                    _part_etags[part_number] = std::move(etag);
+                    return make_ready_future<>();
+                });
+            });
+        }).handle_exception([this, part_number] (auto ex) {
+            // ... the exact exception only remains in logs
+            s3l.warn("couldn't copy-upload part {}: {} (upload id {})", part_number, ex, _upload_id);
+        });
+    }).finally([this, &piece] {
+        return _client->delete_object(piece._object_name).handle_exception([&piece] (auto ex) {
+            s3l.warn("failed to remove copy-upload piece {}", piece._object_name);
+        });
+    }).finally([units = std::move(units), piece_ptr = std::move(piece_ptr)] {});
+}
+
+class client::upload_jumbo_sink final : public upload_sink_base {
+    // "Part numbers can be any number from 1 to 10,000, inclusive."
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+    static constexpr unsigned aws_maximum_parts_in_piece = 10000;
+
+    const unsigned _maximum_parts_in_piece;
+    std::unique_ptr<upload_sink> _current;
+
+    future<> maybe_flush() {
+        if (_current->parts_count() >= _maximum_parts_in_piece) {
+            auto next = std::make_unique<upload_sink>(_client, format("{}_{}", _object_name, parts_count() + 1));
+            co_await upload_part(std::exchange(_current, std::move(next)));
+            s3l.trace("Initiated {} piece (upload_id {})", parts_count(), _upload_id);
+        }
+    }
+
+public:
+    upload_jumbo_sink(shared_ptr<client> cln, sstring object_name, std::optional<unsigned> max_parts_per_piece)
+        : upload_sink_base(std::move(cln), std::move(object_name))
+        , _maximum_parts_in_piece(max_parts_per_piece.value_or(aws_maximum_parts_in_piece))
+        , _current(std::make_unique<upload_sink>(_client, format("{}_{}", _object_name, parts_count())))
+    {}
+
+    virtual future<> put(temporary_buffer<char> buf) override {
+        co_await _current->put(std::move(buf));
+        co_await maybe_flush();
+    }
+
+    virtual future<> put(std::vector<temporary_buffer<char>> data) override {
+        co_await _current->put(std::move(data));
+        co_await maybe_flush();
+    }
+
+    virtual future<> flush() override {
+        if (_current) {
+            co_await upload_part(std::exchange(_current, nullptr));
+        }
+        if (upload_started()) {
+            co_await finalize_upload();
+        }
+    }
+
+    virtual future<> close() override {
+        if (_current) {
+            co_await _current->close();
+            _current.reset();
+        }
+        co_await upload_sink_base::close();
+    }
+};
+
 data_sink client::make_upload_sink(sstring object_name) {
     return data_sink(std::make_unique<upload_sink>(shared_from_this(), std::move(object_name)));
+}
+
+data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece) {
+    return data_sink(std::make_unique<upload_jumbo_sink>(shared_from_this(), std::move(object_name), max_parts_per_piece));
 }
 
 class client::readable_file : public file_impl {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -25,6 +25,7 @@ struct range {
 class client : public enable_shared_from_this<client> {
     class upload_sink_base;
     class upload_sink;
+    class upload_jumbo_sink;
     class readable_file;
     std::string _host;
     endpoint_config_ptr _cfg;
@@ -54,6 +55,7 @@ public:
 
     file make_readable_file(sstring object_name);
     data_sink make_upload_sink(sstring object_name);
+    data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {});
 
     void update_config(endpoint_config_ptr);
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -23,6 +23,7 @@ struct range {
 };
 
 class client : public enable_shared_from_this<client> {
+    class upload_sink_base;
     class upload_sink;
     class readable_file;
     std::string _host;


### PR DESCRIPTION
Current S3 uploading sink has implicit limit for the final file size that comes from two places. First, S3 protocol declares that uploading parts count from 1 to 10000 (inclusive). Second, uploading sink sends out parts once they grow above S3 minimal part size which is 5Mb. Since sstables puts data in 128kb (or smaller) portions, parts are almost exactly 5Mb in size, so the total uploading size cannot grow above ~50Gb. That's too low.

To break the limit the new sink (called jumbo sink) uses the UploadPartCopy S3 call that helps splicing several objects into one right on the server. Jumbo sink starts uploading parts into an intermediate temporary object called a piece and named ${original_object}_${piece_number}. When the number of parts in current piece grows above the configured limit the piece is finalized and upload-copied into the object as its next part, then deleted. This happens in the background, meanwhile the new piece is created and subsequent data is put into it. When the sink is flushed the current piece is flushed as is and also squashed into the object.

The new jumbo sink is capable of uploading ~500Tb of data, which looks enough.

fixes: #13019 