### PR TITLE
Disallow creating duplicated table objects

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1347,6 +1347,7 @@ private:
 
     flat_hash_map<sstring, keyspace> _keyspaces;
     std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;
+    std::unordered_map<sstring, lw_shared_ptr<column_family>> _disposed_column_families;
     using ks_cf_to_uuid_t =
         flat_hash_map<std::pair<sstring, sstring>, table_id, utils::tuple_hash, string_pair_eq>;
     ks_cf_to_uuid_t _ks_cf_to_uuid;
@@ -1439,6 +1440,7 @@ private:
     void update_write_metrics_for_timed_out_write();
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, bool is_bootstrap, system_keyspace system);
     void remove(const table&) noexcept;
+    void clean_disposed_column_families();
 public:
     static table_schema_version empty_version;
 


### PR DESCRIPTION
A table object is stored as a `shared_ptr` in a map in the `database` object. When it's being removed, it really is only erased from this map, which decrements shared_ptr's `use_count()`, but doesn't necessarily deallocate the table object, as other shared_ptr's owners can keep it alive.
When `database` doesn't store a table in its map, but other owners keep this table alive, another table with the same name is allowed to be created, which generally corrupts the data. E.g. metrics data can be corrupted, because metrics inherit table's name, so when eventually both tables (or the first/original one) is destroyed, it causes UB, but usually ends up in throwing a "double registration" metrics exception.
In order to avoid it, we can do the following:
1. Move table objects to a new map before they're being removed, and check if a table with a similar name already exists in this map when creating a new table.
2. When removing/adding a table, clear this additional map.
3. Move checks asserting if a table (object) can be created before it's actually created, otherwise we'd end up with the same state.

TODO:
1. Current implementation throws an error, which, I suppose, is not exactly what we want to do, because that gets us nowhere, as original implementation also crashes, usually by throwing an exception.
2. Apart from production code changes, most probably `test_secondary_index.py` tests will have to be adjusted. Up until now they served as a reproducer for the bug, and I expect them to still error out even after the fix, so they will have to somehow wait until the next table can be created.

Intends to fix https://github.com/scylladb/scylladb/issues/13548