### PR TITLE
doc: remove redundant information about versions

### DIFF
--- a/docs/architecture/sstable/sstable3/sstables-3-data-file-format.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-data-file-format.rst
@@ -1,8 +1,6 @@
 SSTables 3.0 Data File Format
 =============================
 
-.. versionadded:: 3.0
-
 This article aims at describing the format of data files introduced in Cassandra 3.0. The data file is the file that actually stores the data managed by the database. As important as it is, this file does not come alone. There are other files that altogether constitute a set of components sufficient for manipulating the stored data.
 The following table outlines the types of files used by Cassandra SSTables 3.0:
 

--- a/docs/architecture/sstable/sstable3/sstables-3-index.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-index.rst
@@ -1,8 +1,6 @@
 SSTables 3.0 Index File Format
 ==============================
 
-.. versionadded:: 3.0
-
 The SSTables index file, together with the :doc:`SSTables summary file </architecture/sstable/sstable3/sstables-3-summary/>` , provides a way to efficiently locate a partition with a specific key or some position within a partition in the :doc:`SSTables data file</architecture/sstable/sstable3/sstables-3-data-file-format/>`.
 
 Broadly, the index file lists the keys in the data file in order, giving for each key its position in the data file. The summary file, which is held in memory, contains samples of these keys, pointing to their position in the index file. So to efficiently search for a specific key, we use the summary to find a (relatively short) range of positions in the index file which may hold this key, then read this range from the index file and look for the specific key. The details on how to further pinpoint specific columns inside very long partitions are explained below.

--- a/docs/architecture/sstable/sstable3/sstables-3-statistics.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-statistics.rst
@@ -1,8 +1,6 @@
 SSTables 3.0 Statistics File Format
 ===================================
 
-.. versionadded:: 3.0
-
 This file stores metadata for SSTable. There are 4 types of metadata:
 
 1. **Validation metadata** - used to validate SSTable correctness.

--- a/docs/architecture/sstable/sstable3/sstables-3-summary.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-summary.rst
@@ -1,8 +1,6 @@
 SSTables 3.0 Summary File Format
 ================================
 
-.. versionadded:: 3.0
-
 SSTables summary file contains samples of keys that are used for the first, coarse-grained, stage of search through the index. Every summary entry points to a sequence of index entries commonly referred to as an index page where the key looked for is located. So with the summary, it is possible to only read and search through a small part of the index.
 
 The summary file is meant to be read and stored entirely in memory, therefore it is aimed to be reasonably small. This incurs some trade-off between the size of the summary and the cardinality of an index page (number of index entries covered by it). The less the cardinality is, the better precision the initial lookup through summary gives, but this also tends to increase the size of the summary. The balance between the two is regulated by the sampling level which rules how many index entries should one summary entry cover.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -744,8 +744,6 @@ For example, to disable compression:
 CDC options
 ###########
 
-.. versionadded:: 3.2 Scylla Open Source
-
 The following options can be used with Change Data Capture.
 
 +---------------------------+-----------------+------------------------------------------------------------------------------------------------------------------------+

--- a/docs/cql/dml.rst
+++ b/docs/cql/dml.rst
@@ -220,8 +220,6 @@ map keys.
 Grouping results
 ~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2 Scylla Open Source
-
 The ``GROUP BY`` option lets you condense into a single row all selected rows that share the same values for a set of columns. 
 Using the ``GROUP BY`` option, it is only possible to group rows at the partition key level or at a clustering column level. 
 The ``GROUP BY`` arguments must form a prefix of the primary key. 
