### PR TITLE
test: Fix sporadic failures of database_test

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -72,11 +72,7 @@ static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id 
 }
 
 future<> do_with_cql_env_and_compaction_groups(std::function<void(cql_test_env&)> func, cql_test_config cfg = {}, thread_attributes thread_attr = {}) {
-#ifdef SEASTAR_DEBUG
     std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 1 /* 2 CGs */ };
-#else
-    std::vector<unsigned> x_log2_compaction_group_values = { 0 /* 1 CG */, 1 /* 2 CGs */, 8 /* 256 CGs */ };
-#endif
     for (auto x_log2_compaction_groups : x_log2_compaction_group_values) {
         // clean the dir before running
         if (cfg.db_config->data_file_directories.is_set()) {


### PR DESCRIPTION
database_test is failing sporadically and the cause was traced back to commit e3e7c3c7e51bd73d79.

The commit forces a subset of tests in database_test, to run once for each of predefined x_log2_compaction_group settings.

That causes two problems:
1) test becomes 240% slower in dev mode.
2) queries on system.auth is timing out, and the reason is a small table being spread across hundreds of compaction groups in each shard. so to satisfy a range scan, there will be multiple hops, making the overhead huge. additionally, the compaction group aware sstable set is not merged yet. so even point queries will unnecessarily scan through all the groups.

Fixes #13660.