### PR TITLE
cdc: generation: use default-generated operator==

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -1036,15 +1036,6 @@ std::ostream& operator<<(std::ostream& os, const generation_id& gen_id) {
     return os;
 }
 
-bool operator==(const generation_id& a, const generation_id& b) {
-    return std::visit(make_visitor(
-    [] (const generation_id_v1& a, const generation_id_v1& b) { return a.ts == b.ts; },
-    [] (const generation_id_v2& a, const generation_id_v2& b) { return a.ts == b.ts && a.id == b.id; },
-    [] (const generation_id_v1& a, const generation_id_v2& b) { return false; },
-    [] (const generation_id_v2& a, const generation_id_v1& b) { return false; }
-    ), a, b);
-}
-
 db_clock::time_point get_ts(const generation_id& gen_id) {
     return std::visit(make_visitor(
     [] (const generation_id_v1& id) { return id.ts; },

--- a/cdc/generation_id.hh
+++ b/cdc/generation_id.hh
@@ -17,17 +17,18 @@ namespace cdc {
 
 struct generation_id_v1 {
     db_clock::time_point ts;
+    bool operator==(const generation_id_v1&) const = default;
 };
 
 struct generation_id_v2 {
     db_clock::time_point ts;
     utils::UUID id;
+    bool operator==(const generation_id_v2&) const = default;
 };
 
 using generation_id = std::variant<generation_id_v1, generation_id_v2>;
 
 std::ostream& operator<<(std::ostream&, const generation_id&);
-bool operator==(const generation_id&, const generation_id&);
 db_clock::time_point get_ts(const generation_id&);
 
 } // namespace cdc


### PR DESCRIPTION
now that C++20 generates operator== for us, these is no need to handcraft it manually. also, in C++17, the standard library offers default implementation of operator== for `std::variant<>`, so no need to implement it by ourselves.