### PR TITLE
Move pending_ranges and endpoints_for_reading from token_metadata to erm

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1637,7 +1637,7 @@ future<> view_update_generator::mutate_MV(
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto& keyspace_name = mut.s->ks_name();
         auto target_endpoint = get_view_natural_endpoint(_proxy.local().local_db(), keyspace_name, base_token, view_token);
-        auto remote_endpoints = _proxy.local().get_token_metadata_ptr()->pending_endpoints_for(view_token, keyspace_name);
+        auto remote_endpoints = _proxy.local().local_db().find_keyspace(keyspace_name).get_effective_replication_map()->get_pending_endpoints(view_token);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());
 
         const bool update_synchronously = should_update_synchronously(*mut.s);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -349,7 +349,8 @@ future<mutable_vnode_effective_replication_map_ptr> calculate_effective_replicat
     }
 
     auto rf = rs->get_replication_factor(*tmptr);
-    co_return make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(replication_map), rf);
+    co_return make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(replication_map),
+        ring_mapping{}, ring_mapping{}, rf);
 }
 
 future<replication_map> vnode_effective_replication_map::clone_endpoints_gently() const {
@@ -426,7 +427,8 @@ future<vnode_effective_replication_map_ptr> effective_replication_map_factory::c
     if (ref_erm) {
         auto rf = ref_erm->get_replication_factor();
         auto local_replication_map = co_await ref_erm->clone_endpoints_gently();
-        new_erm = make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(local_replication_map), rf);
+        new_erm = make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(local_replication_map),
+            ring_mapping{}, ring_mapping{}, rf);
     } else {
         new_erm = co_await calculate_effective_replication_map(std::move(rs), std::move(tmptr));
     }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -120,6 +120,16 @@ std::optional<inet_address_vector_replica_set> vnode_effective_replication_map::
     return inet_address_vector_replica_set(endpoints->begin(), endpoints->end());
 }
 
