### PR TITLE
range_tombstone_change_generator: fix an edge case in flush()

### DIFF
--- a/mutation/range_tombstone_change_generator.hh
+++ b/mutation/range_tombstone_change_generator.hh
@@ -83,7 +83,7 @@ public:
 
         position_in_partition::tri_compare cmp(_schema);
         std::optional<range_tombstone> prev;
-        const bool allow_eq = end_of_range || upper_bound.is_after_all_clustered_rows(_schema);
+        const bool allow_eq = upper_bound.is_after_all_clustered_rows(_schema);
         const auto should_flush = [&] (position_in_partition_view pos) {
             const auto res = cmp(pos, upper_bound);
             if (allow_eq) {


### PR DESCRIPTION
range_tombstone_change_generator::flush() mishandles the case when two range tombstones are adjacent and flush(pos, end_of_range=true) is called with pos equal to the end bound of the lesser-position range tombstone.

In such case, the start change of the greater-position rtc will be accidentally emitted, and there won't be an end change, which breaks reader assumptions by ending the stream with an unclosed range tombstone, triggering an assertion.

This is due to a non-strict inequality used in a place where strict inequality should be used. The modified line was intended to close range tombstones which end exactly on the flush position, but this is unnecessary because such range tombstones are handled by the last `if` in the function anyway. Instead, this line caused range tombstones beginning right after the flush position to be emitted sometimes.

Fixes #12462