### PR TITLE
error injection: allow enabling injections via config

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -66,6 +66,20 @@ struct seed_provider_type {
 std::ostream& operator<<(std::ostream& os, const db::seed_provider_type& s);
 inline std::istream& operator>>(std::istream& is, seed_provider_type&);
 
+// Describes a single error injection that should be enabled at startup.
+struct error_injection_at_startup {
+    sstring name;
+    bool one_shot = false;
+
+    bool operator==(const error_injection_at_startup& other) const {
+        return name == other.name
+            && one_shot == other.one_shot;
+    }
+};
+
+std::ostream& operator<<(std::ostream& os, const error_injection_at_startup&);
+std::istream& operator>>(std::istream& is, error_injection_at_startup&);
+
 }
 
 
@@ -141,6 +155,7 @@ public:
     using string_list = std::vector<sstring>;
     using seed_provider_type = db::seed_provider_type;
     using hinted_handoff_enabled_type = db::hints::host_filter;
+    using error_injection_at_startup = db::error_injection_at_startup;
 
     /*
      * All values and documentation taken from
@@ -430,6 +445,8 @@ public:
 
     locator::host_id host_id;
     utils::updateable_value<std::unordered_map<sstring, s3::endpoint_config>> object_storage_config;
+
+    named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
 
     static const sstring default_tls_priority;
 private:


### PR DESCRIPTION
Currently, error injections can be enabled either through HTTP or CQL. While these mechanisms are effective for injecting errors after a node has already started, it can't be reliably used to trigger failures shortly after node start. In order to support this use case, this commit adds possibility to enable some error injections via config.

A configuration option `error_injections_at_startup` is added. This option uses our existing configuration framework, so it is possible to supply it either via CLI or in the YAML configuration file.

- When passed in commandline, the option is parsed as a semicolon-separated list of error injection names that should be enabled. Those error injections are enabled in non-oneshot mode.

  The CLI option is marked as not used in release mode and does not appear in the option list.

  Example:

      --error-injections-at-startup failure_point1;failure_point2

- When provided in YAML config, the option is parsed as a list of items. Each item is either a string or a map or parameters. This method is more flexible as it allows to provide parameters for each injection point. At this time, the only benefit is that it allows enabling points in oneshot mode, but more parameters can be added in the future if needed.

  Explanatory example:

      error_injections_at_startup:
      - failure_point1 # enabled in non-oneshot mode
      - name: failure_point2 # enabled in oneshot mode
        one_shot: true       # due to one_shot optional parameter

The primary goal of this feature is to facilitate testing of raft-based cluster features. An error injection will be used to enable an additional feature to simulate node upgrade.

Tests: manual