+bool vnode_effective_replication_map::has_pending_ranges(inet_address endpoint) const {
+    for (const auto& item : _pending_endpoints) {
+        const auto& nodes = item.second;
+        if (nodes.contains(endpoint)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::unique_ptr<token_range_splitter> vnode_effective_replication_map::make_splitter() const {
     return locator::make_splitter(_tmptr);
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -287,10 +287,10 @@ future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 vnode_effective_replication_map::get_range_addresses() const {
     const token_metadata& tm = *_tmptr;
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> ret;
-    for (const auto& [t, eps] : _replication_map) {
+    for (auto& t : tm.sorted_tokens()) {
         dht::token_range_vector ranges = tm.get_primary_ranges_for(t);
         for (auto& r : ranges) {
-            ret.emplace(r, eps);
+            ret.emplace(r, get_natural_endpoints(t));
         }
         co_await coroutine::maybe_yield();
     }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -113,9 +113,6 @@ public:
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
-    virtual inet_address_vector_replica_set get_natural_endpoints(const token& search_token, const vnode_effective_replication_map& erm) const;
-    // Returns the last stop_iteration result of the called func
-    virtual stop_iteration for_each_natural_endpoint_until(const token& search_token, const vnode_effective_replication_map& erm, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
     virtual void validate_options(const gms::feature_service&) const = 0;
     virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const = 0;
     virtual size_t get_replication_factor(const token_metadata& tm) const = 0;
@@ -251,7 +248,6 @@ public:
 
         sstring to_sstring() const;
     };
-
 private:
     replication_map _replication_map;
     ring_mapping _pending_endpoints;
@@ -277,10 +273,6 @@ public:
     vnode_effective_replication_map() = delete;
     vnode_effective_replication_map(vnode_effective_replication_map&&) = default;
     ~vnode_effective_replication_map();
-
-    const replication_map& get_replication_map() const noexcept {
-        return _replication_map;
-    }
 
     struct cloned_data {
         replication_map replication_map;
@@ -323,6 +315,7 @@ public:
 
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
+    const inet_address_vector_replica_set& do_get_natural_endpoints(const token& search_token) const;
 
 public:
     static factory_key make_factory_key(const replication_strategy_ptr& rs, const token_metadata_ptr& tmptr);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -281,8 +281,6 @@ public:
         return _replication_map;
     }
 
-    future<> clear_gently() noexcept;
-
     future<replication_map> clone_endpoints_gently() const;
 
     stop_iteration for_each_natural_endpoint_until(const token& search_token, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -67,6 +67,7 @@ protected:
     replication_strategy_type _my_type;
     bool _per_table = false;
     bool _uses_tablets = false;
+    bool _natural_endpoints_depend_on_token = true;
 
     template <typename... Args>
     void err(const char* fmt, Args&&... args) const {
@@ -92,7 +93,7 @@ public:
 
     // Evaluates to true iff calculate_natural_endpoints
     // returns different results for different tokens.
-    virtual bool natural_endpoints_depend_on_token() const noexcept { return true; }
+    bool natural_endpoints_depend_on_token() const noexcept { return _natural_endpoints_depend_on_token; }
 
     // The returned vector has size O(number of normal token owners), which is O(number of nodes in the cluster).
     // Note: it is not guaranteed that the function will actually yield. If the complexity of a particular implementation

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -281,7 +281,14 @@ public:
         return _replication_map;
     }
 
-    future<replication_map> clone_endpoints_gently() const;
+    struct cloned_data {
+        replication_map replication_map;
+        ring_mapping pending_endpoints;
+        ring_mapping read_endpoints;
+    };
+    // boost::icl::interval_map is not no_throw_move_constructible -> can't return cloned_data by val,
+    // since future_state requires T to be no_throw_move_constructible.
+    future<std::unique_ptr<cloned_data>> clone_data_gently() const;
 
     stop_iteration for_each_natural_endpoint_until(const token& search_token, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -198,7 +198,12 @@ public:
     /// Returns the set of pending replicas for a given token.
     /// Pending replica is a replica which gains ownership of data.
     /// Non-empty only during topology change.
-    virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token, const sstring& ks_name) const = 0;
+    virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const = 0;
+
+    /// Returns a list of nodes to which a read request should be directed.
+    /// Returns not null only during topology changes, if request_read_new was called and
+    /// new set of replicas differs from the old one.
+    virtual std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const = 0;
 
     /// Returns a token_range_splitter which is line with the replica assignment of this replication map.
     /// The splitter can live longer than this instance.
@@ -260,7 +265,8 @@ private:
 public: // effective_replication_map
     inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const override;
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
-    inet_address_vector_topology_change get_pending_endpoints(const token& search_token, const sstring& ks_name) const override;
+    inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
+    std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
 public:
     explicit vnode_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr, replication_map replication_map,

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -205,6 +205,11 @@ public:
     /// new set of replicas differs from the old one.
     virtual std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const = 0;
 
+    /// Returns true if there are any pending ranges for this endpoint.
+    /// This operation is expensive, for vnode_erm it iterates
+    /// over all pending ranges which is O(number of tokens).
+    virtual bool has_pending_ranges(inet_address endpoint) const = 0;
+
     /// Returns a token_range_splitter which is line with the replica assignment of this replication map.
     /// The splitter can live longer than this instance.
     virtual std::unique_ptr<token_range_splitter> make_splitter() const = 0;
@@ -267,6 +272,7 @@ public: // effective_replication_map
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
     inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
     std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override;
+    bool has_pending_ranges(inet_address endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
 public:
     explicit vnode_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr, replication_map replication_map,

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -17,7 +17,9 @@
 namespace locator {
 
 everywhere_replication_strategy::everywhere_replication_strategy(const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options, replication_strategy_type::everywhere_topology) {}
+        abstract_replication_strategy(config_options, replication_strategy_type::everywhere_topology) {
+    _natural_endpoints_depend_on_token = false;
+}
 
 future<endpoint_set> everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const {
     auto eps = tm.get_all_endpoints();

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -22,33 +22,16 @@ everywhere_replication_strategy::everywhere_replication_strategy(const replicati
 }
 
 future<endpoint_set> everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const {
-    auto eps = tm.get_all_endpoints();
-    return make_ready_future<endpoint_set>(endpoint_set(eps.begin(), eps.end()));
+    if (tm.sorted_tokens().empty()) {
+        endpoint_set result{inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()})};
+        return make_ready_future<endpoint_set>(std::move(result));
+    }
+    const auto& all_endpoints = tm.get_all_endpoints();
+    return make_ready_future<endpoint_set>(endpoint_set(all_endpoints.begin(), all_endpoints.end()));
 }
 
 size_t everywhere_replication_strategy::get_replication_factor(const token_metadata& tm) const {
     return tm.sorted_tokens().empty() ? 1 : tm.count_normal_token_owners();
-}
-
-inet_address_vector_replica_set everywhere_replication_strategy::get_natural_endpoints(const token&, const vnode_effective_replication_map& erm) const {
-    const auto& tm = *erm.get_token_metadata_ptr();
-    if (tm.sorted_tokens().empty()) {
-        return inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()});
-    }
-    return boost::copy_range<inet_address_vector_replica_set>(tm.get_all_endpoints());
-}
-
-stop_iteration everywhere_replication_strategy::for_each_natural_endpoint_until(const token&, const vnode_effective_replication_map& erm, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
-    const auto& tm = *erm.get_token_metadata_ptr();
-    if (tm.sorted_tokens().empty()) {
-        return func(utils::fb_utilities::get_broadcast_address());
-    }
-    for (const auto& ep : tm.get_all_endpoints()) {
-        if (func(ep)) {
-            return stop_iteration::yes;
-        }
-    }
-    return stop_iteration::no;
 }
 
 using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, const replication_strategy_config_options&>;

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -18,8 +18,6 @@ class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
     everywhere_replication_strategy(const replication_strategy_config_options& config_options);
 
-    virtual bool natural_endpoints_depend_on_token() const noexcept override { return false; }
-
     virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options(const gms::feature_service&) const override { /* noop */ }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -32,12 +32,5 @@ public:
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return true;
     }
-
-    /**
-     * We need to override this because the default implementation depends
-     * on token calculations but everywhere_replication_strategy may be used before tokens are set up.
-     */
-    virtual inet_address_vector_replica_set get_natural_endpoints(const token&, const vnode_effective_replication_map&) const override;
-    virtual stop_iteration for_each_natural_endpoint_until(const token&, const vnode_effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const override;
 };
 }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -15,7 +15,9 @@
 namespace locator {
 
 local_strategy::local_strategy(const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options, replication_strategy_type::local) {}
+        abstract_replication_strategy(config_options, replication_strategy_type::local) {
+    _natural_endpoints_depend_on_token = false;
+}
 
 future<endpoint_set> local_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
     return make_ready_future<endpoint_set>(endpoint_set({utils::fb_utilities::get_broadcast_address()}));

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -35,14 +35,6 @@ size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }
 
-inet_address_vector_replica_set local_strategy::get_natural_endpoints(const token&, const vnode_effective_replication_map&) const {
-    return inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()});
-}
-
-stop_iteration local_strategy::for_each_natural_endpoint_until(const token&, const vnode_effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
-    return func(utils::fb_utilities::get_broadcast_address());
-}
-
 using registry = class_registrator<abstract_replication_strategy, local_strategy, const replication_strategy_config_options&>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -36,13 +36,6 @@ public:
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return false;
     }
-
-    /**
-     * We need to override this because the default implementation depends
-     * on token calculations but LocalStrategy may be used before tokens are set up.
-     */
-    inet_address_vector_replica_set get_natural_endpoints(const token&, const vnode_effective_replication_map&) const override;
-    virtual stop_iteration for_each_natural_endpoint_until(const token&, const vnode_effective_replication_map&, const noncopyable_function<stop_iteration(const inet_address&)>& func) const override;
 };
 
 }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -27,8 +27,6 @@ public:
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 
-    virtual bool natural_endpoints_depend_on_token() const noexcept override { return false; }
-
     virtual future<endpoint_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
     virtual void validate_options(const gms::feature_service&) const override;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -244,6 +244,19 @@ public:
         return std::nullopt;
     }
 
