### PR TITLE
cql3, db: sstable: specialize fmt::formatter<function_name>

### DIFF
--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -72,9 +72,8 @@ public:
 inline
 void
 abstract_function::print(std::ostream& os) const {
-    os << _name << " : (";
-    os << _arg_types;
-    os << ") -> " << _return_type->as_cql3_type().to_string();
+    fmt::print(os, "{} : ({}) -> {}",
+               _name, _arg_types, _return_type->as_cql3_type().to_string());
 }
 
 }

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -85,7 +85,7 @@ public:
     }
 
     virtual void print(std::ostream& os) const override {
-        os << _name;
+        fmt::print(os, "{}", _name);
     }
 
     virtual sstring column_name(const std::vector<sstring>& column_names) const override {

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -204,7 +204,7 @@ std::optional<function_name> functions::used_by_user_function(const ut_name& use
 lw_shared_ptr<column_specification>
 functions::make_arg_spec(const sstring& receiver_ks, const sstring& receiver_cf,
         const function& fun, size_t i) {
-    auto&& name = boost::lexical_cast<std::string>(fun.name());
+    auto&& name = fmt::to_string(fun.name());
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     return make_lw_shared<column_specification>(receiver_ks,
                                    receiver_cf,

--- a/db/functions/function.cc
+++ b/db/functions/function.cc
@@ -79,7 +79,7 @@ aggregate_function::is_aggregate() const {
 
 void
 aggregate_function::print(std::ostream& os) const {
-    os << name();
+    fmt::print(os, "{}", name());
 }
 
 sstring

--- a/db/functions/function_name.hh
+++ b/db/functions/function_name.hh
@@ -48,19 +48,20 @@ public:
     }
 };
 
-inline
-std::ostream& operator<<(std::ostream& os, const function_name& fn) {
-    if (!fn.keyspace.empty()) {
-        os << fn.keyspace << ".";
+}
+}
+
+template <>
+struct fmt::formatter<db::functions::function_name> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const db::functions::function_name& fn, FormatContext& ctx) const {
+        auto out = ctx.out();
+        if (fn.has_keyspace()) {
+            out = fmt::format_to(out, "{}.", fn.keyspace);
+        }
+        return fmt::format_to(out, "{}", fn.name);
     }
-    return os << fn.name;
-}
-
-}
-}
-
-
-
+};
 
 namespace std {
 


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `function_name` without the help of `operator<<`.

the corresponding `operator<<()` are dropped dropped in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245