### PR TITLE
reader_concurrency_semaphore: reader_permit: clean-up after failed memory requests

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -186,6 +186,11 @@ private:
     }
 
     void on_permit_inactive(reader_permit::state st) {
+        // If the permit is registered as inactive, while waiting for memory,
+        // clear the memory amount, the requests are failed anyway.
+        if (_state == reader_permit::state::waiting_for_memory) {
+            _requested_memory = {};
+        }
         _state = st;
         if (_marked_as_blocked) {
             on_permit_unblocked();

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1645,6 +1645,14 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_permit_waiting_for_me
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, 1);
     BOOST_REQUIRE_EQUAL(permit2.get_state(), reader_permit::state::evicted);
     BOOST_REQUIRE_THROW(res_fut.get(), std::bad_alloc);
+
+    res.clear();
+
+    // Reproduce #13539: successful request for memory, should not include
+    // amounts of failed request in the past
+    BOOST_REQUIRE(permit2.needs_readmission());
+    permit2.wait_readmission().get();
+    permit2.request_memory(1024).get();
 }
 
 // Check that inactive reads are not needlessly evicted when admission is not


### PR DESCRIPTION
When requesting memory via `reader_permit::request_memory()`, the requested amount is added to `_requested_memory` member of the permit impl. This is because multiple concurrent requests may be blocked and waiting at the same time. When the requests are fulfilled, the entire amount is consumed and individual requests track their requested amount with `resource_units` to release later.
There is a corner-case related to this: if a reader permit is registered as inactive while it is waiting for memory, its active requests are killed with `std::bad_alloc`, but the `_requested_memory` fields is not cleared. If the read survives because the killed requests were part of a non-vital background read-ahead, a later memory request will also include amount from the failed requests. This extra amount wil not be released and hence will cause a resource leak when the permit is destroyed.
Fix by detecting this corner case and clearing the `_requested_memory` field. Modify the existing unit test for the scenario of a permit waiting on memory being registered as inactive, to also cover this corner case, reproducing the bug.

Fixes: #13539