### PR TITLE
mv: throttle view update generation for large queries 

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1755,6 +1755,39 @@ future<> view_update_generator::mutate_MV(
     });
 }
 
+
+utils::small_vector<gms::inet_address, 2> view_update_generator::get_endpoints_for_view_update(
+        dht::token base_token,
+        const frozen_mutation_and_schema& view_update) const {
+    dht::token view_token = dht::get_token(*view_update.s, view_update.fm.key());
+    const sstring& keyspace_name = view_update.s->ks_name();
+
+    // For every base table replica there's a single paired view replica.
+    std::optional<gms::inet_address> paired_replica_endpoint =
+        get_view_natural_endpoint(_proxy.local().local_db(), keyspace_name, base_token, view_token);
+
+    // In case of an ongoing topology change it might also be necessary to send the update to pending nodes.
+    inet_address_vector_topology_change pending_endpoints = _proxy.local()
+                                                                .local_db()
+                                                                .find_keyspace(keyspace_name)
+                                                                .get_effective_replication_map()
+                                                                ->get_pending_endpoints(view_token);
+
+    utils::small_vector<gms::inet_address, 2> result;
+    if (paired_replica_endpoint.has_value()) {
+        result.push_back(*paired_replica_endpoint);
+    }
+
+    for (const gms::inet_address& pending_endpoint : pending_endpoints) {
+        // std::find is there to avoid any possible duplicates.
+        if (std::find(result.begin(), result.end(), pending_endpoint) == result.end()) {
+            result.push_back(pending_endpoint);
+        }
+    }
+
+    return result;
+}
+
 view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn, view_update_generator& vug)
         : _db(db)
         , _sys_ks(sys_ks)

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2712,5 +2712,23 @@ void delete_ghost_rows_visitor::accept_new_row(const clustering_key& ck, const q
     }
 }
 
+std::chrono::microseconds calculate_view_update_throttling_delay(db::view::update_backlog backlog,
+                                                                 db::timeout_clock::time_point timeout_delay_limit) {
+    constexpr auto delay_limit_us = 1000000;
+    auto adjust = [] (float x) { return x * x * x; };
+    auto budget = std::max(service::storage_proxy::clock_type::duration(0),
+        timeout_delay_limit - service::storage_proxy::clock_type::now());
+    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
+    // "budget" has millisecond resolution and can potentially be long
+    // in the future so converting it to microseconds may overflow.
+    // So to compare buget and ret we need to convert both to the lower
+    // resolution.
+    if (std::chrono::duration_cast<service::storage_proxy::clock_type::duration>(ret) < budget) {
+        return ret;
+    } else {
+        // budget is small (< ret) so can be converted to microseconds
+        return std::chrono::duration_cast<std::chrono::microseconds>(budget);
+    }
+}
 } // namespace view
 } // namespace db

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -75,6 +75,8 @@ public:
 
     replica::database& get_db() noexcept { return _db; }
 
+    const sharded<service::storage_proxy>& get_storage_proxy() const noexcept { return _proxy; };
+
     future<> mutate_MV(
             dht::token base_token,
             utils::chunked_vector<frozen_mutation_and_schema> view_updates,

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -63,8 +63,8 @@ unavailable_exception::unavailable_exception(db::consistency_level cl, int32_t r
         cl, required, alive)
     {}
 
-request_timeout_exception::request_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept
-    : cassandra_exception{code, prepare_message("Operation timed out for {}.{} - received only {} responses from {} CL={}.", ks, cf, received, block_for, consistency)}
+read_write_timeout_exception::read_write_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept
+    : request_timeout_exception{code, prepare_message("Operation timed out for {}.{} - received only {} responses from {} CL={}.", ks, cf, received, block_for, consistency)}
     , consistency{consistency}
     , received{received}
     , block_for{block_for}

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -70,6 +70,10 @@ read_write_timeout_exception::read_write_timeout_exception(exception_code code, 
     , block_for{block_for}
     { }
 
+view_update_generation_timeout_exception::view_update_generation_timeout_exception()
+    : request_timeout_exception{
+          exception_code::WRITE_TIMEOUT, "Request timed out - couldn't prepare materialized view updates in time"} {}
+
 request_failure_exception::request_failure_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency_, int32_t received_, int32_t failures_, int32_t block_for_) noexcept
     : cassandra_exception{code, prepare_message("Operation failed for {}.{} - received {} responses and {} failures from {} CL={}.", ks, cf, received_, failures_, block_for_, consistency_)}
     , consistency{consistency_}

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -151,6 +151,14 @@ struct mutation_write_timeout_exception : public read_write_timeout_exception {
     { }
 };
 
+// Generating view updates for a single client request can take a long time and might not finish before the timeout is
+// reached. In such case this exception is thrown.
+// "Generating a view update" means creating a view update and scheduling it to be sent later.
+// This exception isn't thrown if the sending timeouts, it's only concrened with generating.
+struct view_update_generation_timeout_exception : public request_timeout_exception {
+    view_update_generation_timeout_exception();
+};
+
 class request_failure_exception : public cassandra_exception {
 public:
     db::consistency_level consistency;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1080,7 +1080,8 @@ private:
             mutation&& m,
             flat_mutation_reader_v2_opt existings,
             tracing::trace_state_ptr tr_state,
-            gc_clock::time_point now) const;
+            gc_clock::time_point now,
+            db::timeout_clock::time_point timeout) const;
 
     mutable row_locker _row_locker;
     future<row_locker::lock_holder> local_base_lock(

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -15,6 +15,9 @@
 #include <seastar/util/closeable.hh>
 #include <seastar/util/defer.hh>
 
+#include "db/view/view_update_backlog.hh"
+#include "exceptions/exceptions.hh"
+#include "gms/inet_address.hh"
 #include "replica/database.hh"
 #include "replica/data_dictionary_impl.hh"
 #include "replica/compaction_group.hh"
@@ -57,6 +60,7 @@
 #include "readers/multi_range.hh"
 #include "readers/combined.hh"
 #include "readers/compacting.hh"
+#include "service/storage_proxy.hh"
 
 namespace replica {
 
@@ -1990,6 +1994,34 @@ static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_sc
     }), size_t{base_overhead_bytes * ms.size()});
 }
 
