### PR TITLE
cdc, db_clock: specialize fmt::formatter<{db_clock::time_point, generation_id}>

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -1090,14 +1090,6 @@ shared_ptr<db::system_distributed_keyspace> generation_service::get_sys_dist_ks(
     return _sys_dist_ks.local_shared();
 }
 
-std::ostream& operator<<(std::ostream& os, const generation_id& gen_id) {
-    std::visit(make_visitor(
-    [&os] (const generation_id_v1& id) { os << id.ts; },
-    [&os] (const generation_id_v2& id) { os << "(" << id.ts << ", " << id.id << ")"; }
-    ), gen_id);
-    return os;
-}
-
 db_clock::time_point get_ts(const generation_id& gen_id) {
     return std::visit([] (auto& id) { return id.ts; }, gen_id);
 }

--- a/cdc/generation_id.hh
+++ b/cdc/generation_id.hh
@@ -28,7 +28,35 @@ struct generation_id_v2 {
 
 using generation_id = std::variant<generation_id_v1, generation_id_v2>;
 
-std::ostream& operator<<(std::ostream&, const generation_id&);
 db_clock::time_point get_ts(const generation_id&);
 
 } // namespace cdc
+
+template <>
+struct fmt::formatter<cdc::generation_id_v1> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const cdc::generation_id_v1& gen_id, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", gen_id.ts);
+    }
+};
+
+template <>
+struct fmt::formatter<cdc::generation_id_v2> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const cdc::generation_id_v2& gen_id, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "({}, {})", gen_id.ts, gen_id.id);
+    }
+};
+
+template <>
+struct fmt::formatter<cdc::generation_id> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const cdc::generation_id& gen_id, FormatContext& ctx) const {
+        return std::visit([&ctx] (auto& id) {
+            return fmt::format_to(ctx.out(), "{}", id);
+        }, gen_id);
+    }
+};

--- a/clocks-impl.cc
+++ b/clocks-impl.cc
@@ -15,12 +15,6 @@
 
 std::atomic<int64_t> clocks_offset;
 
-std::ostream& operator<<(std::ostream& os, db_clock::time_point tp) {
-    auto t = db_clock::to_time_t(tp);
-    ::tm t_buf;
-    return os << std::put_time(::gmtime_r(&t, &t_buf), "%Y/%m/%d %T");
-}
-
 std::string format_timestamp(api::timestamp_type ts) {
     auto t = std::time_t(std::chrono::duration_cast<std::chrono::seconds>(api::timestamp_clock::duration(ts)).count());
     ::tm t_buf;

--- a/db_clock.hh
+++ b/db_clock.hh
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <ratio>
 #include <type_traits>
+#include <fmt/chrono.h>
 
 // the database clock follows Java - 1ms granularity, 64-bit counter, 1970 epoch
 
@@ -54,4 +55,11 @@ gc_clock::time_point to_gc_clock(db_clock::time_point tp) noexcept {
 }
 
 /* For debugging and log messages. */
-std::ostream& operator<<(std::ostream&, db_clock::time_point);
+template <>
+struct fmt::formatter<db_clock::time_point> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const db_clock::time_point& tp, FormatContext& ctx) const {
+        auto t = db_clock::to_time_t(tp);
+        return fmt::format_to(ctx.out(), "{:%Y/%m/%d %T}", fmt::gmtime(t));
+    }
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `cdc::generation_id` and `db_clock::time_point` without the help of `operator<<`.

the formatter of `cdc::generation_id` uses that of `db_clock::time_point` , so these two commits are posted together in a single pull request.

the corresponding `operator<<()` is removed in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245