### PR TITLE
storage_service: specialize fmt::formatter<storage_service::mode>

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2841,24 +2841,6 @@ future<std::map<gms::inet_address, float>> storage_service::effective_ownership(
     });
 }
 
-static const std::map<storage_service::mode, sstring> mode_names = {
-    {storage_service::mode::NONE,           "STARTING"},
-    {storage_service::mode::STARTING,       "STARTING"},
-    {storage_service::mode::NORMAL,         "NORMAL"},
-    {storage_service::mode::JOINING,        "JOINING"},
-    {storage_service::mode::BOOTSTRAP,      "BOOTSTRAP"},
-    {storage_service::mode::LEAVING,        "LEAVING"},
-    {storage_service::mode::DECOMMISSIONED, "DECOMMISSIONED"},
-    {storage_service::mode::MOVING,         "MOVING"},
-    {storage_service::mode::DRAINING,       "DRAINING"},
-    {storage_service::mode::DRAINED,        "DRAINED"},
-};
-
-std::ostream& operator<<(std::ostream& os, const storage_service::mode& m) {
-    os << mode_names.at(m);
-    return os;
-}
-
 void storage_service::set_mode(mode m) {
     if (m != _operation_mode) {
         slogger.info("entering {} mode", m);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -248,7 +248,6 @@ public:
     enum class mode { NONE, STARTING, JOINING, BOOTSTRAP, NORMAL, LEAVING, DECOMMISSIONED, MOVING, DRAINING, DRAINED };
 private:
     mode _operation_mode = mode::NONE;
-    friend std::ostream& operator<<(std::ostream& os, const mode& mode);
     /* Used for tracking drain progress */
 
     endpoint_lifecycle_notifier& _lifecycle_notifier;
@@ -797,3 +796,25 @@ private:
 };
 
 }
+
+template <>
+struct fmt::formatter<service::storage_service::mode> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(service::storage_service::mode mode, FormatContext& ctx) const {
+        std::string_view name;
+        using enum service::storage_service::mode;
+        switch (mode) {
+        case NONE:           name = "STARTING"; break;
+        case STARTING:       name = "STARTING"; break;
+        case NORMAL:         name = "NORMAL"; break;
+        case JOINING:        name = "JOINING"; break;
+        case BOOTSTRAP:      name = "BOOTSTRAP"; break;
+        case LEAVING:        name = "LEAVING"; break;
+        case DECOMMISSIONED: name = "DECOMMISSIONED"; break;
+        case MOVING:         name = "MOVING"; break;
+        case DRAINING:       name = "DRAINING"; break;
+        case DRAINED:        name = "DRAINED"; break;
+        }
+        return fmt::format_to(ctx.out(), "{}", name);
+    }
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `storage_service::mode` without the help of `operator<<`.

the corresponding `operator<<()` for `storage_service::mode` is removed in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245