### PR TITLE
clear_gently: handle null unique_ptr and optional values

### DIFF
--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -89,6 +89,24 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_non_trivial_unique_ptr) {
     utils::clear_gently(p).get();
     BOOST_CHECK(p);
     BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+
+    cleared_gently = 0;
+    p.reset();
+    utils::clear_gently(p).get();
+    BOOST_CHECK(!p);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_vector_of_unique_ptrs) {
+    int cleared_gently = 0;
+    std::vector<std::unique_ptr<clear_gently_tracker<int>>> v;
+    v.emplace_back(std::make_unique<clear_gently_tracker<int>>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    }));
+    v.emplace_back(nullptr);
+
+    utils::clear_gently(v).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_clear_gently_foreign_ptr) {

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -64,6 +64,9 @@ template <typename T>
 struct clear_gently_tracker {
     std::unique_ptr<T> v;
     std::function<void (T)> on_clear;
+    clear_gently_tracker() noexcept
+        : on_clear([] (T) { BOOST_FAIL("clear_gently called on default-constructed clear_gently_tracker"); })
+    {}
     clear_gently_tracker(T i, std::function<void (T)> f) : v(std::make_unique<T>(std::move(i))), on_clear(std::move(f)) {}
     clear_gently_tracker(clear_gently_tracker&& x) noexcept : v(std::move(x.v)), on_clear(std::move(x.on_clear)) {}
     clear_gently_tracker& operator=(clear_gently_tracker&& x) noexcept {
@@ -77,6 +80,9 @@ struct clear_gently_tracker {
         on_clear(*v);
         v.reset();
         return make_ready_future<>();
+    }
+    operator bool() const noexcept {
+        return bool(v);
     }
 };
 
@@ -466,4 +472,61 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_multi_nesting) {
     utils::clear_gently(c).get();
     BOOST_CHECK(c.empty());
     BOOST_REQUIRE_EQUAL(cleared_gently, top_count * mid_count * count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_optional) {
+    int cleared_gently = 0;
+    std::optional<clear_gently_tracker<int>> opt = std::make_optional<clear_gently_tracker<int>>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    });
+
+    BOOST_CHECK(opt);
+    utils::clear_gently(opt).get();
+    BOOST_CHECK(opt);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+
+    cleared_gently = 0;
+    opt.reset();
+    utils::clear_gently(opt).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_vector_of_optionals) {
+    int cleared_gently = 0;
+    std::vector<std::optional<clear_gently_tracker<int>>> v;
+    v.emplace_back(std::make_optional<clear_gently_tracker<int>>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    }));
+    v.emplace_back(std::nullopt);
+
+    utils::clear_gently(v).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_optimized_optional) {
+    int cleared_gently = 0;
+    seastar::optimized_optional<clear_gently_tracker<int>> opt(clear_gently_tracker<int>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    }));
+
+    BOOST_CHECK(opt);
+    utils::clear_gently(opt).get();
+    BOOST_CHECK(!opt);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+
+    cleared_gently = 0;
+    utils::clear_gently(opt).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_vector_of_optimized_optionals) {
+    int cleared_gently = 0;
+    std::vector<seastar::optimized_optional<clear_gently_tracker<int>>> v;
+    v.emplace_back(clear_gently_tracker<int>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    }));
+    v.emplace_back(std::nullopt);
+
+    utils::clear_gently(v).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
 }

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -133,6 +133,12 @@ template <Container T>
 requires (!StringLike<T> && !Sequence<T> && !MapLike<T>)
 future<> clear_gently(T& c) noexcept;
 
+template <typename T>
+future<> clear_gently(std::optional<T>& opt) noexcept;
+
+template <typename T>
+future<> clear_gently(seastar::optimized_optional<T>& opt) noexcept;
+
 namespace internal {
 
 template <typename T>
@@ -235,6 +241,24 @@ future<> clear_gently(T& c) noexcept {
             c.erase(it);
         });
     });
+}
+
+template <typename T>
+future<> clear_gently(std::optional<T>& opt) noexcept {
+    if (opt) {
+        return utils::clear_gently(*opt);
+    } else {
+        return make_ready_future<>();
+    }
+}
+
+template <typename T>
+future<> clear_gently(seastar::optimized_optional<T>& opt) noexcept {
+    if (opt) {
+        return utils::clear_gently(*opt);
+    } else {
+        return make_ready_future<>();
+    }
 }
 
 }

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -60,6 +60,7 @@ concept HasClearGentlyMethod = requires (T x) {
 
 template <typename T>
 concept SmartPointer = requires (T x) {
+    { x.get() } -> std::same_as<typename T::element_type*>;
     { *x } -> std::same_as<typename T::element_type&>;
 };
 
@@ -177,7 +178,11 @@ future<> clear_gently(T& o) noexcept {
 
 template <SmartPointer T>
 future<> clear_gently(T& o) noexcept {
-    return internal::clear_gently(*o);
+    if (auto p = o.get()) {
+        return internal::clear_gently(*p);
+    } else {
+        return make_ready_future<>();
+    }
 }
 
 template <typename T, std::size_t N>


### PR DESCRIPTION
This series adds handling of null std::unique_ptr to utils::clear_gently
and handling of std::optional and seastar::optimized_optional (both engaged and disengaged cases).

Also, unit tests were added to tests the above cases.

Fixes #13636