### PR TITLE
raft topology: ban left nodes from the cluster

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1062,6 +1062,41 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             api::set_server_config(ctx, *cfg).get();
 
+            static sharded<auth::service> auth_service;
+            static sharded<qos::service_level_controller> sl_controller;
+            debug::the_sl_controller = &sl_controller;
+
+            //starting service level controller
+            qos::service_level_options default_service_level_configuration;
+            sl_controller.start(std::ref(auth_service), default_service_level_configuration).get();
+            sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
+            auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {
+                sl_controller.stop().get();
+            });
+
+            //This starts the update loop - but no real update happens until the data accessor is not initialized.
+            sl_controller.local().update_from_distributed_data(std::chrono::seconds(10));
+
+            static sharded<db::system_distributed_keyspace> sys_dist_ks;
+            static sharded<db::system_keyspace> sys_ks;
+            static sharded<db::view::view_update_generator> view_update_generator;
+            static sharded<cdc::generation_service> cdc_generation_service;
+
+            supervisor::notify("starting system keyspace");
+            sys_ks.start(std::ref(qp), std::ref(db), std::ref(snitch)).get();
+            // TODO: stop()?
+
+            // Initialization of a keyspace is done by shard 0 only. For system
+            // keyspace, the procedure  will go through the hardcoded column
+            // families, and in each of them, it will load the sstables for all
+            // shards using distributed database object.
+            // Iteration through column family directory for sstable loading is
+            // done only by shard 0, so we'll no longer face race conditions as
+            // described here: https://github.com/scylladb/scylla/issues/1014
+            supervisor::notify("loading system sstables");
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
+            cfg->host_id = sys_ks.local().load_local_host_id().get0();
+
             netw::messaging_service::config mscfg;
 
             mscfg.ip = utils::resolve(cfg->listen_address, family).get0();
@@ -1101,21 +1136,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 mscfg.tcp_nodelay = netw::messaging_service::tcp_nodelay_what::local;
             }
 
-            static sharded<auth::service> auth_service;
-            static sharded<qos::service_level_controller> sl_controller;
-            debug::the_sl_controller = &sl_controller;
-
-            //starting service level controller
-            qos::service_level_options default_service_level_configuration;
-            sl_controller.start(std::ref(auth_service), default_service_level_configuration).get();
-            sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
-            auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {
-                sl_controller.stop().get();
-            });
-
-            //This starts the update loop - but no real update happens until the data accessor is not initialized.
-            sl_controller.local().update_from_distributed_data(std::chrono::seconds(10));
-
             netw::messaging_service::scheduling_config scfg;
             scfg.statement_tenants = { {dbcfg.statement_scheduling_group, "$user"}, {default_scheduling_group(), "$system"} };
             scfg.streaming = dbcfg.streaming_scheduling_group;
@@ -1135,26 +1155,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_ms = defer_verbose_shutdown("messaging service", [&messaging] {
                 messaging.invoke_on_all(&netw::messaging_service::stop).get();
             });
