### PR TITLE
sstables: add an generation_type::maybe_owned_by_this_shard()

### DIFF
--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -130,6 +130,12 @@ public:
         _last_generation += seastar::smp::count;
         return generation_type(_last_generation);
     }
+    /// returns a hint indicating if an sstable belongs to a shard. The definitive
+    /// way to determine that is overlapping its partition-ranges with the shard's
+    /// owned ranges.
+    static bool maybe_owned_by_this_shard(const sstables::generation_type& gen) {
+        return gen.as_int() % smp::count == seastar::this_shard_id();
+    }
 };
 
 } //namespace sstables

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -73,7 +73,9 @@ sstable_directory::sstable_directory(sstables_manager& manager,
 {}
 
 void sstable_directory::filesystem_components_lister::handle(sstables::entry_descriptor desc, fs::path filename) {
-    if ((desc.generation.as_int() % smp::count) != this_shard_id()) {
+    // TODO: decorate sstable_directory with some noncopyable_function<shard_id (generation_type)>
+    //       to communicate how different tables place sstables into shards.
+    if (!sstables::sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {
         return;
     }
 
@@ -293,7 +295,7 @@ future<> sstable_directory::system_keyspace_components_lister::process(sstable_d
             // FIXME -- handle
             return make_ready_future<>();
         }
-        if ((desc.generation.as_int() % smp::count) != this_shard_id()) {
+        if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {
             return make_ready_future<>();
         }
 


### PR DESCRIPTION
instead of encoding the fact that we are using generation identifier as a hint where the SSTable with this generation should be processed at the caller sites of `as_int()`, just provide an accessor on generation_type's side. this helps to encapsulate the underlying type of generation in `generation_type` instead of exposing it to its users.