+    virtual bool has_pending_ranges(inet_address endpoint) const override {
+        const auto host_id = _tmptr->get_host_id_if_known(endpoint);
+        if (!host_id.has_value()) {
+            return false;
+        }
+        for (const auto& [id, transition_info]: get_tablet_map().transitions()) {
+            if (transition_info.pending_replica.host == *host_id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     virtual std::unique_ptr<token_range_splitter> make_splitter() const override {
         class splitter : public token_range_splitter {
             token_metadata_ptr _tmptr; // To keep the tablet map alive.

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -228,7 +228,7 @@ public:
         return result;
     }
 
-    virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token, const sstring& ks_name) const override {
+    virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override {
         auto&& tablets = get_tablet_map();
         auto tablet = tablets.get_tablet_id(search_token);
         auto&& info = tablets.get_tablet_transition_info(tablet);
@@ -238,6 +238,10 @@ public:
         tablet_logger.trace("get_pending_endpoints({}): table={}, tablet={}, replica={}",
                             search_token, _table, tablet, info->pending_replica);
         return {get_endpoint_for_host_id(info->pending_replica.host)};
+    }
+
+    virtual std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override {
+        return std::nullopt;
     }
 
     virtual std::unique_ptr<token_range_splitter> make_splitter() const override {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -152,6 +152,10 @@ public:
         return _tablets;
     }
 
+    const auto& transitions() const {
+        return _transitions;
+    }
+
     /// Returns an iterable range over tablet_id:s which includes all tablets in token ring order.
     auto tablet_ids() const {
         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -244,8 +244,6 @@ public:
     static boost::icl::interval<token>::interval_type range_to_interval(range<dht::token> r);
     static range<dht::token> interval_to_range(boost::icl::interval<token>::interval_type i);
 
-    bool has_pending_ranges(sstring keyspace_name, inet_address endpoint) const;
-
     future<> update_topology_change_info(dc_rack_fn& get_dc_rack);
 
     const std::optional<topology_change_info>& get_topology_change_info() const;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -28,7 +28,6 @@
 
 #include "locator/types.hh"
 #include "locator/topology.hh"
-#include "service/topology_state_machine.hh"
 
 // forward declaration since replica/database.hh includes this file
 namespace replica {
@@ -273,10 +272,13 @@ public:
     // new set of replicas differs from the old one.
     std::optional<inet_address_vector_replica_set> endpoints_for_reading(const token& token, const sstring& keyspace_name) const;
 
-    // updates the current topology_transition_state of this instance,
-    // this value is preserved in all clone functions,
-    // by default it's not set
-    void set_topology_transition_state(std::optional<service::topology::transition_state> state);
+    // Updates the read_new flag, switching read requests from
+    // the old endpoints to the new ones during topology changes:
+    // read_new_t::no - no read_endpoints will be stored on update_pending_ranges, all reads goes to normal endpoints;
+    // read_new_t::yes - triggers update_pending_ranges to compute and store new ranges for read requests.
+    // The value is preserved in all clone functions, the default is read_new_t::no.
+    using read_new_t = bool_class<class read_new_tag>;
+    void set_read_new(read_new_t value);
 
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
     std::multimap<inet_address, token> get_endpoint_to_token_map_for_reading() const;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -245,17 +245,6 @@ public:
     static range<dht::token> interval_to_range(boost::icl::interval<token>::interval_type i);
 
     bool has_pending_ranges(sstring keyspace_name, inet_address endpoint) const;
-     /**
-     * Calculate pending ranges according to bootstrapping, leaving and replacing nodes.
-     *
-     * We construct an updated version of the token_metadata by incorporating
-     * all proposed modifications (join, bootstrap, and replace operations).
-     * Subsequently, for each token range, we compare the outcomes of the calculate_natural_endpoints
-     * function applied to both the previous and the new token_metadata.
-     * Endpoints present in the updated version but absent in the original one
-     * ought to be appended to the pending_ranges.
-     */
-    future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name, dc_rack_fn& get_dc_rack);
 
     future<> update_topology_change_info(dc_rack_fn& get_dc_rack);
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -269,14 +269,6 @@ public:
      * Bootstrapping tokens are not taken into account. */
     size_t count_normal_token_owners() const;
 
-    // returns empty vector if keyspace_name not found.
-    inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
-
-    // This function returns a list of nodes to which a read request should be directed.
-    // Returns not null only during topology changes, if _topology_change_stage == read_new and
-    // new set of replicas differs from the old one.
-    std::optional<inet_address_vector_replica_set> endpoints_for_reading(const token& token, const sstring& keyspace_name) const;
-
     // Updates the read_new flag, switching read requests from
     // the old endpoints to the new ones during topology changes:
     // read_new_t::no - no read_endpoints will be stored on update_pending_ranges, all reads goes to normal endpoints;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -69,6 +69,7 @@ struct host_id_or_endpoint {
 };
 
 class token_metadata_impl;
+struct topology_change_info;
 
 class token_metadata final {
     std::unique_ptr<token_metadata_impl> _impl;
@@ -256,6 +257,10 @@ public:
      */
     future<> update_pending_ranges(const abstract_replication_strategy& strategy, const sstring& keyspace_name, dc_rack_fn& get_dc_rack);
 
+    future<> update_topology_change_info(dc_rack_fn& get_dc_rack);
+
+    const std::optional<topology_change_info>& get_topology_change_info() const;
+
     token get_predecessor(token t) const;
 
     const std::unordered_set<inet_address>& get_all_endpoints() const;
@@ -292,6 +297,19 @@ public:
     void invalidate_cached_rings();
 
     friend class token_metadata_impl;
+};
+
+struct topology_change_info {
+    token_metadata target_token_metadata;
+    std::optional<token_metadata> base_token_metadata;
+    std::vector<dht::token> all_tokens;
+    token_metadata::read_new_t read_new;
+
+    topology_change_info(token_metadata target_token_metadata_,
+        std::optional<token_metadata> base_token_metadata_,
+        std::vector<dht::token> all_tokens_,
+        token_metadata::read_new_t read_new_);
+    future<> clear_gently();
 };
 
 using token_metadata_ptr = lw_shared_ptr<const token_metadata>;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6008,7 +6008,7 @@ void storage_proxy::sort_endpoints_by_proximity(const locator::topology& topo, i
 }
 
 inet_address_vector_replica_set storage_proxy::get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const {
-    auto endpoints = erm.get_token_metadata_ptr()->endpoints_for_reading(token, ks_name);
+    auto endpoints = erm.get_endpoints_for_reading(token);
     if (!endpoints) {
         endpoints = erm.get_natural_endpoints_without_node_being_replaced(token);
     }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2845,7 +2845,7 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
     replica::table& table = _db.local().find_column_family(s->id());
     auto erm = table.get_effective_replication_map();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm->get_pending_endpoints(token, s->ks_name());
+    inet_address_vector_topology_change pending_endpoints = erm->get_pending_endpoints(token);
 
     slogger.trace("creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints, pending_endpoints);
     tracing::trace(tr_state, "Creating write handler for token: {} natural: {} pending: {}", token, natural_endpoints ,pending_endpoints);
@@ -3208,7 +3208,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
 storage_proxy::paxos_participants
 storage_proxy::get_paxos_participants(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token &token, db::consistency_level cl_for_paxos) {
     inet_address_vector_replica_set natural_endpoints = erm.get_natural_endpoints_without_node_being_replaced(token);
-    inet_address_vector_topology_change pending_endpoints = erm.get_pending_endpoints(token, ks_name);
+    inet_address_vector_topology_change pending_endpoints = erm.get_pending_endpoints(token);
 
     if (cl_for_paxos == db::consistency_level::LOCAL_SERIAL) {
         auto local_dc_filter = erm.get_topology().get_local_dc_filter();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3446,7 +3446,7 @@ future<> storage_service::decommission() {
 
                 auto non_system_keyspaces = db.get_non_local_vnode_based_strategy_keyspaces();
                 for (const auto& keyspace_name : non_system_keyspaces) {
-                    if (ss.get_token_metadata().has_pending_ranges(keyspace_name, ss.get_broadcast_address())) {
+                    if (ss._db.local().find_keyspace(keyspace_name).get_effective_replication_map()->has_pending_ranges(ss.get_broadcast_address())) {
                         throw std::runtime_error("data is currently moving to this node; unable to leave the ring");
                     }
                 }
@@ -5374,7 +5374,7 @@ future<> storage_service::wait_for_normal_state_handled_on_boot(const std::unord
 future<bool> storage_service::is_cleanup_allowed(sstring keyspace) {
     return container().invoke_on(0, [keyspace = std::move(keyspace)] (storage_service& ss) {
         auto my_address = ss.get_broadcast_address();
-        auto pending_ranges = ss.get_token_metadata().has_pending_ranges(keyspace, my_address);
+        auto pending_ranges = ss._db.local().find_keyspace(keyspace).get_effective_replication_map()->has_pending_ranges(my_address);
         bool is_bootstrap_mode = ss._operation_mode == mode::BOOTSTRAP;
         slogger.debug("is_cleanup_allowed: keyspace={}, is_bootstrap_mode={}, pending_ranges={}",
                 keyspace, is_bootstrap_mode, pending_ranges);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -263,7 +263,7 @@ future<> storage_service::wait_for_ring_to_settle(std::chrono::milliseconds dela
             slogger.info("waiting for schema information to complete");
             co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
         }
-        co_await update_pending_ranges("joining");
+        co_await update_topology_change_info("joining");
 
         auto tmptr = get_token_metadata_ptr();
         if (!_db.local().get_config().consistent_rangemovement() ||
@@ -397,7 +397,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                     co_await tmptr->update_normal_tokens(rs.ring.value().tokens, ip);
                 } else {
                     tmptr->add_bootstrap_tokens(rs.ring.value().tokens, ip);
-                    co_await update_pending_ranges(tmptr, ::format("bootstrapping node {}/{}", id, ip));
+                    co_await update_topology_change_info(tmptr, ::format("bootstrapping node {}/{}", id, ip));
                 }
                 break;
             case node_state::decommissioning:
@@ -406,7 +406,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                 co_await tmptr->update_normal_tokens(rs.ring.value().tokens, ip);
                 tmptr->update_host_id(host_id, ip);
                 tmptr->add_leaving_endpoint(ip);
-                co_await update_pending_ranges(tmptr, ::format("{} {}/{}", rs.state, id, ip));
+                co_await update_topology_change_info(tmptr, ::format("{} {}/{}", rs.state, id, ip));
                 break;
             case node_state::replacing: {
                 assert(_topology_state_machine._topology.req_param.contains(id));
@@ -419,7 +419,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                 assert(existing_ip);
                 tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
                 tmptr->add_replacing_endpoint(*existing_ip, ip);
-                co_await update_pending_ranges(tmptr, ::format("replacing {}/{} by {}/{}", replaced_id, *existing_ip, id, ip));
+                co_await update_topology_change_info(tmptr, ::format("replacing {}/{} by {}/{}", replaced_id, *existing_ip, id, ip));
             }
                 break;
             case node_state::rebuilding:
@@ -1912,7 +1912,7 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
                     auto endpoint = get_broadcast_address();
                     tmptr->update_topology(endpoint, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(bootstrap_tokens, endpoint);
-                    return update_pending_ranges(std::move(tmptr), ::format("bootstrapping node {}", endpoint));
+                    return update_topology_change_info(std::move(tmptr), ::format("bootstrapping node {}", endpoint));
                 }).get();
             }
 
@@ -2012,7 +2012,7 @@ future<> storage_service::handle_state_replacing_update_pending_ranges(mutable_t
                 replacing_node, std::current_exception());
     }
     slogger.info("handle_state_replacing: Update pending ranges for replacing node {}", replacing_node);
-    co_await update_pending_ranges(tmptr, ::format("handle_state_replacing {}", replacing_node));
+    co_await update_topology_change_info(tmptr, ::format("handle_state_replacing {}", replacing_node));
 }
 
 future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
@@ -2044,7 +2044,7 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
     }
-    co_await update_pending_ranges(tmptr, ::format("handle_state_bootstrap {}", endpoint));
+    co_await update_topology_change_info(tmptr, ::format("handle_state_bootstrap {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -2186,7 +2186,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
         co_await tmptr->update_normal_tokens(owned_tokens, endpoint);
     }
 
-    co_await update_pending_ranges(tmptr, ::format("handle_state_normal {}", endpoint));
+    co_await update_topology_change_info(tmptr, ::format("handle_state_normal {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -2251,7 +2251,7 @@ future<> storage_service::handle_state_leaving(inet_address endpoint) {
     // normally
     tmptr->add_leaving_endpoint(endpoint);
 
-    co_await update_pending_ranges(tmptr, ::format("handle_state_leaving", endpoint));
+    co_await update_topology_change_info(tmptr, ::format("handle_state_leaving", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -2314,7 +2314,7 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
                 slogger.debug("Tokens {} removed manually (endpoint was {})", remove_tokens, endpoint);
                 // Note that the endpoint is being removed
                 tmptr->add_leaving_endpoint(endpoint);
-                return update_pending_ranges(std::move(tmptr), ::format("handle_state_removing {}", endpoint));
+                return update_topology_change_info(std::move(tmptr), ::format("handle_state_removing {}", endpoint));
             });
             // find the endpoint coordinating this removal that we need to notify when we're done
             auto* value = _gossiper.get_application_state_ptr(endpoint, application_state::REMOVAL_COORDINATOR);
@@ -2464,7 +2464,7 @@ future<> storage_service::on_remove(gms::inet_address endpoint) {
     auto tmlock = co_await get_token_metadata_lock();
     auto tmptr = co_await get_mutable_token_metadata_ptr();
     tmptr->remove_endpoint(endpoint);
-    co_await update_pending_ranges(tmptr, ::format("on_remove {}", endpoint));
+    co_await update_topology_change_info(tmptr, ::format("on_remove {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
@@ -3442,7 +3442,7 @@ future<> storage_service::decommission() {
                     throw std::runtime_error(::format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
                 }
 
-                ss.update_pending_ranges(::format("decommission {}", endpoint)).get();
+                ss.update_topology_change_info(::format("decommission {}", endpoint)).get();
 
                 auto non_system_keyspaces = db.get_non_local_vnode_based_strategy_keyspaces();
                 for (const auto& keyspace_name : non_system_keyspaces) {
@@ -3991,7 +3991,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     slogger.info("removenode[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, ::format("removenode {}", req.leaving_nodes));
+                return update_topology_change_info(tmptr, ::format("removenode {}", req.leaving_nodes));
             }).get();
             node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
@@ -3999,7 +3999,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("removenode[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, ::format("removenode {}", req.leaving_nodes));
+                    return update_topology_change_info(tmptr, ::format("removenode {}", req.leaving_nodes));
                 });
             });
         } else if (req.cmd == node_ops_cmd::removenode_heartbeat) {
@@ -4039,7 +4039,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     slogger.info("decommission[{}]: Added node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                     tmptr->add_leaving_endpoint(node);
                 }
-                return update_pending_ranges(tmptr, ::format("decommission {}", req.leaving_nodes));
+                return update_topology_change_info(tmptr, ::format("decommission {}", req.leaving_nodes));
             }).get();
             node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
@@ -4047,7 +4047,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("decommission[{}]: Removed node={} as leaving node, coordinator={}", req.ops_uuid, node, coordinator);
                         tmptr->del_leaving_endpoint(node);
                     }
-                    return update_pending_ranges(tmptr, ::format("decommission {}", req.leaving_nodes));
+                    return update_topology_change_info(tmptr, ::format("decommission {}", req.leaving_nodes));
                 });
             });
         } else if (req.cmd == node_ops_cmd::decommission_heartbeat) {
@@ -4109,7 +4109,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("replace[{}]: Removed replacing_node={} to replace existing_node={}, coordinator={}", req.ops_uuid, replacing_node, existing_node, coordinator);
                         tmptr->del_replacing_endpoint(existing_node);
                     }
-                    return update_pending_ranges(tmptr, ::format("replace {}", req.replace_nodes));
+                    return update_topology_change_info(tmptr, ::format("replace {}", req.replace_nodes));
                 });
             });
         } else if (req.cmd == node_ops_cmd::replace_prepare_mark_alive) {
@@ -4126,7 +4126,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             // Update the pending_ranges for the replacing node
             slogger.debug("replace[{}]: Updated pending_ranges from coordinator={}", req.ops_uuid, coordinator);
             mutate_token_metadata([&req, this] (mutable_token_metadata_ptr tmptr) mutable {
-                return update_pending_ranges(tmptr, ::format("replace {}", req.replace_nodes));
+                return update_topology_change_info(tmptr, ::format("replace {}", req.replace_nodes));
             }).get();
         } else if (req.cmd == node_ops_cmd::replace_heartbeat) {
             slogger.debug("replace[{}]: Updated heartbeat from coordinator={}", req.ops_uuid, coordinator);
@@ -4151,7 +4151,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                     tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::joining);
                     tmptr->add_bootstrap_tokens(tokens, endpoint);
                 }
