### PR TITLE
cql3: do not capture reference to temporary value

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -516,7 +516,8 @@ bool statement_restrictions::has_eq_restriction_on_column(const column_definitio
 std::vector<const column_definition*> statement_restrictions::get_column_defs_for_filtering(data_dictionary::database db) const {
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
-        auto& sim = db.find_column_family(_schema).get_index_manager();
+        auto cf = db.find_column_family(_schema);
+        auto& sim = cf.get_index_manager();
         auto opt_idx = std::get<0>(find_idx(sim));
         auto column_uses_indexing = [&opt_idx] (const column_definition* cdef, const expr::expression* single_col_restr) {
             return opt_idx && single_col_restr && is_supported_by(*single_col_restr, *opt_idx);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -900,7 +900,8 @@ indexed_table_select_statement::prepare(data_dictionary::database db,
                                          cql_stats &stats,
                                          std::unique_ptr<attributes> attrs)
 {
-    auto& sim = db.find_column_family(schema).get_index_manager();
+    auto cf = db.find_column_family(schema);
+    auto& sim = cf.get_index_manager();
     auto [index_opt, used_index_restrictions] = restrictions->find_idx(sim);
     if (!index_opt) {
         throw std::runtime_error("No index found.");


### PR DESCRIPTION
`data_dictionary::database::find_column_family()` return a temporary value,
and `data_dictionary::table::get_index_manager()` returns a reference in
this temporary value, so we cannot capture this reference and use it after
the expression is evaluated. in this change, we keep the return value
of `find_column_family()` by value, to extend the lifecycle of the return
value of `get_index_manager()`.

this should address the warning from GCC-13, like:

```
/home/kefu/dev/scylladb/cql3/restrictions/statement_restrictions.cc:519:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  519 |         auto& sim = db.find_column_family(_schema).get_index_manager();
      |               ^~~
```

Fixes https://github.com/scylladb/scylladb/issues/13727