### PR TITLE
Revert "dht: incremental_owned_ranges_checker: use lower_bound()"

### DIFF
--- a/dht/partition_filter.hh
+++ b/dht/partition_filter.hh
@@ -11,7 +11,6 @@
 
 #include "dht/i_partitioner.hh"
 #include "readers/flat_mutation_reader_v2.hh"
-#include <algorithm>
 
 namespace dht {
 
@@ -29,10 +28,14 @@ public:
         // While token T is after a range Rn, advance the iterator.
         // iterator will be stopped at a range which either overlaps with T (if T belongs to node),
         // or at a range which is after T (if T doesn't belong to this node).
-        _it = std::lower_bound(_it, _sorted_owned_ranges.end(), t,
-                               [] (const dht::token_range& range, const dht::token& token) {
-            return range.after(token, dht::token_comparator());
-        });
+        //
+        // As the name "incremental" suggests, the search is expected to
+        // terminate quickly (usually after 0 or 1 iterations) and so linear
+        // search is best.
+        while (_it != _sorted_owned_ranges.end() && _it->after(t, dht::token_comparator())) {
+            _it++;
+        }
+
         return _it != _sorted_owned_ranges.end() && _it->contains(t, dht::token_comparator());
     }
 


### PR DESCRIPTION
This reverts commit d85af3dca4c1113053d4b4da5b31c49eb8f471a7. It restores the linear search algorithm, as we expect the search to terminate near the origin. In this case linear search is O(1) while binary search is O(log n).

A comment is added so we don't repeat the mistake.