### PR TITLE
Share s3 clients between sstables

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -309,14 +309,6 @@ public:
     }
 };
 
-sstables::object_storage_config make_object_storage_config(const db::config& db_cfg) {
-    std::unordered_map<sstring, s3::endpoint_config_ptr> ret;
-    for (auto [ ep, cfg ] : db_cfg.object_storage_config()) {
-        ret[ep] = make_lw_shared<s3::endpoint_config>(std::move(cfg));
-    }
-    return ret;
-}
-
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
         compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
@@ -372,7 +364,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_rows_count_warning_threshold,
               _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local(), &sstm, make_object_storage_config(_cfg)))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local(), &sstm))
     , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
@@ -383,7 +375,6 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })
     , _memtable_flush_static_shares_observer(cfg.memtable_flush_static_shares.observe(_update_memtable_flush_static_shares_action.make_observer()))
-    , _object_storage_config_updater(this_shard_id() == 0 ? std::make_unique<object_storage_config_updater>(*this) : nullptr)
 {
     assert(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 
@@ -397,15 +388,6 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
         set_format(*_dbcfg.sstables_format);
     }
 }
-
-database::object_storage_config_updater::object_storage_config_updater(database& db)
-    : action([&db] () mutable {
-        return db.container().invoke_on_all([] (database& db) {
-            db._user_sstables_manager->update_object_storage_config(make_object_storage_config(db._cfg));
-        });
-    })
-    , observer(db._cfg.object_storage_config.observe(action.make_observer()))
-{}
 
 const db::extensions& database::extensions() const {
     return get_config().extensions();
@@ -2296,9 +2278,6 @@ future<> database::stop() {
     co_await _system_read_concurrency_sem.stop();
     dblog.info("Joining memtable update action");
     co_await _update_memtable_flush_static_shares_action.join();
-    if (_object_storage_config_updater) {
-        co_await _object_storage_config_updater->action.join();
-    }
 }
 
 future<> database::flush_all_memtables() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -318,7 +318,7 @@ sstables::object_storage_config make_object_storage_config(const db::config& db_
 }
 
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-        compaction_manager& cm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
+        compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
     , _cl_stats(std::make_unique<cell_locker_stats>())
@@ -372,7 +372,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_rows_count_warning_threshold,
               _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local(), make_object_storage_config(_cfg)))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local(), &sstm, make_object_storage_config(_cfg)))
     , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem.local()))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1389,14 +1389,6 @@ private:
     serialized_action _update_memtable_flush_static_shares_action;
     utils::observer<float> _memtable_flush_static_shares_observer;
 
