### PR TITLE
Remove global proxy usage from view_info::select_statement()

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -85,7 +85,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
         // FIXME(sarna): legacy code, should be removed after "computed_columns" feature is guaranteed
         // to be available on every node. Then, we won't need to check if this view is backing a secondary index.
         const column_definition* legacy_token_column = nullptr;
-        if (service::get_local_storage_proxy().local_db().find_column_family(base_id()).get_index_manager().is_global_index(_schema)) {
+        if (db.find_column_family(base_id()).get_index_manager().is_global_index(_schema)) {
            if (!_schema.clustering_key_columns().empty()) {
                legacy_token_column = &_schema.clustering_key_columns().front();
            }
@@ -103,7 +103,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
         raw->prepare_keyspace(_schema.ks_name());
         raw->set_bound_variables({});
         cql3::cql_stats ignored;
-        auto prepared = raw->prepare(service::get_local_storage_proxy().data_dictionary(), ignored, true);
+        auto prepared = raw->prepare(db, ignored, true);
         _select_statement = static_pointer_cast<cql3::statements::select_statement>(prepared->statement);
     }
     return *_select_statement;

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1439,6 +1439,7 @@ future<stop_iteration> view_update_builder::on_results() {
 }
 
 view_update_builder make_view_update_builder(
+        data_dictionary::database db,
         const replica::table& base_table,
         const schema_ptr& base,
         std::vector<view_and_base>&& views_to_update,
@@ -1454,7 +1455,7 @@ view_update_builder make_view_update_builder(
         bool is_index = base_table.get_index_manager().is_index(v.view);
         return view_updates(std::move(v), is_index);
     }));
