### PR TITLE
sstable: specialize fmt::formatter<component_type>

### DIFF
--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <iosfwd>
+#include <fmt/format.h>
 
 namespace sstables {
 
@@ -29,8 +29,42 @@ enum class component_type {
     Unknown,
 };
 
-std::ostream& operator<<(std::ostream&, const sstables::component_type&);
-
 }
 
 using component_type = ::sstables::component_type;
+
+template <>
+struct fmt::formatter<sstables::component_type> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::component_type& comp_type, FormatContext& ctx) const {
+        using enum sstables::component_type;
+        switch (comp_type) {
+        case Index:
+            return formatter<std::string_view>::format("Index", ctx);
+        case CompressionInfo:
+            return formatter<std::string_view>::format("CompressionInfo", ctx);
+        case Data:
+            return formatter<std::string_view>::format("Data", ctx);
+        case TOC:
+            return formatter<std::string_view>::format("TOC", ctx);
+        case Summary:
+            return formatter<std::string_view>::format("Summary", ctx);
+        case Digest:
+            return formatter<std::string_view>::format("Digest", ctx);
+        case CRC:
+            return formatter<std::string_view>::format("CRC", ctx);
+        case Filter:
+            return formatter<std::string_view>::format("Filter", ctx);
+        case Statistics:
+            return formatter<std::string_view>::format("Statistics", ctx);
+        case TemporaryTOC:
+            return formatter<std::string_view>::format("TemporaryTOC", ctx);
+        case TemporaryStatistics:
+            return formatter<std::string_view>::format("TemporaryStatistics", ctx);
+        case Scylla:
+            return formatter<std::string_view>::format("Scylla", ctx);
+        case Unknown:
+            return formatter<std::string_view>::format("Unknown", ctx);
+        }
+    }
+};

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3483,26 +3483,6 @@ std::ostream& operator<<(std::ostream& out, const deletion_time& dt) {
     return out << "{timestamp=" << dt.marked_for_delete_at << ", deletion_time=" << dt.marked_for_delete_at << "}";
 }
 
-std::ostream& operator<<(std::ostream& out, const sstables::component_type& comp_type) {
-    using ct = sstables::component_type;
-    switch (comp_type) {
-    case ct::Index: out << "Index"; break;
-    case ct::CompressionInfo: out << "CompressionInfo"; break;
-    case ct::Data: out << "Data"; break;
-    case ct::TOC: out << "TOC"; break;
-    case ct::Summary: out << "Summary"; break;
-    case ct::Digest: out << "Digest"; break;
-    case ct::CRC: out << "CRC"; break;
-    case ct::Filter: out << "Filter"; break;
-    case ct::Statistics: out << "Statistics"; break;
-    case ct::TemporaryTOC: out << "TemporaryTOC"; break;
-    case ct::TemporaryStatistics: out << "TemporaryStatistics"; break;
-    case ct::Scylla: out << "Scylla"; break;
-    case ct::Unknown: out << "Unknown"; break;
-    }
-    return out;
-}
-
 std::optional<large_data_stats_entry> sstable::get_large_data_stat(large_data_type t) const noexcept {
     if (_large_data_stats) {
         auto it = _large_data_stats->map.find(t);

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -45,6 +45,7 @@
 #include "readers/combined.hh"
 
 #include <boost/range/algorithm/sort.hpp>
+#include <fmt/ranges.h>
 
 using namespace sstables;
 


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `component_type` without the help of `operator<<`.

the corresponding `operator<<()` are dropped dropped in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245