### PR TITLE
Allow tombstone GC in compaction to be disabled on user request

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -438,6 +438,68 @@
          ]
       },
       {
+         "path":"/column_family/tombstone_gc/{name}",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Check if tombstone GC is enabled for a given table",
+               "type":"boolean",
+               "nickname":"get_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"POST",
+               "summary":"Enable tombstone GC for a given table",
+               "type":"void",
+               "nickname":"enable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable tombstone GC for a given table",
+               "type":"void",
+               "nickname":"disable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/column_family/estimate_keys/{name}",
          "operations":[
             {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2111,6 +2111,65 @@
          ]
       },
       {
+         "path":"/storage_service/tombstone_gc/{keyspace}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Enable tombstone GC",
+               "type":"void",
+               "nickname":"enable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-separated column family names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable tombstone GC",
+               "type":"void",
+               "nickname":"disable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-separated column family names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/deliver_hints",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -220,30 +220,38 @@ seastar::future<json::json_return_type> run_toppartitions_query(db::toppartition
     });
 }
 
-future<json::json_return_type> set_tables_autocompaction(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled) {
+static future<json::json_return_type> set_tables(http_context& ctx, const sstring& keyspace, std::vector<sstring> tables, std::function<future<>(replica::table&)> set) {
     if (tables.empty()) {
         tables = map_keys(ctx.db.local().find_keyspace(keyspace).metadata().get()->cf_meta_data());
     }
 
+    return do_with(keyspace, std::move(tables), [&ctx, set] (const sstring& keyspace, const std::vector<sstring>& tables) {
+        return ctx.db.invoke_on_all([&keyspace, &tables, set] (replica::database& db) {
+            return parallel_for_each(tables, [&db, &keyspace, set] (const sstring& table) {
+                replica::table& t = db.find_column_family(keyspace, table);
+                return set(t);
+            });
+        });
+    }).then([] {
+        return make_ready_future<json::json_return_type>(json_void());
+    });
+}
+
+future<json::json_return_type> set_tables_autocompaction(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled) {
     apilog.info("set_tables_autocompaction: enabled={} keyspace={} tables={}", enabled, keyspace, tables);
-    return do_with(keyspace, std::move(tables), [&ctx, enabled] (const sstring &keyspace, const std::vector<sstring>& tables) {
-        return ctx.db.invoke_on(0, [&ctx, &keyspace, &tables, enabled] (replica::database& db) {
+
+        // FIXME: restore indentation.
+        return ctx.db.invoke_on(0, [&ctx, keyspace, tables = std::move(tables), enabled] (replica::database& db) {
             auto g = replica::database::autocompaction_toggle_guard(db);
-            return ctx.db.invoke_on_all([&keyspace, &tables, enabled] (replica::database& db) {
-                return parallel_for_each(tables, [&db, &keyspace, enabled] (const sstring& table) {
-                    replica::column_family& cf = db.find_column_family(keyspace, table);
+            return set_tables(ctx, keyspace, tables, [enabled] (replica::table& cf) {
                     if (enabled) {
                         cf.enable_auto_compaction();
                     } else {
                         return cf.disable_auto_compaction();
                     }
                     return make_ready_future<>();
-                });
             }).finally([g = std::move(g)] {});
         });
-    }).then([] {
-        return make_ready_future<json::json_return_type>(json_void());
-    });
 }
 
 void set_transport_controller(http_context& ctx, routes& r, cql_transport::controller& ctl) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -240,18 +240,17 @@ static future<json::json_return_type> set_tables(http_context& ctx, const sstrin
 future<json::json_return_type> set_tables_autocompaction(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled) {
     apilog.info("set_tables_autocompaction: enabled={} keyspace={} tables={}", enabled, keyspace, tables);
 
-        // FIXME: restore indentation.
-        return ctx.db.invoke_on(0, [&ctx, keyspace, tables = std::move(tables), enabled] (replica::database& db) {
-            auto g = replica::database::autocompaction_toggle_guard(db);
-            return set_tables(ctx, keyspace, tables, [enabled] (replica::table& cf) {
-                    if (enabled) {
-                        cf.enable_auto_compaction();
-                    } else {
-                        return cf.disable_auto_compaction();
-                    }
-                    return make_ready_future<>();
-            }).finally([g = std::move(g)] {});
-        });
+    return ctx.db.invoke_on(0, [&ctx, keyspace, tables = std::move(tables), enabled] (replica::database& db) {
+        auto g = replica::database::autocompaction_toggle_guard(db);
+        return set_tables(ctx, keyspace, tables, [enabled] (replica::table& cf) {
+            if (enabled) {
+                cf.enable_auto_compaction();
+            } else {
+                return cf.disable_auto_compaction();
+            }
+            return make_ready_future<>();
+        }).finally([g = std::move(g)] {});
+    });
 }
 
 void set_transport_controller(http_context& ctx, routes& r, cql_transport::controller& ctl) {

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -37,6 +37,10 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
         return candidate;
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return compaction_descriptor();
+    }
+
     // if there is no sstable to compact in standard way, try compacting based on droppable tombstone ratio
     // unlike stcs, lcs can look for sstable with highest droppable tombstone ratio, so as not to choose
     // a sstable which droppable data shadow data in older sstable, by starting from highest levels which

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -164,6 +164,10 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
         return sstables::compaction_descriptor(std::move(most_interesting), service::get_local_compaction_priority());
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return compaction_descriptor();
+    }
+
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
     // prefer oldest sstables from biggest size tiers because they will be easier to satisfy conditions for

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -48,6 +48,7 @@ public:
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
+    virtual bool tombstone_gc_enabled() const noexcept = 0;
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
     virtual const std::string& get_group_id() const noexcept = 0;

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -284,6 +284,10 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
         return most_interesting;
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return {};
+    }
+
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
     auto e = boost::range::remove_if(non_expiring_sstables, [this, compaction_time, &table_s] (const shared_sstable& sst) -> bool {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -444,6 +444,7 @@ private:
     sstables::sstables_manager& _sstables_manager;
     secondary_index::secondary_index_manager _index_manager;
     bool _compaction_disabled_by_user = false;
+    bool _tombstone_gc_enabled = true;
     utils::phased_barrier _flush_barrier;
     std::vector<view_ptr> _views;
 
@@ -965,6 +966,9 @@ public:
 
     void enable_auto_compaction();
     future<> disable_auto_compaction();
+
+    void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
+
     bool is_auto_compaction_disabled_by_user() const {
       return _compaction_disabled_by_user;
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -969,6 +969,10 @@ public:
 
     void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
 
+    bool tombstone_gc_enabled() const noexcept {
+        return _tombstone_gc_enabled;
+    }
+
     bool is_auto_compaction_disabled_by_user() const {
       return _compaction_disabled_by_user;
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2550,6 +2550,14 @@ table::disable_auto_compaction() {
     });
 }
 
+void table::set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept {
+    _tombstone_gc_enabled = tombstone_gc_enabled;
+    tlogger.info0("Tombstone GC was {} for {}.{}", tombstone_gc_enabled ? "enabled" : "disabled", _schema->ks_name(), _schema->cf_name());
+    if (_tombstone_gc_enabled) {
+        trigger_compaction();
+    }
+}
+
 flat_mutation_reader_v2
 table::make_reader_v2_excluding_sstables(schema_ptr s,
         reader_permit permit,
@@ -2794,6 +2802,9 @@ public:
     }
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return _t.is_auto_compaction_disabled_by_user();
+    }
+    bool tombstone_gc_enabled() const noexcept override {
+        return _t._tombstone_gc_enabled;
     }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _t.get_compaction_manager().get_tombstone_gc_state();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -116,7 +116,7 @@ public:
         return table().is_auto_compaction_disabled_by_user();
     }
     bool tombstone_gc_enabled() const noexcept override {
-        return true;
+        return table().tombstone_gc_enabled();
     }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _tombstone_gc_state;
@@ -154,6 +154,10 @@ future<> table_for_tests::stop() {
     auto data = _data;
     co_await data->cm.remove(*data->table_s);
     co_await when_all_succeed(data->cm.stop(), data->semaphore.stop()).discard_result();
+}
+
+void table_for_tests::set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept {
+    _data->cf->set_tombstone_gc_enabled(tombstone_gc_enabled);
 }
 
 namespace sstables {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -115,6 +115,9 @@ public:
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return table().is_auto_compaction_disabled_by_user();
     }
+    bool tombstone_gc_enabled() const noexcept override {
+        return true;
+    }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _tombstone_gc_state;
     }

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -97,4 +97,6 @@ struct table_for_tests {
             return make_sstable(version);
         };
     }
+
+    void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
 };

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -61,3 +61,39 @@ def do_test_column_family_attribute_api_table(cql, this_dc, rest_api, api_name):
 
 def test_column_family_auto_compaction_table(cql, this_dc, rest_api):
     do_test_column_family_attribute_api_table(cql, this_dc, rest_api, "autocompaction")
+
+def test_column_family_tombstone_gc_api(cql, this_dc, rest_api):
+    do_test_column_family_attribute_api_table(cql, this_dc, rest_api, "tombstone_gc")
+
+def test_column_family_tombstone_gc_correctness(cql, this_dc, rest_api):
+    ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
+    with new_test_keyspace(cql, ksdef) as test_keyspace:
+        with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
+            test_table = t.split('.')[1]
+
+            # 1 Allow tombstones to be purged by compaction right away
+            cql.execute(f"ALTER TABLE {test_keyspace}.{test_table} with gc_grace_seconds=0")
+
+            # 2 Disable tombstone purge using API
+            resp = rest_api.send("DELETE", f"column_family/tombstone_gc/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+
+            resp = rest_api.send("GET", f"column_family/tombstone_gc/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            assert resp.json() == False
+
+            # 3 Create partition tombstone
+            cql.execute(f"DELETE from {test_keyspace}.{test_table} WHERE a = 1")
+
+            # 4 Flush it into sstable
+            resp = rest_api.send("POST", f"storage_service/keyspace_flush/{test_keyspace}")
+            resp.raise_for_status()
+
+            # 5 Trigger major compaction on that sstable
+            resp = rest_api.send("POST", f"storage_service/keyspace_compaction/{test_keyspace}")
+            resp.raise_for_status()
+
+            # 6 Expect that tombstone was not purged
+            resp = rest_api.send("GET", f"column_family/sstables/by_key/{test_keyspace}:{test_table}?key=1")
+            resp.raise_for_status()
+            assert "-Data.db" in resp.json()[0]

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -12,49 +12,52 @@ import time
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 from util import new_test_table, new_test_keyspace
 
-def test_column_family_auto_compaction_table(cql, this_dc, rest_api):
+def do_test_column_family_attribute_api_table(cql, this_dc, rest_api, api_name):
     ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
     with new_test_keyspace(cql, ksdef) as test_keyspace:
         with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
             test_table = t.split('.')[1]
 
-            resp = rest_api.send("GET", f"column_family/autocompaction/{test_keyspace}:{test_table}")
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
             resp.raise_for_status()
 
-            resp = rest_api.send("DELETE", f"column_family/autocompaction/{test_keyspace}:{test_table}")
+            resp = rest_api.send("DELETE", f"column_family/{api_name}/{test_keyspace}:{test_table}")
             resp.raise_for_status()
 
-            resp = rest_api.send("GET", f"column_family/autocompaction/{test_keyspace}:{test_table}")
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
             resp.raise_for_status()
             assert resp.json() == False
 
-            resp = rest_api.send("POST", f"column_family/autocompaction/{test_keyspace}:{test_table}")
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}:{test_table}")
             resp.raise_for_status()
 
-            resp = rest_api.send("GET", f"column_family/autocompaction/{test_keyspace}:{test_table}")
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
             resp.raise_for_status()
             assert resp.json() == True
 
             # missing table
-            resp = rest_api.send("POST", f"column_family/autocompaction/")
+            resp = rest_api.send("POST", f"column_family/{api_name}/")
             assert resp.status_code == requests.codes.not_found
 
             # bad syntax 1
-            resp = rest_api.send("POST", f"column_family/autocompaction/{test_keyspace}")
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}")
             assert resp.status_code == requests.codes.bad_request
             assert resp.json()['message'] == 'Column family name should be in keyspace:column_family format'
 
             # bad syntax 2
-            resp = rest_api.send("POST", f"column_family/autocompaction/{test_keyspace}.{test_table}")
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}.{test_table}")
             assert resp.status_code == requests.codes.bad_request
             assert resp.json()['message'] == 'Column family name should be in keyspace:column_family format'
 
             # non-existing keyspace