-    return view_update_builder(base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
+    return view_update_builder(std::move(db), base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
 }
 
 future<query::clustering_row_ranges> calculate_affected_clustering_ranges(const schema& base,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -109,7 +109,7 @@ cql3::statements::select_statement& view_info::select_statement() const {
     return *_select_statement;
 }
 
-const query::partition_slice& view_info::partition_slice() const {
+const query::partition_slice& view_info::partition_slice(data_dictionary::database db) const {
     if (!_partition_slice) {
         _partition_slice = select_statement().make_partition_slice(cql3::query_options({ }));
     }
@@ -1476,7 +1476,7 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(data_d
                 view_row_ranges.push_back(nonwrapping_range<clustering_key_prefix_view>::make_open_ended_both_sides());
                 break;
             }
-            for (auto&& r : v.view->view_info()->partition_slice().default_row_ranges()) {
+            for (auto&& r : v.view->view_info()->partition_slice(db).default_row_ranges()) {
                 view_row_ranges.push_back(r.transform(std::mem_fn(&clustering_key_prefix::view)));
                 co_await coroutine::maybe_yield();
             }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -14,6 +14,7 @@
 #include "schema/schema_fwd.hh"
 #include "readers/flat_mutation_reader_v2.hh"
 #include "mutation/frozen_mutation.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 class frozen_mutation_and_schema;
 
@@ -244,6 +245,7 @@ private:
 };
 
 class view_update_builder {
+    data_dictionary::database _db;
     const replica::table& _base;
     schema_ptr _schema; // The base schema
     std::vector<view_updates> _view_updates;
@@ -259,12 +261,13 @@ class view_update_builder {
     partition_key _key = partition_key::make_empty();
 public:
 
-    view_update_builder(const replica::table& base, schema_ptr s,
+    view_update_builder(data_dictionary::database db, const replica::table& base, schema_ptr s,
         std::vector<view_updates>&& views_to_update,
         flat_mutation_reader_v2&& updates,
         flat_mutation_reader_v2_opt&& existings,
         gc_clock::time_point now)
-            : _base(base)
+            : _db(std::move(db))
+            , _base(base)
             , _schema(std::move(s))
             , _view_updates(std::move(views_to_update))
             , _updates(std::move(updates))
@@ -298,6 +301,7 @@ private:
 };
 
 view_update_builder make_view_update_builder(
+        data_dictionary::database db,
         const replica::table& base_table,
         const schema_ptr& base_schema,
         std::vector<view_and_base>&& views_to_update,

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -224,7 +224,7 @@ public:
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
-    void generate_update(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
+    void generate_update(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
 
     size_t op_count() const;
 
@@ -237,10 +237,10 @@ private:
     };
     std::vector<view_row_entry> get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing);
     bool can_skip_view_updates(const clustering_or_static_row& update, const clustering_or_static_row& existing) const;
-    void create_entry(const partition_key& base_key, const clustering_or_static_row& update, gc_clock::time_point now);
-    void delete_old_entry(const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);
+    void create_entry(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, gc_clock::time_point now);
+    void delete_old_entry(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);
     void do_delete_old_entry(const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);
-    void update_entry(const partition_key& base_key, const clustering_or_static_row& update, const clustering_or_static_row& existing, gc_clock::time_point now);
+    void update_entry(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, const clustering_or_static_row& existing, gc_clock::time_point now);
     void update_entry_for_computed_column(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
 };
 

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -125,7 +125,7 @@ public:
  * @return false if we can guarantee that inserting an update for specified key
  * won't affect the view in any way, true otherwise.
  */
-bool partition_key_matches(const schema& base, const view_info& view, const dht::decorated_key& key);
+bool partition_key_matches(data_dictionary::database, const schema& base, const view_info& view, const dht::decorated_key& key);
 
 /**
  * Whether the view might be affected by the provided update.
@@ -140,7 +140,7 @@ bool partition_key_matches(const schema& base, const view_info& view, const dht:
  * @return false if we can guarantee that inserting update for key
  * won't affect the view in any way, true otherwise.
  */
-bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update);
+bool may_be_affected_by(data_dictionary::database, const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update);
 
 /**
  * Whether a given base row matches the view filter (and thus if the view should have a corresponding entry).
@@ -159,9 +159,9 @@ bool may_be_affected_by(const schema& base, const view_info& view, const dht::de
  * @param now the current time in seconds (to decide what is live and what isn't).
  * @return whether the base row matches the view filter.
  */
-bool matches_view_filter(const schema& base, const view_info& view, const partition_key& key, const clustering_or_static_row& update, gc_clock::time_point now);
+bool matches_view_filter(data_dictionary::database, const schema& base, const view_info& view, const partition_key& key, const clustering_or_static_row& update, gc_clock::time_point now);
 
-bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck);
+bool clustering_prefix_matches(data_dictionary::database, const schema& base, const partition_key& key, const clustering_key_prefix& ck);
 
 /*
  * When a base-table update modifies a value in a materialized view's key
@@ -310,6 +310,7 @@ view_update_builder make_view_update_builder(
         gc_clock::time_point now);
 
 future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
+        data_dictionary::database db,
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -189,6 +189,8 @@ public:
     static constexpr size_t batch_size = 128;
     static constexpr size_t batch_memory_max = 1024*1024;
 
+    replica::database& get_db() noexcept { return _db; }
+
 public:
     view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&, view_update_generator& vug);
     view_builder(view_builder&&) = delete;

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -72,6 +72,8 @@ public:
     future<> stop();
     future<> register_staging_sstable(sstables::shared_sstable sst, lw_shared_ptr<replica::table> table);
 
+    replica::database& get_db() noexcept { return _db; }
+
     future<> mutate_MV(
             dht::token base_token,
             utils::chunked_vector<frozen_mutation_and_schema> view_updates,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1064,7 +1064,7 @@ public:
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
-    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update) const;
+    std::vector<view_ptr> affected_views(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base, const mutation& update) const;
     future<> generate_and_propagate_view_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base,
             reader_permit permit,
             std::vector<db::view::view_and_base>&& views,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2014,6 +2014,7 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
     auto base_token = m.token();
     auto m_schema = m.schema();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
+            gen->get_db().as_data_dictionary(),
             *this,
             base,
             std::move(views),
@@ -2151,6 +2152,7 @@ future<> table::populate_views(
         gc_clock::time_point now) {
     auto schema = reader.schema();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
+            gen->get_db().as_data_dictionary(),
             *this,
             schema,
             std::move(views),

--- a/view_info.hh
+++ b/view_info.hh
@@ -49,7 +49,7 @@ public:
     }
 
     cql3::statements::select_statement& select_statement() const;
-    const query::partition_slice& partition_slice() const;
+    const query::partition_slice& partition_slice(data_dictionary::database) const;
     const column_definition* view_column(const schema& base, column_kind kind, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;
     bool has_base_non_pk_columns_in_view_pk() const;

--- a/view_info.hh
+++ b/view_info.hh
@@ -48,7 +48,7 @@ public:
         return _raw.where_clause();
     }
 
-    cql3::statements::select_statement& select_statement() const;
+    cql3::statements::select_statement& select_statement(data_dictionary::database) const;
     const query::partition_slice& partition_slice(data_dictionary::database) const;
     const column_definition* view_column(const schema& base, column_kind kind, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;


### PR DESCRIPTION
The method needs proxy to get data_dictionary::database from to pass down to select_statement::prepare(). And a legacy bit that can come with data_dictionary::database as well. Fortunately, all the call traces that end up at select_statement() start inside table:: methods that have view_update_generator, or at view_builder::consumer that has reference to view_builder. Both services can share the database reference. However, the call traces in question pass through several code layers, so the PR adds data_dictionary::database to those layers one by one.