### PR TITLE
Use table_info in compaction

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1053,7 +1053,10 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         apilog.info("column_family/force_major_compaction: name={}", req->param["name"]);
         auto [ks, cf] = parse_fully_qualified_cf_name(req->param["name"]);
         auto keyspace = validate_keyspace(ctx, ks);
-        std::vector<table_id> table_infos = {ctx.db.local().find_uuid(ks, cf)};
+        std::vector<table_info> table_infos = {table_info{
+            .name = cf,
+            .id = ctx.db.local().find_uuid(ks, cf)
+        }};
 
         auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
         auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, std::move(table_infos));

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -52,20 +52,6 @@ using namespace std::chrono_literals;
 
 extern logging::logger apilog;
 
-namespace std {
-
-std::ostream& operator<<(std::ostream& os, const api::table_info& ti) {
-    fmt::print(os, "{}", ti);
-    return os;
-}
-
-} // namespace std
-
-auto fmt::formatter<api::table_info>::format(const api::table_info& ti,
-                                             fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "table{{name={}, id={}}}", ti.name, ti.id);
-}
-
 namespace api {
 
 const locator::token_metadata& http_context::get_token_metadata() {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -465,14 +465,6 @@ static future<json::json_return_type> describe_ring_as_json(sharded<service::sto
     co_return json::json_return_type(stream_range_as_array(co_await ss.local().describe_ring(keyspace), token_range_endpoints_to_json));
 }
 
-static std::vector<table_id> get_table_ids(const std::vector<table_info>& table_infos) {
-    std::vector<table_id> table_ids{table_infos.size()};
-    boost::transform(table_infos, table_ids.begin(), [] (const auto& ti) {
-        return ti.id;
-    });
-    return table_ids;
-}
-
 void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<cdc::generation_service>& cdc_gs, sharded<db::system_keyspace>& sys_ks) {
     ss::local_hostid.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto id = ctx.db.local().get_config().host_id;
@@ -691,7 +683,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         apilog.debug("force_keyspace_compaction: keyspace={} tables={}", keyspace, table_infos);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), db, get_table_ids(table_infos));
+        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos);
         try {
             co_await task->done();
         } catch (...) {
@@ -714,7 +706,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         }
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, get_table_ids(table_infos));
+        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos);
         try {
             co_await task->done();
         } catch (...) {
@@ -729,7 +721,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         apilog.info("perform_keyspace_offstrategy_compaction: keyspace={} tables={}", keyspace, table_infos);
         bool res = false;
         auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, get_table_ids(table_infos), res);
+        auto task = co_await compaction_module.make_and_start_task<offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, table_infos, res);
         try {
             co_await task->done();
         } catch (...) {
@@ -747,7 +739,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         apilog.info("upgrade_sstables: keyspace={} tables={} exclude_current_version={}", keyspace, table_infos, exclude_current_version);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, get_table_ids(table_infos), exclude_current_version);
+        auto task = co_await compaction_module.make_and_start_task<upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
         try {
             co_await task->done();
         } catch (...) {

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -51,11 +51,6 @@ sstring validate_keyspace(http_context& ctx, const httpd::parameters& param);
 // If the parameter is found and empty, returns a list of all table names in the keyspace.
 std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
-struct table_info {
-    sstring name;
-    table_id id;
-};
-
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.
@@ -79,14 +74,3 @@ void unset_snapshot(http_context& ctx, httpd::routes& r);
 seastar::future<json::json_return_type> run_toppartitions_query(db::toppartitions_query& q, http_context &ctx, bool legacy_request = false);
 
 } // namespace api
