### PR TITLE
cql3: fix spurious token names in syntax error messages

### DIFF
--- a/test/cql/lwt_test.result
+++ b/test/cql/lwt_test.result
@@ -1047,8 +1047,7 @@ OK
 +-------------+-----+
 > -- OR predicate: Cassandra users do not deserve it :(
 > update lwt set c=0 where a = 1 if c = 1 or c = 1;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:40  : syntax error...
-">
+<Error from server: code=2000 [Syntax error in CQL query] message="line 1:40 : Syntax error">
 > -- null
 > update lwt set c=0 where a = 1 if c = null;
 +-------------+-----+

--- a/test/cql/query_bounds_test.result
+++ b/test/cql/query_bounds_test.result
@@ -248,20 +248,17 @@ Error from server: code=2200 [Invalid query] message="Expected 2 elements in val
 > 
 > -- missing values --
 > SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:64  : syntax error...
-">
+<Error from server: code=2000 [Syntax error in CQL query] message="line 1:64 : Syntax error">
 > 
 > -- not tuple  --
 > SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND 45;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:65 missing '(' at '<missing '">
+<Error from server: code=2000 [Syntax error in CQL query] message="line 1:65 : Missing '('">
 > 
 > -- just wrong  --
 > SELECT * FROM foo WHERE a=0 SCYLLA_CLUSTERING_BOUND AND (b, c) > (0, 1);
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:28  : syntax error...
-">
+<Error from server: code=2000 [Syntax error in CQL query] message="line 1:28 : Syntax error">
 > SELECT * FROM foo WHERE a=0 AND (b, c) > (0, 1) SCYLLA_CLUSTERING_BOUND;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:48  : syntax error...
-">
+<Error from server: code=2000 [Syntax error in CQL query] message="line 1:48 : Syntax error">
 > 
 > -- mixing apples and make_count_rows_function
 > SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND(2, 0)  AND (b, c) < (1, 1);


### PR DESCRIPTION
We have known for a long time (see issue #1703) that the quality of our CQL "syntax error" messages leave a lot to be desired, especially when compared to Cassandra. This patch doesn't yet bring us great error messages with great context - doing this isn't easy and it appears that Antlr3's C++ runtime isn't as good as the Java one in this regard - but this patch at least fixes **garbage** printed in some error messages.

Specifically, when the parser can deduce that a specific token is missing, it used to print

    line 1:83 missing ')' at '<missing '

After this patch we get rid of the meaningless string '<missing ':

    line 1:83 : Missing ')'

Also, when the parser deduced that a specific token was unneeded, it used to print:

    line 1:83 extraneous input ')' expecting <invalid>

Now we got rid of this silly "<invalid>" and write just:

    line 1:83 : Unexpected ')'

Refs #1703. I didn't yet marked that issue "fixed" because I think a complete fix would also require printing the entire misparsed line and the point of the parse failure. Scylla still prints a generic "Syntax Error" in most cases now, and although the character number (83 in the above example) can help, it's much more useful to see the actual failed statement and where character 83 is.