### PR TITLE
test/topology: no graceful driver shutdown on ...

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -44,10 +44,6 @@ class ManagerClient():
         self.client = UnixRESTClient(sock_path)
         self.api = ScyllaRESTAPIClient()
 
-    async def stop(self):
-        """Close driver"""
-        self.driver_close()
-
     async def driver_connect(self, server: Optional[ServerInfo] = None) -> None:
         """Connect to cluster"""
         if self.con_gen is not None:

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -175,7 +175,6 @@ async def manager_internal(event_loop, request):
     use_ssl = bool(request.config.getoption('ssl'))
     manager_int = ManagerClient(request.config.getoption('manager_api'), port, use_ssl, cluster_con)
     yield manager_int
-    await manager_int.stop()  # Stop client session and close driver after last test
 
 @pytest.fixture(scope="function")
 async def manager(request, manager_internal):


### PR DESCRIPTION
teardown for manager client.

To avoid hangs, don't do graceful driver shutdown on test teardown.

Fixes #13888