### PR TITLE
scripts/refresh-submodules.sh: use the correct sha1 in title

### DIFF
--- a/scripts/refresh-submodules.sh
+++ b/scripts/refresh-submodules.sh
@@ -36,7 +36,7 @@ for ent in "${@:-${submodules[@]}}"; do
     fi
     # collect the summary
     head_ref=$(git rev-parse --short=8 HEAD)
-    branch_ref=$(git rev-parse --short=8 ${branch})
+    branch_ref=$(git rev-parse --short=8 origin/${branch})
     count=$(git rev-list --no-merges --count HEAD..${bump_to})
     # create a summary using the output format of "git submodule summary"
     SUMMARY="


### PR DESCRIPTION
0d4ffe1d69d70848446129d47570808d618112d7 introduced a regression where it used the sha1 of the local "master" branch instead of the remote's "master" branch in the title of the commit message.

in this change, let's use the origin/${branch}'s sha1 in the title.