@@ -266,8 +264,6 @@ Currently, the possible orderings are limited by the :ref:`clustering order <clu
 
 Limiting results
 ~~~~~~~~~~~~~~~~
-
-.. versionchanged::  3.1 Scylla Open Source
 
 The ``LIMIT`` option to a ``SELECT`` statement limits the number of rows returned by a query, while the ``PER PARTITION
 LIMIT``  option (introduced in Scylla 3.1) limits the number of rows returned for a given **partition** by the query. Note that both types of limit can be
@@ -413,10 +409,6 @@ FILTERING`` and so the following query is valid::
 Bypass Cache
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: Scylla Enterprise 2019.1.1
-.. versionadded:: Scylla 3.1
-                  
-
 The ``BYPASS CACHE`` clause on SELECT statements informs the database that the data being read is unlikely to be read again in the near future, and also was unlikely to have been read in the near past; therefore, no attempt should be made to read it from the cache or to populate the cache with the data. This is mostly useful for range scans; these typically process large amounts of data with no temporal locality and do not benefit from the cache.
 The clause is placed immediately after the optional ALLOW FILTERING clause.
 
@@ -433,8 +425,6 @@ For example::
 Using Timeout
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: Scylla 4.4
-
 The ``USING TIMEOUT`` clause allows specifying a timeout for a specific request.
 
 For example::
@@ -448,8 +438,6 @@ For example::
 
 LIKE Operator
 ~~~~~~~~~~~~~
-
-.. versionadded:: 3.2 Scylla Open Source
 
 The ``LIKE`` operation on ``SELECT`` statements informs Scylla that you are looking for a pattern match. The expression ‘column LIKE pattern’ yields true only if the entire column value matches the pattern.   
  
@@ -660,7 +648,7 @@ Also note that ``INSERT`` does not support counters, while ``UPDATE`` does.
 .. note:: New in Scylla Open Source 3.2, you can use the ``IF NOT EXISTS`` condition with the ``INSERT`` statement. When this is used, the insert is only made if the row does not exist prior to the insertion. Each such ``INSERT`` gets a globally unique timestamp. Using ``IF NOT EXISTS`` incurs a non-negligible performance cost (internally, as Paxos will be used), so use ``IF NOT EXISTS`` wisely.
 
 
-Starting with Scylla Open Source 3.2, if :ref:`enabled <cdc-options>` on a table, you can use UPDATE, INSERT, and DELETE statements with Change Data Capture (CDC) tables. Note that this feature is :ref:`experimental <yaml_enabling_experimental_features>`  in version 3.2. 
+If :ref:`enabled <cdc-options>` on a table, you can use UPDATE, INSERT, and DELETE statements with Change Data Capture (CDC) tables.
 
 .. to-do - add link to cdc doc
 
@@ -737,8 +725,6 @@ Regarding the :token:`assignment`:
 
 IF condition
 ~~~~~~~~~~~~
-
-.. versionadded:: 3.2 Scylla Open Source
 
 It is, however, possible to use the conditions on some columns through ``IF``, in which case the row will not be updated
 unless the conditions are met. Each such ``UPDATE`` gets a globally unique timestamp.
@@ -830,8 +816,6 @@ Range deletions allow you to delete rows from a single partition, given that the
 
 Open range deletions
 ~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 3.2 Scylla Open Source 
 
 Open range deletions delete rows based on an open-ended request (>, <, >=, =<, etc.)
 

--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -172,8 +172,6 @@ The ``uuid`` function takes no parameters and generates a random type 4 uuid sui
 Datetime functions
 ``````````````````
 
-.. versionadded:: 2.3
-
 Retrieving the current date/time
 ################################
 

--- a/docs/cql/json.rst
+++ b/docs/cql/json.rst
@@ -23,8 +23,6 @@
 JSON Support
 ------------
 
-.. versionadded:: 2.3
-
 Scylla introduces JSON support to :ref:`SELECT <select-statement>` and :ref:`INSERT <insert-statement>`
 statements. This support does not fundamentally alter the CQL API (for example, the schema is still enforced). It simply
 provides a convenient way to work with JSON documents.

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -62,8 +62,6 @@ automatically at insertion time.
 Local Secondary Index
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: Scylla 3.1
-
 :doc:`Local Secondary Indexes </using-scylla/local-secondary-indexes>` is an enhancement of :doc:`Global Secondary Indexes </using-scylla/secondary-indexes>`, which allows Scylla to optimize the use case in which the partition key of the base table is also the partition key of the index. Local Secondary Index syntax is the same as above, with extra parentheses on the partition key.
 
 .. code-block::

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -445,8 +445,6 @@ Lastly, as for :ref:`maps <maps>`, TTLs, when used, only apply to the newly inse
 User-Defined Types
 ^^^^^^^^^^^^^^^^^^
 
-.. versionchanged:: 3.2 Scylla Open Source
-
 CQL support the definition of user-defined types (UDT for short). Such a type can be created, modified and removed using
 the :token:`create_type_statement`, :token:`alter_type_statement` and :token:`drop_type_statement` described below. But
 once created, a UDT is simply referred to by its name:
@@ -459,10 +457,6 @@ once created, a UDT is simply referred to by its name:
 
 Creating a UDT
 ~~~~~~~~~~~~~~
-
-.. versionchanged:: 3.2 Scylla Open Source
-
-.. note:: If you are using Scylla Open Source 3.1.x (and prior) or Scylla Enterprise (any version), UDTs must be **frozen** - meaning you cannot update individual components of the UDT value. The whole value must be overwritten. Starting with Scylla Open Source 3.2, UDTs that are not in a collection **can be non-frozen**. 
 
 Creating a new user-defined type is done using a ``CREATE TYPE`` statement defined by:
 

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -1,8 +1,6 @@
 Scylla SStable
 ==============
 
-.. versionadded:: 5.0
-
 Introduction
 -------------
 
@@ -610,8 +608,6 @@ This can be relaxed, for example, if you want to produce intentionally corrupt S
 
 script
 ^^^^^^
-
-.. versionadded:: 5.2
 
 Reads the SStable(s) and passes the resulting `fragment stream <scylla-sstable-sstable-content_>`_ to the script specified by `--script-file`.
 Currently, only scripts written in `Lua <http://www.lua.org/>`_ are supported.

