### PR TITLE
doc: fix the links to the Enterprise docs

### DIFF
--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -9,7 +9,7 @@ Upgrade ScyllaDB
    ScyllaDB Open Source <upgrade-opensource/index>
    ScyllaDB Open Source to ScyllaDB Enterprise <upgrade-to-enterprise/index>
    ScyllaDB AMI <ami-upgrade>
-   ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/enterprise/upgrade/upgrade-enterprise/index.html>
+   ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/stable/upgrade/upgrade-enterprise/index.html>
 
 Overview
 ---------
@@ -48,7 +48,7 @@ Procedures for Upgrading ScyllaDB
 
 * :doc:`Upgrade ScyllaDB AMI <ami-upgrade>`
 
-* `Upgrade ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/enterprise/upgrade/upgrade-enterprise/index.html>`_
+* `Upgrade ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/stable/upgrade/upgrade-enterprise/index.html>`_
 
 
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13915

This commit fixes broken links to the Enterprise docs. They are links to the enterprise branch, which is not published. The links to the Enterprise docs should include "stable" instead of the branch name.

This commit must be backported to branch-5.2, because the broken links are present in the published 5.2 docs.