### PR TITLE
test: sstable_3_x_test: avoid using helper using generation_type::int_t

### DIFF
--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -52,19 +52,23 @@ using namespace sstables;
 class sstable_assertions final {
     test_env& _env;
     shared_sstable _sst;
-public:
-    sstable_assertions(test_env& env, schema_ptr schema, const sstring& path, sstable_version_types version = sstable_version_types::mc, sstables::generation_type::int_t generation = 1)
+
+    sstable_assertions(test_env& env, schema_ptr schema, const sstring& path, sstable_version_types version, sstables::generation_type generation)
         : _env(env)
         , _sst(_env.make_sstable(std::move(schema),
                             path,
-                            sstables::generation_type(generation),
+                            generation,
                             version,
                             sstable_format_types::big,
                             1))
     { }
+public:
+    sstable_assertions(test_env& env, schema_ptr schema, const sstring& path)
+        : sstable_assertions(env, schema, path, sstable_version_types::mc, sstables::generation_type{1})
+    {}
 
     sstable_assertions(test_env& env, shared_sstable sst)
-        : sstable_assertions(env, sst->get_schema(), env.tempdir().path().native(), sst->get_version(), sst->generation().as_int())
+        : sstable_assertions(env, sst->get_schema(), env.tempdir().path().native(), sst->get_version(), sst->generation())
     {}
 
     test_env& get_env() {


### PR DESCRIPTION
this change is one of the series which drops most of the callers using SSTable generation as integer. as the generation of SSTable is but an identifier, we should not use it as an integer out of generation_type's implementation. so, in this change, instead of using `generation_type::int_t` in the helper functions, we just pass `generation_type` in place of integer.