### PR TITLE
build: cmake: link against Boost::unit_test_framework

### DIFF
--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -42,4 +42,5 @@ target_link_libraries(test-lib
     service
     sstables
     utils
-    Boost::regex)
+    Boost::regex
+    Boost::unit_test_framework)


### PR DESCRIPTION
we introduced the linkage to Boost::unit_test_framework in fe70333c19d8c119eda0dc2dec01d043adde57d5, this library is used by test/lib/test_utils.cc, so update CMake accordingly.