### PR TITLE
build: cmake: add missing test

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -285,6 +285,8 @@ add_scylla_test(stall_free_test
   KIND SEASTAR)
 add_scylla_test(storage_proxy_test
   KIND SEASTAR)
+add_scylla_test(string_format_test
+  KIND BOOST)
 add_scylla_test(summary_test
   KIND BOOST)
 add_scylla_test(top_k_test


### PR DESCRIPTION
string_format_test was added in 1b5d5205c803098487ed04bc34cb49025c07fb12, so let's add it to CMake building system as well.