### PR TITLE
db: config: Increase schema_registry_grace_period from 1s to 3min

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -904,8 +904,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , user_defined_function_time_limit_ms(this, "user_defined_function_time_limit_ms", value_status::Used, 10, "The time limit for each UDF invocation")
     , user_defined_function_allocation_limit_bytes(this, "user_defined_function_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate")
     , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
-    , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 1,
-        "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
+    , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 180,
+        "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 3 min.")
     , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
         "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
     , cdc_dont_rewrite_streams(this, "cdc_dont_rewrite_streams", value_status::Used, false,


### PR DESCRIPTION
If we have a situation when two nodes use different versions for the current table schema, the cluster can enter a degraded state when replica-side coordinator will keep requesting the definition of the unknown table schema version synchronously with the request. This will add latency to such requests as they need to wait until the schema pull is complete. Schema pulls are known to be heavy in some cases, and can take seconds to complete.

To reduce impact of such condition on the cluster health, we can increase the amount of time for which temporary schema versions are kept around and this reduce the rate of schema pulls.

There is a tradeoff to be made here. The higher the grace period, the more memory will be used to keep older versions. But it will also increase the likelihood of a hit in the schema registry. The period of 1s proved to be too short in practice.

Refs #4485