### PR TITLE
cql3: drop unused function

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -731,22 +731,6 @@ bool query_processor::has_more_results(::shared_ptr<cql3::internal_query_state> 
 
 future<> query_processor::for_each_cql_result(
         ::shared_ptr<cql3::internal_query_state> state,
-        std::function<stop_iteration(const cql3::untyped_result_set::row&)>&& f) {
-    do {
-        auto msg = co_await execute_paged_internal(state);
-        if (msg->empty()) {
-            co_return;
-        }
-        for (auto& row : *msg) {
-            if (f(row) == stop_iteration::yes) {
-                co_return;
-            }
-        }
-    } while (has_more_results(state));
-}
-
-future<> query_processor::for_each_cql_result(
-        ::shared_ptr<cql3::internal_query_state> state,
          noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set::row&)>&& f) {
     do {
         auto msg = co_await execute_paged_internal(state);

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -433,13 +433,6 @@ private:
     future<::shared_ptr<untyped_result_set>> execute_paged_internal(::shared_ptr<internal_query_state> state);
 
     /*!
-     * \brief iterate over all results using paging
-     */
-    future<> for_each_cql_result(
-            ::shared_ptr<cql3::internal_query_state> state,
-            std::function<stop_iteration(const cql3::untyped_result_set_row&)>&& f);
-
-    /*!
      * \brief iterate over all results using paging, accept a function that returns a future
      */
     future<> for_each_cql_result(


### PR DESCRIPTION
there are two variants of `query_processor::for_each_cql_result()`, both of them perform the pagination of results returned by a CQL statement. the one which accepts a function returning an instant value is not used now. so let's drop it.