### PR TITLE
test/topology: run first slow topology tests

### DIFF
--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -6,3 +6,8 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
     experimental_features: [tablets]
+run_first:
+    - test_topology_ip
+    - test_topology_remove_decom
+    - test_mutation_schema_change
+    - test_tablets


### PR DESCRIPTION
To speed up total test suite run, change configuration to schedule slow
topology tests first.