### PR TITLE
doc: make branch-5.2 latest and stable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ BASE_URL = 'https://docs.scylladb.com'
 TAGS = []
 BRANCHES = ["master", "branch-5.1", "branch-5.2"]
 # Set the latest version.
-LATEST_VERSION = "branch-5.1"
+LATEST_VERSION = "branch-5.2"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-5.2"]
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This commit changes the configuration in the conf.py file to make branch-5.2 the latest version and
remove it from the list of unstable versions.

As a result, the docs for version 5.2 will become
the default for users accessing the ScyllaDB Open Source documentation.

This commit should be merged as soon as version 5.2 is released.