### PR TITLE
data_dictionary: define helpers in options and define == operator only

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -17,13 +17,13 @@ namespace data_dictionary {
 
 struct storage_options {
     struct local {
-        friend auto operator<=>(const local&, const local&) = default;
+        bool operator==(const local&) const = default;
     };
     struct s3 {
         sstring bucket;
         sstring endpoint;
 
-        friend auto operator<=>(const s3&, const s3&) = default;
+        bool operator==(const s3&) const = default;
     };
     using value_type = std::variant<local, s3>;
     value_type value = local{};

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -17,12 +17,19 @@ namespace data_dictionary {
 
 struct storage_options {
     struct local {
+        static constexpr std::string_view name = "LOCAL";
+
+        static local from_map(const std::map<sstring, sstring>&);
+        std::map<sstring, sstring> to_map() const;
         bool operator==(const local&) const = default;
     };
     struct s3 {
         sstring bucket;
         sstring endpoint;
+        static constexpr std::string_view name = "S3";
 
+        static s3 from_map(const std::map<sstring, sstring>&);
+        std::map<sstring, sstring> to_map() const;
         bool operator==(const s3&) const = default;
     };
     using value_type = std::variant<local, s3>;


### PR DESCRIPTION
in this series, `data_dictionary::storage_options` is refactored so that each dedicated storage option takes care of itself, instead of putting all the logic into `storage_options`. cleaner this way. as the next step, i will add yet another set of options for the tiered_storage which is backed by the s3_storage and the local filesystem_storage. with this change, we will be able to group the per-option functionalities together by the option thy are designed for, instead of sharding them by the actual function.