### PR TITLE
treewide: reenable -Wmissing-braces

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -1,7 +1,6 @@
 set(disabled_warnings
   c++11-narrowing
   mismatched-tags
-  missing-braces
   overloaded-virtual
   parentheses-equality
   unsupported-friend)

--- a/configure.py
+++ b/configure.py
@@ -1351,7 +1351,6 @@ warnings = [
     '-Wno-tautological-compare',
     '-Wno-parentheses-equality',
     '-Wno-c++11-narrowing',
-    '-Wno-missing-braces',
     '-Wno-ignored-attributes',
     '-Wno-overloaded-virtual',
     '-Wno-unused-command-line-argument',

--- a/cql3/stats.hh
+++ b/cql3/stats.hh
@@ -85,7 +85,7 @@ private:
     uint64_t _query_cnt[(size_t)source_selector::SIZE]
             [(size_t)ks_selector::SIZE]
             [(size_t)cond_selector::SIZE]
-            [statements::statement_type::MAX_VALUE + 1] = {0ul};
+            [statements::statement_type::MAX_VALUE + 1] = {};
 };
 
 }

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -294,11 +294,12 @@ void compression::set_compressor(compressor_ptr c) {
         unqualified_name uqn(compressor::namespace_prefix, c->name());
         const sstring& cn = uqn;
         name.value = bytes(cn.begin(), cn.end());
-        for (auto& p : c->options()) {
-            if (p.first != compression_parameters::SSTABLE_COMPRESSION) {
-                auto& k = p.first;
-                auto& v = p.second;
-                options.elements.push_back({bytes(k.begin(), k.end()), bytes(v.begin(), v.end())});
+        for (auto& [k, v] : c->options()) {
+            if (k != compression_parameters::SSTABLE_COMPRESSION) {
+                options.elements.push_back({
+                    {bytes(k.begin(), k.end())},
+                    {bytes(v.begin(), v.end())}
+                });
             }
         }
     }
@@ -573,7 +574,7 @@ inline output_stream<char> make_compressed_file_output_stream(output_stream<char
     // FIXME: crc_check_chance can be configured by the user.
     // probability to verify the checksum of a compressed chunk we read.
     // defaults to 1.0.
-    cm->options.elements.push_back({"crc_check_chance", "1.0"});
+    cm->options.elements.push_back({{"crc_check_chance"}, {"1.0"}});
 
     return output_stream<char>(compressed_file_data_sink<ChecksumType, mode>(std::move(out), cm, p));
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1711,8 +1711,8 @@ create_sharding_metadata(schema_ptr schema, const dht::decorated_key& first_key,
             auto&& right_token = right.token();
             auto right_exclusive = !right.has_key() && right.bound() == dht::ring_position::token_bound::start;
             sm.token_ranges.elements.push_back(disk_token_range{
-                {left_exclusive, left_token.data()},
-                {right_exclusive, right_token.data()}});
+                {left_exclusive, {left_token.data()}},
+                {right_exclusive, {right_token.data()}}});
         }
     }
     return sm;


### PR DESCRIPTION
this change silences the warning of `-Wmissing-braces` from
clang. in general, we can initialize an object without constructor
with braces. this is called aggregate initialization.
but the standard does allow us to initialize each element using
either copy-initialization or direct-initialization. but in our case,
neither of them applies, so the clang warns like

```
suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                options.elements.push_back({bytes(k.begin(), k.end()), bytes(v.begin(), v.end())});
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~
                                            {                        }
```

in this change,

also, take the opportunity to use structured binding to simplify the
related code.