-                return update_pending_ranges(tmptr, ::format("bootstrap {}", req.bootstrap_nodes));
+                return update_topology_change_info(tmptr, ::format("bootstrap {}", req.bootstrap_nodes));
             }).get();
             node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                 return mutate_token_metadata([this, coordinator, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
@@ -4161,7 +4161,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                         slogger.info("bootstrap[{}]: Removed node={} as bootstrap, coordinator={}", req.ops_uuid, endpoint, coordinator);
                         tmptr->remove_bootstrap_tokens(tokens);
                     }
-                    return update_pending_ranges(tmptr, ::format("bootstrap {}", req.bootstrap_nodes));
+                    return update_topology_change_info(tmptr, ::format("bootstrap {}", req.bootstrap_nodes));
                 });
             });
         } else if (req.cmd == node_ops_cmd::bootstrap_heartbeat) {
@@ -4538,7 +4538,7 @@ future<> storage_service::excise(std::unordered_set<token> tokens, inet_address 
     tmptr->remove_endpoint(endpoint);
     tmptr->remove_bootstrap_tokens(tokens);
 
-    co_await update_pending_ranges(tmptr, ::format("excise {}", endpoint));
+    co_await update_topology_change_info(tmptr, ::format("excise {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
     tmlock.reset();
 
@@ -4584,7 +4584,7 @@ future<> storage_service::leave_ring() {
     co_await mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
         auto endpoint = get_broadcast_address();
         tmptr->remove_endpoint(endpoint);
-        return update_pending_ranges(std::move(tmptr), ::format("leave_ring {}", endpoint));
+        return update_topology_change_info(std::move(tmptr), ::format("leave_ring {}", endpoint));
     });
 
     auto expire_time = _gossiper.compute_expire_time().time_since_epoch().count();
@@ -4746,30 +4746,22 @@ future<> storage_service::mutate_token_metadata(std::function<future<> (mutable_
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
-future<> storage_service::update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason) {
+future<> storage_service::update_topology_change_info(mutable_token_metadata_ptr tmptr, sstring reason) {
     assert(this_shard_id() == 0);
 
     try {
         locator::dc_rack_fn get_dc_rack_from_gossiper([this] (inet_address ep) { return get_dc_rack_for(ep); });
         co_await tmptr->update_topology_change_info(get_dc_rack_from_gossiper);
-
-        auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
-        for (const auto& [keyspace_name, erm] : ks_erms) {
-            auto& strategy = erm->get_replication_strategy();
-            slogger.debug("Updating pending ranges for keyspace={} starts ({})", keyspace_name, reason);
-            co_await tmptr->update_pending_ranges(strategy, keyspace_name, get_dc_rack_from_gossiper);
-            slogger.debug("Updating pending ranges for keyspace={} ends ({})", keyspace_name, reason);
-        }
     } catch (...) {
         auto ep = std::current_exception();
-        slogger.error("Failed to update pending ranges for {}: {}", reason, ep);
+        slogger.error("Failed to update topology change info for {}: {}", reason, ep);
         std::rethrow_exception(std::move(ep));
     }
 }
 
-future<> storage_service::update_pending_ranges(sstring reason, acquire_merge_lock acquire_merge_lock) {
+future<> storage_service::update_topology_change_info(sstring reason, acquire_merge_lock acquire_merge_lock) {
     return mutate_token_metadata([this, reason = std::move(reason)] (mutable_token_metadata_ptr tmptr) mutable {
-        return update_pending_ranges(std::move(tmptr), std::move(reason));
+        return update_topology_change_info(std::move(tmptr), std::move(reason));
     }, acquire_merge_lock);
 }
 
@@ -4777,7 +4769,7 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
     // Update pending ranges since keyspace can be changed after we calculate pending ranges.
     sstring reason = ::format("keyspace {}", ks_name);
     return container().invoke_on(0, [reason = std::move(reason)] (auto& ss) mutable {
-        return ss.update_pending_ranges(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
+        return ss.update_topology_change_info(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
             slogger.warn("Failure to update pending ranges for {} ignored", reason);
         });
     });

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -190,8 +190,8 @@ private:
     // Update pending ranges locally and then replicate to all cores.
     // Should be serialized under token_metadata_lock.
     // Must be called on shard 0.
-    future<> update_pending_ranges(mutable_token_metadata_ptr tmptr, sstring reason);
-    future<> update_pending_ranges(sstring reason, acquire_merge_lock aml = acquire_merge_lock::yes);
+    future<> update_topology_change_info(mutable_token_metadata_ptr tmptr, sstring reason);
+    future<> update_topology_change_info(sstring reason, acquire_merge_lock aml = acquire_merge_lock::yes);
     future<> keyspace_changed(const sstring& ks_name);
     void register_metrics();
     future<> snitch_reconfigured();

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -46,12 +46,13 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_first_node) {
         {"replication_factor", "1"}
     });
     token_metadata->add_bootstrap_token(t1, e1);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(0), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(0)),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(2)),
         inet_address_vector_topology_change{e1});
 }
 
