### PR TITLE
auth: disallow CREATE permission on a specific function

### DIFF
--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -79,6 +79,13 @@ static permission_set applicable_permissions(const service_level_resource_view &
 }
 
 static permission_set applicable_permissions(const functions_resource_view& fv) {
+    if (fv.function_name() || fv.function_signature()) {
+        return permission_set::of<
+                permission::ALTER,
+                permission::DROP,
+                permission::AUTHORIZE,
+                permission::EXECUTE>();
+    }
     return permission_set::of<
             permission::CREATE,
             permission::ALTER,


### PR DESCRIPTION
Similarly to how we handle Roles and Tables, we do not allow permissions on non-existent objects, so the CREATE permission on a specific function is meaningless, because for the permission to be granted to someone, the function must be already created.
This patch removes the CREATE permission from the set of permissions applicable to a specific function.

Fixes #13822