### PR TITLE
test: s/os.P_NOWAIT/os.WNOHANG/

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -352,7 +352,7 @@ def wait_for_services(pid, checkers):
         # to first get rid of the zombie (if it exists) with waitpid, and
         # then check if the process still exists, with kill.
         try:
-            os.waitpid(pid, os.P_NOWAIT)
+            os.waitpid(pid, os.WNOHANG)
             os.kill(pid, 0)
         except (ProcessLookupError, ChildProcessError):
             # Scylla is dead, we cannot recover
@@ -370,7 +370,7 @@ def wait_for_services(pid, checkers):
         print(f'Boot failed after {duration}.')
         # Run the checkers again, not catching NotYetUp, to show exception
         # traces of which of the checks failed and how.
-        os.waitpid(pid, os.P_NOWAIT)
+        os.waitpid(pid, os.WNOHANG)
         os.kill(pid, 0)
         for checker in checkers:
             checker()


### PR DESCRIPTION
`os.P_NOWAIT` is supposed to be used in spawn calls, while `os.WNOHANG` is used in the options parameter passed to wait calls. fortunately, `P_NOWAIT` is defined as "1" in CPython, and `os.WNOHANG` is defined as "1" in linux kernel. that's why the existing implementation works.

but we should not rely on this coincidence. so, in this change, `os.P_NOWAIT` is replaced with `os.WNOHANG` for correctness and for better readability.