### PR TITLE
raft: specialize fmt::formatter<raft::server_address&> and friends

### DIFF
--- a/raft/raft.cc
+++ b/raft/raft.cc
@@ -6,25 +6,28 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #include "raft.hh"
-#include "utils/to_string.hh"
+#include <fmt/ranges.h>
 
 namespace raft {
 
 seastar::logger logger("raft");
 
-std::ostream& operator<<(std::ostream& os, const raft::server_address& addr) {
-    return os << format("{{.id={}}}", addr.id);
-}
-
-std::ostream& operator<<(std::ostream& os, const raft::config_member& s) {
-    return os << format("{{.id={} .can_vote={}}}", s.addr.id, s.can_vote);
-}
-
-std::ostream& operator<<(std::ostream& os, const raft::configuration& cfg) {
-    if (cfg.previous.empty()) {
-        return os << cfg.current;
-    }
-    return os << format("{}->{}", cfg.previous, cfg.current);
-}
-
 } // end of namespace raft
+
+auto fmt::formatter<raft::server_address>::format(const raft::server_address& addr,
+                                                fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{.id={}}}", addr.id);
+}
+
+auto fmt::formatter<raft::config_member>::format(const raft::config_member& s,
+                                                fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{.id={} .can_vote={}}}", s.addr.id, s.can_vote);
+}
+
+auto fmt::formatter<raft::configuration>::format(const raft::configuration& cfg,
+                                                fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    if (cfg.previous.empty()) {
+        return fmt::format_to(ctx.out(), "{}", cfg.current);
+    }
+    return fmt::format_to(ctx.out(), "{}->{}", cfg.previous, cfg.current);
+}

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -74,8 +74,6 @@ struct server_address {
     bool operator<(const server_address& rhs) const {
         return id < rhs.id;
     }
-
-    friend std::ostream& operator<<(std::ostream&, const server_address&);
 };
 
 struct config_member {
@@ -97,8 +95,6 @@ struct config_member {
     bool operator<(const config_member& rhs) const {
         return addr < rhs.addr;
     }
-
-    friend std::ostream& operator<<(std::ostream&, const config_member&);
 };
 
 struct server_address_hash {
@@ -236,8 +232,6 @@ struct configuration {
         assert(is_joint());
         previous.clear();
     }
-
-    friend std::ostream& operator<<(std::ostream&, const configuration&);
 };
 
 struct log_entry {
@@ -801,3 +795,17 @@ public:
 
 } // namespace raft
 
+template <>
+struct fmt::formatter<raft::server_address> : fmt::formatter<std::string_view> {
+    auto format(const raft::server_address&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<raft::config_member> : fmt::formatter<std::string_view> {
+    auto format(const raft::config_member&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<raft::configuration> : fmt::formatter<std::string_view> {
+    auto format(const raft::configuration&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print

- raft::server_address
- raft::config_member
- raft::configuration

without the help of `operator<<`.

the corresponding `operator<<()` is removed in this change, as all its callers are now using fmtlib for formatting now.

Refs #13245