### PR TITLE
types: timestamp_from_string: print current_exception on error

### DIFF
--- a/types/types.cc
+++ b/types/types.cc
@@ -15,6 +15,7 @@
 #include "cql3/sets.hh"
 #include "cql3/util.hh"
 #include "concrete_types.hh"
+#include <exception>
 #include <seastar/core/print.hh>
 #include "types/types.hh"
 #include "utils/exceptions.hh"
@@ -325,7 +326,7 @@ int64_t timestamp_from_string(sstring_view s) {
     } catch (const marshal_exception& me) {
         throw marshal_exception(format("unable to parse date '{}': {}", s, me.what()));
     } catch (...) {
-        throw marshal_exception(format("unable to parse date '{}'", s));
+        throw marshal_exception(format("unable to parse date '{}': {}", s, std::current_exception()));
     }
 }
 


### PR DESCRIPTION
We may catch exceptions that are not `marshal_exception`. Print std::current_exception() in this case to provide some context about the marshalling error.