### PR TITLE
perform_cleanup: wait until all candidates are cleaned up

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1616,29 +1616,34 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
         throw std::runtime_error(format("cleanup request failed: there is an ongoing cleanup on {}", t));
     }
 
+    co_await run_with_compaction_disabled(t, [&] () -> future<> {
+        auto update_sstables_cleanup_state = [&] (const sstables::sstable_set& set) -> future<> {
+            // Hold on to the sstable set since it may be overwritten
+            // while we yield in this loop.
+            auto set_holder = set.shared_from_this();
+            co_await set.for_each_sstable_gently([&] (const sstables::shared_sstable& sst) {
+                update_sstable_cleanup_state(t, sst, *sorted_owned_ranges);
+            });
+        };
+        co_await update_sstables_cleanup_state(t.main_sstable_set());
+        co_await update_sstables_cleanup_state(t.maintenance_sstable_set());
+    });
+
+    auto& cs = get_compaction_state(&t);
+    if (cs.sstables_requiring_cleanup.empty()) {
+        cmlog.debug("perform_cleanup for {} found no sstables requiring cleanup", t);
+        co_return;
+    }
+
+    // Some sstables may remain in sstables_requiring_cleanup
+    // for later processing if they can't be cleaned up right now.
+    // They are erased from sstables_requiring_cleanup by compacting.release_compacting
+    cs.owned_ranges_ptr = std::move(sorted_owned_ranges);
+
     // Called with compaction_disabled
