### PR TITLE
Fix heart_beat_state::force_highest_possible_version_unsafe

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -510,6 +510,7 @@ scylla_tests = set([
     'test/boost/s3_test',
     'test/boost/locator_topology_test',
     'test/boost/string_format_test',
+    'test/boost/tagged_integer_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/gms/heart_beat_state.hh
+++ b/gms/heart_beat_state.hh
@@ -58,6 +58,7 @@ public:
     }
 
     void force_highest_possible_version_unsafe() noexcept {
+        static_assert(std::numeric_limits<version_type>::is_bounded);
         _version = std::numeric_limits<version_type>::max();
     }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2156,7 +2156,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint) {
         }
     } else {
         if (owned_tokens.empty()) {
-            on_internal_error_noexcept(slogger, ::format("endpoint={} is not marked for removal but owns no tokens", endpoint));
+            on_internal_error(slogger, ::format("endpoint={} is not marked for removal but owns no tokens", endpoint));
         }
 
         if (!is_normal_token_owner) {

--- a/test/boost/tagged_integer_test.cc
+++ b/test/boost/tagged_integer_test.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+#include <seastar/testing/test_case.hh>
+#include "test/lib/scylla_test_case.hh"
+
+#include "utils/tagged_integer.hh"
+
+using namespace seastar;
+
+using test_tagged_int = utils::tagged_integer<struct test_int_tag, int>;
+
+SEASTAR_THREAD_TEST_CASE(test_tagged_integer_ops) {
+    int i = 17;
+    auto t = test_tagged_int(i);
+
+    BOOST_REQUIRE_EQUAL(t.value(), i);
+    BOOST_REQUIRE_EQUAL((++t).value(), ++i);
+    BOOST_REQUIRE_EQUAL((--t).value(), --i);
+    BOOST_REQUIRE_EQUAL((t++).value(), i++);
+    BOOST_REQUIRE_EQUAL((t--).value(), i--);
+    BOOST_REQUIRE_EQUAL((t + test_tagged_int(42)).value(), i + 42);
+    BOOST_REQUIRE_EQUAL((t - test_tagged_int(42)).value(), i - 42);
+    BOOST_REQUIRE_EQUAL((t += test_tagged_int(42)).value(), i += 42);
+    BOOST_REQUIRE_EQUAL((t -= test_tagged_int(42)).value(), i -= 42);
+}

--- a/test/boost/tagged_integer_test.cc
+++ b/test/boost/tagged_integer_test.cc
@@ -7,10 +7,14 @@
  */
 
 
-#include <seastar/testing/test_case.hh>
+#include <limits>
+
 #include "test/lib/scylla_test_case.hh"
+#include <seastar/testing/test_case.hh>
 
 #include "utils/tagged_integer.hh"
+#include "gms/generation-number.hh"
+#include "gms/version_generator.hh"
 
 using namespace seastar;
 
@@ -29,4 +33,25 @@ SEASTAR_THREAD_TEST_CASE(test_tagged_integer_ops) {
     BOOST_REQUIRE_EQUAL((t - test_tagged_int(42)).value(), i - 42);
     BOOST_REQUIRE_EQUAL((t += test_tagged_int(42)).value(), i += 42);
     BOOST_REQUIRE_EQUAL((t -= test_tagged_int(42)).value(), i -= 42);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tagged_integer_numeric_limits) {
+    BOOST_REQUIRE(std::numeric_limits<test_tagged_int>::is_specialized);
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::is_signed, std::numeric_limits<test_tagged_int::value_type>::is_signed);
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::is_integer, std::numeric_limits<test_tagged_int::value_type>::is_integer);
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::is_exact, std::numeric_limits<test_tagged_int::value_type>::is_exact);
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::is_bounded, std::numeric_limits<test_tagged_int::value_type>::is_bounded);
+
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::min().value(), std::numeric_limits<test_tagged_int::value_type>::min());
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<test_tagged_int>::max().value(), std::numeric_limits<test_tagged_int::value_type>::max());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_gms_generation_type_numeric_limits) {
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<gms::generation_type>::min().value(), std::numeric_limits<gms::generation_type::value_type>::min());
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<gms::generation_type>::max().value(), std::numeric_limits<gms::generation_type::value_type>::max());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_gms_version_type_numeric_limits) {
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<gms::version_type>::min().value(), std::numeric_limits<gms::version_type::value_type>::min());
+    BOOST_REQUIRE_EQUAL(std::numeric_limits<gms::version_type>::max().value(), std::numeric_limits<gms::version_type::value_type>::max());
 }

--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -69,11 +69,11 @@ public:
         return tagged_tagged_integer(_value - o._value);
     }
 
-    tagged_tagged_integer& operator+=(const tagged_tagged_integer& o) const {
+    tagged_tagged_integer& operator+=(const tagged_tagged_integer& o) {
         _value += o._value;
         return *this;
     }
-    tagged_tagged_integer& operator-=(const tagged_tagged_integer& o) const {
+    tagged_tagged_integer& operator-=(const tagged_tagged_integer& o) {
         _value -= o._value;
         return *this;
     }

--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -98,4 +98,19 @@ template <typename Final, typename Tag, std::integral ValueType>
     return s << x.value();
 }
 
+template <typename Final, typename Tag, std::integral ValueType>
+struct numeric_limits<utils::tagged_tagged_integer<Final, Tag, ValueType>> : public numeric_limits<ValueType> {
+    using tagged_tagged_integer_t = utils::tagged_tagged_integer<Final, Tag, ValueType>;
+    using value_limits = numeric_limits<ValueType>;
+    static_assert(numeric_limits<ValueType>::is_specialized && numeric_limits<ValueType>::is_bounded);
+
+    static constexpr tagged_tagged_integer_t min() {
+        return tagged_tagged_integer_t(value_limits::min());
+    }
+
+    static constexpr tagged_tagged_integer_t max() {
+        return tagged_tagged_integer_t(value_limits::max());
+    }
+};
+
 } // namespace std


### PR DESCRIPTION
It turns out that numeric_limits defines an implicit implementation
for std::numeric_limits<utils::tagged_integer<Tag, ValueType>>
which apprently returns a default-constructed tagged_integer
for min() and max(), and this broke
`gms::heart_beat_state::force_highest_possible_version_unsafe()`
since [gms: heart_beat_state: use generation_type and version_type](https://github.com/scylladb/scylladb/compare/4cdad8bc8bc68cfcf1b2677da78e2b87aef77631)
(merged in [Merge 'gms: define and use generation and version types'...](https://github.com/scylladb/scylladb/compare/7f04d8231df86ae4dda31318464fa0e8a100eaff))

Implementing min/max correctly
Fixes #13801