### PR TITLE
build: add tools for optimizing the Wasm binaries and translating to wat

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -107,6 +107,8 @@ fedora_packages=(
     cargo
     rapidxml-devel
     rust-std-static-wasm32-wasi
+    wabt
+    binaryen
 )
 
 # lld is not available on s390x, see

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20230320
+docker.io/scylladb/scylla-toolchain:fedora-37-20230424


### PR DESCRIPTION
After the addition of the rust-std-static-wasm32-wasi target, we're able to compile the Rust programs to Wasm binaries. However, we're still only able to handle the Wasm UDFs in the Text format, so we need a tool to translate the .wasm files to .wat. Additionally, the .wasm files generated by default are unnecessarily large, which can be helped using wasm-opt and wasm-strip.
The tool for translating wasm to wat (wasm2wat), and the tool for stripping the wasm binaries (wasm-strip) are included in the `wabt` package, and the optimization tool (wasm-opt) is included in the `binaryen` package. Both packages are added to install-dependencies.sh

Closes #13282

[avi: regenerate frozen toolchain]