### PR TITLE
treewide: do not include unused header

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <regex>
-
 #include "utils/base64.hh"
 
 #include <seastar/core/sleep.hh>

--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -11,8 +11,6 @@
 #include "cql3/util.hh"
 #include "cql3/query_options.hh"
 
-#include <regex>
-
 namespace cql3 {
 
 column_identifier::column_identifier(sstring raw_text, bool keep_case) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -8,7 +8,6 @@
  */
 
 #include <unordered_map>
-#include <regex>
 #include <sstream>
 
 #include <boost/any.hpp>

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -11,8 +11,6 @@
 #include "marshal_exception.hh"
 #include <seastar/core/print.hh>
 
-#include <regex>
-
 #ifdef __clang__
 
 // Clang or boost have a problem navigating the enable_if maze

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -8,7 +8,6 @@
  */
 
 #include <unordered_map>
-#include <regex>
 
 #include <yaml-cpp/yaml.h>
 


### PR DESCRIPTION
since #13452, we switched most of the caller sites from std::regex to boost::regex. in this change, all occurences of `#include <regex>` are dropped unless std::regex is used in the same source file.