@@ -70,16 +71,17 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_second_node) {
     });
     token_metadata->update_normal_tokens({t1}, e1).get();
     token_metadata->add_bootstrap_token(t2, e2);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(0), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(0)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(2)),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(100)),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(101)),
         inet_address_vector_topology_change{});
 }
 
@@ -103,16 +105,17 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_with_replicas) {
     token_metadata->update_normal_tokens({t1, t1000}, e2).get();
     token_metadata->update_normal_tokens({t10}, e3).get();
     token_metadata->add_bootstrap_token(t100, e1);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(2)),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(11)),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(100)),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(101)),
         inet_address_vector_topology_change{});
 }
 
@@ -137,16 +140,17 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_leave_with_replicas) {
     token_metadata->update_normal_tokens({t10}, e3).get();
     token_metadata->update_normal_tokens({t100}, e1).get();
     token_metadata->add_leaving_endpoint(e1);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(2)),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(11)),
         inet_address_vector_topology_change{e3});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(100)),
         inet_address_vector_topology_change{e3});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(101)),
         inet_address_vector_topology_change{});
 }
 
@@ -173,20 +177,21 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_replace_with_replicas) {
     token_metadata->update_normal_tokens({t1, t100}, e2).get();
     token_metadata->update_normal_tokens({t10}, e3).get();
     token_metadata->add_replacing_endpoint(e3, e4);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(100)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1000), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1000)),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1001), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1001)),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(2)),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(10), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(10)),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(11)),
         inet_address_vector_topology_change{});
 }
 
