### PR TITLE
cql: check permissions for used functions when creating a UDA

### DIFF
--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -26,6 +26,7 @@ namespace statements {
 class create_aggregate_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     future<std::pair<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;
 

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -348,6 +348,8 @@ def test_grant_revoke_uda_permissions(scylla_only, cql):
                         def create_aggr_idempotent():
                             user_session.execute(f"CREATE AGGREGATE IF NOT EXISTS {keyspace}.{custom_avg} {custom_avg_body}")
                             cql.execute(f"DROP AGGREGATE IF EXISTS {keyspace}.{custom_avg}(bigint)")
+                        grant(cql, 'EXECUTE', f'function {keyspace}.{avg_partial}(tuple<bigint, bigint>, bigint)', username)
+                        grant(cql, 'EXECUTE', f'function {keyspace}.{div_fun}(tuple<bigint, bigint>)', username)
                         check_enforced(cql, username, permission='CREATE', resource=f'all functions in keyspace {keyspace}',
                                 function=create_aggr_idempotent)
                         check_enforced(cql, username, permission='CREATE', resource='all functions',


### PR DESCRIPTION
Currently, when creating a UDA, we only check for permissions for creating functions. However, the creator gains all permissions to the UDA, including the EXECUTE permission. This enables the user to also execute the state/reduce/final functions that were used in the UDA, even if they don't have the EXECUTE permissions on them.

This patch adds checks for the missing EXECUTE permissions, so that the UDA can be only created if the user has all required permissions.

Fixes #13818