### PR TITLE
database: Remove compaction_manager.hh inclusion into database.hh

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -17,6 +17,7 @@
 #include "db/system_keyspace.hh"
 #include "db/data_listeners.hh"
 #include "storage_service.hh"
+#include "compaction/compaction_manager.hh"
 #include "unimplemented.hh"
 
 extern logging::logger apilog;

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -7,6 +7,7 @@
  */
 
 #include "compaction/task_manager_module.hh"
+#include "compaction/compaction_manager.hh"
 #include "replica/database.hh"
 
 namespace compaction {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -48,6 +48,7 @@
 #include "mutation/mutation_partition.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
+#include "compaction/compaction_manager.hh"
 #include "utils/small_vector.hh"
 #include "view_info.hh"
 #include "view_update_checks.hh"

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -55,6 +55,7 @@
 #include "repair/decorated_key_with_hash.hh"
 #include "repair/row.hh"
 #include "repair/writer.hh"
+#include "compaction/compaction_manager.hh"
 #include "utils/xx_hasher.hh"
 
 extern logging::logger rlogger;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -64,7 +64,6 @@
 #include "db/operation_type.hh"
 #include "utils/serialized_action.hh"
 #include "compaction/compaction_fwd.hh"
-#include "compaction/compaction_manager.hh"
 #include "utils/disk-error-handler.hh"
 #include "rust/wasmtime_bindings.hh"
 
@@ -1672,13 +1671,7 @@ private:
 
     static future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& db, table_id uuid);
 
-    struct table_truncate_state {
-        gate::holder holder;
-        db_clock::time_point low_mark_at;
-        db::replay_position low_mark;
-        std::vector<compaction_manager::compaction_reenabler> cres;
-        bool did_flush;
-    };
+    struct table_truncate_state;
 
     static future<> truncate_table_on_all_shards(sharded<database>& db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
     future<> truncate(column_family& cf, const table_truncate_state&, db_clock::time_point truncated_at);

--- a/replica/dirty_memory_manager.cc
+++ b/replica/dirty_memory_manager.cc
@@ -6,6 +6,7 @@
 #include "database.hh" // for memtable_list
 #include <seastar/core/metrics_api.hh>
 #include <seastar/util/later.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include "seastarx.hh"

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -37,6 +37,7 @@
 #include "db/data_listeners.hh"
 #include "multishard_mutation_query.hh"
 #include "transport/messages/result_message.hh"
+#include "compaction/compaction_manager.hh"
 #include "db/snapshot-ctl.hh"
 
 using namespace std::chrono_literals;

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -17,6 +17,7 @@
 #include "exceptions/exceptions.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "replica/database.hh"
+#include "compaction/compaction_manager.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "gms/feature_service.hh"
 


### PR DESCRIPTION
The only reason why it's there (right next to compaction_fwd.hh) is because the database::table_truncate_state subclass needs the definition of compaction_manager::compaction_reenabler subclass.

However, the former sub is not used outside of database.cc and can be defined in .cc. Keeping it outside of the header allows dropping the compaction_manager.hh from database.hh thus greatly reducing its fanout over the code (from ~180 indirect inclusions down to ~20).