### PR TITLE
test: sstable_*test: avoid using helper using generation_type::int_t 

### DIFF
--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -4586,8 +4586,8 @@ static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader
                                           tracing::trace_state_ptr(), use_caching::yes);
 }
 
-shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name, sstables::generation_type::int_t gen = 1) {
-    return env.reusable_sst(schema, get_read_index_test_path(table_name), gen).get0();
+shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name) {
+    return env.reusable_sst(schema, get_read_index_test_path(table_name), sstables::generation_type{1}).get0();
 }
 
 /*

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1927,12 +1927,12 @@ static void copy_directory(fs::path src_dir, fs::path dst_dir) {
 SEASTAR_TEST_CASE(test_unknown_component) {
     return test_env::do_with_async([] (test_env& env) {
         copy_directory("test/resource/sstables/unknown_component", std::string(env.tempdir().path().string()) + "/unknown_component");
-        auto sstp = env.reusable_sst(uncompressed_schema(), env.tempdir().path().string() + "/unknown_component", 1).get0();
+        auto sstp = env.reusable_sst(uncompressed_schema(), env.tempdir().path().string() + "/unknown_component").get0();
         test::create_links(*sstp, env.tempdir().path().string()).get();
         // check that create_links() moved unknown component to new dir
         BOOST_REQUIRE(file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get0());
 
-        sstp = env.reusable_sst(uncompressed_schema(), 1).get0();
+        sstp = env.reusable_sst(uncompressed_schema(), generation_type{1}).get0();
         sstables::sstable_directory::delete_atomically({sstp}).get();
         // assure unknown component is deleted
         BOOST_REQUIRE(!file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get0());
@@ -2119,7 +2119,7 @@ SEASTAR_TEST_CASE(sstable_bad_tombstone_histogram_test) {
                 .with_column("id", utf8_type, column_kind::partition_key)
                 .with_column("value", int32_type);
         auto s = builder.build();
-        auto sst = env.reusable_sst(s, "test/resource/sstables/bad_tombstone_histogram", 1).get0();
+        auto sst = env.reusable_sst(s, "test/resource/sstables/bad_tombstone_histogram").get0();
         auto histogram = sst->get_stats_metadata().estimated_tombstone_drop_time;
         BOOST_REQUIRE(histogram.max_bin_size == sstables::TOMBSTONE_HISTOGRAM_BIN_SIZE);
         // check that bad histogram was discarded

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -19,7 +19,7 @@ using namespace sstables;
 namespace fs = std::filesystem;
 
 // Must be called from a seastar thread
-static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schema_ptr schema_ptr, fs::path src_path, sstables::generation_type::int_t gen) {
+static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schema_ptr schema_ptr, fs::path src_path, sstables::generation_type gen) {
     auto sst = env.reusable_sst(schema_ptr, src_path.native(), gen).get0();
     auto dst_path = tmp_path / src_path.filename() / format("gen-{}", gen);
     recursive_touch_directory(dst_path.native()).get();
@@ -35,14 +35,15 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
     auto env = test_env();
     auto stop_env = defer([&env] { env.stop().get(); });
 
-    sstables::generation_type::int_t gen = 1;
-    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
+    sstables::sstable_generation_generator gen_generator{0};
+    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_generator());
 
+    generation_type gen{0};
     for (auto i = 0; i < 2; i++) {
-        ++gen;
+        gen = gen_generator();
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
-        test(sst).move_to_new_dir(new_dir, generation_from_value(gen)).get();
+        test(sst).move_to_new_dir(new_dir, gen).get();
         // the source directory must be empty now
         remove_file(cur_dir).get();
         cur_dir = new_dir;
@@ -57,8 +58,9 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
     tmpdir tmp;
     auto env = test_env();
     auto stop_env = defer([&env] { env.stop().get(); });
+    sstables::sstable_generation_generator gen_generator{0};
 
-    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), 1);
+    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_generator());
     sstring old_path = test(sst).storage_prefix();
     touch_directory(format("{}/{}", old_path, sstables::staging_dir)).get();
     sst->change_state(sstables::staging_dir).get();
@@ -76,22 +78,22 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
 // Returns true when done
 //
 // Must be called from a seastar thread
-static bool partial_create_links(sstable_ptr sst, fs::path dst_path, sstables::generation_type::int_t gen, int count) {
+static bool partial_create_links(sstable_ptr sst, fs::path dst_path, sstables::generation_type gen, int count) {
     auto schema = sst->get_schema();
-    auto tmp_toc = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), generation_from_value(gen), sstable_format_types::big, component_type::TemporaryTOC);
+    auto tmp_toc = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), gen, sstable_format_types::big, component_type::TemporaryTOC);
     link_file(test(sst).filename(component_type::TOC).native(), tmp_toc).get();
     for (auto& [c, s] : sst->all_components()) {
         if (count-- <= 0) {
             return false;
         }
         auto src = test(sst).filename(c);
-        auto dst = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), generation_from_value(gen), sstable_format_types::big, c);
+        auto dst = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), gen, sstable_format_types::big, c);
         link_file(src.native(), dst).get();
     }
     if (count-- <= 0) {
         return false;
     }
-    auto dst = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), generation_from_value(gen), sstable_format_types::big, component_type::TOC);
+    auto dst = sstable::filename(dst_path.native(), schema->ks_name(), schema->cf_name(), sst->get_version(), gen, sstable_format_types::big, component_type::TOC);
     remove_file(tmp_toc).get();
     return true;
 }
@@ -101,17 +103,17 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
     auto env = test_env();
     auto stop_env = defer([&env] { env.stop().get(); });
 
-    sstables::generation_type::int_t gen = 1;
-    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
+    sstables::sstable_generation_generator gen_generator{0};
+    auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_generator());
 
     bool done;
     int count = 0;
     do {
-        ++gen;
+        auto gen = gen_generator();
         auto new_dir = format("{}/gen-{}", fs::path(cur_dir).parent_path().native(), gen);
         touch_directory(new_dir).get();
         done = partial_create_links(sst, fs::path(new_dir), gen, count++);
-        test(sst).move_to_new_dir(new_dir, generation_from_value(gen)).get();
+        test(sst).move_to_new_dir(new_dir, gen).get();
         remove_file(cur_dir).get();
         cur_dir = new_dir;
     } while (!done);
@@ -122,10 +124,13 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     auto env = test_env();
     auto stop_env = defer([&env] { env.stop().get(); });
 
-    sstables::generation_type::int_t gen = 1;
-    auto [ src_sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen);
-    auto [ dst_sst, new_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), ++gen);
-
+    // please note, the SSTables used by this test are stored under
+    // get_test_dir("uncompressed", "ks", fs::path(uncompressed_dir())), so the
+    // gen_1 and gen_2 have to match with the these SSTables under that directory.
+    sstables::generation_type gen_1{1};
+    auto [ src_sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_1);
+    sstables::generation_type gen_2{2};
+    auto [ dst_sst, new_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_2);
     dst_sst->close_files().get();
-    BOOST_REQUIRE_THROW(test(src_sst).move_to_new_dir(new_dir, generation_from_value(gen)).get(), malformed_sstable_exception);
+    BOOST_REQUIRE_THROW(test(src_sst).move_to_new_dir(new_dir, gen_2).get(), malformed_sstable_exception);
 }

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 
 SEASTAR_TEST_CASE(nonexistent_key) {
   return test_env::do_with_async([] (test_env& env) {
-    env.reusable_sst(uncompressed_schema(), uncompressed_dir(), 1).then([&env] (auto sstp) {
+    env.reusable_sst(uncompressed_schema(), uncompressed_dir()).then([&env] (auto sstp) {
         return do_with(dht::partition_range::make_singular(make_dkey(uncompressed_schema(), "invalid_key")), [&env, sstp] (auto& pr) {
             auto s = uncompressed_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s] (auto& rd) {
@@ -58,7 +58,7 @@ SEASTAR_TEST_CASE(nonexistent_key) {
 }
 
 future<> test_no_clustered(sstables::test_env& env, bytes&& key, std::unordered_map<bytes, data_value> &&map) {
-    return env.reusable_sst(uncompressed_schema(), uncompressed_dir(), 1).then([&env, k = std::move(key), map = std::move(map)] (auto sstp) mutable {
+    return env.reusable_sst(uncompressed_schema(), uncompressed_dir()).then([&env, k = std::move(key), map = std::move(map)] (auto sstp) mutable {
         return do_with(dht::partition_range::make_singular(make_dkey(uncompressed_schema(), std::move(k))), [&env, sstp, map = std::move(map)] (auto& pr) {
             auto s = uncompressed_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s, map = std::move(map)] (auto& rd) mutable {
@@ -331,7 +331,7 @@ SEASTAR_TEST_CASE(complex_sst3_k2) {
 }
 
 future<> test_range_reads(sstables::test_env& env, const dht::token& min, const dht::token& max, std::vector<bytes>& expected) {
-    return env.reusable_sst(uncompressed_schema(), uncompressed_dir(), 1).then([&env, min, max, &expected] (auto sstp) mutable {
+    return env.reusable_sst(uncompressed_schema(), uncompressed_dir()).then([&env, min, max, &expected] (auto sstp) mutable {
         auto s = uncompressed_schema();
         auto count = make_lw_shared<size_t>(0);
         auto expected_size = expected.size();
@@ -439,7 +439,7 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
 
 SEASTAR_TEST_CASE(compact_storage_sparse_read) {
   return test_env::do_with_async([] (test_env& env) {
-    env.reusable_sst(compact_sparse_schema(), "test/resource/sstables/compact_sparse", 1).then([&env] (auto sstp) {
+    env.reusable_sst(compact_sparse_schema(), "test/resource/sstables/compact_sparse").then([&env] (auto sstp) {
         return do_with(dht::partition_range::make_singular(make_dkey(compact_sparse_schema(), "first_row")), [&env, sstp] (auto& pr) {
             auto s = compact_sparse_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s] (auto& rd) {
@@ -459,7 +459,7 @@ SEASTAR_TEST_CASE(compact_storage_sparse_read) {
 
 SEASTAR_TEST_CASE(compact_storage_simple_dense_read) {
   return test_env::do_with_async([] (test_env& env) {
-    env.reusable_sst(compact_simple_dense_schema(), "test/resource/sstables/compact_simple_dense", 1).then([&env] (auto sstp) {
+    env.reusable_sst(compact_simple_dense_schema(), "test/resource/sstables/compact_simple_dense").then([&env] (auto sstp) {
         return do_with(dht::partition_range::make_singular(make_dkey(compact_simple_dense_schema(), "first_row")), [&env, sstp] (auto& pr) {
             auto s = compact_simple_dense_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s] (auto& rd) {
@@ -481,7 +481,7 @@ SEASTAR_TEST_CASE(compact_storage_simple_dense_read) {
 
 SEASTAR_TEST_CASE(compact_storage_dense_read) {
   return test_env::do_with_async([] (test_env& env) {
-    env.reusable_sst(compact_dense_schema(), "test/resource/sstables/compact_dense", 1).then([&env] (auto sstp) {
+    env.reusable_sst(compact_dense_schema(), "test/resource/sstables/compact_dense").then([&env] (auto sstp) {
         return do_with(dht::partition_range::make_singular(make_dkey(compact_dense_schema(), "first_row")), [&env, sstp] (auto& pr) {
             auto s = compact_dense_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s] (auto& rd) {
@@ -507,7 +507,7 @@ SEASTAR_TEST_CASE(compact_storage_dense_read) {
 // Make sure we don't regress on that.
 SEASTAR_TEST_CASE(broken_ranges_collection) {
   return test_env::do_with_async([] (test_env& env) {
-    env.reusable_sst(peers_schema(), "test/resource/sstables/broken_ranges", 2).then([&env] (auto sstp) {
+    env.reusable_sst(peers_schema(), "test/resource/sstables/broken_ranges", generation_type{2}).then([&env] (auto sstp) {
         auto s = peers_schema();
         return with_closeable(sstp->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), query::full_partition_range), [s] (auto& reader) {
           return repeat([s, &reader] {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -132,9 +132,8 @@ SEASTAR_TEST_CASE(uncompressed_4) {
  */
 
 // FIXME: we are lacking a full deletion test