-            resp = rest_api.send("POST", f"column_family/autocompaction/{test_keyspace}XXX:{test_table}")
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}XXX:{test_table}")
             assert resp.status_code == requests.codes.bad_request
             assert "Can't find a column family" in resp.json()['message']
 
             # non-existing table
-            resp = rest_api.send("POST", f"column_family/autocompaction/{test_keyspace}:{test_table}XXX")
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}:{test_table}XXX")
             assert resp.status_code == requests.codes.bad_request
             assert "Can't find a column family" in resp.json()['message']
+
+def test_column_family_auto_compaction_table(cql, this_dc, rest_api):
+    do_test_column_family_attribute_api_table(cql, this_dc, rest_api, "autocompaction")

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -68,6 +68,9 @@ def do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, api_n
 def test_storage_service_auto_compaction_keyspace(cql, this_dc, rest_api):
     do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, "auto_compaction")
 
+def test_storage_service_tombstone_gc_keyspace(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, "tombstone_gc")
+
 def do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
     with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
@@ -86,6 +89,9 @@ def do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, api_name
 
 def test_storage_service_auto_compaction_table(cql, this_dc, rest_api):
     do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, "auto_compaction")
+
+def test_storage_service_tombstone_gc_table(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, "tombstone_gc")
 
 def do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
