### PR TITLE
raft topology: implement `check_and_repair_cdc_streams` API

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -260,6 +260,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("transition_state", utf8_type, column_kind::static_column)
             .with_column("current_cdc_generation_uuid", uuid_type, column_kind::static_column)
             .with_column("current_cdc_generation_timestamp", timestamp_type, column_kind::static_column)
+            .with_column("global_topology_request", utf8_type, column_kind::static_column)
             .set_comment("Current state of topology change machine")
             .with_version(generate_schema_version(id))
             .build();
@@ -3692,6 +3693,12 @@ future<service::topology> system_keyspace::load_topology_state() {
                 on_internal_error(slogger,
                     "load_topology_state: normal nodes present but no current CDC generation ID");
             }
+        }
+
+        if (some_row.has("global_topology_request")) {
+            auto req = service::global_topology_request_from_string(
+                    some_row.get_as<sstring>("global_topology_request"));
+            ret.global_request.emplace(req);
         }
     }
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -4,76 +4,119 @@ The topology state machine tracks all the nodes in a cluster,
 their state, properties (topology, tokens, etc) and requested actions.
 
 Node state can be one of those:
- none             - the new node joined group0 but did not bootstraped yet (has no tokens and data to serve)
- bootstrapping    - the node is currently in the process of streaming its part of the ring
- decommissioning  - the node is being decomissioned and stream its data to nodes that took over
- removing         - the node is being removed and its data is streamed to nodes that took over from still alive owners
- replacing        - the node replaces another dead node in the cluster and it data is being streamed to it
- rebuilding       - the node is being rebuild and is streaming data from other replicas
- normal           - the node does not do any streaming and serves the slice of the ring that belongs to it
- left             - the node left the cluster and group0
+- `none`             - the new node joined group0 but did not bootstraped yet (has no tokens and data to serve)
+- `bootstrapping`    - the node is currently in the process of streaming its part of the ring
+- `decommissioning`  - the node is being decomissioned and stream its data to nodes that took over
+- `removing`         - the node is being removed and its data is streamed to nodes that took over from still alive owners
+- `replacing`        - the node replaces another dead node in the cluster and it data is being streamed to it
+- `rebuilding`       - the node is being rebuild and is streaming data from other replicas
+- `normal`           - the node does not do any streaming and serves the slice of the ring that belongs to it
+- `left`             - the node left the cluster and group0
 
 Nodes in state left are never removed from the state.
 
-State transition diagram:
-
+State transition diagram for nodes:
+```
 {none} ------> {bootstrapping|replacing} ------> {normal} <---> {rebuilding}
  |                   |                              |
  |                   |                              |
  |                   V                              V
  ----------------> {left}  <--------  {decommissioning|removing}
+```
 
 
-A state may have additional parameters associated with it. For instance
+A node state may have additional parameters associated with it. For instance
 'replacing' state has host id of a node been replaced as a parameter.
 
-Tokens also can be in one of the states:
+Additionally to specific node states, there entire topology can also be in a transitioning state:
 
-write_both_read_old - writes are going to new and old replica, but reads are from
-             old replicas still
-write_both_read_new - writes still going to old and new replicas but reads are
-             from new replica
-owner      - tokens are owned by the node and reads and write go to new
-             replica set only
+- `commit_cdc_generation` - a new CDC generation data was written to internal tables earlier
+    and now we need to commit the generation - create a timestamp for it and tell every node
+    to start using it for CDC log table writes.
+- `publish_cdc_generation` - a new CDC generation was committed and now we need to publish it
+    to user-facing description tables.
+- `write_both_read_old` - one of the nodes is in a bootstrapping/decommissioning/removing/replacing state.
+    Writes are going to both new and old replicas (new replicas means calculated according to modified
+token ring), reads are using old replicas.
+- `write_both_read_new` - as above, but reads are using new replicas.
 
-Tokens that needs to be move start in 'write_both_read_old' state. After entire
-cluster learns about it streaming start. After the streaming tokens move
-to 'write_both_read_new' state and again the whole cluster needs to learn about it
-and make sure no reads started before that point exist in the system.
-After that tokens may move to the 'owner' state.
+When a node bootstraps, we create new tokens for it and a new CDC generation
+and enter the `commit_cdc_generation` state. After committing the generation we
+move to `publish_cdc_generation`. Once the generation is published, we enter
+`write_both_read_old` state. After the entire cluster learns about it,
+streaming starts. When streaming finishes, we move to `write_both_read_new`
+state and again the whole cluster needs to learn about it and make sure that no
+reads that started before this point exist in the system. Finally we remove the
+transitioning state.
+
+Decommission, removenode and replace work similarly, except they don't go through
+`commit_cdc_generation` and `publish_cdc_generation`.
+
+The state machine may also go only through `commit_cdc_generation` and
+`publish_cdc_generation` states after getting a request from the user to create
+a new CDC generation if the current one is suboptimal (e.g. after a
+decommission).
 
 The state machine also maintains a map of topology requests per node.
 When a request is issued to a node the entry is added to the map. A
