### PR TITLE
cql3: result_set, selector: change value type to managed_bytes_opt

### DIFF
--- a/alternator/auth.cc
+++ b/alternator/auth.cc
@@ -53,7 +53,7 @@ future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::strin
     if (result_set->empty()) {
         co_await coroutine::return_exception(api_error::unrecognized_client(format("User not found: {}", username)));
     }
-    const bytes_opt& salted_hash = result_set->rows().front().front(); // We only asked for 1 row and 1 column
+    const managed_bytes_opt& salted_hash = result_set->rows().front().front(); // We only asked for 1 row and 1 column
     if (!salted_hash) {
         co_await coroutine::return_exception(api_error::unrecognized_client(format("No password found for user: {}", username)));
     }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -229,7 +229,7 @@ public:
         const std::optional<attrs_to_get>& attrs_to_get);
 
     static void describe_single_item(const cql3::selection::selection&,
-        const std::vector<bytes_opt>&,
+        const std::vector<managed_bytes_opt>&,
         const std::optional<attrs_to_get>&,
         rjson::value&,
         bool = false);

--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -53,6 +53,10 @@ public:
         using difference_type = std::ptrdiff_t;
         using pointer = bytes_view*;
         using reference = bytes_view&;
+
+        struct implementation {
+            blob_storage* current_chunk;
+        };
     private:
         chunk* _current = nullptr;
     public:
@@ -76,6 +80,11 @@ public:
             return tmp;
         }
         bool operator==(const fragment_iterator&) const = default;
+        implementation extract_implementation() const {
+            return implementation {
+                .current_chunk = _current,
+            };
+        }
     };
     using const_iterator = fragment_iterator;
 

--- a/cql3/selection/aggregate_function_selector.hh
+++ b/cql3/selection/aggregate_function_selector.hh
@@ -31,16 +31,17 @@ public:
         for (size_t i = 0; i < m; ++i) {
             auto&& s = _arg_selectors[i];
             s->add_input(rs);
-            _args[i + 1] = s->get_output();
+            _args[i + 1] = to_bytes_opt(s->get_output());
             s->reset();
         }
         _accumulator = _aggregate.aggregation_function->execute(_args);
     }
 