-
-            static sharded<db::system_distributed_keyspace> sys_dist_ks;
-            static sharded<db::system_keyspace> sys_ks;
-            static sharded<db::view::view_update_generator> view_update_generator;
-            static sharded<cdc::generation_service> cdc_generation_service;
-
-            supervisor::notify("starting system keyspace");
-            sys_ks.start(std::ref(qp), std::ref(db), std::ref(snitch)).get();
-            // TODO: stop()?
-
-            // Initialization of a keyspace is done by shard 0 only. For system
-            // keyspace, the procedure  will go through the hardcoded column
-            // families, and in each of them, it will load the sstables for all
-            // shards using distributed database object.
-            // Iteration through column family directory for sstable loading is
-            // done only by shard 0, so we'll no longer face race conditions as
-            // described here: https://github.com/scylladb/scylla/issues/1014
-            supervisor::notify("loading system sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
-            cfg->host_id = sys_ks.local().load_local_host_id().get0();
 
             supervisor::notify("starting gossiper");
             gms::gossip_config gcfg;

--- a/main.cc
+++ b/main.cc
@@ -1099,6 +1099,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             netw::messaging_service::config mscfg;
 
+            mscfg.id = cfg->host_id;
             mscfg.ip = utils::resolve(cfg->listen_address, family).get0();
             mscfg.port = cfg->storage_port();
             mscfg.ssl_port = cfg->ssl_storage_port();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -226,8 +226,9 @@ future<> messaging_service::unregister_handler(messaging_verb verb) {
     return _rpc->unregister_handler(verb);
 }
 
-messaging_service::messaging_service(gms::inet_address ip, uint16_t port)
-    : messaging_service(config{std::move(ip), port}, scheduling_config{{{{}, "$default"}}, {}, {}}, nullptr)
+messaging_service::messaging_service(locator::host_id id, gms::inet_address ip, uint16_t port)
+    : messaging_service(config{std::move(id), std::move(ip), port},
+                        scheduling_config{{{{}, "$default"}}, {}, {}}, nullptr)
 {}
 
 static

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -322,8 +322,7 @@ private:
 public:
     using clock_type = lowres_clock;
 
-    messaging_service(gms::inet_address ip = gms::inet_address("0.0.0.0"),
-            uint16_t port = 7000);
+    messaging_service(gms::inet_address ip, uint16_t port);
     messaging_service(config cfg, scheduling_config scfg, std::shared_ptr<seastar::tls::credentials_builder>);
     ~messaging_service();
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -318,6 +318,7 @@ private:
 
     struct connection_ref;
     std::unordered_multimap<locator::host_id, connection_ref> _host_connections;
+    std::unordered_set<locator::host_id> _banned_hosts;
 
     future<> shutdown_tls_server();
     future<> shutdown_nontls_server();
@@ -501,6 +502,12 @@ public:
     future<table_schema_version> send_schema_check(msg_addr, abort_source&);
 
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
+
+    // Drops all connections from the given host and prevents further communication from it to happen.
+    //
+    // No further RPC handlers will be called for that node,
+    // but we don't prevent handlers that were started concurrently from finishing.
+    future<> ban_host(locator::host_id);
 private:
     template <typename Fn>
     requires std::is_invocable_r_v<bool, Fn, const shard_info&>
@@ -510,6 +517,8 @@ private:
     bool topology_known_for(inet_address) const;
     bool is_same_dc(inet_address ep) const;
     bool is_same_rack(inet_address ep) const;
+
+    bool is_host_banned(locator::host_id);
 
 public:
     // Return rpc::protocol::client for a shard which is a ip + cpuid pair.

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -19,6 +19,7 @@
 #include "range.hh"
 #include "schema/schema_fwd.hh"
 #include "streaming/stream_fwd.hh"
+#include "locator/host_id.hh"
 
 #include <list>
 #include <vector>
@@ -261,6 +262,7 @@ public:
     };
 
     struct config {
+        locator::host_id id;
         gms::inet_address ip;
         uint16_t port;
         uint16_t ssl_port = 0;
@@ -322,7 +324,7 @@ private:
 public:
     using clock_type = lowres_clock;
 
-    messaging_service(gms::inet_address ip, uint16_t port);
+    messaging_service(locator::host_id id, gms::inet_address ip, uint16_t port);
     messaging_service(config cfg, scheduling_config scfg, std::shared_ptr<seastar::tls::credentials_builder>);
     ~messaging_service();
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -316,6 +316,9 @@ private:
     std::vector<scheduling_info_for_connection_index> _scheduling_info_for_connection_index;
     std::vector<tenant_connection_index> _connection_index_for_tenant;
 
+    struct connection_ref;
+    std::unordered_multimap<locator::host_id, connection_ref> _host_connections;
+
     future<> shutdown_tls_server();
     future<> shutdown_nontls_server();
     future<> stop_tls_server();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1005,10 +1005,10 @@ class topology_coordinator {
 
     future<node_to_work_on> global_token_metadata_barrier(node_to_work_on&& node) {
         node = co_await exec_global_command(std::move(node),
-            raft_topology_cmd { raft_topology_cmd::command::barrier_and_drain },
+            raft_topology_cmd::command::barrier_and_drain,
             true);
         node = co_await exec_global_command(std::move(node),
-            raft_topology_cmd { raft_topology_cmd::command::fence },
+            raft_topology_cmd::command::fence,
             true);
         co_return std::move(node);
     }
@@ -1040,7 +1040,7 @@ class topology_coordinator {
                 // introduced during replace/remove.
                 {
                     auto f = co_await coroutine::as_future(exec_global_command(std::move(guard),
-                        raft_topology_cmd{raft_topology_cmd::command::barrier},
+                        raft_topology_cmd::command::barrier,
                         {_raft.id()}));
                     if (f.failed()) {
                         slogger.error("raft topology: transition_state::commit_cdc_generation, "
@@ -1336,7 +1336,7 @@ class topology_coordinator {
             }
             case node_state::rebuilding: {
                 node = co_await exec_direct_command(
-                        std::move(node), raft_topology_cmd{raft_topology_cmd::command::stream_ranges});
+                        std::move(node), raft_topology_cmd::command::stream_ranges);
                 topology_mutation_builder builder(node.guard.write_timestamp());
                 builder.with_node(node.id)
                        .set("node_state", node_state::normal)

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -769,6 +769,8 @@ private:
     std::optional<shared_future<>> _decomission_result;
     std::optional<shared_future<>> _rebuild_result;
     std::unordered_map<raft::server_id, std::optional<shared_future<>>> _remove_result;
+    // During decommission, the node waits for the coordinator to tell it to shut down.
+    std::optional<promise<>> _shutdown_request_promise;
     struct {
         raft::term_t term{0};
         uint64_t last_index{0};

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -69,6 +69,7 @@ static std::unordered_map<node_state, sstring> node_state_to_name_map = {
     {node_state::decommissioning, "decommissioning"},
     {node_state::removing, "removing"},
     {node_state::normal, "normal"},
+    {node_state::left_token_ring, "left_token_ring"},
     {node_state::left, "left"},
     {node_state::replacing, "replacing"},
     {node_state::rebuilding, "rebuilding"},

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -151,6 +151,9 @@ std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd
         case raft_topology_cmd::command::fence:
             os << "fence";
             break;
+        case raft_topology_cmd::command::shutdown:
+            os << "shutdown";
+            break;
     }
     return os;
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -141,6 +141,8 @@ struct raft_topology_cmd {
           fence                 // erect the fence against requests with stale versions
       };
       command cmd;
+
+      raft_topology_cmd(command c) : cmd(c) {}
 };
 
 // returned as a result of raft_bootstrap_cmd

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -139,7 +139,8 @@ struct raft_topology_cmd {
           barrier_and_drain,    // same + drain requests which use previous versions
           stream_ranges,        // reqeust to stream data, return when streaming is
                                 // done
-          fence                 // erect the fence against requests with stale versions
+          fence,                // erect the fence against requests with stale versions
+          shutdown,             // a decommissioning node should shut down
       };
       command cmd;
 

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -34,6 +34,7 @@ enum class node_state: uint16_t {
     replacing,           // the node replaces another dead node in the cluster and it data is being streamed to it
     rebuilding,          // the node is being rebuild and is streaming data from other replicas
     normal,              // the node does not do any streaming and serves the slice of the ring that belongs to it
+    left_token_ring,     // the node left the token ring, but not group0 yet; we wait until other nodes stop writing to it
     left                 // the node left the cluster and group0
 };
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -716,7 +716,7 @@ public:
             }
 
             // don't start listening so tests can be run in parallel
-            ms.start(listen, std::move(7000)).get();
+            ms.start(cfg->host_id, listen, std::move(7000)).get();
             auto stop_ms = defer([&ms] { ms.stop().get(); });
 
             // Normally the auth server is already stopped in here,

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -68,7 +68,7 @@ int main(int ac, char ** av) {
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, locator::token_metadata::config{}).get();
             auto stop_token_mgr = defer([&] { token_metadata.stop().get(); });
 
-            messaging.start(listen).get();
+            messaging.start(listen, 7000).get();
             auto stop_messaging = deferred_stop(messaging);
 
             gms::gossip_config gcfg;

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -68,7 +68,7 @@ int main(int ac, char ** av) {
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, locator::token_metadata::config{}).get();
             auto stop_token_mgr = defer([&] { token_metadata.stop().get(); });
 
-            messaging.start(listen, 7000).get();
+            messaging.start(locator::host_id{}, listen, 7000).get();
             auto stop_messaging = deferred_stop(messaging);
 
             gms::gossip_config gcfg;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -171,7 +171,7 @@ int main(int ac, char ** av) {
         const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
         utils::fb_utilities::set_broadcast_address(listen);
         seastar::sharded<netw::messaging_service> messaging;
-        return messaging.start(listen, 7000).then([config, stay_alive, &messaging] () {
+        return messaging.start(locator::host_id{}, listen, 7000).then([config, stay_alive, &messaging] () {
             auto testers = new distributed<tester>;
             return testers->start(std::ref(messaging)).then([testers]{
                 auto port = testers->local().port();

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -171,7 +171,7 @@ int main(int ac, char ** av) {
         const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
         utils::fb_utilities::set_broadcast_address(listen);
         seastar::sharded<netw::messaging_service> messaging;
-        return messaging.start(listen).then([config, stay_alive, &messaging] () {
+        return messaging.start(listen, 7000).then([config, stay_alive, &messaging] () {
             auto testers = new distributed<tester>;
             return testers->start(std::ref(messaging)).then([testers]{
                 auto port = testers->local().port();

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -76,6 +76,10 @@ class ManagerClient():
             logger.debug("refresh driver node list")
             self.ccluster.control_connection.refresh_node_list_and_token_map()
 
+    def get_cql(self) -> CassandraSession:
+        assert self.cql
+        return self.cql
+
     async def before_test(self, test_case_name: str) -> None:
         """Before a test starts check if cluster needs cycling and update driver connection"""
         logger.debug("before_test for %s", test_case_name)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -161,6 +161,16 @@ class ManagerClient():
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         self._driver_update()
 
+    async def server_pause(self, server_id: ServerNum) -> None:
+        """Pause the specified server."""
+        logger.debug("ManagerClient pausing %s", server_id)
+        await self.client.get(f"/cluster/server/{server_id}/pause")
+
+    async def server_unpause(self, server_id: ServerNum) -> None:
+        """Unpause the specified server."""
+        logger.debug("ManagerClient unpausing %s", server_id)
+        await self.client.get(f"/cluster/server/{server_id}/unpause")
+
     async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, Any]] = None, start: bool = True) -> ServerInfo:
         """Add a new server"""
         try:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -272,7 +272,7 @@ class ManagerClient():
             alive_nodes = await self.api.get_alive_endpoints(server_ip)
             if len(alive_nodes) > count:
                 return True
-        await wait_for(_sees_min_others, time() + interval, period=.1)
+        await wait_for(_sees_min_others, time() + interval, period=.5)
 
     async def server_sees_other_server(self, server_ip: IPAddress, other_ip: IPAddress,
                                        interval: float = 45.):
@@ -281,7 +281,7 @@ class ManagerClient():
             alive_nodes = await self.api.get_alive_endpoints(server_ip)
             if other_ip in alive_nodes:
                 return True
-        await wait_for(_sees_another_server, time() + interval, period=.1)
+        await wait_for(_sees_another_server, time() + interval, period=.5)
 
     async def server_not_sees_other_server(self, server_ip: IPAddress, other_ip: IPAddress,
                                            interval: float = 45.):
@@ -290,4 +290,4 @@ class ManagerClient():
             alive_nodes = await self.api.get_alive_endpoints(server_ip)
             if not other_ip in alive_nodes:
                 return True
-        await wait_for(_not_sees_another_server, time() + interval, period=.1)
+        await wait_for(_not_sees_another_server, time() + interval, period=.5)

--- a/test/topology_experimental_raft/test_node_isolation.py
+++ b/test/topology_experimental_raft/test_node_isolation.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import logging
+import pytest
+import time
+
+from cassandra.cluster import ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT # type: ignore
+from cassandra.cluster import NoHostAvailable, OperationTimedOut # type: ignore
+from cassandra.query import SimpleStatement # type: ignore
+from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier
+
+from cassandra.cluster import Cluster
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_banned_node_cannot_communicate(manager: ManagerClient) -> None:
+    """Test that a node banned from the cluster is not able to perform inserts
+       that require communicating with other nodes."""
+    # Decrease the failure detector threshold so we don't have to wait for too long.
+    config = {
+        'failure_detector_timeout_in_ms': 2000
+    }
+    srvs = [await manager.server_add(config=config) for _ in range(3)]
+    cql = manager.get_cql()
+
+    # Use RF=2 keyspace and below CL=ALL so that performing an INSERT requires
+    # communicating with another node.
+    await cql.run_async("create keyspace ks with replication = "
+                        "{'class': 'SimpleStrategy', 'replication_factor': 2}")
+    await cql.run_async("create table ks.t (pk int primary key)")
+
+    # Pause one of the servers so other nodes mark it as dead and we can remove it.
+    # We deliberately don't shut it down, but only pause it - we want to test
+    # that we solved the harder problem of safely removing nodes which didn't shut down.
+    logger.info(f"Pausing server {srvs[2]}")
+    await manager.server_pause(srvs[2].server_id)
+    logger.info(f"Waiting until server {srvs[0]} marks {srvs[2]} as dead")
+    await manager.server_not_sees_other_server(srvs[0].ip_addr, srvs[2].ip_addr)
+    logger.info(f"Removing {srvs[2]} using {srvs[0]}")
+    await manager.remove_node(srvs[0].server_id, srvs[2].server_id)
+    # Perform a read barrier on srvs[1] so it learns about the ban.
+    logger.info(f"Performing read barrier on server {srvs[1]}")
+    host = (await wait_for_cql_and_get_hosts(cql, [srvs[1]], time.time() + 60))[0]
+    await read_barrier(cql, host)
+    logger.info(f"Unpausing {srvs[2]}")
+    await manager.server_unpause(srvs[2].server_id)
+
+    # We need a separate driver session to communicate with the removed server,
+    # the original driver session bugs out.
+    profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([srvs[2].ip_addr]))
+    with Cluster([srvs[2].ip_addr], execution_profiles={EXEC_PROFILE_DEFAULT: profile}) as c:
+        with c.connect() as s:
+            q = SimpleStatement('insert into ks.t (pk) values (0)', consistency_level=ConsistencyLevel.ALL)
+            # Before introducing host banning, a removed node was able to participate
+            # as if it was a normal node and, for example, could insert data into the cluster.
+            # Now other nodes refuse to communicate so we'll get an exception.
+            with pytest.raises((NoHostAvailable, OperationTimedOut)):
+                await s.run_async(q)


### PR DESCRIPTION
Use the new Seastar functionality for storing references to connections to implement banning hosts that have left the cluster (either decommissioned or using removenode) in raft-topology mode. Any attempts at communication from those nodes will be rejected.

This works not only for nodes that restart, but also for nodes that were running behind a network partition and we removed them. Even when the partition resolves, the existing nodes will effectively put a firewall from that node.

Some changes to the decommission algorithm had to be introduced for it to work with node banning. As a side effect a pre-existing problem with decommission was fixed. Read the "introduce `left_token_ring` state" and "prepare decommission path for node banning" commits for details.