### PR TITLE
counters: specialize fmt::formatter<counter_{shard,cell}_view>

### DIFF
--- a/counters.cc
+++ b/counters.cc
@@ -12,15 +12,16 @@
 
 #include <boost/range/algorithm/sort.hpp>
 
-std::ostream& operator<<(std::ostream& os, counter_shard_view csv) {
-    fmt::print(os, "{{global_shard id: {} value: {}, clock: {}}}",
-               csv.id(), csv.value(), csv.logical_clock());
-    return os;
+auto fmt::formatter<counter_shard_view>::format(const counter_shard_view& csv,
+                                                fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{global_shard id: {} value: {}, clock: {}}}",
+                          csv.id(), csv.value(), csv.logical_clock());
 }
 
-std::ostream& operator<<(std::ostream& os, counter_cell_view ccv) {
-    fmt::print(os, "{{counter_cell timestamp: {} shards: {{{}}}}}", ccv.timestamp(), fmt::join(ccv.shards(), ", "));
-    return os;
+auto fmt::formatter<counter_cell_view>::format(const counter_cell_view& ccv,
+                                               fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{counter_cell timestamp: {} shards: {{{}}}}}",
+                          ccv.timestamp(), fmt::join(ccv.shards(), ", "));
 }
 
 void counter_cell_builder::do_sort_and_remove_duplicates()

--- a/counters.hh
+++ b/counters.hh
@@ -88,7 +88,10 @@ public:
 
 using counter_shard_view = basic_counter_shard_view<mutable_view::no>;
 
-std::ostream& operator<<(std::ostream& os, counter_shard_view csv);
+template <>
+struct fmt::formatter<counter_shard_view> : fmt::formatter<std::string_view> {
+    auto format(const counter_shard_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 class counter_shard {
     counter_id _id;
@@ -346,9 +349,13 @@ struct counter_cell_view : basic_counter_cell_view<mutable_view::no> {
     // Computes a counter cell containing minimal amount of data which, when
     // applied to 'b' returns the same cell as 'a' and 'b' applied together.
     static std::optional<atomic_cell> difference(atomic_cell_view a, atomic_cell_view b);
-
-    friend std::ostream& operator<<(std::ostream& os, counter_cell_view ccv);
 };
+
+template <>
+struct fmt::formatter<counter_cell_view> : fmt::formatter<std::string_view> {
+    auto format(const counter_cell_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+extern template struct fmt::formatter<counter_cell_view>;
 
 struct counter_cell_mutable_view : basic_counter_cell_view<mutable_view::yes> {
     using basic_counter_cell_view::basic_counter_cell_view;

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -23,6 +23,16 @@
 #include "mutation/frozen_mutation.hh"
 #include "mutation/mutation_partition_view.hh"
 
+std::ostream& boost_test_print_type(std::ostream& os, const counter_shard_view& csv) {
+    fmt::print(os, "{}", csv);
+    return os;
+}
+
+std::ostream& boost_test_print_type(std::ostream& os, const counter_cell_view& ccv) {
+    fmt::print(os, "{}", ccv);
+    return os;
+}
+
 void verify_shard_order(counter_cell_view ccv) {
     if (ccv.shards().begin() == ccv.shards().end()) {
         return;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2270,7 +2270,7 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
                     auto acv = ac_o_c.as_atomic_cell(s->regular_column_at(id));
                     counter_cell_view ccv(acv);
                     counter_shard_view::less_compare_by_id cmp;
-                    BOOST_REQUIRE_MESSAGE(boost::algorithm::is_sorted(ccv.shards(), cmp), ccv << " is expected to be sorted");
+                    BOOST_REQUIRE_MESSAGE(boost::algorithm::is_sorted(ccv.shards(), cmp), fmt::format("{} is expected to be sorted", ccv));
                     BOOST_REQUIRE_EQUAL(ccv.total_value(), expected_value);
                     n++;
                 });


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)`
based formatting to fmtlib based formatting. the goal here is to enable
fmtlib to print `counter_shard_view` and `counter_cell_view` without the
help of `operator<<`.

the corresponding `operator<<()` is removed in this change, as all its
callers are now using fmtlib for formatting now.

please note, to reduce the size of the header file, unlike existing
fmt::formatter specializations, this time, instead of defining a
template function for `template<typename FormatContext>
auto format(const Type&, FormatContext&) const`, we just define a specialization
of it, namely
```
auto format(const Type&, fmt::format_context& ctx) const -> decltype(ctx.out())
```
this should reduce the size of header file, and hence shorten the
compilation time a little bit. the downside of this approach is
just we won't be able to format the customize type with {fmt} with
customized FormatContext. please note, in our use case, we don't
have such a use case -- under most of the circumstances, we use
the core function of
`fmt::format_to(OutputIt, format_string<T...>, T&&... args)` directly
or undirectly for printing, which in turn prints the args to
`fmt::buffer_context<Char>`, where `Char` is always `char`. and
{fmt} has an alias for it, namely `fmt::format_context`.

that's why we can define this specific case and it should cover
our needs without sacrificing the flexibility or functionality.

Refs #13245