### PR TITLE
s3: Provide timestamps in the s3 file implementation

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -175,6 +175,29 @@ future<uint64_t> client::get_object_size(sstring object_name) {
     co_return len;
 }
 
+// TODO: possibly move this to seastar's http subsystem.
+static std::time_t parse_http_last_modified_time(const sstring& object_name, sstring last_modified) {
+    std::tm tm = {0};
+
+    // format conforms to HTTP-date, defined in the specification (RFC 7231).
+    if (strptime(last_modified.c_str(), "%a, %d %b %Y %H:%M:%S %Z", &tm) == nullptr) {
+        s3l.warn("Unable to parse {} as Last-Modified for {}", last_modified, object_name);
+    } else {
+        s3l.trace("Successfully parsed {} as Last-modified for {}", last_modified, object_name);
+    }
+    return std::mktime(&tm);
+}
+
+future<client::stats> client::get_object_stats(sstring object_name) {
+    struct stats st{};
+    co_await get_object_header(object_name, [&] (const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
+        st.size = rep.content_length;
+        st.last_modified = parse_http_last_modified_time(object_name, rep.get_header("Last-Modified"));
+        return make_ready_future<>();
+    });
+    co_return st;
+}
+
 future<temporary_buffer<char>> client::get_object_contiguous(sstring object_name, std::optional<range> range) {
     auto req = http::request::make("GET", _host, object_name);
     http::reply::status_type expected = http::reply::status_type::ok;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -39,6 +39,11 @@ public:
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg);
 
     future<uint64_t> get_object_size(sstring object_name);
+    struct stats {
+        uint64_t size;
+        std::time_t last_modified;
+    };
+    future<stats> get_object_stats(sstring object_name);
     future<temporary_buffer<char>> get_object_contiguous(sstring object_name, std::optional<range> range = {});
     future<> put_object(sstring object_name, temporary_buffer<char> buf);
     future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -32,6 +32,8 @@ class client : public enable_shared_from_this<client> {
     struct private_tag {};
 
     void authorize(http::request&);
+
+    future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler);
 public:
     explicit client(std::string host, endpoint_config_ptr cfg, private_tag);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg);


### PR DESCRIPTION
SSTable relies on st.st_mtime for providing creation time of data
file, which in turn is used by features like tombstone compaction.

Therefore, let's implement it.

Fixes https://github.com/scylladb/scylladb/issues/13649.