### PR TITLE
cql: update permissions when creating/altering a function/keyspace

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -127,6 +127,13 @@ future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creat
                 *cs.user(),
                 r).handle_exception_type([](const auth::unsupported_authorization_operation&) {
             // Nothing.
+        }).then([&cs, &fr] {
+            return auth::grant_applicable_permissions(
+                    *cs.get_auth_service(),
+                    *cs.user(),
+                    fr).handle_exception_type([](const auth::unsupported_authorization_operation&) {
+                // Nothing.
+            });
         });
     });
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -120,8 +120,8 @@ cql3::statements::create_keyspace_statement::prepare(data_dictionary::database d
     return std::make_unique<prepared_statement>(make_shared<create_keyspace_statement>(*this));
 }
 
-future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creator(const service::client_state& cs) const {
-    return do_with(auth::make_data_resource(keyspace()), [&cs](const auth::resource& r) {
+future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
+    return do_with(auth::make_data_resource(keyspace()), auth::make_functions_resource(keyspace()), [&cs](const auth::resource& r, const auth::resource& fr) {
         return auth::grant_applicable_permissions(
                 *cs.get_auth_service(),
                 *cs.user(),

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -68,7 +68,7 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    virtual future<> grant_permissions_to_creator(const service::client_state&) const override;
+    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const override;
 
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -39,7 +39,7 @@ public:
 
     std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    future<> grant_permissions_to_creator(const service::client_state&) const;
+    future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const;
 
     void validate(query_processor&, const service::client_state&) const override;
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -146,7 +146,7 @@ create_table_statement::prepare(data_dictionary::database db, cql_stats& stats) 
     abort();
 }
 
-future<> create_table_statement::grant_permissions_to_creator(const service::client_state& cs) const {
+future<> create_table_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
     return do_with(auth::make_data_resource(keyspace(), column_family()), [&cs](const auth::resource& r) {
         return auth::grant_applicable_permissions(
                 *cs.get_auth_service(),

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -77,7 +77,7 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    virtual future<> grant_permissions_to_creator(const service::client_state&) const override;
+    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const override;
 
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -22,16 +22,19 @@ namespace statements {
 future<> function_statement::check_access(query_processor& qp, const service::client_state& state) const { return make_ready_future<>(); }
 
 future<> create_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const {
-    co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
-    if (_or_replace) {
-        create_arg_types(qp);
-        sstring encoded_signature = auth::encode_signature(_name.name, _arg_types);
-
-        co_await state.has_function_access(qp.db(), _name.keyspace, encoded_signature, auth::permission::ALTER);
+    create_arg_types(qp);
+    if (!functions::functions::find(_name, _arg_types)) {
+        co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
+    } else if (_or_replace) {
+        _altering = true;
+        co_await state.has_function_access(qp.db(), _name.keyspace, auth::encode_signature(_name.name, _arg_types), auth::permission::ALTER);
     }
 }
 
 future<> create_function_statement_base::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
+    if (_altering) {
+        return make_ready_future<>();
+    }
     std::string_view keyspace = _name.has_keyspace() ? _name.keyspace : cs.get_keyspace();
 
     return do_with(auth::make_functions_resource(keyspace, auth::encode_signature(_name.name, _arg_types)), [&cs](const auth::resource& r) {

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -47,6 +47,7 @@ protected:
 
     bool _or_replace;
     bool _if_not_exists;
+    mutable bool _altering = false;
 
     create_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types,
             bool or_replace, bool if_not_exists);

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -43,6 +43,7 @@ protected:
     virtual void validate(query_processor& qp, const service::client_state& state) const override;
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const = 0;
     virtual seastar::future<shared_ptr<db::functions::function>> validate_while_executing(query_processor&) const override;
+    virtual seastar::future<> grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const override;
 
     bool _or_replace;
     bool _if_not_exists;

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -38,7 +38,7 @@ schema_altering_statement::schema_altering_statement(cf_name name, timeout_confi
 {
 }
 
-future<> schema_altering_statement::grant_permissions_to_creator(const service::client_state&) const {
+future<> schema_altering_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state&) const {
     return make_ready_future<>();
 }
 
@@ -119,10 +119,10 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
         }
     }
 
-    return execute0(qp, state, options).then([this, &state, internal](::shared_ptr<messages::result_message> result) {
+    return execute0(qp, state, options).then([this, &qp, &state, internal](::shared_ptr<messages::result_message> result) {
         auto permissions_granted_fut = internal
                 ? make_ready_future<>()
-                : grant_permissions_to_creator(state.get_client_state());
+                : grant_permissions_to_creator(qp, state.get_client_state());
         return permissions_granted_fut.then([result = std::move(result)] {
            return result;
         });

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -48,7 +48,7 @@ protected:
      *
      * By default, this function does nothing.
      */
-    virtual future<> grant_permissions_to_creator(const service::client_state&) const;
+    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const;
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 


### PR DESCRIPTION
Currently, when a user creates a function or a keyspace, no
permissions on functions are update.
Instead, the user should gain all permissions on the function
that they created, or on all functions in the keyspace they have
created. This is also the behavior in Cassandra.

However, if the user is granted permissions on an function after
performing a CREATE OR REPLACE statement, they may
actually only alter the function but still gain permissions to it
as a result of the approach above, which requires another
workaround added to this series.

Lastly, as of right now, when a user is altering a function, they
need both CREATE and ALTER permissions, which is incompatible
with Cassandra - instead, only the ALTER permission should be
required.

This series fixes the mentioned issues, and the tests are already
present in the auth_roles_test dtest.
 
Fixes #13747