-    auto get_sstables = [this, &t, sorted_owned_ranges] () -> future<std::vector<sstables::shared_sstable>> {
-        return seastar::async([this, &t, sorted_owned_ranges = std::move(sorted_owned_ranges)] {
-            auto update_sstables_cleanup_state = [&] (const sstables::sstable_set& set) {
-                // Hold on to the sstable set since it may be overwritten
-                // while we yield in this loop.
-                auto set_holder = set.shared_from_this();
-                set.for_each_sstable([&] (const sstables::shared_sstable& sst) {
-                    update_sstable_cleanup_state(t, sst, *sorted_owned_ranges);
-                    seastar::thread::maybe_yield();
-                });
-            };
-            update_sstables_cleanup_state(t.main_sstable_set());
-            update_sstables_cleanup_state(t.maintenance_sstable_set());
-            // Some sstables may remain in sstables_requiring_cleanup
-            // for later processing if they can't be cleaned up right now.
-            // They are erased from sstables_requiring_cleanup by compacting.release_compacting
-            auto& cs = get_compaction_state(&t);
-            if (!cs.sstables_requiring_cleanup.empty()) {
-                cs.owned_ranges_ptr = std::move(sorted_owned_ranges);
-            }
-            return get_candidates(t, cs.sstables_requiring_cleanup);
-        });
+    auto get_sstables = [this, &t] () -> future<std::vector<sstables::shared_sstable>> {
+        auto& cs = get_compaction_state(&t);
+        co_return get_candidates(t, cs.sstables_requiring_cleanup);
     };
 
     co_await perform_task_on_all_files<cleanup_sstables_compaction_task_executor>(t, sstables::compaction_type_options::make_cleanup(), std::move(sorted_owned_ranges),

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1640,6 +1640,13 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
     // They are erased from sstables_requiring_cleanup by compacting.release_compacting
     cs.owned_ranges_ptr = std::move(sorted_owned_ranges);
 
+    auto found_maintenance_sstables = bool(t.maintenance_sstable_set().for_each_sstable_until([this, &t] (const sstables::shared_sstable& sst) {
+        return stop_iteration(requires_cleanup(t, sst));
+    }));
+    if (found_maintenance_sstables) {
+        co_await perform_offstrategy(t);
+    }
+
     // Called with compaction_disabled
     auto get_sstables = [this, &t] () -> future<std::vector<sstables::shared_sstable>> {
         auto& cs = get_compaction_state(&t);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1607,6 +1607,43 @@ bool compaction_manager::requires_cleanup(table_state& t, const sstables::shared
 }
 
 future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t) {
+    constexpr auto sleep_duration = std::chrono::seconds(10);
+    constexpr auto max_idle_duration = std::chrono::seconds(300);
+    auto& cs = get_compaction_state(&t);
+
+    co_await try_perform_cleanup(sorted_owned_ranges, t);
+    auto last_idle = seastar::lowres_clock::now();
+
+    while (!cs.sstables_requiring_cleanup.empty()) {
+        auto idle = seastar::lowres_clock::now() - last_idle;
+        if (idle >= max_idle_duration) {
+            auto msg = ::format("Cleanup timed out after {} seconds of no progress", std::chrono::duration_cast<std::chrono::seconds>(idle).count());
+            cmlog.warn("{}", msg);
+            co_await coroutine::return_exception(std::runtime_error(msg));
+        }
+
+        auto has_sstables_eligible_for_compaction = [&] {
+            for (auto& sst : cs.sstables_requiring_cleanup) {
+                if (sstables::is_eligible_for_compaction(sst)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        cmlog.debug("perform_cleanup: waiting for sstables to become eligible for cleanup");
+        // FIXME: wait for a signal from view update builder
+        co_await sleep(sleep_duration);
+
+        if (!has_sstables_eligible_for_compaction()) {
+            continue;
+        }
+        co_await try_perform_cleanup(sorted_owned_ranges, t);
+        last_idle = seastar::lowres_clock::now();
+    }
+}
+
+future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t) {
     auto check_for_cleanup = [this, &t] {
         return boost::algorithm::any_of(_tasks, [&t] (auto& task) {
             return task->compacting_table() == &t && task->type() == sstables::compaction_type::Cleanup;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1632,8 +1632,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
         };
 
         cmlog.debug("perform_cleanup: waiting for sstables to become eligible for cleanup");
-        // FIXME: wait for a signal from view update builder
-        co_await sleep(sleep_duration);
+        co_await t.get_staging_done_condition().when(sleep_duration, [&] { return has_sstables_eligible_for_compaction(); });
 
         if (!has_sstables_eligible_for_compaction()) {
             continue;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -304,7 +304,10 @@ public:
     // given sstable, e.g. after node loses part of its token range because
     // of a newly added node.
     future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t);
+private:
+    future<> try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t);
 
+public:
     // Submit a table to be upgraded and wait for its termination.
     future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, bool exclude_current_version);
 

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <seastar/core/condition-variable.hh>
+
 #include "schema/schema_fwd.hh"
 #include "compaction_descriptor.hh"
 
@@ -52,6 +54,7 @@ public:
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
     virtual const std::string& get_group_id() const noexcept = 0;
+    virtual seastar::condition_variable& get_staging_done_condition() noexcept = 0;
 };
 
 } // namespace compaction

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/core/condition-variable.hh>
+
 #include "database_fwd.hh"
 #include "compaction/compaction_descriptor.hh"
 #include "compaction/compaction_backlog_manager.hh"
@@ -47,6 +49,7 @@ class compaction_group {
     std::vector<sstables::shared_sstable> _sstables_compacted_but_not_deleted;
     uint64_t _main_set_disk_space_used = 0;
     uint64_t _maintenance_set_disk_space_used = 0;
+    seastar::condition_variable _staging_done_condition;
 private:
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see
@@ -126,6 +129,10 @@ public:
     uint64_t total_disk_space_used() const noexcept;
 
     compaction::table_state& as_table_state() const noexcept;
+
+    seastar::condition_variable& get_staging_done_condition() noexcept {
+        return _staging_done_condition;
+    }
 };
 
 // Used by the tests to increase the default number of compaction groups by increasing the minimum to X.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2590,6 +2590,7 @@ table::make_reader_v2_excluding_sstables(schema_ptr s,
 future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable> sstables) {
     auto units = co_await get_units(_sstable_deletion_sem, 1);
     sstables::delayed_commit_changes delay_commit;
+    std::unordered_set<compaction_group*> compaction_groups_to_notify;
     for (auto sst : sstables) {
         try {
             // Off-strategy can happen in parallel to view building, so the SSTable may be deleted already if the former
@@ -2597,12 +2598,16 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
             // The _sstable_deletion_sem prevents list update on off-strategy completion and move_sstables_from_staging()
             // from stepping on each other's toe.
             co_await sst->change_state(sstables::normal_dir, &delay_commit);
+            auto& cg = compaction_group_for_sstable(sst);
+            if (get_compaction_manager().requires_cleanup(cg.as_table_state(), sst)) {
+                compaction_groups_to_notify.insert(&cg);
+            }
             // If view building finished faster, SSTable with repair origin still exists.
             // It can also happen the SSTable is not going through reshape, so it doesn't have a repair origin.
             // That being said, we'll only add this SSTable to tracker if its origin is other than repair.
             // Otherwise, we can count on off-strategy completion to add it when updating lists.
             if (sst->get_origin() != sstables::repair_origin) {
-                add_sstable_to_backlog_tracker(compaction_group_for_sstable(sst).get_backlog_tracker(), sst);
+                add_sstable_to_backlog_tracker(cg.get_backlog_tracker(), sst);
             }
         } catch (...) {
             tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), std::current_exception());
@@ -2611,6 +2616,10 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
     }
 
     co_await delay_commit.commit();
+
+    for (auto* cg : compaction_groups_to_notify) {
+        cg->get_staging_done_condition().broadcast();
+    }
 
     // Off-strategy timer will be rearmed, so if there's more incoming data through repair / streaming,
     // the timer can be updated once again. In practice, it allows off-strategy compaction to kick off
@@ -2814,6 +2823,10 @@ public:
     }
     const std::string& get_group_id() const noexcept override {
         return _cg.get_group_id();
+    }
+
+    seastar::condition_variable& get_staging_done_condition() noexcept override {
+        return _cg.get_staging_done_condition();
     }
 };
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -331,6 +331,16 @@ stop_iteration partitioned_sstable_set::for_each_sstable_until(std::function<sto
     return stop_iteration::no;
 }
 