@@ -106,6 +112,9 @@ def do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, api_nam
 
 def test_storage_service_auto_compaction_tables(cql, this_dc, rest_api):
     do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, "auto_compaction")
+
+def test_storage_service_tombstone_gc_tables(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, "tombstone_gc")
 
 def test_storage_service_keyspace_offstrategy_compaction(cql, this_dc, rest_api):
     keyspace = new_keyspace(cql, this_dc)

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -42,61 +42,70 @@ def test_storage_service_keyspaces(cql, this_dc, rest_api):
         assert keyspace in resp.json()
 
 
-def test_storage_service_auto_compaction_keyspace(cql, this_dc, rest_api):
+def do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
     # test empty keyspace
-    resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}")
+    resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}")
     resp.raise_for_status()
 
-    resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}")
+    resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}")
     resp.raise_for_status()
 
     # test non-empty keyspace
     with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
-        resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}")
+        resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}")
         resp.raise_for_status()
 
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}")
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}")
         resp.raise_for_status()
 
         # non-existing keyspace
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/XXX")
+        resp = rest_api.send("POST", f"storage_service/{api_name}/XXX")
+        assert resp.status_code == requests.codes.bad_request
+
+    cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_storage_service_auto_compaction_keyspace(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, "auto_compaction")
+
+def do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, api_name):
+    keyspace = new_keyspace(cql, this_dc)
+    with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
+        test_table = t.split('.')[1]
+        resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}", { "cf": test_table })
+        resp.raise_for_status()
+
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": test_table })
+        resp.raise_for_status()
+
+        # non-existing table
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": "XXX" })
         assert resp.status_code == requests.codes.bad_request
 
     cql.execute(f"DROP KEYSPACE {keyspace}")
 
 def test_storage_service_auto_compaction_table(cql, this_dc, rest_api):
