### PR TITLE
streaming: remove unused operator==

### DIFF
--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -54,7 +54,6 @@ struct stream_bytes {
         ret += y;
         return ret;
     }
-    friend bool operator==(const stream_bytes&, const stream_bytes&) = default;
     stream_bytes& operator+=(const stream_bytes& x) {
         bytes_sent += x.bytes_sent;
         bytes_received += x.bytes_received;


### PR DESCRIPTION
since this operator is used nowhere, let's drop it.