### PR TITLE
test/cql-pytest: revert incorrect fix to avoid a warning

### DIFF
--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -81,7 +81,7 @@ def test_order_of_indexes(scylla_only, cql, test_keyspace):
         # server restart), but some of them fail. Once a proper ordering
         # is implemented, all cases below should succeed.
         def index_used(query, index_name):
-            assert any([index_name in event.description for event in cql.execute(query, trace=True).one().get_query_trace().events])
+            assert any([index_name in event.description for event in cql.execute(query, trace=True).get_query_trace().events])
         index_used(f"SELECT * FROM {table} WHERE v3 = 1", "my_v3_idx")
         index_used(f"SELECT * FROM {table} WHERE v3 = 1 and v1 = 2 allow filtering", "my_v3_idx")
         index_used(f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 allow filtering", "my_v1_idx")


### PR DESCRIPTION
In commit 0a71151bc4aed36850e04ac4c3a890fe00e05630 I wanted to avoid a incorrect deprecation warning from the Python driver but fixed it in an incorrect way. I never noticed the fix was incorrect because the test was already xfailing, and the incorrect fix just made it fail differently... In this patch I revert that commit.

With this revert, I am *not* bringing back the spurious warning - the Python driver bug was already fixed in
https://github.com/datastax/python-driver/pull/1103 - so developers with a fairly recent version will no longer see the spurious warning. Both old and new drivers will at least do the correct thing, as it was before that unfortunate commit.

Fixes #8752.