-    virtual bytes_opt get_output() override {
-        return _aggregate.state_to_result_function
+    virtual managed_bytes_opt get_output() override {
+        return to_managed_bytes_opt(
+               _aggregate.state_to_result_function
                 ? _aggregate.state_to_result_function->execute(std::span(&_accumulator, 1))
-                : std::move(_accumulator);
+                : std::move(_accumulator));
     }
 
     virtual void reset() override {

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -62,12 +62,12 @@ public:
         _selected->add_input(rs);
     }
 
-    virtual bytes_opt get_output() override {
+    virtual managed_bytes_opt get_output() override {
         auto&& value = _selected->get_output();
         if (!value) {
             return std::nullopt;
         }
-        return get_nth_tuple_element(single_fragmented_view(*value), _field);
+        return get_nth_tuple_element(managed_bytes_view(*value), _field);
     }
 
     virtual data_type get_type() const override {

--- a/cql3/selection/scalar_function_selector.hh
+++ b/cql3/selection/scalar_function_selector.hh
@@ -38,14 +38,14 @@ public:
     virtual void reset() override {
     }
 
-    virtual bytes_opt get_output() override {
+    virtual managed_bytes_opt get_output() override {
         size_t m = _arg_selectors.size();
         for (size_t i = 0; i < m; ++i) {
             auto&& s = _arg_selectors[i];
-            _args[i] = s->get_output();
+            _args[i] = to_bytes_opt(s->get_output());
             s->reset();
         }
-        return fun()->execute(_args);
+        return to_managed_bytes_opt(fun()->execute(_args));
     }
 
     virtual bool requires_thread() const override;

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -122,7 +122,7 @@ public:
 protected:
     class simple_selectors : public selectors {
     private:
-        std::vector<bytes_opt> _current;
+        std::vector<managed_bytes_opt> _current;
         bool _first = true; ///< Whether the next row we receive is the first in its group.
     public:
         virtual void reset() override {
@@ -132,7 +132,7 @@ protected:
 
         virtual bool requires_thread() const override { return false; }
 
-        virtual std::vector<bytes_opt> get_output_row() override {
+        virtual std::vector<managed_bytes_opt> get_output_row() override {
             return std::move(_current);
         }
 
@@ -234,8 +234,8 @@ protected:
             return _factories->does_aggregation();
         }
 
-        virtual std::vector<bytes_opt> get_output_row() override {
-            std::vector<bytes_opt> output_row;
+        virtual std::vector<managed_bytes_opt> get_output_row() override {
+            std::vector<managed_bytes_opt> output_row;
             output_row.reserve(_selectors.size());
             for (auto&& s : _selectors) {
                 output_row.emplace_back(s->get_output());

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -52,7 +52,7 @@ public:
     */
     virtual void add_input_row(result_set_builder& rs) = 0;
 
-    virtual std::vector<bytes_opt> get_output_row() = 0;
+    virtual std::vector<managed_bytes_opt> get_output_row() = 0;
 
     virtual void reset() = 0;
 };
@@ -189,10 +189,10 @@ private:
     std::unique_ptr<result_set> _result_set;
     std::unique_ptr<selectors> _selectors;
     const std::vector<size_t> _group_by_cell_indices; ///< Indices in \c current of cells holding GROUP BY values.
-    std::vector<bytes_opt> _last_group; ///< Previous row's group: all of GROUP BY column values.
+    std::vector<managed_bytes_opt> _last_group; ///< Previous row's group: all of GROUP BY column values.
     bool _group_began; ///< Whether a group began being formed.
 public:
-    std::optional<std::vector<bytes_opt>> current;
+    std::optional<std::vector<managed_bytes_opt>> current;
 private:
     std::vector<api::timestamp_type> _timestamps;
     std::vector<int32_t> _ttls;

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -49,7 +49,7 @@ public:
      * @return the selector output
      * @throws InvalidRequestException if a problem occurs while computing the output value
      */
-    virtual bytes_opt get_output() = 0;
+    virtual managed_bytes_opt get_output() = 0;
 
     /**
      * Returns the <code>selector</code> output type.

--- a/cql3/selection/simple_selector.hh
+++ b/cql3/selection/simple_selector.hh
@@ -49,7 +49,7 @@ private:
     const sstring _column_name;
     const uint32_t _idx;
     data_type _type;
-    bytes_opt _current;
+    managed_bytes_opt _current;
     bool _first; ///< Whether the next row we receive is the first in its group.
 public:
     static ::shared_ptr<factory> new_factory(const sstring& column_name, uint32_t idx, data_type type) {
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    virtual bytes_opt get_output() override {
+    virtual managed_bytes_opt get_output() override {
         return std::move(_current);
     }
 

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -75,7 +75,7 @@ public:
     template<typename T>
     using compare_fn = std::function<bool(const T&, const T&)>;
 
-    using result_row_type = std::vector<bytes_opt>;
+    using result_row_type = std::vector<managed_bytes_opt>;
     using ordering_comparator_type = compare_fn<result_row_type>;
 private:
     using prepared_orderings_type = std::vector<std::pair<const column_definition*, ordering>>;

--- a/cql3/statements/strongly_consistent_select_statement.cc
+++ b/cql3/statements/strongly_consistent_select_statement.cc
@@ -119,7 +119,7 @@ strongly_consistent_select_statement::execute_without_checking_exception_message
     });
 
     if (query_result->value) {
-        result_set->add_row({ query_result->value });
+        result_set->add_row({ managed_bytes_opt(query_result->value) });
     }
 
     co_return ::make_shared<cql_transport::messages::result_message::rows>(cql3::result{std::move(result_set)});

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -74,7 +74,7 @@ struct cql3::untyped_result_set::visitor {
     void start_row() {
         tmp.reserve(index.size());
     }
-    void accept_value(std::optional<query::result_bytes_view>&& v) {
+    void accept_value(managed_bytes_view_opt&& v) {
         if (v) {
             tmp.emplace_back(v->linearize());
         } else {

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -76,7 +76,7 @@ struct cql3::untyped_result_set::visitor {
     }
     void accept_value(managed_bytes_view_opt&& v) {
         if (v) {
-            tmp.emplace_back(v->linearize());
+            tmp.emplace_back(*v);
         } else {
             tmp.emplace_back(std::nullopt);
         }

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -30,17 +30,17 @@ size_t cql3::untyped_result_set_row::index(const std::string_view& name) const {
 bool cql3::untyped_result_set_row::has(std::string_view name) const {
     auto i = index(name);
     if (i < _data.size()) {
-        return !std::holds_alternative<std::monostate>(_data.at(i));
+        return _data.at(i).has_value();
     }
     return false;
 }
 
 cql3::untyped_result_set_row::view_type cql3::untyped_result_set_row::get_view(std::string_view name) const {
-    return std::visit(make_visitor(
-        [](std::monostate) -> view_type { throw std::bad_variant_access(); },
-        [](const view_type& v) -> view_type { return v; },
-        [](const bytes& b) -> view_type { return view_type(b); }
-    ), _data.at(index(name)));
+    auto& data = _data.at(index(name));
+    if (!data) {
+        throw std::bad_variant_access();
+    }
+    return *data;
 }
 
 const std::vector<lw_shared_ptr<cql3::column_specification>>& cql3::untyped_result_set_row::get_columns() const {
@@ -76,10 +76,10 @@ struct cql3::untyped_result_set::visitor {
     }
     void accept_value(std::optional<query::result_bytes_view>&& v) {
         if (v) {
-            tmp.emplace_back(std::move(*v));
+            tmp.emplace_back(v->linearize());
         } else {
-            tmp.emplace_back(std::monostate{});
-        } 
+            tmp.emplace_back(std::nullopt);
+        }
     }
     // somewhat weird dispatch, but when visiting directly via
     // result_generator, pk:s will be temporary - and sent 

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -41,12 +41,12 @@ class metadata;
 
 class untyped_result_set_row {
 public:
-    using view_type = bytes_view;
+    using view_type = managed_bytes_view;
     using opt_view_type = std::optional<view_type>;
 private:
     friend class untyped_result_set;
     using index_map = std::unordered_map<std::string_view, size_t>;
-    using data_views = std::vector<bytes_opt>;
+    using data_views = std::vector<managed_bytes_opt>;
 
     const index_map& _name_to_index;
     const cql3::metadata& _metadata;

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -41,13 +41,12 @@ class metadata;
 
 class untyped_result_set_row {
 public:
-    using view_type = query::result_bytes_view;
+    using view_type = bytes_view;
     using opt_view_type = std::optional<view_type>;
-    using view_holder = std::variant<std::monostate, view_type, bytes>;
 private:
     friend class untyped_result_set;
     using index_map = std::unordered_map<std::string_view, size_t>;
-    using data_views = std::vector<view_holder>;
+    using data_views = std::vector<bytes_opt>;
 
     const index_map& _name_to_index;
     const cql3::metadata& _metadata;
@@ -62,7 +61,7 @@ public:
     bool has(std::string_view) const;
     view_type get_view(std::string_view name) const;
     bytes get_blob(std::string_view name) const {
-        return get_view(name).linearize();
+        return to_bytes(get_view(name));
     }
     managed_bytes get_blob_fragmented(std::string_view name) const {
         return managed_bytes(get_view(name));

--- a/serializer.cc
+++ b/serializer.cc
@@ -13,3 +13,26 @@ namespace ser {
 logging::logger serlog("serializer");
 
 } // namespace ser
+
+namespace utils {
+
+managed_bytes_view
+buffer_view_to_managed_bytes_view(ser::buffer_view<bytes_ostream::fragment_iterator> bv) {
+    auto impl = bv.extract_implementation();
+    return build_managed_bytes_view_from_internals(
+            impl.current,
+            impl.next.extract_implementation().current_chunk,
+            impl.size
+    );
+}
+
+managed_bytes_view_opt
+buffer_view_to_managed_bytes_view(std::optional<ser::buffer_view<bytes_ostream::fragment_iterator>> bvo) {
+    if (!bvo) {
+        return std::nullopt;
+    }
+    return buffer_view_to_managed_bytes_view(*bvo);
+}
+
+
+} // namespace utils

--- a/serializer.hh
+++ b/serializer.hh
@@ -45,6 +45,12 @@ class buffer_view {
 public:
     using fragment_type = bytes_view;
 
+    struct implementation {
+        bytes_view current;
+        FragmentIterator next;
+        size_t size;
+    };
+
     class iterator {
         bytes_view _current;
         size_t _left = 0;
@@ -176,6 +182,14 @@ public:
             bv = _first;
         }
         return fn(bv);
+    }
+
+    implementation extract_implementation() const {
+        return implementation {
+            .current = _first,
+            .next = _next,
+            .size = _total_size,
+        };
     }
 };
 static_assert(FragmentedView<buffer_view<bytes_ostream::fragment_iterator>>);

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -478,7 +478,7 @@ future<query::forward_result> forward_service::execute_on_this_shard(
             flogger.error("aggregation result column count does not match requested column count");
             throw std::runtime_error("aggregation result column count does not match requested column count");
         }
-        query::forward_result res = { .query_results = rows[0] };
+        query::forward_result res = { .query_results = boost::copy_range<std::vector<bytes_opt>>(rows[0] | boost::adaptors::transformed([] (const managed_bytes_opt& x) { return to_bytes_opt(x); })) };
 
         auto printer = seastar::value_of([&req, &res] {
             return query::forward_result::printer {

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -372,7 +372,7 @@ static std::vector<std::vector<bytes_opt>> to_bytes(const cql_transport::message
     auto rs = rows.rs().result_set().rows();
     std::vector<std::vector<bytes_opt>> results;
     for (auto it = rs.begin(); it != rs.end(); ++it) {
-        results.push_back(*it);
+        results.push_back(boost::copy_range<std::vector<bytes_opt>>(*it | boost::adaptors::transformed([] (const managed_bytes_opt& x) { return to_bytes_opt(x); })));
     }
     return results;
 }

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(test_functions) {
                     BOOST_REQUIRE_EQUAL(rs.rows().size(), 3);
                     for (auto&& rw : rs.rows()) {
                         BOOST_REQUIRE_EQUAL(rw.size(), 1);
-                        res.push_back(rw[0]);
+                        res.push_back(to_bytes_opt(rw[0]));
                     }
                 }
                 virtual void visit(const result_message::bounce_to_shard& rows) override { throw "bad"; }

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -91,8 +91,8 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         BOOST_REQUIRE_EQUAL(rows.size(), 1);
         auto row0 = rows[0];
         BOOST_REQUIRE_EQUAL(row0.size(), 3);
-        BOOST_REQUIRE_EQUAL(*row0[0], "44");
-        BOOST_REQUIRE_EQUAL(*row0[2], "tbl");
+        BOOST_REQUIRE_EQUAL(to_bytes(*row0[0]), "44");
+        BOOST_REQUIRE_EQUAL(to_bytes(*row0[2]), "tbl");
 
         // Unfortunately we cannot check the exact size, since it includes a timestemp written as a vint of the delta
         // since start of the write. This means that the size of the row depends on the time it took to write the

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -943,7 +943,7 @@ SEASTAR_TEST_CASE(test_limit_is_respected_across_partitions) {
             const auto& rs = rows->rs().result_set();
             for (auto&& row : rs.rows()) {
                 BOOST_REQUIRE(row[0]);
-                keys.push_back(*row[0]);
+                keys.push_back(to_bytes(*row[0]));
             }
             BOOST_REQUIRE(keys.size() == 2);
             bytes k1 = keys[0];
@@ -1003,7 +1003,7 @@ SEASTAR_TEST_CASE(test_partitions_have_consistent_ordering_in_range_query) {
             const auto& rs = rows->rs().result_set();
             for (auto&& row : rs.rows()) {
                 BOOST_REQUIRE(row[0]);
-                keys.push_back(*row[0]);
+                keys.push_back(to_bytes(*row[0]));
             }
             BOOST_REQUIRE(keys.size() == 6);
 
@@ -1087,7 +1087,7 @@ SEASTAR_TEST_CASE(test_partition_range_queries_with_bounds) {
             for (auto&& row : rs.rows()) {
                 BOOST_REQUIRE(row[0]);
                 BOOST_REQUIRE(row[1]);
-                keys.push_back(*row[0]);
+                keys.push_back(to_bytes(*row[0]));
                 tokens.push_back(value_cast<int64_t>(long_type->deserialize(*row[1])));
             }
             BOOST_REQUIRE(keys.size() == 5);
@@ -3783,7 +3783,7 @@ SEASTAR_TEST_CASE(test_rf_expand) {
             auto row0 = rows[0];
             BOOST_REQUIRE_EQUAL(row0.size(), 1);
 
-            auto parsed = rjson::parse(to_sstring_view(*row0[0]));
+            auto parsed = rjson::parse(to_sstring_view(to_bytes(*row0[0])));
             return std::move(rjson::get(parsed, "replication"));
         };
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -18,7 +18,7 @@
 #include "service/migration_manager.hh"
 #include "seastar/core/metrics_api.hh"
 
-static future<utils::chunked_vector<std::vector<bytes_opt>>> fetch_rows(cql_test_env& e, std::string_view cql) {
+static future<utils::chunked_vector<std::vector<managed_bytes_opt>>> fetch_rows(cql_test_env& e, std::string_view cql) {
     auto msg = co_await e.execute_cql(cql);
     auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
     BOOST_REQUIRE(rows);

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1178,7 +1178,7 @@ table_config read_config(cql_test_env& env, const sstring& name) {
     if (rs.size() < 1) {
         throw std::runtime_error("config not found. Did you run --populate ?");
     }
-    const std::vector<bytes_opt>& config_row = rs.rows()[0];
+    const std::vector<managed_bytes_opt>& config_row = rs.rows()[0];
     if (config_row.size() != 2) {
         throw std::runtime_error("config row has invalid size");
     }

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -180,6 +180,16 @@ std::string bytes_to_string(query::result_bytes_view v) {
     return str;
 }
 
+std::string bytes_to_string(managed_bytes_view v) {
+    std::string str;
+    str.reserve(v.size_bytes());
+    for (auto fragment : fragment_range(v)) {
+        auto view = std::string_view(reinterpret_cast<const char*>(fragment.data()), fragment.size());
+        str.insert(str.end(), view.begin(), view.end());
+    }
+    return str;
+}
+
 namespace thrift {
 template<typename T>
 concept Aggregator =
@@ -1210,7 +1220,7 @@ private:
                 _column_id = 0;
                 _columns.reserve(_metadata.column_count());
             }
-            void accept_value(std::optional<query::result_bytes_view> cell) {
+            void accept_value(managed_bytes_view_opt cell) {
                 auto& col = _metadata.get_names()[_column_id++];
 
                 Column& c = _columns.emplace_back();

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -53,16 +53,15 @@ std::ostream& operator<<(std::ostream& os, const result_message::rows& msg) {
     struct visitor {
         std::ostream& _os;
         void start_row() { _os << "{row: "; }
-        void accept_value(std::optional<query::result_bytes_view> value) {
+        void accept_value(managed_bytes_view_opt value) {
             if (!value) {
                 _os << " null";
                 return;
             }
             _os << " ";
-            using boost::range::for_each;
-            for_each(*value, [this] (bytes_view fragment) {
+            for (auto fragment : fragment_range(*value)) {
                 _os << fragment;
-            });
+            }
         }
         void end_row() { _os << "}"; }
     };

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -74,7 +74,7 @@ public:
     void write_string_map(std::map<sstring, sstring> string_map);
     void write_string_multimap(std::multimap<sstring, sstring> string_map);
     void write_value(bytes_opt value);
-    void write_value(std::optional<query::result_bytes_view> value);
+    void write_value(std::optional<managed_bytes_view> value);
     void write(const cql3::metadata& m, bool skip = false);
     void write(const cql3::prepared_metadata& m, uint8_t version);
 

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -91,7 +91,7 @@ std::optional<View> read_tuple_element(View& v) {
 }
 
 template <FragmentedView View>
-bytes_opt get_nth_tuple_element(View v, size_t n) {
+managed_bytes_opt get_nth_tuple_element(View v, size_t n) {
     for (size_t i = 0; i < n; ++i) {
         if (v.empty()) {
             return std::nullopt;
@@ -103,7 +103,7 @@ bytes_opt get_nth_tuple_element(View v, size_t n) {
     }
     auto el = read_tuple_element(v);
     if (el) {
-        return linearized(*el);
+        return managed_bytes(*el);
     }
     return std::nullopt;
 }

--- a/types/types.cc
+++ b/types/types.cc
@@ -2396,6 +2396,14 @@ std::strong_ordering abstract_type::compare(managed_bytes_view v1, managed_bytes
     }
 }
 
+std::strong_ordering abstract_type::compare(managed_bytes_view v1, bytes_view v2) const {
+    return compare(v1, managed_bytes_view(v2));
+}
+
+std::strong_ordering abstract_type::compare(bytes_view v1, managed_bytes_view v2) const {
+    return compare(managed_bytes_view(v1), v2);
+}
+
 bool abstract_type::equal(bytes_view v1, bytes_view v2) const {
     return ::visit(*this, [&](const auto& t) {
         if (is_byte_order_equal_visitor{}(t)) {
@@ -2412,6 +2420,14 @@ bool abstract_type::equal(managed_bytes_view v1, managed_bytes_view v2) const {
         }
         return compare_visitor{v1, v2}(t) == 0;
     });
+}
+
+bool abstract_type::equal(managed_bytes_view v1, bytes_view v2) const {
+    return equal(v1, managed_bytes_view(v2));
+}
+
+bool abstract_type::equal(bytes_view v1, managed_bytes_view v2) const {
+    return equal(managed_bytes_view(v1), v2);
 }
 
 // Count number of ':' which are not preceded by '\'.

--- a/types/types.hh
+++ b/types/types.hh
@@ -342,9 +342,12 @@ public:
     size_t hash(managed_bytes_view v) const;
     bool equal(bytes_view v1, bytes_view v2) const;
     bool equal(managed_bytes_view v1, managed_bytes_view v2) const;
+    bool equal(managed_bytes_view v1, bytes_view v2) const;
+    bool equal(bytes_view v1, managed_bytes_view v2) const;
     std::strong_ordering compare(bytes_view v1, bytes_view v2) const;
     std::strong_ordering compare(managed_bytes_view v1, managed_bytes_view v2) const;
-
+    std::strong_ordering compare(managed_bytes_view v1, bytes_view v2) const;
+    std::strong_ordering compare(bytes_view v1, managed_bytes_view v2) const;
 private:
     // Explicitly instantiated in .cc
     template <FragmentedView View> data_value deserialize_impl(View v) const;

--- a/types/types.hh
+++ b/types/types.hh
@@ -362,6 +362,9 @@ public:
     data_value deserialize(bytes_view v) const {
         return deserialize_impl(single_fragmented_view(v));
     }
+    data_value deserialize(const managed_bytes& v) const {
+        return deserialize(managed_bytes_view(v));
+    }
     template <FragmentedView View> data_value deserialize_value(View v) const {
         return deserialize(v);
     }

--- a/utils/buffer_view-to-managed_bytes_view.hh
+++ b/utils/buffer_view-to-managed_bytes_view.hh
@@ -1,0 +1,18 @@
+// Copyright 2023-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include "managed_bytes.hh"
+#include "serializer.hh"
+#include "bytes_ostream.hh"
+
+namespace utils {
+
+managed_bytes_view
+buffer_view_to_managed_bytes_view(ser::buffer_view<bytes_ostream::fragment_iterator> bv);
+
+managed_bytes_view_opt
+buffer_view_to_managed_bytes_view(std::optional<ser::buffer_view<bytes_ostream::fragment_iterator>> bvo);
+
+}

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -10,6 +10,23 @@
 
 #include "managed_bytes.hh"
 
+bytes_opt
+to_bytes_opt(const managed_bytes_opt& mbo) {
+    if (!mbo) {
+        return std::nullopt;
+    }
+    return mbo->with_linearized([] (bytes_view bv) {
+        return bytes_opt(bv);
+    });
+}
+
+managed_bytes_opt to_managed_bytes_opt(const bytes_opt& bo) {
+    if (!bo) {
+        return std::nullopt;
+    }
+    return managed_bytes(*bo);
+}
+
 std::unique_ptr<bytes_view::value_type[]>
 managed_bytes::do_linearize_pure() const {
     auto b = _u.ptr;

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -436,7 +436,7 @@ public:
     bytes linearize() const {
         return linearized(*this);
     }
-    bool is_linearized() {
+    bool is_linearized() const {
         return _current_fragment.size() == _size;
     }
 

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -451,6 +451,20 @@ public:
         , _next_fragments(other._next_fragments)
         , _size(other._size)
     {}
+
+    template <std::invocable<bytes_view> Func>
+    std::invoke_result_t<Func, bytes_view> with_linearized(Func&& func) const {
+        bytes b;
+        auto bv = std::invoke([&] () -> bytes_view {
+            if (is_linearized()) {
+                return _current_fragment;
+            } else {
+                b = linearize();
+                return b;
+            }
+        });
+        return func(bv);
+    }
 };
 static_assert(FragmentedView<managed_bytes_view>);
 static_assert(FragmentedMutableView<managed_bytes_mutable_view>);

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -374,6 +374,12 @@ private:
     fragment_type _current_fragment = {};
     blob_storage* _next_fragments = nullptr;
     size_t _size = 0;
+private:
+    managed_bytes_basic_view(fragment_type current_fragment, blob_storage* next_fragments, size_t size)
+        : _current_fragment(current_fragment)
+        , _next_fragments(next_fragments)
+        , _size(size) {
+    }
 public:
     managed_bytes_basic_view() = default;
     managed_bytes_basic_view(const managed_bytes_basic_view&) = default;
@@ -465,6 +471,8 @@ public:
         });
         return func(bv);
     }
+
+    friend managed_bytes_basic_view<mutable_view::no> build_managed_bytes_view_from_internals(bytes_view current_fragment, blob_storage* next_fragment, size_t size);
 };
 static_assert(FragmentedView<managed_bytes_view>);
 static_assert(FragmentedMutableView<managed_bytes_mutable_view>);
@@ -495,6 +503,12 @@ template<FragmentedView View>
 inline managed_bytes::managed_bytes(View v) : managed_bytes(initialized_later(), v.size_bytes()) {
     managed_bytes_mutable_view self(*this);
     write_fragmented(self, v);
+}
+
+inline
+managed_bytes_view
+build_managed_bytes_view_from_internals(bytes_view current_fragment, blob_storage* next_fragment, size_t size) {
+    return managed_bytes_view(current_fragment, next_fragment, size);
 }
 
 template<>

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -479,6 +479,18 @@ inline bytes to_bytes(managed_bytes_view v) {
     return linearized(v);
 }
 
+/// Converts a possibly fragmented managed_bytes_opt to a
+/// linear bytes_opt.
+///
+/// \note copies data
+bytes_opt to_bytes_opt(const managed_bytes_opt&);
+
+/// Converts a linear bytes_opt to a possibly fragmented
+/// managed_bytes_opt.
+///
+/// \note copies data
+managed_bytes_opt to_managed_bytes_opt(const bytes_opt&);
+
 template<FragmentedView View>
 inline managed_bytes::managed_bytes(View v) : managed_bytes(initialized_later(), v.size_bytes()) {
     managed_bytes_mutable_view self(*this);


### PR DESCRIPTION
CQL evolved several expression evaluation mechanisms: WHERE clause,
selectors (the SELECT clause), and the LWT IF clause are just some
examples. Most now use expressions, which use managed_bytes_opt
as the underlying value representation, but selectors still use bytes_opt.

This poses two problems:
1. bytes_opt generates large contiguous allocations when used with large blobs, impacting latency
2. trying to use expressions with bytes_opt will incur a copy, reducing performance

To solve the problem, we harmonize the data types to managed_bytes_opt
(#13216 notwithstanding). This is somewhat difficult since the source of the values
are views into a bytes_ostream. However, luckily bytes_ostream and managed_bytes_view
are mostly compatible so with a little effort this can be done.

The series is neutral wrt performance:

before:
```
222118.61 tps ( 61.1 allocs/op,  12.1 tasks/op,   43092 insns/op,        0 errors)
224250.14 tps ( 61.1 allocs/op,  12.1 tasks/op,   43094 insns/op,        0 errors)
224115.66 tps ( 61.1 allocs/op,  12.1 tasks/op,   43092 insns/op,        0 errors)
223508.70 tps ( 61.1 allocs/op,  12.1 tasks/op,   43107 insns/op,        0 errors)
223498.04 tps ( 61.1 allocs/op,  12.1 tasks/op,   43087 insns/op,        0 errors)
```

after:
```
220708.37 tps ( 61.1 allocs/op,  12.1 tasks/op,   43118 insns/op,        0 errors)
225168.99 tps ( 61.1 allocs/op,  12.1 tasks/op,   43081 insns/op,        0 errors)
222406.00 tps ( 61.1 allocs/op,  12.1 tasks/op,   43088 insns/op,        0 errors)
224608.27 tps ( 61.1 allocs/op,  12.1 tasks/op,   43102 insns/op,        0 errors)
225458.32 tps ( 61.1 allocs/op,  12.1 tasks/op,   43098 insns/op,        0 errors)
```

Though I expect with some more effort we can eliminate some copies.