--- a/docs/operating-scylla/admin-tools/scylla-types.rst
+++ b/docs/operating-scylla/admin-tools/scylla-types.rst
@@ -1,8 +1,6 @@
 Scylla Types
 ==============
 
-.. versionadded:: 5.0
-
 Introduction
 -------------
 This tool allows you to examine raw values obtained from SStables, logs, coredumps, etc., by performing operations on them,

--- a/docs/operating-scylla/nodetool-commands/disableautocompaction.rst
+++ b/docs/operating-scylla/nodetool-commands/disableautocompaction.rst
@@ -1,8 +1,6 @@
 Nodetool disableautocompaction
 ==============================
 
-.. versionadded:: 4.1 Scylla Open Source
-
 **disableautocompaction** disables automatic compaction for the given keyspace and table according to its compaction strategy.
 
 For example:

--- a/docs/operating-scylla/nodetool-commands/enbleautocompaction.rst
+++ b/docs/operating-scylla/nodetool-commands/enbleautocompaction.rst
@@ -1,8 +1,6 @@
 Nodetool enableautocompaction
 =============================
 
-.. versionadded:: 4.1 Scylla Open Source
-
 **enableautocompaction** enables automatic compaction for the given keyspace and table according to its compaction strategy.
 
 For example:

--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -25,8 +25,6 @@ For example:
 Load and Stream
 ---------------
 
-.. versionadded:: 4.6
-
 .. code::
 
    nodetool refresh <my_keyspace> <my_table> [--load-and-stream | -las]

--- a/docs/operating-scylla/nodetool-commands/removenode.rst
+++ b/docs/operating-scylla/nodetool-commands/removenode.rst
@@ -42,9 +42,6 @@ Example:
 .. code-block:: console
 
     nodetool removenode --ignore-dead-nodes 192.168.1.4,192.168.1.5 675ed9f4-6564-6dbd-can8-43fddce952gy
