### PR TITLE
tombstone_gc: Fix gc_before for immediate mode

### DIFF
--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -77,7 +77,7 @@ tombstone_gc_state::get_gc_before_for_range_result tombstone_gc_state::get_gc_be
     }
     case tombstone_gc_mode::immediate: {
         dblog.trace("Get gc_before for ks={}, table={}, range={}, mode=immediate", s->ks_name(), s->cf_name(), range);
-        return {gc_clock::time_point::max(), gc_clock::time_point::max(), knows_entire_range};
+        return {query_time, query_time, knows_entire_range};
     }
     case tombstone_gc_mode::repair: {
         const std::chrono::seconds& propagation_delay = options.propagation_delay_in_seconds();
@@ -135,7 +135,7 @@ gc_clock::time_point tombstone_gc_state::get_gc_before_for_key(schema_ptr s, con
         return gc_clock::time_point::min();
     case tombstone_gc_mode::immediate:
         dblog.trace("Get gc_before for ks={}, table={}, dk={}, mode=immediate", s->ks_name(), s->cf_name(), dk);
-        return gc_clock::time_point::max();
+        return query_time;
     case tombstone_gc_mode::repair:
         const std::chrono::seconds& propagation_delay = options.propagation_delay_in_seconds();
         auto gc_before = gc_clock::time_point::min();


### PR DESCRIPTION
The immediate mode is similar to timeout mode with gc_grace_seconds zero. Thus, the gc_before returned should be the query_time instead of gc_clock::time_point::max in immediate mode.

Setting gc_before to gc_clock::time_point::max, a row could be dropped by compaction even if the ttl is not expired yet.

The following procedure reproduces the issue:

- Start 2 nodes

- Insert data

```
CREATE KEYSPACE ks2a WITH REPLICATION = { 'class' : 'SimpleStrategy',
'replication_factor' : 2 };
CREATE TABLE ks2a.tb (pk int, ck int, c0 text, c1 text, c2 text, PRIMARY
KEY(pk, ck)) WITH tombstone_gc = {'mode': 'immediate'};
INSERT into ks2a.tb (pk,ck, c0, c1, c2) values (10 ,1, 'x', 'y', 'z')
USING TTL 1000000;
INSERT into ks2a.tb (pk,ck, c0, c1, c2) values (20 ,1, 'x', 'y', 'z')
USING TTL 1000000;
INSERT into ks2a.tb (pk,ck, c0, c1, c2) values (30 ,1, 'x', 'y', 'z')
USING TTL 1000000;
```

- Run nodetool flush and nodetool compact

- Compaction drops all data

```
~128 total partitions merged to 0.
```

Fixes #13572