### PR TITLE
 mvcc: make schema upgrades gentle

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -487,7 +487,7 @@ mutation_partition& view_updates::partition_for(partition_key&& key) {
     if (it != _updates.end()) {
         return it->second;
     }
-    return _updates.emplace(std::move(key), mutation_partition(_view)).first->second;
+    return _updates.emplace(std::move(key), mutation_partition(*_view)).first->second;
 }
 
 size_t view_updates::op_count() const {

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -13,13 +13,13 @@
 mutation::data::data(dht::decorated_key&& key, schema_ptr&& schema)
     : _schema(std::move(schema))
     , _dk(std::move(key))
-    , _p(_schema)
+    , _p(*_schema)
 { }
 
 mutation::data::data(partition_key&& key_, schema_ptr&& schema)
     : _schema(std::move(schema))
     , _dk(dht::decorate_key(*_schema, std::move(key_)))
-    , _p(_schema)
+    , _p(*_schema)
 { }
 
 mutation::data::data(schema_ptr&& schema, dht::decorated_key&& key, const mutation_partition& mp)

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -90,6 +90,9 @@ public:
     void apply(const schema& s, const deletable_row& r) {
         _row.apply(s, r);
     }
+    void apply(const schema& our_schema, const schema& their_schema, const deletable_row& r) {
+        _row.apply(our_schema, their_schema, r);
+    }
 
     position_in_partition_view position() const;
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1581,6 +1581,16 @@ row::row(const schema& s, column_kind kind, const row& o) : _size(o._size)
     _cells.clone_from(o._cells, clone_cell_and_hash);
 }
 
+row row::construct(const schema& our_schema, const schema& their_schema, column_kind kind, const row& o) {
+    if (our_schema.version() == their_schema.version()) {
+        return row(our_schema, kind, o);
+    } else {
+        row r;
+        r.apply(our_schema, their_schema, kind, o);
+        return r;
+    }
+}
+
 row::~row() {
 }
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -243,21 +243,6 @@ void mutation_partition::ensure_last_dummy(const schema& s) {
     }
 }
 
-void mutation_partition::apply(const schema& s, const mutation_partition& p, const schema& p_schema,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, p, p_schema, app_stats);
-}
-
-void mutation_partition::apply(const schema& s, mutation_partition&& p,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, std::move(p), app_stats);
-}
-
-void mutation_partition::apply(const schema& s, mutation_partition_view p, const schema& p_schema,
-        mutation_application_stats& app_stats) {
-    apply_weak(s, p, p_schema, app_stats);
-}
-
 struct mutation_fragment_applier {
     const schema& _s;
     mutation_partition& _mp;
@@ -508,7 +493,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
 }
 
 void
-mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
+mutation_partition::apply(const schema& s, mutation_partition_view p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
     mutation_partition p2(*this, copy_comparators_only{});
@@ -517,13 +502,13 @@ mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
     apply_monotonically(s, std::move(p2), p_schema, app_stats);
 }
 
-void mutation_partition::apply_weak(const schema& s, const mutation_partition& p,
+void mutation_partition::apply(const schema& s, const mutation_partition& p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
     apply_monotonically(s, mutation_partition(p_schema, p), p_schema, app_stats);
 }
 
-void mutation_partition::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
+void mutation_partition::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
     apply_monotonically(s, std::move(p), no_cache_tracker, app_stats);
 }
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -489,7 +489,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
     if (s.version() == p_schema.version()) {
         return apply_monotonically(s, std::move(p), no_cache_tracker, app_stats, preemptible, res);
     } else {
-        mutation_partition p2(s, p);
+        mutation_partition p2(p_schema, p);
         p2.upgrade(p_schema, s);
         return apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::no, res); // FIXME: make preemptible
     }
