### PR TITLE
scripts: open-coredump.sh: suggest solib-search-path

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -324,7 +324,7 @@ Launching dbuild container.
 
 To examine the coredump with gdb:
 
-    $ gdb -x scylla-gdb.py -ex 'set directories /src/scylla' --core ${COREFILE} /opt/scylladb/libexec/scylla
+    $ gdb -x scylla-gdb.py -ex 'set directories /src/scylla' -iex 'set solib-search-path /opt/scylladb/libreloc/' --core ${COREFILE} /opt/scylladb/libexec/scylla
 
 See https://github.com/scylladb/scylladb/blob/master/docs/dev/debugging.md for more information on how to debug scylla.
 


### PR DESCRIPTION
Loading cores from Scylla executables installed in a non-standard location can cause gdb to fail reading required libraries.

This is an example of a warning I've got after trying to load [core generated by dtest jenkins job](https://github.com/scylladb/scylladb/issues/12604) (using ./scripts/open-coredump.sh):
> warning: Can't open file /jenkins/workspace/scylla-master/dtest-daily-debug/scylla/.ccm/scylla-repository/0d64f327e1af9bcbb711ee217eda6df16e517c42/libreloc/libboost_system.so.1.78.0 during file-backed mapping note processing

Invocations of `scylla threads` command ended with an error:
> (gdb) scylla threads
> Python Exception <class 'gdb.error'>: Cannot find thread-local storage for LWP 2758, executable file `(...)/scylla-debug-unstripped-5.3.0~dev-0.20230121.0d64f327e1af.x86_64/scylla/libexec/scylla`:
> Cannot find thread-local variables on this target
> Error occurred in Python: Cannot find thread-local storage for LWP 2758, executable file `(...)/scylla-debug-unstripped-5.3.0~dev-0.20230121.0d64f327e1af.x86_64/scylla/libexec/scylla`:
> Cannot find thread-local variables on this target

An easy fix for this is to set solib-search-path to /opt/scylladb/libreloc/.

This pull request adds that set command to suggested command line gdb arguments. I guess it's a good idea to always suggest setting solib-search-path to that path, as it can save other people from wasting their time on looking why does coredump opening does not work.