### PR TITLE
migration_manager: do not pull schema if raft is on

### DIFF
--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -187,7 +187,7 @@ private:
 
     future<> passive_announce();
 
-    void schedule_schema_pull(const gms::inet_address& endpoint, const gms::endpoint_state& state);
+    future<> schedule_schema_pull(const gms::inet_address& endpoint, const gms::endpoint_state& state);
 
     future<> maybe_schedule_schema_pull(const table_schema_version& their_version, const gms::inet_address& endpoint);
 


### PR DESCRIPTION
After consistent schema changes, remove schema pulls from gossiper events if Raft is enabled.

Coroutinize the methods.

Resolves https://github.com/scylladb/scylladb/issues/12870