### PR TITLE
replica: table: Allow a SSTable to be owned by multiple compaction groups

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -541,8 +541,8 @@ private:
     compaction_group& compaction_group_for_token(dht::token token) const noexcept;
     // Select a compaction group from a given key.
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const noexcept;
-    // Select a compaction group from a given sstable based on its token range.
-    compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const noexcept;
+    // Select compaction group(s) from a given sstable based on its token range.
+    auto compaction_groups_for_sstable(const sstables::shared_sstable& sst) const noexcept;
     // Returns a list of all compaction groups.
     const std::vector<std::unique_ptr<compaction_group>>& compaction_groups() const noexcept;
     // Safely iterate through compaction groups, while performing async operations on them.


### PR DESCRIPTION
A SSTable being shared by multiple groups / tablets was not yet supported.

Determining the owner groups of a SSTable is only a matter of finding groups that overlap with its token range.