### PR TITLE
test: do not declare a global variable for read

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -204,8 +204,6 @@ def find_scylla():
 def run_scylla_cmd(pid, dir):
     ip = pid_to_ip(pid)
     print('Booting Scylla on ' + ip + ' in ' + dir + '...')
-    global scylla
-    global source_path
     # To make things easier for users of "killall", "top", and similar,
     # we want the Scylla executable which we run during the test to have
     # a different name from manual runs of Scylla. Unfortunately, using


### PR DESCRIPTION
we only need to declare a variable with `global` when we need to write to it, but if we just want to read it, there is no need to declare it. because the way how python looks up for a variable when reading from it enables python to find the global variables (and apparently the functions!). but when we assign a variable in python, the interpreter would have to tell in which scope the variable lives. by default the local scope is used, and a new variable is added to `locals()`.

but in this case, we just read from it. so no need to add the `global` statement.

see also
https://docs.python.org/3/reference/simple_stmts.html#global