### PR TITLE
sstables: mx: validate: close consumer context

### DIFF
--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -2176,6 +2176,7 @@ future<uint64_t> validate(
         co_await idx_reader->close();
     }
 
+    co_await context->close();
     co_return consumer.error_count();
 }
 


### PR DESCRIPTION
data_consume_rows keeps an input_stream member that must be closed. In particular, on the error path, when we destroy it possibly with readaheads in flight.

Fixes #13836