### PR TITLE
s3/test: collect log on exit

### DIFF
--- a/test/object_store/run
+++ b/test/object_store/run
@@ -4,8 +4,10 @@ import sys
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 import run
 
+import atexit
 import os
 import requests
+import shutil
 import time
 import cassandra.cluster
 
@@ -27,8 +29,16 @@ def get_tempdir(pid):
     global test_tempdir
     return test_tempdir
 
+def teardown(pid):
+    print('Kill scylla')
+    sys.stdout.flush()
+    log = run.abort_run_with_dir(pid, test_tempdir)
+    shutil.copyfileobj(log, sys.stdout.buffer)
+
 print(f'Start scylla (dir={test_tempdir}')
 pid = run.run_with_generated_dir(cmd, get_tempdir)
+atexit.register(lambda: teardown(pid))
+
 ip = run.pid_to_ip(pid)
 run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 s3_server_address = os.environ['S3_SERVER_ADDRESS_FOR_TEST']
@@ -84,8 +94,5 @@ for row in res:
     success = False
 
 cluster.shutdown()
-
-print('Kill scylla')
-run.abort_run_with_dir(pid, test_tempdir)
 
 exit(0 if success else 1)


### PR DESCRIPTION
the temporary directory holding the log file collecting the scylla subprocess's output is specified by the test itself, and it is `test_tempdir`. but unfortunately, cql-pytest/run.py is not aware of this. so `cleanup_all()` is not able to print out the logging messages at exit. as, please note, cql-pytest/run.py always collect "log" file under the directory created using `pid_to_dir()` where pid is the spawned subprocesses. but `object_store/run` uses the main process's pid for its reusable tempdir.

so, with this change, we also register a cleanup func to printout the logging message when the test exits.