### PR TITLE
cdc: generation: simplify std::visit() call

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -1108,10 +1108,7 @@ bool operator==(const generation_id& a, const generation_id& b) {
 }
 
 db_clock::time_point get_ts(const generation_id& gen_id) {
-    return std::visit(make_visitor(
-    [] (const generation_id_v1& id) { return id.ts; },
-    [] (const generation_id_v2& id) { return id.ts; }
-    ), gen_id);
+    return std::visit([] (auto& id) { return id.ts; }, gen_id);
 }
 
 } // namespace cdc


### PR DESCRIPTION
if the visitor clauses are the same, we can just use the generic version of it by specifying the parameter with `auto&`. simpler this way.