### PR TITLE
db/system_keyspace: remove the dependency on storage_proxy

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -19,7 +19,6 @@
 #include <seastar/json/json_elements.hh>
 #include "system_keyspace.hh"
 #include "types/types.hh"
-#include "service/storage_proxy.hh"
 #include "service/client_state.hh"
 #include "service/query_state.hh"
 #include "cql3/query_options.hh"
@@ -3008,41 +3007,37 @@ locator::endpoint_dc_rack system_keyspace::local_dc_rack() const {
 }
 
 future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-system_keyspace::query_mutations(distributed<service::storage_proxy>& proxy, const sstring& ks_name, const sstring& cf_name) {
-    replica::database& db = proxy.local().get_db().local();
-    schema_ptr schema = db.find_schema(ks_name, cf_name);
-    return replica::query_mutations(proxy.local().get_db(), schema, query::full_partition_range, schema->full_slice(), db::no_timeout);
+system_keyspace::query_mutations(distributed<replica::database>& db, const sstring& ks_name, const sstring& cf_name) {
+    schema_ptr schema = db.local().find_schema(ks_name, cf_name);
+    return replica::query_mutations(db, schema, query::full_partition_range, schema->full_slice(), db::no_timeout);
 }
 
 future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-system_keyspace::query_mutations(distributed<service::storage_proxy>& proxy, const sstring& ks_name, const sstring& cf_name, const dht::partition_range& partition_range, query::clustering_range row_range) {
-    auto& db = proxy.local().get_db().local();
-    auto schema = db.find_schema(ks_name, cf_name);
+system_keyspace::query_mutations(distributed<replica::database>& db, const sstring& ks_name, const sstring& cf_name, const dht::partition_range& partition_range, query::clustering_range row_range) {
+    auto schema = db.local().find_schema(ks_name, cf_name);
     auto slice_ptr = std::make_unique<query::partition_slice>(partition_slice_builder(*schema)
         .with_range(std::move(row_range))
         .build());
-    return replica::query_mutations(proxy.local().get_db(), std::move(schema), partition_range, *slice_ptr, db::no_timeout).finally([slice_ptr = std::move(slice_ptr)] { });
+    return replica::query_mutations(db, std::move(schema), partition_range, *slice_ptr, db::no_timeout).finally([slice_ptr = std::move(slice_ptr)] { });
 }
 
 future<lw_shared_ptr<query::result_set>>
-system_keyspace::query(distributed<service::storage_proxy>& proxy, const sstring& ks_name, const sstring& cf_name) {
-    replica::database& db = proxy.local().get_db().local();
-    schema_ptr schema = db.find_schema(ks_name, cf_name);
-    return replica::query_data(proxy.local().get_db(), schema, query::full_partition_range, schema->full_slice(), db::no_timeout).then([schema] (auto&& qr) {
+system_keyspace::query(distributed<replica::database>& db, const sstring& ks_name, const sstring& cf_name) {
+    schema_ptr schema = db.local().find_schema(ks_name, cf_name);
+    return replica::query_data(db, schema, query::full_partition_range, schema->full_slice(), db::no_timeout).then([schema] (auto&& qr) {
         return make_lw_shared<query::result_set>(query::result_set::from_raw_result(schema, schema->full_slice(), *qr));
     });
 }
 
 future<lw_shared_ptr<query::result_set>>
-system_keyspace::query(distributed<service::storage_proxy>& proxy, const sstring& ks_name, const sstring& cf_name, const dht::decorated_key& key, query::clustering_range row_range)
+system_keyspace::query(distributed<replica::database>& db, const sstring& ks_name, const sstring& cf_name, const dht::decorated_key& key, query::clustering_range row_range)
 {
-    auto&& db = proxy.local().get_db().local();
-    auto schema = db.find_schema(ks_name, cf_name);
+    auto schema = db.local().find_schema(ks_name, cf_name);
     auto pr_ptr = std::make_unique<dht::partition_range>(dht::partition_range::make_singular(key));
     auto slice_ptr = std::make_unique<query::partition_slice>(partition_slice_builder(*schema)
         .with_range(std::move(row_range))
         .build());
-    return replica::query_data(proxy.local().get_db(), schema, *pr_ptr, *slice_ptr, db::no_timeout).then(
+    return replica::query_data(db, schema, *pr_ptr, *slice_ptr, db::no_timeout).then(
             [schema, pr_ptr = std::move(pr_ptr), slice_ptr = std::move(slice_ptr)] (auto&& qr) {
         return make_lw_shared<query::result_set>(query::result_set::from_raw_result(schema, schema->full_slice(), *qr));
     });
@@ -3472,9 +3467,9 @@ mutation system_keyspace::make_group0_history_state_id_mutation(
     return m;
 }
 
-future<mutation> system_keyspace::get_group0_history(distributed<service::storage_proxy>& sp) {
+future<mutation> system_keyspace::get_group0_history(distributed<replica::database>& db) {
     auto s = group0_history();
-    auto rs = co_await db::system_keyspace::query_mutations(sp, db::system_keyspace::NAME, db::system_keyspace::GROUP0_HISTORY);
+    auto rs = co_await db::system_keyspace::query_mutations(db, db::system_keyspace::NAME, db::system_keyspace::GROUP0_HISTORY);
     assert(rs);
     auto& ps = rs->partitions();
     for (auto& p: ps) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -32,7 +32,6 @@ namespace sstables {
 
 namespace service {
 
-class storage_proxy;
 class storage_service;
 class raft_group_registry;
 struct topology;
@@ -280,12 +279,12 @@ public:
     /// overloads
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-    static query_mutations(distributed<service::storage_proxy>& proxy,
+    static query_mutations(distributed<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name);
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-    static query_mutations(distributed<service::storage_proxy>& proxy,
+    static query_mutations(distributed<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name,
                     const dht::partition_range& partition_range,
@@ -293,14 +292,14 @@ public:
 
     // Returns all data from given system table.
     // Intended to be used by code which is not performance critical.
-    static future<lw_shared_ptr<query::result_set>> query(distributed<service::storage_proxy>& proxy,
+    static future<lw_shared_ptr<query::result_set>> query(distributed<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name);
 
     // Returns a slice of given system table.
     // Intended to be used by code which is not performance critical.
     static future<lw_shared_ptr<query::result_set>> query(
-        distributed<service::storage_proxy>& proxy,
+        distributed<replica::database>& db,
         const sstring& ks_name,
         const sstring& cf_name,
         const dht::decorated_key& key,
@@ -474,7 +473,7 @@ public:
 
     // Obtain the contents of the group 0 history table in mutation form.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
-    static future<mutation> get_group0_history(distributed<service::storage_proxy>&);
+    static future<mutation> get_group0_history(distributed<replica::database>&);
 
     future<> sstables_registry_create_entry(sstring location, utils::UUID uuid, sstring status, sstables::entry_descriptor desc);
     future<utils::UUID> sstables_registry_lookup_entry(sstring location, sstables::generation_type gen);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -795,7 +795,7 @@ static future<>
 do_parse_schema_tables(distributed<service::storage_proxy>& proxy, const sstring cf_name, std::function<future<> (db::schema_tables::schema_result_value_type&)> func) {
     using namespace db::schema_tables;
 
-    auto rs = co_await db::system_keyspace::query(proxy, db::schema_tables::NAME, cf_name);
+    auto rs = co_await db::system_keyspace::query(proxy.local().get_db(), db::schema_tables::NAME, cf_name);
     auto names = std::set<sstring>();
     for (auto& r : rs->rows()) {
         auto keyspace_name = r.template get_nonnull<sstring>("keyspace_name");

--- a/replica/query.hh
+++ b/replica/query.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*
+ * Utilities for executing queries on the local replica.
+ *
+ * Allows for bypassing storage proxy entirely when querying local (system) tables.
+ */
+
+#include "replica/database.hh"
+
+namespace replica {
+
+/// Reads the specified range and slice of the given table, from the local replica.
+///
+/// There is no paging or limits applied to the result, make sure the result is
+/// sufficiently small.
+future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> query_mutations(
+        sharded<database>& db,
+        schema_ptr s,
+        const dht::partition_range& pr,
+        const query::partition_slice& ps,
+        db::timeout_clock::time_point timeout);
+
+/// Reads the specified range and slice of the given table, from the local replica.
+///
+/// A variant of query_mutations() which returns query result, instead of mutations (only live data).
+future<foreign_ptr<lw_shared_ptr<query::result>>> query_data(
+        sharded<database>& db,
+        schema_ptr s,
+        const dht::partition_range& pr,
+        const query::partition_slice& ps,
+        db::timeout_clock::time_point timeout);
+
+} // namespace replica

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -199,9 +199,9 @@ future<tablet_metadata> read_tablet_metadata(cql3::query_processor& qp) {
     co_return std::move(tm);
 }
 
-future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<service::storage_proxy>& proxy) {
+future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<replica::database>& db) {
     auto s = db::system_keyspace::tablets();
-    auto rs = co_await db::system_keyspace::query_mutations(proxy, db::system_keyspace::NAME, db::system_keyspace::TABLETS);
+    auto rs = co_await db::system_keyspace::query_mutations(db, db::system_keyspace::NAME, db::system_keyspace::TABLETS);
     std::vector<canonical_mutation> result;
     result.reserve(rs->partitions().size());
     for (auto& p: rs->partitions()) {

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -26,10 +26,6 @@ class query_processor;
 
 }
 
-namespace service {
-class storage_proxy;
-}
-
 namespace replica {
 
 schema_ptr make_tablets_schema();
@@ -60,6 +56,6 @@ future<> save_tablet_metadata(replica::database&, const locator::tablet_metadata
 future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 
 /// Reads tablet metadata from system.tablets in the form of mutations.
-future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<service::storage_proxy>&);
+future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
 
 } // namespace replica

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -126,6 +126,7 @@ void migration_manager::init_messaging_service()
 
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
+        auto& db = proxy.local().get_db();
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
         if (options->group0_snapshot_transfer) {
             // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
@@ -134,15 +135,15 @@ void migration_manager::init_messaging_service()
                 on_internal_error(mlogger,
                     "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
             }
-            cm.emplace_back(co_await db::system_keyspace::get_group0_history(proxy));
-            for (auto&& m : co_await replica::read_tablet_mutations(proxy)) {
+            cm.emplace_back(co_await db::system_keyspace::get_group0_history(db));
+            for (auto&& m : co_await replica::read_tablet_mutations(db)) {
                 cm.emplace_back(std::move(m));
             }
         }
         if (cm_retval_supported) {
             co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
         }
-        auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = proxy.local().get_db().local()] (const canonical_mutation& cm) {
+        auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = db.local()] (const canonical_mutation& cm) {
             return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
         }));
         co_return rpc::tuple(std::move(fm), std::move(cm));

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -124,7 +124,7 @@ static future<> test_basic_operations(app_template& app) {
 
         std::vector<canonical_mutation> muts;
         auto time_to_read_muts = duration_in_seconds([&] {
-            muts = replica::read_tablet_mutations(e.local_qp().proxy().container()).get0();
+            muts = replica::read_tablet_mutations(e.local_qp().proxy().get_db()).get0();
         });
 
         testlog.info("Read mutations in {:.6f} [ms]", time_to_read_muts.count() * 1000);


### PR DESCRIPTION
The `system_keyspace` has several methods to query the tables in it. These currently require a storage proxy parameter, because the read has to go through storage-proxy. This PR uses the observation that all these reads are really local-replica reads and they only actually need a relatively small code snippet from storage proxy. These small code snippets are exported into standalone function in a new header (`replica/query.hh`). Then the system keyspace code is patched to use these new standalone functions instead of their equivalent in storage proxy. This allows us to replace the storage proxy dependency with a much more reasonable dependency on `replica::database`.

This PR patches the system keyspace code and the signatures of the affected methods as well as their immediate callers. Indirect callers are only patched to the extent it was needed to avoid introducing new includes (some had only a forward-declaration of storage proxy and so couldn't get database from it). There are a lot of opportunities left to free other methods or maybe even entire subsystems from storage proxy dependency, but this is not pursued in this PR, instead being left for follow-ups.

This PR was conceived to help us break the storage proxy -> storage service -> system tables -> storage proxy dependency loop, which become a major roadblock in migrating from IP -> host_id. After this PR, system keyspace still indirectly depends on storage proxy, because it still uses `cql3::query_processor` in some places. This will be addressed in another PR.

Refs: #11870