@@ -520,7 +520,7 @@ mutation_partition::apply_weak(const schema& s, mutation_partition_view p,
 void mutation_partition::apply_weak(const schema& s, const mutation_partition& p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
-    apply_monotonically(s, mutation_partition(s, p), p_schema, app_stats);
+    apply_monotonically(s, mutation_partition(p_schema, p), p_schema, app_stats);
 }
 
 void mutation_partition::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1919,7 +1919,7 @@ bool row_marker::compact_and_expire(tombstone tomb, gc_clock::time_point now,
 mutation_partition mutation_partition::difference(schema_ptr s, const mutation_partition& other) const
 {
     check_schema(*s);
-    mutation_partition mp(s);
+    mutation_partition mp(*s);
     if (_tombstone > other._tombstone) {
         mp.apply(_tombstone);
     }
@@ -1979,7 +1979,7 @@ void mutation_partition::accept(const schema& s, mutation_partition_visitor& v) 
 void
 mutation_partition::upgrade(const schema& old_schema, const schema& new_schema) {
     // We need to copy to provide strong exception guarantees.
-    mutation_partition tmp(new_schema.shared_from_this());
+    mutation_partition tmp(new_schema);
     tmp.set_static_row_continuous(_static_row_continuous);
     converting_mutation_partition_applier v(old_schema.get_column_mapping(), new_schema, tmp);
     accept(old_schema, v);

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1007,6 +1007,9 @@ public:
     void apply_monotonically(const schema& s, rows_entry&& e) {
         _row.apply(s, std::move(e._row));
     }
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, rows_entry&& e) {
+        _row.apply_monotonically(our_schema, their_schema, std::move(e._row));
+    }
     bool empty() const {
         return _row.empty();
     }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1398,7 +1398,7 @@ public:
     // Returns the minimal mutation_partition that when applied to "other" will
     // create a mutation_partition equal to the sum of other and this one.
     // This and other must both be governed by the same schema s.
-    mutation_partition difference(schema_ptr s, const mutation_partition& other) const;
+    mutation_partition difference(const schema& s, const mutation_partition& other) const;
 
     // Returns a subset of this mutation holding only information relevant for given clustering ranges.
     // Range tombstones will be trimmed to the boundaries of the clustering ranges.

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -97,6 +97,7 @@ public:
     row();
     ~row();
     row(const schema&, column_kind, const row&);
+    static row construct(const schema& our_schema, const schema& their_schema, column_kind, const row&);
     row(row&& other) noexcept;
     row& operator=(row&& other) noexcept;
     size_t size() const { return _size; }
@@ -824,6 +825,11 @@ public:
         : _deleted_at(other._deleted_at)
         , _marker(other._marker)
         , _cells(s, column_kind::regular_column, other._cells)
+    { }
+    deletable_row(const schema& our_schema, const schema& their_schema, const deletable_row& other)
+        : _deleted_at(other._deleted_at)
+        , _marker(other._marker)
+        , _cells(row::construct(our_schema, their_schema, column_kind::regular_column, other._cells))
     { }
     deletable_row(row_tombstone&& tomb, row_marker&& marker, row&& cells)
         : _deleted_at(std::move(tomb)), _marker(std::move(marker)), _cells(std::move(cells))

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1279,14 +1279,14 @@ public:
     // is not representable in this_schema is dropped, thus apply() loses commutativity.
     //
     // Weak exception guarantees.
+    // Assumes this and p are not owned by a cache_tracker.
     void apply(const schema& this_schema, const mutation_partition& p, const schema& p_schema,
             mutation_application_stats& app_stats);
-    // Use in case this instance and p share the same schema.
-    // Same guarantees as apply(const schema&, mutation_partition&&, const schema&);
-    void apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
-    // Same guarantees and constraints as for apply(const schema&, const mutation_partition&, const schema&).
     void apply(const schema& this_schema, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
+    // Use in case this instance and p share the same schema.
+    // Same guarantees and constraints as for other variants of apply().
+    void apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -1319,15 +1319,6 @@ public:
     stop_iteration apply_monotonically(const schema& s, mutation_partition&& p, cache_tracker* tracker,
             mutation_application_stats& app_stats);
     stop_iteration apply_monotonically(const schema& s, mutation_partition&& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-
-    // Weak exception guarantees.
-    // Assumes this and p are not owned by a cache_tracker.
-    void apply_weak(const schema& s, const mutation_partition& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition&&,
-            mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition_view p, const schema& p_schema,
             mutation_application_stats& app_stats);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -972,6 +972,12 @@ public:
         , _range_tombstone(e._range_tombstone)
         , _flags(e._flags)
     { }
+    rows_entry(const schema& our_schema, const schema& their_schema, const rows_entry& e)
+        : _key(e._key)
+        , _row(our_schema, their_schema, e._row)
+        , _range_tombstone(e._range_tombstone)
+        , _flags(e._flags)
+    { }
     // Valid only if !dummy()
     clustering_key& key() {
         return _key;

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -422,6 +422,14 @@ public:
         get_existing().apply_monotonically(s, kind, std::move(src.get_existing()));
     }
 
+    // Monotonic exception guarantees
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, lazy_row&& src) {
+        if (src.empty()) {
+            return;
+        }
+        maybe_create().apply_monotonically(our_schema, their_schema, kind, std::move(src.get_existing()));
+    }
+
     // Expires cells based on query_time. Expires tombstones based on gc_before
     // and max_purgeable. Removes cells covered by tomb.
     // Returns true iff there are any live cells left.

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -178,10 +178,15 @@ public:
 
     // Weak exception guarantees
     void apply(const schema&, column_kind, const row& src);
-    // Weak exception guarantees
     void apply(const schema&, column_kind, row&& src);
+    void apply(const schema& our_schema, const schema& their_schema, column_kind kind, const row& other);
+    void apply(const schema& our_schema, const schema& their_schema, column_kind kind, row&& other);
+
     // Monotonic exception guarantees
     void apply_monotonically(const schema&, column_kind, row&& src);
+    void apply_monotonically(const schema&, column_kind, const row& src);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, row&& src);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, const row& src);
 
     // Expires cells based on query_time. Expires tombstones based on gc_before
     // and max_purgeable. Removes cells covered by tomb.
@@ -852,10 +857,15 @@ public:
 
     // Weak exception guarantees. After exception, both src and this will commute to the same value as
     // they would should the exception not happen.
-    void apply(const schema& s, const deletable_row& src);
-    void apply(const schema& s, deletable_row&& src);
-    void apply_monotonically(const schema& s, const deletable_row& src);
-    void apply_monotonically(const schema& s, deletable_row&& src);
+    void apply(const schema&, deletable_row&& src);
+    void apply(const schema&, const deletable_row& src);
+    void apply(const schema& our_schema, const schema& their_schema, const deletable_row& src);
+    void apply(const schema& our_schema, const schema& their_schema, deletable_row&& src);
+
+    void apply_monotonically(const schema&, deletable_row&& src);
+    void apply_monotonically(const schema&, const deletable_row& src);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, deletable_row&& src);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, const deletable_row& src);
 public:
     row_tombstone deleted_at() const { return _deleted_at; }
     api::timestamp_type created_at() const { return _marker.timestamp(); }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1005,7 +1005,7 @@ public:
         _row.apply(t);
     }
     void apply_monotonically(const schema& s, rows_entry&& e) {
-        _row.apply(s, std::move(e._row));
+        _row.apply_monotonically(s, std::move(e._row));
     }
     void apply_monotonically(const schema& our_schema, const schema& their_schema, rows_entry&& e) {
         _row.apply_monotonically(our_schema, their_schema, std::move(e._row));

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1203,11 +1203,11 @@ public:
     static mutation_partition make_incomplete(const schema& s, tombstone t = {}) {
         return mutation_partition(incomplete_tag(), s, t);
     }
-    mutation_partition(schema_ptr s)
+    mutation_partition(const schema& s)
         : _rows()
-        , _row_tombstones(*s)
+        , _row_tombstones(s)
 #ifdef SEASTAR_DEBUG
-        , _schema_version(s->version())
+        , _schema_version(s.version())
 #endif
     { }
     mutation_partition(mutation_partition& other, copy_comparators_only)

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -66,7 +66,7 @@ mutation_partition_v2::mutation_partition_v2(const schema& s, mutation_partition
     auto&& tombstones = x.mutable_row_tombstones();
     if (!tombstones.empty()) {
         try {
-            mutation_partition_v2 p(s.shared_from_this());
+            mutation_partition_v2 p(s);
 
             for (auto&& t: tombstones) {
                 range_tombstone & rt = t.tombstone();

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -510,7 +510,7 @@ mutation_partition_v2::apply_row_tombstone(const schema& schema, clustering_key_
 void
 mutation_partition_v2::apply_row_tombstone(const schema& schema, range_tombstone rt) {
     check_schema(schema);
-    mutation_partition mp(schema.shared_from_this());
+    mutation_partition mp(schema);
     mp.apply_row_tombstone(schema, std::move(rt));
     apply(schema, std::move(mp));
 }
@@ -919,7 +919,7 @@ void mutation_partition_v2::accept(const schema& s, mutation_partition_visitor& 
 void
 mutation_partition_v2::upgrade(const schema& old_schema, const schema& new_schema) {
     // We need to copy to provide strong exception guarantees.
-    mutation_partition tmp(new_schema.shared_from_this());
+    mutation_partition tmp(new_schema);
     tmp.set_static_row_continuous(_static_row_continuous);
     converting_mutation_partition_applier v(old_schema.get_column_mapping(), new_schema, tmp);
     accept(old_schema, v);
@@ -927,7 +927,7 @@ mutation_partition_v2::upgrade(const schema& old_schema, const schema& new_schem
 }
 
 mutation_partition mutation_partition_v2::as_mutation_partition(const schema& s) const {
-    mutation_partition tmp(s.shared_from_this());
+    mutation_partition tmp(s);
     tmp.set_static_row_continuous(_static_row_continuous);
     partition_builder v(s, tmp);
     accept(s, v);

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -215,7 +215,6 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, mutat
     alloc_strategy_unique_ptr<rows_entry> p_sentinel;
     alloc_strategy_unique_ptr<rows_entry> this_sentinel;
     auto insert_sentinel_back = defer([&] {
-        // Insert this_sentinel before sentinel so that the former lands before the latter in LRU.
         if (this_sentinel) {
             assert(p_i != p._rows.end());
             auto rt = this_sentinel->range_tombstone();

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -523,23 +523,7 @@ void mutation_partition_v2::apply(const schema& s, mutation_partition_v2&& p, mu
     apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
 }
 
-void
-mutation_partition_v2::apply_weak(const schema& s, mutation_partition_view p,
-                                  const schema& p_schema, mutation_application_stats& app_stats) {
-    // FIXME: Optimize
-    mutation_partition p2(p_schema.shared_from_this());
-    partition_builder b(p_schema, p2);
-    p.accept(p_schema, b);
-    apply_monotonically(s, mutation_partition_v2(p_schema, std::move(p2)), p_schema, app_stats);
-}
-
-void mutation_partition_v2::apply_weak(const schema& s, const mutation_partition& p,
-                                       const schema& p_schema, mutation_application_stats& app_stats) {
-    // FIXME: Optimize
-    apply_monotonically(s, mutation_partition_v2(s, p), p_schema, app_stats);
-}
-
-void mutation_partition_v2::apply_weak(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
+void mutation_partition_v2::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
     apply_monotonically(s, mutation_partition_v2(s, std::move(p)), no_cache_tracker, app_stats, is_evictable::no);
 }
 
@@ -557,7 +541,7 @@ mutation_partition_v2::apply_row_tombstone(const schema& schema, range_tombstone
     mutation_partition mp(schema.shared_from_this());
     mp.apply_row_tombstone(schema, std::move(rt));
     mutation_application_stats stats;
-    apply_weak(schema, std::move(mp), stats);
+    apply(schema, std::move(mp), stats);
 }
 
 void

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -178,7 +178,10 @@ public:
             mutation_application_stats& app_stats);
     // Use in case this instance and p share the same schema.
     // Same guarantees as apply(const schema&, mutation_partition_v2&&, const schema&);
+    // Weak exception guarantees.
+    // Assumes this and p are not owned by a cache_tracker and non-evictable.
     void apply(const schema& s, mutation_partition_v2&& p, mutation_application_stats& app_stats);
+    void apply(const schema& s, mutation_partition&&, mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -214,15 +217,6 @@ public:
             mutation_application_stats& app_stats);
     stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
             mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
-
-    // Weak exception guarantees.
-    // Assumes this and p are not owned by a cache_tracker and non-evictable.
-    void apply_weak(const schema& s, const mutation_partition& p, const schema& p_schema,
-                    mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition&&,
-                    mutation_application_stats& app_stats);
-    void apply_weak(const schema& s, mutation_partition_view p, const schema& p_schema,
-                    mutation_application_stats& app_stats);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed
     // using the new schema.

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -167,21 +167,11 @@ public:
     // prefix must not be full
     void apply_row_tombstone(const schema& schema, clustering_key_prefix prefix, tombstone t);
     void apply_row_tombstone(const schema& schema, range_tombstone rt);
-    //
     // Applies p to current object.
-    //
-    // Commutative when this_schema == p_schema. If schemas differ, data in p which
-    // is not representable in this_schema is dropped, thus apply() loses commutativity.
-    //
-    // Weak exception guarantees.
-    void apply(const schema& this_schema, const mutation_partition_v2& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    // Use in case this instance and p share the same schema.
-    // Same guarantees as apply(const schema&, mutation_partition_v2&&, const schema&);
     // Weak exception guarantees.
     // Assumes this and p are not owned by a cache_tracker and non-evictable.
-    void apply(const schema& s, mutation_partition_v2&& p, mutation_application_stats& app_stats);
-    void apply(const schema& s, mutation_partition&&, mutation_application_stats& app_stats);
+    void apply(const schema& s, mutation_partition&&);
+    void apply(const schema& s, mutation_partition_v2&& p, cache_tracker* = nullptr, is_evictable evictable = is_evictable::no);
 
     // Applies p to this instance.
     //
@@ -207,16 +197,8 @@ public:
     //
     // If is_preemptible::yes is passed, apply_resume must also be passed,
     // same instance each time until stop_iteration::yes is returned.
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
-            mutation_application_stats& app_stats, is_preemptible, apply_resume&, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-            mutation_application_stats& app_stats, is_preemptible, apply_resume&, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker* tracker,
-            mutation_application_stats& app_stats, is_evictable);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, const schema& p_schema,
-            mutation_application_stats& app_stats);
-    stop_iteration apply_monotonically(const schema& s, mutation_partition_v2&& p, cache_tracker*,
-            mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
+    stop_iteration apply_monotonically(const schema& this_schema, const schema& p_schema, mutation_partition_v2&& p,
+            cache_tracker*, mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed
     // using the new schema.

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -89,10 +89,10 @@ public:
     static mutation_partition_v2 make_incomplete(const schema& s, tombstone t = {}) {
         return mutation_partition_v2(incomplete_tag(), s, t);
     }
-    mutation_partition_v2(schema_ptr s)
+    mutation_partition_v2(const schema& s)
         : _rows()
 #ifdef SEASTAR_DEBUG
-        , _schema_version(s->version())
+        , _schema_version(s.version())
 #endif
     { }
     mutation_partition_v2(mutation_partition_v2& other, copy_comparators_only)

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -329,7 +329,7 @@ partition_version& partition_entry::add_version(const schema& s, cache_tracker* 
     // Such versions must be fully discontinuous, and thus have a dummy at the end.
     auto new_version = tracker
                        ? current_allocator().construct<partition_version>(mutation_partition_v2::make_incomplete(s))
-                       : current_allocator().construct<partition_version>(mutation_partition_v2(s.shared_from_this()));
+                       : current_allocator().construct<partition_version>(mutation_partition_v2(s));
     new_version->partition().set_static_row_continuous(_version->partition().static_row_continuous());
     new_version->insert_before(*_version);
     set_version(new_version);
@@ -548,7 +548,7 @@ utils::coroutine partition_entry::apply_to_incomplete(const schema& s,
 
 mutation_partition_v2 partition_entry::squashed(schema_ptr from, schema_ptr to, is_evictable evictable)
 {
-    mutation_partition_v2 mp(to);
+    mutation_partition_v2 mp(*to);
     mp.set_static_row_continuous(_version->partition().static_row_continuous());
     for (auto&& v : _version->all_elements()) {
         auto older = mutation_partition_v2(*from, v.partition());

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -577,7 +577,7 @@ mutation_partition partition_entry::squashed(const schema& s, is_evictable evict
     return squashed_v2(s, evictable).as_mutation_partition(s);
 }
 
-void partition_entry::upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
+void partition_entry::upgrade(logalloc::region& r, schema_ptr to, mutation_cleaner& cleaner, cache_tracker* tracker)
 {
   with_allocator(r.allocator(), [&] {
     auto new_version = r.allocator().construct<partition_version>(squashed_v2(*to, is_evictable(bool(tracker))), to);

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -644,7 +644,7 @@ std::ostream& operator<<(std::ostream& out, const partition_entry::printer& p) {
                 }
                 out << ") ";
             }
-            out << fmt::ptr(v) << ": " << mutation_partition_v2::printer(p._schema, v->partition());
+            out << fmt::ptr(v) << ": " << mutation_partition_v2::printer(*v->get_schema(), v->partition());
             v = v->next();
             first = false;
         }

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -120,12 +120,12 @@ inline Result squashed(const partition_version_ref& v, Map&& map, Reduce&& reduc
     return ::static_row(::squashed<row>(version(),
                          [&] (const mutation_partition_v2& mp) -> const row& {
                             if (digest_requested) {
-                                mp.static_row().prepare_hash(*_schema, column_kind::static_column);
+                                mp.static_row().prepare_hash(*schema(), column_kind::static_column);
                             }
                             return mp.static_row().get();
                          },
-                         [this] (const row& r) { return row(*_schema, column_kind::static_column, r); },
-                         [this] (row& a, const row& b) { a.apply(*_schema, column_kind::static_column, b); }));
+                         [this] (const row& r) { return row(*schema(), column_kind::static_column, r); },
+                         [this] (row& a, const row& b) { a.apply(*schema(), column_kind::static_column, b); }));
 }
 
 bool partition_snapshot::static_row_continuous() const {
@@ -141,12 +141,12 @@ tombstone partition_snapshot::partition_tombstone() const {
 mutation_partition partition_snapshot::squashed() const {
     return ::squashed<mutation_partition>(version(),
                                [this] (const mutation_partition_v2& mp) -> mutation_partition {
-                                   return mp.as_mutation_partition(*_schema);
+                                   return mp.as_mutation_partition(*schema());
                                },
                                [] (mutation_partition&& mp) { return std::move(mp); },
                                [this] (mutation_partition& a, const mutation_partition& b) {
                                    mutation_application_stats app_stats;
-                                   a.apply(*_schema, b, *_schema, app_stats);
+                                   a.apply(*schema(), b, *schema(), app_stats);
                                });
 }
 
@@ -604,7 +604,7 @@ partition_snapshot_ptr partition_entry::read(logalloc::region& r,
         }
     }
 
-    auto snp = make_lw_shared<partition_snapshot>(entry_schema, r, cleaner, this, tracker, phase);
+    auto snp = make_lw_shared<partition_snapshot>(r, cleaner, this, tracker, phase);
     _snapshot = snp.get();
     return partition_snapshot_ptr(std::move(snp));
 }

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -609,7 +609,6 @@ public:
     // When is_locked(), read() can only be called with a phase which is <= the phase of the current snapshot.
     partition_snapshot_ptr read(logalloc::region& region,
         mutation_cleaner&,
-        schema_ptr entry_schema,
         cache_tracker*,
         partition_snapshot::phase_type phase = partition_snapshot::default_phase);
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -601,7 +601,7 @@ public:
 
     // needs to be called with reclaiming disabled
     // Must not be called when is_locked().
-    void upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
+    void upgrade(logalloc::region& r, schema_ptr to, mutation_cleaner&, cache_tracker*);
 
     const schema_ptr& get_schema() const noexcept { return _version->get_schema(); }
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -80,21 +80,7 @@ class static_row;
 // When the partition_snapshot is destroyed partition_versions are squashed
 // together to minimize the amount of elements on the list.
 //
-// Scene IV. Schema upgrade
-//   pv    pv --- pv
-//   ^     ^      ^
-//   |     |      |
-//   pe    ps(u)  ps
-// When there is a schema upgrade the list of partition versions pointed to
-// by partition_entry is replaced by a new single partition_version that is a
-// result of squashing and upgrading the old versions.
-// Old versions not used by any partition snapshot are removed. The first
-// partition snapshot on the list is marked as unique which means that upon
-// its destruction it won't attempt to squash versions but instead remove
-// the unused ones and pass the "unique owner" mark the next snapshot on the
-// list (if there is any).
-//
-// Scene V. partition_entry eviction
+// Scene IV. partition_entry eviction
 //   pv
 //   ^
 //   |
@@ -104,12 +90,110 @@ class static_row;
 // upgrade scenario. The unused ones are destroyed right away and the first
 // snapshot on the list is marked as unique owner so that on its destruction
 // it continues removal of the partition versions.
+//
+
+// Schema upgrades
+//
+// After a schema change (e.g. a column is removed), the layout of existing
+// rows in memory becomes outdated and has to be adjusted before they are
+// emitted by a query expecting the newer schema.
+//
+// Rows can be upgraded on the fly during queries. But upgrades have a high CPU
+// cost, so we want them to happen only once. The upgraded row should be saved
+// in memory so that future queries don't have to upgrade it again.
+// And it should replace the old row as soon as possible (when there
+// the row is no longer reachable through the old schema) to conserve memory.
+//
+// This behavior is akin to MVCC. A schema upgrade can be thought of as a
+// special kind of update which affects all rows, and the MVCC machinery can be
+// naturally hijacked to implement it.
+//
+// Currently, we do it as follows:
+//
+// - Each MVCC version has its own schema pointer. Versions in the same chain
+//   can be of different schemas.
+//
+// - The schema of a partition entry is defined as the schema of the newest version.
+//   A partition entry upgrade is performed simply by inserting a new empty version with
+//   the new schema. (And triggering a background version merge by creating and immediately
+//   destroying a snapshot pointing at the previous newest version).
+//   Due to this, schemas of versions in the chain are ordered chronologically.
+//   (The order is important because it's forbidden to upgrade to an older version,
+//   because that's lossy -- e.g. a new column can be lost).
+//
+// - On read, the cursor upgrades rows on the fly to the cursor's schema.
+//   If the cursor reads the latest version, the upgraded rows are written to the latest
+//   version.
+//
+// - When versions are merged, rows are upgraded to the newer schema, the result of the
+//   merge has the newer schema.
+//
+//   This one is tricky. A natural idea is to merge older versions into the newer version,
+//   (upgrading rows when moving/copying them between versions), so that after a merge
+//   only the new version is left. But usually we want to merge in the other direction.
+//
+//   (When an database write arrives, we want to merge it into the existing
+//   older version, so that it has a cost proportional to the size of the
+//   write, not to the size of the existing version, which can be arbitrarily
+//   large. Doing otherwise would invite quadratic behaviour)
+//
+//   The merging algorithm is already very complicated and making it work in both
+//   directions (or adding a separate algorithm specifically for upgrades) would
+//   complicate things even further.
+//
+//   So instead, when two versions of different schema are merged, the older version
+//   (which also has the older schema) is first upgraded to the newer schema in a special
+//   upgrade process which only uses regular newer-into-older merging.
+//   This is done by appending a fresh empty version with the newer schema after
+//   the version-to-be-upgraded, and merging the version-to-be-upgraded into the new one.
+//   In the end, only the new version with the newer schema is left.
+//
+//   Technically the above procedure temporarily violates the rule that schema versions
+//   in the chain are ordered chronologically (which is needed for correctness).
+//   So while the above is happening, the version-to-be-upgraded has _is_being_upgraded set.
+//   A version with _is_being_upgraded is understood to be special in that its
+//   schema is older than its next neighbour's, and care is taken so that the
+//   neighbour isn't recursively downgraded back to the older schema.
+//   A version with _is_being_upgraded can be viewed together with its next() as
+//   conceptually a single version with the schema of next().
+//
+// The typical upgrade sequence, illustrated:
+//   1. Initial state:
+//        pv1 (s1)
+//        ^
+//        |
+//        pe
+//   2. partition_entry::upgrade(s2) is called. Empty pv2 is added.
+//        pv2 (s2) -- pv1 (s1)
+//        ^           ^
+//        |           |
+//        pe          ps1 (created and instantly dropped, so that merging is initiated)
+//   3. Some time later, mutation_cleaner calls merge_partition_versions(ps1).
+//      Merge of pv2 and pv1 is attempted.
+//      Schemas differ, so instead an upgrade of pv1 is initiated. Empty pv1' is added.
+//      pv1 is now conceptually "owned" by pv1', and no snapshot is allowed to point to it
+//      after this point.
+//        pv2 (s2) -- pv1 (s1, _is_being_upgraded) -- pv1' (s2)
+//        ^                                           ^
+//        |                                           |
+//        pe                                          ps1
+//   4. Eventually pv1 is fully upgrade-merged into pv1' and destroyed.
+//        pv2 (s2) -- pv1' (s2)
+//        ^           ^
+//        |           |
+//        pe          ps1
+//   5. Upgrade over, further merge proceeds as usual. Eventually pv2 is fully merged into pv1'.
+//        pv1' (s2)
+//        ^
+//        |
+//        pe
 
 class partition_version_ref;
 
 class partition_version : public anchorless_list_base_hook<partition_version> {
     partition_version_ref* _backref = nullptr;
     schema_ptr _schema;
+    bool _is_being_upgraded = false;
     mutation_partition_v2 _partition;
 
     friend class partition_version_ref;

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -120,7 +120,7 @@ public:
     }
 
     explicit partition_version(schema_ptr s) noexcept
-        : _partition(std::move(s)) { }
+        : _partition(*s) { }
     explicit partition_version(mutation_partition_v2 mp) noexcept
         : _partition(std::move(mp)) { }
     partition_version(partition_version&& pv) noexcept;

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -601,7 +601,7 @@ public:
 
     // needs to be called with reclaiming disabled
     // Must not be called when is_locked().
-    void upgrade(schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
+    void upgrade(logalloc::region& r, schema_ptr from, schema_ptr to, mutation_cleaner&, cache_tracker*);
 
     const schema_ptr& get_schema() const noexcept { return _version->get_schema(); }
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -613,10 +613,9 @@ public:
         partition_snapshot::phase_type phase = partition_snapshot::default_phase);
 
     class printer {
-        const schema& _schema;
         const partition_entry& _partition_entry;
     public:
-        printer(const schema& s, const partition_entry& pe) : _schema(s), _partition_entry(pe) { }
+        printer(const partition_entry& pe) : _partition_entry(pe) { }
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -268,7 +268,6 @@ public:
         }
     };
 private:
-    schema_ptr _schema;
     // Either _version or _entry is non-null.
     partition_version_ref _version;
     partition_entry* _entry;
@@ -282,13 +281,12 @@ private:
     friend class partition_entry;
     friend class mutation_cleaner_impl;
 public:
-    explicit partition_snapshot(schema_ptr s,
-                                logalloc::region& region,
+    explicit partition_snapshot(logalloc::region& region,
                                 mutation_cleaner& cleaner,
                                 partition_entry* entry,
                                 cache_tracker* tracker, // non-null for evictable snapshots
                                 phase_type phase = default_phase)
-        : _schema(std::move(s)), _entry(entry), _phase(phase), _region(&region), _cleaner(&cleaner), _tracker(tracker) { }
+        : _entry(entry), _phase(phase), _region(&region), _cleaner(&cleaner), _tracker(tracker) { }
     partition_snapshot(const partition_snapshot&) = delete;
     partition_snapshot(partition_snapshot&&) = delete;
     partition_snapshot& operator=(const partition_snapshot&) = delete;
@@ -370,7 +368,7 @@ public:
         return !version()->next();
     }
 
-    const schema_ptr& schema() const { return _schema; }
+    const schema_ptr& schema() const { return version()->get_schema(); }
     logalloc::region& region() const { return *_region; }
     cache_tracker* tracker() const { return _tracker; }
     mutation_cleaner& cleaner() { return *_cleaner; }

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -595,7 +595,7 @@ public:
         return *_version;
     }
 
-    mutation_partition_v2 squashed(schema_ptr from, schema_ptr to, is_evictable);
+    mutation_partition_v2 squashed_v2(const schema& to, is_evictable);
     mutation_partition squashed(const schema&, is_evictable);
     tombstone partition_tombstone() const;
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -523,24 +523,28 @@ public:
                const schema& mp_schema,
                mutation_application_stats& app_stats);
 
-    // Adds mutation_partition represented by "other" to the one represented
+    // Adds mutation_partition represented by "pe" to the one represented
     // by this entry.
     // This entry must be evictable.
+    // "pe" must be fully-continuous.
+    // (Alternatively: applies the "pe" memtable entry to "this" cache entry.)
     //
-    // The argument must be fully-continuous.
-    //
-    // The continuity of this entry remains unchanged. Information from "other"
+    // The continuity of this entry remains unchanged. Information from "pe"
     // which is incomplete in this instance is dropped. In other words, this
     // performs set intersection on continuity information, drops information
     // which falls outside of the continuity range, and applies regular merging
     // rules for the rest.
+    // (Rationale: updates from the memtable are only applied to intervals
+    // which were already in cache. The cache treats the entire sstable set as a
+    // single source -- it isn't able to store partial information only from a
+    // single sstable.)
     //
     // Weak exception guarantees.
-    // If an exception is thrown this and pe will be left in some valid states
+    // If an exception is thrown, "this" and "pe" will be left in some valid states
     // such that if the operation is retried (possibly many times) and eventually
     // succeeds the result will be as if the first attempt didn't fail.
     //
-    // The schema of pe must conform to s.
+    // The schema of "pe" must conform to "s".
     //
     // Returns a coroutine object representing the operation.
     // The coroutine must be resumed with the region being unlocked.

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -696,7 +696,7 @@ public:
 };
 
 partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
-    return _pe.read(mtbl.region(), mtbl.cleaner(), schema(), no_cache_tracker);
+    return _pe.read(mtbl.region(), mtbl.cleaner(), no_cache_tracker);
 }
 
 flat_mutation_reader_v2_opt

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -840,7 +840,7 @@ bool memtable::is_flushed() const noexcept {
 
 void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
-        partition().upgrade(r, schema(), s, cleaner, no_cache_tracker);
+        partition().upgrade(r, s, cleaner, no_cache_tracker);
     }
 }
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -868,7 +868,7 @@ std::ostream& operator<<(std::ostream& out, memtable& mt) {
 }
 
 std::ostream& operator<<(std::ostream& out, const memtable_entry& mt) {
-    return out << "{" << mt.key() << ": " << partition_entry::printer(*mt.schema(), mt.partition()) << "}";
+    return out << "{" << mt.key() << ": " << partition_entry::printer(mt.partition()) << "}";
 }
 
 }

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -840,16 +840,14 @@ bool memtable::is_flushed() const noexcept {
 
 void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
-        partition().upgrade(schema(), s, cleaner, no_cache_tracker);
+        partition().upgrade(r, schema(), s, cleaner, no_cache_tracker);
     }
 }
 
 void memtable::upgrade_entry(memtable_entry& e) {
     if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
-        with_allocator(allocator(), [this, &e] {
-            e.upgrade_schema(region(), _schema, cleaner());
-        });
+        e.upgrade_schema(region(), _schema, cleaner());
     }
 }
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -225,7 +225,7 @@ memtable::find_or_create_partition(const dht::decorated_key& key) {
     if (i == partitions.end() || !hint.match) {
         partitions_type::iterator entry = partitions.emplace_before(i,
                 key.token().raw(), hint,
-                _schema, dht::decorated_key(key), mutation_partition(_schema));
+                _schema, dht::decorated_key(key), mutation_partition(*_schema));
         ++nr_partitions;
         ++_table_stats.memtable_partition_insertions;
         if (!hint.emplace_keeps_iterators()) {
@@ -793,7 +793,7 @@ memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_han
     with_allocator(allocator(), [this, &m, &m_schema] {
         _allocating_section(*this, [&, this] {
             auto& p = find_or_create_partition_slow(m.key());
-            mutation_partition mp(m_schema);
+            mutation_partition mp(*m_schema);
             partition_builder pb(*m_schema, mp);
             m.partition().accept(*m_schema, pb);
             _stats_collector.update(*m_schema, mp);

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -838,7 +838,7 @@ bool memtable::is_flushed() const noexcept {
     return bool(_underlying);
 }
 
-void memtable_entry::upgrade_schema(const schema_ptr& s, mutation_cleaner& cleaner) {
+void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
     if (schema() != s) {
         partition().upgrade(schema(), s, cleaner, no_cache_tracker);
     }
@@ -848,7 +848,7 @@ void memtable::upgrade_entry(memtable_entry& e) {
     if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
         with_allocator(allocator(), [this, &e] {
-            e.upgrade_schema(_schema, cleaner());
+            e.upgrade_schema(region(), _schema, cleaner());
         });
     }
 }

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -696,7 +696,7 @@ public:
 };
 
 partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
-    return _pe.read(mtbl.region(), mtbl.cleaner(), _schema, no_cache_tracker);
+    return _pe.read(mtbl.region(), mtbl.cleaner(), schema(), no_cache_tracker);
 }
 
 flat_mutation_reader_v2_opt
@@ -821,8 +821,7 @@ mutation_source memtable::as_data_source() {
 }
 
 memtable_entry::memtable_entry(memtable_entry&& o) noexcept
-    : _schema(std::move(o._schema))
-    , _key(std::move(o._key))
+    : _key(std::move(o._key))
     , _pe(std::move(o._pe))
     , _flags(o._flags)
 { }
@@ -840,14 +839,13 @@ bool memtable::is_flushed() const noexcept {
 }
 
 void memtable_entry::upgrade_schema(const schema_ptr& s, mutation_cleaner& cleaner) {
-    if (_schema != s) {
-        partition().upgrade(_schema, s, cleaner, no_cache_tracker);
-        _schema = s;
+    if (schema() != s) {
+        partition().upgrade(schema(), s, cleaner, no_cache_tracker);
     }
 }
 
 void memtable::upgrade_entry(memtable_entry& e) {
-    if (e._schema != _schema) {
+    if (e.schema() != _schema) {
         assert(!reclaiming_enabled());
         with_allocator(allocator(), [this, &e] {
             e.upgrade_schema(_schema, cleaner());

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -68,7 +68,7 @@ public:
 
     // Makes the entry conform to given schema.
     // Must be called under allocating section of the region which owns the entry.
-    void upgrade_schema(const schema_ptr&, mutation_cleaner&);
+    void upgrade_schema(logalloc::region&, const schema_ptr&, mutation_cleaner&);
 
     size_t external_memory_usage_without_rows() const {
         return _key.key().external_memory_usage();

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -86,7 +86,7 @@ public:
     size_t size_in_allocator(allocation_strategy& allocator) {
         auto size = size_in_allocator_without_rows(allocator);
         for (auto&& v : _pe.versions()) {
-            size += v.size_in_allocator(*_schema, allocator);
+            size += v.size_in_allocator(allocator);
         }
         return size;
     }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -33,7 +33,6 @@ namespace bi = boost::intrusive;
 namespace replica {
 
 class memtable_entry {
-    schema_ptr _schema;
     dht::decorated_key _key;
     partition_entry _pe;
     struct {
@@ -52,9 +51,8 @@ public:
     friend class memtable;
 
     memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p)
-        : _schema(std::move(s))
-        , _key(std::move(key))
-        , _pe(*_schema, std::move(p))
+        : _key(std::move(key))
+        , _pe(*s, std::move(p))
     { }
 
     memtable_entry(memtable_entry&& o) noexcept;
@@ -65,8 +63,7 @@ public:
     dht::decorated_key& key() { return _key; }
     const partition_entry& partition() const { return _pe; }
     partition_entry& partition() { return _pe; }
-    const schema_ptr& schema() const { return _schema; }
-    schema_ptr& schema() { return _schema; }
+    const schema_ptr& schema() const { return _pe.get_schema(); }
     partition_snapshot_ptr snapshot(memtable& mtbl);
 
     // Makes the entry conform to given schema.

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1369,6 +1369,6 @@ std::ostream& operator<<(std::ostream& out, const cache_entry& e) {
     return out << "{cache_entry: " << e.position()
                << ", cont=" << e.continuous()
                << ", dummy=" << e.is_dummy_entry()
-               << ", " << partition_entry::printer(*e.schema(), e.partition())
+               << ", " << partition_entry::printer(e.partition())
                << "}";
 }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -846,7 +846,7 @@ cache_entry& row_cache::find_or_create_incomplete(const partition_start& ps, row
 
 cache_entry& row_cache::find_or_create_missing(const dht::decorated_key& key) {
     return do_find_or_create_entry(key, nullptr, [&] (auto i, const partitions_type::bound_hint& hint) {
-        mutation_partition mp(_schema);
+        mutation_partition mp(*_schema);
         bool cont = i->continuous();
         partitions_type::iterator entry = _partitions.emplace_before(i, key.token().raw(), hint,
                 _schema, key, std::move(mp));
@@ -1035,7 +1035,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
             // Partition is absent in underlying. First, insert a neutral partition entry.
             partitions_type::iterator entry = _partitions.emplace_before(cache_i, mem_e.key().token().raw(), hint,
                 cache_entry::evictable_tag(), _schema, dht::decorated_key(mem_e.key()),
-                partition_entry::make_evictable(*_schema, mutation_partition(_schema)));
+                partition_entry::make_evictable(*_schema, mutation_partition(*_schema)));
             entry->set_continuous(cache_i->continuous());
             _tracker.insert(*entry);
             mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1295,7 +1295,7 @@ flat_mutation_reader_v2 cache_entry::read(row_cache& rc, std::unique_ptr<read_co
 
 // Assumes reader is in the corresponding partition
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, reader.phase());
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, reader.phase());
     auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), reader.native_slice(), _key.key());
     schema_ptr entry_schema = to_query_domain(reader.slice(), schema());
     auto r = make_cache_flat_mutation_reader(entry_schema, _key, std::move(ckr), rc, reader, std::move(snp));
@@ -1305,7 +1305,7 @@ flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, read_context& reader
 }
 
 flat_mutation_reader_v2 cache_entry::do_read(row_cache& rc, std::unique_ptr<read_context> unique_ctx) {
-    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), schema(), &rc._tracker, unique_ctx->phase());
+    auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, unique_ctx->phase());
     auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), unique_ctx->native_slice(), _key.key());
     schema_ptr reader_schema = unique_ctx->schema();
     schema_ptr entry_schema = to_query_domain(unique_ctx->slice(), schema());

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1026,7 +1026,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
             upgrade_entry(entry);
             assert(entry.schema() == _schema);
             _tracker.on_partition_merge();
-            mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());
+            mem_e.upgrade_schema(_tracker.region(), _schema, _tracker.memtable_cleaner());
             return entry.partition().apply_to_incomplete(*_schema, std::move(mem_e.partition()), _tracker.memtable_cleaner(),
                 alloc, _tracker.region(), _tracker, _underlying_phase, acc);
         } else if (cache_i->continuous()
@@ -1038,7 +1038,7 @@ future<> row_cache::update(external_updater eu, replica::memtable& m) {
                 partition_entry::make_evictable(*_schema, mutation_partition(*_schema)));
             entry->set_continuous(cache_i->continuous());
             _tracker.insert(*entry);
-            mem_e.upgrade_schema(_schema, _tracker.memtable_cleaner());
+            mem_e.upgrade_schema(_tracker.region(), _schema, _tracker.memtable_cleaner());
             return entry->partition().apply_to_incomplete(*_schema, std::move(mem_e.partition()), _tracker.memtable_cleaner(),
                 alloc, _tracker.region(), _tracker, _underlying_phase, acc);
         } else {

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1324,9 +1324,7 @@ void row_cache::upgrade_entry(cache_entry& e) {
     if (e.schema() != _schema && !e.partition().is_locked()) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
-        with_allocator(r.allocator(), [this, &e] {
-            e.partition().upgrade(e.schema(), _schema, _tracker.cleaner(), &_tracker);
-        });
+        e.partition().upgrade(r, e.schema(), _schema, _tracker.cleaner(), &_tracker);
     }
 }
 

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1324,7 +1324,7 @@ void row_cache::upgrade_entry(cache_entry& e) {
     if (e.schema() != _schema && !e.partition().is_locked()) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
-        e.partition().upgrade(r, e.schema(), _schema, _tracker.cleaner(), &_tracker);
+        e.partition().upgrade(r, _schema, _tracker.cleaner(), &_tracker);
     }
 }
 

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -50,7 +50,6 @@ class lsa_manager;
 //
 // TODO: Make memtables use this format too.
 class cache_entry {
-    schema_ptr _schema;
     dht::decorated_key _key;
     partition_entry _pe;
     // True when we know that there is nothing between this entry and the previous one in cache
@@ -86,9 +85,8 @@ public:
     }
 
     cache_entry(schema_ptr s, const dht::decorated_key& key, const mutation_partition& p)
-        : _schema(std::move(s))
-        , _key(key)
-        , _pe(partition_entry::make_evictable(*_schema, mutation_partition(*_schema, p)))
+        : _key(key)
+        , _pe(partition_entry::make_evictable(*s, mutation_partition(*s, p)))
     { }
 
     cache_entry(schema_ptr s, dht::decorated_key&& key, mutation_partition&& p)
@@ -99,8 +97,7 @@ public:
     // It is assumed that pe is fully continuous
     // pe must be evictable.
     cache_entry(evictable_tag, schema_ptr s, dht::decorated_key&& key, partition_entry&& pe) noexcept
-        : _schema(std::move(s))
-        , _key(std::move(key))
+        : _key(std::move(key))
         , _pe(std::move(pe))
     { }
 
@@ -130,8 +127,7 @@ public:
 
     const partition_entry& partition() const noexcept { return _pe; }
     partition_entry& partition() { return _pe; }
-    const schema_ptr& schema() const noexcept { return _schema; }
-    schema_ptr& schema() noexcept { return _schema; }
+    const schema_ptr& schema() const noexcept { return _pe.get_schema(); }
     flat_mutation_reader_v2 read(row_cache&, cache::read_context&);
     flat_mutation_reader_v2 read(row_cache&, std::unique_ptr<cache::read_context>);
     flat_mutation_reader_v2 read(row_cache&, cache::read_context&, utils::phased_barrier::phase_type);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4507,7 +4507,7 @@ public:
             const mutation& m = z.get<1>().mut;
             for (const version& v : z.get<0>()) {
                 auto diff = v.par
-                          ? m.partition().difference(schema, (co_await v.par->mut().unfreeze_gently(schema)).partition())
+                          ? m.partition().difference(*schema, (co_await v.par->mut().unfreeze_gently(schema)).partition())
                           : mutation_partition(*schema, m.partition());
                 std::optional<mutation> mdiff;
                 if (!diff.empty()) {

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -190,7 +190,7 @@ public:
     static partition_snapshot_ptr snapshot_for_key(row_cache& rc, const dht::decorated_key& dk) {
         return rc._read_section(rc._tracker.region(), [&] {
             cache_entry& e = rc.lookup(dk);
-            return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), e.schema(), &rc._tracker);
+            return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker);
         });
     }
 };

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -260,7 +260,7 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
 
         // Difference
 
-        m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m2.partition()));
+        m = mutation(s, m1.decorated_key(), m1.partition().difference(*s, m2.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
       {
@@ -277,7 +277,7 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         verify_shard_order(ccv);
       }
 
-        m = mutation(s, m1.decorated_key(), m2.partition().difference(s, m1.partition()));
+        m = mutation(s, m1.decorated_key(), m2.partition().difference(*s, m1.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
       {
@@ -294,11 +294,11 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         verify_shard_order(ccv);
       }
 
-        m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m3.partition()));
+        m = mutation(s, m1.decorated_key(), m1.partition().difference(*s, m3.partition()));
         BOOST_REQUIRE_EQUAL(m.partition().clustered_rows().calculate_size(), 0);
         BOOST_REQUIRE(m.partition().static_row().empty());
 
-        m = mutation(s, m1.decorated_key(), m3.partition().difference(s, m1.partition()));
+        m = mutation(s, m1.decorated_key(), m3.partition().difference(*s, m1.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(!ac.is_live());
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1195,7 +1195,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12.apply(m1);
         m12.apply(m2);
 
-        auto m2_1 = m2.partition().difference(s, m1.partition());
+        auto m2_1 = m2.partition().difference(*s, m1.partition());
         BOOST_REQUIRE_EQUAL(m2_1.partition_tombstone(), tombstone());
         BOOST_REQUIRE(!m2_1.static_row().size());
         BOOST_REQUIRE(!m2_1.find_row(*s, ckey1));
@@ -1212,7 +1212,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12_1.partition().apply(*s, m2_1, *s, app_stats);
         BOOST_REQUIRE_EQUAL(m12, m12_1);
 
-        auto m1_2 = m1.partition().difference(s, m2.partition());
+        auto m1_2 = m1.partition().difference(*s, m2.partition());
         BOOST_REQUIRE_EQUAL(m1_2.partition_tombstone(), m12.partition().partition_tombstone());
         BOOST_REQUIRE(m1_2.find_row(*s, ckey1));
         BOOST_REQUIRE(m1_2.find_row(*s, ckey2));
@@ -1230,10 +1230,10 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m12_2.partition().apply(*s, m1_2, *s, app_stats);
         BOOST_REQUIRE_EQUAL(m12, m12_2);
 
-        auto m3_12 = m3.partition().difference(s, m12.partition());
+        auto m3_12 = m3.partition().difference(*s, m12.partition());
         BOOST_REQUIRE(m3_12.empty());
 
-        auto m12_3 = m12.partition().difference(s, m3.partition());
+        auto m12_3 = m12.partition().difference(*s, m3.partition());
         BOOST_REQUIRE_EQUAL(m12_3.partition_tombstone(), m12.partition().partition_tombstone());
 
         mutation m123(s, partition_key::from_single_value(*s, "key1"));
@@ -1364,13 +1364,13 @@ SEASTAR_TEST_CASE(test_query_digest) {
 
                 auto m3 = m2;
                 {
-                    auto diff = m1.partition().difference(s, m2.partition());
+                    auto diff = m1.partition().difference(*s, m2.partition());
                     m3.partition().apply(*m3.schema(), std::move(diff), app_stats);
                 }
 
                 auto m4 = m1;
                 {
-                    auto diff = m2.partition().difference(s, m1.partition());
+                    auto diff = m2.partition().difference(*s, m1.partition());
                     m4.partition().apply(*m4.schema(), std::move(diff), app_stats);
                 }
 
@@ -1881,7 +1881,7 @@ SEASTAR_TEST_CASE(test_collection_cell_diff) {
         mutation m12 = m1;
         m12.apply(m2);
 
-        auto diff = m12.partition().difference(s, m1.partition());
+        auto diff = m12.partition().difference(*s, m1.partition());
         BOOST_REQUIRE(!diff.empty());
         BOOST_REQUIRE(m2.partition().equal(*s, diff));
     });
@@ -1919,11 +1919,11 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             auto m12 = m1;
             m12.apply(m2);
             auto m12_with_diff = m1;
-            m12_with_diff.partition().apply(*s, m2.partition().difference(s, m1.partition()), app_stats);
+            m12_with_diff.partition().apply(*s, m2.partition().difference(*s, m1.partition()), app_stats);
             check_partitions_match(m12.partition(), m12_with_diff.partition(), *s);
-            check_partitions_match(mutation_partition{*s}, m1.partition().difference(s, m1.partition()), *s);
-            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{*s}), *s);
-            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(s, m1.partition()), *s);
+            check_partitions_match(mutation_partition{*s}, m1.partition().difference(*s, m1.partition()), *s);
+            check_partitions_match(m1.partition(), m1.partition().difference(*s, mutation_partition{*s}), *s);
+            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(*s, m1.partition()), *s);
         });
     });
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1921,9 +1921,9 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             auto m12_with_diff = m1;
             m12_with_diff.partition().apply(*s, m2.partition().difference(s, m1.partition()), app_stats);
             check_partitions_match(m12.partition(), m12_with_diff.partition(), *s);
-            check_partitions_match(mutation_partition{s}, m1.partition().difference(s, m1.partition()), *s);
-            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{s}), *s);
-            check_partitions_match(mutation_partition{s}, mutation_partition{s}.difference(s, m1.partition()), *s);
+            check_partitions_match(mutation_partition{*s}, m1.partition().difference(s, m1.partition()), *s);
+            check_partitions_match(m1.partition(), m1.partition().difference(s, mutation_partition{*s}), *s);
+            check_partitions_match(mutation_partition{*s}, mutation_partition{*s}.difference(s, m1.partition()), *s);
         });
     });
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2132,7 +2132,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_non_evictable_snapshot) {
 
 static void clear(cache_tracker& tracker, const schema& s, mutation_partition_v2& p) {
     while (p.clear_gently(&tracker) == stop_iteration::no) {}
-    p = mutation_partition_v2(s.shared_from_this());
+    p = mutation_partition_v2(s);
     tracker.insert(p);
 }
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -221,7 +221,7 @@ mvcc_partition& mvcc_partition::operator+=(const mutation& m) {
 void mvcc_partition::apply(const mutation_partition& mp, schema_ptr mp_s) {
     with_allocator(region().allocator(), [&] {
         if (_evictable) {
-            apply_to_evictable(partition_entry(mutation_partition_v2(*mp_s, mp)), mp_s);
+            apply_to_evictable(partition_entry(*mp_s, mutation_partition_v2(*mp_s, mp)), mp_s);
         } else {
             logalloc::allocating_section as;
             as(region(), [&] {
@@ -249,7 +249,7 @@ mvcc_partition mvcc_container::make_not_evictable(const mutation_partition& mp) 
     return with_allocator(region().allocator(), [&] {
         logalloc::allocating_section as;
         return as(region(), [&] {
-            return mvcc_partition(_schema, partition_entry(mutation_partition_v2(*_schema, mp)), *this, false);
+            return mvcc_partition(_schema, partition_entry(*_schema, mutation_partition_v2(*_schema, mp)), *this, false);
         });
     });
 }
@@ -592,7 +592,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging_for_nonevictab
             {
                 mutation_application_stats app_stats;
                 logalloc::reclaim_lock rl(r);
-                auto e = partition_entry(mutation_partition_v2(*s, m3.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m3.partition()));
                 auto snap1 = e.read(r, cleaner, s, no_cache_tracker);
                 e.apply(r, cleaner, *s, m2.partition(), *s, app_stats);
                 auto snap2 = e.read(r, cleaner, s, no_cache_tracker);
@@ -1173,7 +1173,7 @@ public:
             , _tracker(t)
             , _r(r)
             , _e(_tracker ? partition_entry::make_evictable(*_schema, mutation_partition::make_incomplete(*_schema))
-                          : partition_entry(mutation_partition_v2(*_schema)))
+                          : partition_entry(*_schema, mutation_partition_v2(*_schema)))
     {
         if (_tracker) {
             _tracker->insert(_e);
@@ -1654,7 +1654,7 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
             while (true) {
                 logalloc::reclaim_lock rl(r);
                 mutation_partition_v2 m2 = mutation_partition_v2(*second.schema(), second.partition());
-                auto e = partition_entry(mutation_partition_v2(*target.schema(), target.partition()));
+                auto e = partition_entry(*target.schema(), mutation_partition_v2(*target.schema(), target.partition()));
                 //auto snap1 = e.read(r, gen.schema());
 
                 alloc.fail_after(fail_offset++);
@@ -1703,7 +1703,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
             m3.partition().make_fully_continuous();
 
             {
-                auto e = partition_entry(mutation_partition_v2(*s, m1.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m1.partition()));
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {
@@ -1724,7 +1724,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
             }
 
             {
-                auto e = partition_entry(mutation_partition_v2(*s, m1.partition()));
+                auto e = partition_entry(*s, mutation_partition_v2(*s, m1.partition()));
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -41,7 +41,7 @@ static thread_local mutation_application_stats app_stats_for_tests;
 // The cursor must be pointing at a row and valid.
 // The cursor will not be pointing at a row after this.
 static mutation_partition read_partition_from(const schema& schema, partition_snapshot_row_cursor& cur) {
-    mutation_partition p(schema.shared_from_this());
+    mutation_partition p(schema);
     position_in_partition prev = position_in_partition::before_all_clustered_rows();
     do {
         testlog.trace("cur: {}", cur);
@@ -304,7 +304,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete) {
             assert_that(table.schema(), e.squashed()).is_equal_to((m2 + m3).partition());
 
             // Check that snapshot data is not stolen when its entry is applied
-            auto e2 = ms.make_evictable(mutation_partition(table.schema()));
+            auto e2 = ms.make_evictable(mutation_partition(s));
             e2 += std::move(e);
             assert_that(table.schema(), ms.squashed(snap1)).is_equal_to(m1.partition());
             assert_that(table.schema(), e2.squashed()).is_equal_to((m2 + m3).partition());
@@ -381,7 +381,7 @@ SEASTAR_TEST_CASE(test_eviction_with_active_reader) {
             auto ck1 = table.make_ckey(1);
             auto ck2 = table.make_ckey(2);
 
-            auto e = ms.make_evictable(mutation_partition(table.schema()));
+            auto e = ms.make_evictable(mutation_partition(s));
 
             mutation m1(table.schema(), pk);
             m1.partition().clustered_row(s, ck2);
@@ -670,7 +670,7 @@ SEASTAR_TEST_CASE(test_partition_snapshot_row_cursor) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {
@@ -841,7 +841,7 @@ SEASTAR_TEST_CASE(test_partition_snapshot_row_cursor_reversed) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             int ck_0 = 10;
@@ -1032,7 +1032,7 @@ SEASTAR_TEST_CASE(test_cursor_tracks_continuity_in_reversed_mode) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             tracker.insert(e);
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
@@ -1537,7 +1537,7 @@ SEASTAR_TEST_CASE(test_ensure_entry_in_latest_in_reversed_mode) {
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {
@@ -1593,7 +1593,7 @@ SEASTAR_TEST_CASE(test_ensure_entry_in_latest_does_not_set_continuity_in_reverse
             simple_schema table;
             auto&& s = *table.schema();
 
-            auto e = partition_entry::make_evictable(s, mutation_partition(table.schema()));
+            auto e = partition_entry::make_evictable(s, mutation_partition(s));
             auto snap1 = e.read(r, tracker.cleaner(), table.schema(), &tracker);
 
             {

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -170,7 +170,7 @@ public:
 
     void upgrade(schema_ptr new_schema) {
         _container.allocate_in_region([&] {
-            _e.upgrade(_container.region(), _s, new_schema, _container.cleaner(), _container.tracker());
+            _e.upgrade(_container.region(), new_schema, _container.cleaner(), _container.tracker());
             _s = new_schema;
         });
     }
@@ -194,7 +194,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
         mutation_cleaner src_cleaner(region(), no_cache_tracker, app_stats_for_tests);
         auto c = as(region(), [&] {
             if (_s != src_schema) {
-                src.upgrade(region(), src_schema, _s, src_cleaner, no_cache_tracker);
+                src.upgrade(region(), _s, src_cleaner, no_cache_tracker);
             }
             return _e.apply_to_incomplete(*schema(), std::move(src), src_cleaner, as, region(),
                 *_container.tracker(), _container.next_phase(), _container.accounter());

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -1173,7 +1173,7 @@ public:
             , _tracker(t)
             , _r(r)
             , _e(_tracker ? partition_entry::make_evictable(*_schema, mutation_partition::make_incomplete(*_schema))
-                          : partition_entry(mutation_partition_v2(_schema)))
+                          : partition_entry(mutation_partition_v2(*_schema)))
     {
         if (_tracker) {
             _tracker->insert(_e);

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -170,7 +170,7 @@ public:
 
     void upgrade(schema_ptr new_schema) {
         _container.allocate_in_region([&] {
-            _e.upgrade(_s, new_schema, _container.cleaner(), _container.tracker());
+            _e.upgrade(_container.region(), _s, new_schema, _container.cleaner(), _container.tracker());
             _s = new_schema;
         });
     }
@@ -194,7 +194,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
         mutation_cleaner src_cleaner(region(), no_cache_tracker, app_stats_for_tests);
         auto c = as(region(), [&] {
             if (_s != src_schema) {
-                src.upgrade(src_schema, _s, src_cleaner, no_cache_tracker);
+                src.upgrade(region(), src_schema, _s, src_cleaner, no_cache_tracker);
             }
             return _e.apply_to_incomplete(*schema(), std::move(src), src_cleaner, as, region(),
                 *_container.tracker(), _container.next_phase(), _container.accounter());

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -505,7 +505,7 @@ void evict_with_consistency_check(mvcc_container& ms, mvcc_partition& e, const m
         testlog.trace("evicting");
         auto ret = ms.tracker()->evict_from_lru_shallow();
 
-        testlog.trace("entry: {}", partition_entry::printer(s, e.entry()));
+        testlog.trace("entry: {}", partition_entry::printer(e.entry()));
 
         auto p = e.squashed();
         auto cont = p.get_continuity(s);
@@ -553,7 +553,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging) {
                 auto snap2 = e.read();
                 e += m3;
 
-                testlog.trace("e: {}", partition_entry::printer(*e.schema(), e.entry()));
+                testlog.trace("e: {}", partition_entry::printer(e.entry()));
 
                 auto expected = e.squashed();
                 auto snap = e.read();
@@ -2005,7 +2005,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_with_dummies) {
             }
         });
 
-        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(*s, e.entry()));
+        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(e.entry()));
 
         mutation m2(s, ss.make_pkey());
         // This one covers the dummy row for before(3) and before(2), marking the range [1, 3] as continuous.
@@ -2020,7 +2020,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_with_dummies) {
         e += m3;
         auto snp3 = e.read();
 
-        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(*s, e.entry()));
+        testlog.trace("entry @{}: {}", __LINE__, partition_entry::printer(e.entry()));
 
         auto expected = m0 + m1 + m2 + m3;
 

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -452,7 +452,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_respects_continuity) {
                 }
 
                 auto expected = mutation_partition(*s, before);
-                expected.apply_weak(*s, std::move(expected_to_apply_slice), app_stats);
+                expected.apply(*s, std::move(expected_to_apply_slice), app_stats);
 
                 e += to_apply;
 

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -950,6 +950,7 @@ SEASTAR_TEST_CASE(test_eviction_after_schema_change) {
             rd.fill_buffer().get();
         }
 
+        tracker.cleaner().drain().get0();
         while (tracker.region().evict_some() == memory::reclaiming_result::reclaimed_something) ;
 
         // The partition should be evictable after schema change


### PR DESCRIPTION
After a schema change, memtable and cache have to be upgraded to the new schema. Currently, they are upgraded (on the first access after a schema change) atomically, i.e. all rows of the entry are upgraded with one non-preemptible call. This is a one of the last vestiges of the times when partition were treated atomically, and it is a well known source of numerous large stalls.

This series makes schema upgrades gentle (preemptible). This is done by co-opting the existing MVCC machinery.
Before the series, all partition_versions in the partition_entry chain have the same schema, and an entry upgrade replaces the entire chain with a single squashed and upgraded version.
After the series, each partition_version has its own schema. A partition entry upgrade happens simply by adding an empty version with the new schema to the head of the chain. Row entries are upgraded to the current schema on-the-fly by the cursor during reads, and by the MVCC version merge ongoing in the background after the upgrade.

The series:
1. Does some code cleanup in the mutation_partition area.
2. Adds a schema field to partition_version and removes it from its containers (partition_snapshot, cache_entry, memtable_entry).
3. Adds upgrading variants of constructors and apply() for `row` and its wrappers.
4. Prepares partition_snapshot_row_cursor, mutation_partition_v2::apply_monotonically and partition_snapshot::merge_partition_versions for dealing with heterogeneous version chains.
5. Modifies partition_entry::upgrade to perform upgrades by extending the version chain with a new schema instead of squashing it to a single upgraded version.

Fixes #2577