### PR TITLE
multishard_mutation_query: make reader_context::lookup_readers() exception safe

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -562,10 +562,11 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
         return _db.invoke_on_all([this, cmd = &_cmd, ranges = &_ranges, gs = global_schema_ptr(_schema),
                 gts = tracing::global_trace_state_ptr(_trace_state), timeout] (replica::database& db) mutable -> future<> {
             auto schema = gs.get();
-            auto querier_opt = db.get_querier_cache().lookup_shard_mutation_querier(cmd->query_uuid, *schema, *ranges, cmd->slice, gts.get(), timeout);
             auto& table = db.find_column_family(schema);
             auto& semaphore = this->semaphore();
             auto shard = this_shard_id();
+
+            auto querier_opt = db.get_querier_cache().lookup_shard_mutation_querier(cmd->query_uuid, *schema, *ranges, cmd->slice, gts.get(), timeout);
 
             if (!querier_opt) {
                 _readers[shard] = reader_meta(reader_state::inexistent);
@@ -575,6 +576,7 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
             auto& q = *querier_opt;
 
             if (&q.permit().semaphore() != &semaphore) {
+                co_await q.close();
                 on_internal_error(mmq_log, format("looked-up reader belongs to different semaphore than the one appropriate for this query class: "
                         "looked-up reader belongs to {} (0x{:x}) the query class appropriate is {} (0x{:x})",
                         q.permit().semaphore().name(),
@@ -583,6 +585,9 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
                         reinterpret_cast<uintptr_t>(&semaphore)));
             }
 
+            // At this point the readers is passed to the semaphore and we are
+            // safe w.r.t. exceptions. The code between this point and obtaining
+            // the querier must take care of closing it if an error happens.
             auto handle = semaphore.register_inactive_read(std::move(q).reader());
             _readers[shard] = reader_meta(
                     reader_state::successful_lookup,

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -560,7 +560,7 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
     }
     try {
         return _db.invoke_on_all([this, cmd = &_cmd, ranges = &_ranges, gs = global_schema_ptr(_schema),
-                gts = tracing::global_trace_state_ptr(_trace_state), timeout] (replica::database& db) mutable {
+                gts = tracing::global_trace_state_ptr(_trace_state), timeout] (replica::database& db) mutable -> future<> {
             auto schema = gs.get();
             auto querier_opt = db.get_querier_cache().lookup_shard_mutation_querier(cmd->query_uuid, *schema, *ranges, cmd->slice, gts.get(), timeout);
             auto& table = db.find_column_family(schema);
@@ -569,7 +569,7 @@ future<> read_context::lookup_readers(db::timeout_clock::time_point timeout) noe
 
             if (!querier_opt) {
                 _readers[shard] = reader_meta(reader_state::inexistent);
-                return;
+                co_return;
             }
 
             auto& q = *querier_opt;

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -104,6 +104,12 @@ partition_slice_builder::mutate_specific_ranges(std::function<void(query::specif
 }
 
 partition_slice_builder&
+partition_slice_builder::set_specific_ranges(query::specific_ranges ranges) {
+    _specific_ranges = std::make_unique<query::specific_ranges>(std::move(ranges));
+    return *this;
+}
+
+partition_slice_builder&
 partition_slice_builder::with_no_regular_columns() {
     _regular_columns = query::column_id_vector();
     return *this;

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -45,6 +45,7 @@ public:
     partition_slice_builder& mutate_ranges(std::function<void(std::vector<query::clustering_range>&)>);
     // noop if no specific ranges have been set yet
     partition_slice_builder& mutate_specific_ranges(std::function<void(query::specific_ranges&)>);
+    partition_slice_builder& set_specific_ranges(query::specific_ranges);
     partition_slice_builder& without_partition_key_columns();
     partition_slice_builder& without_clustering_key_columns();
     partition_slice_builder& reversed();


### PR DESCRIPTION
With regards to closing the looked-up querier if an exception is thrown. In particular, this requires closing the querier if a semaphore mismatch is detected. Move the table lookup above the line where the querier is looked up, to avoid having to handle the exception from it. As a consequence of closing the querier on the error path, the lookup lambda has to be made a coroutine. This is sad, but this is executed once per page, so its cost should be insignificant when spread over an
entire page worth of work.

Also add a unit test checking that the mismatch is detected in the first place and that readers are closed.

Fixes: #13784
