### PR TITLE
compaction_manager: perform_cleanup: hold on to sstable_set around yielding

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1619,6 +1619,9 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
     auto get_sstables = [this, &t, sorted_owned_ranges] () -> future<std::vector<sstables::shared_sstable>> {
         return seastar::async([this, &t, sorted_owned_ranges = std::move(sorted_owned_ranges)] {
             auto update_sstables_cleanup_state = [&] (const sstables::sstable_set& set) {
+                // Hold on to the sstable set since it may be overwritten
+                // while we yield in this loop.
+                auto set_holder = set.shared_from_this();
                 set.for_each_sstable([&] (const sstables::shared_sstable& sst) {
                     update_sstable_cleanup_state(t, sst, *sorted_owned_ranges);
                     seastar::thread::maybe_yield();


### PR DESCRIPTION
Updates to the compaction_group sstable sets are
never done in place.  Instead, the update is done
on a mutable copy of the sstable set, and the lw_shared result is set back in the compaction_group.
(see for example compaction_group::set_main_sstables)

Therefore, there's currently a risk in perform_cleanup `get_sstables` lambda that if it yield while in
set.for_each_sstable, the sstable_set might be replaced and the copy it is traversing may be destroyed.
This was introduced in c2bf0e0b72fdfdf92d8552a276a26f6a873ef729.

To prevent that, hold on to set.shared_from_this() around set.for_each_sstable.