### PR TITLE
Respect tablet shard assignment

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -430,6 +430,7 @@ class token_ranges_owned_by_this_shard {
     size_t _range_idx;
     size_t _end_idx;
     std::optional<dht::selective_token_range_sharder> _intersecter;
+    locator::effective_replication_map_ptr _erm;
 public:
     token_ranges_owned_by_this_shard(replica::database& db, gms::gossiper& g, schema_ptr s)
         :  _s(s)
@@ -437,6 +438,7 @@ public:
                 g, utils::fb_utilities::get_broadcast_address())
         , _range_idx(random_offset(0, _token_ranges.size() - 1))
         , _end_idx(_range_idx + _token_ranges.size())
+        , _erm(s->table().get_effective_replication_map())
     {
         tlogger.debug("Generating token ranges starting from base range {} of {}", _range_idx, _token_ranges.size());
     }
@@ -469,7 +471,7 @@ public:
                     return std::nullopt;
                 }
             }
-            _intersecter.emplace(_s->get_sharder(), _token_ranges[_range_idx % _token_ranges.size()], this_shard_id());
+            _intersecter.emplace(_erm->get_sharder(*_s), _token_ranges[_range_idx % _token_ranges.size()], this_shard_id());
         }
     }
 

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -151,6 +151,8 @@ struct compaction_descriptor {
     compaction_type_options options = compaction_type_options::make_regular();
     // If engaged, compaction will cleanup the input sstables by skipping non-owned ranges.
     compaction::owned_ranges_ptr owned_ranges;
+    // Required for reshard compaction.
+    const dht::sharder* sharder;
 
     compaction_sstable_creator_fn creator;
     compaction_sstable_replacer_fn replacer;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -401,7 +401,7 @@ select_statement::do_execute(query_processor& qp,
              throw exceptions::invalid_request_exception(
                      "SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time");
         }
-        unsigned shard = dht::shard_of(*_schema, key_ranges[0].start()->value().as_decorated_key().token());
+        unsigned shard = _schema->table().shard_of(key_ranges[0].start()->value().as_decorated_key().token());
         if (this_shard_id() != shard) {
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                     qp.bounce_to_shard(shard, std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()))

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -242,8 +242,9 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
             return make_ready_future<>();
         }
 
-        const auto& schema = *_db.local().find_column_family(uuid).schema();
-        auto shard = fm.shard_of(schema);
+        auto& table = _db.local().find_column_family(uuid);
+        const auto& schema = *table.schema();
+        auto shard = table.get_effective_replication_map()->shard_of(schema, fm.token(schema));
         return _db.invoke_on(shard, [this, cer = std::move(cer), &src_cm, rp] (replica::database& db) mutable -> future<> {
             auto& fm = cer.mutation();
             // TODO: might need better verification that the deserialized mutation

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -100,15 +100,16 @@ namespace {
     });
 }
 
-schema_ctxt::schema_ctxt(const db::config& cfg, std::shared_ptr<data_dictionary::user_types_storage> uts)
-    : _extensions(cfg.extensions())
+schema_ctxt::schema_ctxt(const db::config& cfg, std::shared_ptr<data_dictionary::user_types_storage> uts, replica::database* db)
+    : _db(db)
+    , _extensions(cfg.extensions())
     , _murmur3_partitioner_ignore_msb_bits(cfg.murmur3_partitioner_ignore_msb_bits())
     , _schema_registry_grace_period(cfg.schema_registry_grace_period())
     , _user_types(std::move(uts))
 {}
 
-schema_ctxt::schema_ctxt(const replica::database& db)
-    : schema_ctxt(db.get_config(), db.as_user_types_storage())
+schema_ctxt::schema_ctxt(replica::database& db)
+    : schema_ctxt(db.get_config(), db.as_user_types_storage(), &db)
 {}
 
 schema_ctxt::schema_ctxt(distributed<replica::database>& db)

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -66,8 +66,8 @@ class config;
 
 class schema_ctxt {
 public:
-    schema_ctxt(const config&, std::shared_ptr<data_dictionary::user_types_storage> uts);
-    schema_ctxt(const replica::database&);
+    schema_ctxt(const config&, std::shared_ptr<data_dictionary::user_types_storage> uts, replica::database* = nullptr);
+    schema_ctxt(replica::database&);
     schema_ctxt(distributed<replica::database>&);
     schema_ctxt(distributed<service::storage_proxy>&);
 
@@ -87,7 +87,11 @@ public:
         return *_user_types;
     }
 
+    replica::database* get_db() {
+        return _db;
+    }
 private:
