### PR TITLE
db, sstable: use generation_type instead of its value when appropriate

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1075,7 +1075,7 @@ schema_ptr system_keyspace::sstables_registry() {
         auto id = generate_legacy_id(NAME, SSTABLES_REGISTRY);
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
             .with_column("location", utf8_type, column_kind::partition_key)
-            .with_column("generation", long_type, column_kind::clustering_key)
+            .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("uuid", uuid_type)
             .with_column("status", utf8_type)
             .with_column("version", utf8_type)
@@ -3773,7 +3773,7 @@ future<> system_keyspace::sstables_registry_list(sstring location, sstable_regis
     co_await _qp.local().query_internal(req, db::consistency_level::ONE, { location }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto uuid = row.get_as<utils::UUID>("uuid");
         auto status = row.get_as<sstring>("status");
-        auto gen = sstables::generation_from_value(row.get_as<int64_t>("generation"));
+        auto gen = sstables::generation_type::from_uuid(row.get_as<utils::UUID>("generation"));
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
         sstables::entry_descriptor desc("", "", "", gen, ver, fmt, sstables::component_type::TOC);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3736,33 +3736,33 @@ system_keyspace::read_cdc_generation(utils::UUID id) {
 
 future<> system_keyspace::sstables_registry_create_entry(sstring location, utils::UUID uuid, sstring status, sstables::entry_descriptor desc) {
     static const auto req = format("INSERT INTO system.{} (location, generation, uuid, status, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
-    slogger.trace("Inserting {}.{}:{} into {}", location, desc.generation.value(), uuid, SSTABLES_REGISTRY);
+    slogger.trace("Inserting {}.{}:{} into {}", location, desc.generation, uuid, SSTABLES_REGISTRY);
     co_await execute_cql(req, location, desc.generation.value(), uuid, status, fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
 future<utils::UUID> system_keyspace::sstables_registry_lookup_entry(sstring location, sstables::generation_type gen) {
     static const auto req = format("SELECT uuid FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Looking up {}.{} in {}", location, gen.value(), SSTABLES_REGISTRY);
+    slogger.trace("Looking up {}.{} in {}", location, gen, SSTABLES_REGISTRY);
     auto msg = co_await execute_cql(req, location, gen.value());
     if (msg->empty() || !msg->one().has("uuid")) {
-        slogger.trace("ERROR: Cannot find {}.{} in {}", location, gen.value(), SSTABLES_REGISTRY);
+        slogger.trace("ERROR: Cannot find {}.{} in {}", location, gen, SSTABLES_REGISTRY);
         co_await coroutine::return_exception(std::runtime_error("No entry in sstables registry"));
     }
 
     auto uuid = msg->one().get_as<utils::UUID>("uuid");
-    slogger.trace("Found {}.{}:{} in {}", location, gen.value(), uuid, SSTABLES_REGISTRY);
+    slogger.trace("Found {}.{}:{} in {}", location, gen, uuid, SSTABLES_REGISTRY);
     co_return uuid;
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status) {
     static const auto req = format("UPDATE system.{} SET status = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Updating {}.{} -> {} in {}", location, gen.value(), status, SSTABLES_REGISTRY);
+    slogger.trace("Updating {}.{} -> {} in {}", location, gen, status, SSTABLES_REGISTRY);
     co_await execute_cql(req, status, location, gen.value()).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_delete_entry(sstring location, sstables::generation_type gen) {
     static const auto req = format("DELETE FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Removing {}.{} from {}", location, gen.value(), SSTABLES_REGISTRY);
+    slogger.trace("Removing {}.{} from {}", location, gen, SSTABLES_REGISTRY);
     co_await execute_cql(req, location, gen.value()).discard_result();
 }
 

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -17,6 +17,7 @@
 #include <boost/range/adaptors.hpp>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
+#include "types/types.hh"
 
 namespace sstables {
 
@@ -32,6 +33,10 @@ public:
 
     explicit constexpr generation_type(int_t value) noexcept: _value(value) {}
     constexpr int_t value() const noexcept { return _value; }
+
+    explicit operator data_value() const noexcept {
+        return data_value(_value);
+    }
 
     constexpr bool operator==(const generation_type& other) const noexcept { return _value == other._value; }
     constexpr std::strong_ordering operator<=>(const generation_type& other) const noexcept { return _value <=> other._value; }

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <fmt/core.h>
 #include <cstdint>
 #include <compare>
@@ -18,6 +19,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include "types/types.hh"
+#include "utils/UUID_gen.hh"
 
 namespace sstables {
 
@@ -34,8 +36,32 @@ public:
     explicit constexpr generation_type(int_t value) noexcept: _value(value) {}
     constexpr int_t value() const noexcept { return _value; }
 
+    // convert to data_value
+    //
+    // this function is used when performing queries to SSTABLES_REGISTRY in
+    // the "system_keyspace", since its "generation" column cannot be a variant
+    // of bigint and timeuuid, we need to use a single value to represent these
+    // two types, and single value should allow us to tell the type of the
+    // original value of generation identifier, so we can convert the value back
+    // to the generation when necessary without losing its type information.
+    // since the timeuuid always encodes the timestamp in its MSB, and the timestamp
+    // should always be greater than zero, we use this fact to tell a regular
+    // timeuuid from a timeuuid converted from a bigint -- we just use zero
+    // for its timestamp of the latter.
     explicit operator data_value() const noexcept {
-        return data_value(_value);
+        // use zero as the timestamp to differentiate from the regular timeuuid,
+        // and use the least_sig_bits to encode the value of generation identifier.
+        return data_value(
+            utils::UUID(
+                utils::UUID_gen::create_time(std::chrono::milliseconds::zero()),
+                _value));
+    }
+    static generation_type from_uuid(utils::UUID value) {
+        // if the value of generation_type should be an int64_t, its timestamp
+        // must be zero, and the least significant bits is used to encode the
+        // value of the int64_t.
+        assert(value.timestamp() == 0);
+        return generation_type(value.get_least_significant_bits());
     }
 
     constexpr bool operator==(const generation_type& other) const noexcept { return _value == other._value; }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1038,7 +1038,7 @@ void sstable::filesystem_storage::open(sstable& sst, const io_priority_class& pc
         // the generation of a sstable that exists.
         w.close();
         remove_file(file_path).get();
-        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {:d} of {}.{}", sst._generation.value(), sst._schema->ks_name(), sst._schema->cf_name()));
+        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {:d} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
     }
 
     sst.write_toc(std::move(w));


### PR DESCRIPTION
in this series, we try to use `generation_type` as a proxy to hide the consumers from its underlying type. this paves the road to the UUID based generation identifier. as by then, we cannot assume the type of the `value()` without asking `generation_type` first. better off leaving all the formatting and conversions to the `generation_type`. also, this series changes the "generation" column of sstable registry table to "uuid", and convert the value of it to the original generation_type when necessary, this paves the road to a world with UUID based generation id.