### PR TITLE
Resurrect optimization to avoid bloom filter checks during compaction

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -168,7 +168,7 @@ std::ostream& operator<<(std::ostream& os, pretty_printed_throughput tp) {
 }
 
 static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_s, sstable_set::incremental_selector& selector,
-        const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk) {
+        const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk, uint64_t& bloom_filter_checks) {
     if (!table_s.tombstone_gc_enabled()) [[unlikely]] {
         return api::min_timestamp;
     }
@@ -183,6 +183,7 @@ static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_
             hk = sstables::sstable::make_hashed_key(*table_s.schema(), dk.key());
         }
         if (sst->filter_has_key(*hk)) {
+            bloom_filter_checks++;
             timestamp = std::min(timestamp, sst->get_stats_metadata().min_timestamp);
         }
     }
@@ -462,6 +463,7 @@ protected:
     uint64_t _start_size = 0;
     uint64_t _end_size = 0;
     uint64_t _estimated_partitions = 0;
+    uint64_t _bloom_filter_checks = 0;
     db::replay_position _rp;
     encoding_stats_collector _stats_collector;
     bool _can_split_large_partition = false;
@@ -783,6 +785,7 @@ protected:
                 .ended_at = ended_at,
                 .start_size = _start_size,
                 .end_size = _end_size,
+                .bloom_filter_checks = _bloom_filter_checks,
             },
         };
 
@@ -823,7 +826,7 @@ private:
             };
         }
         return [this] (const dht::decorated_key& dk) {
-            return get_max_purgeable_timestamp(_table_s, *_selector, _compacting_for_max_purgeable_func, dk);
+            return get_max_purgeable_timestamp(_table_s, *_selector, _compacting_for_max_purgeable_func, dk, _bloom_filter_checks);
         };
     }
 

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -92,12 +92,15 @@ struct compaction_stats {
     uint64_t start_size = 0;
     uint64_t end_size = 0;
     uint64_t validation_errors = 0;
+    // Bloom filter checks during max purgeable calculation
+    uint64_t bloom_filter_checks = 0;
 
     compaction_stats& operator+=(const compaction_stats& r) {
         ended_at = std::max(ended_at, r.ended_at);
         start_size += r.start_size;
         end_size += r.end_size;
         validation_errors += r.validation_errors;
+        bloom_filter_checks += r.bloom_filter_checks;
         return *this;
     }
     friend compaction_stats operator+(const compaction_stats& l, const compaction_stats& r) {

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -231,12 +231,27 @@ private:
         }
     }
 
+    bool satisfy_grace_period(const gc_clock::time_point& deletion_time) {
+        return deletion_time < get_gc_before();
+    }
+
+    bool can_purge_tombstone(const tombstone& t, const gc_clock::time_point deletion_time) {
+        if (_tombstone_gc_state.cheap_to_get_gc_before(_schema)) {
+            // if retrieval of grace period is cheap, can_gc() will only be
+            // called for tombstones that are older than grace period, in
+            // order to avoid unnecessary bloom filter checks when calculating
+            // max purgeable timestamp.
+            return satisfy_grace_period(deletion_time) && can_gc(t);
+        }
+        return can_gc(t) && satisfy_grace_period(deletion_time);
+    }
+
     bool can_purge_tombstone(const tombstone& t) {
-        return can_gc(t) && t.deletion_time < get_gc_before();
+        return can_purge_tombstone(t, t.deletion_time);
     };
 
     bool can_purge_tombstone(const row_tombstone& t) {
-        return can_gc(t.tomb()) && t.max_deletion_time() < get_gc_before();
+        return can_purge_tombstone(t.tomb(), t.max_deletion_time());
     };
 
     gc_clock::time_point get_gc_before() {

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -120,6 +120,10 @@ tombstone_gc_state::get_gc_before_for_range_result tombstone_gc_state::get_gc_be
     std::abort();
 }
 
+bool tombstone_gc_state::cheap_to_get_gc_before(const schema& s) const noexcept {
+    return s.tombstone_gc_options().mode() != tombstone_gc_mode::repair;
+}
+
 gc_clock::time_point tombstone_gc_state::get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) const {
     // if mode = timeout    // default option, if user does not specify tombstone_gc options
     // if mode = disabled   // never gc tombstone

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -44,6 +44,9 @@ public:
         return _repair_history_maps != nullptr;
     }
 
+    // Returns true if it's cheap to retrieve gc_before, e.g. the mode will not require accessing a system table.
+    bool cheap_to_get_gc_before(const schema& s) const noexcept;
+
     seastar::lw_shared_ptr<repair_history_map> get_repair_history_map_for_table(const table_id& id) const;
     seastar::lw_shared_ptr<repair_history_map> get_or_create_repair_history_map_for_table(const table_id& id);
     void drop_repair_history_map_for_table(const table_id& id);


### PR DESCRIPTION
Commit 8c4b5e4283a09a18594d1 introduced an optimization which only calculates max purgeable timestamp when a tombstone satisfy the grace period.

Commit 'repair: Get rid of the gc_grace_seconds' inverted the order, probably under the assumption that getting grace period can be more expensive than calculating max purgeable, as repair-mode GC will look up into history data in order to calculate gc_before.

This caused a significant regression on tombstone heavy compactions, where most of tombstones are still newer than grace period. A compaction which used to take 5s, now takes 35s. 7x slower.

The reason is simple, now calculation of max purgeable happens for every single tombstone (once for each key), even the ones that cannot be GC'ed yet. And each calculation has to iterate through every single sstable that doesn't participate in compaction.

Flame graph makes it very clear that bloom filter is a heavy path without the optimization:
```
    45.64%    45.64%  sstable_compact  sstable_compaction_test_g
        [.] utils::filter::bloom_filter::is_present
```

With its resurrection, the problem is gone.

This scenario can easily happen, e.g. after a deletion burst, and tombstones becoming only GC'able after they reach upper tiers in the LSM tree.

Before this patch, a compaction can be estimated to have this # of filter checks:
```
(# of keys containing *any* tombstone) * (# of uncompacting sstable runs[1])

[1] It's # of *runs*, as each key tend to overlap with only one fragment of each run.
```

After this patch, the estimation becomes:
`(# of keys containing a GC'able tombstone) * (# of uncompacting runs).`

With repair mode for tombstone GC, the assumption, that retrieval of gc_before is more expensive than calculating max purgeable, is kept. We can revisit it later. But the default mode, which is the "timeout" (i.e. gc_grace_seconds) one, we still benefit from the optimization of deferring the calculation until needed.