### PR TITLE
Use member initializer list for trace_state and related helper classes

### DIFF
--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -57,17 +57,7 @@ void trace_state::init_session_records(
     std::optional<utils::UUID> session_id,
     span_id parent_id) {
 
-    _records = make_lw_shared<one_session_records>(type, slow_query_ttl, session_id, parent_id);
-
-    if (full_tracing()) {
-        if (!log_slow_query()) {
-            _records->ttl = ttl_by_type(type);
-        } else {
-            _records->ttl = std::max(ttl_by_type(type), slow_query_ttl);
-        }
-    } else {
-        _records->ttl = slow_query_ttl;
-    }
+    _records = make_lw_shared<one_session_records>(type, ttl_by_type(type, slow_query_ttl), slow_query_ttl, session_id, parent_id);
 }
 
 

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -57,8 +57,7 @@ void trace_state::init_session_records(
     std::optional<utils::UUID> session_id,
     span_id parent_id) {
 
-    _records = make_lw_shared<one_session_records>(type, slow_query_ttl);
-    _records->session_id = session_id ? *session_id : utils::UUID_gen::get_time_UUID();
+    _records = make_lw_shared<one_session_records>(type, slow_query_ttl, session_id, parent_id);
 
     if (full_tracing()) {
         if (!log_slow_query()) {
@@ -69,9 +68,6 @@ void trace_state::init_session_records(
     } else {
         _records->ttl = slow_query_ttl;
     }
-
-    _records->my_span_id = span_id::make_span_id();
-    _records->parent_id = parent_id;
 }
 
 

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -57,7 +57,7 @@ void trace_state::init_session_records(
     std::optional<utils::UUID> session_id,
     span_id parent_id) {
 
-    _records = make_lw_shared<one_session_records>();
+    _records = make_lw_shared<one_session_records>(type, slow_query_ttl);
     _records->session_id = session_id ? *session_id : utils::UUID_gen::get_time_UUID();
 
     if (full_tracing()) {
@@ -70,8 +70,6 @@ void trace_state::init_session_records(
         _records->ttl = slow_query_ttl;
     }
 
-    _records->session_rec.command = type;
-    _records->session_rec.slow_query_record_ttl = slow_query_ttl;
     _records->my_span_id = span_id::make_span_id();
     _records->parent_id = parent_id;
 }

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -51,16 +51,6 @@ void trace_state::params_values_deleter::operator()(params_values* pv) {
     delete pv;
 }
 
-void trace_state::init_session_records(
-    trace_type type,
-    std::chrono::seconds slow_query_ttl,
-    std::optional<utils::UUID> session_id,
-    span_id parent_id) {
-
-    _records = make_lw_shared<one_session_records>(type, ttl_by_type(type, slow_query_ttl), slow_query_ttl, session_id, parent_id);
-}
-
-
 void trace_state::set_batchlog_endpoints(const inet_address_vector_replica_set& val) {
     _params_ptr->batchlog_endpoints.emplace(val);
 }

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -229,6 +229,18 @@ private:
         std::optional<utils::UUID> session_id = std::nullopt,
         span_id parent_id = span_id::illegal_id);
 
+    std::chrono::seconds ttl_by_type(trace_type type, std::chrono::seconds slow_query_ttl) noexcept {
+        if (full_tracing()) {
+            if (!log_slow_query()) {
+                return ::tracing::ttl_by_type(type);
+            } else {
+                return std::max(::tracing::ttl_by_type(type), slow_query_ttl);
+            }
+        } else {
+            return slow_query_ttl;
+        }
+    }
+
     bool should_write_records() const {
         return full_tracing() || _records->do_log_slow_query;
     }

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -102,14 +102,14 @@ public:
         : _state_props(props)
         , _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
     {
+        auto slow_query_ttl = _local_tracing_ptr->slow_query_record_ttl();
         if (!full_tracing() && !log_slow_query()) {
             throw std::logic_error("A primary session has to be created for either full tracing or a slow query logging");
         }
 
         // This is a primary session
         _state_props.set(trace_state_props::primary);
-
-        init_session_records(type, _local_tracing_ptr->slow_query_record_ttl());
+        _records = make_lw_shared<one_session_records>(type, ttl_by_type(type, slow_query_ttl), slow_query_ttl);
         _slow_query_threshold = _local_tracing_ptr->slow_query_threshold();
     }
 
@@ -117,6 +117,8 @@ public:
         : _state_props(info.state_props)
         , _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
     {
+        // inherit the slow query threshold and ttl from the coordinator
+        auto slow_query_ttl = std::chrono::seconds(info.slow_query_ttl_sec);
         // This is a secondary session
         _state_props.remove(trace_state_props::primary);
 
@@ -125,8 +127,7 @@ public:
         // primary session is created with an older server version.
         _state_props.set_if<trace_state_props::full_tracing>(!full_tracing() && !log_slow_query());
 
-        // inherit the slow query threshold and ttl from the coordinator
-        init_session_records(info.type, std::chrono::seconds(info.slow_query_ttl_sec), info.session_id, info.parent_id);
+        _records = make_lw_shared<one_session_records>(info.type, ttl_by_type(info.type, slow_query_ttl), slow_query_ttl, info.session_id, info.parent_id);
         _slow_query_threshold = std::chrono::microseconds(info.slow_query_threshold_us);
 
         if (info.state_props.contains<trace_state_props::log_slow_query>() && info.start_ts_us > 0u) {
@@ -224,10 +225,6 @@ private:
     bool should_log_slow_query(elapsed_clock::duration e) const {
         return log_slow_query() && e > _slow_query_threshold;
     }
-
-    void init_session_records(trace_type type, std::chrono::seconds slow_query_ttl,
-        std::optional<utils::UUID> session_id = std::nullopt,
-        span_id parent_id = span_id::illegal_id);
 
     std::chrono::seconds ttl_by_type(trace_type type, std::chrono::seconds slow_query_ttl) noexcept {
         if (full_tracing()) {

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -63,15 +63,15 @@ public:
     };
 
 private:
+    shared_ptr<tracing> _local_tracing_ptr;
+    trace_state_props_set _state_props;
     lw_shared_ptr<one_session_records> _records;
     // Used for calculation of time passed since the beginning of a tracing
     // session till each tracing event. Secondary slow-query-logging sessions inherit `_start` from parents.
     elapsed_clock::time_point _start;
     std::optional<uint64_t> _supplied_start_ts_us; // Parent's `_start`, as microseconds from POSIX epoch.
     std::chrono::microseconds _slow_query_threshold;
-    trace_state_props_set _state_props;
     state _state = state::inactive;
-    shared_ptr<tracing> _local_tracing_ptr;
 
     struct params_values;
     struct params_values_deleter {
@@ -99,8 +99,8 @@ private:
 
 public:
     trace_state(trace_type type, trace_state_props_set props)
-        : _state_props(props)
-        , _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+        : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+        , _state_props(props)
     {
         auto slow_query_ttl = _local_tracing_ptr->slow_query_record_ttl();
         if (!full_tracing() && !log_slow_query()) {
@@ -114,8 +114,8 @@ public:
     }
 
     trace_state(const trace_info& info)
-        : _state_props(info.state_props)
-        , _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+        : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+        , _state_props(info.state_props)
     {
         // inherit the slow query threshold and ttl from the coordinator
         auto slow_query_ttl = std::chrono::seconds(info.slow_query_ttl_sec);

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -97,37 +97,40 @@ private:
         }
     } _params_ptr;
 
+    static trace_state_props_set make_primary(trace_state_props_set props) {
+        if (!props.contains(trace_state_props::full_tracing) && !props.contains(trace_state_props::log_slow_query)) {
+            throw std::logic_error("A primary session has to be created for either full tracing or a slow query logging");
+        }
+        props.set(trace_state_props::primary);
+        return props;
+    }
+
+    static trace_state_props_set make_secondary(trace_state_props_set props) noexcept {
+        props.remove(trace_state_props::primary);
+        // Default a secondary session to a full tracing.
+        // We may get both zeroes for a full_tracing and a log_slow_query if a
+        // primary session is created with an older server version.
+        props.set_if<trace_state_props::full_tracing>(!props.contains(trace_state_props::full_tracing) && !props.contains(trace_state_props::log_slow_query));
+        return props;
+    }
+
 public:
     trace_state(trace_type type, trace_state_props_set props)
         : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
-        , _state_props(props)
+        , _state_props(make_primary(props))
         , _slow_query_threshold(_local_tracing_ptr->slow_query_threshold())
     {
         auto slow_query_ttl = _local_tracing_ptr->slow_query_record_ttl();
-        if (!full_tracing() && !log_slow_query()) {
-            throw std::logic_error("A primary session has to be created for either full tracing or a slow query logging");
-        }
-
-        // This is a primary session
-        _state_props.set(trace_state_props::primary);
         _records = make_lw_shared<one_session_records>(type, ttl_by_type(type, slow_query_ttl), slow_query_ttl);
     }
 
     trace_state(const trace_info& info)
         : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
-        , _state_props(info.state_props)
+        , _state_props(make_secondary(info.state_props))
         , _slow_query_threshold(info.slow_query_threshold_us)
     {
         // inherit the slow query threshold and ttl from the coordinator
         auto slow_query_ttl = std::chrono::seconds(info.slow_query_ttl_sec);
-        // This is a secondary session
-        _state_props.remove(trace_state_props::primary);
-
-        // Default a secondary session to a full tracing.
-        // We may get both zeroes for a full_tracing and a log_slow_query if a
-        // primary session is created with an older server version.
-        _state_props.set_if<trace_state_props::full_tracing>(!full_tracing() && !log_slow_query());
-
         _records = make_lw_shared<one_session_records>(info.type, ttl_by_type(info.type, slow_query_ttl), slow_query_ttl, info.session_id, info.parent_id);
 
         if (info.state_props.contains<trace_state_props::log_slow_query>() && info.start_ts_us > 0u) {

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -204,11 +204,12 @@ void tracing::set_trace_probability(double p) {
     tracing_logger.info("Setting tracing probability to {} (normalized {})", _trace_probability, _normalized_trace_probability);
 }
 
-one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl,
+one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
             std::optional<utils::UUID> session_id_, span_id parent_id_)
     : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
     , session_id(session_id_ ? *session_id_ : utils::UUID_gen::get_time_UUID())
     , session_rec(type, slow_query_rec_ttl)
+    , ttl(slow_query_ttl)
     , backend_state_ptr(_local_tracing_ptr->allocate_backend_session_state())
     , budget_ptr(_local_tracing_ptr->get_cached_records_ptr())
     , parent_id(parent_id_)

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -203,8 +203,9 @@ void tracing::set_trace_probability(double p) {
     tracing_logger.info("Setting tracing probability to {} (normalized {})", _trace_probability, _normalized_trace_probability);
 }
 
-one_session_records::one_session_records()
+one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl)
     : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    , session_rec(type, slow_query_rec_ttl)
     , backend_state_ptr(_local_tracing_ptr->allocate_backend_session_state())
     , budget_ptr(_local_tracing_ptr->get_cached_records_ptr()) {}
 

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -11,6 +11,7 @@
 #include "tracing/tracing.hh"
 #include "tracing/trace_state.hh"
 #include "utils/class_registrator.hh"
+#include "utils/UUID_gen.hh"
 
 namespace tracing {
 
@@ -203,11 +204,17 @@ void tracing::set_trace_probability(double p) {
     tracing_logger.info("Setting tracing probability to {} (normalized {})", _trace_probability, _normalized_trace_probability);
 }
 
-one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl)
+one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl,
+            std::optional<utils::UUID> session_id_, span_id parent_id_)
     : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    , session_id(session_id_ ? *session_id_ : utils::UUID_gen::get_time_UUID())
     , session_rec(type, slow_query_rec_ttl)
     , backend_state_ptr(_local_tracing_ptr->allocate_backend_session_state())
-    , budget_ptr(_local_tracing_ptr->get_cached_records_ptr()) {}
+    , budget_ptr(_local_tracing_ptr->get_cached_records_ptr())
+    , parent_id(parent_id_)
+    , my_span_id(span_id::make_span_id())
+{
+}
 
 std::ostream& operator<<(std::ostream& os, const span_id& id) {
     return os << id.get_id();

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -240,7 +240,8 @@ public:
     span_id parent_id;
     span_id my_span_id;
 
-    one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl);
+    one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl,
+            std::optional<utils::UUID> session_id, span_id parent_id);
 
     /**
      * Consume a single record from the per-shard budget.

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -240,7 +240,7 @@ public:
     span_id parent_id;
     span_id my_span_id;
 
-    one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl,
+    one_session_records(trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
             std::optional<utils::UUID> session_id, span_id parent_id);
 
     /**

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -241,7 +241,7 @@ public:
     span_id my_span_id;
 
     one_session_records(trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
-            std::optional<utils::UUID> session_id, span_id parent_id);
+            std::optional<utils::UUID> session_id = std::nullopt, span_id parent_id = span_id::illegal_id);
 
     /**
      * Consume a single record from the per-shard budget.

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -201,9 +201,12 @@ private:
     bool _consumed = false;
 
 public:
-    session_record()
+    session_record(trace_type cmd, std::chrono::seconds ttl)
         : username("<unauthenticated request>")
-        , elapsed(-1) {}
+        , command(cmd)
+        , elapsed(-1)
+        , slow_query_record_ttl(ttl)
+    {}
 
     bool ready() const {
         return elapsed.count() >= 0 && !_consumed;
@@ -237,7 +240,7 @@ public:
     span_id parent_id;
     span_id my_span_id;
 
-    one_session_records();
+    one_session_records(trace_type type, std::chrono::seconds slow_query_rec_ttl);
 
     /**
      * Consume a single record from the per-shard budget.


### PR DESCRIPTION
Constructors of trace_state class initialize most of the fields in constructor body with the help of non-inline helper method. It's possible and is better to initialize as much as possible with initializer lists.