### PR TITLE
doc: publish the docs for branch-5.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,11 +15,11 @@ sys.path.insert(0, os.path.abspath(".."))
 BASE_URL = 'https://docs.scylladb.com'
 # Build documentation for the following tags and branches.
 TAGS = []
-BRANCHES = ["master", "branch-5.1", "branch-5.2"]
+BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.3"]
 # Set the latest version.
 LATEST_VERSION = "branch-5.2"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master"]
+UNSTABLE_VERSIONS = ["master", "branch-5.3"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13969

This commit enables publishing the docs for branch-5.3. The documentation for version 5.3 will be marked as unstable until it is released and an appropriate warning is in place.