### PR TITLE
compaction: Help debugging by linking manager's task to its compaction object

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -481,6 +481,7 @@ protected:
     utils::observable<> _stop_request_observable;
 private:
     compaction_data& init_compaction_data(compaction_data& cdata, const compaction_descriptor& descriptor) const {
+        cdata.the_compaction = static_cast<const void *>(this);
         cdata.compaction_fan_in = descriptor.fan_in();
         return cdata;
     }

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -63,6 +63,7 @@ struct compaction_info {
 };
 
 struct compaction_data {
+    const void* the_compaction = nullptr; // for debugging only. points to the compaction object.
     uint64_t total_partitions = 0;
     uint64_t total_keys_written = 0;
     sstring stop_requested;


### PR DESCRIPTION
Today, some heroic quest must be completed in order to find the
compaction object associated with a particular compaction
manager task.

See https://github.com/scylladb/scylladb/issues/10743#issuecomment-1163814108

In order to save everyone's precious time, let's add a pointer
to "the compaction object" which can be easily accessed from
compaction manager's task list.
