### PR TITLE
replica, sstable: replace generation_type::value() with generation_type::as_int()

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1257,7 +1257,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                             ss::sstable info;
 
                             info.timestamp = t;
-                            info.generation = sstables::generation_value(sstable->generation());
+                            info.generation = sstable->generation().as_int();
                             info.level = sstable->get_sstable_level();
                             info.size = sstable->bytes_on_disk();
                             info.data_size = sstable->ondisk_data_size();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -474,7 +474,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
         sharded<sstables::sstable_generation_generator> sharded_gen;
         auto highest_generation = highest_generation_seen(directory).get0().value_or(
             sstables::generation_type{0});
-        sharded_gen.start(highest_generation.value()).get();
+        sharded_gen.start(highest_generation.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
         auto make_sstable = [&] (shard_id shard) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -67,7 +67,7 @@ static seastar::metrics::label keyspace_label("ks");
 using namespace std::chrono_literals;
 
 void table::update_sstables_known_generation(std::optional<sstables::generation_type> generation) {
-    auto gen = generation.value_or(sstables::generation_type(0)).value();
+    auto gen = generation.value_or(sstables::generation_type(0)).as_int();
     if (_sstable_generation_generator) {
         _sstable_generation_generator->update_known_generation(gen);
     } else {

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -34,8 +34,9 @@ public:
     generation_type() = delete;
 
     explicit constexpr generation_type(int_t value) noexcept: _value(value) {}
-    constexpr int_t value() const noexcept { return _value; }
-
+    constexpr int_t as_int() const noexcept {
+	return _value;
+    }
     // convert to data_value
     //
     // this function is used when performing queries to SSTABLES_REGISTRY in
@@ -70,9 +71,6 @@ public:
 
 constexpr generation_type generation_from_value(generation_type::int_t value) {
     return generation_type{value};
-}
-constexpr generation_type::int_t generation_value(generation_type generation) {
-    return generation.value();
 }
 
 template <std::ranges::range Range, typename Target = std::vector<sstables::generation_type>>
@@ -124,7 +122,7 @@ namespace std {
 template <>
 struct hash<sstables::generation_type> {
     size_t operator()(const sstables::generation_type& generation) const noexcept {
-        return hash<sstables::generation_type::int_t>{}(generation.value());
+        return hash<sstables::generation_type::int_t>{}(generation.as_int());
     }
 };
 
@@ -144,6 +142,6 @@ template <>
 struct fmt::formatter<sstables::generation_type> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const sstables::generation_type& generation, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", generation.value());
+        return fmt::format_to(ctx.out(), "{}", generation.as_int());
     }
 };

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -73,7 +73,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
 {}
 
 void sstable_directory::filesystem_components_lister::handle(sstables::entry_descriptor desc, fs::path filename) {
-    if ((generation_value(desc.generation) % smp::count) != this_shard_id()) {
+    if ((desc.generation.as_int() % smp::count) != this_shard_id()) {
         return;
     }
 
@@ -293,7 +293,7 @@ future<> sstable_directory::system_keyspace_components_lister::process(sstable_d
             // FIXME -- handle
             return make_ready_future<>();
         }
-        if ((generation_value(desc.generation) % smp::count) != this_shard_id()) {
+        if ((desc.generation.as_int() % smp::count) != this_shard_id()) {
             return make_ready_future<>();
         }
 
@@ -573,7 +573,7 @@ highest_generation_seen(sharded<sstables::sstable_directory>& directory) {
             return sstables::generation_type(0);
         }
     });
-    co_return highest.value() ? std::make_optional(highest): std::nullopt;
+    co_return highest.as_int() ? std::make_optional(highest) : std::nullopt;
 }
 
 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -64,7 +64,7 @@ public:
     { }
 
     sstable_assertions(test_env& env, shared_sstable sst)
-        : sstable_assertions(env, sst->get_schema(), env.tempdir().path().native(), sst->get_version(), sst->generation().value())
+        : sstable_assertions(env, sst->get_schema(), env.tempdir().path().native(), sst->get_version(), sst->generation().as_int())
     {}
 
     test_env& get_env() {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2894,7 +2894,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
             BOOST_REQUIRE(*expected_sst == old_sstables.front()->generation());
             expected_sst++;
             // check that previously released sstables were already closed
-            if (generation_value(old_sstables.front()->generation()) % 4 == 0) {
+            if (auto v = old_sstables.front()->generation().as_int(); v % 4 == 0) {
                 // Due to performance reasons, sstables are not released immediately, but in batches.
                 // At the time of writing, mutation_reader_merger releases it's sstable references
                 // in batches of 4. That's why we only perform this check every 4th sstable. 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2822,7 +2822,7 @@ SEASTAR_TEST_CASE(compound_sstable_set_basic_test) {
         set2->insert(sstable_for_overlapping_test(env, s, keys[0].key(), keys[1].key(), 0));
         set2->insert(sstable_for_overlapping_test(env, s, keys[0].key(), keys[1].key(), 0));
 
-        BOOST_REQUIRE(boost::accumulate(*compound->all() | boost::adaptors::transformed([] (const sstables::shared_sstable& sst) { return generation_value(sst->generation()); }), unsigned(0)) == 6);
+        BOOST_REQUIRE(boost::accumulate(*compound->all() | boost::adaptors::transformed([] (const sstables::shared_sstable& sst) { return sst->generation().as_int(); }), unsigned(0)) == 6);
         {
             unsigned found = 0;
             for (auto sstables = compound->all(); [[maybe_unused]] auto& sst : *sstables) {

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -491,7 +491,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
 
         auto max_generation_seen = highest_generation_seen(sstdir).get0();
         std::atomic<sstables::generation_type::int_t> generation_for_test = {};
-        generation_for_test.store(max_generation_seen->value() + 1, std::memory_order_relaxed);
+        generation_for_test.store(max_generation_seen->as_int() + 1, std::memory_order_relaxed);
 
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);
@@ -532,7 +532,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
 
         auto max_generation_seen = highest_generation_seen(sstdir).get0();
         std::atomic<sstables::generation_type::int_t> generation_for_test = {};
-        generation_for_test.store(max_generation_seen->value() + 1, std::memory_order_relaxed);
+        generation_for_test.store(max_generation_seen->as_int() + 1, std::memory_order_relaxed);
 
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);
@@ -573,7 +573,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
 
         auto max_generation_seen = highest_generation_seen(sstdir).get0();
         std::atomic<sstables::generation_type::int_t> generation_for_test = {};
-        generation_for_test.store(max_generation_seen->value() + 1, std::memory_order_relaxed);
+        generation_for_test.store(max_generation_seen->as_int() + 1, std::memory_order_relaxed);
 
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", [&e, upload_path, &generation_for_test] (shard_id id) {
             auto generation = generation_for_test.fetch_add(1, std::memory_order_relaxed);

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -118,7 +118,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
     std::unordered_set<shard_id> processed_shards;
 
     for (auto& sstable : new_sstables) {
-        auto new_sst = env.reusable_sst(s, sstable->generation().as_int(), version).get0();
+        auto new_sst = env.reusable_sst(s, sstable->generation(), version).get0();
         bloom_filter_size_after += filter_size(new_sst);
         auto shards = new_sst->get_shards_for_this_sstable();
         BOOST_REQUIRE(shards.size() == 1); // check sstable is unshared.
@@ -196,7 +196,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
             BOOST_REQUIRE(!sst->is_shared());
 
             auto all_shards_s = get_schema(smp::count, cfg->murmur3_partitioner_ignore_msb_bits());
-            sst = env.reusable_sst(all_shards_s, sst->generation().as_int(), version).get0();
+            sst = env.reusable_sst(all_shards_s, sst->generation(), version).get0();
             BOOST_REQUIRE(smp::count == 1 || sst->is_shared());
             BOOST_REQUIRE(sst->get_shards_for_this_sstable().size() == smp::count);
             assert_sstable_computes_correct_owners(env, sst).get();

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -118,7 +118,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
     std::unordered_set<shard_id> processed_shards;
 
     for (auto& sstable : new_sstables) {
-        auto new_sst = env.reusable_sst(s, generation_value(sstable->generation()), version).get0();
+        auto new_sst = env.reusable_sst(s, sstable->generation().as_int(), version).get0();
         bloom_filter_size_after += filter_size(new_sst);
         auto shards = new_sst->get_shards_for_this_sstable();
         BOOST_REQUIRE(shards.size() == 1); // check sstable is unshared.
@@ -196,7 +196,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
             BOOST_REQUIRE(!sst->is_shared());
 
             auto all_shards_s = get_schema(smp::count, cfg->murmur3_partitioner_ignore_msb_bits());
-            sst = env.reusable_sst(all_shards_s, generation_value(sst->generation()), version).get0();
+            sst = env.reusable_sst(all_shards_s, sst->generation().as_int(), version).get0();
             BOOST_REQUIRE(smp::count == 1 || sst->is_shared());
             BOOST_REQUIRE(sst->get_shards_for_this_sstable().size() == smp::count);
             assert_sstable_computes_correct_owners(env, sst).get();

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -175,7 +175,7 @@ SEASTAR_TEST_CASE(missing_summary_first_last_sane) {
 
 static future<sstable_ptr> do_write_sst(test_env& env, schema_ptr schema, sstring load_dir, sstring write_dir, sstables::generation_type generation) {
     return env.reusable_sst(std::move(schema), load_dir, generation).then([write_dir, generation] (sstable_ptr sst) mutable {
-        sstable_generation_generator gen(generation.value());
+        sstable_generation_generator gen{generation.as_int()};
         sstables::test(sst).change_generation_number(gen());
         sstables::test(sst).change_dir(write_dir);
         auto fut = sstables::test(sst).store();

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -148,10 +148,6 @@ public:
             sstable::version_types version, sstable::format_types f = sstable::format_types::big) {
         return reusable_sst(std::move(schema), _impl->dir.path().native(), std::move(generation), std::move(version), std::move(f));
     }
-    future<shared_sstable> reusable_sst(schema_ptr schema, sstables::generation_type::int_t gen_value,
-            sstable::version_types version, sstable::format_types f = sstable::format_types::big) {
-        return reusable_sst(std::move(schema), sstables::generation_type(gen_value), std::move(version), std::move(f));
-    }
 
     future<shared_sstable> reusable_sst(schema_ptr schema, shared_sstable sst) {
         return reusable_sst(std::move(schema), sst->get_storage().prefix(), sst->generation(), sst->get_version());


### PR DESCRIPTION
this series prepares for the UUID based generation by replacing the general `value()` function with the function with more specific name: `as_int()`.