-request is one of the topology operation currently supported: join,
-leave, replace, remove and rebuild. A request may also have parameters
+request is one of the topology operation currently supported: `join`,
+`leave`, `replace`, `remove` and `rebuild`. A request may also have parameters
 associated with it which are also stored in a separate map.
+
+Note that some nodes may require work but the topology as a whole does not
+transition. An example of this is the `rebuilding` state which does not change
+the topology but requires streaming data.
+
+Separately from the per-node requests, there is also a 'global' request field
+for operations that don't affect any specific node but the entire cluster,
+such as `check_and_repair_cdc_streams`.
 
 # Topology state persistence table
 
-The in memory state's machine state is persisted in a local table system.topology.
-The schema of the tables is:
-
+The in memory state's machine state is persisted in a local table `system.topology`.
+The schema of the table is:
+```
 CREATE TABLE system.topology (
-    host_id uuid PRIMARY KEY,
+    key text,
+    host_id uuid,
     datacenter text,
+    ignore_msb int,
     node_state text,
+    num_tokens int,
     rack text,
+    rebuild_option text,
     release_version text,
     replaced_id uuid,
+    shard_count int,
     tokens set<text>,
-    replication_state text,
-    topology_request text
-    rebuild_option text
+    topology_request text,
+    transition_state text static,
+    current_cdc_generation_timestamp timestamp static,
+    current_cdc_generation_uuid uuid static,
+    global_topology_request text static,
+    new_cdc_generation_data_uuid uuid static,
+    PRIMARY KEY (key, host_id)
 )
+```
+This is a single-partition table, with `key = 'topology'`.
 
-Each node has a row in the table where its host_id is the primary key. The row contains:
- host_id            -  id of the node
- datacenter         -  a name of the datacenter the node belongs to
- rack               -  a name of the rack the node belongs to
- release_version    -  release version of the Scylla on the node
- node_state         -  current state of the node
- topology_request   -  if set contains one of the supported topology requests
- tokens             -  if set contains a list of tokens that belongs to the node
- replication_state  -  if set contains a state the state the token replication is now in
- replaced_id        -  if the node replacing or replaced another node here will be the id of that node
- rebuild_option     -  if the node is being rebuild contains datacenter name that is used as a rebuild source
+Each node has a clustering row in the table where its `host_id` is the clustering key. The row contains:
+- `host_id`            -  id of the node
+- `datacenter`         -  a name of the datacenter the node belongs to
+- `rack`               -  a name of the rack the node belongs to
+- `ignore_msb`         -  the value of the node's `murmur3_partitioner_ignore_msb_bits` parameter
+- `shard_count`        -  the node's `smp::count`
+- `release_version`    -  the node's `version::current()` (corresponding to a Cassandra version, used by drivers)
+- `node_state`         -  current state of the node (as described earlier)
+- `topology_request`   -  if set contains one of the supported node-specific topology requests
+- `tokens`             -  if set contains a list of tokens that belongs to the node
+- `replaced_id`        -  if the node replacing or replaced another node here will be the id of that node
+- `rebuild_option`     -  if the node is being rebuild contains datacenter name that is used as a rebuild source
+- `num_tokens`         -  the requested number of tokens when the node bootstraps
+
+There are also a few static columns for cluster-global properties:
+- `transition_state` - the transitioning state of the cluster (as described earlier), may be null
+- `current_cdc_generation_timestamp` - the timestamp of the last introduced CDC generation
+- `current_cdc_generation_uuid` - the UUID of the last introduced CDC generation (used to access its data)
+- `global_topology_request` - if set, contains one of the supported global topology requests
+- `new_cdc_generation_data_uuid` - used in `commit_cdc_generation` state, the UUID of the generation to be committed

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -710,6 +710,9 @@ public:
 
     future<std::map<gms::inet_address, float>> effective_ownership(sstring keyspace_name);
 
