### PR TITLE
build: cmake: pick up tablets related changes and cleanups

### DIFF
--- a/locator/CMakeLists.txt
+++ b/locator/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(scylla_locator
     ec2_snitch.cc
     ec2_multi_region_snitch.cc
     gce_snitch.cc
+    tablets.cc
     topology.cc
     util.cc)
 target_include_directories(scylla_locator

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(replica
     distributed_loader.cc
     database.cc
     table.cc
+    tablets.cc
     distributed_loader.cc
     memtable.cc
     exceptions.cc

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(service
     raft/raft_sys_table_storage.cc
     storage_proxy.cc
     storage_service.cc
+    tablet_allocator.cc
     topology_state_machine.cc)
 target_include_directories(service
   PUBLIC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,31 +2,11 @@ find_package(jsoncpp REQUIRED)
 
 add_subdirectory(lib)
 
-add_library(test-perf STATIC)
-target_sources(test-perf
-  PRIVATE
-    perf/perf_fast_forward.cc
-    perf/perf_row_cache_update.cc
-    perf/perf_simple_query.cc
-    perf/perf_sstable.cc
-    perf/perf_tablets.cc
-    perf/perf.cc)
-target_include_directories(test-perf
-  PUBLIC
-    ${CMAKE_SOURCE_DIR})
 if(NOT TARGET Seastar::seastar_perf_testing)
     add_library(Seastar::seastar_perf_testing)
     target_sources(
         tests/perf/linux_perf_event.cc)
 endif()
-target_link_libraries(test-perf
-  PRIVATE
-    idl
-    test-lib
-    Seastar::seastar_perf_testing
-    JsonCpp::JsonCpp
-    xxHash::xxhash
-    wasmtime_bindings)
 
 add_subdirectory(perf)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(test-perf
     perf/perf_row_cache_update.cc
     perf/perf_simple_query.cc
     perf/perf_sstable.cc
+    perf/perf_tablets.cc
     perf/perf.cc)
 target_include_directories(test-perf
   PUBLIC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,6 @@
 find_package(jsoncpp REQUIRED)
 
 add_subdirectory(lib)
-
-if(NOT TARGET Seastar::seastar_perf_testing)
-    add_library(Seastar::seastar_perf_testing)
-    target_sources(
-        tests/perf/linux_perf_event.cc)
-endif()
-
 add_subdirectory(perf)
 
 #

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -23,6 +23,27 @@ function(add_perf_test name)
   endif()
 endfunction()
 
+add_library(test-perf STATIC)
+target_sources(test-perf
+  PRIVATE
+    perf_fast_forward.cc
+    perf_row_cache_update.cc
+    perf_simple_query.cc
+    perf_sstable.cc
+    perf_tablets.cc
+    perf.cc)
+target_include_directories(test-perf
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(test-perf
+  PRIVATE
+    idl
+    test-lib
+    Seastar::seastar_perf_testing
+    JsonCpp::JsonCpp
+    xxHash::xxhash
+    wasmtime_bindings)
+
 add_library(perf-lib OBJECT perf.cc)
 target_include_directories(perf-lib
   PUBLIC


### PR DESCRIPTION
this series syncs the CMake building system with `configure.py` which was updated for introducing the tablets feature. also, this series include a couple cleanups.