### PR TITLE
scylla_raid_setup: wipe filesystem signatures from specified disks

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -125,9 +125,12 @@ if __name__ == '__main__':
                 procs.append(proc)
     for proc in procs:
         proc.wait()
+    for disk in disks:
+        run(f'wipefs -a {disk}', shell=True, check=True)
     if raid:
         run('udevadm settle', shell=True, check=True)
         run('mdadm --create --verbose --force --run {raid} --level={level} -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, level=args.raid_level, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
+        run(f'wipefs -a {fsdev}', shell=True, check=True)
         run('udevadm settle', shell=True, check=True)
 
     major_minor = os.stat(fsdev).st_rdev
@@ -138,7 +141,7 @@ if __name__ == '__main__':
     # and it also cannot be smaller than the sector size.
     block_size = max(1024, sector_size)
     run('udevadm settle', shell=True, check=True)
-    run(f'mkfs.xfs -b size={block_size} {fsdev} -f -K', shell=True, check=True)
+    run(f'mkfs.xfs -b size={block_size} {fsdev} -K', shell=True, check=True)
     run('udevadm settle', shell=True, check=True)
 
     if is_debian_variant():


### PR DESCRIPTION
The discussion on the thread says, when we reformat a volume with another filesystem, kernel and libblkid may skip to populate /dev/disk/by-* since it detected two filesystem signatures, because mkfs.xxx did not cleared previous filesystem signature.
To avoid this, we need to run wipefs before running mkfs.

Also dropped -f option from mkfs.xfs, it will check wipefs is working as we expected.

Closes #13737