-    nodetool removenode --ignore-dead-nodes 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e 675ed9f4-6564-6dbd-can8-43fddce952gy
-
-
-.. versionadded:: version 4.6 ``--ignore-dead-nodes`` option    
+    nodetool removenode --ignore-dead-nodes 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e 675ed9f4-6564-6dbd-can8-43fddce952gy   
 
 .. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool-commands/scrub.rst
+++ b/docs/operating-scylla/nodetool-commands/scrub.rst
@@ -19,8 +19,6 @@ SYNOPSIS
                    [(-m <scrub_mode> | --mode <scrub_mode>)]
                    [--] <keyspace> [<table...>]
 
-.. versionadded:: version 4.6 ``scrub mode``
-
    Supported scrub modes: ABORT, SKIP, SEGREGATE, VALIDATE
 
 OPTIONS

--- a/docs/operating-scylla/nodetool-commands/stop.rst
+++ b/docs/operating-scylla/nodetool-commands/stop.rst
@@ -8,8 +8,6 @@ Usage
 .. code:: sh
 
           nodetool <options> stop -- <compaction_type>
-
-.. versionadded:: version 4.5 ``compaction type``
    
    Supported compaction types: COMPACTION, CLEANUP, VALIDATION, SCRUB, RESHARD, RESHAPE
 

--- a/docs/operating-scylla/nodetool-commands/toppartitions.rst
+++ b/docs/operating-scylla/nodetool-commands/toppartitions.rst
@@ -1,11 +1,7 @@
 Nodetool toppartitions
 ======================
 
-.. versionadded:: 3.1
-
 **toppartitions** <keyspace> <table> <duration> - Samples cluster writes and reads and reports the most active partitions in a specified table and time frame.
-                  
-.. versionchanged:: 4.6
 
 **toppartitions**  [<--ks-filters ks>] [<--cf-filters tables>] [<-d duration>]
 

--- a/docs/operating-scylla/nodetool-commands/viewbuildstatus.rst
+++ b/docs/operating-scylla/nodetool-commands/viewbuildstatus.rst
@@ -1,8 +1,6 @@
 Nodetool viewbuildstatus
 ========================
 
-.. versionadded:: 2.3 (experimental)
-
 **viewbuildstatus** - ``<keyspace> <view>`` Shows the progress of a materialized view build.
 
 For example:

--- a/docs/operating-scylla/procedures/maintenance/repair.rst
+++ b/docs/operating-scylla/procedures/maintenance/repair.rst
@@ -37,8 +37,6 @@ In most cases, the proportion of data that is out of sync is very small.  In a f
 Row-level Repair
 ----------------
 
-.. versionadded:: 3.1 Scylla Open Source
-
 In previous versions of Scylla (prior to 3.1), repairs were done on the partition level. Scylla 3.1 introduced row-level repair where the repair process only transferred the mismatched rows, instead of the entire partition.   
 
 Row-level repair improves Scylla in two ways:

--- a/docs/operating-scylla/scylla-yaml.inc
+++ b/docs/operating-scylla/scylla-yaml.inc
@@ -102,8 +102,6 @@ To enable all experimental features to add to the scylla.yaml:
 Enable Specific Experimental Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 3.2 Scylla Open Source
-
 To enable specific experimental features, add to the scylla.yaml the list of experimental features you want to enable, by setting the experimental_features array.
 The list of valid elements for this array can be obtained from ``scylla --help``.
 Note that this list is version specific. Your results may be different.

--- a/docs/troubleshooting/clients-table.rst
+++ b/docs/troubleshooting/clients-table.rst
@@ -1,10 +1,6 @@
 Clients Table
 ==============
 
-.. versionadded:: 3.3
-
-
-
 This document describes how to work with Scylla's client table, which provides real-time information on CQL clients **currently** connected to the Scylla cluster.
 
 Viewing - List Active CQL connections

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -1,10 +1,6 @@
 ScyllaDB Large Partitions Table
 ================================
 
