### PR TITLE
test: issue a read barrier before checking ring consistency

### DIFF
--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -7,10 +7,12 @@
 Test consistency of schema changes with topology changes.
 """
 import logging
+import pytest 
 import time
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from cassandra.protocol import InvalidRequest, ConfigurationException
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 
 
 logger = logging.getLogger(__name__)
@@ -36,6 +38,9 @@ async def get_current_group0_config(manager: ManagerClient, srv: ServerInfo) -> 
      """
     assert manager.cql
     host = (await wait_for_cql_and_get_hosts(manager.cql, [srv], time.time() + 60))[0]
+    # Issue a read barrer on that host. 
+    with pytest.raises(InvalidRequest, match="nosuch"):
+        _ = await manager.cql.run_async("alter table nosuchkeyspace.nosuchtable with comment=''", host = host)
     group0_id = (await manager.cql.run_async(
         "select value from system.scylla_local where key = 'raft_group0_id'",
         host=host))[0].value


### PR DESCRIPTION
Raft replication doesn't guarantee that all replicas see identical Raft state at all times, it only guarantees the same order of events on all replicas.

When comparing raft state with gossip state on a node, first issue a read barrier to ensure the node has the latest raft state.

To issue a read barrier it is sufficient to alter a non-existing state: in order to validate the DDL the node needs to sync with the leader and fetch its latest group0 state.

Fixes #13518 (flaky topology test).