### PR TITLE
tablets: Fix stack smashing in tablet_map_to_mutation()

### DIFF
--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -66,8 +66,8 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         data_value(id.uuid()).serialize_nonnull()
     }));
     m.partition().apply(tombstone(tombstone_ts, gc_now));
-    m.set_static_cell("tablet_count", data_value(int(tablets.tablet_count())).serialize(), ts);
-    m.set_static_cell("table_name", data_value(table_name).serialize(), ts);
+    m.set_static_cell("tablet_count", data_value(int(tablets.tablet_count())), ts);
+    m.set_static_cell("table_name", data_value(table_name), ts);
 
     tablet_id tid = tablets.first_tablet();
     for (auto&& tablet : tablets.tablets()) {


### PR DESCRIPTION
The code was incorrectly passing a data_value of type bytes due to implicit conversion of the result of serialize() (bytes_opt) to a data_value object of type bytes_type via:

```
   data_value(std::optional<NativeType>);
```

mutation::set_static_cell() accepts a data_value object, which is then serialized using column's type in abstract_type::decompose(data_value&):

```
    bytes b(bytes::initialized_later(), serialized_size(*this, value._value));
    auto i = b.begin();
    value.serialize(i);
```

Notice that serialized_size() is taken from the column type, but serialization is done using data_value's type. The two types may have a compatible CQL binary representation, but may differ in native types. serialized_size() may incorrectly interpret the native type and come up with the wrong size. If the size is too smaller, we end up with stack or heap corruption later after serialize().

For example, if the column type is utf8 but value holds bytes, the size will be wrong because even though both use the basic_sstring type, they have a different layout due to max_size (15 vs 31).

Causes SIGSEGV on aarch64 in release mode.

Fixes #13717