### PR TITLE
build: update frozen toolchain to Fedora 38

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -52,6 +52,9 @@ debian_base_packages=(
 
 fedora_packages=(
     clang
+    compiler-rt
+    libasan
+    libubsan
     gdb
     lua-devel
     yaml-cpp-devel

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:37
+FROM docker.io/fedora:38
 ADD ./install-dependencies.sh ./
 ADD ./seastar/install-dependencies.sh ./seastar/
 ADD ./tools/jmx/install-dependencies.sh ./tools/jmx/

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-20230424
+docker.io/scylladb/scylla-toolchain:fedora-38-20230729


### PR DESCRIPTION
This refreshes clang to 16.0.1 and libstdc++ to 13.1.1.