### PR TITLE
db, cql3: functions: switch argument passing to std::span

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -12,6 +12,7 @@
 #include <iosfwd>
 #include <algorithm>
 #include <vector>
+#include <span>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include "utils/serialization.hh"
@@ -113,16 +114,16 @@ public:
     static managed_bytes serialize_value(std::initializer_list<T> values) {
         return serialize_value(boost::make_iterator_range(values.begin(), values.end()));
     }
-    managed_bytes serialize_optionals(const std::vector<bytes_opt>& values) const {
-        return serialize_value(values | boost::adaptors::transformed([] (const bytes_opt& bo) -> bytes_view {
+    managed_bytes serialize_optionals(std::span<const bytes_opt> values) const {
+        return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const bytes_opt& bo) -> bytes_view {
             if (!bo) {
                 throw std::logic_error("attempted to create key component from empty optional");
             }
             return *bo;
         }));
     }
-    managed_bytes serialize_optionals(const std::vector<managed_bytes_opt>& values) const {
-        return serialize_value(values | boost::adaptors::transformed([] (const managed_bytes_opt& bo) -> managed_bytes_view {
+    managed_bytes serialize_optionals(std::span<const managed_bytes_opt> values) const {
+        return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const managed_bytes_opt& bo) -> managed_bytes_view {
             if (!bo) {
                 throw std::logic_error("attempted to create key component from empty optional");
             }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2661,7 +2661,7 @@ convert_map_back_to_listlike(expression e) {
             return "NONE";
         }
 
-        virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+        virtual bytes_opt execute(std::span<const bytes_opt> parameters) override {
             auto& p = parameters[0];
             if (!p) {
                 return std::nullopt;

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1322,7 +1322,7 @@ public:
         return "LIKE";
     }
 
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) override {
         auto& str_opt = parameters[0];
         if (!str_opt) {
             return std::nullopt;

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -46,7 +46,7 @@ public:
 
     virtual bool requires_thread() const override;
 
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) override {
         bytes_ostream encoded_row;
         encoded_row.write("{", 1);
         for (size_t i = 0; i < _selector_names.size(); ++i) {

--- a/cql3/functions/bytes_conversion_fcts.hh
+++ b/cql3/functions/bytes_conversion_fcts.hh
@@ -27,7 +27,7 @@ shared_ptr<function>
 make_to_blob_function(data_type from_type) {
     auto name = from_type->as_cql3_type().to_string() + "asblob";
     return make_native_scalar_function<true>(name, bytes_type, { from_type },
-            [] (const std::vector<bytes_opt>& parameters) {
+            [] (std::span<const bytes_opt> parameters) {
         return parameters[0];
     });
 }
@@ -37,7 +37,7 @@ shared_ptr<function>
 make_from_blob_function(data_type to_type) {
     sstring name = sstring("blobas") + to_type->as_cql3_type().to_string();
     return make_native_scalar_function<true>(name, to_type, { bytes_type },
-            [name, to_type] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [name, to_type] (std::span<const bytes_opt> parameters) -> bytes_opt {
         auto&& val = parameters[0];
         if (!val) {
             return val;
@@ -57,7 +57,7 @@ inline
 shared_ptr<function>
 make_varchar_as_blob_fct() {
     return make_native_scalar_function<true>("varcharasblob", bytes_type, { utf8_type },
-            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (std::span<const bytes_opt> parameters) -> bytes_opt {
         return parameters[0];
     });
 }
@@ -66,7 +66,7 @@ inline
 shared_ptr<function>
 make_blob_as_varchar_fct() {
     return make_native_scalar_function<true>("blobasvarchar", utf8_type, { bytes_type },
-            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (std::span<const bytes_opt> parameters) -> bytes_opt {
         return parameters[0];
     });
 }

--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -35,7 +35,7 @@ public:
     virtual void print(std::ostream& os) const override {
         os << "cast(" << _arg_types[0]->name() << " as " << _return_type->name() << ")";
     }
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) override {
         auto from_type = arg_types()[0];
         auto to_type = return_type();
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -216,7 +216,7 @@ inline
 shared_ptr<function>
 make_to_json_function(data_type t) {
     return make_native_scalar_function<true>("tojson", utf8_type, {t},
-            [t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [t](std::span<const bytes_opt> parameters) -> bytes_opt {
         return utf8_type->decompose(to_json_string(*t, parameters[0]));
     });
 }
@@ -225,7 +225,7 @@ inline
 shared_ptr<function>
 make_from_json_function(data_dictionary::database db, const sstring& keyspace, data_type t) {
     return make_native_scalar_function<true>("fromjson", t, {utf8_type},
-            [keyspace, t](const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [keyspace, t](std::span<const bytes_opt> parameters) -> bytes_opt {
         try {
             rjson::value json_value = rjson::parse(utf8_type->to_string(parameters[0].value()));
             bytes_opt parsed_json_value;

--- a/cql3/functions/native_scalar_function.hh
+++ b/cql3/functions/native_scalar_function.hh
@@ -47,7 +47,7 @@ public:
     virtual bool is_pure() const override {
         return Pure;
     }
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) override {
         try {
             return _func(parameters);
         } catch(exceptions::cassandra_exception&) {

--- a/cql3/functions/time_uuid_fcts.hh
+++ b/cql3/functions/time_uuid_fcts.hh
@@ -24,7 +24,7 @@ inline
 shared_ptr<function>
 make_now_fct() {
     return make_native_scalar_function<false>("now", timeuuid_type, {},
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         return {to_bytes(utils::UUID_gen::get_time_UUID())};
     });
 }
@@ -42,7 +42,7 @@ inline
 shared_ptr<function>
 make_min_timeuuid_fct() {
     return make_native_scalar_function<true>("mintimeuuid", timeuuid_type, { timestamp_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         auto& bb = values[0];
         if (!bb) {
             return {};
@@ -60,7 +60,7 @@ inline
 shared_ptr<function>
 make_max_timeuuid_fct() {
     return make_native_scalar_function<true>("maxtimeuuid", timeuuid_type, { timestamp_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         auto& bb = values[0];
         if (!bb) {
             return {};
@@ -89,7 +89,7 @@ inline
 shared_ptr<function>
 make_date_of_fct() {
     return make_native_scalar_function<true>("dateof", timestamp_type, { timeuuid_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -104,7 +104,7 @@ inline
 shared_ptr<function>
 make_unix_timestamp_of_fct() {
     return make_native_scalar_function<true>("unixtimestampof", long_type, { timeuuid_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -117,7 +117,7 @@ make_unix_timestamp_of_fct() {
 inline shared_ptr<function>
 make_currenttimestamp_fct() {
     return make_native_scalar_function<false>("currenttimestamp", timestamp_type, {},
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         return {timestamp_type->decompose(db_clock::now())};
     });
 }
@@ -125,7 +125,7 @@ make_currenttimestamp_fct() {
 inline shared_ptr<function>
 make_currenttime_fct() {
     return make_native_scalar_function<false>("currenttime", time_type, {},
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         constexpr int64_t milliseconds_in_day = 3600 * 24 * 1000;
         int64_t milliseconds_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(db_clock::now().time_since_epoch()).count();
         int64_t nanoseconds_today = (milliseconds_since_epoch % milliseconds_in_day) * 1000 * 1000;
@@ -136,7 +136,7 @@ make_currenttime_fct() {
 inline shared_ptr<function>
 make_currentdate_fct() {
     return make_native_scalar_function<false>("currentdate", simple_date_type, {},
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         auto to_simple_date = get_castas_fctn(simple_date_type, timestamp_type);
         return {simple_date_type->decompose(to_simple_date(db_clock::now()))};
     });
@@ -146,7 +146,7 @@ inline
 shared_ptr<function>
 make_currenttimeuuid_fct() {
     return make_native_scalar_function<false>("currenttimeuuid", timeuuid_type, {},
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         return {timeuuid_type->decompose(timeuuid_native_type{utils::UUID_gen::get_time_UUID()})};
     });
 }
@@ -155,7 +155,7 @@ inline
 shared_ptr<function>
 make_timeuuidtodate_fct() {
     return make_native_scalar_function<true>("todate", simple_date_type, { timeuuid_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -171,7 +171,7 @@ inline
 shared_ptr<function>
 make_timestamptodate_fct() {
     return make_native_scalar_function<true>("todate", simple_date_type, { timestamp_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -190,7 +190,7 @@ inline
 shared_ptr<function>
 make_timeuuidtotimestamp_fct() {
     return make_native_scalar_function<true>("totimestamp", timestamp_type, { timeuuid_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -205,7 +205,7 @@ inline
 shared_ptr<function>
 make_datetotimestamp_fct() {
     return make_native_scalar_function<true>("totimestamp", timestamp_type, { simple_date_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -224,7 +224,7 @@ inline
 shared_ptr<function>
 make_timeuuidtounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { timeuuid_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -242,7 +242,7 @@ inline
 shared_ptr<function>
 make_timestamptounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { timestamp_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {
@@ -260,7 +260,7 @@ inline
 shared_ptr<function>
 make_datetounixtimestamp_fct() {
     return make_native_scalar_function<true>("tounixtimestamp", long_type, { simple_date_type },
-            [] (const std::vector<bytes_opt>& values) -> bytes_opt {
+            [] (std::span<const bytes_opt> values) -> bytes_opt {
         using namespace utils;
         auto& bb = values[0];
         if (!bb) {

--- a/cql3/functions/token_fct.hh
+++ b/cql3/functions/token_fct.hh
@@ -31,8 +31,8 @@ public:
                     , _schema(s) {
     }
 
-    bytes_opt execute(const std::vector<bytes_opt>& parameters) override {
-        if (std::any_of(parameters.cbegin(), parameters.cend(), [](const auto& param){ return !param; })) {
+    bytes_opt execute(std::span<const bytes_opt> parameters) override {
+        if (std::any_of(parameters.begin(), parameters.end(), [](const auto& param){ return !param; })) {
             return std::nullopt;
         }
         auto key = partition_key::from_optional_exploded(*_schema, parameters);

--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -32,7 +32,7 @@ bool user_function::is_aggregate() const { return false; }
 
 bool user_function::requires_thread() const { return true; }
 
-bytes_opt user_function::execute(const std::vector<bytes_opt>& parameters) {
+bytes_opt user_function::execute(std::span<const bytes_opt> parameters) {
     const auto& types = arg_types();
     if (parameters.size() != types.size()) {
         throw std::logic_error("Wrong number of parameters");

--- a/cql3/functions/user_function.hh
+++ b/cql3/functions/user_function.hh
@@ -59,7 +59,7 @@ public:
     virtual bool is_native() const override;
     virtual bool is_aggregate() const override;
     virtual bool requires_thread() const override;
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) override;
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) override;
 
     virtual sstring keypace_name() const override { return name().keyspace; }
     virtual sstring element_name() const override { return name().name; }

--- a/cql3/functions/uuid_fcts.hh
+++ b/cql3/functions/uuid_fcts.hh
@@ -22,7 +22,7 @@ inline
 shared_ptr<function>
 make_uuid_fct() {
     return make_native_scalar_function<false>("uuid", uuid_type, {},
-            [] (const std::vector<bytes_opt>& parameters) -> bytes_opt {
+            [] (std::span<const bytes_opt> parameters) -> bytes_opt {
         return {uuid_type->decompose(utils::make_random_uuid())};
     });
 }

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -13,6 +13,7 @@
 #include "cql3/functions/function.hh"
 #include "cql3/functions/function_name.hh"
 #include "cql3/functions/user_aggregate.hh"
+#include "utils/small_vector.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 
 namespace cql3 {
@@ -28,7 +29,7 @@ protected:
      * The list used to pass the function arguments is recycled to avoid the cost of instantiating a new list
      * with each function call.
      */
-    std::vector<bytes_opt> _args;
+    utils::small_vector<bytes_opt, 4> _args;
     std::vector<shared_ptr<selector>> _arg_selectors;
     const bool _requires_thread;
 

--- a/cql3/selection/aggregate_function_selector.hh
+++ b/cql3/selection/aggregate_function_selector.hh
@@ -39,7 +39,7 @@ public:
 
     virtual bytes_opt get_output() override {
         return _aggregate.state_to_result_function
-                ? _aggregate.state_to_result_function->execute({std::move(_accumulator)})
+                ? _aggregate.state_to_result_function->execute(std::span(&_accumulator, 1))
                 : std::move(_accumulator);
     }
 

--- a/db/functions/scalar_function.hh
+++ b/db/functions/scalar_function.hh
@@ -12,7 +12,7 @@
 
 #include "bytes.hh"
 #include "function.hh"
-#include <vector>
+#include <span>
 
 namespace db::functions {
 
@@ -25,7 +25,7 @@ public:
      * @return the result of applying this function to the parameter
      * @throws InvalidRequestException if this function cannot not be applied to the parameter
      */
-    virtual bytes_opt execute(const std::vector<bytes_opt>& parameters) = 0;
+    virtual bytes_opt execute(std::span<const bytes_opt> parameters) = 0;
 };
 
 

--- a/keys.hh
+++ b/keys.hh
@@ -20,6 +20,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <compare>
+#include <span>
 
 //
 // This header defines type system for primary key holders.
@@ -200,10 +201,10 @@ public:
     }
 
     // We don't allow optional values, but provide this method as an efficient adaptor
-    static TopLevel from_optional_exploded(const schema& s, const std::vector<bytes_opt>& v) {
+    static TopLevel from_optional_exploded(const schema& s, std::span<const bytes_opt> v) {
         return TopLevel::from_bytes(get_compound_type(s)->serialize_optionals(v));
     }
-    static TopLevel from_optional_exploded(const schema& s, const std::vector<managed_bytes_opt>& v) {
+    static TopLevel from_optional_exploded(const schema& s, std::span<const managed_bytes_opt> v) {
         return TopLevel::from_bytes(get_compound_type(s)->serialize_optionals(v));
     }
 

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -250,7 +250,7 @@ seastar::future<> precompile(alien_thread_runner& alien_runner, context& ctx, co
         co_await coroutine::return_exception_ptr(std::move(ex));
     }
 }
-seastar::future<bytes_opt> run_script(context& ctx, wasmtime::Store& store, wasmtime::Instance& instance, wasmtime::Func& func, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input) {
+seastar::future<bytes_opt> run_script(context& ctx, wasmtime::Store& store, wasmtime::Instance& instance, wasmtime::Func& func, const std::vector<data_type>& arg_types, std::span<const bytes_opt> params, data_type return_type, bool allow_null_input) {
     wasm_logger.debug("Running function {}", ctx.function_name);
 
     rust::Box<wasmtime::ValVec> argv = wasmtime::get_val_vec();
@@ -308,7 +308,7 @@ seastar::future<bytes_opt> run_script(context& ctx, wasmtime::Store& store, wasm
     }
 }
 
-seastar::future<bytes_opt> run_script(const db::functions::function_name& name, context& ctx, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input) {
+seastar::future<bytes_opt> run_script(const db::functions::function_name& name, context& ctx, const std::vector<data_type>& arg_types, std::span<const bytes_opt> params, data_type return_type, bool allow_null_input) {
     wasm::instance_cache::value_type func_inst;
     std::exception_ptr ex;
     bytes_opt ret;

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <span>
 #include "types/types.hh"
 #include <seastar/core/future.hh>
 #include "db/functions/function_name.hh"
@@ -56,6 +57,6 @@ struct context {
 
 seastar::future<> precompile(alien_thread_runner& alien_runner, context& ctx, const std::vector<sstring>& arg_names, std::string script);
 
-seastar::future<bytes_opt> run_script(const db::functions::function_name& name, context& ctx, const std::vector<data_type>& arg_types, const std::vector<bytes_opt>& params, data_type return_type, bool allow_null_input);
+seastar::future<bytes_opt> run_script(const db::functions::function_name& name, context& ctx, const std::vector<data_type>& arg_types, std::span<const bytes_opt> params, data_type return_type, bool allow_null_input);
 
 }


### PR DESCRIPTION
Database functions currently receive their arguments as an std::vector. This
is inflexible (for example, one cannot use small_vector to reduce allocations).

This series adapts the function signature to accept parameters using std::span.
Some changes in the keys interface are needed to support this. Lastly, one call
site is migrated to small_vector.

This is in support of changing selectors to use expressions.