@@ -211,39 +216,46 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
     token_metadata->update_normal_tokens({t10}, e3).get();
     token_metadata->add_bootstrap_token(t100, e1);
 
-    auto check_endpoints = [&](int64_t t, inet_address_vector_replica_set expected_replicas,
+    auto check_endpoints = [](mutable_vnode_erm_ptr erm, int64_t t,
+        inet_address_vector_replica_set expected_replicas,
         seastar::compat::source_location sl = seastar::compat::source_location::current())
     {
         BOOST_TEST_INFO("line: " << sl.line());
         const auto expected_set = std::unordered_set<inet_address>(expected_replicas.begin(),
             expected_replicas.end());
-        const auto actual_replicas = token_metadata->endpoints_for_reading(dht::token::from_int64(t), ks_name);
+        const auto actual_replicas = erm->get_endpoints_for_reading(dht::token::from_int64(t));
         BOOST_REQUIRE(actual_replicas.has_value());
         const auto actual_set = std::unordered_set<inet_address>(actual_replicas->begin(),
             actual_replicas->end());
         BOOST_REQUIRE_EQUAL(expected_set, actual_set);
     };
 
-    auto check_no_endpoints = [&](int64_t t,
+    auto check_no_endpoints = [](mutable_vnode_erm_ptr erm, int64_t t,
         seastar::compat::source_location sl = seastar::compat::source_location::current())
     {
         BOOST_TEST_INFO("line: " << sl.line());
-        BOOST_REQUIRE(!token_metadata->endpoints_for_reading(dht::token::from_int64(t), ks_name).has_value());
+        BOOST_REQUIRE(!erm->get_endpoints_for_reading(dht::token::from_int64(t)).has_value());
     };
 
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    check_no_endpoints(2);
+    {
+        token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+        auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+        check_no_endpoints(erm, 2);
+    }
 
-    token_metadata->set_read_new(locator::token_metadata::read_new_t::yes);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    {
+        token_metadata->set_read_new(locator::token_metadata::read_new_t::yes);
+        token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+        auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
 
-    check_endpoints(2, {e3, e1});
-    check_endpoints(10, {e3, e1});
-    check_endpoints(11, {e1, e2});
-    check_endpoints(100, {e1, e2});
-    check_no_endpoints(101);
-    check_no_endpoints(1001);
-    check_no_endpoints(1);
+        check_endpoints(erm, 2, {e3, e1});
+        check_endpoints(erm, 10, {e3, e1});
+        check_endpoints(erm, 11, {e1, e2});
+        check_endpoints(erm, 100, {e1, e2});
+        check_no_endpoints(erm, 101);
+        check_no_endpoints(erm, 1001);
+        check_no_endpoints(erm, 1);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_replace_node_with_same_endpoint) {
@@ -258,8 +270,9 @@ SEASTAR_THREAD_TEST_CASE(test_replace_node_with_same_endpoint) {
     });
     token_metadata->update_normal_tokens({t1}, e1).get();
     token_metadata->add_replacing_endpoint(e1, e1);
-    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_topology_change_info(get_dc_rack_fn).get();
+    auto erm = calculate_effective_replication_map(replication_strategy, token_metadata).get0();
+    BOOST_REQUIRE_EQUAL(erm->get_pending_endpoints(dht::token::from_int64(1)),
         inet_address_vector_topology_change{e1});
     BOOST_REQUIRE_EQUAL(token_metadata->get_endpoint(t1), e1);
 }

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -24,8 +24,8 @@ namespace {
         };
     }
 
