### PR TITLE
Restore raft::internal::tagged_uint64 type

### DIFF
--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -8,6 +8,9 @@
 
 #include "gms/inet_address_serializer.hh"
 #include "gms/version_generator.hh"
+#include "gms/generation-number.hh"
+
+#include "idl/utils.idl.hh"
 
 namespace gms {
 enum class application_state:int {

--- a/idl/raft.idl.hh
+++ b/idl/raft.idl.hh
@@ -8,7 +8,7 @@
 
 #include "raft/raft.hh"
 
-#include "idl/utils.idl.hh"
+#include "idl/raft_storage.idl.hh"
 
 namespace raft {
 

--- a/idl/raft_storage.idl.hh
+++ b/idl/raft_storage.idl.hh
@@ -9,7 +9,6 @@
 #include "raft/raft.hh"
 
 #include "idl/uuid.idl.hh"
-#include "idl/utils.idl.hh"
 
 namespace raft {
 
@@ -18,6 +17,11 @@ namespace internal {
 template<typename Tag>
 struct tagged_id {
     utils::UUID id;
+};
+
+template<typename Tag>
+struct tagged_uint64 {
+    uint64_t value();
 };
 
 } // namespace internal

--- a/raft/internal.hh
+++ b/raft/internal.hh
@@ -10,12 +10,16 @@
 #include <ostream>
 #include <functional>
 #include "utils/UUID.hh"
+#include "utils/tagged_integer.hh"
 
 namespace raft {
 namespace internal {
 
 template<typename Tag>
 using tagged_id = utils::tagged_uuid<Tag>;
+
+template<typename Tag>
+using tagged_uint64 = utils::tagged_tagged_integer<struct non_final, Tag, uint64_t>;
 
 } // end of namespace internal
 } // end of namespace raft

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -40,7 +40,7 @@ using server_id = internal::tagged_id<struct server_id_tag>;
 using group_id = raft::internal::tagged_id<struct group_id_tag>;
 
 // This type represents the raft term
-using term_t = utils::tagged_integer<struct term_tag, int64_t>;
+using term_t = utils::tagged_integer<struct term_tag, uint64_t>;
 // This type represensts the index into the raft log
 using index_t = utils::tagged_integer<struct index_tag, uint64_t>;
 // Identifier for a read barrier request

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -19,7 +19,6 @@
 #include <seastar/core/abort_source.hh>
 #include "bytes_ostream.hh"
 #include "utils/UUID.hh"
-#include "utils/tagged_integer.hh"
 #include "internal.hh"
 #include "logical_clock.hh"
 
@@ -40,11 +39,11 @@ using server_id = internal::tagged_id<struct server_id_tag>;
 using group_id = raft::internal::tagged_id<struct group_id_tag>;
 
 // This type represents the raft term
-using term_t = utils::tagged_integer<struct term_tag, uint64_t>;
+using term_t = raft::internal::tagged_uint64<struct term_tag>;
 // This type represensts the index into the raft log
-using index_t = utils::tagged_integer<struct index_tag, uint64_t>;
+using index_t = raft::internal::tagged_uint64<struct index_tag>;
 // Identifier for a read barrier request
-using read_id = utils::tagged_integer<struct read_id_tag, uint64_t>;
+using read_id = raft::internal::tagged_uint64<struct read_id_tag>;
 
 // Opaque connection properties. May contain ip:port pair for instance.
 // This value is disseminated between cluster member

--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -15,17 +15,22 @@
 
 namespace utils {
 
-template <typename Tag, std::integral ValueType>
-class tagged_integer {
+// Note: do not use directly, use utils::tagged_integer instead.
+// The reason this double-tagged template exist
+// is to distinguish between utils::tagged_integer
+// and raft::internal::tagged_uint64 that have incompatible
+// idl types and therefore must not be convertible to each other.
+template <typename Final, typename Tag, std::integral ValueType>
+class tagged_tagged_integer {
 public:
     using value_type = ValueType;
 private:
     value_type _value;
 public:
-    tagged_integer() noexcept : _value(0) {}
-    explicit tagged_integer(value_type v) noexcept : _value(v) {}
+    tagged_tagged_integer() noexcept : _value(0) {}
+    explicit tagged_tagged_integer(value_type v) noexcept : _value(v) {}
 
-    tagged_integer& operator=(value_type v) noexcept {
+    tagged_tagged_integer& operator=(value_type v) noexcept {
         _value = v;
         return *this;
     }
@@ -35,58 +40,61 @@ public:
 
     explicit operator bool() const { return _value != 0; }
 
-    auto operator<=>(const tagged_integer& o) const = default;
+    auto operator<=>(const tagged_tagged_integer& o) const = default;
 
-    tagged_integer& operator++() noexcept {
+    tagged_tagged_integer& operator++() noexcept {
         ++_value;
         return *this;
     }
-    tagged_integer& operator--() noexcept {
+    tagged_tagged_integer& operator--() noexcept {
         --_value;
         return *this;
     }
 
-    tagged_integer operator++(int) noexcept {
+    tagged_tagged_integer operator++(int) noexcept {
         auto ret = *this;
         ++_value;
         return ret;
     }
-    tagged_integer operator--(int) noexcept {
+    tagged_tagged_integer operator--(int) noexcept {
         auto ret = *this;
         --_value;
         return ret;
     }
 
-    tagged_integer operator+(const tagged_integer& o) const {
-        return tagged_integer(_value + o._value);
+    tagged_tagged_integer operator+(const tagged_tagged_integer& o) const {
+        return tagged_tagged_integer(_value + o._value);
     }
-    tagged_integer operator-(const tagged_integer& o) const {
-        return tagged_integer(_value - o._value);
+    tagged_tagged_integer operator-(const tagged_tagged_integer& o) const {
+        return tagged_tagged_integer(_value - o._value);
     }
 
-    tagged_integer& operator+=(const tagged_integer& o) const {
+    tagged_tagged_integer& operator+=(const tagged_tagged_integer& o) const {
         _value += o._value;
         return *this;
     }
-    tagged_integer& operator-=(const tagged_integer& o) const {
+    tagged_tagged_integer& operator-=(const tagged_tagged_integer& o) const {
         _value -= o._value;
         return *this;
     }
 };
 
+template <typename Tag, std::integral ValueType>
+using tagged_integer = tagged_tagged_integer<struct final, Tag, ValueType>;
+
 } // namespace utils
 
 namespace std {
 
-template <typename Tag, std::integral ValueType>
-struct hash<utils::tagged_integer<Tag, ValueType>> {
-    size_t operator()(const utils::tagged_integer<Tag, ValueType>& x) const noexcept {
+template <typename Final, typename Tag, std::integral ValueType>
+struct hash<utils::tagged_tagged_integer<Final, Tag, ValueType>> {
+    size_t operator()(const utils::tagged_tagged_integer<Final, Tag, ValueType>& x) const noexcept {
         return hash<ValueType>{}(x.value());
     }
 };
 
-template <typename Tag, std::integral ValueType>
-[[maybe_unused]] ostream& operator<<(ostream& s, const utils::tagged_integer<Tag, ValueType>& x) {
+template <typename Final, typename Tag, std::integral ValueType>
+[[maybe_unused]] ostream& operator<<(ostream& s, const utils::tagged_tagged_integer<Final, Tag, ValueType>& x) {
     return s << x.value();
 }
 


### PR DESCRIPTION
Change f5f566bdd8b2fbffd104593dba033175f51b26ae introduced
tagged_integer and replaced raft::internal::tagged_uint64
with utils::tagged_integer.

However, the idl type for raft::internal::tagged_uint64
was not marked as final, but utils::tagged_integer is, breaking
the on-the-wire compatibility.

This change restores the use of raft::internal::tagged_uint64
for the raft types and adds back an idl definition for
it that is not marked as final, similar to the way
raft::internal::tagged_id extends utils::tagged_uuid.

Fixes #13752