### PR TITLE
everywhere: optimize calls to make_flat_mutation_reader_from_mutations_v2 with single mutation

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -589,7 +589,7 @@ public:
         , _create_reader(std::move(create_reader))
         , _filter(std::move(filter))
         , _dummy_reader(make_flat_mutation_reader_from_mutations_v2(_query_schema,
-                std::move(permit), {mutation(_query_schema, std::move(pk))}, _query_schema->full_slice(), fwd_sm))
+                std::move(permit), mutation(_query_schema, std::move(pk)), _query_schema->full_slice(), fwd_sm))
         , _reversed(reversed)
     {
         while (_it != _end && !this->filter(*_it->second)) {
@@ -885,7 +885,7 @@ sstable_set_impl::create_single_key_sstable_reader(
     // all sstables actually containing the partition were filtered.
     auto num_readers = readers.size();
     if (num_readers != num_sstables) {
-        readers.push_back(make_flat_mutation_reader_from_mutations_v2(schema, permit, {mutation(schema, *pos.key())}, slice, fwd));
+        readers.push_back(make_flat_mutation_reader_from_mutations_v2(schema, permit, mutation(schema, *pos.key()), slice, fwd));
     }
     sstable_histogram.add(num_readers);
     return make_combined_reader(schema, std::move(permit), std::move(readers), fwd, fwd_mr);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -86,7 +86,7 @@ snapshot_source make_decorated_snapshot_source(snapshot_source src, std::functio
 mutation_source make_source_with(mutation m) {
     return mutation_source([m] (schema_ptr s, reader_permit permit, const dht::partition_range&, const query::partition_slice&, const io_priority_class&, tracing::trace_state_ptr, streamed_mutation::forwarding fwd) {
         assert(m.schema() == s);
-        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), {m}, std::move(fwd));
+        return make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd));
     });
 }
 
@@ -289,7 +289,7 @@ void test_cache_delegates_to_underlying_only_once_with_single_partition(schema_p
             streamed_mutation::forwarding fwd) {
         assert(m.schema() == s);
         if (range.contains(dht::ring_position(m.decorated_key()), dht::ring_position_comparator(*s))) {
-            return make_counting_reader(make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), {m}, std::move(fwd)), secondary_calls_count);
+            return make_counting_reader(make_flat_mutation_reader_from_mutations_v2(s, std::move(permit), m, std::move(fwd)), secondary_calls_count);
         } else {
             return make_counting_reader(make_empty_flat_reader_v2(s, std::move(permit)), secondary_calls_count);
         }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3081,7 +3081,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         sstable_writer_config sst_cfg = env.manager().configure_writer();
         sst_cfg.run_identifier = partial_sstable_run_identifier;
-        auto partial_sstable_run_sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), { std::move(mut) }), sst_cfg);
+        auto partial_sstable_run_sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut)), sst_cfg);
 
         column_family_test(cf).add_sstable(partial_sstable_run_sst).get();
         column_family_test::update_sstables_known_generation(*cf, partial_sstable_run_sst->generation());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1761,7 +1761,7 @@ SEASTAR_TEST_CASE(test_repeated_tombstone_skipping) {
         for (auto&& mf : fragments) {
             mut.apply(mf);
         }
-        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), { std::move(mut) }), cfg, version);
+        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), std::move(mut)), cfg, version);
         auto ms = as_mutation_source(sst);
 
         for (uint32_t i = 3; i < seq; i++) {
@@ -2502,7 +2502,7 @@ SEASTAR_TEST_CASE(sstable_run_identifier_correctness) {
 
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.run_identifier = sstables::run_id::create_random_id();
-        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), { std::move(mut) }), cfg);
+        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut)), cfg);
 
         BOOST_REQUIRE(sst->run_identifier() == cfg.run_identifier);
     });
@@ -2679,7 +2679,7 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
         for (const auto version : writable_sstable_versions) {
             testlog.info("version={}", version);
 
-            auto mr = make_flat_mutation_reader_from_mutations_v2(ss.schema(), env.make_reader_permit(), {mut});
+            auto mr = make_flat_mutation_reader_from_mutations_v2(ss.schema(), env.make_reader_permit(), mut);
             sstable_writer_config cfg = env.manager().configure_writer();
             auto sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);
 