+    // Must run on shard 0.
+    future<> check_and_repair_cdc_streams(cdc::generation_service&);
+
 private:
     promise<> _drain_finished;
     std::optional<shared_future<>> _transport_stopped;
@@ -789,6 +792,7 @@ private:
     future<> raft_removenode(locator::host_id host_id);
     future<> raft_replace(raft::server&, raft::server_id, gms::inet_address);
     future<> raft_rebuild(sstring source_dc);
+    future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
 
     // This is called on all nodes for each new command received through raft

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -109,6 +109,28 @@ topology_request topology_request_from_string(const sstring& s) {
     throw std::runtime_error(fmt::format("cannot map name {} to topology_request", s));
 }
 
+static std::unordered_map<global_topology_request, sstring> global_topology_request_to_name_map = {
+    {global_topology_request::new_cdc_generation, "new_cdc_generation"},
+};
+
+std::ostream& operator<<(std::ostream& os, const global_topology_request& req) {
+    auto it = global_topology_request_to_name_map.find(req);
+    if (it == global_topology_request_to_name_map.end()) {
+        on_internal_error(tsmlogger, format("cannot print global topology request {}", static_cast<uint8_t>(req)));
+    }
+    return os << it->second;
+}
+
+global_topology_request global_topology_request_from_string(const sstring& s) {
+    for (auto&& e : global_topology_request_to_name_map) {
+        if (e.second == s) {
+            return e.first;
+        }
+    }
+
+    on_internal_error(tsmlogger, format("cannot map name {} to global_topology_request", s));
+}
+
 std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd) {
     switch (cmd) {
         case raft_topology_cmd::command::barrier:

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -38,6 +38,7 @@ bool topology::contains(raft::server_id id) {
 
 static std::unordered_map<topology::transition_state, sstring> transition_state_to_name_map = {
     {topology::transition_state::commit_cdc_generation, "commit cdc generation"},
+    {topology::transition_state::publish_cdc_generation, "publish cdc generation"},
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
 };

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -47,6 +47,10 @@ enum class topology_request: uint16_t {
 
 using request_param = std::variant<raft::server_id, sstring, uint32_t>;
 
+enum class global_topology_request: uint16_t {
+    new_cdc_generation,
+};
+
 struct ring_slice {
     std::unordered_set<dht::token> tokens;
 };
@@ -86,6 +90,9 @@ struct topology {
     // Holds parameters for a request per node and valid during entire
     // operation untill the node becomes normal
     std::unordered_map<raft::server_id, request_param> req_param;
+
+    // Pending global topology request (i.e. not related to any specific node).
+    std::optional<global_topology_request> global_request;
 
     // The ID of the last introduced CDC generation.
     std::optional<cdc::generation_id_v2> current_cdc_generation_id;
@@ -145,5 +152,7 @@ std::ostream& operator<<(std::ostream& os, node_state s);
 node_state node_state_from_string(const sstring& s);
 std::ostream& operator<<(std::ostream& os, const topology_request& req);
 topology_request topology_request_from_string(const sstring& s);
+std::ostream& operator<<(std::ostream&, const global_topology_request&);
+global_topology_request global_topology_request_from_string(const sstring&);
 std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd);
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -26,7 +26,7 @@
 
 namespace service {
 
-enum class node_state: uint8_t {
+enum class node_state: uint16_t {
     none,                // the new node joined group0 but did not bootstraped yet (has no tokens and data to serve)
     bootstrapping,       // the node is currently in the process of streaming its part of the ring
     decommissioning,     // the node is being decomissioned and stream its data to nodes that took over
@@ -37,7 +37,7 @@ enum class node_state: uint8_t {
     left                 // the node left the cluster and group0
 };
 
-enum class topology_request: uint8_t {
+enum class topology_request: uint16_t {
     join,
     leave,
     remove,
@@ -62,7 +62,7 @@ struct replica_state {
 };
 
 struct topology {
-    enum class transition_state: uint8_t {
+    enum class transition_state: uint16_t {
         commit_cdc_generation,
         write_both_read_old,
         write_both_read_new,
@@ -121,7 +121,7 @@ struct topology_state_machine {
 
 // Raft leader uses this command to drive bootstrap process on other nodes
 struct raft_topology_cmd {
-      enum class command: uint8_t {
+      enum class command: uint16_t {
           barrier,         // request to wait for the latest topology
           stream_ranges,   // reqeust to stream data, return when streaming is
                            // done
@@ -132,7 +132,7 @@ struct raft_topology_cmd {
 
 // returned as a result of raft_bootstrap_cmd
 struct raft_topology_cmd_result {
-    enum class command_status: uint8_t {
+    enum class command_status: uint16_t {
         fail,
         success
     };

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -68,6 +68,7 @@ struct replica_state {
 struct topology {
     enum class transition_state: uint16_t {
         commit_cdc_generation,
+        publish_cdc_generation,
         write_both_read_old,
         write_both_read_new,
     };

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -49,11 +49,6 @@ using request_param = std::variant<raft::server_id, sstring, uint32_t>;
 
 struct ring_slice {
     std::unordered_set<dht::token> tokens;
-
-    // When a new node joins the cluster, always a new CDC generation is created.
-    // This is the UUID used to access the data of the CDC generation introduced
-    // when the node owning this ring_slice joined (it's the partition key in CDC_GENERATIONS_V3 table).
-    utils::UUID new_cdc_generation_data_uuid;
 };
 
 struct replica_state {
@@ -92,7 +87,13 @@ struct topology {
     // operation untill the node becomes normal
     std::unordered_map<raft::server_id, request_param> req_param;
 
+    // The ID of the last introduced CDC generation.
     std::optional<cdc::generation_id_v2> current_cdc_generation_id;
+
+    // This is the UUID used to access the data of a new CDC generation introduced
+    // e.g. when a new node bootstraps, needed in `commit_cdc_generation` transition state.
+    // It's used as partition key in CDC_GENERATIONS_V3 table.
+    std::optional<utils::UUID> new_cdc_generation_data_uuid;
 
     // Find only nodes in non 'left' state
     const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -65,6 +65,11 @@ class ManagerClient():
             self.ccluster = None
         self.cql = None
 
+    def get_cql(self) -> CassandraSession:
+        """Precondition: driver is connected"""
+        assert(self.cql)
+        return self.cql
+
     # Make driver update endpoints from remote connection
     def _driver_update(self) -> None:
         if self.ccluster is not None:

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -5,11 +5,17 @@
 #
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import unique_name
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.topology.util import check_token_ring_and_group0_consistency
+
+from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement # type: ignore # pylint: disable=no-name-in-module
 
 import pytest
 import logging
+import time
+from datetime import datetime
+from typing import Optional
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +41,26 @@ async def test_topology_ops(request, manager: ManagerClient):
     logger.info(f"Removing node {servers[0]} using {servers[1]}")
     await manager.remove_node(servers[1].server_id, servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)
+    servers = servers[1:]
 
-    logger.info(f"Decommissioning node {servers[1]}")
-    await manager.decommission_node(servers[1].server_id)
+    cql = manager.get_cql()
+    query = SimpleStatement(
+        "select time from system_distributed.cdc_generation_timestamps where key = 'timestamps'",
+        consistency_level = ConsistencyLevel.QUORUM)
+
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    gen_timestamps = {r.time for r in await manager.get_cql().run_async(query)}
+    logger.info(f"Timestamps before check_and_repair: {gen_timestamps}")
+    await manager.api.client.post("/storage_service/cdc_streams_check_and_repair", servers[1].ip_addr)
+    async def new_gen_appeared() -> Optional[set[datetime]]:
+        new_gen_timestamps = {r.time for r in await manager.get_cql().run_async(query)}
+        assert(gen_timestamps <= new_gen_timestamps)
+        if gen_timestamps < new_gen_timestamps:
+            return new_gen_timestamps
+        return None
+    new_gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60)
+    logger.info(f"Timestamps after check_and_repair: {new_gen_timestamps}")
+
+    logger.info(f"Decommissioning node {servers[0]}")
+    await manager.decommission_node(servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)


### PR DESCRIPTION
`check_and_repair_cdc_streams` is an existing API which you can use when the
current CDC generation is suboptimal, e.g. after you decommissioned a node the
current generation has more stream IDs than you need. In that case you can do
`nodetool checkAndRepairCdcStreams` to create a new generation with fewer
streams.

It also works when you change number of shards on some node. We don't
automatically introduce a new generation in that case but you can use
`checkAndRepairCdcStreams` to create a new generation with restored
shard-colocation.

This PR implements the API on top of raft topology, it was originally
implemented using gossiper.  It uses the `commit_cdc_generation` topology
transition state and a new `publish_cdc_generation` state to create new CDC
generations in a cluster without any nodes changing their `node_state`s in the
process.
