### PR TITLE
De-globalize storage proxy

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -437,6 +437,7 @@ sharded<streaming::stream_manager> *the_stream_manager;
 sharded<gms::feature_service> *the_feature_service;
 sharded<gms::gossiper> *the_gossiper;
 sharded<locator::snitch_ptr> *the_snitch;
+sharded<service::storage_proxy> *the_storage_proxy;
 }
 
 static int scylla_main(int ac, char** av) {
@@ -516,7 +517,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     distributed<replica::database> db;
     seastar::sharded<service::cache_hitrate_calculator> cf_cache_hitrate_calculator;
     service::load_meter load_meter;
-    auto& proxy = service::get_storage_proxy();
+    sharded<service::storage_proxy> proxy;
     sharded<service::storage_service> ss;
     sharded<service::migration_manager> mm;
     sharded<tasks::task_manager> task_manager;
@@ -1078,6 +1079,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);
             }).get();
 
+            debug::the_storage_proxy = &proxy;
             supervisor::notify("starting storage proxy");
             service::storage_proxy::config spcfg {
                 .hints_directory_initializer = hints_dir_initializer,

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1993,7 +1993,10 @@ class scylla_memory(gdb.Command):
 
     @staticmethod
     def print_coordinator_stats():
-        sp = sharded(gdb.parse_and_eval('service::_the_storage_proxy')).local()
+        try:
+            sp = sharded(gdb.parse_and_eval('debug::the_storage_proxy')).local()
+        except gdb.error:
+            sp = sharded(gdb.parse_and_eval('service::_the_storage_proxy')).local()
         if not sp:
             return
         global_sp_stats, per_sg_sp_stats = scylla_memory.summarize_storage_proxy_coordinator_stats(sp)

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -805,8 +805,6 @@ private:
     }
 };
 
-distributed<service::storage_proxy> _the_storage_proxy;
-
 using namespace exceptions;
 using fbu = utils::fb_utilities;
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -688,18 +688,4 @@ public:
     friend class cas_mutation;
 };
 
-extern distributed<storage_proxy> _the_storage_proxy;
-
-// DEPRECATED, DON'T USE!
-// Pass references to services through constructor/function parameters. Don't use globals.
-inline distributed<storage_proxy>& get_storage_proxy() {
-    return _the_storage_proxy;
-}
-
-// DEPRECATED, DON'T USE!
-// Pass references to services through constructor/function parameters. Don't use globals.
-inline storage_proxy& get_local_storage_proxy() {
-    return _the_storage_proxy.local();
-}
-
 }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -772,7 +772,7 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
             // with highest timestamp will win and be sent to other nodes.
             // Thus, system_distributed.* tables are officially not taken into account,
             // which makes it less likely that this test case would need to be needlessly regenerated.
-            auto actual = calculate_schema_digest(service::get_storage_proxy(), sf, std::not_fn(&is_internal_keyspace)).get0();
+            auto actual = calculate_schema_digest(e.get_storage_proxy(), sf, std::not_fn(&is_internal_keyspace)).get0();
             if (regenerate) {
                 std::cout << format("        utils::UUID(\"{}\"),", actual) << "\n";
             } else {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -552,7 +552,7 @@ public:
             distributed<service::migration_manager> mm;
             sharded<service::storage_service> ss;
             distributed<db::batchlog_manager> bm;
-            distributed<service::storage_proxy>& proxy = service::get_storage_proxy();
+            sharded<service::storage_proxy> proxy;
 
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -176,6 +176,8 @@ public:
 
     virtual sharded<db::system_keyspace>& get_system_keyspace() = 0;
 
+    virtual sharded<service::storage_proxy>& get_storage_proxy() = 0;
+
     data_dictionary::database data_dictionary();
 };
 


### PR DESCRIPTION
All users of global proxy are gone (*), proxy can be made fully main/cql_test_env local.

(*) one test case still needs it, but can get it via cql_test_env