### PR TITLE
compaction: disambiguate format_to()

### DIFF
--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -62,7 +62,7 @@ struct formatter<compaction::table_state> : formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const compaction::table_state& t, FormatContext& ctx) const {
         auto s = t.schema();
-        return format_to(ctx.out(), "{}.{} compaction_group={}", s->ks_name(), s->cf_name(), t.get_group_id());
+        return fmt::format_to(ctx.out(), "{}.{} compaction_group={}", s->ks_name(), s->cf_name(), t.get_group_id());
     }
 };
 


### PR DESCRIPTION
we should always qualify `format_to` with its namespace. otherwise we'd have following failure when compiling with libstdc++ from GCC-13:

```
/home/kefu/dev/scylladb/compaction/table_state.hh:65:16: error: call to 'format_to' is ambiguous
        return format_to(ctx.out(), "{}.{} compaction_group={}", s->ks_name(), s->cf_name(), t.get_group_id());
               ^~~~~~~~~
```