### PR TITLE
treewide: s/boost::lexical_cast<std::string>/fmt::to_string()/

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -827,7 +827,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     }
 
     if (!schema || !base || !is_alternator_keyspace(schema->ks_name())) {
-        throw api_error::resource_not_found(boost::lexical_cast<std::string>(iter.table));
+        throw api_error::resource_not_found(fmt::to_string(iter.table));
     }
 
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());

--- a/api/api.hh
+++ b/api/api.hh
@@ -65,7 +65,7 @@ template <typename MAP>
 std::vector<sstring> map_keys(const MAP& map) {
     std::vector<sstring> res;
     for (const auto& i : map) {
-        res.push_back(boost::lexical_cast<std::string>(i.first));
+        res.push_back(fmt::to_string(i.first));
     }
     return res;
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -475,14 +475,14 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
     ss::get_tokens.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return make_ready_future<json::json_return_type>(stream_range_as_array(ctx.get_token_metadata().sorted_tokens(), [](const dht::token& i) {
-           return boost::lexical_cast<std::string>(i);
+           return fmt::to_string(i);
         }));
     });
 
     ss::get_node_tokens.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         gms::inet_address addr(req->param["endpoint"]);
         return make_ready_future<json::json_return_type>(stream_range_as_array(ctx.get_token_metadata().get_tokens(addr), [](const dht::token& i) {
-           return boost::lexical_cast<std::string>(i);
+           return fmt::to_string(i);
        }));
     });
 

--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -109,7 +109,7 @@ static data_value castas_fctn_from_integer_to_decimal(data_value from) {
 template<typename FromType>
 static data_value castas_fctn_from_float_to_decimal(data_value from) {
     auto val_from = value_cast<FromType>(from);
-    return big_decimal(boost::lexical_cast<std::string>(val_from));
+    return big_decimal(fmt::to_string(val_from));
 }
 
 template<typename FromType>

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1471,7 +1471,7 @@ sstring gossiper::get_rpc_address(const inet_address& endpoint) const {
             return v->value;
         }
     }
-    return boost::lexical_cast<std::string>(endpoint);
+    return fmt::to_string(endpoint);
 }
 
 void gossiper::update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map) {

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -123,7 +123,7 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
             details._datacenter = topology.get_datacenter(endpoint);
             details._rack = topology.get_rack(endpoint);
             tr._rpc_endpoints.push_back(gossiper.get_rpc_address(endpoint));
-            tr._endpoints.push_back(boost::lexical_cast<std::string>(details._host));
+            tr._endpoints.push_back(fmt::to_string(details._host));
             tr._endpoint_details.push_back(details);
         }
         ranges.push_back(tr);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1655,7 +1655,7 @@ storage_service::get_rpc_address(const inet_address& endpoint) const {
             return v->value;
         }
     }
-    return boost::lexical_cast<std::string>(endpoint);
+    return fmt::to_string(endpoint);
 }
 
 future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>

--- a/test/boost/serialization_test.cc
+++ b/test/boost/serialization_test.cc
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(inet_address) {
         for (sstring s : { "2001:6b0:8:2::232", "2a05:d018:223:f00:97af:f4d9:eac2:6a0f", "fe80::8898:3e04:215b:2cd6" }) {
             gms::inet_address ip(s);
             BOOST_CHECK(ip.addr().is_ipv6());
-            auto s2 = boost::lexical_cast<std::string>(ip);
+            auto s2 = fmt::to_string(ip);
             gms::inet_address ip2(s);
             BOOST_CHECK_EQUAL(ip2, ip);
         }

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -765,7 +765,7 @@ public:
                 std::vector<EndpointDetails> eds;
                 std::transform(tr._endpoint_details.begin(), tr._endpoint_details.end(), std::back_inserter(eds), [](auto&& ed) {
                     EndpointDetails detail;
-                    detail.__set_host(boost::lexical_cast<std::string>(ed._host));
+                    detail.__set_host(fmt::to_string(ed._host));
                     detail.__set_datacenter(ed._datacenter);
                     detail.__set_rack(ed._rack);
                     return detail;


### PR DESCRIPTION
this change replaces all occurrences of `boost::lexical_cast<std::string>` in the source tree with `fmt::to_string()`. for couple reasons:

* `boost::lexical_cast<std::string>` is longer than `fmt::to_string()`, so the latter is easier to parse and read.
* `boost::lexical_cast<std::string>` creates a stringstream under the hood, so it can use the `operator<<` to stringify the given object. but stringstream is known to be less performant than fmtlib.
* we are migrating to fmtlib based formatting, see #13245. so using `fmt::to_string()` helps us to remove yet another dependency on `operator<<`.