### PR TITLE
utils/chunked_managed_vector: use operator<=> when appropriate

### DIFF
--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -240,17 +240,8 @@ public:
         bool operator==(iterator_type x) const {
             return _i == x._i;
         }
-        bool operator<(iterator_type x) const {
-            return _i < x._i;
-        }
-        bool operator<=(iterator_type x) const {
-            return _i <= x._i;
-        }
-        bool operator>(iterator_type x) const {
-            return _i > x._i;
-        }
-        bool operator>=(iterator_type x) const {
-            return _i >= x._i;
+        std::strong_ordering operator<=>(iterator_type x) const {
+            return _i <=> x._i;
         }
         friend class chunked_managed_vector;
     };


### PR DESCRIPTION
instead of crafting 4 operators manually, just delegate it to <=>.