### PR TITLE
build: only apply -Wno-parentheses-equality to ANTLR generated sources

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -2,7 +2,6 @@ set(disabled_warnings
   c++11-narrowing
   mismatched-tags
   overloaded-virtual
-  parentheses-equality
   unsupported-friend)
 include(CheckCXXCompilerFlag)
 foreach(warning ${disabled_warnings})

--- a/configure.py
+++ b/configure.py
@@ -1351,7 +1351,6 @@ warnings = [
     '-Werror',
     '-Wno-mismatched-tags',  # clang-only
     '-Wno-tautological-compare',
-    '-Wno-parentheses-equality',
     '-Wno-c++11-narrowing',
     '-Wno-ignored-attributes',
     '-Wno-overloaded-virtual',
@@ -2031,13 +2030,14 @@ with open(buildfile, 'w') as f:
             for cc in grammar.sources('$builddir/{}/gen'.format(mode)):
                 obj = cc.replace('.cpp', '.o')
                 f.write('build {}: cxx.{} {} || {}\n'.format(obj, mode, cc, ' '.join(serializers)))
+                flags = '-Wno-parentheses-equality'
                 if cc.endswith('Parser.cpp'):
                     # Unoptimized parsers end up using huge amounts of stack space and overflowing their stack
-                    flags = '-O1' if modes[mode]['optimization-level'] in ['0', 'g', 's'] else ''
+                    flags += ' -O1' if modes[mode]['optimization-level'] in ['0', 'g', 's'] else ''
 
                     if has_sanitize_address_use_after_scope:
                         flags += ' -fno-sanitize-address-use-after-scope'
-                    f.write('  obj_cxxflags = %s\n' % flags)
+                f.write(f'  obj_cxxflags = {flags}\n')
         f.write(f'build $builddir/{mode}/gen/empty.cc: gen\n')
         for hh in headers:
             f.write('build $builddir/{mode}/{hh}.o: checkhh.{mode} {hh} | $builddir/{mode}/gen/empty.cc || {gen_headers_dep}\n'.format(

--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -7,7 +7,7 @@ generate_cql_grammar(
   SOURCES cql_grammar_srcs)
 set_source_files_properties(${cql_grammar_srcs}
   PROPERTIES
-    COMPILE_FLAGS "-Wno-uninitialized")
+    COMPILE_FLAGS "-Wno-uninitialized -Wno-parentheses-equality")
 
 add_library(cql3 STATIC)
 target_sources(cql3


### PR DESCRIPTION
it turns out the only places where we have compiler warnings of -W-parentheses-equality is the source code generated by ANTLR. strictly speaking, this is valid C++ code, just not quite readable from the hygienic point of view. so let's enable this warning in the source tree, but only disable it when compiling the sources generated by ANTLR.

please note, this warning option is supported by both GCC and Clang, so no need to test if it is supported.

for a sample of the warnings, see:
```
/home/kefu/dev/scylladb/build/cmake/cql3/CqlLexer.cpp:21752:38: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
                            if ( (LA4_0 == '$'))
                                  ~~~~~~^~~~~~
/home/kefu/dev/scylladb/build/cmake/cql3/CqlLexer.cpp:21752:38: note: remove extraneous parentheses around the comparison to silence this warning
                            if ( (LA4_0 == '$'))
                                 ~      ^     ~
```