-    keyspace = new_keyspace(cql, this_dc)
-    with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
-        test_table = t.split('.')[1]
-        resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}", { "cf": test_table })
-        resp.raise_for_status()
+    do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, "auto_compaction")
 
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": test_table })
-        resp.raise_for_status()
-
-        # non-existing table
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": "XXX" })
-        assert resp.status_code == requests.codes.bad_request
-
-    cql.execute(f"DROP KEYSPACE {keyspace}")
-
-def test_storage_service_auto_compaction_tables(cql, this_dc, rest_api):
+def do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
     with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t0:
         with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t1:
             test_tables = [t0.split('.')[1], t1.split('.')[1]]
-            resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
+            resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
             resp.raise_for_status()
 
-            resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
+            resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
             resp.raise_for_status()
 
             # non-existing table
-            resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},XXX" })
+            resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},XXX" })
             assert resp.status_code == requests.codes.bad_request
 
     cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_storage_service_auto_compaction_tables(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, "auto_compaction")
 
 def test_storage_service_keyspace_offstrategy_compaction(cql, this_dc, rest_api):
     keyspace = new_keyspace(cql, this_dc)


### PR DESCRIPTION
Adding new APIs /column_family/tombstone_gc and /storage_service/tombstone_gc, that will allow for disabling tombstone garbage collection (GC) in compaction.
    
Mimicks existing APIs /column_family/autocompaction and /storage_service/autocompaction.

column_family variant must specify a single table only, following existing convention.

whereas the storage_service one can specify an entire keyspace, or a subset of a tables in a keyspace.

column_family API usage
-----

```
    The table name must be in keyspace:name format

    Get status:
    curl -s -X GET "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"

    Enable GC
    curl -s -X POST "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"

    Disable GC
    curl -s -X DELETE "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"
```

storage_service API usage
-----

```
    Tables can be specified using a comma-separated list.

    Enable GC on keyspace
    curl -s -X POST "http://127.0.0.1:10000/storage_service/tombstone_gc/ks"

    Disable GC on keyspace
    curl -s -X DELETE "http://127.0.0.1:10000/storage_service/tombstone_gc/ks"

    Enable GC on a subset of tables
    curl -s -X POST
    "http://127.0.0.1:10000/storage_service/tombstone_gc/ks?cf=table1,table2"
```