-template <int Generation>
-future<mutation> generate_clustered(sstables::test_env& env, bytes&& key) {
-    return env.reusable_sst(complex_schema(), "test/resource/sstables/complex", Generation).then([&env, k = std::move(key)] (auto sstp) mutable {
+static future<mutation> generate_clustered(sstables::test_env& env, bytes&& key, generation_type gen) {
+    return env.reusable_sst(complex_schema(), "test/resource/sstables/complex", gen).then([&env, k = std::move(key)] (auto sstp) mutable {
         return do_with(dht::partition_range::make_singular(make_dkey(complex_schema(), std::move(k))), [&env, sstp] (auto& pr) {
             auto s = complex_schema();
             return with_closeable(sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice()), [sstp, s] (auto& rd) {
@@ -155,7 +154,7 @@ inline auto clustered_row(mutation& mutation, const schema& s, std::vector<bytes
 
 SEASTAR_TEST_CASE(complex_sst1_k1) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<1>(env, "key1").then([] (auto&& mutation) {
+    generate_clustered(env, "key1", generation_type{1}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto& sr = mutation.partition().static_row().get();
@@ -186,7 +185,7 @@ SEASTAR_TEST_CASE(complex_sst1_k1) {
 
 SEASTAR_TEST_CASE(complex_sst1_k2) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<1>(env, "key2").then([] (auto&& mutation) {
+    generate_clustered(env, "key2", generation_type{1}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto& sr = mutation.partition().static_row().get();
@@ -219,7 +218,7 @@ SEASTAR_TEST_CASE(complex_sst1_k2) {
 
 SEASTAR_TEST_CASE(complex_sst2_k1) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<2>(env, "key1").then([] (auto&& mutation) {
+    generate_clustered(env, "key1", generation_type{2}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto exploded = exploded_clustering_prefix({"cl1.1", "cl2.1"});
@@ -239,7 +238,7 @@ SEASTAR_TEST_CASE(complex_sst2_k1) {
 
 SEASTAR_TEST_CASE(complex_sst2_k2) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<2>(env, "key2").then([] (auto&& mutation) {
+    generate_clustered(env, "key2", generation_type{2}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto& sr = mutation.partition().static_row().get();
@@ -270,7 +269,7 @@ SEASTAR_TEST_CASE(complex_sst2_k2) {
 
 SEASTAR_TEST_CASE(complex_sst2_k3) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<2>(env, "key3").then([] (auto&& mutation) {
+    generate_clustered(env, "key3", generation_type{2}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto& sr = mutation.partition().static_row().get();
@@ -290,7 +289,7 @@ SEASTAR_TEST_CASE(complex_sst2_k3) {
 
 SEASTAR_TEST_CASE(complex_sst3_k1) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<3>(env, "key1").then([] (auto&& mutation) {
+    generate_clustered(env, "key1", generation_type{3}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto row = clustered_row(mutation, *s, {"cl1.2", "cl2.2"});
@@ -312,7 +311,7 @@ SEASTAR_TEST_CASE(complex_sst3_k1) {
 
 SEASTAR_TEST_CASE(complex_sst3_k2) {
   return test_env::do_with_async([] (test_env& env) {
-    generate_clustered<3>(env, "key2").then([] (auto&& mutation) {
+    generate_clustered(env, "key2", generation_type{3}).then([] (auto&& mutation) {
         auto s = complex_schema();
 
         auto& sr = mutation.partition().static_row().get();

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -41,14 +41,14 @@ bytes as_bytes(const sstring& s) {
     return { reinterpret_cast<const int8_t*>(s.data()), s.size() };
 }
 
-future<> test_using_working_sst(schema_ptr s, sstring dir, sstables::generation_type::int_t gen) {
-    return test_env::do_with([s = std::move(s), dir = std::move(dir), gen] (test_env& env) {
-        return env.reusable_sst(std::move(s), std::move(dir), gen).discard_result();
+future<> test_using_working_sst(schema_ptr s, sstring dir) {
+    return test_env::do_with([s = std::move(s), dir = std::move(dir)] (test_env& env) {
+        return env.reusable_sst(std::move(s), std::move(dir)).discard_result();
     });
 }
 
 SEASTAR_TEST_CASE(uncompressed_data) {
-    return test_using_working_sst(uncompressed_schema(), uncompressed_dir(), 1);
+    return test_using_working_sst(uncompressed_schema(), uncompressed_dir());
 }
 
 static auto make_schema_for_compressed_sstable() {
@@ -57,11 +57,11 @@ static auto make_schema_for_compressed_sstable() {
 
 SEASTAR_TEST_CASE(compressed_data) {
     auto s = make_schema_for_compressed_sstable();
-    return test_using_working_sst(std::move(s), "test/resource/sstables/compressed", 1);
+    return test_using_working_sst(std::move(s), "test/resource/sstables/compressed");
 }
 
 SEASTAR_TEST_CASE(composite_index) {
-    return test_using_working_sst(composite_schema(), "test/resource/sstables/composite", 1);
+    return test_using_working_sst(composite_schema(), "test/resource/sstables/composite");
 }
 
 template<typename Func>
@@ -503,15 +503,15 @@ SEASTAR_TEST_CASE(statistics_rewrite) {
         auto generation_dir = (uncompressed_dir_copy / sstables::staging_dir).native();
         std::filesystem::create_directories(generation_dir);
 
-        auto sstp = env.reusable_sst(uncompressed_schema(), uncompressed_dir_copy.native(), 1).get0();
+        auto sstp = env.reusable_sst(uncompressed_schema(), uncompressed_dir_copy.native()).get0();
         test::create_links(*sstp, generation_dir).get();
         test_sstable_exists(generation_dir, 1, true).get();
 
-        sstp = env.reusable_sst(uncompressed_schema(), generation_dir, 1).get0();
+        sstp = env.reusable_sst(uncompressed_schema(), generation_dir).get0();
         // mutate_sstable_level results in statistics rewrite
         sstp->mutate_sstable_level(10).get();
 
-        sstp = env.reusable_sst(uncompressed_schema(), generation_dir, 1).get0();
+        sstp = env.reusable_sst(uncompressed_schema(), generation_dir).get0();
         BOOST_REQUIRE(sstp->get_sstable_level() == 10);
     });
 }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -159,15 +159,9 @@ public:
 
     // looks up the sstable in the given dir
     future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation = sstables::generation_type{1});
-    future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type::int_t gen_value) {
-        return reusable_sst(std::move(schema), std::move(dir), sstables::generation_type(gen_value));
-    }
 
     future<shared_sstable> reusable_sst(schema_ptr schema, sstables::generation_type generation) {
         return reusable_sst(std::move(schema), _impl->dir.path().native(), generation);
-    }
-    future<shared_sstable> reusable_sst(schema_ptr schema, sstables::generation_type::int_t gen_value) {
-        return reusable_sst(std::move(schema), sstables::generation_type(gen_value));
     }
 
     test_env_sstables_manager& manager() { return _impl->mgr; }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -158,7 +158,7 @@ public:
     }
 
     // looks up the sstable in the given dir
-    future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation);
+    future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation = sstables::generation_type{1});
     future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type::int_t gen_value) {
         return reusable_sst(std::move(schema), std::move(dir), sstables::generation_type(gen_value));
     }


### PR DESCRIPTION
the series drops some of the callers using SSTable generation as integer. as the generation of SSTable is but an identifier, we should not use it as an integer out of generation_type's implementation.
