### PR TITLE
test: pylib: random_tables: perform read barrier in `verify_schema`

### DIFF
--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -9,10 +9,9 @@ Test consistency of schema changes with topology changes.
 import logging
 import pytest
 import time
-from cassandra.protocol import InvalidRequest, ConfigurationException
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier
 
 
 logger = logging.getLogger(__name__)
@@ -38,9 +37,7 @@ async def get_current_group0_config(manager: ManagerClient, srv: ServerInfo) -> 
      """
     assert manager.cql
     host = (await wait_for_cql_and_get_hosts(manager.cql, [srv], time.time() + 60))[0]
-    # Issue a read barrer on that host.
-    with pytest.raises(InvalidRequest, match="nosuch"):
-        _ = await manager.cql.run_async("alter table nosuchkeyspace.nosuchtable with comment=''", host = host)
+    await read_barrier(manager.cql, host)
     group0_id = (await manager.cql.run_async(
         "select value from system.scylla_local where key = 'raft_group0_id'",
         host=host))[0].value


### PR DESCRIPTION
`RandomTables.verify_schema` is often called in topology tests after performing a schema change. It compares the schema tables fetched from some node to the expected latest schema stored by the `RandomTables` object.

However there's no guarantee that the latest schema change has already propagated to the node which we query. We could have performed the schema change on a different node and the change may not have been applied yet on all nodes.

To fix that, pick a specific node and perform a read barrier on it, then use that node to fetch the schema tables.

Fixes #13788