-    token_metadata create_token_metadata(inet_address this_endpoint) {
-        return token_metadata({
+    mutable_token_metadata_ptr create_token_metadata(inet_address this_endpoint) {
+        return make_lw_shared<token_metadata>(token_metadata::config {
             topology::config {
                 .this_host_id = host_id::create_random_id(),
                 .this_endpoint = this_endpoint,
@@ -41,17 +41,17 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_first_node) {
     const auto e1 = inet_address("192.168.0.1");
     const auto t1 = dht::token::from_int64(1);
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "1"}
     });
-    token_metadata.add_bootstrap_token(t1, e1);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(0), ks_name),
+    token_metadata->add_bootstrap_token(t1, e1);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(0), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
         inet_address_vector_topology_change{e1});
 }
 
@@ -63,23 +63,23 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_second_node) {
     const auto e2 = inet_address("192.168.0.2");
     const auto t2 = dht::token::from_int64(100);
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    token_metadata.update_topology(e2, get_dc_rack(e2));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    token_metadata->update_topology(e2, get_dc_rack(e2));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "1"}
     });
-    token_metadata.update_normal_tokens({t1}, e1).get();
-    token_metadata.add_bootstrap_token(t2, e2);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(0), ks_name),
+    token_metadata->update_normal_tokens({t1}, e1).get();
+    token_metadata->add_bootstrap_token(t2, e2);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(0), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
         inet_address_vector_topology_change{});
 }
 
@@ -94,25 +94,25 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_bootstrap_with_replicas) {
     const auto e2 = inet_address("192.168.0.2");
     const auto e3 = inet_address("192.168.0.3");
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    token_metadata.update_topology(e2, get_dc_rack(e2));
-    token_metadata.update_topology(e3, get_dc_rack(e3));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    token_metadata->update_topology(e2, get_dc_rack(e2));
+    token_metadata->update_topology(e3, get_dc_rack(e3));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "2"}
     });
-    token_metadata.update_normal_tokens({t1, t1000}, e2).get();
-    token_metadata.update_normal_tokens({t10}, e3).get();
-    token_metadata.add_bootstrap_token(t100, e1);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_normal_tokens({t1, t1000}, e2).get();
+    token_metadata->update_normal_tokens({t10}, e3).get();
+    token_metadata->add_bootstrap_token(t100, e1);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
         inet_address_vector_topology_change{});
 }
 
@@ -127,26 +127,26 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_leave_with_replicas) {
     const auto e2 = inet_address("192.168.0.2");
     const auto e3 = inet_address("192.168.0.3");
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    token_metadata.update_topology(e2, get_dc_rack(e2));
-    token_metadata.update_topology(e3, get_dc_rack(e3));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    token_metadata->update_topology(e2, get_dc_rack(e2));
+    token_metadata->update_topology(e3, get_dc_rack(e3));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "2"}
     });
-    token_metadata.update_normal_tokens({t1, t1000}, e2).get();
-    token_metadata.update_normal_tokens({t10}, e3).get();
-    token_metadata.update_normal_tokens({t100}, e1).get();
-    token_metadata.add_leaving_endpoint(e1);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_normal_tokens({t1, t1000}, e2).get();
+    token_metadata->update_normal_tokens({t10}, e3).get();
+    token_metadata->update_normal_tokens({t100}, e1).get();
+    token_metadata->add_leaving_endpoint(e1);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
         inet_address_vector_topology_change{e2});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
         inet_address_vector_topology_change{e3});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
         inet_address_vector_topology_change{e3});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(101), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(101), ks_name),
         inet_address_vector_topology_change{});
 }
 
@@ -162,31 +162,31 @@ SEASTAR_THREAD_TEST_CASE(test_pending_endpoints_for_replace_with_replicas) {
     const auto e3 = inet_address("192.168.0.3");
     const auto e4 = inet_address("192.168.0.4");
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    token_metadata.update_topology(e2, get_dc_rack(e2));
-    token_metadata.update_topology(e3, get_dc_rack(e3));
-    token_metadata.update_topology(e4, get_dc_rack(e4));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    token_metadata->update_topology(e2, get_dc_rack(e2));
+    token_metadata->update_topology(e3, get_dc_rack(e3));
+    token_metadata->update_topology(e4, get_dc_rack(e4));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "2"}
     });
-    token_metadata.update_normal_tokens({t1000}, e1).get();
-    token_metadata.update_normal_tokens({t1, t100}, e2).get();
-    token_metadata.update_normal_tokens({t10}, e3).get();
-    token_metadata.add_replacing_endpoint(e3, e4);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(100), ks_name),
+    token_metadata->update_normal_tokens({t1000}, e1).get();
+    token_metadata->update_normal_tokens({t1, t100}, e2).get();
+    token_metadata->update_normal_tokens({t10}, e3).get();
+    token_metadata->add_replacing_endpoint(e3, e4);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(100), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1000), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1000), ks_name),
         inet_address_vector_topology_change{});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1001), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1001), ks_name),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(2), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(2), ks_name),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(10), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(10), ks_name),
         inet_address_vector_topology_change{e4});
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(11), ks_name),
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(11), ks_name),
         inet_address_vector_topology_change{});
 }
 
