### PR TITLE
mv: fix unbounded concurrency in materialized views, stop dropping view updates on overload

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1071,7 +1071,8 @@ private:
             mutation&& m,
             flat_mutation_reader_v2_opt existings,
             tracing::trace_state_ptr tr_state,
-            gc_clock::time_point now) const;
+            gc_clock::time_point now,
+            db::timeout_clock::time_point timeout) const;
 
     mutable row_locker _row_locker;
     future<row_locker::lock_holder> local_base_lock(

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1984,8 +1984,8 @@ std::vector<view_ptr> table::affected_views(const schema_ptr& base, const mutati
 }
 
 static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_schema>& ms) {
-    // Overhead of sending a view mutation, in terms of data structures used by the storage_proxy.
-    constexpr size_t base_overhead_bytes = 256;
+    // Overhead of sending a view mutation.
+    constexpr size_t base_overhead_bytes = 65536;
     return boost::accumulate(ms | boost::adaptors::transformed([] (const frozen_mutation_and_schema& m) {
         return m.fm.representation().size();
     }), size_t{base_overhead_bytes * ms.size()});


### PR DESCRIPTION
When a base table receives an update, it needs to prepare corresponding updates to all of the materialized view tables.
The updates are generated and spawned as background tasks, then the base table update is applied.

The amount of such background tasks is somewhat limited by the `view_update_concurrency_semaphore`. Before generating any updates we check if the semaphore has any units available, and if it doesn't we just drop the view update.
The idea was that throttling will control the concurrency - as the units from the `view_update_concurrency_semaphore` are used up, replies to base table queries are slowed down more and more to keep the amount of view updates reasonable.

This logic doesn't account for partition deletes and range deletes. Imagine a query which deletes a whole partition with 10 million rows inside of it. In such case we need to generate the 10 million view updates, one for each row, and send them to the corresponding view replicas.
The problem is that we spawn all of these updates as background tasks, without any regard for the semaphore. Yes, each update consumes some units from the semaphore, but this is done using `seastar::consume`, which doesn't wait for units to become available, it just decreases the amount of units in the semaphore, even when they are negative.

This causes unbounded concurrency. A `DELETE`, which deletes a partition with a large amount of rows will spawn all of these updates at once and cause an OOM.

I wrote a detailed explanation of the problem and some possible solution ideas under the issue:
https://github.com/scylladb/scylladb/issues/12379

---

This PR attempts to fix the problem by actually waiting for the units from `view_update_concurrency_semaphore` before doing the updates.

Generally the updates are generated in a batches of 100 rows.
The loops goes like this:
```c++
for(;;;) {
    auto updates = generate_next_100_updates()
    auto units = seastar::consume(view_update_concurrency_semaphore)
    co_await spawn_background_updates(updates)
}
```

Instead of blindly consuming units from the semaphore the new code uses `seastar::get_units` to acquire the units.

A significant change happens to the view update dropping logic:
```c++
if (!_config.view_update_concurrency_semaphore->current()) {
    // Make sure that we have some resources available to generate the view update.
    // We don't have resources to generate view updates for this write. If we reached this point, we failed to
    // If the database has been overwhelemed to the point where getting a few units timeouts,
    // throttle the client. The memory queue is already full, waiting on the semaphore would cause this node to
    // then it just can't handle the write at this moment. In such situation the query should timeout.
    // run out of memory, and generating hints would ultimately result in the disk queue being full too. We don't
    auto view_update_permit_units = co_await seastar::get_units(*_config.view_update_concurrency_semaphore, 1024, timeout);
    // drop the base write, which could create inconsistencies between base replicas. So we dolefully continue,
    // and note the fact we dropped a view update.
    ++_config.cf_stats->dropped_view_updates;
    co_return row_locker::lock_holder();
}
```

The old logic decides to drop a view update when the `view_update_concurrency_semaphore` doesn't have any units available.

However this doesn't account for large `DELETE` queries. Let's say that somebody deletes a partition with 10 million rows. This would spawn 10 million concurrent updates, but hopefully the `view_update_concurrency_semaphore` will limit the amount of concurrent updates by running out of units. At this point any new query running started parallel will see that the semaphore doesn't have any units and think that something went horribly wrong so the view update should be dropped.

Running two valid queries in parallel shouldn't cause dropped view updates and then view inconsistencies. I guess some sort of solution would be to have a separate semaphore for the long-running view updates, but overall I dislike the very idea of dropping view updates because of overload.

I think that as an application developer, I would like my database to be honest about how long it takes to run a query to full completion. If I'm doing too much at once then tell me via timeouts, don't just perform a part of the write and pretend everything is going great.
Dropping updates makes it harder to use the database correctly. The user must take care to never make too many queries, because then the views will get silently corrupted. There's no real feedback from the database that they're doing too much,
other than broken views that need to be rebuilt and an increase in one statistic. There's no real way for the application to know that the write was only partially applied.

Materialized views might be asynchronous, but they should still be eventually consistent. When a view update is dropped the only way the view might achieve consistency is via repair. AFAIK we don't have a repair that repairs view replica based on the base replica. We only have read-repair between view replicas. But read-repair requires at least one replica to hold valid data, which might not be the case when all of the view replicas are overwhelmed and all of the updates get dropped. Additionally read-repair has it's own problems like causing ghost rows to appear.

The original reasoning referred to high-availability. It's true that without dropping view updates the base write might not happen because the view logic is overwhelmed, but is this bad? That's what I would expect from the database - either my write happens or not.
It's not like the base write will fail if a view replica is unavailable, in such case we know that the node is dead and the update gets written as a hint. Here there might be some trouble caused by the fact that view updates have a 5 minute timeout, but is a situation where we send a request and not receive a response without any errors even possible?

One more reason that the original code dropped the update was that it wanted to avoid unbounded amount of hints. This doesn't seem like a valid argument to me. AFAIU hints have a limited amount of storage space, when this space runs out the hints are just dropped. This is like dropping the view updates, but in a more reasonable way.
Dropping a hint is better than dropping a whole request. In case of overload we will wait for the semaphore (not drop the update) and try the write. If it doesn't happen, too bad, write a hint. If it does happen, that's a win, it was worth it to wait on a semaphore.

I have a hard time thinking of an application that would like the view updates to be dropped on high load instead of getting timeouts. Dropping updates makes the views very inconsistent, which kills most of the use cases that I can think of.

Also, global indexes are implemented using materialized views and I AFAIR they aren't synchronous. Indexes seem like the thing that should be pretty consistent, even on overloads. Especially since the user has no way to opt out of using an index, the query planner decides that and it considers the index to be the same thing as the base table.

Btw when running the test that caused the OOM I also kept track of how many units the semaphore has available.
It turned out that even in case of OOM the semaphore still had plenty of units to spare. This would suggest
that it's very hard to actually use up all of the units from the semaphore, here it OOMd before that.
Does the update dropping actually happen in the wild? Or is the amount of dropped view updates always zero
because Scylla OOMs before that could happen?

Overall I think it would be better to wait on the semaphore rather than drop the view update.

---

After this change the statistic `dropped_view_updates` becomes useless. It was only increased in the place that this PR removes. I could remove the statistic, but maybe that cause issues with Grafana and other statistic consumers?

---

If we decide to keep the update dropping logic I could make a separate semaphore for range DELETEs. Other updates would keep the old logic (throttle, if no units then drop), but range DELETEs would wait on their own semaphore.

---

Regarding performance, I aggressively increased the amount of semaphore units needed to perform a single view update. This could cause a slowdown as now less view updates will be performed in parallel. I think the slowdown shouldn't be that significant. I chose a value that allowed to avoid an OOM.  The original amount of units was `256`, changing it to `32768` still caused a crash, but having `65536` made the test pass. I think it's a reasonable choice. In the future if we find more cases that read to overload we could just increase this value further.

I could run some benchmarks to make sure that the performance is still reasonable, even with this much semaphore units required for a single update.

The `view_update_concurrency_semaphore` has as many units as `10%` of shard's memory, so even with `65536` a lot of them should fit.

---

This might not be an ideal solution to concurrency control in materialized views,
but I think it's reasonable, fixes the issue and doesn't change too much.

We might need to rethink some mechanisms in materialized views, but for now this would do.

---

Fixes: #12379