+// Finds all endpoints to which the view updates will be sent, reads their current view backlogs,
+// chooses the backlog that is the most full and calculates the amount of time to sleep for based on it.
+// The local node's backlog is also included in the calculations, as every view update spawns a local
+// task before being sent away to the remote node.
+// The throttling is a heuristic, so we don't need to have 100% accurate endpoints, there's no need to lock
+// topology changes during the calculation or anything like that.
+static std::chrono::microseconds calculate_throttling_delay_for_view_update_batch(
+    const utils::chunked_vector<frozen_mutation_and_schema>& view_updates,
+    const dht::token& base_token,
+    const shared_ptr<db::view::view_update_generator>& gen,
+    const db::timeout_clock::time_point timeout) {
+
+    // Find the maximum batchlog, initial value is the local batchlog
+    db::view::update_backlog max_backlog = gen->get_storage_proxy().local().get_view_update_backlog();
+
+    for (const frozen_mutation_and_schema& view_update : view_updates) {
+        auto target_endpoints = gen->get_endpoints_for_view_update(base_token, view_update);
+
+        for (const gms::inet_address& endpoint_addr : target_endpoints) {
+            db::view::update_backlog endpoint_backlog = gen->get_storage_proxy().local().get_backlog_of(endpoint_addr);
+            max_backlog = std::max(max_backlog, endpoint_backlog);
+        }
+    }
+
+    // Calculate the delay
+    return db::view::calculate_view_update_throttling_delay(max_backlog, timeout);
+}
+
 /**
  * Given some updates on the base table and the existing values for the rows affected by that update, generates the
  * mutations to be applied to the base table's views, and sends them to the paired view replicas.
@@ -1998,6 +2030,8 @@ static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_sc
  * @param views the affected views which need to be updated.
  * @param updates the base table updates being applied.
  * @param existings the existing values for the rows affected by updates. This is used to decide if a view is
+ * @param now the current time, used to calculate timeouts for individual view updates
+ * @param timeout client reques timeout
  * obsoleted by the update and should be removed, gather the values for columns that may not be part of the update if
  * a new view entry needs to be created, and compute the minimal updates to be applied if the view entry isn't changed
  * but has simply some updated values.
@@ -2009,7 +2043,8 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
         mutation&& m,
         flat_mutation_reader_v2_opt existings,
         tracing::trace_state_ptr tr_state,
-        gc_clock::time_point now) const {
+        gc_clock::time_point now,
+        db::timeout_clock::time_point timeout) const {
     auto base_token = m.token();
     auto m_schema = m.schema();
     db::view::view_update_builder builder = db::view::make_view_update_builder(
@@ -2022,7 +2057,7 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
             now);
 
     std::exception_ptr err = nullptr;
-    while (true) {
+    for (size_t batch_num = 0; ; batch_num++) {
         std::optional<utils::chunked_vector<frozen_mutation_and_schema>> updates;
         try {
             updates = co_await builder.build_some();
@@ -2035,6 +2070,29 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
         }
         tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
         auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(*updates));
+
+        // To prevent overload we sleep for a moment before sending another batch of view updates.
+        // The amount of time to sleep for is chosen based on how full the view update backlog is,
+        // the more full the queue of pending view updates is the more aggresively we should delay
+        // new ones.
+        // The first batch of updates doesn't have any delays becase it's slowed down by the other throttling mechanism,
+        // the one which limits the number of incoming client requests by delaying the response to the client.
+        try {
+            if (batch_num > 0) {
+                std::chrono::microseconds throttle_delay =
+                    calculate_throttling_delay_for_view_update_batch(*updates, base_token, gen, timeout);
+
+                co_await seastar::sleep(throttle_delay);
+
+                if (db::timeout_clock::now() > timeout) {
+                    throw exceptions::view_update_generation_timeout_exception();
+                }
+            }
+        } catch(...) {
+            err = std::current_exception();
+            break;
+        }
+
         try {
             co_await gen->mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats, tr_state,
                 std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no);
@@ -2655,7 +2713,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     const bool need_static = db::view::needs_static_row(m.partition(), views);
     if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
-        co_await generate_and_propagate_view_updates(gen, base, sem.make_tracking_only_permit(s.get(), "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now);
+        co_await generate_and_propagate_view_updates(gen, base, sem.make_tracking_only_permit(s.get(), "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
@@ -2690,7 +2748,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = sem.make_tracking_only_permit(base.get(), "push-view-updates-2", timeout, tr_state);
     auto reader = source.make_reader_v2(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    co_await this->generate_and_propagate_view_updates(gen, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now);
+    co_await this->generate_and_propagate_view_updates(gen, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());
     // return the local partition/row lock we have taken so it
     // remains locked until the caller is done modifying this

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1386,28 +1386,11 @@ public:
                     return std::max(lhs, rhs);
                 });
     }
-    std::chrono::microseconds calculate_delay(db::view::update_backlog backlog) {
-        constexpr auto delay_limit_us = 1000000;
-        auto adjust = [] (float x) { return x * x * x; };
-        auto budget = std::max(storage_proxy::clock_type::duration(0),
-            _expire_timer.get_timeout() - storage_proxy::clock_type::now());
-        std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
-        // "budget" has millisecond resolution and can potentially be long
-        // in the future so converting it to microseconds may overflow.
-        // So to compare buget and ret we need to convert both to the lower
-        // resolution.
-        if (std::chrono::duration_cast<storage_proxy::clock_type::duration>(ret) < budget) {
-            return ret;
-        } else {
-            // budget is small (< ret) so can be converted to microseconds
-            return std::chrono::duration_cast<std::chrono::microseconds>(budget);
-        }
-    }
     // Calculates how much to delay completing the request. The delay adds to the request's inherent latency.
     template<typename Func>
     void delay(tracing::trace_state_ptr trace, Func&& on_resume) {
         auto backlog = max_backlog();
-        auto delay = calculate_delay(backlog);
+        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout());
         stats().last_mv_flow_control_delay = delay;
         if (delay.count() == 0) {
             tracing::trace(trace, "Delay decision due to throttling: do not delay, resuming now");

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -223,6 +223,13 @@ public:
     query::tombstone_limit get_tombstone_limit() const;
     inet_address_vector_replica_set get_live_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
 
+    // Get information about this node's view update backlog. It combines information from all local shards.
+    db::view::update_backlog get_view_update_backlog() const;
+
+    // Get information about a remote node's view update backlog. Information about remote backlogs is constantly updated
+    // using gossip and by passing the information in each MUTATION_DONE rpc call response.
+    db::view::update_backlog get_backlog_of(gms::inet_address) const;
+
     future<std::vector<dht::token_range_endpoints>> describe_ring(const sstring& keyspace, bool include_only_local_dc = false) const;
 
 private:
@@ -421,11 +428,7 @@ private:
             allow_hints,
             is_cancellable);
 
-    db::view::update_backlog get_view_update_backlog() const;
-
     void maybe_update_view_backlog_of(gms::inet_address, std::optional<db::view::update_backlog>);
-
-    db::view::update_backlog get_backlog_of(gms::inet_address) const;
 
     template<typename Range>
     future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);


### PR DESCRIPTION
This is another attempt at a fix for problems with materialized views concurrency #12379.

See #12379 and #13583 for a detailed description of the problem and discussions.

This PR aims to extend the existing throttling mechanism to work with requests that internally generate a large amount of view updates, as suggested by @nyh.

The existing mechanism works in the following way:
* Client sends a request, we generate the view updates corresponding to the request and spawn background tasks which will send these updates to remote nodes
* Each background task consumes some units from the `view_update_concurrency_semaphore`, but doesn't wait for these units, it's just for tracking
* We keep track of the percent of consumed units on each node, this is called `view update backlog`.
* Before sending a response to the client we sleep for a short amount of time. The amount of time to sleep for is based on the fullness of this `view update backlog`. For a well behaved client with limited concurrency this will limit the amount of incoming requests to a manageable level.

This mechanism doesn't handle large DELETE queries. Deleting a partition is fast for the base table, but it requires us to generate a view update for every single deleted row. The number of deleted rows per single client request can be in the millions. Delaying response to the request doesn't help when a single request can generate millions of updates.

To deal with this we could treat the view update generator just like any other client and force it to wait a bit of time before sending the next batch of updates. The amount of time to wait for is calculated just like in the existing throttling code, it's based on the fullness of `view update backlogs`.

The new algorithm of view update generation looks something like this:
```c++
for(;;) {
    auto updates = generate_updates_batch_with_max_100_rows();
    co_await seastar::sleep(calculate_sleep_time_from_backlogs());
    spawn_background_tasks_for_updates(updates);
}
```

Fixes: https://github.com/scylladb/scylladb/issues/12379