+future<stop_iteration> partitioned_sstable_set::for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const {
+    for (auto& sst : *_all) {
+        auto stop = co_await func(sst);
+        if (stop) {
+            co_return stop_iteration::yes;
+        }
+    }
+    co_return stop_iteration::no;
+}
+
 void partitioned_sstable_set::insert(shared_sstable sst) {
     _all->insert(sst);
     auto undo_all_insert = defer([&] () { _all->erase(sst); });
@@ -470,6 +480,16 @@ stop_iteration time_series_sstable_set::for_each_sstable_until(std::function<sto
         }
     }
     return stop_iteration::no;
+}
+
+future<stop_iteration> time_series_sstable_set::for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const {
+    for (const auto& [pos, sst] : *_sstables) {
+        auto stop = co_await func(sst);
+        if (stop) {
+            co_return stop_iteration::yes;
+        }
+    }
+    co_return stop_iteration::no;
 }
 
 // O(log n)
@@ -1044,6 +1064,16 @@ stop_iteration compound_sstable_set::for_each_sstable_until(std::function<stop_i
         }
     }
     return stop_iteration::no;
+}
+
+future<stop_iteration> compound_sstable_set::for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const {
+    for (auto& set : _sets) {
+        auto stop = co_await set->for_each_sstable_gently_until([&func] (const shared_sstable& sst) { return func(sst); });
+        if (stop) {
+            co_return stop_iteration::yes;
+        }
+    }
+    co_return stop_iteration::no;
 }
 
 void compound_sstable_set::insert(shared_sstable sst) {

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -15,6 +15,7 @@
 #include "dht/i_partitioner.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/io_priority_class.hh>
+#include <type_traits>
 #include <vector>
 
 namespace utils {
@@ -22,9 +23,6 @@ class estimated_histogram;
 }
 
 namespace sstables {
-
-class sstable_set_impl;
-class incremental_selector_impl;
 
 struct sstable_first_key_less_comparator {
     bool operator()(const shared_sstable& s1, const shared_sstable& s2) const;
@@ -49,6 +47,39 @@ public:
     double estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const;
 };
 
+class incremental_selector_impl {
+public:
+    virtual ~incremental_selector_impl() {}
+    virtual std::tuple<dht::partition_range, std::vector<shared_sstable>, dht::ring_position_ext> select(const dht::ring_position_view&) = 0;
+};
+
+class sstable_set_impl {
+public:
+    virtual ~sstable_set_impl() {}
+    virtual std::unique_ptr<sstable_set_impl> clone() const = 0;
+    virtual std::vector<shared_sstable> select(const dht::partition_range& range) const = 0;
+    virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const;
+    virtual lw_shared_ptr<const sstable_list> all() const = 0;
+    virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const = 0;
+    virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const = 0;
+    virtual void insert(shared_sstable sst) = 0;
+    virtual void erase(shared_sstable sst) = 0;
+    virtual size_t size() const noexcept = 0;
+    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
+
+    virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
+        replica::column_family*,
+        schema_ptr,
+        reader_permit,
+        utils::estimated_histogram&,
+        const dht::partition_range&,
+        const query::partition_slice&,
+        const io_priority_class&,
+        tracing::trace_state_ptr,
+        streamed_mutation::forwarding,
+        mutation_reader::forwarding) const;
+};
+
 class sstable_set : public enable_lw_shared_from_this<sstable_set> {
     std::unique_ptr<sstable_set_impl> _impl;
     schema_ptr _schema;
@@ -66,9 +97,26 @@ public:
     lw_shared_ptr<const sstable_list> all() const;
     // Prefer for_each_sstable() over all() for iteration purposes, as the latter may have to copy all sstables into a temporary
     void for_each_sstable(std::function<void(const shared_sstable&)> func) const;
+    template <typename Func>
+    requires std::same_as<typename futurize<std::invoke_result_t<Func, shared_sstable>>::type, future<>>
+    future<> for_each_sstable_gently(Func&& func) const {
+        using futurator = futurize<std::invoke_result_t<Func, shared_sstable>>;
+        co_await _impl->for_each_sstable_gently_until([func = std::forward<Func>(func)] (const shared_sstable& sst) -> future<stop_iteration> {
+            co_await futurator::invoke(func, sst);
+            co_return stop_iteration::no;
+        });
+    }
     // Calls func for each sstable or until it returns stop_iteration::yes
     // Returns the last stop_iteration value.
     stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const;
+    template <typename Func>
+    requires std::same_as<typename futurize<std::invoke_result_t<Func, shared_sstable>>::type, future<stop_iteration>>
+    future<stop_iteration> for_each_sstable_gently_until(Func&& func) const {
+        return _impl->for_each_sstable_gently_until([func = std::forward<Func>(func)] (const shared_sstable& sst) -> future<stop_iteration> {
+            using futurator = futurize<std::invoke_result_t<Func, shared_sstable>>;
+            return futurator::invoke(func, sst);
+        });
+    }
     void insert(shared_sstable sst);
     void erase(shared_sstable sst);
     size_t size() const noexcept;

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -17,38 +17,6 @@
 
 namespace sstables {
 
-class incremental_selector_impl {
-public:
-    virtual ~incremental_selector_impl() {}
-    virtual std::tuple<dht::partition_range, std::vector<shared_sstable>, dht::ring_position_ext> select(const dht::ring_position_view&) = 0;
-};
-
-class sstable_set_impl {
-public:
-    virtual ~sstable_set_impl() {}
-    virtual std::unique_ptr<sstable_set_impl> clone() const = 0;
-    virtual std::vector<shared_sstable> select(const dht::partition_range& range) const = 0;
-    virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const;
-    virtual lw_shared_ptr<const sstable_list> all() const = 0;
-    virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const = 0;
-    virtual void insert(shared_sstable sst) = 0;
-    virtual void erase(shared_sstable sst) = 0;
-    virtual size_t size() const noexcept = 0;
-    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
-
-    virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
-        replica::column_family*,
-        schema_ptr,
-        reader_permit,
-        utils::estimated_histogram&,
-        const dht::partition_range&,
-        const query::partition_slice&,
-        const io_priority_class&,
-        tracing::trace_state_ptr,
-        streamed_mutation::forwarding,
-        mutation_reader::forwarding) const;
-};
-
 // specialized when sstables are partitioned in the token range space
 // e.g. leveled compaction strategy
 class partitioned_sstable_set : public sstable_set_impl {
@@ -96,6 +64,7 @@ public:
     virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
+    virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
     virtual void insert(shared_sstable sst) override;
     virtual void erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
@@ -123,6 +92,7 @@ public:
     virtual std::vector<shared_sstable> select(const dht::partition_range& range = query::full_partition_range) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
+    virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
     virtual void insert(shared_sstable sst) override;
     virtual void erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
@@ -163,6 +133,7 @@ public:
     virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
+    virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
     virtual void insert(shared_sstable sst) override;
     virtual void erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -52,6 +52,7 @@ class table_for_tests::table_state : public compaction::table_state {
     mutable compaction_backlog_tracker _backlog_tracker;
     compaction::compaction_strategy_state _compaction_strategy_state;
     std::string _group_id;
+    seastar::condition_variable _staging_condition;
 private:
     replica::table& table() const noexcept {
         return *_data.cf;
@@ -126,6 +127,9 @@ public:
     }
     const std::string& get_group_id() const noexcept override {
         return _group_id;
+    }
+    seastar::condition_variable& get_staging_done_condition() noexcept override {
+        return _staging_condition;
     }
 };
 


### PR DESCRIPTION
cleanup_compaction should resolve only after all
sstables that require cleanup are cleaned up.

Since it is possible that some of them are in staging
and therefore cannot be cleaned up, retry once a second
until they become eligible.

Timeout if there is no progress within 5 minutes
to prevent hanging due to view building bug.

Fixes #9559