### PR TITLE
mutation/mutation_partition: append_clustered_row(): use on_internal_error()

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -709,7 +709,7 @@ mutation_partition::append_clustered_row(const schema& s, position_in_partition_
     const auto cmp = rows_entry::tri_compare(s);
     auto i = _rows.end();
     if (!_rows.empty() && (cmp(*std::prev(i), pos) >= 0)) {
-        throw std::runtime_error(format("mutation_partition::append_clustered_row(): cannot append clustering row with key {} to the partition"
+        on_internal_error(mplog, format("mutation_partition::append_clustered_row(): cannot append clustering row with key {} to the partition"
                 ", last clustering row is equal or greater: {}", pos, std::prev(i)->position()));
     }
     auto e = alloc_strategy_unique_ptr<rows_entry>(current_allocator().construct<rows_entry>(s, pos, dummy, continuous));


### PR DESCRIPTION
Instead of simply throwing an exception. With just the exception, it is impossible to find out what went wrong, as this API is very generic and is used in a variety of places. The backtrace printed by `on_internal_error()` will help zero in on the problem.

Fixes: #13876