### PR TITLE
cql3/expr: print expressions in user-friendly way by default

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1017,7 +1017,7 @@ std::ostream& operator<<(std::ostream& os, const column_value& cv) {
 std::ostream& operator<<(std::ostream& os, const expression& expr) {
     expression::printer pr {
         .expr_to_print = expr,
-        .debug_mode = true
+        .debug_mode = false
     };
 
     return os << pr;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -828,12 +828,12 @@ bool has_only_eq_binops(const expression&);
 } // namespace cql3
 
 /// Custom formatter for an expression. Use {:user} for user-oriented
-/// output, {:debug} for debug-oriented output. Debug is the default.
+/// output, {:debug} for debug-oriented output. User is the default.
 ///
 /// Required for fmt::join() to work on expression.
 template <>
 class fmt::formatter<cql3::expr::expression> {
-    bool _debug = true;
+    bool _debug = false;
 private:
     constexpr static bool try_match_and_advance(format_parse_context& ctx, std::string_view s) {
         auto [ctx_end, s_end] = std::ranges::mismatch(ctx, s);


### PR DESCRIPTION
When a CQL expression is printed, it can be done using either the `debug` mode, or the `user` mode.

`user` mode is basically how you would expect the CQL to be printed, it can be printed and then parsed back.

`debug` mode is more detailed, for example in `debug` mode a column name can be displayed as `unresolved_identifier(my_column)`, which can't be parsed back to CQL.

The default way of printing is the `debug` mode, but this requires us to remember to enable the `user` mode each time we're printing a user-facing message, for example for an invalid_request_exception.

It's cumbersome and people forget about it, so let's change the default to `user`.

There were some issues about expressions being printed in a *strange* way, this fixes them.
Refs: #10632