### PR TITLE
[DOCS] Update `LATEST_VERSION` and `UNSTABLE_VERSIONS`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ BASE_URL = 'https://docs.scylladb.com'
 TAGS = []
 BRANCHES = ["master", "branch-5.1", "branch-5.2"]
 # Set the latest version.
-LATEST_VERSION = "branch-5.1"
+LATEST_VERSION = "branch-5.2"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-5.2"]
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
**Fixes:** #13770

**Description:**
Update the docs `LATEST_VERSION` to `branch-5.2` and remove it from `UNSTABLE_VERSIONS`.

**Tasks:**
- [x] Set value of `LATEST_VERSION` to `branch-5.2`.
- [x] Remove `branch-5.2` from `UNSTABLE_VERSIONS`.

@scylladb-promoter Pls let me know if anything needs to be updated.

**Edit:** Oh my! I seem to have referenced the wrong issue in the comment, fixed it but the issue 13370 still have a reference to this PR. Just an FYI for anyone coming here from issue 13370.