### PR TITLE
exceptions: remove relation field from unrecognized_entity_exception

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1202,7 +1202,7 @@ static const column_value resolve_column(const unresolved_identifier& col_ident,
     ::shared_ptr<column_identifier> id = col_ident.ident->prepare_column_identifier(schema);
     const column_definition* def = get_column_definition(schema, *id);
     if (!def || def->is_hidden_from_cql()) {
-        throw exceptions::unrecognized_entity_exception(*id, fmt::format("{}", col_ident));
+        throw exceptions::unrecognized_entity_exception(*id);
     }
     return column_value(def);
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1800,7 +1800,7 @@ select_statement::prepare_restrictions(data_dictionary::database db,
             selection->contains_only_static_columns(), for_view, allow_filtering);
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {
-            throw exceptions::invalid_request_exception(format("Aliases aren't allowed in the where clause ('{}')", e.relation_str));
+            throw exceptions::invalid_request_exception(format("Aliases aren't allowed in the WHERE clause (name: '{}')", e.entity));
         }
         throw;
     }

--- a/exceptions/unrecognized_entity_exception.hh
+++ b/exceptions/unrecognized_entity_exception.hh
@@ -17,7 +17,7 @@
 namespace exceptions {
 
 /**
- * Exception thrown when an entity is not recognized within a relation.
+ * Exception thrown when an entity is not recognized.
  */
 class unrecognized_entity_exception : public invalid_request_exception {
 public:
@@ -27,19 +27,12 @@ public:
     cql3::column_identifier entity;
 
     /**
-     * The entity relation in a stringified form.
-     */
-    sstring relation_str;
-
-    /**
      * Creates a new <code>UnrecognizedEntityException</code>.
      * @param entity the unrecognized entity
-     * @param relation_str the entity relation string
      */
-    unrecognized_entity_exception(cql3::column_identifier entity, sstring relation_str)
-        : invalid_request_exception(format("Undefined name {} in where clause ('{}')", entity, relation_str))
+    unrecognized_entity_exception(cql3::column_identifier entity)
+        : invalid_request_exception(format("Unrecognized name {}", entity))
         , entity(std::move(entity))
-        , relation_str(std::move(relation_str))
     { }
 };
 


### PR DESCRIPTION
The exception unrecognized_entity_exception used to have two fields:
* entity - the name that wasn't recognized
* relation_str - part of the WHERE clause that contained this entity

In 4e0a089f3ef34dda01cab5c46eca586f44b50e8c the places that throw this exception were modified, the thrower started passing unrecognized column name to both fields - entity and relation_str. It was easier to do things this way, accessing the whole WHERE clause can be problematic.

The problem is that this caused error messages to get weird, e.g: `"Undefined name x in where clause ('x')"`.
x is not the WHERE clause, it's the unrecognized name.

Let's remove the `relation_str` field as it isn't used anymore, it only causes confusion. After this change the message would be: `"Unrecognized name x"`
Which makes much more sense.

Refs #10632