### PR TITLE
transport: capture reference to temp value by value

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -201,7 +201,7 @@ void cql_sg_stats::register_metrics()
 {
     namespace sm = seastar::metrics;
     std::vector<sm::metric_definition> transport_metrics;
-    auto& cur_sg_name = current_scheduling_group().name();
+    auto cur_sg_name = current_scheduling_group().name();
 
     for (uint8_t i = 0; i < static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT); ++i) {
         cql_binary_opcode opcode = cql_binary_opcode{i};


### PR DESCRIPTION
`current_scheduling_group()` returns a temporary value, and `name()` returns a reference, so we cannot capture the return value by reference, and use the reference after this expression is evaluated. this would cause undefined behavior. so let's just capture it by value.

this change also silence following warning from GCC-13:

```
/home/kefu/dev/scylladb/transport/server.cc:204:11: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  204 |     auto& cur_sg_name = current_scheduling_group().name();
      |           ^~~~~~~~~~~
/home/kefu/dev/scylladb/transport/server.cc:204:56: note: the temporary was destroyed at the end of the full expression ‘seastar::current_scheduling_group().seastar::scheduling_group::name()’
  204 |     auto& cur_sg_name = current_scheduling_group().name();
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

Fixes #13719
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>