### PR TITLE
auth: fix formatting of function resource with no arguments

### DIFF
--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -292,7 +292,7 @@ std::optional<std::vector<std::string_view>> functions_resource_view::function_a
 
     std::vector<std::string_view> parts;
     if (_resource._parts[3] == "") {
-        return {};
+        return parts;
     }
     for (size_t i = 3; i < _resource._parts.size(); i++) {
         parts.push_back(_resource._parts[i]);

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -418,3 +418,6 @@ def test_udf_permissions_no_args(cql):
                     grant(cql, 'SELECT', table, username)
                     check_enforced(cql, username, permission='EXECUTE', resource=f'function {keyspace}.{fun}()',
                             function=lambda: user_session.execute(f'SELECT {keyspace}.{fun}() FROM {table}'))
+                    with pytest.raises(SyntaxException):
+                        nonexistent_func = unique_name()
+                        user_session.execute(f'GRANT SELECT ON FUNCTION {keyspace}.{nonexistent_func}() TO cassandra')


### PR DESCRIPTION
Currently, when a function has no arguments, the function_args() method, which is supposed to return a vector of string_views representing the arguments of the function, returns a nullopt instead, as if it was a functions_resource on all functions or all functions in a keyspace. As a result, the functions_resource can't be properly formatted.
This is fixed in this patch by returning an empty vector instead, and the fix is confirmed in a cql-pytest.

Fixes #13842