### PR TITLE
test: pylib: fix `read_barrier` implementation

### DIFF
--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -113,12 +113,12 @@ async def get_available_host(cql: Session, deadline: float) -> Host:
 
 
 async def read_barrier(cql: Session, host: Host):
-    """To issue a read barrier it is sufficient to attempt altering
-       a non-existing table: in order to validate the DDL the node needs to sync
-       with the leader and fetch latest group 0 state.
+    """To issue a read barrier it is sufficient to attempt dropping a
+    non-existing table. We need to use `if exists`, otherwise the statement
+    would fail on prepare/validate step which happens before a read barrier is
+    performed.
     """
-    with pytest.raises(InvalidRequest, match="nosuch"):
-        await cql.run_async("alter table nosuchkeyspace.nosuchtable with comment=''", host = host)
+    await cql.run_async("drop table if exists nosuchkeyspace.nosuchtable", host = host)
 
 
 unique_name.last_ms = 0

--- a/test/topology/test_snapshot.py
+++ b/test/topology/test_snapshot.py
@@ -47,7 +47,7 @@ async def test_snapshot(manager, random_tables):
     logger.info("Driver connecting to D %s", server_d)
     await manager.driver_connect()
 
-    await random_tables.verify_schema()
+    await random_tables.verify_schema(do_read_barrier=False)
 
     # Start servers to have quorum for post-test checkup
     # TODO: remove once there's a way to disable post-test checkup


### PR DESCRIPTION
The previous implementation didn't actually do a read barrier, because
the statement failed on an early prepare/validate step which happened
before read barrier was even performed.

Change it to a statement which does not fail and doesn't perform any
schema change but requires a read barrier.

This breaks one test which uses `RandomTables.verify_schema()` when only
one node is alive, but `verify_schema` performs a read barrier. Unbreak
it by skipping the read barrier in this case (it makes sense in this
particular test).
