### PR TITLE
test: object_store: fix various pylint warnings

### DIFF
--- a/test/object_store/run
+++ b/test/object_store/run
@@ -6,8 +6,6 @@ import run
 
 import os
 import requests
-import time
-import cassandra.cluster
 
 print('Scylla is: ' + run.find_scylla() + '.')
 success = True

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -22,7 +22,6 @@ test_tempdir = run.pid_to_dir(os.getpid())
 os.mkdir(test_tempdir)
 
 def get_tempdir(pid):
-    global test_tempdir
     return test_tempdir
 
 print(f'Start scylla (dir={test_tempdir}')

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -85,4 +85,4 @@ cluster.shutdown()
 print('Kill scylla')
 run.abort_run_with_dir(pid, test_tempdir)
 
-exit(0 if success else 1)
+sys.exit(0 if success else 1)

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -41,7 +41,7 @@ conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('1', 'one');")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('2', 'two');")
 res = conn.execute("SELECT * FROM test_ks.test_cf;")
 
-r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/test_ks')
+r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/test_ks', timeout=60)
 if r.status_code != 200:
     print(f'Error flushing keyspace: {r}')
     success = False


### PR DESCRIPTION
when reading this source code, there are a handful issues reported by my flycheck plugin. none of them is critical, but better off fixing them.