### PR TITLE
doc: fix the broken Glossary link

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,8 +1,11 @@
 ### a dictionary of redirections
 #old path: new path
 
+# moving Glossary under Reference (starting from version 5.3)
+# needs to be replaced with the following when 5.3 is released:
+# /stable/glossary.html: /stable/reference/glossary.html
 
-/stable/glossary.html: /stable/reference/glossary.html
+/master/glossary.html: /master/reference/glossary.html
 
 # removing the Enterprise upgrade guides from the Open Source documentation
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13805

This commit fixes the redirection required by moving the Glossary page from the top of the page tree to the Reference section.

As the change was only merged to master (not to branch-5.2), it is not working for version 5.2, which is now the latest stable version.
For this reason, "stable" in the path must be replaced with "master".