### PR TITLE
auth: do not include unused header

### DIFF
--- a/auth/authenticated_user.cc
+++ b/auth/authenticated_user.cc
@@ -10,8 +10,6 @@
 
 #include "auth/authenticated_user.hh"
 
-#include <iostream>
-
 namespace auth {
 
 authenticated_user::authenticated_user(std::string_view name)

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -12,7 +12,6 @@
 
 #include <string_view>
 #include <functional>
-#include <iosfwd>
 #include <optional>
 
 #include <seastar/core/sstring.hh>


### PR DESCRIPTION
in 5a9b4c02e3a33dd0fdc1d6ab5fe7033510c591a6, the iostream based formatter was dropped, there is no need to include `<iostream>` or `<iosfwd>` in these source files anymore.