### PR TITLE
treewide:  stop using std::rel_ops

### DIFF
--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -296,8 +296,6 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
                 auto clock = value_cast<int64_t>(tuple[2]);
                 auto value = value_cast<int64_t>(tuple[3]);
 
-                using namespace std::rel_ops;
-
                 if (id <= last) {
                     throw marshal_exception(
                                     format("invalid counter id order, {} <= {}",

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -95,7 +95,7 @@ decorated_key::equal(const schema& s, const decorated_key& other) const {
 
 std::strong_ordering
 decorated_key::tri_compare(const schema& s, const decorated_key& other) const {
-    auto r = dht::tri_compare(_token, other._token);
+    auto r = _token <=> other._token;
     if (r != 0) {
         return r;
     } else {
@@ -105,7 +105,7 @@ decorated_key::tri_compare(const schema& s, const decorated_key& other) const {
 
 std::strong_ordering
 decorated_key::tri_compare(const schema& s, const ring_position& other) const {
-    auto r = dht::tri_compare(_token, other.token());
+    auto r = _token <=> other.token();
     if (r != 0) {
         return r;
     } else if (other.has_key()) {
@@ -279,7 +279,7 @@ std::strong_ordering ring_position::tri_compare(const schema& s, const ring_posi
 }
 
 std::strong_ordering token_comparator::operator()(const token& t1, const token& t2) const {
-    return tri_compare(t1, t2);
+    return t1 <=> t2;
 }
 
 bool ring_position::equal(const schema& s, const ring_position& other) const {
@@ -291,7 +291,7 @@ bool ring_position::less_compare(const schema& s, const ring_position& other) co
 }
 
 std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_view lh, ring_position_view rh) {
-    auto token_cmp = tri_compare(*lh._token, *rh._token);
+    auto token_cmp = *lh._token <=> *rh._token;
     if (token_cmp != 0) {
         return token_cmp;
     }
@@ -312,7 +312,7 @@ std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_vi
 }
 
 std::strong_ordering ring_position_comparator_for_sstables::operator()(ring_position_view lh, sstables::decorated_key_view rh) const {
-    auto token_cmp = tri_compare(*lh._token, rh.token());
+    auto token_cmp = *lh._token <=> rh.token();
     if (token_cmp != 0) {
         return token_cmp;
     }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -95,7 +95,7 @@ range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, lo
                 seastar::thread::yield();
             }
             const range<token>& src_range = x.first;
-            if (src_range.contains(desired_range, dht::tri_compare)) {
+            if (src_range.contains(desired_range, dht::operator<=>)) {
                 inet_address_vector_replica_set preferred(x.second.begin(), x.second.end());
                 get_token_metadata().get_topology().sort_by_proximity(_address, preferred);
                 for (inet_address& p : preferred) {
@@ -142,7 +142,7 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
             if (need_preempt()) {
                 seastar::thread::yield();
             }
-            if (src_range.contains(desired_range, dht::tri_compare)) {
+            if (src_range.contains(desired_range, dht::operator<=>)) {
                 std::vector<inet_address> old_endpoints(x.second.begin(), x.second.end());
                 auto it = pending_range_addresses.find(desired_range);
                 if (it == pending_range_addresses.end()) {

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -40,7 +40,7 @@ maximum_token() noexcept {
     return max_token;
 }
 
-std::strong_ordering tri_compare(const token& t1, const token& t2) {
+std::strong_ordering operator<=>(const token& t1, const token& t2) {
     if (t1._kind < t2._kind) {
             return std::strong_ordering::less;
     } else if (t1._kind > t2._kind) {

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -208,14 +208,8 @@ struct raw_token_less_comparator {
 
 const token& minimum_token() noexcept;
 const token& maximum_token() noexcept;
-std::strong_ordering tri_compare(const token& t1, const token& t2);
-inline bool operator==(const token& t1, const token& t2) { return tri_compare(t1, t2) == 0; }
-inline bool operator<(const token& t1, const token& t2) { return tri_compare(t1, t2) < 0; }
-
-inline bool operator!=(const token& t1, const token& t2) { return std::rel_ops::operator!=(t1, t2); }
-inline bool operator>(const token& t1, const token& t2) { return std::rel_ops::operator>(t1, t2); }
-inline bool operator<=(const token& t1, const token& t2) { return std::rel_ops::operator<=(t1, t2); }
-inline bool operator>=(const token& t1, const token& t2) { return std::rel_ops::operator>=(t1, t2); }
+std::strong_ordering operator<=>(const token& t1, const token& t2);
+inline bool operator==(const token& t1, const token& t2) { return t1 <=> t2 == 0; }
 std::ostream& operator<<(std::ostream& out, const token& t);
 
 uint64_t unbias(const token& t);

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -65,10 +65,6 @@ public:
     friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept {
         return x._addr == y._addr;
     }
-    friend inline bool operator!=(const inet_address& x, const inet_address& y) noexcept {
-        using namespace std::rel_ops;
-        return x._addr != y._addr;
-    }
     friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
         return x.bytes() < y.bytes();
     }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1414,7 +1414,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
                 for (auto& x : range_addresses) {
                     const range<dht::token>& src_range = x.first;
                     seastar::thread::maybe_yield();
-                    if (src_range.contains(desired_range, dht::tri_compare)) {
+                    if (src_range.contains(desired_range, dht::operator<=>)) {
                         std::vector<inet_address> old_endpoints(x.second.begin(), x.second.end());
                         auto it = pending_range_addresses.find(desired_range);
                         if (it == pending_range_addresses.end()) {

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(test_generation_of_name_based_UUID) {
 }
 
 using utils::UUID;
-using namespace std::rel_ops;
 
 BOOST_AUTO_TEST_CASE(test_UUID_comparison) {
     static const std::initializer_list<std::pair<UUID, UUID>> uuid_pairs = {

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -97,7 +97,7 @@ tombstone_gc_state::get_gc_before_for_range_result tombstone_gc_state::get_gc_be
                 auto r = locator::token_metadata::interval_to_range(x.first);
                 min = std::min(x.second, min);
                 max = std::max(x.second, max);
-                if (++hits == 1 && r.contains(range, dht::tri_compare)) {
+                if (++hits == 1 && r.contains(range, dht::operator<=>)) {
                     contains_all = true;
                 }
             }


### PR DESCRIPTION
std::rel_ops was deprecated in C++20, as C++20 provides a better solution for defining comparison operators. and all the use cases previously to be addressed by `using namespace std::rel_ops` have been addressed either by `operator<=>` or the default-generated `operator!=`.
    
so, in this series, to avoid using deprecated facilities, let's drop all these `using namespace std::rel_ops`. there are many more cases where we could either use `operator<=>` or the default-generated `operator!=` to simplify the implementation. but here, we care more about `std::rel_ops`, we will drop the most (if not all of them) of the explicitly defined `operator!=`  and other comparison operators later.
