### PR TITLE
Use implicit default prio class in tests

### DIFF
--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -266,7 +266,7 @@ public:
         return make_flat_reader(s, std::move(permit), range, full_slice);
     }
 
-    flat_mutation_reader_v2 make_flush_reader(schema_ptr, reader_permit permit, const io_priority_class& pc);
+    flat_mutation_reader_v2 make_flush_reader(schema_ptr, reader_permit permit, const io_priority_class& pc = default_priority_class());
 
     mutation_source as_data_source();
 

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -293,7 +293,7 @@ SEASTAR_TEST_CASE(test_unspooled_dirty_accounting_on_flush) {
         std::vector<size_t> unspooled_dirty_values;
         unspooled_dirty_values.push_back(mgr.unspooled_dirty_memory());
 
-        auto flush_reader_check = assert_that(mt->make_flush_reader(s, semaphore.make_permit(), service::get_local_priority_manager().memtable_flush_priority()));
+        auto flush_reader_check = assert_that(mt->make_flush_reader(s, semaphore.make_permit()));
         flush_reader_check.produces_partition(current_ring[0]);
         unspooled_dirty_values.push_back(mgr.unspooled_dirty_memory());
         flush_reader_check.produces_partition(current_ring[1]);
@@ -412,7 +412,7 @@ SEASTAR_TEST_CASE(test_segment_migration_during_flush) {
             mt->apply(m);
         }
 
-        auto rd = mt->make_flush_reader(s, semaphore.make_permit(), service::get_local_priority_manager().memtable_flush_priority());
+        auto rd = mt->make_flush_reader(s, semaphore.make_permit());
         auto close_rd = deferred_close(rd);
 
         for (int i = 0; i < partitions; ++i) {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -159,7 +159,7 @@ SEASTAR_TEST_CASE(test_memtable_flush_reader) {
                 testlog.info("Simple read");
                 auto mt = make_memtable(mgr, tbl_stats, muts);
 
-                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit(), default_priority_class()))
+                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit()))
                     .produces_compacted(compacted_muts[0], now)
                     .produces_compacted(compacted_muts[1], now)
                     .produces_compacted(compacted_muts[2], now)
@@ -168,7 +168,7 @@ SEASTAR_TEST_CASE(test_memtable_flush_reader) {
 
                 testlog.info("Read with next_partition() calls between partition");
                 mt = make_memtable(mgr, tbl_stats, muts);
-                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit(), default_priority_class()))
+                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit()))
                     .next_partition()
                     .produces_compacted(compacted_muts[0], now)
                     .next_partition()
@@ -182,7 +182,7 @@ SEASTAR_TEST_CASE(test_memtable_flush_reader) {
 
                 testlog.info("Read with next_partition() calls inside partitions");
                 mt = make_memtable(mgr, tbl_stats, muts);
-                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit(), default_priority_class()))
+                assert_that(mt->make_flush_reader(gen.schema(), semaphore.make_permit()))
                     .produces_compacted(compacted_muts[0], now)
                     .produces_partition_start(muts[1].decorated_key(), muts[1].partition().partition_tombstone())
                     .next_partition()
@@ -495,7 +495,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_flush_reads) {
             auto revert = defer([&] {
                 mt->revert_flushed_memory();
             });
-            assert_that(mt->make_flush_reader(s, semaphore.make_permit(), default_priority_class()))
+            assert_that(mt->make_flush_reader(s, semaphore.make_permit()))
                 .produces(ms);
         });
     });
@@ -555,7 +555,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_compaction_during_flush) {
 
     mt->apply(rt_m); // whatever
 
-    auto flush_rd = mt->make_flush_reader(ss.schema(), semaphore.make_permit(), default_priority_class());
+    auto flush_rd = mt->make_flush_reader(ss.schema(), semaphore.make_permit());
     auto close_flush_rd = defer([&] { flush_rd.close().get(); });
 
     while (!flush_rd.is_end_of_stream()) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2767,7 +2767,7 @@ SEASTAR_TEST_CASE(test_missing_partition_end_fragment) {
             sstable_writer_config cfg = env.manager().configure_writer();
 
             try {
-                auto wr = sst->get_writer(*s, 1, cfg, encoding_stats{}, default_priority_class());
+                auto wr = sst->get_writer(*s, 1, cfg, encoding_stats{});
                 mr.consume_in_thread(std::move(wr));
                 BOOST_FAIL("write_components() should have failed");
             } catch (const std::runtime_error&) {
@@ -2911,7 +2911,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 auto sst = env.make_sstable(sst_schema, version);
                 sstable_writer_config cfg = env.manager().configure_writer();
 
-                auto wr = sst->get_writer(*sst_schema, 1, cfg, encoding_stats{}, default_priority_class());
+                auto wr = sst->get_writer(*sst_schema, 1, cfg, encoding_stats{});
                 mr.consume_in_thread(std::move(wr));
 
                 sst->load().get();
@@ -2992,7 +2992,7 @@ SEASTAR_TEST_CASE(test_index_fast_forwarding_after_eof) {
 
             sstable_writer_config cfg = env.manager().configure_writer();
 
-            auto wr = sst->get_writer(*schema, 1, cfg, encoding_stats{}, default_priority_class());
+            auto wr = sst->get_writer(*schema, 1, cfg, encoding_stats{});
             mr.consume_in_thread(std::move(wr));
 
             sst->load().get();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2932,7 +2932,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     const auto size = std::min(sst->ondisk_data_size() / 2, uint64_t(1024));
                     auto buf = temporary_buffer<char>::aligned(sst_file.disk_write_dma_alignment(), size);
                     std::fill(buf.get_write(), buf.get_write() + size, 0xba);
-                    sst_file.dma_write(sst->ondisk_data_size() / 2, buf.begin(), buf.size(), default_priority_class()).get();
+                    sst_file.dma_write(sst->ondisk_data_size() / 2, buf.begin(), buf.size()).get();
                 }
 
                 valid = sstables::validate_checksums(sst, permit, default_priority_class()).get();

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -440,10 +440,8 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
         auto write_to_sstable = [&] (mutation m) {
             auto sst = t->make_streaming_staging_sstable();
             sstables::sstable_writer_config sst_cfg = e.db().local().get_user_sstables_manager().configure_writer("test");
-            auto& pc = service::get_local_streaming_priority();
-
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;
@@ -554,10 +552,8 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
 
         auto sst = t->make_streaming_staging_sstable();
         sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer("test");
-        auto& pc = service::get_local_streaming_priority();
-
         auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
+        sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
         sst->open_data().get();
         t->add_sstable_and_update_cache(sst).get();
 
@@ -628,10 +624,8 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
 
             auto sst = t->make_streaming_staging_sstable();
             sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer("test");
-            auto& pc = service::get_local_streaming_priority();
-
             auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout, {});
-            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}, pc).get();
+            sst->write_components(make_flat_mutation_reader_from_mutations_v2(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
             sst->open_data().get();
             t->add_sstable_and_update_cache(sst).get();
             return sst;


### PR DESCRIPTION
There are several places in tests that either use default_priority_class() explicitly, or use some specific prio class obtained from priority manager. There's currently an ongoing work to remove all priority classes, this set makes the final patch a bit smaller and easier to review. In particular -- in many cases default_priority_class() is implicit and can be avoided by callers. Also, using any prio class by test is excessive, it can go with (implicit) default_priority_class.

ref: #13963 