### PR TITLE
build: cmake: use Seastar API level 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 set(Seastar_TESTING ON CACHE BOOL "" FORCE)
+set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
 add_subdirectory(seastar)
 
 # System libraries dependencies

--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -11,7 +11,11 @@ foreach(warning ${disabled_warnings})
   endif()
 endforeach()
 list(TRANSFORM _supported_warnings PREPEND "-Wno-")
-string(JOIN " " CMAKE_CXX_FLAGS "-Wall" "-Werror" ${_supported_warnings})
+string(JOIN " " CMAKE_CXX_FLAGS
+  "-Wall"
+  "-Werror"
+  "-Wno-error=deprecated-declarations"
+  ${_supported_warnings})
 
 function(default_target_arch arch)
   set(x86_instruction_sets i386 i686 x86_64)


### PR DESCRIPTION
to avoid the FTBFS after we bump up the Seastar submodule which bumped up its API level to v7. and API v7 is a breaking change. so, in order to unbreak the build, we have to hardwire the API level to 6. `configure.py` also does this.