### PR TITLE
Clean index_reader API

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -752,6 +752,16 @@ private:
             b.current_list = {};
         });
     }
+
+    file_input_stream_options get_file_input_stream_options(const io_priority_class& pc) {
+        file_input_stream_options options;
+        options.buffer_size = _sstable->sstable_buffer_size;
+        options.read_ahead = 2;
+        options.io_priority_class = pc;
+        options.dynamic_adjustments = _sstable->_index_history;
+        return options;
+    }
+
 public:
     index_reader(shared_sstable sst, reader_permit permit, const io_priority_class& pc, tracing::trace_state_ptr trace_state,
                  use_caching caching, bool single_partition_read = false)
@@ -795,15 +805,6 @@ public:
     // The returned reference is LSA-managed so call with the region locked.
     index_entry& current_partition_entry() {
         return current_partition_entry(_lower_bound);
-    }
-
-    file_input_stream_options get_file_input_stream_options(const io_priority_class& pc) {
-        file_input_stream_options options;
-        options.buffer_size = _sstable->sstable_buffer_size;
-        options.read_ahead = 2;
-        options.io_priority_class = pc;
-        options.dynamic_adjustments = _sstable->_index_history;
-        return options;
     }
 
     // Returns a pointer to the clustered index cursor for the current partition

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -439,7 +439,7 @@ class index_reader {
     std::unique_ptr<index_consume_entry_context<index_consumer>> make_context(uint64_t begin, uint64_t end, index_consumer& consumer) {
         auto index_file = make_tracked_index_file(*_sstable, _permit, _trace_state, _use_caching);
         auto input = make_file_input_stream(index_file, begin, (_single_page_read ? end : _sstable->index_size()) - begin,
-                        get_file_input_stream_options(_pc));
+                        get_file_input_stream_options());
         auto trust_pi = trust_promoted_index(_sstable->has_correct_promoted_index_entries());
         auto ck_values_fixed_lengths = _sstable->get_version() >= sstable_version_types::mc
                             ? std::make_optional(get_clustering_values_fixed_lengths(_sstable->get_serialization_header()))
@@ -753,11 +753,11 @@ private:
         });
     }
 
-    file_input_stream_options get_file_input_stream_options(const io_priority_class& pc) {
+    file_input_stream_options get_file_input_stream_options() {
         file_input_stream_options options;
         options.buffer_size = _sstable->sstable_buffer_size;
         options.read_ahead = 2;
-        options.io_priority_class = pc;
+        options.io_priority_class = _pc;
         options.dynamic_adjustments = _sstable->_index_history;
         return options;
     }
@@ -821,7 +821,7 @@ public:
                 promoted_index* pi = e.get_promoted_index().get();
                 if (pi) {
                     bound.clustered_cursor = pi->make_cursor(_sstable, _permit, _trace_state,
-                        get_file_input_stream_options(_pc), _use_caching);
+                        get_file_input_stream_options(), _use_caching);
                 }
             });
             if (!bound.clustered_cursor) {

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -763,8 +763,11 @@ private:
     }
 
 public:
-    index_reader(shared_sstable sst, reader_permit permit, const io_priority_class& pc, tracing::trace_state_ptr trace_state,
-                 use_caching caching, bool single_partition_read = false)
+    index_reader(shared_sstable sst, reader_permit permit,
+                 const io_priority_class& pc = default_priority_class(),
+                 tracing::trace_state_ptr trace_state = {},
+                 use_caching caching = use_caching::yes,
+                 bool single_partition_read = false)
         : _sstable(std::move(sst))
         , _permit(std::move(permit))
         , _pc(pc)

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2784,7 +2784,7 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
     std::exception_ptr ex;
     auto sem = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::has_partition_key()");
     try {
-        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), s->get_filename(), db::no_timeout, {}), default_priority_class(), tracing::trace_state_ptr(), use_caching::yes);
+        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), s->get_filename(), db::no_timeout, {}));
         present = co_await lh_index_ptr->advance_lower_and_check_if_present(dk);
     } catch (...) {
         ex = std::current_exception();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -4586,8 +4586,7 @@ static sstring get_read_index_test_path(sstring table_name) {
 }
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+    return std::make_unique<index_reader>(sst, std::move(permit));
 }
 
 shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2309,8 +2309,7 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
 }
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+    return std::make_unique<index_reader>(sst, std::move(permit));
 }
 
 SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -900,8 +900,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
 }
 
 static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit), default_priority_class(),
-                                          tracing::trace_state_ptr(), use_caching::yes);
+    return std::make_unique<index_reader>(sst, std::move(permit));
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -64,8 +64,7 @@ public:
     }
 
     std::unique_ptr<index_reader> make_index_reader(reader_permit permit) {
-        return std::make_unique<index_reader>(_sst, std::move(permit), default_priority_class(),
-                                              tracing::trace_state_ptr(), use_caching::yes);
+        return std::make_unique<index_reader>(_sst, std::move(permit));
     }
 
     struct index_entry {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -962,7 +962,7 @@ void dump_index_operation(schema_ptr schema, reader_permit permit, const std::ve
     json_writer writer;
     writer.StartStream();
     for (auto& sst : sstables) {
-        sstables::index_reader idx_reader(sst, permit, default_priority_class(), {}, sstables::use_caching::yes);
+        sstables::index_reader idx_reader(sst, permit);
         auto close_idx_reader = deferred_close(idx_reader);
 
         writer.SstableKey(*sst);


### PR DESCRIPTION
The way index_reader maintains io_priority_class can be relaxed a bit. The main intent is to shorten the #13963 final patch a bit, as a side effect index_reader gets its portion of API polishing.

ref: #13963 