### PR TITLE
sstables: use default generated operator==

### DIFF
--- a/sstables/key.hh
+++ b/sstables/key.hh
@@ -39,8 +39,7 @@ public:
         return partition_key::from_exploded_view(explode(s));
     }
 
-    bool operator==(const key_view& k) const { return k._bytes == _bytes; }
-    bool operator!=(const key_view& k) const { return !(k == *this); }
+    bool operator==(const key_view& k) const = default;
 
     bool empty() const { return _bytes.empty(); }
 


### PR DESCRIPTION
C++20 compiler is able to generate defaulted operator== and operator!=. and the default generated operators behaves exactly the same as the ones crafted by us. so let's it do its job.