### PR TITLE
mutation: specialize fmt::formatter<range_tombstone_{entry,list}>

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -444,7 +444,8 @@ bool mutation_fragment_v2::relevant_for_range(const schema& s, position_in_parti
 }
 
 std::ostream& operator<<(std::ostream& out, const range_tombstone_stream& rtl) {
-    return out << rtl._list;
+    fmt::print(out, "{}", rtl._list);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const clustering_interval_set& set) {

--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -424,16 +424,6 @@ void range_tombstone_list::update_undo_op::undo(const schema& s, range_tombstone
     *it = std::move(_old_rt);
 }
 
-std::ostream& operator<<(std::ostream& out, const range_tombstone_list& list) {
-    fmt::print(out, "{{{}}}", fmt::join(list, ", "));
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const range_tombstone_entry& rt) {
-    fmt::print(out, "{}", rt._tombstone);
-    return out;
-}
-
 bool range_tombstone_list::equal(const schema& s, const range_tombstone_list& other) const {
     return boost::equal(_tombstones, other._tombstones, [&s] (auto&& rt1, auto&& rt2) {
         return rt1.tombstone().equal(s, rt2.tombstone());

--- a/mutation/range_tombstone_list.hh
+++ b/mutation/range_tombstone_list.hh
@@ -68,8 +68,6 @@ public:
         return sizeof(range_tombstone_entry) + _tombstone.external_memory_usage(s);
     }
 
-    friend std::ostream& operator<<(std::ostream& out, const range_tombstone_entry& rt);
-
 private:
     void update_node(bi::set_member_hook<bi::link_mode<bi::auto_unlink>>& other_link) noexcept {
         if (other_link.is_linked()) {
@@ -77,6 +75,14 @@ private:
             container_type::node_algorithms::replace_node(other_link.this_ptr(), _link.this_ptr());
             container_type::node_algorithms::init(other_link.this_ptr());
         }
+    }
+};
+
+template <>
+struct fmt::formatter<range_tombstone_entry> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const range_tombstone_entry& rt, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", rt.tombstone());
     }
 };
 
@@ -272,7 +278,6 @@ public:
     // See reversibly_mergeable.hh
     reverter apply_reversibly(const schema& s, range_tombstone_list& rt_list);
 
-    friend std::ostream& operator<<(std::ostream& out, const range_tombstone_list&);
     bool equal(const schema&, const range_tombstone_list&) const;
     size_t external_memory_usage(const schema& s) const noexcept {
         size_t result = 0;
@@ -293,4 +298,12 @@ private:
                      reverter& rev);
 
     range_tombstones_type::iterator find(const schema& s, const range_tombstone_entry& rt);
+};
+
+template <>
+struct fmt::formatter<range_tombstone_list> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const range_tombstone_list& list, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(list, ", "));
+    }
 };

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -28,6 +28,11 @@ static thread_local schema_ptr s = schema_builder("ks", "cf")
 
 static auto gc_now = gc_clock::now();
 
+static std::ostream& operator<<(std::ostream& out, const range_tombstone_entry& entry) {
+    fmt::print(out, "{}", entry);
+    return out;
+}
+
 static clustering_key_prefix key(std::vector<int32_t> components) {
     std::vector<bytes> exploded;
     std::transform(components.begin(), components.end(), std::back_inserter(exploded), [](auto&& c) {


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `range_tombstone_list` and `range_tombstone_entry` without the help of `operator<<`.

the corresponding `operator<<()` operators are dropped in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245