@@ -201,15 +201,15 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
     const auto e2 = inet_address("192.168.0.2");
     const auto e3 = inet_address("192.168.0.3");
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    token_metadata.update_topology(e2, get_dc_rack(e2));
-    token_metadata.update_topology(e3, get_dc_rack(e3));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    token_metadata->update_topology(e2, get_dc_rack(e2));
+    token_metadata->update_topology(e3, get_dc_rack(e3));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "2"}
     });
-    token_metadata.update_normal_tokens({t1, t1000}, e2).get();
-    token_metadata.update_normal_tokens({t10}, e3).get();
-    token_metadata.add_bootstrap_token(t100, e1);
+    token_metadata->update_normal_tokens({t1, t1000}, e2).get();
+    token_metadata->update_normal_tokens({t10}, e3).get();
+    token_metadata->add_bootstrap_token(t100, e1);
 
     auto check_endpoints = [&](int64_t t, inet_address_vector_replica_set expected_replicas,
         seastar::compat::source_location sl = seastar::compat::source_location::current())
@@ -217,7 +217,7 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
         BOOST_TEST_INFO("line: " << sl.line());
         const auto expected_set = std::unordered_set<inet_address>(expected_replicas.begin(),
             expected_replicas.end());
-        const auto actual_replicas = token_metadata.endpoints_for_reading(dht::token::from_int64(t), ks_name);
+        const auto actual_replicas = token_metadata->endpoints_for_reading(dht::token::from_int64(t), ks_name);
         BOOST_REQUIRE(actual_replicas.has_value());
         const auto actual_set = std::unordered_set<inet_address>(actual_replicas->begin(),
             actual_replicas->end());
@@ -228,14 +228,14 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
         seastar::compat::source_location sl = seastar::compat::source_location::current())
     {
         BOOST_TEST_INFO("line: " << sl.line());
-        BOOST_REQUIRE(!token_metadata.endpoints_for_reading(dht::token::from_int64(t), ks_name).has_value());
+        BOOST_REQUIRE(!token_metadata->endpoints_for_reading(dht::token::from_int64(t), ks_name).has_value());
     };
 
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
     check_no_endpoints(2);
 
-    token_metadata.set_read_new(locator::token_metadata::read_new_t::yes);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
+    token_metadata->set_read_new(locator::token_metadata::read_new_t::yes);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
 
     check_endpoints(2, {e3, e1});
     check_endpoints(10, {e3, e1});
@@ -252,14 +252,14 @@ SEASTAR_THREAD_TEST_CASE(test_replace_node_with_same_endpoint) {
     const auto t1 = dht::token::from_int64(1);
     const auto e1 = inet_address("192.168.0.1");
     auto token_metadata = create_token_metadata(e1);
-    token_metadata.update_topology(e1, get_dc_rack(e1));
-    const auto replication_strategy = simple_strategy(replication_strategy_config_options {
+    token_metadata->update_topology(e1, get_dc_rack(e1));
+    const auto replication_strategy = seastar::make_shared<simple_strategy>(replication_strategy_config_options {
         {"replication_factor", "2"}
     });
-    token_metadata.update_normal_tokens({t1}, e1).get();
-    token_metadata.add_replacing_endpoint(e1, e1);
-    token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
-    BOOST_REQUIRE_EQUAL(token_metadata.pending_endpoints_for(dht::token::from_int64(1), ks_name),
+    token_metadata->update_normal_tokens({t1}, e1).get();
+    token_metadata->add_replacing_endpoint(e1, e1);
+    token_metadata->update_pending_ranges(*replication_strategy, ks_name, get_dc_rack_fn).get();
+    BOOST_REQUIRE_EQUAL(token_metadata->pending_endpoints_for(dht::token::from_int64(1), ks_name),
         inet_address_vector_topology_change{e1});
-    BOOST_REQUIRE_EQUAL(token_metadata.get_endpoint(t1), e1);
+    BOOST_REQUIRE_EQUAL(token_metadata->get_endpoint(t1), e1);
 }

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -234,7 +234,7 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
     token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
     check_no_endpoints(2);
 
-    token_metadata.set_topology_transition_state(service::topology::transition_state::write_both_read_new);
+    token_metadata.set_read_new(locator::token_metadata::read_new_t::yes);
     token_metadata.update_pending_ranges(replication_strategy, ks_name, get_dc_rack_fn).get();
 
     check_endpoints(2, {e3, e1});

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -129,6 +129,10 @@ public:
         return _set;
     }
 
+    auto extract_vector() && noexcept {
+        return std::move(_vec);
+    }
+
     auto extract_set() && noexcept {
         return std::move(_set);
     }

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -95,7 +95,7 @@ concept TriviallyClearableSequence =
 
 template <typename T>
 concept Container = Iterable<T> && requires (T x, typename T::iterator it) {
-    { x.erase(it) } -> std::same_as<typename T::iterator>;
+    x.erase(it);
 };
 
 template <typename T>


### PR DESCRIPTION
This refactoring is a follow-up for https://github.com/scylladb/scylladb/pull/13376, move per keyspace data structures related to topology changes from `token_metadata` to `erm`.

We move `pending_endpoints` and `read_endpoints`, along with their computation logic, from `token_metadata` to `vnode_effective_replication_map`. The `vnode_effective_replication_map` seems more appropriate for them since it contains functionally similar `replication_map` and we will be able to reuse `pending_endpoints/read_endpoints` across keyspaces sharing the same `factory_key`.

At present, `pending_endpoints` and `read_endpoints` are updated in the `update_pending_ranges` function. The update logic comprises two parts - preparing data common to all keyspaces/replication_strategies, and calculating the `migration_info` for specific keyspaces. In this PR we introduce a new `topology_change_info` structure to hold the first part's data and create an `update_topology_change_info` function to update it. This structure will be used in `vnode_effective_replication_map` to compute `pending_endpoints` and `read_endpoints`. This enables the reuse of `topology_change_info` across all keyspaces, unlike the current `update_pending_ranges` implementation, which is another benefit of this refactoring.

The PR also optimises `replication_map` memory usage for the case `natural_endpoints_depend_on_token == false`. We store endpoints list only once with special key
instead of duplicating them for each `vnode` token.

The original `update_pending_ranges` remains unchanged during the PR commits, and will be removed entirely upon transitioning to the new implementation.