### PR TITLE
build: cmake: remove failure_detector.cc

### DIFF
--- a/gms/CMakeLists.txt
+++ b/gms/CMakeLists.txt
@@ -3,8 +3,8 @@ target_sources(gms
   PRIVATE
     application_state.cc
     endpoint_state.cc
-    failure_detector.cc
     feature_service.cc
+    generation-number.cc
     gossip_digest_ack2.cc
     gossip_digest_ack.cc
     gossip_digest_syn.cc


### PR DESCRIPTION
this changes updates the CMake building system with the changes introduced by 3f1ac846d85fd1df12f0e631e11d504cc29e0a7a