### PR TITLE
cql3: capture reference to temporary value by value

### DIFF
--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -65,7 +65,8 @@ void cql3::statements::authorization_statement::maybe_correct_resource(auth::res
             // This is an "ALL FUNCTIONS IN KEYSPACE" resource.
             return;
         }
-        const auto& utm = qp.db().find_keyspace(*keyspace).user_types();
+        auto ks = qp.db().find_keyspace(*keyspace);
+        const auto& utm = ks.user_types();
         auto function_name = *functions_view.function_name();
         auto function_args = functions_view.function_args();
         std::vector<data_type> parsed_types;


### PR DESCRIPTION
`data_dictionary::database::find_keyspace()` returns a temporary
object, and `data_dictionary::keyspace::user_types()` returns a
references pointing to a member of this temporary object. so we
cannot use the reference after the expression is evaluated. in
this change, we capture the return value of `find_keyspace()` using
universal reference, and keep the return value of `user_types()`
with a reference, to ensure us that we can use it later.

this change silences the warning from GCC-13, like:

```
/home/kefu/dev/scylladb/cql3/statements/authorization_statement.cc:68:21: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
   68 |         const auto& utm = qp.db().find_keyspace(*keyspace).user_types();
      |                     ^~~
```

Fixes https://github.com/scylladb/scylladb/issues/13725
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>