### PR TITLE
storage_service: Fix removing replace node as pending

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1928,6 +1928,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
         } else if (existing && *existing == endpoint) {
             tmptr->del_replacing_endpoint(endpoint);
         } else {
+            tmptr->del_replacing_endpoint(endpoint);
             auto nodes = _gossiper.get_nodes_with_host_id(host_id);
             bool left = std::any_of(nodes.begin(), nodes.end(), [this] (const gms::inet_address& node) { return _gossiper.is_left(node); });
             if (left) {


### PR DESCRIPTION
Consider

- n1, n2, n3
- n3 is down
- n4 replaces n3 with the same ip address 127.0.0.3
- Inside the storage_service::handle_state_normal callback for 127.0.0.3 on n1/n2

  ``` auto host_id = _gossiper.get_host_id(endpoint); auto existing = tmptr->get_endpoint_for_host_id(host_id); ```

  host_id = new host id existing = empty

  As a result, del_replacing_endpoint() will not be called.

This means 127.0.0.3 will not be removed as a pending node on n1 and n2 when replacing is done. This is wrong.

This is a regression since commit 9942c60d930d2bd3e4b29bb843b27c0361f9a4bb (storage_service: do not inherit the host_id of a replaced a node), where replacing node uses a new host id than the node to be replaced.

To fix, call del_replacing_endpoint() when a node becomes NORMAL and existing is empty.

Before:
n1:
storage_service - replace[cd1f187a-0eee-4b04-91a9-905ecc499cfc]: Added replacing_node=127.0.0.3 to replace existing_node=127.0.0.3, coordinator=127.0.0.3 token_metadata - Added node 127.0.0.3 as pending replacing endpoint which replaces existing node 127.0.0.3 storage_service - replace[cd1f187a-0eee-4b04-91a9-905ecc499cfc]: Marked ops done from coordinator=127.0.0.3 storage_service - Node 127.0.0.3 state jump to normal storage_service - Set host_id=6f9ba4e8-9457-4c76-8e2a-e2be257fe123 to be owned by node=127.0.0.3

After:
n1:
storage_service - replace[28191ea6-d43b-3168-ab01-c7e7736021aa]: Added replacing_node=127.0.0.3 to replace existing_node=127.0.0.3, coordinator=127.0.0.3 token_metadata - Added node 127.0.0.3 as pending replacing endpoint which replaces existing node 127.0.0.3 storage_service - replace[28191ea6-d43b-3168-ab01-c7e7736021aa]: Marked ops done from coordinator=127.0.0.3 storage_service - Node 127.0.0.3 state jump to normal token_metadata - Removed node 127.0.0.3 as pending replacing endpoint which replaces existing node 127.0.0.3 storage_service - Set host_id=72219180-e3d1-4752-b644-5c896e4c2fed to be owned by node=127.0.0.3

Tests: https://github.com/scylladb/scylla-dtest/pull/3126