### PR TITLE
Do not access owned_ranges_ptr across shards in update_sstable_cleanup_state

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -625,11 +625,6 @@ protected:
 
     flat_mutation_reader_v2::filter make_partition_filter() const {
         return [this] (const dht::decorated_key& dk) {
-#ifdef SEASTAR_DEBUG
-            // sstables should never be shared with other shards at this point.
-            assert(dht::shard_of(*_schema, dk.token()) == this_shard_id());
-#endif
-
             if (!_owned_ranges_checker->belongs_to_current_node(dk.token())) {
                 log_trace("Token {} does not belong to this node, skipping", dk.token());
                 return false;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1580,15 +1580,20 @@ bool needs_cleanup(const sstables::shared_sstable& sst,
     return true;
 }
 
-bool compaction_manager::update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, owned_ranges_ptr owned_ranges_ptr) {
+bool compaction_manager::update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges) {
     auto& cs = get_compaction_state(&t);
-    if (owned_ranges_ptr && needs_cleanup(sst, *owned_ranges_ptr)) {
+    if (needs_cleanup(sst, sorted_owned_ranges)) {
         cs.sstables_requiring_cleanup.insert(sst);
         return true;
     } else {
         cs.sstables_requiring_cleanup.erase(sst);
         return false;
     }
+}
+
+bool compaction_manager::erase_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst) {
+    auto& cs = get_compaction_state(&t);
+    return cs.sstables_requiring_cleanup.erase(sst);
 }
 
 bool compaction_manager::requires_cleanup(table_state& t, const sstables::shared_sstable& sst) const {
@@ -1616,7 +1621,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
         return seastar::async([this, &t, sorted_owned_ranges = std::move(sorted_owned_ranges)] {
             auto update_sstables_cleanup_state = [&] (const sstables::sstable_set& set) {
                 set.for_each_sstable([&] (const sstables::shared_sstable& sst) {
-                    update_sstable_cleanup_state(t, sst, sorted_owned_ranges);
+                    update_sstable_cleanup_state(t, sst, *sorted_owned_ranges);
                     seastar::thread::maybe_yield();
                 });
             };

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -405,7 +405,11 @@ public:
     };
 
     // Add sst to or remove it from the respective compaction_state.sstables_requiring_cleanup set.
-    bool update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, owned_ranges_ptr owned_ranges_ptr);
+    bool update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);
+
+    // Uncoditionally erase sst from `sstables_requiring_cleanup`
+    // Returns true iff sst was found and erased.
+    bool erase_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst);
 
     // checks if the sstable is in the respective compaction_state.sstables_requiring_cleanup set.
     bool requires_cleanup(table_state& t, const sstables::shared_sstable& sst) const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1122,7 +1122,11 @@ public:
     future<> parallel_foreach_table_state(std::function<future<>(compaction::table_state&)> action);
 
     // Add sst to or remove it from the sstables_requiring_cleanup set.
-    bool update_sstable_cleanup_state(const sstables::shared_sstable& sst, compaction::owned_ranges_ptr owned_ranges_ptr);
+    bool update_sstable_cleanup_state(const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);
+
+    // Uncoditionally erase sst from `sstables_requiring_cleanup`
+    // Returns true iff sst was found and erased.
+    bool erase_sstable_cleanup_state(const sstables::shared_sstable& sst);
 
     // Returns true if the sstable requries cleanup.
     bool requires_cleanup(const sstables::shared_sstable& sst) const;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -161,13 +161,14 @@ collect_all_shared_sstables(sharded<sstables::sstable_directory>& dir, sharded<r
     auto coordinator = this_shard_id();
     // We will first move all of the foreign open info to temporary storage so that we can sort
     // them. We want to distribute bigger sstables first.
+    const auto* sorted_owned_ranges_ptr = owned_ranges_ptr.get();
     co_await dir.invoke_on_all([&] (sstables::sstable_directory& d) -> future<> {
         auto shared_sstables = d.retrieve_shared_sstables();
         sstables::sstable_directory::sstable_open_info_vector need_cleanup;
-        if (owned_ranges_ptr) {
+        if (sorted_owned_ranges_ptr) {
             auto& table = db.local().find_column_family(ks_name, table_name);
             co_await d.do_for_each_sstable([&] (sstables::shared_sstable sst) -> future<> {
-                if (table.update_sstable_cleanup_state(sst, owned_ranges_ptr)) {
+                if (table.update_sstable_cleanup_state(sst, *sorted_owned_ranges_ptr)) {
                     need_cleanup.push_back(co_await sst->get_open_info());
                 }
             });
@@ -245,7 +246,7 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
     co_await coroutine::parallel_for_each(shared_info, [&] (sstables::foreign_sstable_open_info& info) -> future<> {
         auto sst = co_await dir.load_foreign_sstable(info);
         if (owned_ranges_ptr) {
-            table.update_sstable_cleanup_state(sst, owned_ranges_ptr);
+            table.update_sstable_cleanup_state(sst, *owned_ranges_ptr);
         }
         // Last bucket gets leftover SSTables
         if ((buckets.back().size() >= sstables_per_job) && (buckets.size() < num_jobs)) {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -206,9 +206,15 @@ distribute_reshard_jobs(sstables::sstable_directory::sstable_open_info_vector so
     });
 
     for (auto& info : source) {
-        auto shard_it = boost::min_element(destinations, std::mem_fn(&reshard_shard_descriptor::total_size_smaller));
-        shard_it->uncompressed_data_size += info.uncompressed_data_size;
-        shard_it->info_vec.push_back(std::move(info));
+        // Choose the stable shard owner with the smallest amount of accumulated work.
+        // Note that for sstables that need cleanup via resharding, owners may contain
+        // a single shard.
+        auto shard_it = boost::min_element(info.owners, [&] (const shard_id& lhs, const shard_id& rhs) {
+            return destinations[lhs].total_size_smaller(destinations[rhs]);
+        });
+        auto& dest = destinations[*shard_it];
+        dest.uncompressed_data_size += info.uncompressed_data_size;
+        dest.info_vec.push_back(std::move(info));
         co_await coroutine::maybe_yield();
     }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1913,7 +1913,7 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
             remove_sstable_from_backlog_tracker(r.cg.get_backlog_tracker(), r.sst);
         }
         co_await sstables::sstable_directory::delete_atomically({r.sst});
-        update_sstable_cleanup_state(r.sst, {});
+        erase_sstable_cleanup_state(r.sst);
     });
     co_return p->rp;
 }
@@ -2825,10 +2825,16 @@ table::as_data_dictionary() const {
     return _impl.wrap(*this);
 }
 
-bool table::update_sstable_cleanup_state(const sstables::shared_sstable& sst, compaction::owned_ranges_ptr owned_ranges_ptr) {
+bool table::update_sstable_cleanup_state(const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges) {
     // FIXME: it's possible that the sstable belongs to multiple compaction_groups
     auto& cg = compaction_group_for_sstable(sst);
-    return get_compaction_manager().update_sstable_cleanup_state(cg.as_table_state(), sst, std::move(owned_ranges_ptr));
+    return get_compaction_manager().update_sstable_cleanup_state(cg.as_table_state(), sst, sorted_owned_ranges);
+}
+
+bool table::erase_sstable_cleanup_state(const sstables::shared_sstable& sst) {
+    // FIXME: it's possible that the sstable belongs to multiple compaction_groups
+    auto& cg = compaction_group_for_sstable(sst);
+    return get_compaction_manager().erase_sstable_cleanup_state(cg.as_table_state(), sst);
 }
 
 bool table::requires_cleanup(const sstables::shared_sstable& sst) const {


### PR DESCRIPTION
This series fixes a few issues caused by f1bbf705f9b6faa406baac04f418a93b09a53c19
(f1bbf705f9b6faa406baac04f418a93b09a53c19):

- table, compaction_manager: prevent cross shard access to owned_ranges_ptr
  - Fixes #13631 
- distributed_loader: distribute_reshard_jobs: pick one of the sstable shard owners
- compaction: make_partition_filter: do not assert shard ownership
  - allow the filtering reader now used during resharding to process tokens owned by other shards