-    struct object_storage_config_updater {
-        serialized_action action;
-        utils::observer<std::unordered_map<sstring, s3::endpoint_config>> observer;
-        object_storage_config_updater(database&);
-    };
-
-    std::unique_ptr<object_storage_config_updater> _object_storage_config_updater;
-
 public:
     data_dictionary::database as_data_dictionary() const;
     std::shared_ptr<data_dictionary::user_types_storage> as_user_types_storage() const noexcept;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -93,6 +93,7 @@ namespace sstables {
 class sstable;
 class compaction_descriptor;
 class compaction_completion_desc;
+class storage_manager;
 class sstables_manager;
 class compaction_data;
 class sstable_set;
@@ -1469,7 +1470,7 @@ public:
 
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            compaction_manager& cm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -78,7 +78,9 @@ void storage_manager::update_config(const db::config& cfg) {
 shared_ptr<s3::client> storage_manager::get_endpoint_client(sstring endpoint) {
     auto& ep = _s3_endpoints.at(endpoint);
     if (ep.client == nullptr) {
-        ep.client = s3::client::make(endpoint, ep.cfg);
+        ep.client = s3::client::make(endpoint, ep.cfg, [ &ct = container() ] (std::string ep) {
+            return ct.local().get_endpoint_client(ep);
+        });
     }
     return ep.client;
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -20,8 +20,9 @@ namespace sstables {
 logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
-    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem, object_storage_config oscfg)
-    : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
+    db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem, storage_manager* shared, object_storage_config oscfg)
+    : _storage(shared)
+    , _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
     , _sstable_metadata_concurrency_sem(
         max_count_sstable_metadata_concurrent_reads,
         max_memory_sstable_metadata_concurrent_reads(available_memory),
@@ -38,6 +39,14 @@ sstables_manager::~sstables_manager() {
     assert(_closing);
     assert(_active.empty());
     assert(_undergoing_close.empty());
+}
+
+storage_manager::storage_manager(const db::config& cfg)
+{
+}
+
+future<> storage_manager::stop() {
+    co_return;
 }
 
 void sstables_manager::update_object_storage_config(object_storage_config oscfg) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -62,11 +62,13 @@ future<> storage_manager::stop() {
 }
 
 void storage_manager::update_config(const db::config& cfg) {
-    // FIXME -- entries grabbed by sstables' storages are not yet updated
     for (auto [ep, ecfg] : cfg.object_storage_config()) {
         auto it = _s3_endpoints.find(ep);
         if (it != _s3_endpoints.end()) {
             it->second.cfg = std::move(ecfg);
+            if (it->second.client != nullptr) {
+                it->second.client->update_config(it->second.cfg);
+            }
         } else {
             _s3_endpoints.emplace(std::make_pair(std::move(ep), make_lw_shared<s3::endpoint_config>(std::move(ecfg))));
         }

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -178,6 +178,8 @@ public:
 
     virtual sharded<service::storage_proxy>& get_storage_proxy() = 0;
 
+    virtual sharded<sstables::storage_manager>& get_sstorage_manager() = 0;
+
     data_dictionary::database data_dictionary();
 };
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -64,7 +64,7 @@ class test_env {
         sstables::sstable_generation_generator gen{0};
         data_dictionary::storage_options storage;
 
-        impl(test_env_config cfg);
+        impl(test_env_config cfg, sstables::storage_manager* sstm);
         impl(impl&&) = delete;
         impl(const impl&) = delete;
 
@@ -75,7 +75,7 @@ class test_env {
     std::unique_ptr<impl> _impl;
 public:
 
-    explicit test_env(test_env_config cfg = {}) : _impl(std::make_unique<impl>(std::move(cfg))) { }
+    explicit test_env(test_env_config cfg = {}, sstables::storage_manager* sstm = nullptr) : _impl(std::make_unique<impl>(std::move(cfg), sstm)) { }
 
     future<> stop() {
         return _impl->mgr.close().finally([this] {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -107,10 +107,11 @@ public:
     }
 };
 
-client::client(std::string host, endpoint_config_ptr cfg, private_tag)
+client::client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag)
         : _host(std::move(host))
         , _cfg(std::move(cfg))
         , _http(std::make_unique<dns_connection_factory>(_host, _cfg->port, _cfg->use_https))
+        , _gf(std::move(gf))
 {
 }
 
@@ -121,8 +122,8 @@ void client::update_config(endpoint_config_ptr cfg) {
     _cfg = std::move(cfg);
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg) {
-    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), private_tag{});
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), std::move(gf), private_tag{});
 }
 
 void client::authorize(http::request& req) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -114,6 +114,13 @@ client::client(std::string host, endpoint_config_ptr cfg, private_tag)
 {
 }
 
+void client::update_config(endpoint_config_ptr cfg) {
+    if (_cfg->port != cfg->port || _cfg->use_https != cfg->use_https) {
+        throw std::runtime_error("Updating port and/or https usage is not possible");
+    }
+    _cfg = std::move(cfg);
+}
+
 shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg) {
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), private_tag{});
 }

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -54,6 +54,20 @@ public:
 
     void update_config(endpoint_config_ptr);
 
+    struct handle {
+        std::string _host;
+        endpoint_config_ptr _cfg;
+    public:
+        handle(const client& cln)
+                : _host(cln._host)
+                , _cfg(cln._cfg)
+        {}
+
+        shared_ptr<client> to_client() && {
+            return make(std::move(_host), std::move(_cfg));
+        }
+    };
+
     future<> close();
 };
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -52,6 +52,8 @@ public:
     file make_readable_file(sstring object_name);
     data_sink make_upload_sink(sstring object_name);
 
+    void update_config(endpoint_config_ptr);
+
     future<> close();
 };
 


### PR DESCRIPTION
Currently s3::client is created for each sstable::storage. It's later shared between sstable's files and upload sink(s). Also foreign_sstable_open_info can produce a file from a handle making a new standalone client. Coupled with the seastar's http client spawning connections on demand, this makes it impossible to control the amount of opened connections to object storage server.

In order to put some policy on top of that (as well as apply workload prioritization) s3 clients should be collected in one place and then shared by users. Since s3::client uses seastar::http::client under the hood which, in turn, can generate many connections on demand, it's enough to produce a single s3::client per configured endpoint one each shard and then share it between all the sstables, files and sinks.

There's one difficulty however, solving which is most of what this PR does. The file handle, that's used to transfer sstable's file across shards, should keep aboard all it needs to re-create a file on another shard. Since there's a single s3::client per shard, creation of a file out of a handle should grab that shard's client somehow. The meaningful shard-local object that can help is the sstables_manager and there are three ways to make use of it. All deal with the fact that sstables_manager-s are not sharded<> services, but are owner by the database independently on each shard.

1. walk the client -> sst.manager -> database -> container -> database -> sst.manager -> client chain by keeping its first half on the handle and unrolling the second half to produce a file
2. keep sharded peering service referenced by the sstables_manager that's initialized in main and passed though the database constructor down to sstables_manager(s)
3. equip file_handle::to_file with the "context" argument and teach sstables foreign info opener to push sstables_manager down to s3 file ... somehow

This PR chooses the 2nd way and introduces the sstables::storage_manager main-local sharded peering service that maintains all the s3::clients. "While at it" the new manager gets the object_storage_config updating facilities from the database (it's overloaded even without it already). Later the manager will also be in charge of collecting and exporting S3 metrics. In order to limit the number of S3 connections it also needs a patch seastar http::client, there's PR already doing that, once (if) merged there'll come one more fix on top.

refs: #13458 
refs: #13369
refs: scylladb/seastar#1652