-.. versionadded:: 2.3
-
-
-
 This document describes how to work with Scylla's large partitions table.
 The large partitions table can be used to trace large partitions in a cluster.
 The table is updated every time a partition is written and/or deleted,and includes a compaction process which flushes MemTables to SSTables.

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -1,9 +1,6 @@
 ScyllaDB Large Rows and Large Cells Tables
 ===========================================
 
-.. versionadded:: Scylla Open Source 3.1
-
-
 This document describes how to detect large rows and large cells in Scylla.
 Scylla is not optimized for very large rows or large cells. They require allocation of large, contiguous memory areas and therefore may increase latency.
 Rows may also grow over time. For example, many insert operations may add elements to the same collection, or a large blob can be inserted in a single operation.

--- a/docs/upgrade/_common/upgrade-image-enterprise.rst
+++ b/docs/upgrade/_common/upgrade-image-enterprise.rst
@@ -8,8 +8,6 @@ There are two alternative upgrade procedures:
 
 **To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
 
-.. versionadded:: 2021.1.10
-
 Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command. 
 
 #. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.

--- a/docs/upgrade/_common/upgrade-image-opensource.rst
+++ b/docs/upgrade/_common/upgrade-image-opensource.rst
@@ -8,8 +8,6 @@ There are two alternative upgrade procedures:
 
 **To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
 
-.. versionadded:: 5.0
-
 Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command. 
 
 #. Update the |SCYLLA_REPO|_ to |NEW_VERSION|.

--- a/docs/using-scylla/local-secondary-indexes.rst
+++ b/docs/using-scylla/local-secondary-indexes.rst
@@ -2,9 +2,6 @@
 Local Secondary Indexes
 ===============================
 
-.. versionchanged:: Scylla Open Source 4.0
-.. versionadded:: Scylla Enterprise 2020.1
-
 Local Secondary Indexes is an enhancement to :doc:`Global Secondary Indexes <secondary-indexes>`,
 which allows Scylla to optimize workloads where the partition key of the base table and the index are the same key.
 

--- a/docs/using-scylla/lwt.rst
+++ b/docs/using-scylla/lwt.rst
@@ -2,12 +2,6 @@
 Lightweight Transactions
 ========================
 
-.. versionadded:: 3.2 Scylla Open Source (experimental)
-.. versionchanged:: 4.0 Scylla Open Source (production ready)
-
-
-In releases prior to **Scylla 4.0** this feature is an **experimental** feature, to use it you must :ref:`enable the experimental status <yaml_enabling_experimental_features>`.
-
 There are cases when it is necessary to modify data based on its current state: that is, to perform an update that is executed only if a row does not exist or contains a certain value.
 :abbr:`LWTs (lightweight transactions)` provide this functionality by only allowing changes to data to occur if the condition provided evaluates as true.
 The conditional statements provide linearizable semantics thus allowing data to remain consistent.

--- a/docs/using-scylla/tracing.rst
+++ b/docs/using-scylla/tracing.rst
@@ -247,8 +247,6 @@ Slow query logging results are stored in the ``node_slow_log`` table for 24 hour
 Lightweight slow-queries logging mode
 ............................................
 
-.. versionadded:: 4.5
-
 Natural desire is to run database with slow query tracing mode always enabled.
 But the implementation can't detect early if the request will be slow before
 it got processed so it has to record all the tracing events before making

--- a/docs/using-scylla/workload-attributes.rst
+++ b/docs/using-scylla/workload-attributes.rst
@@ -2,12 +2,6 @@
 Defining Workload Attributes
 =============================
 
-.. versionadded:: 2022.1 ScyllaDB Enterprise
-
-
-.. versionadded:: 5.0 ScyllaDB Open Source
-
-
 Introduction
 -------------
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13578

Now that the documentation is versioned, we can remove the `.. versionadded::` and `.. versionchanged::` information (especially that the latter is hard to maintain and now outdated), as well as the outdated information about experimental features in very old releases.

This commit removes that information and nothing else.