### PR TITLE
raft topology: send cdc generation data in parts

### DIFF
--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -27,8 +27,12 @@ struct topology_change {
     std::vector<canonical_mutation> mutations;
 };
 
+struct write_mutations {
+    std::vector<canonical_mutation> mutations;
+};
+
 struct group0_command {
-    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change> change;
+    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change, service::write_mutations> change;
     canonical_mutation history_append;
 
     std::optional<utils::UUID> prev_state_id;

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -31,7 +31,7 @@ struct raft_topology_cmd_result {
 
 struct raft_topology_snapshot {
     std::vector<canonical_mutation> topology_mutations;
-    std::optional<canonical_mutation> cdc_generation_mutation;
+    std::vector<canonical_mutation> cdc_generation_mutations;
 };
 
 struct raft_topology_pull_params {};

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -98,6 +98,7 @@ public:
     future<> modify_config(std::vector<config_member> add, std::vector<server_id> del, seastar::abort_source* as = nullptr) override;
     future<entry_id> add_entry_on_leader(command command, seastar::abort_source* as);
     void register_metrics() override;
+    size_t max_command_size() const override;
 private:
     std::unique_ptr<rpc> _rpc;
     std::unique_ptr<state_machine> _state_machine;
@@ -1684,6 +1685,10 @@ future<> server_impl::stepdown(logical_clock::duration timeout) {
     }
     _stepdown_promise = promise<>();
     return _stepdown_promise->get_future();
+}
+
+size_t server_impl::max_command_size() const {
+    return _config.max_command_size;
 }
 
 std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -246,6 +246,8 @@ public:
     // Server id of this server
     virtual raft::server_id id() const = 0;
     virtual void set_applier_queue_max_size(size_t queue_max_size) = 0;
+
+    virtual size_t max_command_size() const = 0;
 };
 
 std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -28,7 +28,7 @@ bool is_broadcast_table_statement(const sstring& keyspace, const sstring& column
 }
 
 future<query_result> execute(service::raft_group0_client& group0_client, const query& query) {
-    auto group0_cmd = group0_client.prepare_command(broadcast_table_query{query});
+    auto group0_cmd = group0_client.prepare_command(broadcast_table_query{query}, "broadcast_tables query");
     auto guard = group0_client.create_result_guard(group0_cmd.new_state_id);
     co_await group0_client.add_entry_unguarded(std::move(group0_cmd));
     co_return guard.get();

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -91,7 +91,8 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
         merger(group0_state_machine& sm_, utils::UUID id, semaphore_units<> mux) : last_group0_state_id(id)
             , sm(sm_)
             , read_apply_mutex_holder(std::move(mux))
-            , max_command_size(sm._sp.data_dictionary().get_config().commitlog_segment_size_in_mb() * 1024 * 1024 / 2) {}
+            // max_mutation_size = 1/2 of commitlog segment size, thus max_command_size is set 1/3 of commitlog segment size to leave space for metadata.
+            , max_command_size(sm._sp.data_dictionary().get_config().commitlog_segment_size_in_mb() * 1024 * 1024 / 3) {}
 
         size_t cmd_size(group0_command& cmd) {
             if (holds_alternative<broadcast_table_query>(cmd.change)) {

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -121,7 +121,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
         void add(group0_command&& cmd, size_t added_size) {
             slogger.trace("add to merging set new_state_id: {}", cmd.new_state_id);
             auto m = convert_history_mutation(std::move(cmd.history_append), sm._sp.data_dictionary());
-            last_group0_state_id = cmd.new_state_id;
+            last_group0_state_id = std::max(last_group0_state_id, cmd.new_state_id);
             cmd_to_merge.push_back(std::move(cmd));
             size += added_size;
             if (merged_history_mutation) {

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -37,8 +37,14 @@ struct topology_change {
     std::vector<canonical_mutation> mutations;
 };
 
+// This command is used to write data to tables other than topology or
+// schema tables and it doesn't update any in-memory data structures.
+struct write_mutations {
+    std::vector<canonical_mutation> mutations;
+};
+
 struct group0_command {
-    std::variant<schema_change, broadcast_table_query, topology_change> change;
+    std::variant<schema_change, broadcast_table_query, topology_change, write_mutations> change;
 
     // Mutation of group0 history table, appending a new state ID and optionally a description.
     canonical_mutation history_append;

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -308,13 +308,13 @@ group0_command raft_group0_client::prepare_command(Command change, group0_guard&
 
 template<typename Command>
 requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
-group0_command raft_group0_client::prepare_command(Command change) {
+group0_command raft_group0_client::prepare_command(Command change, std::string_view description) {
     const auto new_group0_state_id = generate_group0_state_id(utils::UUID{});
 
     group0_command group0_cmd {
         .change{std::move(change)},
         .history_append{db::system_keyspace::make_group0_history_state_id_mutation(
-            new_group0_state_id, _history_gc_duration, "")},
+            new_group0_state_id, _history_gc_duration, description)},
 
         .prev_state_id{std::nullopt},
         .new_state_id{new_group0_state_id},
@@ -466,7 +466,7 @@ void raft_group0_client::set_query_result(utils::UUID query_id, service::broadca
 
 template group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(topology_change change, group0_guard& guard, std::string_view description);
-template group0_command raft_group0_client::prepare_command(broadcast_table_query change);
-template group0_command raft_group0_client::prepare_command(write_mutations change);
+template group0_command raft_group0_client::prepare_command(broadcast_table_query change, std::string_view description);
+template group0_command raft_group0_client::prepare_command(write_mutations change, std::string_view description);
 
 }

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -19,6 +19,7 @@
 #include "idl/experimental/broadcast_tables_lang.dist.impl.hh"
 #include "idl/group0_state_machine.dist.hh"
 #include "idl/group0_state_machine.dist.impl.hh"
+#include "service/raft/group0_state_machine.hh"
 
 
 namespace service {
@@ -305,11 +306,13 @@ group0_command raft_group0_client::prepare_command(Command change, group0_guard&
     return group0_cmd;
 }
 
-group0_command raft_group0_client::prepare_command(broadcast_table_query query) {
+template<typename Command>
+requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
+group0_command raft_group0_client::prepare_command(Command change) {
     const auto new_group0_state_id = generate_group0_state_id(utils::UUID{});
 
     group0_command group0_cmd {
-        .change{std::move(query)},
+        .change{std::move(change)},
         .history_append{db::system_keyspace::make_group0_history_state_id_mutation(
             new_group0_state_id, _history_gc_duration, "")},
 
@@ -463,5 +466,7 @@ void raft_group0_client::set_query_result(utils::UUID query_id, service::broadca
 
 template group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(topology_change change, group0_guard& guard, std::string_view description);
+template group0_command raft_group0_client::prepare_command(broadcast_table_query change);
+template group0_command raft_group0_client::prepare_command(write_mutations change);
 
 }

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -142,6 +142,7 @@ bool group0_guard::with_raft() const {
     return _impl->_raft_enabled;
 }
 
+void release_guard(group0_guard guard) {}
 
 void raft_group0_client::set_history_gc_duration(gc_clock::duration d) {
     _history_gc_duration = d;

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -127,7 +127,9 @@ public:
     // and add_entry would again forward to shard 0.
     future<group0_guard> start_operation(seastar::abort_source* as = nullptr);
 
-    group0_command prepare_command(broadcast_table_query query);
+    template<typename Command>
+    requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
+    group0_command prepare_command(Command change);
     template<typename Command>
     requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change>
     group0_command prepare_command(Command change, group0_guard& guard, std::string_view description);

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -55,6 +55,8 @@ public:
     bool with_raft() const;
 };
 
+void release_guard(group0_guard guard);
+
 class group0_concurrent_modification : public std::runtime_error {
 public:
     group0_concurrent_modification()

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -129,7 +129,7 @@ public:
 
     template<typename Command>
     requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
-    group0_command prepare_command(Command change);
+    group0_command prepare_command(Command change, std::string_view description);
     template<typename Command>
     requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change>
     group0_command prepare_command(Command change, group0_guard& guard, std::string_view description);

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -34,7 +34,8 @@ raft_sys_table_storage::raft_sys_table_storage(cql3::query_processor& qp, raft::
     , _qp(qp)
     , _dummy_query_state(service::client_state::for_internal_calls(), empty_service_permit())
     , _pending_op_fut(make_ready_future<>())
-    , _max_mutation_size(_qp.db().get_config().commitlog_segment_size_in_mb() * 1024 * 1204 / 2)
+    // max_mutation_size = 1/2 of commitlog segment size, thus _max_mutation_size is set 1/3 of commitlog segment size to leave space for metadata.
+    , _max_mutation_size(_qp.db().get_config().commitlog_segment_size_in_mb() * 1024 * 1024 / 3)
 {
     static const auto store_cql = format("INSERT INTO system.{} (group_id, term, \"index\", data) VALUES (?, ?, ?, ?)",
         db::system_keyspace::RAFT);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -467,16 +467,18 @@ future<> storage_service::topology_transition(cdc::generation_service& cdc_gen_s
 
 future<> storage_service::merge_topology_snapshot(raft_topology_snapshot snp) {
    std::vector<mutation> muts;
-   muts.reserve(snp.topology_mutations.size() + (snp.cdc_generation_mutation ? 1 : 0));
+   muts.reserve(snp.topology_mutations.size() + (snp.cdc_generation_mutations.size()));
    {
        auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
        boost::transform(snp.topology_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
            return m.to_mutation(s);
        });
    }
-   if (snp.cdc_generation_mutation) {
+   if (snp.cdc_generation_mutations.size() > 0) {
        auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
-       muts.push_back(snp.cdc_generation_mutation->to_mutation(s));
+       boost::transform(snp.cdc_generation_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
+           return m.to_mutation(s);
+       });
    }
    co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
@@ -5358,7 +5360,6 @@ void storage_service::init_messaging_service(sharded<service::storage_proxy>& pr
             auto& db = proxy.local().get_db();
 
             std::vector<canonical_mutation> topology_mutations;
-            std::optional<cdc::generation_id_v2> curr_cdc_gen_id;
             {
                 // FIXME: make it an rwlock, here we only need to lock for reads,
                 // might be useful if multiple nodes are trying to pull concurrently.
@@ -5371,41 +5372,33 @@ void storage_service::init_messaging_service(sharded<service::storage_proxy>& pr
                         rs->partitions(), std::back_inserter(topology_mutations), [s] (const partition& p) {
                     return canonical_mutation{p.mut().unfreeze(s)};
                 });
-
-                curr_cdc_gen_id = ss._topology_state_machine._topology.current_cdc_generation_id;
             }
 
-            std::optional<canonical_mutation> cdc_generation_mutation;
-            if (curr_cdc_gen_id) {
-                // We don't need to fetch this data under group0 apply mutex, it's immutable.
-                // We only need to include the current CDC generation data in the snapshot,
-                // because nodes only load whatever `current_cdc_generation_id` points to in topology.
-                //
+            std::vector<canonical_mutation> cdc_generation_mutations;
+            {
                 // FIXME: when we bootstrap nodes in quick succession, the timestamp of the newest CDC generation
-                // may be for some time larger than the clocks of our nodes. The last bootstrapped node
-                // will only receive the newest CDC generation and not earlier ones, so it will only be able
+                // may be for some time larger than the clocks of our nodes. The last bootstrapped node will only
+                // read the newest CDC generation into memory and not earlier ones, so it will only be able
                 // to coordinate writes to CDC-enabled tables after its clock advances to reach the newest
                 // generation's timestamp. In other words, it may not be able to coordinate writes for some
                 // time after bootstrapping and drivers connecting to it will receive errors.
                 // To fix that, we could store in topology a small history of recent CDC generation IDs
                 // (garbage-collected with time) instead of just the last one, and load all of them.
                 // Alternatively, a node would wait for some time before switching to normal state.
-                auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
-                auto key = dht::decorate_key(*s, partition_key::from_singular(*s, curr_cdc_gen_id->id));
-                auto partition_range = dht::partition_range::make_singular(key);
+                auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
                 auto rs = co_await db::system_keyspace::query_mutations(
-                    db, db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3, partition_range);
-                if (rs->partitions().size() != 1) {
-                    on_internal_error(slogger, ::format(
-                        "pull_raft_topology_snapshot: expected a single partition in CDC generation query,"
-                        ", got {} (generation ID: {})", rs->partitions().size(), *curr_cdc_gen_id));
-                }
-                cdc_generation_mutation.emplace(rs->partitions().begin()->mut().unfreeze(s));
+                    db, db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
+                auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
+                cdc_generation_mutations.reserve(rs->partitions().size());
+                boost::range::transform(
+                        rs->partitions(), std::back_inserter(cdc_generation_mutations), [s] (const partition& p) {
+                    return canonical_mutation{p.mut().unfreeze(s)};
+                });
             }
 
             co_return raft_topology_snapshot{
                 .topology_mutations = std::move(topology_mutations),
-                .cdc_generation_mutation = std::move(cdc_generation_mutation),
+                .cdc_generation_mutations = std::move(cdc_generation_mutations),
             };
         });
     });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1599,6 +1599,8 @@ future<> topology_coordinator::run() {
             }
         } catch (raft::request_aborted&) {
             slogger.debug("raft topology: topology change coordinator fiber aborted");
+        } catch (raft::commit_status_unknown&) {
+            slogger.warn("raft topology: topology change coordinator fiber got commit_status_unknown");
         } catch (group0_concurrent_modification&) {
         } catch (term_changed_error&) {
             // Term changed. We may no longer be a leader

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1048,7 +1048,8 @@ class topology_coordinator {
         // with many large mutations.
         // See `system_distributed_keyspace::insert_cdc_generation` for inspiration how it
         // was done when the mutations were stored in a regular distributed table.
-        const size_t mutation_size_threshold = 2'000'000;
+        const size_t max_command_size = _raft.max_command_size();
+        const size_t mutation_size_threshold = max_command_size / 2;
         auto gen_mutations = co_await cdc::get_cdc_generation_mutations(
             gen_table_schema, gen_uuid, gen_desc, mutation_size_threshold, guard.write_timestamp());
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -789,7 +789,8 @@ private:
 
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held
-    future<> topology_transition(storage_proxy& proxy, cdc::generation_service&, gms::inet_address, std::vector<canonical_mutation>);
+    // Precondition: the topology mutations were already written to disk; the function only transitions the in-memory state machine.
+    future<> topology_transition(cdc::generation_service&);
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load(cdc::generation_service&);

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -122,8 +122,8 @@ struct raft_topology_snapshot {
     // Mutations for the system.topology table.
     std::vector<canonical_mutation> topology_mutations;
 
-    // Mutation for system.cdc_generations_v3, contains the current CDC generation data.
-    std::optional<canonical_mutation> cdc_generation_mutation;
+    // Mutations for system.cdc_generations_v3, contains all the CDC generation data.
+    std::vector<canonical_mutation> cdc_generation_mutations;
 };
 
 struct raft_topology_pull_params {

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -39,9 +39,9 @@ SEASTAR_TEST_CASE(test_group0_cmd_merge) {
         std::vector<canonical_mutation> cms;
         size_t size = 0;
         auto muts = mm.prepare_keyspace_drop_announcement("ks", api::new_timestamp()).get0();
-        // Maximum mutation size is half of commitlog segment size wich we set
+        // Maximum mutation size is 1/3 of commitlog segment size wich we set
         // to 1M. Make one command a little bit larger than third of the max size.
-        while (size < 200*1024) {
+        while (size < 150*1024) {
             for (auto&& m : muts) {
                 cms.emplace_back(m);
                 size += cms.back().representation().size();

--- a/test/topology_experimental_raft/test_cdc_generation_data.py
+++ b/test/topology_experimental_raft/test_cdc_generation_data.py
@@ -1,0 +1,31 @@
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error
+from test.topology.util import check_token_ring_and_group0_consistency
+
+import pytest
+
+"""
+The injection forces the topology coordinator to send CDC generation data in multiple parts,
+if it didn't the command size would go over commitlog segment size limit making it impossible to commit and apply the command.
+"""
+@pytest.mark.asyncio
+async def test_send_data_in_parts(manager: ManagerClient):
+    config = {
+        'commitlog_segment_size_in_mb': 2
+    }
+
+    first_server = await manager.server_add(config=config)
+
+    async with inject_error(manager.api, first_server.ip_addr, 'cdc_generation_mutations_replication'):
+        await manager.server_add(config=config)
+
+    await check_token_ring_and_group0_consistency(manager)
+
+    cql = manager.get_cql()
+    rows = await cql.run_async("SELECT description FROM system.group0_history")
+
+    for row in rows:
+        if row.description.startswith('insert CDC generation data (UUID: ') and row.description.endswith('), part'):
+            break
+    else:
+        pytest.fail("No CDC generation data sent in parts was found")


### PR DESCRIPTION
The CDC generation data can be large and not fit in a single command. This pr splits it into multiple mutations by smartly picking a `mutation_size_threshold` and sending each mutation as a separate group 0 command.

Commands are sent sequentially to avoid concurrency problems. 

Topology snapshots contain only mutation of current CDC generation data but don't contain any previous or future generations. If a new generation of data is being broadcasted but hasn't been entirely applied yet, the applied part won't be sent in a snapshot. New or delayed nodes can never get the applied part in this scenario.

Send the entire cdc_generations_v3 table in the snapshot to resolve this problem.

A mechanism to remove old CDC generations will be introduced as a follow-up.