+    replica::database* _db;
     const db::extensions& _extensions;
     const unsigned _murmur3_partitioner_ignore_msb_bits;
     const uint32_t _schema_registry_grace_period;

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -135,7 +135,7 @@ static std::vector<sstring> get_keyspaces(const schema& s, const replica::databa
     return boost::copy_range<std::vector<sstring>>(
         range.slice(keyspaces, std::move(cmp)) | boost::adaptors::filtered([&s] (const auto& ks) {
             // If this is a range query, results are divided between shards by the partition key (keyspace_name).
-            return shard_of(s, dht::get_token(s,
+            return dht::static_shard_of(s, dht::get_token(s,
                         partition_key::from_single_value(s, utf8_type->decompose(ks))))
                 == this_shard_id();
         })

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2026,7 +2026,12 @@ public:
         };
 
         auto keyspace_names = boost::copy_range<std::vector<decorated_keyspace_name>>(
-                _db.get_keyspaces() | boost::adaptors::transformed([this] (auto&& e) {
+            _db.get_keyspaces()
+                | boost::adaptors::filtered([] (auto&& e) {
+                      auto&& rs = e.second.get_replication_strategy();
+                      return rs.is_vnode_based();
+                  })
+                | boost::adaptors::transformed([this] (auto&& e) {
                     return decorated_keyspace_name{e.first, make_partition_key(e.first)};
         }));
 

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -28,7 +28,7 @@ void virtual_table::set_cell(row& cr, const bytes& column_name, data_value value
 }
 
 bool virtual_table::this_shard_owns(const dht::decorated_key& dk) const {
-    return dht::shard_of(*_s, dk.token()) == this_shard_id();
+    return dht::static_shard_of(*_s, dk.token()) == this_shard_id();
 }
 
 bool virtual_table::contains_key(const dht::partition_range& pr, const dht::decorated_key& dk) const {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -182,7 +182,7 @@ std::ostream& operator<<(std::ostream& out, const i_partitioner& p) {
     return out << "}";
 }
 
-unsigned shard_of(const schema& s, const token& t) {
+unsigned static_shard_of(const schema& s, const token& t) {
     return s.get_sharder().shard_of(t);
 }
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -260,8 +260,7 @@ ring_position_range_vector_sharder::next(const schema& s) {
 }
 
 future<utils::chunked_vector<partition_range>>
-split_range_to_single_shard(const schema& s, const partition_range& pr, shard_id shard) {
-    const sharder& sharder = s.get_sharder();
+split_range_to_single_shard(const schema& s, const sharder& sharder, const partition_range& pr, shard_id shard) {
     auto next_shard = shard + 1 == sharder.shard_count() ? 0 : shard + 1;
     auto start_token = pr.start() ? pr.start()->value().token() : minimum_token();
     auto start_shard = sharder.shard_of(start_token);
@@ -376,9 +375,9 @@ dht::partition_range_vector to_partition_ranges(const dht::token_range_vector& r
 }
 
 std::map<unsigned, dht::partition_range_vector>
-split_range_to_shards(dht::partition_range pr, const schema& s) {
+split_range_to_shards(dht::partition_range pr, const schema& s, const sharder& raw_sharder) {
     std::map<unsigned, dht::partition_range_vector> ret;
-    auto sharder = dht::ring_position_range_sharder(s.get_sharder(), std::move(pr));
+    auto sharder = dht::ring_position_range_sharder(raw_sharder, std::move(pr));
     auto rprs = sharder.next(s);
     while (rprs) {
         ret[rprs->shard].emplace_back(rprs->ring_range);

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -637,10 +637,11 @@ dht::partition_range_vector to_partition_ranges(const dht::token_range_vector& r
 
 // Each shard gets a sorted, disjoint vector of ranges
 std::map<unsigned, dht::partition_range_vector>
-split_range_to_shards(dht::partition_range pr, const schema& s);
+split_range_to_shards(dht::partition_range pr, const schema& s, const sharder& sharder);
 
 // Intersect a partition_range with a shard and return the the resulting sub-ranges, in sorted order
-future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const schema& s, const dht::partition_range& pr, shard_id shard);
+future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const schema& s,
+    const sharder& sharder, const dht::partition_range& pr, shard_id shard);
 
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring name);
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -653,6 +653,14 @@ future<dht::partition_range_vector> subtract_ranges(const schema& schema, const 
 // Returns a token_range vector split based on the given number of most-significant bits
 dht::token_range_vector split_token_range_msb(unsigned most_significant_bits);
 
+// Returns the first token included by a partition range.
+// May return tokens for which is_minimum() or is_maximum() is true.
+dht::token first_token(const dht::partition_range&);
+
+// Returns true iff a given partition range is wholly owned by a single shard.
+// If so, returns that shard. Otherwise, return std::nullopt.
+std::optional<shard_id> is_single_shard(const dht::sharder&, const schema&, const dht::partition_range&);
+
 } // dht
 
 namespace std {

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -620,7 +620,10 @@ public:
 };
 std::ostream& operator<<(std::ostream& out, partition_ranges_view v);
 
-unsigned shard_of(const schema&, const token&);
+// Returns the owning shard number for vnode-based replication strategies.
+// Use table::shard_of() for the general case.
+unsigned static_shard_of(const schema&, const token&);
+
 inline decorated_key decorate_key(const schema& s, const partition_key& key) {
     return s.get_partitioner().decorate_key(s, key);
 }

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -23,6 +23,11 @@ unsigned shard_of(unsigned shard_count, unsigned sharding_ignore_msb_bits, const
 
 token token_for_next_shard(const std::vector<uint64_t>& shard_start, unsigned shard_count, unsigned sharding_ignore_msb_bits, const token& t, shard_id shard, unsigned spans);
 
+struct shard_and_token {
+    shard_id shard;
+    token token;
+};
+
 class sharder {
 protected:
     unsigned _shard_count;
@@ -48,6 +53,14 @@ public:
      * On overflow, maximum_token() is returned.
      */
     virtual token token_for_next_shard(const token& t, shard_id shard, unsigned spans = 1) const;
+
+    /**
+     * Finds the next token greater than t which is owned by a different shard than the owner of t
+     * and returns that token and its owning shard. If no such token exists, returns nullopt.
+     *
+     * The next shard may not necessarily be a successor of the shard owning t.
+     */
+    virtual std::optional<shard_and_token> next_shard(const token& t) const;
 
     /**
      * @return number of shards configured for this partitioner

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -28,6 +28,14 @@ struct shard_and_token {
     token token;
 };
 
+/**
+ * Describes mapping between token space of a given table and owning shards on the local node.
+ * The mapping reflected by this instance is constant for the lifetime of this sharder object.
+ * It is not guaranteed to be the same for different sharder instances, even within a single process lifetime.
+ *
+ * For vnode-based replication strategies, the mapping is constant for the lifetime of the local process even
+ * across different sharder instances.
+ */
 class sharder {
 protected:
     unsigned _shard_count;

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -83,6 +83,12 @@ public:
         return _kind == kind::after_all_keys;
     }
 
+    // Returns true iff this is the largest token which can be associated with a partition key.
+    // Note that this is different that is_maximum().
+    bool is_last() const {
+        return _kind == dht::token::kind::key && _data == std::numeric_limits<int64_t>::max();
+    }
+
     size_t external_memory_usage() const {
         return 0;
     }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -134,6 +134,10 @@ std::unique_ptr<token_range_splitter> vnode_effective_replication_map::make_spli
     return locator::make_splitter(_tmptr);
 }
 
+const dht::sharder& vnode_effective_replication_map::get_sharder(const schema& s) const {
+    return s.get_sharder();
+}
+
 const per_table_replication_strategy* abstract_replication_strategy::maybe_as_per_table() const {
     if (!_per_table) {
         return nullptr;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -213,6 +213,14 @@ public:
     /// Returns a token_range_splitter which is line with the replica assignment of this replication map.
     /// The splitter can live longer than this instance.
     virtual std::unique_ptr<token_range_splitter> make_splitter() const = 0;
+
+    /// Returns a sharder which reflects shard replica assignment of this replication map.
+    /// The sharder is valid as long as this instance is kept alive.
+    virtual const dht::sharder& get_sharder(const schema& s) const = 0;
+
+    shard_id shard_of(const schema& s, dht::token t) const {
+        return get_sharder(s).shard_of(t);
+    }
 };
 
 using effective_replication_map_ptr = seastar::shared_ptr<const effective_replication_map>;
@@ -274,6 +282,7 @@ public: // effective_replication_map
     std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override;
     bool has_pending_ranges(inet_address endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
+    const dht::sharder& get_sharder(const schema& s) const override;
 public:
     explicit vnode_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr, replication_map replication_map,
             ring_mapping pending_endpoints, ring_mapping read_endpoints, size_t replication_factor) noexcept

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "locator/topology.hh"
+#include "locator/token_metadata.hh"
+#include "locator/tablets.hh"
+#include "utils/stall_free.hh"
+
+#include <seastar/core/smp.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <optional>
+#include <vector>
+
+namespace locator {
+
+/// A data structure which keeps track of load associated with data ownership
+/// on shards of the whole cluster.
+class load_sketch {
+    using shard_id = seastar::shard_id;
+    struct shard_load {
+        shard_id id;
+        size_t load; // In tablets.
+    };
+    // Used in a max-heap to yield lower load first.
+    struct shard_load_cmp {
+        bool operator()(const shard_load& a, const shard_load& b) const {
+            return a.load > b.load;
+        }
+    };
+    struct node_load {
+        std::vector<shard_load> _shards;
+
+        node_load(size_t shard_count) : _shards(shard_count) {
+            shard_id next_shard = 0;
+            for (auto&& s : _shards) {
+                s.id = next_shard++;
+                s.load = 0;
+            }
+        }
+    };
+    std::unordered_map<host_id, node_load> _nodes;
+    token_metadata_ptr _tm;
+public:
+    load_sketch(token_metadata_ptr tm)
+        : _tm(std::move(tm)) {
+    }
+
+    future<> populate(std::optional<host_id> host = std::nullopt) {
+        const topology& topo = _tm->get_topology();
+        co_await utils::clear_gently(_nodes);
+        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
+            for (const tablet_info& ti : tmap.tablets()) {
+                co_await coroutine::maybe_yield();
+                for (auto&& replica : ti.replicas) {
+                    if (host && *host != replica.host) {
+                        continue;
+                    }
+                    if (!_nodes.contains(replica.host)) {
+                        _nodes.emplace(replica.host, node_load{topo.find_node(replica.host)->get_shard_count()});
+                    }
+                    node_load& n = _nodes.at(replica.host);
+                    if (replica.shard < n._shards.size()) {
+                        n._shards[replica.shard].load += 1;
+                    }
+                }
+            }
+        }
+        for (auto&& n : _nodes) {
+            std::make_heap(n.second._shards.begin(), n.second._shards.end(), shard_load_cmp());
+        }
+    }
+
+    shard_id next_shard(host_id node) {
+        const topology& topo = _tm->get_topology();
+        if (!_nodes.contains(node)) {
+            auto shard_count = topo.find_node(node)->get_shard_count();
+            if (shard_count == 0) {
+                throw std::runtime_error(format("Shard count not known for node {}", node));
+            }
+            _nodes.emplace(node, node_load{shard_count});
+        }
+        auto& n = _nodes.at(node);
+        std::pop_heap(n._shards.begin(), n._shards.end(), shard_load_cmp());
+        shard_load& s = n._shards.back();
+        auto shard = s.id;
+        s.load += 1;
+        std::push_heap(n._shards.begin(), n._shards.end(), shard_load_cmp());
+        return shard;
+    }
+};
+
+} // namespace locator

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "locator/tablets.hh"
+#include "dht/sharder.hh"
+#include "locator/token_metadata.hh"
+
+namespace locator {
+
+/// Implements sharder object which reflects assignment of tablets of a given table to local shards.
+/// Token ranges which don't have local tablets are reported to belong to shard 0.
+class tablet_sharder : public dht::sharder {
+    const token_metadata& _tm;
+    table_id _table;
+    mutable const tablet_map* _tmap = nullptr;
+private:
+    // Tablet map is lazily initialized to avoid exceptions during effective_replication_map construction
+    // in case tablet mapping is not yet available in token metadata at the time the table is constructed.
+    void ensure_tablet_map() const {
+        if (!_tmap) {
+            _tmap = &_tm.tablets().get_tablet_map(_table);
+        }
+    }
+public:
+    tablet_sharder(const token_metadata& tm, table_id table)
+            : _tm(tm)
+            , _table(table)
+    { }
+
+    virtual ~tablet_sharder() = default;
+
+    virtual unsigned shard_of(const dht::token& token) const override {
+        ensure_tablet_map();
+        auto tid = _tmap->get_tablet_id(token);
+        auto shard = _tmap->get_shard(tid, _tm.get_my_id());
+        tablet_logger.trace("[{}] shard_of({}) = {}, tablet={}", _table, token, shard, tid);
+        return shard.value_or(0);
+    }
+
+    virtual std::optional<dht::shard_and_token> next_shard(const token& t) const override {
+        ensure_tablet_map();
+        auto me = _tm.get_my_id();
+        std::optional<tablet_id> tb = _tmap->get_tablet_id(t);
+        while ((tb = _tmap->next_tablet(*tb))) {
+            auto r = _tmap->get_shard(*tb, me);
+            auto next = _tmap->get_first_token(*tb);
+            tablet_logger.trace("[{}] token_for_next_shard({}) = {{{}, {}}}, tablet={}", _table, t, next, r, *tb);
+            return dht::shard_and_token{r.value_or(0), next};
+        }
+        tablet_logger.trace("[{}] token_for_next_shard({}) = null", _table, t);
+        return std::nullopt;
+    }
+
+    virtual token token_for_next_shard(const token& t, shard_id shard, unsigned spans = 1) const override {
+        ensure_tablet_map();
+        auto token = t;
+        while (auto s_a_t = next_shard(token)) {
+            token = s_a_t->token;
+            if (s_a_t->shard == shard) {
+                if (--spans == 0) {
+                    tablet_logger.trace("[{}] token_for_next_shard({}, {}, {}) = {}", _table, t, shard, spans, s_a_t->token);
+                    return token;
+                }
+            }
+        }
+        tablet_logger.trace("[{}] token_for_next_shard({}, {}, {}) = null", _table, t, shard, spans);
+        return dht::maximum_token();
+    }
+};
+
+} // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -8,6 +8,7 @@
 
 #include "locator/tablet_replication_strategy.hh"
 #include "locator/tablets.hh"
+#include "locator/tablet_sharder.hh"
 #include "locator/token_range_splitter.hh"
 #include "dht/i_partitioner.hh"
 #include "types/types.hh"

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -105,6 +105,23 @@ void tablet_map::set_tablet_transition_info(tablet_id id, tablet_transition_info
     _transitions.insert_or_assign(id, std::move(info));
 }
 
+std::optional<shard_id> tablet_map::get_shard(tablet_id tid, host_id host) const {
+    auto&& info = get_tablet_info(tid);
+
+    for (auto&& r : info.replicas) {
+        if (r.host == host) {
+            return r.shard;
+        }
+    }
+
+    auto tinfo = get_tablet_transition_info(tid);
+    if (tinfo && tinfo->pending_replica.host == host) {
+        return tinfo->pending_replica.shard;
+    }
+
+    return std::nullopt;
+}
+
 future<> tablet_map::clear_gently() {
     return utils::clear_gently(_tablets);
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -202,6 +202,7 @@ size_t tablet_metadata::external_memory_usage() const {
 
 class tablet_effective_replication_map : public effective_replication_map {
     table_id _table;
+    tablet_sharder _sharder;
 private:
     gms::inet_address get_endpoint_for_host_id(host_id host) const {
         auto endpoint_opt = _tmptr->get_endpoint_for_host_id(host);
@@ -228,6 +229,7 @@ public:
                                      size_t replication_factor)
             : effective_replication_map(std::move(rs), std::move(tmptr), replication_factor)
             , _table(table)
+            , _sharder(*_tmptr, table)
     { }
 
     virtual ~tablet_effective_replication_map() = default;
@@ -300,6 +302,10 @@ public:
             }
         };
         return std::make_unique<splitter>(_tmptr, get_tablet_map());
+    }
+
+    const dht::sharder& get_sharder(const schema& s) const override {
+        return _sharder;
     }
 };
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -52,15 +52,6 @@ using tablet_replica_set = utils::small_vector<tablet_replica, 3>;
 struct tablet_info {
     tablet_replica_set replicas;
 
-    std::optional<shard_id> get_shard(host_id host) const {
-        for (auto&& r : replicas) {
-            if (r.host == host) {
-                return r.shard;
-            }
-        }
-        return std::nullopt;
-    }
-
     bool operator==(const tablet_info&) const = default;
 };
 
@@ -147,6 +138,12 @@ public:
         }
         return tablet_id(size_t(t) + 1);
     }
+
+    /// Returns shard id which is a replica for a given tablet on a given host.
+    /// If there is no replica on a given host, returns nullopt.
+    /// If the topology is transitional, also considers the new replica set.
+    /// The old replica set is preferred in case of ambiguity.
+    std::optional<shard_id> get_shard(tablet_id, host_id) const;
 
     const tablet_container& tablets() const {
         return _tablets;

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -117,8 +117,8 @@ public:
         return _bootstrap_tokens;
     }
 
-    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
-        _topology.add_or_update_endpoint(ep, std::move(dr), std::move(opt_st));
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count = std::nullopt) {
+        _topology.add_or_update_endpoint(ep, std::nullopt, std::move(dr), std::move(opt_st), std::move(shard_count));
     }
 
     /**
@@ -920,8 +920,8 @@ token_metadata::get_bootstrap_tokens() const {
 }
 
 void
-token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st) {
-    _impl->update_topology(ep, std::move(dr), std::move(opt_st));
+token_metadata::update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count) {
+    _impl->update_topology(ep, std::move(dr), std::move(opt_st), std::move(shard_count));
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -132,7 +132,8 @@ public:
     /**
      * Update or add endpoint given its inet_address and endpoint_dc_rack.
      */
-    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st = std::nullopt);
+    void update_topology(inet_address ep, endpoint_dc_rack dr, std::optional<node::state> opt_st = std::nullopt,
+                         std::optional<shard_id> shard_count = std::nullopt);
     /**
      * Creates an iterable range of the sorted tokens starting at the token t
      * such that t >= start.

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -192,6 +192,7 @@ class read_context : public reader_lifecycle_policy_v2 {
 
     distributed<replica::database>& _db;
     schema_ptr _schema;
+    locator::effective_replication_map_ptr _erm;
     reader_permit _permit;
     const query::read_command& _cmd;
     const dht::partition_range_vector& _ranges;
@@ -208,10 +209,12 @@ class read_context : public reader_lifecycle_policy_v2 {
     future<> save_reader(shard_id shard, full_position_view last_pos);
 
 public:
-    read_context(distributed<replica::database>& db, schema_ptr s, const query::read_command& cmd, const dht::partition_range_vector& ranges,
-            tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout)
+    read_context(distributed<replica::database>& db, schema_ptr s, locator::effective_replication_map_ptr erm,
+                 const query::read_command& cmd, const dht::partition_range_vector& ranges,
+                 tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout)
             : _db(db)
             , _schema(std::move(s))
+            , _erm(std::move(erm))
             , _permit(_db.local().get_reader_concurrency_semaphore().make_tracking_only_permit(_schema.get(), "multishard-mutation-query", timeout, trace_state))
             , _cmd(cmd)
             , _ranges(ranges)
@@ -233,6 +236,10 @@ public:
 
     reader_permit permit() const {
         return _permit;
+    }
+
+    const locator::effective_replication_map_ptr& erm() const {
+        return _erm;
     }
 
     query::max_result_size get_max_result_size() {
@@ -398,7 +405,7 @@ future<> read_context::stop() {
 
 read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(flat_mutation_reader_v2::tracked_buffer combined_buffer,
         const dht::decorated_key& pkey) {
-    auto& sharder = _schema->get_sharder();
+    auto& sharder = _erm->get_sharder(*_schema);
 
     std::vector<mutation_fragment_v2> tmp_buffer;
     dismantle_buffer_stats stats;
@@ -446,7 +453,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(fla
 
 read_context::dismantle_buffer_stats read_context::dismantle_compaction_state(detached_compaction_state compaction_state) {
     auto stats = dismantle_buffer_stats();
-    auto& sharder = _schema->get_sharder();
+    auto& sharder = _erm->get_sharder(*_schema);
     const auto shard = sharder.shard_of(compaction_state.partition_start.key().token());
 
     auto& rtc_opt = compaction_state.current_tombstone;
@@ -714,7 +721,7 @@ future<page_consume_result<ResultBuilder>> read_page(
     auto compaction_state = make_lw_shared<compact_for_query_state_v2>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
             cmd.partition_limit);
 
-    auto reader = make_multishard_combining_reader_v2(ctx, s, ctx->permit(), ranges.front(), cmd.slice,
+    auto reader = make_multishard_combining_reader_v2(ctx, s, ctx->erm(), ctx->permit(), ranges.front(), cmd.slice,
             trace_state, mutation_reader::forwarding(ranges.size() > 1));
     if (ranges.size() > 1) {
         reader = make_flat_mutation_reader_v2<multi_range_reader>(s, ctx->permit(), std::move(reader), ranges);
@@ -755,7 +762,9 @@ future<typename ResultBuilder::result_type> do_query(
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
         noncopyable_function<ResultBuilder(const compact_for_query_state_v2&)> result_builder_factory) {
-    auto ctx = seastar::make_shared<read_context>(db, s, cmd, ranges, trace_state, timeout);
+    auto& table = db.local().find_column_family(s);
+    auto erm = table.get_effective_replication_map();
+    auto ctx = seastar::make_shared<read_context>(db, s, erm, cmd, ranges, trace_state, timeout);
 
     // Use coroutine::as_future to prevent exception on timesout.
     auto f = co_await coroutine::as_future(ctx->lookup_readers(timeout).then([&, result_builder_factory = std::move(result_builder_factory)] () mutable {

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -215,8 +215,8 @@ public:
     template<FlattenedConsumerV2 Consumer>
     auto consume_gently(schema_ptr s, frozen_mutation_consumer_adaptor<Consumer>& adaptor) const -> future<frozen_mutation_consume_result<decltype(adaptor.consumer().consume_end_of_stream())>>;
 
-    unsigned shard_of(const schema& s) const {
-        return dht::shard_of(s, dht::get_token(s, key()));
+    dht::token token(const schema& s) const {
+        return dht::get_token(s, key());
     }
 
     struct printer {

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -178,10 +178,6 @@ public:
     // Range tombstones will be trimmed to the boundaries of the clustering ranges.
     mutation sliced(const query::clustering_row_ranges&) const;
 
-    unsigned shard_of() const {
-        return dht::shard_of(*schema(), token());
-    }
-
     // Returns a mutation which contains the same writes but in a minimal form.
     // Drops data covered by tombstones.
     // Does not drop expired tombstones.

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -38,7 +38,7 @@ public:
     {}
 
     future<> consume(partition_start&& ps) {
-        _current_shard = dht::shard_of(*_schema, ps.key().token());
+        _current_shard = dht::static_shard_of(*_schema, ps.key().token()); // FIXME: Use table sharder
         if (!_shards[_current_shard]) {
             _shards[_current_shard] = shard_writer(_schema, _permit, _consumer);
         }

--- a/readers/multishard.hh
+++ b/readers/multishard.hh
@@ -13,6 +13,7 @@
 #include "readers/flat_mutation_reader_v2.hh"
 #include "tracing/trace_state.hh"
 #include "seastarx.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 /// Reader lifecycle policy for the mulitshard combining reader.
 ///
@@ -123,6 +124,7 @@ public:
 flat_mutation_reader_v2 make_multishard_combining_reader_v2(
         shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
         schema_ptr schema,
+        locator::effective_replication_map_ptr erm,
         reader_permit permit,
         const dht::partition_range& pr,
         const query::partition_slice& ps,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1000,6 +1000,7 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
     }
     ks.add_or_update_column_family(schema);
     cf->start();
+    schema->registry_entry()->set_table(cf->weak_from_this());
     _column_families.emplace(uuid, std::move(cf));
     _ks_cf_to_uuid.emplace(std::move(kscf), uuid);
     if (schema->is_view()) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1939,7 +1939,7 @@ future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::t
                               first_cf.schema()->ks_name(), first_cf.schema()->cf_name()));
         }
 
-        auto m_shard = dht::shard_of(*s, dht::get_token(*s, muts[i].key()));
+        auto m_shard = cf.shard_of(dht::get_token(*s, muts[i].key()));
         if (!shard) {
             if (this_shard_id() != m_shard) {
                 on_internal_error(dblog, format("Must call apply() on the owning shard ({} != {})", this_shard_id(), m_shard));

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -772,6 +772,10 @@ public:
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_mutation_partition_ptr> find_partition_slow(schema_ptr, reader_permit permit, const partition_key& key) const;
     future<const_row_ptr> find_row(schema_ptr, reader_permit permit, const dht::decorated_key& partition_key, clustering_key clustering_key) const;
+    shard_id shard_of(dht::token t) const {
+        return _erm ? _erm->shard_of(*_schema, t)
+                    : dht::shard_of(*_schema, t); // for tests.
+    }
     // Applies given mutation to this column family
     // The mutation is always upgraded to current schema.
     void apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h = {}) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -777,7 +777,7 @@ public:
     }
     shard_id shard_of(dht::token t) const {
         return _erm ? _erm->shard_of(*_schema, t)
-                    : dht::shard_of(*_schema, t); // for tests.
+                    : dht::static_shard_of(*_schema, t); // for tests.
     }
     // Applies given mutation to this column family
     // The mutation is always upgraded to current schema.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1589,7 +1589,7 @@ public:
     // Apply mutations atomically.
     // On restart, either all mutations will be replayed or none of them.
     // All mutations must belong to the same commitlog domain.
-    // All mutations must be owned by the current shard (in terms of dht::shard_of).
+    // All mutations must be owned by the current shard.
     // Mutations may be partially visible to reads during the call.
     // Mutations may be partially visible to reads until restart on exception (FIXME).
     future<> apply(const std::vector<frozen_mutation>&, db::timeout_clock::time_point timeout);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -352,7 +352,8 @@ struct table_stats {
 
 using storage_options = data_dictionary::storage_options;
 
-class table : public enable_lw_shared_from_this<table> {
+class table : public enable_lw_shared_from_this<table>
+            , public weakly_referencable<table> {
 public:
     struct config {
         std::vector<sstring> all_datadirs;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -889,6 +889,10 @@ public:
         _config.enable_incremental_backups = val;
     }
 
+    bool uses_static_sharding() const {
+        return !_erm || _erm->get_replication_strategy().is_vnode_based();
+    }
+
     /*!
      * \brief get sstables by key
      * Return a set of the sstables names that contain the given

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -772,6 +772,9 @@ public:
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_mutation_partition_ptr> find_partition_slow(schema_ptr, reader_permit permit, const partition_key& key) const;
     future<const_row_ptr> find_row(schema_ptr, reader_permit permit, const dht::decorated_key& partition_key, clustering_key clustering_key) const;
+    shard_id shard_of(const mutation& m) const {
+        return shard_of(m.token());
+    }
     shard_id shard_of(dht::token t) const {
         return _erm ? _erm->shard_of(*_schema, t)
                     : dht::shard_of(*_schema, t); // for tests.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -873,6 +873,7 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
           try {
             sstables::sstable_writer_config cfg = get_sstables_manager().configure_writer("memtable");
             cfg.backup = incremental_backups_enabled();
+            cfg.erm = _erm;
 
             auto newtab = make_sstable();
             newtabs.push_back(newtab);
@@ -2782,7 +2783,9 @@ public:
         return _t.make_sstable();
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
-        return _t.get_sstables_manager().configure_writer(std::move(origin));
+        auto cfg = _t.get_sstables_manager().configure_writer(std::move(origin));
+        cfg.erm = _t.get_effective_replication_map();
+        return cfg;
     }
     api::timestamp_type min_memtable_timestamp() const override {
         return _cg.min_memtable_timestamp();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -102,7 +102,7 @@ table::make_sstable_reader(schema_ptr s,
     // regardless of what the fwd_mr parameter says.
     if (pr.is_singular() && pr.start()->value().has_key()) {
         const dht::ring_position& pos = pr.start()->value();
-        if (dht::shard_of(*s, pos.token()) != this_shard_id()) {
+        if (_erm->shard_of(*s, pos.token()) != this_shard_id()) {
             return make_empty_flat_reader_v2(s, std::move(permit)); // range doesn't belong to this shard
         }
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -155,6 +155,21 @@ const dht::sharder& schema::get_sharder() const {
     return _raw._sharder.get();
 }
 
+replica::table* schema::maybe_table() const {
+    if (_registry_entry) {
+        return _registry_entry->table();
+    }
+    return nullptr;
+}
+
+replica::table& schema::table() const {
+    auto t = maybe_table();
+    if (!t) {
+        seastar::throw_with_backtrace<replica::no_such_column_family>(id());
+    }
+    return *t;
+}
+
 bool schema::has_custom_partitioner() const {
     return _raw._partitioner.get().name() != default_partitioner_name;
 }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -152,6 +152,11 @@ const dht::i_partitioner& schema::get_partitioner() const {
 }
 
 const dht::sharder& schema::get_sharder() const {
+    auto t = maybe_table();
+    if (t && !t->uses_static_sharding()) {
+        // Use table()->get_effective_replication_map()->get_sharder() instead.
+        on_internal_error(dblog, format("Attempted to obtain static sharder for table {}.{}", ks_name(), cf_name()));
+    }
     return _raw._sharder.get();
 }
 

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -46,6 +46,7 @@ class options;
 
 namespace replica {
 class database;
+class table;
 }
 
 using column_count_type = uint32_t;
@@ -826,6 +827,14 @@ public:
     static void set_default_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
     const dht::i_partitioner& get_partitioner() const;
     const dht::sharder& get_sharder() const;
+
+    // Returns a pointer to the table if the local database has a table which this object references by id().
+    // The table pointer is not guaranteed to be stable, schema_ptr doesn't keep the table alive.
+    replica::table* maybe_table() const;
+
+    // Like maybe_table() but throws replica::no_such_column_family if the table is not set.
+    replica::table& table() const;
+
     bool has_custom_partitioner() const;
 
     const column_definition* get_column_definition(const bytes& name) const;

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -826,6 +826,11 @@ public:
 
     static void set_default_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
     const dht::i_partitioner& get_partitioner() const;
+
+    // Returns a sharder for this table.
+    // Use only for tables which use vnode-based replication strategy, that is for which
+    // table::uses_static_sharding() is true.
+    // To obtain a sharder which is valid for all kinds of tables, use table::get_effective_replication_map()->get_sharder()
     const dht::sharder& get_sharder() const;
 
     // Returns a pointer to the table if the local database has a table which this object references by id().

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -54,6 +54,26 @@ void schema_registry::init(const db::schema_ctxt& ctxt) {
     _ctxt = std::make_unique<db::schema_ctxt>(ctxt);
 }
 
+void schema_registry::attach_table(schema_registry_entry& e) noexcept {
+    if (e._table) {
+        return;
+    }
+    replica::database* db = _ctxt->get_db();
+    if (!db) {
+        return;
+    }
+    try {
+        auto& table = db->find_column_family(e.get_schema()->id());
+        e.set_table(table.weak_from_this());
+    } catch (const replica::no_such_column_family&) {
+        if (slogger.is_enabled(seastar::log_level::debug)) {
+            slogger.debug("No table for schema version {} of {}.{}: {}", e._version,
+                          e.get_schema()->ks_name(), e.get_schema()->cf_name(), seastar::current_backtrace());
+        }
+        // ignore
+    }
+}
+
 schema_ptr schema_registry::learn(const schema_ptr& s) {
     if (s->registry_entry()) {
         return std::move(s);
@@ -63,12 +83,14 @@ schema_ptr schema_registry::learn(const schema_ptr& s) {
         schema_registry_entry& e = *i->second;
         if (e._state == schema_registry_entry::state::LOADING) {
             e.load(s);
+            attach_table(e);
         }
         return e.get_schema();
     }
     slogger.debug("Learning about version {} of {}.{}", s->version(), s->ks_name(), s->cf_name());
     auto e_ptr = make_lw_shared<schema_registry_entry>(s->version(), *this);
     auto loaded_s = e_ptr->load(s);
+    attach_table(*e_ptr);
     _entries.emplace(s->version(), e_ptr);
     return loaded_s;
 }
@@ -129,12 +151,15 @@ schema_ptr schema_registry::get_or_load(table_schema_version v, const schema_loa
     if (i == _entries.end()) {
         auto e_ptr = make_lw_shared<schema_registry_entry>(v, *this);
         auto s = e_ptr->load(loader(v));
+        attach_table(*e_ptr);
         _entries.emplace(v, e_ptr);
         return s;
     }
     schema_registry_entry& e = *i->second;
     if (e._state == schema_registry_entry::state::LOADING) {
-        return e.load(loader(v));
+        auto s = e.load(loader(v));
+        attach_table(e);
+        return s;
     }
     return e.get_schema();
 }
@@ -181,6 +206,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
         try {
             try {
                 load(f.get0());
+                _registry.attach_table(*this);
             } catch (...) {
                 std::throw_with_nested(schema_version_loading_failed(_version));
             }
@@ -246,6 +272,7 @@ future<> schema_registry_entry::maybe_sync(std::function<future<>()> syncer) {
                     _synced_promise.set_exception(f.get_exception());
                 } else {
                     slogger.debug("Synced {}", _version);
+                    _registry.attach_table(*this);
                     _sync_state = schema_registry_entry::sync_state::SYNCED;
                     _synced_promise.set_value();
                 }
@@ -261,9 +288,13 @@ bool schema_registry_entry::is_synced() const {
 }
 
 void schema_registry_entry::mark_synced() {
+    if (_sync_state == sync_state::SYNCED) {
+        return;
+    }
     if (_sync_state == sync_state::SYNCING) {
         _synced_promise.set_value();
     }
+    _registry.attach_table(*this);
     _sync_state = sync_state::SYNCED;
     slogger.debug("Marked {} as synced", _version);
 }

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -60,7 +60,11 @@ schema_ptr schema_registry::learn(const schema_ptr& s) {
     }
     auto i = _entries.find(s->version());
     if (i != _entries.end()) {
-        return i->second->get_schema();
+        schema_registry_entry& e = *i->second;
+        if (e._state == schema_registry_entry::state::LOADING) {
+            e.load(s);
+        }
+        return e.get_schema();
     }
     slogger.debug("Learning about version {} of {}.{}", s->version(), s->ks_name(), s->cf_name());
     auto e_ptr = make_lw_shared<schema_registry_entry>(s->version(), *this);

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -76,6 +76,7 @@ public:
     schema_registry_entry(const schema_registry_entry&) = delete;
     ~schema_registry_entry();
     schema_ptr load(frozen_schema);
+    schema_ptr load(schema_ptr);
     future<schema_ptr> start_loading(async_schema_loader);
     schema_ptr get_schema(); // call only when state >= LOADED
     // Can be called from other shards
@@ -137,10 +138,9 @@ public:
 
     // Attempts to add given schema to the registry. If the registry already
     // knows about the schema, returns existing entry, otherwise returns back
-    // the schema which was passed as argument. Users should prefer to use the
-    // schema_ptr returned by this method instead of the one passed to it,
-    // because doing so ensures that the entry will be kept in the registry as
-    // long as the schema is actively used.
+    // the schema which was passed as argument.
+    // The schema instance pointed to by the argument will be attached to the registry
+    // entry and will keep it alive.
     schema_ptr learn(const schema_ptr&);
 };
 

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -214,11 +214,13 @@ class partition_ranges_owned_by_this_shard {
     const dht::partition_range_vector _partition_ranges;
     size_t _range_idx;
     std::optional<dht::ring_position_range_sharder> _intersecter;
+    locator::effective_replication_map_ptr _erm;
 public:
     partition_ranges_owned_by_this_shard(schema_ptr s, dht::partition_range_vector v)
         :  _s(s)
         , _partition_ranges(v)
         , _range_idx(0)
+        , _erm(_s->table().get_effective_replication_map())
     {}
 
     // Return the next partition_range owned by this shard, or nullopt when the
@@ -246,7 +248,7 @@ public:
                 return std::nullopt;
             }
 
-            _intersecter.emplace(_s->get_sharder(), std::move(_partition_ranges[_range_idx]));
+            _intersecter.emplace(_erm->get_sharder(*_s), std::move(_partition_ranges[_range_idx]));
         }
     }
 };

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -750,7 +750,7 @@ private:
         return get_schema_for_read(cmd.schema_version, src_addr, *timeout).then([&sp = _sp, cmd = std::move(cmd), key = std::move(key), ballot,
                          only_digest, da, timeout, tr_state = std::move(tr_state), src_ip] (schema_ptr schema) mutable {
             dht::token token = dht::get_token(*schema, key);
-            unsigned shard = dht::shard_of(*schema, token);
+            unsigned shard = schema->table().shard_of(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -780,7 +780,7 @@ private:
         auto f = get_schema_for_read(proposal.update.schema_version(), src_addr, *timeout).then([&sp = _sp, tr_state = std::move(tr_state),
                                                               proposal = std::move(proposal), timeout] (schema_ptr schema) mutable {
             dht::token token = proposal.update.decorated_key(*schema).token();
-            unsigned shard = dht::shard_of(*schema, token);
+            unsigned shard = schema->table().shard_of(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -823,7 +823,7 @@ private:
         return get_schema_for_read(schema_id, src_addr, *timeout).then([&sp = _sp, key = std::move(key), ballot,
                          timeout, tr_state = std::move(tr_state), src_ip, d = std::move(d)] (schema_ptr schema) mutable {
             dht::token token = dht::get_token(*schema, key);
-            unsigned shard = dht::shard_of(*schema, token);
+            unsigned shard = schema->table().shard_of(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return smp::submit_to(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -862,7 +862,7 @@ const dht::token& end_token(const dht::partition_range& r) {
 }
 
 unsigned storage_proxy::cas_shard(const schema& s, dht::token token) {
-    return dht::shard_of(s, token);
+    return s.table().shard_of(token);
 }
 
 static uint32_t random_variable_for_rate_limit() {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2840,7 +2840,8 @@ storage_proxy::response_id_type storage_proxy::unique_response_handler::release(
 
 future<>
 storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
-    auto shard = m.shard_of();
+    auto erm = _db.local().find_column_family(m.schema()).get_effective_replication_map();
+    auto shard = erm->get_sharder(*m.schema()).shard_of(m.token());
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {smp_grp, timeout},
             [s = global_schema_ptr(m.schema()),
@@ -2856,7 +2857,8 @@ storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_sta
 future<>
 storage_proxy::mutate_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout,
         smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
-    auto shard = m.shard_of(*s);
+    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto shard = erm->get_sharder(*s).shard_of(m.token(*s));
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {smp_grp, timeout},
             [&m, gs = global_schema_ptr(s), gtr = tracing::global_trace_state_ptr(std::move(tr_state)), timeout, sync, rate_limit_info] (replica::database& db) mutable -> future<> {
@@ -2877,7 +2879,8 @@ storage_proxy::mutate_locally(std::vector<mutation> mutation, tracing::trace_sta
 }
 future<>
 storage_proxy::mutate_hint(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout) {
-    auto shard = m.shard_of(*s);
+    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto shard = erm->get_sharder(*s).shard_of(m.token(*s));
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {_hints_write_smp_service_group, timeout}, [&m, gs = global_schema_ptr(s), tr_state = std::move(tr_state), timeout] (replica::database& db) mutable -> future<> {
         return db.apply_hint(gs, m, std::move(tr_state), timeout);
@@ -2927,7 +2930,8 @@ storage_proxy::mutate_counters_on_leader(std::vector<frozen_mutation_and_schema>
 future<>
 storage_proxy::mutate_counter_on_leader_and_replicate(const schema_ptr& s, frozen_mutation fm, db::consistency_level cl, clock_type::time_point timeout,
                                                       tracing::trace_state_ptr trace_state, service_permit permit) {
-    auto shard = fm.shard_of(*s);
+    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto shard = erm->get_sharder(*s).shard_of(fm.token(*s));
     bool local = shard == this_shard_id();
     get_stats().replica_cross_shard_ops += !local;
     return _db.invoke_on(shard, {_write_smp_service_group, timeout}, [&proxy = container(), gs = global_schema_ptr(s), fm = std::move(fm), cl, timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state)), permit = std::move(permit), local] (replica::database& db) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -345,12 +345,16 @@ private:
             const inet_address_vector_replica_set& preferred_endpoints,
             bool& is_bounced_read,
             service_permit permit);
-    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
-                                                                           query::result_options opts,
-                                                                           tracing::trace_state_ptr trace_state,
-                                                                           clock_type::time_point timeout,
-                                                                           db::per_partition_rate_limit::info rate_limit_info);
+    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(
+            locator::effective_replication_map_ptr,
+            schema_ptr,
+            lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
+            query::result_options opts,
+            tracing::trace_state_ptr trace_state,
+            clock_type::time_point timeout,
+            db::per_partition_rate_limit::info rate_limit_info);
     future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>> query_result_local_digest(
+            locator::effective_replication_map_ptr,
             schema_ptr,
             lw_shared_ptr<query::read_command> cmd,
             const dht::partition_range& pr,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -347,6 +347,10 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
 
         tmptr->set_version(_topology_state_machine._topology.version);
 
+        auto update_topology = [&] (inet_address ip, const replica_state& rs) {
+            tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+        };
+
         auto add_normal_node = [&] (raft::server_id id, const replica_state& rs) -> future<> {
             locator::host_id host_id{id.uuid()};
             auto ip = co_await id2ip(id);
@@ -371,7 +375,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                 co_await _sys_ks.local().update_tokens(rs.ring.value().tokens);
                 co_await _gossiper.add_local_application_state({{ gms::application_state::STATUS, gms::versioned_value::normal(rs.ring.value().tokens) }});
             }
-            tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+            update_topology(ip, rs);
             co_await tmptr->update_normal_tokens(rs.ring.value().tokens, ip);
             tmptr->update_host_id(host_id, ip);
         };
@@ -409,7 +413,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                     co_await _sys_ks.local().update_tokens(ip, {});
                     co_await _sys_ks.local().update_peer_info(ip, "host_id", id.uuid());
                 }
-                tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+                update_topology(ip, rs);
                 if (_topology_state_machine._topology.normal_nodes.empty()) {
                     // This is the first node in the cluster. Insert the tokens as normal to the token ring early
                     // so we can perform writes to regular 'distributed' tables during the bootstrap procedure
@@ -423,7 +427,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                 break;
             case node_state::decommissioning:
             case node_state::removing:
-                tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+                update_topology(ip, rs);
                 co_await tmptr->update_normal_tokens(rs.ring.value().tokens, ip);
                 tmptr->update_host_id(host_id, ip);
                 tmptr->add_leaving_endpoint(ip);
@@ -438,7 +442,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
                     on_fatal_internal_error(slogger, ::format("Cannot map id of a node being replaced {} to its ip", replaced_id));
                 }
                 assert(existing_ip);
-                tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+                update_topology(ip, rs);
                 tmptr->add_replacing_endpoint(*existing_ip, ip);
                 co_await update_topology_change_info(tmptr, ::format("replacing {}/{} by {}/{}", replaced_id, *existing_ip, id, ip));
             }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -348,15 +348,15 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
         tmptr->set_version(_topology_state_machine._topology.version);
 
         auto update_topology = [&] (inet_address ip, const replica_state& rs) {
-            tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack});
+            tmptr->update_topology(ip, locator::endpoint_dc_rack{rs.datacenter, rs.rack}, std::nullopt, rs.shard_count);
         };
 
         auto add_normal_node = [&] (raft::server_id id, const replica_state& rs) -> future<> {
             locator::host_id host_id{id.uuid()};
             auto ip = co_await id2ip(id);
 
-            slogger.trace("raft topology: loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={}",
-                          id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate, rs.ring.value().tokens);
+            slogger.trace("raft topology: loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={} shards={}",
+                          id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate, rs.ring.value().tokens, rs.shard_count);
             // Save tokens, not needed for raft topology management, but needed by legacy
             // Also ip -> id mapping is needed for address map recreation on reboot
             if (!utils::fb_utilities::is_me(ip)) {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1471,7 +1471,9 @@ void writer::consume_end_of_stream() {
             { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
         }
     });
-    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
+    const dht::sharder& sharder = _cfg.erm ? _cfg.erm->get_sharder(_schema)
+                                           : _schema.get_sharder(); // Used in tests
+    _sst.write_scylla_metadata(_shard, sharder, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -175,11 +175,11 @@ sstable_directory::sort_sstable(sstables::entry_descriptor desc, process_flags f
             dirlog.trace("{} identified as a local unshared SSTable", sstable_filename(desc));
             _unshared_local_sstables.push_back(co_await load_sstable(std::move(desc), flags));
         } else {
-            dirlog.trace("{} identified as a remote unshared SSTable", sstable_filename(desc));
+            dirlog.trace("{} identified as a remote unshared SSTable, shard={}", sstable_filename(desc), shards[0]);
             _unshared_remote_sstables[shards[0]].push_back(std::move(desc));
         }
     } else {
-        dirlog.trace("{} identified as a shared SSTable", sstable_filename(desc));
+        dirlog.trace("{} identified as a shared SSTable, shards={}", sstable_filename(desc), shards);
         _shared_sstable_info.push_back(co_await get_open_info_for_this_sstable(desc));
     }
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -136,6 +136,7 @@ private:
     std::filesystem::path _sstable_dir;
     io_error_handler_gen _error_handler_gen;
     std::unique_ptr<components_lister> _lister;
+    const dht::sharder& _sharder;
 
     std::optional<generation_type> _max_generation_seen;
     sstables::sstable_version_types _max_version_seen = sstables::sstable_version_types::ka;
@@ -185,6 +186,7 @@ private:
 public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
+            const dht::sharder& sharder,
             lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
             std::filesystem::path sstable_dir,
             io_error_handler_gen error_handler_gen);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1446,6 +1446,7 @@ future<foreign_sstable_open_info> sstable::get_open_info() & {
 future<>
 sstable::load_owner_shards(const dht::sharder& sharder) {
     if (!_shards.empty()) {
+        sstlog.trace("{}: shards={}", get_filename(), _shards);
         co_return;
     }
     co_await read_scylla_metadata();
@@ -1473,6 +1474,7 @@ sstable::load_owner_shards(const dht::sharder& sharder) {
     }
 
     _shards = compute_shards_for_this_sstable(sharder);
+    sstlog.trace("{}: shards={}", get_filename(), _shards);
 }
 
 void prepare_summary(summary& s, uint64_t expected_partition_count, uint32_t min_index_interval) {
@@ -2753,6 +2755,7 @@ sstable::compute_shards_for_this_sstable(const dht::sharder& sharder_) const {
                 sm->token_ranges.elements
                 | boost::adaptors::transformed(disk_token_range_to_ring_position_range));
     }
+    sstlog.trace("{}: token_ranges={}", get_filename(), token_ranges);
     auto sharder = dht::ring_position_range_vector_sharder(sharder_, std::move(token_ranges));
     auto rpras = sharder.next(*_schema);
     while (rpras) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1624,11 +1624,12 @@ sstable::read_scylla_metadata() noexcept {
 }
 
 void
-sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features, struct run_identifier identifier,
+sstable::write_scylla_metadata(shard_id shard, const dht::sharder& sharder, sstable_enabled_features features, struct run_identifier identifier,
         std::optional<scylla_metadata::large_data_stats> ld_stats, sstring origin) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
-    auto sm = create_sharding_metadata(_schema, _schema->get_sharder(), first_key, last_key, shard);
+
+    auto sm = create_sharding_metadata(_schema, sharder, first_key, last_key, shard);
 
     // sstable write may fail to generate empty metadata if mutation source has only data from other shard.
     // see https://github.com/scylladb/scylla/issues/2932 for details on how it can happen.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -39,6 +39,7 @@
 #include "readers/flat_mutation_reader_fwd.hh"
 #include "tracing/trace_state.hh"
 #include "utils/updateable_value.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 #include <seastar/util/optimized_optional.hh>
 
@@ -110,6 +111,7 @@ struct sstable_writer_config {
     run_id run_identifier = run_id::create_random_id();
     size_t summary_byte_cost;
     sstring origin;
+    locator::effective_replication_map_ptr erm;
 
 private:
     explicit sstable_writer_config() {}
@@ -579,8 +581,13 @@ private:
     void write_compression();
 
     future<> read_scylla_metadata() noexcept;
-    void write_scylla_metadata(shard_id shard, sstable_enabled_features features, run_identifier identifier,
-            std::optional<scylla_metadata::large_data_stats> ld_stats, sstring origin);
+
+    void write_scylla_metadata(shard_id shard,
+                               const dht::sharder& sharder,
+                               sstable_enabled_features features,
+                               run_identifier identifier,
+                               std::optional<scylla_metadata::large_data_stats> ld_stats,
+                               sstring origin);
 
     future<> read_filter(sstable_open_config cfg = {});
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -198,13 +198,13 @@ public:
     // load all components from disk
     // this variant will be useful for testing purposes and also when loading
     // a new sstable from scratch for sharing its components.
-    future<> load(sstable_open_config cfg = {}) noexcept;
+    future<> load(const dht::sharder& sharder, sstable_open_config cfg = {}) noexcept;
     future<> open_data(sstable_open_config cfg = {}) noexcept;
     future<> update_info_for_opened_data(sstable_open_config cfg = {});
 
     // Load set of shards that own the SSTable, while reading the minimum
     // from disk to achieve that.
-    future<> load_owner_shards();
+    future<> load_owner_shards(const dht::sharder& sharder);
 
     // Call as the last method before the object is destroyed.
     // No other uses of the object can happen at this point.
@@ -671,7 +671,7 @@ private:
     std::optional<std::pair<uint64_t, uint64_t>> get_sample_indexes_for_range(const dht::token_range& range);
     std::optional<std::pair<uint64_t, uint64_t>> get_index_pages_for_range(const dht::token_range& range);
 
-    std::vector<unsigned> compute_shards_for_this_sstable() const;
+    std::vector<unsigned> compute_shards_for_this_sstable(const dht::sharder&) const;
     template <typename Components>
     static auto& get_mutable_serialization_header(Components& components) {
         auto entry = components.statistics.contents.find(metadata_type::Serialization);

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -54,9 +54,10 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                 }
                 schema_ptr s = reader.schema();
 
+                auto cfg = cf->get_sstables_manager().configure_writer(origin);
+                cfg.erm = cf->get_effective_replication_map();
                 return sst->write_components(std::move(reader), adjusted_estimated_partitions, s,
-                                             cf->get_sstables_manager().configure_writer(origin),
-                                             encoding_stats{}).then([sst] {
+                                             cfg, encoding_stats{}).then([sst] {
                     return sst->open_data();
                 }).then([cf, sst, offstrategy, origin] {
                     if (offstrategy && sstables::repair_origin == origin) {

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -100,7 +100,7 @@ static generated_table create_test_table(
             keys.emplace_back(mut.decorated_key());
             compacted_frozen_mutations.emplace_back(freeze(mut.compacted()));
             (void)with_gate(write_gate, [&] {
-                return smp::submit_to(dht::shard_of(*schema, mut.decorated_key().token()), [&env, gs = global_schema_ptr(schema), mut = freeze(mut)] () mutable {
+                return smp::submit_to(dht::static_shard_of(*schema, mut.decorated_key().token()), [&env, gs = global_schema_ptr(schema), mut = freeze(mut)] () mutable {
                     return env.local_db().apply(gs.get(), std::move(mut), {}, db::commitlog_force_sync::no, db::no_timeout);
                 });
             });

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -424,7 +424,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         for (const auto& [ring_point, endpoint, id] : ring_points) {
             std::unordered_set<token> tokens;
             tokens.insert({dht::token::kind::key, d2t(ring_point / ring_points.size())});
-            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint), locator::node::state::normal);
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint), locator::node::state::normal, 1);
             tm.update_host_id(id, endpoint);
             co_await tm.update_normal_tokens(std::move(tokens), endpoint);
         }

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -355,7 +355,7 @@ static
 void
 do_test_split_range_to_single_shard(const schema& s, const dht::partition_range& pr) {
     for (auto shard : boost::irange(0u, s.get_sharder().shard_count())) {
-        auto ranges = dht::split_range_to_single_shard(s, pr, shard).get0();
+        auto ranges = dht::split_range_to_single_shard(s, s.get_sharder(), pr, shard).get0();
         auto sharder = dht::ring_position_range_sharder(s.get_sharder(), pr);
         auto x = sharder.next(s);
         auto cmp = dht::ring_position_comparator(s);

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -310,7 +310,7 @@ normalize(dht::partition_range pr) {
 
 static
 void
-test_something_with_some_interesting_ranges_and_sharder(std::function<void (const schema&, const dht::partition_range&)> func_to_test) {
+test_something_with_some_interesting_ranges_and_sharder(std::function<void (const schema&, const dht::sharder&, const dht::partition_range&)> func_to_test) {
     auto s = schema_builder("ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
@@ -346,17 +346,17 @@ test_something_with_some_interesting_ranges_and_sharder(std::function<void (cons
         auto schema = schema_builder(s)
             .with_sharder(sharder.shard_count(), sharder.sharding_ignore_msb()).build();
         for (auto&& range : some_murmur3_ranges) {
-            func_to_test(*schema, range);
+            func_to_test(*schema, sharder, range);
         }
     }
 }
 
 static
 void
-do_test_split_range_to_single_shard(const schema& s, const dht::partition_range& pr) {
-    for (auto shard : boost::irange(0u, s.get_sharder().shard_count())) {
-        auto ranges = dht::split_range_to_single_shard(s, s.get_sharder(), pr, shard).get0();
-        auto sharder = dht::ring_position_range_sharder(s.get_sharder(), pr);
+do_test_split_range_to_single_shard(const schema& s, const dht::sharder& sharder_, const dht::partition_range& pr) {
+    for (auto shard : boost::irange(0u, sharder_.shard_count())) {
+        auto ranges = dht::split_range_to_single_shard(s, sharder_, pr, shard).get0();
+        auto sharder = dht::ring_position_range_sharder(sharder_, pr);
         auto x = sharder.next(s);
         auto cmp = dht::ring_position_comparator(s);
         auto reference_ranges = std::vector<dht::partition_range>();

--- a/test/boost/per_partition_rate_limit_test.cc
+++ b/test/boost/per_partition_rate_limit_test.cc
@@ -24,7 +24,7 @@ SEASTAR_TEST_CASE(test_internal_operation_filtering) {
 
         auto pk = partition_key::from_singular(*sptr, int32_t(0));
 
-        unsigned local_shard = dht::shard_of(*sptr, dht::get_token(*sptr, pk.view()));
+        unsigned local_shard = sptr->table().shard_of(dht::get_token(*sptr, pk.view()));
         unsigned foreign_shard = (local_shard + 1) % smp::count;
         
         auto run_writes = [&qp, &db, pk] (db::allow_per_partition_rate_limit allow_limit) -> future<> {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1341,7 +1341,7 @@ memory_limit_table create_memory_limit_table(cql_test_env& env, uint64_t target_
                     s,
                     writer_cfg,
                     encoding_stats{}).get();
-                sst->load().get();
+                sst->open_data().get();
                 tbl.add_sstable_and_update_cache(std::move(sst)).get();
             }
         });

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -34,6 +34,7 @@
 #include "test/lib/log.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/random_utils.hh"
+#include "utils/throttle.hh"
 
 #include <boost/range/algorithm/min_element.hpp>
 #include "readers/from_mutations_v2.hh"
@@ -1230,62 +1231,16 @@ SEASTAR_TEST_CASE(test_update_failure) {
 }
 #endif
 
-class throttle {
-    unsigned _block_counter = 0;
-    promise<> _p; // valid when _block_counter != 0, resolves when goes down to 0
-    std::optional<promise<>> _entered;
-    bool _one_shot;
-public:
-    // one_shot means whether only the first enter() after block() will block.
-    throttle(bool one_shot = false) : _one_shot(one_shot) {}
-    future<> enter() {
-        if (_block_counter && (!_one_shot || _entered)) {
-            promise<> p1;
-            promise<> p2;
-
-            auto f1 = p1.get_future();
-
-            // Intentional, the future is waited on indirectly.
-            (void)p2.get_future().then([p1 = std::move(p1), p3 = std::move(_p)] () mutable {
-                p1.set_value();
-                p3.set_value();
-            });
-            _p = std::move(p2);
-            if (_entered) {
-                _entered->set_value();
-                _entered.reset();
-            }
-            return f1;
-        } else {
-            return make_ready_future<>();
-        }
-    }
-
-    future<> block() {
-        ++_block_counter;
-        _p = promise<>();
-        _entered = promise<>();
-        return _entered->get_future();
-    }
-
-    void unblock() {
-        assert(_block_counter);
-        if (--_block_counter == 0) {
-            _p.set_value();
-        }
-    }
-};
-
 class throttled_mutation_source {
 private:
     class impl : public enable_lw_shared_from_this<impl> {
         mutation_source _underlying;
-        ::throttle& _throttle;
+        utils::throttle& _throttle;
     private:
         class reader : public delegating_reader_v2 {
-            throttle& _throttle;
+            utils::throttle& _throttle;
         public:
-            reader(throttle& t, flat_mutation_reader_v2 r)
+            reader(utils::throttle& t, flat_mutation_reader_v2 r)
                     : delegating_reader_v2(std::move(r))
                     , _throttle(t)
             {}
@@ -1296,7 +1251,7 @@ private:
             }
         };
     public:
-        impl(::throttle& t, mutation_source underlying)
+        impl(utils::throttle& t, mutation_source underlying)
             : _underlying(std::move(underlying))
             , _throttle(t)
         { }
@@ -1308,7 +1263,7 @@ private:
     };
     lw_shared_ptr<impl> _impl;
 public:
-    throttled_mutation_source(throttle& t, mutation_source underlying)
+    throttled_mutation_source(utils::throttle& t, mutation_source underlying)
         : _impl(make_lw_shared<impl>(t, std::move(underlying)))
     { }
 
@@ -1388,7 +1343,7 @@ SEASTAR_TEST_CASE(test_cache_population_and_update_race) {
         auto s = make_schema();
         tests::reader_concurrency_semaphore_wrapper semaphore;
         memtable_snapshot_source memtables(s);
-        throttle thr;
+        utils::throttle thr;
         auto cache_source = make_decorated_snapshot_source(snapshot_source([&] { return memtables(); }), [&] (mutation_source src) {
             return throttled_mutation_source(thr, std::move(src));
         });
@@ -1527,7 +1482,7 @@ SEASTAR_TEST_CASE(test_cache_population_and_clear_race) {
         auto s = make_schema();
         tests::reader_concurrency_semaphore_wrapper semaphore;
         memtable_snapshot_source memtables(s);
-        throttle thr;
+        utils::throttle thr;
         auto cache_source = make_decorated_snapshot_source(snapshot_source([&] { return memtables(); }), [&] (mutation_source src) {
             return throttled_mutation_source(thr, std::move(src));
         });
@@ -4268,7 +4223,7 @@ SEASTAR_TEST_CASE(test_eviction_of_upper_bound_of_population_range) {
         cache_mt->apply(m1);
 
         cache_tracker tracker;
-        throttle thr(true);
+        utils::throttle thr(true);
         auto cache_source = make_decorated_snapshot_source(snapshot_source([&] { return cache_mt->as_data_source(); }),
                                                            [&] (mutation_source src) {
             return throttled_mutation_source(thr, std::move(src));

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -18,6 +18,8 @@
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "types/list.hh"
+#include "utils/throttle.hh"
+#include "test/lib/cql_test_env.hh"
 
 static bytes random_column_name() {
     return to_bytes(to_hex(make_blob(32)));
@@ -140,4 +142,111 @@ SEASTAR_TEST_CASE(test_failed_sync_can_be_retried) {
         s->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
         BOOST_REQUIRE(s->is_synced());
     });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        auto s0 = schema_builder("ks", "cf")
+                .with_column("pk", bytes_type, column_kind::partition_key)
+                .with_column("v1", bytes_type)
+                .build();
+
+        auto s0_wild = schema_builder(s0)
+                .with_column(random_column_name(), bytes_type)
+                .build();
+
+        // Simulate fetching schema version before the table is created.
+        local_schema_registry().learn(s0);
+
+        // Use schema mutations so that table id is the same as in s0.
+        {
+            auto sm0 = db::schema_tables::make_schema_mutations(s0, api::new_timestamp(), true);
+            std::vector<mutation> muts;
+            sm0.copy_to(muts);
+            db::schema_tables::merge_schema(e.get_system_keyspace(), e.get_storage_proxy(),
+                                            e.get_feature_service().local(), muts).get();
+        }
+
+        // This should attach the table
+        s0->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
+        BOOST_REQUIRE(s0->maybe_table());
+
+        // mark_synced() should attach the table
+        local_schema_registry().learn(s0_wild);
+        s0_wild->registry_entry()->mark_synced();
+        BOOST_REQUIRE(s0_wild->maybe_table());
+
+        auto s1 = schema_builder(s0)
+                .with_column(random_column_name(), bytes_type)
+                .build();
+        BOOST_REQUIRE(!s1->maybe_table());
+
+        e.execute_cql("ALTER TABLE ks.cf ADD dummy int").get();
+
+        s1 = local_schema_registry().learn(s1);
+        s1->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
+        BOOST_REQUIRE(&s1->table() == s0->maybe_table());
+
+        auto learned_s1 = local_schema_registry().learn(s1);
+        BOOST_REQUIRE(learned_s1->maybe_table() == s0->maybe_table());
+        BOOST_REQUIRE(&learned_s1->table() == s0->maybe_table());
+
+        auto s2 = schema_builder(s0)
+                .with_column(random_column_name(), bytes_type)
+                .build();
+
+        auto learned_s2 = local_schema_registry().get_or_load(s2->version(), [&] (table_schema_version) {
+            return frozen_schema(s2);
+        });
+        BOOST_REQUIRE(learned_s2->maybe_table() == s0->maybe_table());
+
+        if (smp::count > 1) {
+            smp::submit_to(1, [&e, gs = global_schema_ptr(learned_s2)] {
+                schema_ptr s0 = e.local_db().find_column_family("ks", "cf").schema();
+                BOOST_REQUIRE(gs.get()->maybe_table());
+                BOOST_REQUIRE(gs.get()->maybe_table() == s0->maybe_table());
+            }).get();
+        }
+
+        // Simulate concurrent schema version fetch and learn() from schema merge which cuts the race.
+        auto s3 = schema_builder(s2)
+                .with_column(random_column_name(), bytes_type)
+                .build();
+        utils::throttle s3_thr;
+        auto s3_entered = s3_thr.block();
+        auto learned_s3 = local_schema_registry().get_or_load(s3->version(), [&, fs = frozen_schema(s3)] (table_schema_version) -> future<frozen_schema> {
+            co_await s3_thr.enter();
+            co_return fs;
+        });
+        s3_entered.get();
+        local_schema_registry().learn(s3);
+        s3_thr.unblock();
+        auto s3_s = learned_s3.get0();
+        BOOST_REQUIRE(s3_s->maybe_table() == s0->maybe_table());
+        BOOST_REQUIRE(s3->maybe_table() == s0->maybe_table());
+
+        // Simulate concurrent schema version fetch and get_or_load() from global_schema_ptr which cuts the race.
+        auto s4 = schema_builder(s3)
+                .with_column(random_column_name(), bytes_type)
+                .build();
+        utils::throttle s4_thr;
+        auto s4_entered = s4_thr.block();
+        auto learned_s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) -> future<frozen_schema> {
+            co_await s4_thr.enter();
+            co_return fs;
+        });
+        s4_entered.get();
+        s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) { return fs; });
+        s4_thr.unblock();
+        auto s4_s = learned_s4.get0();
+        BOOST_REQUIRE(s4_s->maybe_table() == s0->maybe_table());
+        BOOST_REQUIRE(s4->maybe_table() == s0->maybe_table());
+
+        e.execute_cql("DROP TABLE ks.cf;").get();
+
+        BOOST_REQUIRE(!s0->maybe_table());
+        BOOST_REQUIRE(!learned_s1->maybe_table());
+        BOOST_REQUIRE(!learned_s2->maybe_table());
+        BOOST_REQUIRE_THROW(learned_s1->table(), replica::no_such_column_family);
+    }).get();
 }

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1909,7 +1909,7 @@ SEASTAR_TEST_CASE(test_deleting_ghost_rows) {
                 mutation m(schema, partition_key::from_singular(*schema, pk));
                 auto& row = m.partition().clustered_row(*schema, clustering_key::from_exploded(*schema, {int32_type->decompose(8), int32_type->decompose(7)}));
                 row.apply(row_marker{api::new_timestamp()});
-                unsigned shard = m.shard_of();
+                unsigned shard = t.shard_of(m);
                 if (shard == this_shard_id()) {
                     t.apply(m);
                 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -88,7 +88,7 @@ public:
         _sst->read_statistics().get();
     }
     void load() {
-        _sst->load().get();
+        _sst->load(_sst->get_schema()->get_sharder()).get();
     }
     future<std::vector<sstables::test::index_entry>> read_index() {
         load();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2114,7 +2114,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
                 }
             });
 
-            sst->load().get();
+            sst->load(sst->get_schema()->get_sharder()).get();
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
@@ -2214,7 +2214,7 @@ SEASTAR_TEST_CASE(sstable_validate_test) {
         config.validation_level = mutation_fragment_stream_validation_level::partition_region; // this test violates key order on purpose
         auto sst = env.make_sstable(schema);
         sst->write_components(std::move(rd), local_keys.size(), schema, config, encoding_stats{}).get();
-        sst->load().get();
+        sst->load(sst->get_schema()->get_sharder()).get();
         return sst;
     };
 
@@ -2308,7 +2308,7 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
 
             testlog.info("Writing sstable {}", sst->get_filename());
 
-            sst->load().get();
+            sst->load(sst->get_schema()->get_sharder()).get();
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
@@ -2399,7 +2399,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
                 }
             });
 
-            sst->load().get();
+            sst->load(sst->get_schema()->get_sharder()).get();
 
             testlog.info("Loaded sstable {}", sst->get_filename());
 
@@ -2505,7 +2505,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
                     }
                 });
 
-                sst->load().get();
+                sst->load(sst->get_schema()->get_sharder()).get();
 
                 testlog.info("Loaded sstable {}", sst->get_filename());
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2246,7 +2246,7 @@ SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {
 
         auto sst = env.make_sstable(s, get_test_dir("broken_non_compound_pi_and_range_tombstone", s), sstables::generation_type(1), version);
         try {
-            sst->load().get();
+            sst->load(sst->get_schema()->get_sharder()).get();
         } catch (...) {
             BOOST_REQUIRE_EXCEPTION(current_exception_as_future().get(), sstables::malformed_sstable_exception, exception_predicate::message_contains(
                 "Failed to read partition from SSTable "));
@@ -2825,7 +2825,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 auto wr = sst->get_writer(*sst_schema, 1, cfg, encoding_stats{});
                 mr.consume_in_thread(std::move(wr));
 
-                sst->load().get();
+                sst->load(sst->get_schema()->get_sharder()).get();
 
                 bool valid;
 
@@ -2906,7 +2906,7 @@ SEASTAR_TEST_CASE(test_index_fast_forwarding_after_eof) {
             auto wr = sst->get_writer(*schema, 1, cfg, encoding_stats{});
             mr.consume_in_thread(std::move(wr));
 
-            sst->load().get();
+            sst->load(sst->get_schema()->get_sharder()).get();
         }
 
         const auto t1 = muts.front().decorated_key()._token;

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -158,6 +158,7 @@ static void with_sstable_directory(
 
     sstdir.start(seastar::sharded_parameter([&env_wrap] { return std::ref(env_wrap.get_manager()); }),
             seastar::sharded_parameter([] { return test_table_schema(); }),
+            seastar::sharded_parameter([] { return std::ref(test_table_schema()->get_sharder()); }),
             seastar::sharded_parameter([] { return make_lw_shared<data_dictionary::storage_options>(); }),
             path.native(), default_io_error_handler_gen()).get();
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -42,7 +42,7 @@ static schema_ptr get_schema(unsigned shard_count, unsigned sharding_ignore_msb_
 // Asserts that sstable::compute_owner_shards(...) produces correct results.
 static future<> assert_sstable_computes_correct_owners(test_env& env, const sstables::shared_sstable& base_sst) {
     auto sst = co_await env.reusable_sst(base_sst);
-    co_await sst->load_owner_shards();
+    co_await sst->load_owner_shards(sst->get_schema()->get_sharder());
     BOOST_REQUIRE_EQUAL(sst->get_shards_for_this_sstable(), base_sst->get_shards_for_this_sstable());
 }
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -96,8 +96,11 @@ void run_sstable_resharding_test(sstables::test_env& env) {
 
     uint64_t bloom_filter_size_before = filter_size(sst);
 
+    auto erm = cf->get_effective_replication_map();
+
     auto descriptor = sstables::compaction_descriptor({sst}, 0, std::numeric_limits<uint64_t>::max());
     descriptor.options = sstables::compaction_type_options::make_reshard();
+    descriptor.sharder = &cf->schema()->get_sharder();
     descriptor.creator = [&env, &cf, version] (shard_id shard) mutable {
         // we need generation calculated by instance of cf at requested shard,
         // or resource usage wouldn't be fairly distributed among shards.

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -17,7 +17,9 @@
 
 #include "replica/tablets.hh"
 #include "locator/tablets.hh"
+#include "locator/tablet_sharder.hh"
 #include "locator/tablet_replication_strategy.hh"
+#include "utils/fb_utilities.hh"
 
 using namespace locator;
 using namespace replica;
@@ -260,6 +262,112 @@ SEASTAR_TEST_CASE(test_get_shard) {
         BOOST_REQUIRE_EQUAL(tmap.get_shard(tid, h2), std::make_optional(shard_id(3)));
         BOOST_REQUIRE_EQUAL(tmap.get_shard(tid, h3), std::make_optional(shard_id(5)));
 
+    }, tablet_cql_test_config());
+}
+
+SEASTAR_TEST_CASE(test_sharder) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto h1 = host_id(utils::UUID_gen::get_time_UUID());
+        auto h2 = host_id(utils::UUID_gen::get_time_UUID());
+        auto h3 = host_id(utils::UUID_gen::get_time_UUID());
+
+        auto table1 = table_id(utils::UUID_gen::get_time_UUID());
+
+        token_metadata tokm(token_metadata::config{});
+        tokm.get_topology().add_or_update_endpoint(utils::fb_utilities::get_broadcast_address(), h1);
+
+        std::vector<tablet_id> tablet_ids;
+        {
+            tablet_map tmap(4);
+            auto tid = tmap.first_tablet();
+
+            tablet_ids.push_back(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica {h1, 3},
+                    tablet_replica {h3, 5},
+                }
+            });
+
+            tid = *tmap.next_tablet(tid);
+            tablet_ids.push_back(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica {h2, 3},
+                    tablet_replica {h3, 1},
+                }
+            });
+
+            tid = *tmap.next_tablet(tid);
+            tablet_ids.push_back(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica {h3, 2},
+                    tablet_replica {h1, 1},
+                }
+            });
+            tmap.set_tablet_transition_info(tid, tablet_transition_info {
+                tablet_replica_set {
+                    tablet_replica {h1, 1},
+                    tablet_replica {h2, 3},
+                },
+                tablet_replica {h2, 3}
+            });
+
+            tid = *tmap.next_tablet(tid);
+            tablet_ids.push_back(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica {h3, 7},
+                    tablet_replica {h2, 3},
+                }
+            });
+
+            tablet_metadata tm;
+            tm.set_tablet_map(table1, std::move(tmap));
+            tokm.set_tablets(std::move(tm));
+        }
+
+        auto& tm = tokm.tablets().get_tablet_map(table1);
+        tablet_sharder sharder(tokm, table1);
+        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[0])), 3);
+        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[1])), 0); // missing
+        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[2])), 1);
+        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[3])), 0); // missing
+
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 3), dht::maximum_token());
+
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 3), dht::maximum_token());
+
+        {
+            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[0]));
+            BOOST_REQUIRE(shard_opt);
+            BOOST_REQUIRE_EQUAL(shard_opt->shard, 0);
+            BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[1]));
+        }
+
+        {
+            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[1]));
+            BOOST_REQUIRE(shard_opt);
+            BOOST_REQUIRE_EQUAL(shard_opt->shard, 1);
+            BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[2]));
+        }
+
+        {
+            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[2]));
+            BOOST_REQUIRE(shard_opt);
+            BOOST_REQUIRE_EQUAL(shard_opt->shard, 0);
+            BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[3]));
+        }
+
+        {
+            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[3]));
+            BOOST_REQUIRE(!shard_opt);
+        }
     }, tablet_cql_test_config());
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -350,7 +350,7 @@ public:
         auto ckey = clustering_key::from_deeply_exploded(*schema, ck);
         auto exp = expected.type()->decompose(expected);
         auto dk = dht::decorate_key(*schema, pkey);
-        auto shard = dht::shard_of(*schema, dk._token);
+        auto shard = cf.get_effective_replication_map()->shard_of(*schema, dk._token);
         return _db.invoke_on(shard, [pkey = std::move(pkey),
                                       ckey = std::move(ckey),
                                       ks_name = std::move(ks_name),

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -178,6 +178,8 @@ public:
 
     virtual sharded<service::storage_proxy>& get_storage_proxy() = 0;
 
+    virtual sharded<gms::feature_service>& get_feature_service() = 0;
+
     virtual sharded<sstables::storage_manager>& get_sstorage_manager() = 0;
 
     data_dictionary::database data_dictionary();

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -65,7 +65,7 @@ std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, 
             s->partition_key_type()->types(),
             [s, shard, tokens = std::set<dht::token>()] (const partition_key& pkey) mutable -> std::optional<dht::decorated_key> {
                 auto dkey = dht::decorate_key(*s, pkey);
-                if (shard && *shard != dht::shard_of(*s, dkey.token())) {
+                if (shard && *shard != dht::static_shard_of(*s, dkey.token())) {
                     return {};
                 }
                 if (!tokens.insert(dkey.token()).second) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -135,7 +135,7 @@ public:
             sstable::version_types version, sstable::format_types f = sstable::format_types::big) {
         auto sst = make_sstable(std::move(schema), dir, generation, version, f);
         sstable_open_config cfg { .load_first_and_last_position_metadata = true };
-        return sst->load(cfg).then([sst = std::move(sst)] {
+        return sst->load(sst->get_schema()->get_sharder(), cfg).then([sst = std::move(sst)] {
             return make_ready_future<shared_sstable>(std::move(sst));
         });
     }

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -91,7 +91,7 @@ shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, 
     auto sst = env.make_sstable(s, dir_path.string(), env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     auto mr = mt->make_flat_reader(s, env.make_reader_permit());
     sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();
-    sst->load().get();
+    sst->load(s->get_sharder()).get();
     return sst;
 }
 
@@ -100,7 +100,7 @@ shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, ssta
     auto s = rd.schema();
     auto sst = env.make_sstable(s, gen, version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     sst->write_components(std::move(rd), expected_partition, s, cfg, encoding_stats{}).get();
-    sst->load().get();
+    sst->load(s->get_sharder()).get();
     return sst;
 }
 

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -209,7 +209,7 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
             auto mt2 = make_lw_shared<replica::memtable>(s);
             mt2->apply(*mt, env.make_reader_permit()).get();
             write_memtable_to_sstable_for_test(*mt2, sst).get();
-            sst->load().get();
+            sst->open_data().get();
             result.sstable[v] = sst->data_size();
         }
     }).get();

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -180,7 +180,7 @@ public:
 
     future<> load_sstables(unsigned iterations) {
         _sst.push_back(_env.make_sstable(s, this->dir()));
-        return _sst.back()->load();
+        return _sst.back()->load(s->get_sharder());
     }
 
     using clk = std::chrono::steady_clock;

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -5,6 +5,6 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
-    experimental_features: ['raft']
+    experimental_features: ['raft', 'tablets']
 skip_in_release:
   - test_blocked_bootstrap

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -26,7 +26,8 @@ async def inject_error_one_shot_on(manager, error_name, servers):
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ManagerClient):
     """Test that you can create a table and insert and query data"""
 
-    servers = await manager.running_servers()
+    logger.info("Bootstrapping cluster")
+    servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
 
     s0 = servers[0].server_id
     not_s0 = servers[1:]
@@ -88,9 +89,12 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
 
 @pytest.mark.asyncio
 async def test_scans(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
+
     cql = manager.get_cql()
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                        "'replication_factor': 1, 'initial_tablets': 8};")
+                  "'replication_factor': 1, 'initial_tablets': 8};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     keys = range(100)

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -354,6 +354,7 @@ mutation_opt read_schema_table_mutation(sharded<sstable_manager_service>& sst_ma
     sst_dirs.start(
         sharded_parameter([&sst_man] { return std::ref(sst_man.local().sst_man); }),
         sharded_parameter([&schema_factory] { return schema_factory(); }),
+        sharded_parameter([&] { return std::ref(schema_factory()->get_sharder()); }),
         sharded_parameter([] { return make_lw_shared<const data_dictionary::storage_options>(); }),
         schema_table_data_path,
         sharded_parameter([] { return default_io_error_handler_gen(); })).get();

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -251,7 +251,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         data_dictionary::storage_options local;
         auto sst = sst_man.make_sstable(schema, local, dir_path.c_str(), ed.generation, ed.version, ed.format);
 
-        co_await sst->load(sstables::sstable_open_config{.load_first_and_last_position_metadata = false});
+        co_await sst->load(schema->get_sharder(), sstables::sstable_open_config{.load_first_and_last_position_metadata = false});
 
         sstables[i] = std::move(sst);
     }).get();

--- a/utils/throttle.hh
+++ b/utils/throttle.hh
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <optional>
+
+namespace utils {
+
+using namespace seastar;
+
+/// Synchronizes two processes (primary and secondary) in a way such that the primary process can know
+/// that between block().get() and unblock() the secondary process is at a particular execution point, blocked in enter().
+///
+/// The primary calls block() to arm the throttle. The returned future resolves when the secondary calls enter().
+/// enter() will return a future to the secondary which will resolve when the primary calls unblock().
+class throttle {
+    unsigned _block_counter = 0;
+    promise<> _p; // valid when _block_counter != 0, resolves when goes down to 0
+    std::optional<promise<>> _entered;
+    bool _one_shot;
+public:
+    // one_shot means whether only the first enter() after block() will block.
+    throttle(bool one_shot = false) : _one_shot(one_shot) {}
+    future<> enter() {
+        if (_block_counter && (!_one_shot || _entered)) {
+            promise<> p1;
+            promise<> p2;
+
+            auto f1 = p1.get_future();
+
+            // Intentional, the future is waited on indirectly.
+            (void)p2.get_future().then([p1 = std::move(p1), p3 = std::move(_p)] () mutable {
+                p1.set_value();
+                p3.set_value();
+            });
+            _p = std::move(p2);
+            if (_entered) {
+                _entered->set_value();
+                _entered.reset();
+            }
+            return f1;
+        } else {
+            return make_ready_future<>();
+        }
+    }
+
+    future<> block() {
+        ++_block_counter;
+        _p = promise<>();
+        _entered = promise<>();
+        return _entered->get_future();
+    }
+
+    void unblock() {
+        assert(_block_counter);
+        if (--_block_counter == 0) {
+            _p.set_value();
+        }
+    }
+};
+
+} // namespace utils


### PR DESCRIPTION
This PR changes the system to respect shard assignment to tablets in tablet metadata (system.tablets):
1. The tablet allocator is changed to distribute tablets evenly across shards taking into account currently allocated tablets in the system. Each tablet has equal weight. vnode load is ignored.
2. CDC subsystem was not adjusted (not supported yet)
3. sstable sharding metadata reflects tablet boundaries
5. resharding is NOT supported yet (the node will abort on boot if there is a need to reshard tablet-based tables)
6. The system is NOT prepared to handle tablet migration / topology changes in a safe way.
7. Sstable cleanup is not wired properly yet

After this PR, dht::shard_of() and schema::get_sharder() are deprecated. One should use table::shard_of() and effective_replication_map::get_sharder() instead.

To make the life easier, support was added to obtain table pointer from the schema pointer:

```
schema_ptr s;
s->table().shard_of(...)
```
