### PR TITLE
treewide: use std::lexicographical_compare_threeway

### DIFF
--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -153,7 +153,7 @@ public:
             if (_type.is_singular()) {
                 return compare_unsigned(*_type.begin(k1), *_type.begin(k2));
             }
-            return lexicographical_tri_compare(
+            return std::lexicographical_compare_three_way(
                 _type.begin(k1), _type.end(k1),
                 _type.begin(k2), _type.end(k2),
                 [] (const managed_bytes_view& c1, const managed_bytes_view& c2) -> std::strong_ordering {

--- a/sstables/key.hh
+++ b/sstables/key.hh
@@ -51,7 +51,7 @@ public:
     std::strong_ordering tri_compare(const schema& s, partition_key_view other) const {
         return with_linearized([&] (bytes_view v) {
             auto lf = other.legacy_form(s);
-            return lexicographical_tri_compare(
+            return std::lexicographical_compare_three_way(
                     v.begin(), v.end(), lf.begin(), lf.end(),
                     [](uint8_t b1, uint8_t b2) { return  b1 <=> b2; });
         });

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -114,7 +114,7 @@ std::strong_ordering timeuuid_legacy_tri_compare(bytes_view o1, bytes_view o2) {
                             compare_pos(2, 0xff,
                                 compare_pos(3, 0xff, std::strong_ordering::equal))))))));
     if (res == 0) {
-        res = lexicographical_tri_compare(o1.begin(), o1.end(), o2.begin(), o2.end(),
+        res = std::lexicographical_compare_three_way(o1.begin(), o1.end(), o2.begin(), o2.end(),
             [] (const int8_t& a, const int8_t& b) { return a <=> b; });
     }
     return res;

--- a/types/types.cc
+++ b/types/types.cc
@@ -2296,7 +2296,7 @@ struct compare_visitor {
     std::strong_ordering operator()(const listlike_collection_type_impl& l) {
         using llpdi = listlike_partial_deserializing_iterator;
         return with_empty_checks([&] {
-            return lexicographical_tri_compare(llpdi::begin(v1), llpdi::end(v1), llpdi::begin(v2),
+            return std::lexicographical_compare_three_way(llpdi::begin(v1), llpdi::end(v1), llpdi::begin(v2),
                     llpdi::end(v2),
                     [&] (const managed_bytes_view_opt& o1, const managed_bytes_view_opt& o2) {
                         if (!o1.has_value() || !o2.has_value()) {

--- a/utils/lexicographical_compare.hh
+++ b/utils/lexicographical_compare.hh
@@ -89,36 +89,6 @@ std::strong_ordering lexicographical_tri_compare(TypesIterator types_first, Type
     }
 }
 
-// Trichotomic version of std::lexicographical_compare()
-template <typename InputIt1, typename InputIt2, typename Compare>
-requires requires (InputIt1 i1, InputIt2 i2, Compare c) {
-    { c(*i1, *i2) } -> std::same_as<std::strong_ordering>;
-}
-std::strong_ordering lexicographical_tri_compare(InputIt1 first1, InputIt1 last1,
-        InputIt2 first2, InputIt2 last2,
-        Compare comp,
-        lexicographical_relation relation1 = lexicographical_relation::before_all_strictly_prefixed,
-        lexicographical_relation relation2 = lexicographical_relation::before_all_strictly_prefixed) {
-    while (first1 != last1 && first2 != last2) {
-        auto c = comp(*first1, *first2);
-        if (c != 0) {
-            return c;
-        }
-        ++first1;
-        ++first2;
-    }
-    bool e1 = first1 == last1;
-    bool e2 = first2 == last2;
-    if (e1 == e2) {
-        return static_cast<int>(relation1) <=> static_cast<int>(relation2);
-    }
-    if (e2) {
-        return relation2 == lexicographical_relation::after_all_prefixed ? std::strong_ordering::less : std::strong_ordering::greater;
-    } else {
-        return relation1 == lexicographical_relation::after_all_prefixed ? std::strong_ordering::greater : std::strong_ordering::less;
-    }
-}
-
 // A trichotomic comparator for prefix equality total ordering.
 // In this ordering, two sequences are equal iff any of them is a prefix
 // of the another. Otherwise, lexicographical ordering determines the order.


### PR DESCRIPTION
since the standard library offers `std::lexicographical_compare_threeway()`, and we never uses the last two additional parameters which are not provided by `std::lexicographical_compare_threeway()`. there is no need to have the homebrew version of trichotomic compare function.

in this change,

* all occurrences of `lexicographical_tri_compare()` are replaced with `std::lexicographical_compare_threeway()`.
* ``lexicographical_tri_compare()` is dropped.