### PR TITLE
s3/client: Zeroify stat by default

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -444,7 +444,7 @@ public:
 
     virtual future<struct stat> stat(void) override {
         auto size = co_await _client->get_object_size(_object_name);
-        struct stat ret;
+        struct stat ret {};
         ret.st_nlink = 1;
         ret.st_mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
         ret.st_size = size;


### PR DESCRIPTION
The s3::readable_file::stat() call returns a hand-crafted stat structure with some fields set to some sane values, most are constants. However, other fields remain not initialized which leads to troubles sometimes. Better to fill the stat with zeroes and later revisit it for more sane values.

fixes: #13645
refs: #13649
Using designated initializers is not an option here, see PR #13499