### PR TITLE
Allow no owned token ranges in cleanup compaction

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1561,6 +1561,11 @@ private:
 
 bool needs_cleanup(const sstables::shared_sstable& sst,
                    const dht::token_range_vector& sorted_owned_ranges) {
+    // Finish early if the keyspace has no owned token ranges (in this data center)
+    if (sorted_owned_ranges.empty()) {
+        return true;
+    }
+
     auto first_token = sst->get_first_decorated_key().token();
     auto last_token = sst->get_last_decorated_key().token();
     dht::token_range sst_token_range = dht::token_range::make(first_token, last_token);
@@ -1609,10 +1614,6 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
     };
     if (check_for_cleanup()) {
         throw std::runtime_error(format("cleanup request failed: there is an ongoing cleanup on {}", t));
-    }
-
-    if (sorted_owned_ranges->empty()) {
-        throw std::runtime_error("cleanup request failed: sorted_owned_ranges is empty");
     }
 
     // Called with compaction_disabled

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -460,6 +460,62 @@ def test_storage_service_keyspace_cleanup(cql, this_dc, rest_api):
                 resp = rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}", { "cf": f"{test_tables[0]},XXX" })
                 assert resp.status_code == requests.codes.bad_request
 
+                resp = rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}")
+                resp.raise_for_status()
+
+def test_storage_service_keyspace_cleanup_with_no_owned_ranges(cql, this_dc, rest_api):
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+        schema = 'p int, v text, primary key (p)'
+        with new_test_table(cql, keyspace, schema) as t0:
+            stmt = cql.prepare(f"INSERT INTO {t0} (p, v) VALUES (?, ?)")
+            cql.execute(stmt, [0, 'hello'])
+
+            # the node fixture may hold snapshots from other tests
+            # so keep the tags of the snapshots explicitly taken by this instance
+            my_snapshot_tags = dict()
+
+            def make_snapshot_tag(name):
+                tag = f"{int(time.time())}-{name}"
+                my_snapshot_tags[name] = tag
+                return tag
+
+            def snapshot_tag(name):
+                return my_snapshot_tags[name]
+
+            resp = rest_api.send("POST", f"storage_service/keyspace_flush/{keyspace}")
+            resp.raise_for_status()
+            resp = rest_api.send("POST", "storage_service/snapshots", {'kn': keyspace, 'tag': make_snapshot_tag('after-flush')})
+            resp.raise_for_status()
+
+            cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 0 }}")
+            resp = rest_api.send("POST", "storage_service/snapshots", {'kn': keyspace, 'tag': make_snapshot_tag('after-alter-keyspace')})
+            resp.raise_for_status()
+
+            resp = rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}")
+            resp.raise_for_status()
+            resp = rest_api.send("POST", "storage_service/snapshots", {'kn': keyspace, 'tag': make_snapshot_tag('after-cleanup')})
+            resp.raise_for_status()
+
+            resp = rest_api.send("GET", "storage_service/snapshots")
+            resp.raise_for_status()
+            snapshots = dict()
+            for p in resp.json():
+                key = p['key']
+                assert isinstance(key, str), f"key is expected to be a string: {p}"
+                if key in my_snapshot_tags.values():
+                    value = p['value']
+                    if isinstance(value, list):
+                        assert len(value) == 1, f"Expecting a single value in {p}"
+                        value = value[0]
+                    assert isinstance(value, dict), f"value is expected to be a dict: {p}"
+                    snapshots[key] = value
+
+            print(f"snapshot metadata: {snapshots}")
+
+            assert snapshots[snapshot_tag('after-flush')]['total'] > 0, f"snapshots after flush should have non-zero data: {snapshots}"
+            assert snapshots[snapshot_tag('after-alter-keyspace')]['total'] == snapshots[snapshot_tag('after-flush')]['total'], f"snapshots after alter-keyspace should have the same data as after flush: {snapshots}"
+            assert snapshots[snapshot_tag('after-cleanup')]['total'] == 0, f"snapshots after clean should have no data: {snapshots}"
+
 def test_storage_service_keyspace_upgrade_sstables(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         schema = 'p int, v text, primary key (p)'


### PR DESCRIPTION
It is possible that a node will have no owned token ranges
in some keyspaces based on their replication strategy,
if the strategy is configured to have no replicas in
this node's data center.

In this case we should go ahead with cleanup that will
effectively delete all data.

Note that this is current very inefficient as we need
to filter every partition and drop it as unowned.
It can be optimized by either special casing this case
or, better, use skip forward to the next owned range.
This will skip to end-of-stream since there are no
owned ranges.

Fixes #13634

Also, add a respective rest_api unit test