### PR TITLE
sstables: storage: s/atomic_deleter/atomic_delete/

### DIFF
--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -166,8 +166,8 @@ future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
     // in the same storage so it's OK to get the deleter from the
     // front element. The deleter implementation is welcome to check
     // that sstables from the vector really live in it.
-    auto deleter = ssts.front()->get_storage().atomic_deleter();
-    co_await deleter(std::move(ssts));
+    auto first_sstable = ssts.front();
+    co_await first_sstable->get_storage().atomic_delete(std::move(ssts));
 }
 
 future<> sstables_manager::close() {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -66,8 +66,8 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) override;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
-        return sstable_directory::delete_with_pending_deletion_log;
+    virtual future<> atomic_delete(std::vector<shared_sstable> sstables) const override {
+        return sstable_directory::delete_with_pending_deletion_log(std::move(sstables));
     }
 
     virtual sstring prefix() const override { return dir; }
@@ -450,8 +450,8 @@ public:
     virtual future<> destroy(const sstable& sst) override {
         return make_ready_future<>();
     }
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
-        return delete_with_system_keyspace;
+    virtual future<> atomic_delete(std::vector<shared_sstable> sstables) const override {
+        return delete_with_system_keyspace(std::move(sstables));
     }
 
     virtual sstring prefix() const override { return _location; }

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -59,7 +59,7 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type, io_priority_class pc) = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
+    virtual future<> atomic_delete(std::vector<shared_sstable>) const = 0;
 
     virtual sstring prefix() const  = 0;
 };


### PR DESCRIPTION
instead of returning a functor, let's just execute it. for better readability.

before this change, `atomic_deleter()` returns a functor which deletes the SSTable in batch, but this functor actually consumes the vector of SSTable which contains the instance which holds the the storage which in turn provides the function deleting the SSTables. in theory, a plain call like

ssts.front()->get_storage().atomic_delete(std::move(ssts))

does not necessarily work, as C++ evalutes the expression in the order of (in a coarse grained manner):
1. ssts.front()
2. shared_ptr::operator->()
3. SSTable::get_storage()
4. std::move(ssts)
5. storage.atomic_delete()

so, when we call the member function of `atomic_delete()` of the derived class of storage, its owner shared_ptr is moved away already as an element of the vector passed to this function. we cannot assume the availability of the storage instance during calling the hypothetical `atomic_delete()`. as it could destroy the owner shared_ptr at anytime.

but the pattern of deleter is a little bit obscure. so in this change, we just replace it with a plain function all. and extend the lifecyle of the first element with a copy of the shared_ptr.