-
-namespace std {
-
-std::ostream& operator<<(std::ostream& os, const api::table_info& ti);
-
-} // namespace std
-
-template <>
-struct fmt::formatter<api::table_info> : fmt::formatter<std::string_view> {
-    auto format(const api::table_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
-};

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -13,17 +13,17 @@
 namespace compaction {
 
 // Run on all tables, skipping dropped tables
-future<> run_on_existing_tables(sstring op, replica::database& db, std::string_view keyspace, const std::vector<table_id> local_tables, std::function<future<> (replica::table&)> func) {
+future<> run_on_existing_tables(sstring op, replica::database& db, std::string_view keyspace, const std::vector<table_info> local_tables, std::function<future<> (replica::table&)> func) {
     std::exception_ptr ex;
     for (const auto& ti : local_tables) {
-        tasks::tmlogger.debug("Starting {} on {}.{}", op, keyspace, ti);
+        tasks::tmlogger.debug("Starting {} on {}.{}", op, keyspace, ti.name);
         try {
-            co_await func(db.find_column_family(ti));
+            co_await func(db.find_column_family(ti.id));
         } catch (const replica::no_such_column_family& e) {
-            tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti, e.what());
+            tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti.name, e.what());
         } catch (...) {
             ex = std::current_exception();
-            tasks::tmlogger.error("Failed {} of {}.{}: {}", op, keyspace, ti, ex);
+            tasks::tmlogger.error("Failed {} of {}.{}: {}", op, keyspace, ti.name, ex);
         }
         if (ex) {
             co_await coroutine::return_exception_ptr(std::move(ex));
@@ -46,9 +46,9 @@ tasks::is_internal shard_major_keyspace_compaction_task_impl::is_internal() cons
 
 future<> shard_major_keyspace_compaction_task_impl::run() {
     // Major compact smaller tables first, to increase chances of success if low on space.
-    std::ranges::sort(_local_tables, std::less<>(), [&] (const table_id& ti) {
+    std::ranges::sort(_local_tables, std::less<>(), [&] (const table_info& ti) {
         try {
-            return _db.find_column_family(ti).get_stats().live_disk_space_used;
+            return _db.find_column_family(ti.id).get_stats().live_disk_space_used;
         } catch (const replica::no_such_column_family& e) {
             return int64_t(-1);
         }
@@ -61,7 +61,7 @@ future<> shard_major_keyspace_compaction_task_impl::run() {
 future<> cleanup_keyspace_compaction_task_impl::run() {
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
         auto& module = db.get_compaction_manager().get_task_manager_module();
-        auto task = co_await module.make_and_start_task<shard_cleanup_keyspace_compaction_task_impl>({_status.id, _status.shard}, _status.keyspace, _status.id, db, _table_ids);
+        auto task = co_await module.make_and_start_task<shard_cleanup_keyspace_compaction_task_impl>({_status.id, _status.shard}, _status.keyspace, _status.id, db, _table_infos);
         co_await task->done();
     });
 }
@@ -72,9 +72,9 @@ tasks::is_internal shard_cleanup_keyspace_compaction_task_impl::is_internal() co
 
 future<> shard_cleanup_keyspace_compaction_task_impl::run() {
     // Cleanup smaller tables first, to increase chances of success if low on space.
-    std::ranges::sort(_local_tables, std::less<>(), [&] (const table_id& ti) {
+    std::ranges::sort(_local_tables, std::less<>(), [&] (const table_info& ti) {
         try {
-            return _db.find_column_family(ti).get_stats().live_disk_space_used;
+            return _db.find_column_family(ti.id).get_stats().live_disk_space_used;
         } catch (const replica::no_such_column_family& e) {
             return int64_t(-1);
         }

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -58,12 +58,12 @@ protected:
 class major_keyspace_compaction_task_impl : public major_compaction_task_impl {
 private:
     sharded<replica::database>& _db;
-    std::vector<table_id> _table_infos;
+    std::vector<table_info> _table_infos;
 public:
     major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_id> table_infos) noexcept
+            std::vector<table_info> table_infos) noexcept
         : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
@@ -75,13 +75,13 @@ protected:
 class shard_major_keyspace_compaction_task_impl : public major_compaction_task_impl {
 private:
     replica::database& _db;
-    std::vector<table_id> _local_tables;
+    std::vector<table_info> _local_tables;
 public:
     shard_major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
-            std::vector<table_id> local_tables) noexcept
+            std::vector<table_info> local_tables) noexcept
         : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _local_tables(std::move(local_tables))
@@ -116,15 +116,15 @@ protected:
 class cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
 private:
     sharded<replica::database>& _db;
-    std::vector<table_id> _table_ids;
+    std::vector<table_info> _table_infos;
 public:
     cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_id> table_ids) noexcept
+            std::vector<table_info> table_infos) noexcept
         : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
-        , _table_ids(std::move(table_ids))
+        , _table_infos(std::move(table_infos))
     {}
 protected:
     virtual future<> run() override;
@@ -133,13 +133,13 @@ protected:
 class shard_cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
 private:
     replica::database& _db;
-    std::vector<table_id> _local_tables;
+    std::vector<table_info> _local_tables;
 public:
     shard_cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
-            std::vector<table_id> local_tables) noexcept
+            std::vector<table_info> local_tables) noexcept
         : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _local_tables(std::move(local_tables))
@@ -174,13 +174,13 @@ protected:
 class offstrategy_keyspace_compaction_task_impl : public offstrategy_compaction_task_impl {
 private:
     sharded<replica::database>& _db;
-    std::vector<table_id> _table_infos;
+    std::vector<table_info> _table_infos;
     bool& _needed;
 public:
     offstrategy_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_id> table_infos,
+            std::vector<table_info> table_infos,
             bool& needed) noexcept
         : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
@@ -194,14 +194,14 @@ protected:
 class shard_offstrategy_keyspace_compaction_task_impl : public offstrategy_compaction_task_impl {
 private:
     replica::database& _db;
-    std::vector<table_id> _table_infos;
+    std::vector<table_info> _table_infos;
     bool& _needed;
 public:
     shard_offstrategy_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
-            std::vector<table_id> table_infos,
+            std::vector<table_info> table_infos,
             bool& needed) noexcept
         : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
         , _db(db)
@@ -238,13 +238,13 @@ protected:
 class upgrade_sstables_compaction_task_impl : public sstables_compaction_task_impl {
 private:
     sharded<replica::database>& _db;
-    std::vector<table_id> _table_infos;
+    std::vector<table_info> _table_infos;
     bool _exclude_current_version;
 public:
     upgrade_sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_id> table_infos,
+            std::vector<table_info> table_infos,
             bool exclude_current_version) noexcept
         : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
@@ -258,14 +258,14 @@ protected:
 class shard_upgrade_sstables_compaction_task_impl : public sstables_compaction_task_impl {
 private:
     replica::database& _db;
-    std::vector<table_id> _table_infos;
+    std::vector<table_info> _table_infos;
     bool _exclude_current_version;
 public:
     shard_upgrade_sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
-            std::vector<table_id> table_infos,
+            std::vector<table_info> table_infos,
             bool exclude_current_version) noexcept
         : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
         , _db(db)

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1964,6 +1964,20 @@ std::ostream& operator<<(std::ostream& os, const view_ptr& view) {
     return view ? os << *view : os << "null";
 }
 
+namespace std {
+
+std::ostream& operator<<(std::ostream& os, const table_info& ti) {
+    fmt::print(os, "{}", ti);
+    return os;
+}
+
+} // namespace std
+
+auto fmt::formatter<table_info>::format(const table_info& ti,
+                                             fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "table{{name={}, id={}}}", ti.name, ti.id);
+}
+
 schema_mismatch_error::schema_mismatch_error(table_schema_version expected, const schema& access)
     : std::runtime_error(fmt::format("Attempted to deserialize schema-dependent object of version {} using {}.{} {}",
         expected, access.ks_name(), access.cf_name(), access.version()))

--- a/schema/schema_fwd.hh
+++ b/schema/schema_fwd.hh
@@ -25,6 +25,22 @@ using schema_ptr = seastar::lw_shared_ptr<const schema>;
 
 using table_id = utils::tagged_uuid<struct table_id_tag>;
 
+struct table_info {
+    sstring name;
+    table_id id;
+};
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& os, const table_info& ti);
+
+} // namespace std
+
+template <>
+struct fmt::formatter<table_info> : fmt::formatter<std::string_view> {
+    auto format(const table_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
 // Cluster-wide identifier of schema version of particular table.
 //
 // The version changes the value not only on structural changes but also


### PR DESCRIPTION
In compaction logs table is identified by {keyspace}.{table_id}.

Instead, table name should be used in run_on_existing_tables
logs. To do so, task manager's compaction tasks use table_info
instead of table_id.

Keyspace argument is copied to run_on_existing_tables
to ensure it's alive.