### PR TITLE
mutation/mutation_compactor: validate range tombstone change before it is moved

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -269,7 +269,7 @@ public:
     compact_mutation_state(compact_mutation_state&&) = delete; // Because 'this' is captured
 
     compact_mutation_state(const schema& s, gc_clock::time_point query_time, const query::partition_slice& slice, uint64_t limit,
-              uint32_t partition_limit)
+              uint32_t partition_limit, mutation_fragment_stream_validation_level validation_level = mutation_fragment_stream_validation_level::token)
         : _schema(s)
         , _query_time(query_time)
         , _can_gc(always_gc)
@@ -280,7 +280,7 @@ public:
         , _tombstone_gc_state(nullptr)
         , _last_dk({dht::token(), partition_key::make_empty()})
         , _last_pos(position_in_partition::for_partition_end())
-        , _validator("mutation_compactor for read", _schema, mutation_fragment_stream_validation_level::token)
+        , _validator("mutation_compactor for read", _schema, validation_level)
     {
         static_assert(!sstable_compaction(), "This constructor cannot be used for sstable compaction.");
     }

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -197,8 +197,8 @@ private:
         if (_current_emitted_tombstone || (rtc.tombstone() && !can_purge)) {
             partition_is_not_empty(consumer);
             _current_emitted_tombstone = rtc.tombstone();
-            consumer_stop = consumer.consume(std::move(rtc));
             _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
+            consumer_stop = consumer.consume(std::move(rtc));
         }
         return gc_consumer_stop || consumer_stop;
     }


### PR DESCRIPTION
e2c9cdb576c2186719ce7181dd6619f1994e262e moved the validation of the range tombstone change to the place where it is actually consumed, so we don't attempt to pass purged or discarded range tombstones to the validator. In doing so however, the validate pass was moved after the consume call, which moves the range tombstone change, the validator having been passed a moved-from range tombstone. Fix this by moving he validation to before the consume call.

Refs: #12575