### PR TITLE
sstables: move get_components_lister() into sstable_directory

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -154,6 +154,8 @@ private:
 
     std::vector<sstables::shared_sstable> _unsorted_sstables;
 private:
+    std::unique_ptr<sstable_directory::components_lister> make_components_lister();
+
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
     future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg = {}) const;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -177,17 +177,6 @@ future<> sstables_manager::close() {
     co_await _sstable_metadata_concurrency_sem.stop();
 }
 
-std::unique_ptr<sstable_directory::components_lister> sstables_manager::get_components_lister(const data_dictionary::storage_options& storage, std::filesystem::path dir) {
-    return std::visit(overloaded_functor {
-        [dir] (const data_dictionary::storage_options::local& loc) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::make_unique<sstable_directory::filesystem_components_lister>(std::move(dir));
-        },
-        [this, dir] (const data_dictionary::storage_options::s3& os) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::make_unique<sstable_directory::system_keyspace_components_lister>(system_keyspace(), dir.native());
-        }
-    }, storage.value);
-}
-
 void sstables_manager::plug_system_keyspace(db::system_keyspace& sys_ks) noexcept {
     _sys_ks = sys_ks.shared_from_this();
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -19,7 +19,6 @@
 #include "sstables/shared_sstable.hh"
 #include "sstables/version.hh"
 #include "sstables/component_type.hh"
-#include "sstables/sstable_directory.hh"
 #include "db/cache_tracker.hh"
 #include "locator/host_id.hh"
 #include "reader_concurrency_semaphore.hh"
@@ -115,8 +114,6 @@ public:
             gc_clock::time_point now = gc_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
-
-    std::unique_ptr<sstable_directory::components_lister> get_components_lister(const data_dictionary::storage_options& storage, std::filesystem::path dir);
 
     shared_ptr<s3::client> get_endpoint_client(sstring endpoint) const {
         assert(_storage != nullptr);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -17,6 +17,7 @@
 #include <seastar/util/file.hh>
 
 #include "sstables/exceptions.hh"
+#include "sstables/sstable_directory.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_version.hh"
 #include "sstables/integrity_checked_file_impl.hh"

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -31,6 +31,7 @@
 #include "readers/combined.hh"
 #include "replica/database.hh"
 #include "sstables/sstables_manager.hh"
+#include "sstables/sstable_directory.hh"
 #include "types/list.hh"
 #include "data_dictionary/impl.hh"
 #include "data_dictionary/data_dictionary.hh"


### PR DESCRIPTION
sstables_manager::get_component_lister() is used by sstable_directory. and almost all the "ingredients" used to create a component lister are located in sstable_directory. among the other things, the two implementations of `components_lister` are located right in `sstable_directory`. there is no need to outsource this to sstables_manager just for accessing the system_keyspace, which is already exposed as a public function of `sstables_manager`. so let's move this helper into sstable_directory.cc.

with this change, we can even go further by moving the `components_lister` implementations into the same .cc file.