### PR TITLE
Deregister table's metrics when disposing a table

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1031,9 +1031,10 @@ bool database::update_column_family(schema_ptr new_schema) {
     return columns_changed;
 }
 
-void database::remove(const table& cf) noexcept {
+void database::remove(table& cf) noexcept {
     auto s = cf.schema();
     auto& ks = find_keyspace(s->ks_name());
+    cf.deregister_metrics();
     _column_families.erase(s->id());
     ks.metadata()->remove_column_family(s);
     _ks_cf_to_uuid.erase(std::make_pair(s->ks_name(), s->cf_name()));

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -496,6 +496,8 @@ private:
     sstables::shared_sstable make_sstable(sstring dir);
 
 public:
+    void deregister_metrics();
+
     data_dictionary::table as_data_dictionary() const;
 
     future<> add_sstable_and_update_cache(sstables::shared_sstable sst,
@@ -1438,7 +1440,7 @@ private:
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, bool is_bootstrap, system_keyspace system);
-    void remove(const table&) noexcept;
+    void remove(table&) noexcept;
 public:
     static table_schema_version empty_version;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1021,6 +1021,11 @@ void table::set_metrics() {
     }
 }
 
+void table::deregister_metrics() {
+    _metrics.clear();
+    _view_stats._metrics.clear();
+}
+
 size_t compaction_group::live_sstable_count() const noexcept {
     return _main_sstables->size() + _maintenance_sstables->size();
 }

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -111,6 +111,7 @@ struct write_stats {
     uint64_t cas_coordinator_dropped_prune = 0;
     uint64_t cas_replica_dropped_prune = 0;
 
+    seastar::metrics::metric_groups _metrics;
 
     std::chrono::microseconds last_mv_flow_control_delay; // delay added for MV flow control in the last request
 public:
@@ -119,8 +120,6 @@ public:
 
     void register_stats();
     void register_split_metrics_local();
-protected:
-    seastar::metrics::metric_groups _metrics;
 };
 
 struct stats : public write_stats {


### PR DESCRIPTION
The metrics that are being deregistered (in this PR) cause Scylla to crash when a
table is dropped, but the corresponding table object in memory is not
yet deallocated, and a new table with the same name is created. This
caused a double-metrics-registration exception to be thrown. In order to
avoid it, we are deregistering table's metrics as soon as the table is
marked to be disposed from the database. Table's representation in memory can
still live, but shouldn't forbid other table with the same name to be
created.

Fixes https://github.com/scylladb/scylladb/issues/13548