### PR TITLE
dht: specialize fmt::formatter<dht::token>

### DIFF
--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -602,8 +602,6 @@ struct token_comparator {
     std::strong_ordering operator()(const token& t1, const token& t2) const;
 };
 
-std::ostream& operator<<(std::ostream& out, const token& t);
-
 std::ostream& operator<<(std::ostream& out, const decorated_key& t);
 
 std::ostream& operator<<(std::ostream& out, const i_partitioner& p);

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -52,13 +52,7 @@ std::strong_ordering tri_compare(const token& t1, const token& t2) {
 }
 
 std::ostream& operator<<(std::ostream& out, const token& t) {
-    if (t._kind == token::kind::after_all_keys) {
-        out << "maximum token";
-    } else if (t._kind == token::kind::before_all_keys) {
-        out << "minimum token";
-    } else {
-        out << t.to_sstring();
-    }
+    fmt::print(out, "{}", t);
     return out;
 }
 

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -223,3 +223,17 @@ token bias(uint64_t n);
 size_t compaction_group_of(unsigned most_significant_bits, const token& t);
 
 } // namespace dht
+
+template <>
+struct fmt::formatter<dht::token> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const dht::token& t, FormatContext& ctx) const {
+        if (t.is_maximum()) {
+            return fmt::format_to(ctx.out(), "maximum token");
+        } else if (t.is_minimum()) {
+            return fmt::format_to(ctx.out(), "minimum token");
+        } else {
+            return fmt::format_to(ctx.out(), "{}", dht::token::to_int64(t));
+        }
+    }
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `dht::token` without the help of `operator<<`.

the corresponding `operator<<()` is preserved in this change, as it has lots of users in this project, we will tackle them case-by-case in follow-up changes.

also, the forward declaration of `operator<<(ostream&, constdht::token&)` in `dht/i_partitioner.hh` is removed. ias it not necessary.

Refs https://github.com/scylladb/scylladb/issues/13245