### PR TITLE
cql3: fix a few misformatted printouts of column names in error messages

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -79,7 +79,7 @@ static
 void
 usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver) {
     if (!receiver.type->is_user_type()) {
-        throw exceptions::invalid_request_exception(format("Invalid user type literal for {} of type {}", receiver.name, receiver.type->as_cql3_type()));
+        throw exceptions::invalid_request_exception(format("Invalid user type literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
 
     auto ut = static_pointer_cast<const user_type_impl>(receiver.type);
@@ -91,7 +91,7 @@ usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_
         const expression& value = u.elements.at(field);
         auto&& field_spec = usertype_field_spec_of(receiver, i);
         if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, *field_spec))) {
-            throw exceptions::invalid_request_exception(format("Invalid user type literal for {}: field {} is not of type {}", receiver.name, field, field_spec->type->as_cql3_type()));
+            throw exceptions::invalid_request_exception(format("Invalid user type literal for {}: field {} is not of type {}", *receiver.name, field, field_spec->type->as_cql3_type()));
         }
     }
 }
@@ -314,7 +314,7 @@ set_validate_assignable_to(const collection_constructor& c, data_dictionary::dat
             return;
         }
 
-        throw exceptions::invalid_request_exception(format("Invalid set literal for {} of type {}", receiver.name, receiver.type->as_cql3_type()));
+        throw exceptions::invalid_request_exception(format("Invalid set literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
 
     auto&& value_spec = set_value_spec_of(receiver);
@@ -502,18 +502,18 @@ void
 tuple_constructor_validate_assignable_to(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver) {
     auto tt = dynamic_pointer_cast<const tuple_type_impl>(receiver.type->underlying_type());
     if (!tt) {
-        throw exceptions::invalid_request_exception(format("Invalid tuple type literal for {} of type {}", receiver.name, receiver.type->as_cql3_type()));
+        throw exceptions::invalid_request_exception(format("Invalid tuple type literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
     for (size_t i = 0; i < tc.elements.size(); ++i) {
         if (i >= tt->size()) {
             throw exceptions::invalid_request_exception(format("Invalid tuple literal for {}: too many elements. Type {} expects {:d} but got {:d}",
-                                                            receiver.name, tt->as_cql3_type(), tt->size(), tc.elements.size()));
+                                                            *receiver.name, tt->as_cql3_type(), tt->size(), tc.elements.size()));
         }
 
         auto&& value = tc.elements[i];
         auto&& spec = component_spec_of(receiver, i);
         if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, *spec))) {
-            throw exceptions::invalid_request_exception(format("Invalid tuple literal for {}: component {:d} is not of type {}", receiver.name, i, spec->type->as_cql3_type()));
+            throw exceptions::invalid_request_exception(format("Invalid tuple literal for {}: component {:d} is not of type {}", *receiver.name, i, spec->type->as_cql3_type()));
         }
     }
 }

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -32,9 +32,9 @@ operation::set_element::prepare(data_dictionary::database db, const sstring& key
     using exceptions::invalid_request_exception;
     auto rtype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!rtype) {
-        throw invalid_request_exception(format("Invalid operation ({}) for non collection column {}", to_string(receiver), receiver.name()));
+        throw invalid_request_exception(format("Invalid operation ({}) for non collection column {}", to_string(receiver), receiver.name_as_text()));
     } else if (!rtype->is_multi_cell()) {
-        throw invalid_request_exception(format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name()));
+        throw invalid_request_exception(format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name_as_text()));
     }
 
     if (rtype->get_kind() == abstract_type::kind::list) {
@@ -47,7 +47,7 @@ operation::set_element::prepare(data_dictionary::database db, const sstring& key
             return make_shared<lists::setter_by_index>(receiver, std::move(idx), std::move(lval));
         }
     } else if (rtype->get_kind() == abstract_type::kind::set) {
-        throw invalid_request_exception(format("Invalid operation ({}) for set column {}", to_string(receiver), receiver.name()));
+        throw invalid_request_exception(format("Invalid operation ({}) for set column {}", to_string(receiver), receiver.name_as_text()));
     } else if (rtype->get_kind() == abstract_type::kind::map) {
         auto key = prepare_expression(_selector, db, keyspace, nullptr, maps::key_spec_of(*receiver.column_specification));
         auto mval = prepare_expression(_value, db, keyspace, nullptr, maps::value_spec_of(*receiver.column_specification));
@@ -136,11 +136,11 @@ operation::addition::prepare(data_dictionary::database db, const sstring& keyspa
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
         if (!receiver.is_counter()) {
-            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name()));
+            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
         }
         return make_shared<constants::adder>(receiver, std::move(v));
     } else if (!ctype->is_multi_cell()) {
-        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name()));
+        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name_as_text()));
     }
 
     if (ctype->get_kind() == abstract_type::kind::list) {
@@ -169,14 +169,14 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
         if (!receiver.is_counter()) {
-            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name()));
+            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
         }
         auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
         return make_shared<constants::subtracter>(receiver, std::move(v));
     }
     if (!ctype->is_multi_cell()) {
         throw exceptions::invalid_request_exception(
-                format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name()));
+                format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name_as_text()));
     }
 
     if (ctype->get_kind() == abstract_type::kind::list) {
@@ -211,9 +211,9 @@ operation::prepend::prepare(data_dictionary::database db, const sstring& keyspac
     auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
 
     if (!dynamic_cast<const list_type_impl*>(receiver.type.get())) {
-        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non list column {}", to_string(receiver), receiver.name()));
+        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non list column {}", to_string(receiver), receiver.name_as_text()));
     } else if (!receiver.type->is_multi_cell()) {
-        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen list column {}", to_string(receiver), receiver.name()));
+        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen list column {}", to_string(receiver), receiver.name_as_text()));
     }
 
     return make_shared<lists::prepender>(receiver, std::move(v));
@@ -343,9 +343,9 @@ operation::element_deletion::affected_column() const {
 shared_ptr<operation>
 operation::element_deletion::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     if (!receiver.type->is_collection()) {
-        throw exceptions::invalid_request_exception(format("Invalid deletion operation for non collection column {}", receiver.name()));
+        throw exceptions::invalid_request_exception(format("Invalid deletion operation for non collection column {}", receiver.name_as_text()));
     } else if (!receiver.type->is_multi_cell()) {
-        throw exceptions::invalid_request_exception(format("Invalid deletion operation for frozen collection column {}", receiver.name()));
+        throw exceptions::invalid_request_exception(format("Invalid deletion operation for frozen collection column {}", receiver.name_as_text()));
     }
     auto ctype = static_pointer_cast<const collection_type_impl>(receiver.type);
     if (ctype->get_kind() == abstract_type::kind::list) {

--- a/test/cql/lwt_test.result
+++ b/test/cql/lwt_test.result
@@ -968,7 +968,7 @@ Error from server: code=2200 [Invalid query] message="Missing mandatory PRIMARY 
 |   1 |   1 | ['d']     | [1, 2]     |
 +-----+-----+-----------+------------+
 > update lwt set flistint = flistint + [3] where a = 1 and b = 1 if exists;
-Error from server: code=2200 [Invalid query] message="Invalid operation (flistint = flistint + [3]) for frozen collection column 666c697374696e74"
+Error from server: code=2200 [Invalid query] message="Invalid operation (flistint = flistint + [3]) for frozen collection column flistint"
 > select * from lwt allow filtering;
 +-----+-----+-----------+------------+
 |   a |   b | smapint   | flistint   |
@@ -1866,7 +1866,7 @@ Error from server: code=2200 [Invalid query] message="null is not supported insi
 > update lwt set s = {false} where a = 1 if s = 1;
 Error from server: code=2200 [Invalid query] message="Invalid INTEGER constant (1) for "s" of type set<boolean>"
 > update lwt set s = {true} + s where a = 1 if s = {false};
-Error from server: code=2200 [Invalid query] message="Invalid operation (s = {true} + s) for non list column 73"
+Error from server: code=2200 [Invalid query] message="Invalid operation (s = {true} + s) for non list column s"
 > -- sets
 > -- null value == empty set
 > update lwt set s = {} where a = 1 if s = {};
@@ -1902,7 +1902,7 @@ Error from server: code=2200 [Invalid query] message="null is not supported insi
 > update lwt set s = {false} where a = 1 if s = 1;
 Error from server: code=2200 [Invalid query] message="Invalid INTEGER constant (1) for "s" of type set<boolean>"
 > update lwt set s = {true} + s where a = 1 if s = {false};
-Error from server: code=2200 [Invalid query] message="Invalid operation (s = {true} + s) for non list column 73"
+Error from server: code=2200 [Invalid query] message="Invalid operation (s = {true} + s) for non list column s"
 > drop table lwt;
 OK
 > --
@@ -1937,9 +1937,9 @@ OK
 | False       | [False] |
 +-------------+---------+
 > update lwt set b[true] = false where a = 1 if b[true] != true;
-Error from server: code=2200 [Invalid query] message="Invalid operation (b[true] = false) for frozen collection column 62"
+Error from server: code=2200 [Invalid query] message="Invalid operation (b[true] = false) for frozen collection column b"
 > update lwt set b = b + {false:true} where a = 1 if b[true] = true;
-Error from server: code=2200 [Invalid query] message="Invalid operation (b = b + {false:true}) for frozen collection column 62"
+Error from server: code=2200 [Invalid query] message="Invalid operation (b = b + {false:true}) for frozen collection column b"
 > select b from lwt where a = 1;
 +---------+
 | b       |
@@ -2089,7 +2089,7 @@ Error from server: code=2200 [Invalid query] message="Invalid FLOAT constant (-1
 | True        | [False] |
 +-------------+---------+
 > update lwt set c = [true] + c where a = 1 if c = [false];
-Error from server: code=2200 [Invalid query] message="Invalid operation (c = [true] + c) for frozen list column 63"
+Error from server: code=2200 [Invalid query] message="Invalid operation (c = [true] + c) for frozen list column c"
 > update lwt set c = [true,true,true,false,false,false] where a = 1 if exists;
 +-------------+-----+------+--------+------+
 | [applied]   |   a | b    | c      | s    |
@@ -2141,7 +2141,7 @@ Error from server: code=2200 [Invalid query] message="null is not supported insi
 > update lwt set s = {true, false} where a = 1 if s{true} = false;
 <Error from server: code=2000 [Syntax error in CQL query] message="line 1:49 no viable alternative at input '{'">
 > update lwt set s = s + {true} where a = 1 if s = {true, false};
-Error from server: code=2200 [Invalid query] message="Invalid operation (s = s + {true}) for frozen collection column 73"
+Error from server: code=2200 [Invalid query] message="Invalid operation (s = s + {true}) for frozen collection column s"
 > update lwt set s = {true, true} where a = 1 if exists;
 +-------------+-----+------+------+-----+
 | [applied]   |   a | b    | c    | s   |


### PR DESCRIPTION
Fix a few cases where instead of printing column names in error messages, we printed weird stuff like ASCII codes or the address of the name.

Fixes #13657