### PR TITLE
treewide: fix warnings from GCC-13

### DIFF
--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -389,7 +389,7 @@ struct extract_changes_visitor {
     }
 
     void partition_delete(const tombstone& t) {
-        _result[t.timestamp].partition_deletions = {t};
+        _result[t.timestamp].partition_deletions = partition_deletion{t};
     }
 
     constexpr bool finished() const { return false; }

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -35,7 +35,7 @@ struct compaction_state {
     compaction_backlog_tracker backlog_tracker;
 
     std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
-    owned_ranges_ptr owned_ranges_ptr;
+    compaction::owned_ranges_ptr owned_ranges_ptr;
 
     explicit compaction_state(table_state& t);
     compaction_state(compaction_state&&) = delete;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1486,7 +1486,6 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     // to a mv not finding its schema when snapshoting since the main table
     // was already dropped (see https://github.com/scylladb/scylla/issues/5614)
     auto& db = proxy.local().get_db();
-    auto ts = db_clock::now();
     co_await max_concurrent_for_each(views_diff.dropped, max_concurrent, [&db] (schema_diff::dropped_schema& dt) {
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, s.ks_name(), s.cf_name());

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -51,8 +51,8 @@ public:
     };
 
 private:
-    const topology* _topology;
-    host_id _host_id;
+    const locator::topology* _topology;
+    locator::host_id _host_id;
     inet_address _endpoint;
     endpoint_dc_rack _dc_rack;
     state _state;
@@ -67,11 +67,11 @@ public:
     node(const node&) = delete;
     node(node&&) = delete;
 
-    const topology* topology() const noexcept {
+    const locator::topology* topology() const noexcept {
         return _topology;
     }
 
-    const host_id& host_id() const noexcept {
+    const locator::host_id& host_id() const noexcept {
         return _host_id;
     }
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -39,12 +39,12 @@ struct active_read {
 };
 
 struct awaited_index {
-    promise<> promise;
+    seastar::promise<> promise;
     optimized_optional<abort_source::subscription> abort;
 };
 
 struct awaited_conf_change {
-    promise<> promise;
+    seastar::promise<> promise;
     optimized_optional<abort_source::subscription> abort;
 };
 


### PR DESCRIPTION
this series silences the warnings from GCC 13. some of these changes are considered as critical fixes, and posted separately.

see also #13243