### PR TITLE
create-relocatable-package.py: raise if rmtree fails

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -123,7 +123,10 @@ gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.P
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
 # relocatable package format version = 3.0
-shutil.rmtree(f'build/{SCYLLA_DIR}', ignore_errors=True)
+try:
+    shutil.rmtree(f'build/{SCYLLA_DIR}')
+except FileNotFoundError:
+    pass
 os.makedirs(f'build/{SCYLLA_DIR}')
 with open(f'build/{SCYLLA_DIR}/.relocatable_package_version', 'w') as f:
     f.write('3.0\n')


### PR DESCRIPTION
occasionally, we are observing build failures like:
```
17:20:54  FAILED: build/release/dist/tar/scylla-debuginfo-5.4.0~dev-0.20230522.5b2687e11800.x86_64.tar.gz
17:20:54  dist/debuginfo/scripts/create-relocatable-package.py --mode release 'build/release/dist/tar/scylla-debuginfo-5.4.0~dev-0.20230522.5b2687e11800.x86_64.tar.gz'
17:20:54  Traceback (most recent call last):
17:20:54    File "/jenkins/workspace/scylla-master/scylla-ci/scylla/dist/debuginfo/scripts/create-relocatable-package.py", line 60, in <module>
17:20:54      os.makedirs(f'build/{SCYLLA_DIR}')
17:20:54    File "<frozen os>", line 225, in makedirs
17:20:54  FileExistsError: [Errno 17] File exists: 'build/scylla-debuginfo-package'
```

to understand the root cause better, instead of swallowing the error, let's raise the exception it is not caused by non-existing directory.