### PR TITLE
timeout_config: correct the misconfigured {truncate, other}_timeout

### DIFF
--- a/timeout_config.cc
+++ b/timeout_config.cc
@@ -20,7 +20,7 @@ updateable_timeout_config::updateable_timeout_config(const db::config& cfg)
     , write_timeout_in_ms(cfg.write_request_timeout_in_ms)
     , range_read_timeout_in_ms(cfg.range_request_timeout_in_ms)
     , counter_write_timeout_in_ms(cfg.counter_write_request_timeout_in_ms)
-    , truncate_timeout_in_ms(cfg.counter_write_request_timeout_in_ms)
+    , truncate_timeout_in_ms(cfg.truncate_request_timeout_in_ms)
     , cas_timeout_in_ms(cfg.cas_contention_timeout_in_ms)
     , other_timeout_in_ms(cfg.request_timeout_in_ms)
 {}
@@ -33,6 +33,6 @@ timeout_config updateable_timeout_config::current_values() const {
         std::chrono::milliseconds(counter_write_timeout_in_ms),
         std::chrono::milliseconds(truncate_timeout_in_ms),
         std::chrono::milliseconds(cas_timeout_in_ms),
-        std::chrono::milliseconds(cas_timeout_in_ms),
+        std::chrono::milliseconds(other_timeout_in_ms),
     };
 }


### PR DESCRIPTION
this change fixes the regression introduced by
ebf5e138e84827d3d2314643f71d65affe9895f5, which

* initialized `truncate_timeout_in_ms` with `counter_write_request_timeout_in_ms`,
* returns `cas_timeout_in_ms` in the place of `other_timeout_in_ms`.

in this change, these two misconfigurations are fixed.

Fixes #13633
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>