### PR TITLE
Generalize global table pointer

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1056,6 +1056,11 @@ void global_table_ptr::assign(table& t) {
 table* global_table_ptr::operator->() const noexcept { return &*_p[this_shard_id()]; }
 table& global_table_ptr::operator*() const noexcept { return *_p[this_shard_id()]; }
 
+future<global_table_ptr> get_table_on_all_shards(sharded<database>& sharded_db, sstring ks_name, sstring cf_name) {
+    auto uuid = sharded_db.local().find_uuid(ks_name, cf_name);
+    return get_table_on_all_shards(sharded_db, std::move(uuid));
+}
+
 future<global_table_ptr> get_table_on_all_shards(sharded<database>& sharded_db, table_id uuid) {
     global_table_ptr table_shards;
     co_await sharded_db.invoke_on_all([&] (auto& db) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -69,6 +69,7 @@
 #include "tombstone_gc.hh"
 
 #include "replica/data_dictionary_impl.hh"
+#include "replica/global_table_ptr.hh"
 #include "replica/exceptions.hh"
 #include "readers/multi_range.hh"
 #include "readers/multishard.hh"
@@ -1038,7 +1039,7 @@ future<> database::detach_column_family(table& cf) {
     }
 }
 
-future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> database::get_table_on_all_shards(sharded<database>& sharded_db, table_id uuid) {
+future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& sharded_db, table_id uuid) {
     std::vector<foreign_ptr<lw_shared_ptr<table>>> table_shards;
     table_shards.resize(smp::count);
     co_await sharded_db.invoke_on_all([&] (auto& db) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1039,8 +1039,8 @@ future<> database::detach_column_family(table& cf) {
     }
 }
 
-future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& sharded_db, table_id uuid) {
-    std::vector<foreign_ptr<lw_shared_ptr<table>>> table_shards;
+future<global_table_ptr> get_table_on_all_shards(sharded<database>& sharded_db, table_id uuid) {
+    global_table_ptr table_shards;
     table_shards.resize(smp::count);
     co_await sharded_db.invoke_on_all([&] (auto& db) {
         try {
@@ -2359,7 +2359,7 @@ struct database::table_truncate_state {
     bool did_flush;
 };
 
-future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>& table_shards, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt) {
+future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, const global_table_ptr& table_shards, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt) {
     auto& cf = *table_shards[this_shard_id()];
     auto s = cf.schema();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -66,7 +66,6 @@
 #include "compaction/compaction_fwd.hh"
 #include "utils/disk-error-handler.hh"
 #include "rust/wasmtime_bindings.hh"
-#include "replica/global_table_ptr.hh" // temporary -- replace with fwd decl
 
 class cell_locker;
 class cell_locker_stats;
@@ -140,6 +139,7 @@ extern logging::logger dblog;
 namespace replica {
 
 using shared_memtable = lw_shared_ptr<memtable>;
+class global_table_ptr;
 
 // We could just add all memtables, regardless of types, to a single list, and
 // then filter them out when we read them. Here's why I have chosen not to do

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1682,8 +1682,6 @@ public:
 private:
     future<> detach_column_family(table& cf);
 
-    static future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& db, table_id uuid);
-
     struct table_truncate_state;
 
     static future<> truncate_table_on_all_shards(sharded<database>& db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -66,6 +66,7 @@
 #include "compaction/compaction_fwd.hh"
 #include "utils/disk-error-handler.hh"
 #include "rust/wasmtime_bindings.hh"
+#include "replica/global_table_ptr.hh" // temporary -- replace with fwd decl
 
 class cell_locker;
 class cell_locker_stats;
@@ -855,7 +856,7 @@ private:
     static future<> seal_snapshot(sstring jsondir, std::vector<snapshot_file_set> file_sets);
 
 public:
-    static future<> snapshot_on_all_shards(sharded<database>& sharded_db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>& table_shards, sstring name);
+    static future<> snapshot_on_all_shards(sharded<database>& sharded_db, const global_table_ptr& table_shards, sstring name);
 
     future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
@@ -1684,7 +1685,7 @@ private:
 
     struct table_truncate_state;
 
-    static future<> truncate_table_on_all_shards(sharded<database>& db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
+    static future<> truncate_table_on_all_shards(sharded<database>& db, const global_table_ptr&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
     future<> truncate(column_family& cf, const table_truncate_state&, db_clock::time_point truncated_at);
 public:
     /** Truncates the given column family */

--- a/replica/global_table_ptr.hh
+++ b/replica/global_table_ptr.hh
@@ -16,7 +16,17 @@ namespace replica {
 class database;
 class table;
 
-using global_table_ptr = std::vector<foreign_ptr<lw_shared_ptr<table>>>;
+class global_table_ptr {
+    std::vector<foreign_ptr<lw_shared_ptr<table>>> _p;
+public:
+    global_table_ptr();
+    global_table_ptr(global_table_ptr&&) noexcept;
+    ~global_table_ptr();
+    void assign(table& t);
+    table* operator->() const noexcept;
+    table& operator*() const noexcept;
+};
+
 future<global_table_ptr> get_table_on_all_shards(sharded<database>& db, table_id uuid);
 
 } // replica namespace

--- a/replica/global_table_ptr.hh
+++ b/replica/global_table_ptr.hh
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+#include "schema/schema_fwd.hh"
+
+namespace replica {
+class database;
+class table;
+
+future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& db, table_id uuid);
+
+} // replica namespace

--- a/replica/global_table_ptr.hh
+++ b/replica/global_table_ptr.hh
@@ -28,5 +28,6 @@ public:
 };
 
 future<global_table_ptr> get_table_on_all_shards(sharded<database>& db, table_id uuid);
+future<global_table_ptr> get_table_on_all_shards(sharded<database>& db, sstring ks_name, sstring cf_name);
 
 } // replica namespace

--- a/replica/global_table_ptr.hh
+++ b/replica/global_table_ptr.hh
@@ -16,6 +16,7 @@ namespace replica {
 class database;
 class table;
 
-future<std::vector<foreign_ptr<lw_shared_ptr<table>>>> get_table_on_all_shards(sharded<database>& db, table_id uuid);
+using global_table_ptr = std::vector<foreign_ptr<lw_shared_ptr<table>>>;
+future<global_table_ptr> get_table_on_all_shards(sharded<database>& db, table_id uuid);
 
 } // replica namespace

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1681,7 +1681,7 @@ future<> table::write_schema_as_cql(database& db, sstring dir) const {
 }
 
 // Runs the orchestration code on an arbitrary shard to balance the load.
-future<> table::snapshot_on_all_shards(sharded<database>& sharded_db, const std::vector<foreign_ptr<lw_shared_ptr<table>>>& table_shards, sstring name) {
+future<> table::snapshot_on_all_shards(sharded<database>& sharded_db, const global_table_ptr& table_shards, sstring name) {
     auto jsondir = table_shards[this_shard_id()]->_config.datadir + "/snapshots/" + name;
     auto orchestrator = std::hash<sstring>()(jsondir) % smp::count;
 


### PR DESCRIPTION
There are several places that need to carry a pointer to a table that's shard-wide accessible -- database snapshot and truncate code and distributed loader. The database code uses `get_table_on_all_shards()` returning a vector of foreign lw-pointers, the loader code uses its own global_column_family_ptr class.

This PR generalizes both into global_table_ptr facility.