@@ -2782,13 +2782,13 @@ SEASTAR_TEST_CASE(test_sstable_origin) {
             }
 
             // Test empty sstable_origin.
-            auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+            auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
             sstable_writer_config cfg = env.manager().configure_writer("");
             auto sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);
             BOOST_REQUIRE_EQUAL(sst->get_origin(), "");
 
             // Test that a random sstable_origin is stored and retrieved properly.
-            mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+            mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
             sstring origin = fmt::format("test-{}", tests::random::get_sstring());
             cfg = env.manager().configure_writer(origin);
             sst = make_sstable_easy(env, std::move(mr), cfg, version, 0);

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -36,7 +36,7 @@ SEASTAR_TEST_CASE(test_sstables_sstable_set_read_modify_write) {
         auto mut = mutation(s, pk);
         ss.add_row(mut, ss.make_ckey(0), "val");
 
-        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
         sstable_writer_config cfg = env.manager().configure_writer("");
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
 
@@ -44,7 +44,7 @@ SEASTAR_TEST_CASE(test_sstables_sstable_set_read_modify_write) {
         BOOST_REQUIRE_EQUAL(ss1->all()->size(), 1);
 
         // Test that a random sstable_origin is stored and retrieved properly.
-        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
         auto sst2 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss2 = make_lw_shared<sstables::sstable_set>(*ss1);
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         ss.add_row(mut, ss.make_ckey(0), "val");
         sstable_writer_config cfg = env.manager().configure_writer("");
 
-        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+        auto mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss1 = make_lw_shared<time_series_sstable_set>(ss.schema(), true);
@@ -72,7 +72,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_read_modify_write) {
         BOOST_REQUIRE_EQUAL(ss1->all()->size(), 1);
 
         // Test that a random sstable_origin is stored and retrieved properly.
-        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), {mut});
+        mr = make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), mut);
         auto sst2 = make_sstable_easy(env, std::move(mr), cfg);
 
         auto ss2 = make_lw_shared<time_series_sstable_set>(*ss1);

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -443,7 +443,7 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
             auto& pc = service::get_local_streaming_priority();
 
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), {m}), 1ul, s, sst_cfg, {}, pc).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;
@@ -557,7 +557,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         auto& pc = service::get_local_streaming_priority();
 
         auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), {m}), 1ul, s, sst_cfg, {}, pc).get();
+        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
         sst->open_data().get();
         t->add_sstable_and_update_cache(sst).get();
 
@@ -631,7 +631,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
             auto& pc = service::get_local_streaming_priority();
 
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), {m}), 1ul, s, sst_cfg, {}, pc).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -288,7 +288,7 @@ PERF_TEST_F(clustering_combined, ranges_generic)
         boost::copy_range<std::vector<flat_mutation_reader_v2>>(
             almost_disjoint_clustering_ranges()
             | boost::adaptors::transformed([this] (auto&& mb) {
-                return make_flat_mutation_reader_from_mutations_v2(schema().schema(), permit(), {std::move(mb.m)});
+                return make_flat_mutation_reader_from_mutations_v2(schema().schema(), permit(), std::move(mb.m));
             })
         )
     ));
@@ -299,7 +299,7 @@ PERF_TEST_F(clustering_combined, ranges_specialized)
     auto rbs = boost::copy_range<std::vector<reader_bounds>>(
         almost_disjoint_clustering_ranges() | boost::adaptors::transformed([this] (auto&& mb) {
             return reader_bounds{
-                make_flat_mutation_reader_from_mutations_v2(schema().schema(), permit(), {std::move(mb.m)}),
+                make_flat_mutation_reader_from_mutations_v2(schema().schema(), permit(), std::move(mb.m)),
                 std::move(mb.lower), std::move(mb.upper)};
         }));
     auto q = std::make_unique<simple_position_reader_queue>(*schema().schema(), std::move(rbs));


### PR DESCRIPTION
No point in going through the vector<mutation> entry-point just to discover in run time that it was called
with a single-element vector, when we know that
in advance.