### PR TITLE
Docs: add feature store tutorial

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -60,4 +60,4 @@ Getting Started
   
   * `Build an IoT App with sensor simulator and a REST API <https://iot.scylladb.com/stable/>`_ - ScyllaDB Tutorial
   * `Implement CRUD operations with a TODO App <https://github.com/scylladb/scylla-cloud-getting-started/>`_ - ScyllaDB Cloud Tutorial
-  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial  ` <>`_
+  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -58,6 +58,6 @@ Getting Started
 
   The tutorials will show you how to use ScyllaDB as a data source for an application.
   
-  * `Build an IoT App with sensor simulator and a REST API <https://care-pet.docs.scylladb.com/>`_ - ScyllaDB Tutorial
+  * `Build an IoT App with sensor simulator and a REST API <https://iot.scylladb.com/stable/>`_ - ScyllaDB Tutorial
   * `Implement CRUD operations with a TODO App <https://github.com/scylladb/scylla-cloud-getting-started/>`_ - ScyllaDB Cloud Tutorial
-  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial
+  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial  ` <>`_

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -60,3 +60,4 @@ Getting Started
   
   * `Build an IoT App with sensor simulator and a REST API <https://care-pet.docs.scylladb.com/>`_ - ScyllaDB Tutorial
   * `Implement CRUD operations with a TODO App <https://github.com/scylladb/scylla-cloud-getting-started/>`_ - ScyllaDB Cloud Tutorial
+  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial

--- a/docs/getting-started/tutorials.rst
+++ b/docs/getting-started/tutorials.rst
@@ -8,7 +8,7 @@ The tutorials will show you how to use ScyllaDB as a data source for an applicat
 ScyllaDB Tutorial
 ===================
 
-`Build an IoT App with sensor simulator and a REST API <https://care-pet.docs.scylladb.com/>`_
+`Build an IoT App with sensor simulator and a REST API <https://iot.scylladb.com/stable/>`_
 
 ScyllaDB Cloud Tutorial
 =======================

--- a/docs/getting-started/tutorials.rst
+++ b/docs/getting-started/tutorials.rst
@@ -14,3 +14,8 @@ ScyllaDB Cloud Tutorial
 =======================
 
 `Implement CRUD operations with a TODO App <https://github.com/scylladb/scylla-cloud-getting-started/>`_
+
+ScyllaDB Cloud Feature Store Tutorial
+=====================================
+
+`Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_


### PR DESCRIPTION
* Adds the new feature tutorial site to the docs
* fixes the unnecessary redirection (iot.scylladb.com)