### PR TITLE
mutation/mutation_compactor: validate the input stream

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -463,19 +463,19 @@ public:
         // Only check if the active tombstone has to be closed, if the partition
         // was cut by the consumer. Otherwise, leave the stream as-is.
         if (_stop) {
-          if (_effective_tombstone) {
-            auto rtc = range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), tombstone{});
-            // do_consume() overwrites _effective_tombstone with {}, so save and restore it.
-            auto prev_tombstone = _effective_tombstone;
-            do_consume(std::move(rtc), consumer, gc_consumer);
-            _effective_tombstone = prev_tombstone;
-          } else if (_validator.validator().current_tombstone()) {
-              // It is possible that the range-tombstone providing the active
-              // tombstone was purged and never got to the consumer and therefore
-              // didn't set `_effective_tombstone`. In this case we generate a
-              // closing tombstone just for the validator.
-             _validator(mutation_fragment_v2::kind::range_tombstone_change, position_in_partition::after_key(_schema, _last_pos), tombstone{});
-          }
+            if (_effective_tombstone) {
+                auto rtc = range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), tombstone{});
+                // do_consume() overwrites _effective_tombstone with {}, so save and restore it.
+                auto prev_tombstone = _effective_tombstone;
+                do_consume(std::move(rtc), consumer, gc_consumer);
+                _effective_tombstone = prev_tombstone;
+            } else if (_validator.validator().current_tombstone()) {
+                // It is possible that the range-tombstone providing the active
+                // tombstone was purged and never got to the consumer and therefore
+                // didn't set `_effective_tombstone`. In this case we generate a
+                // closing tombstone just for the validator.
+                _validator(mutation_fragment_v2::kind::range_tombstone_change, position_in_partition::after_key(_schema, _last_pos), tombstone{});
+            }
         }
         _validator.on_end_of_partition();
         if (!_empty_partition_in_gc_consumer) {

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -177,6 +177,7 @@ private:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration do_consume(range_tombstone_change&& rtc, Consumer& consumer, GCConsumer& gc_consumer) {
+        _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
         stop_iteration gc_consumer_stop = stop_iteration::no;
         stop_iteration consumer_stop = stop_iteration::no;
         if (rtc.tombstone() <= _partition_tombstone) {
@@ -197,7 +198,6 @@ private:
         if (_current_emitted_tombstone || (rtc.tombstone() && !can_purge)) {
             partition_is_not_empty(consumer);
             _current_emitted_tombstone = rtc.tombstone();
-            _validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position(), rtc.tombstone());
             consumer_stop = consumer.consume(std::move(rtc));
         }
         return gc_consumer_stop || consumer_stop;
@@ -460,12 +460,22 @@ public:
     template <typename Consumer, typename GCConsumer>
     requires CompactedFragmentsConsumerV2<Consumer> && CompactedFragmentsConsumerV2<GCConsumer>
     stop_iteration consume_end_of_partition(Consumer& consumer, GCConsumer& gc_consumer) {
-        if (_effective_tombstone) {
+        // Only check if the active tombstone has to be closed, if the partition
+        // was cut by the consumer. Otherwise, leave the stream as-is.
+        if (_stop) {
+          if (_effective_tombstone) {
             auto rtc = range_tombstone_change(position_in_partition::after_key(_schema, _last_pos), tombstone{});
             // do_consume() overwrites _effective_tombstone with {}, so save and restore it.
             auto prev_tombstone = _effective_tombstone;
             do_consume(std::move(rtc), consumer, gc_consumer);
             _effective_tombstone = prev_tombstone;
+          } else if (_validator.validator().current_tombstone()) {
+              // It is possible that the range-tombstone providing the active
+              // tombstone was purged and never got to the consumer and therefore
+              // didn't set `_effective_tombstone`. In this case we generate a
+              // closing tombstone just for the validator.
+             _validator(mutation_fragment_v2::kind::range_tombstone_change, position_in_partition::after_key(_schema, _last_pos), tombstone{});
+          }
         }
         _validator.on_end_of_partition();
         if (!_empty_partition_in_gc_consumer) {

--- a/mutation/mutation_fragment_stream_validator.hh
+++ b/mutation/mutation_fragment_stream_validator.hh
@@ -203,6 +203,8 @@ public:
 
     sstring full_name() const;
 
+    const mutation_fragment_stream_validator& validator() const { return  _validator; }
+
     bool operator()(const dht::decorated_key& dk);
     bool operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos, std::optional<tombstone> new_current_tombstone);
     bool operator()(mutation_fragment::kind kind, position_in_partition_view pos);


### PR DESCRIPTION
The mutation compactor has a validator which it uses to validate the stream of mutation fragments that passes through it. This validator is supposed to validate the stream as it enters the compactor, as opposed to its compacted form (output). This was true for most fragment kinds except range tombstones, as purged range tombstones were not visible to
the validator for the most part.

This mistake was introduced by https://github.com/scylladb/scylladb/commit e2c9cdb576c2186719ce7181dd6619f1994e262e, which itself was a flawed attempt at fixing an error seen because purged tombstones were not terminated by the compactor.

This patch corrects this mistake by fixing the above problem properly: on page-cut, if the validator has an active tombstone, a closing tombstone is generated for it, to avoid the false-positive error. With this, range tombstones can be validated again as they come in.

The existing unit test checking the validation in the compactor is greatly expanded to check all (I hope) different validation scenarios.