### PR TITLE
docs/dev/system_keyspace: use timeuuid for sstables.generation

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -364,7 +364,7 @@ Schema:
 ~~~
 CREATE TABLE system.sstables (
     location text,
-    generation bigint,
+    generation timeuuid,
     format text,
     status text,
     uuid uuid,


### PR DESCRIPTION
we changed the type of generation column in system.sstables from bigint to timeuuid in 74e9e6dd1a488ba93a77d02120be994eda8a2109. but that change failed to update the document accordingly. so let's update the document to reflect the change.