### PR TITLE
commitlog: Introduce and use comitlog sched group

### DIFF
--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -87,8 +87,9 @@ public:
     struct config {
         config() = default;
         config(const config&) = default;
-        static config from_db_config(const db::config&, size_t shard_available_memory);
+        static config from_db_config(const db::config&, seastar::scheduling_group sg, size_t shard_available_memory);
 
+        seastar::scheduling_group sched_group;
         sstring commit_log_location;
         sstring metrics_category_name;
         uint64_t commitlog_total_space_in_mb = 0;

--- a/main.cc
+++ b/main.cc
@@ -924,6 +924,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             dbcfg.memtable_scheduling_group = make_sched_group("memtable", 1000);
             dbcfg.memtable_to_cache_scheduling_group = make_sched_group("memtable_to_cache", 200);
             dbcfg.gossip_scheduling_group = make_sched_group("gossip", 1000);
+            dbcfg.commitlog_scheduling_group = make_sched_group("commitlog", 1000);
             dbcfg.available_memory = memory::stats().total_memory();
 
             netw::messaging_service::config mscfg;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -866,7 +866,7 @@ database::init_commitlog() {
         return make_ready_future<>();
     }
 
-    return db::commitlog::create_commitlog(db::commitlog::config::from_db_config(_cfg, _dbcfg.available_memory)).then([this](db::commitlog&& log) {
+    return db::commitlog::create_commitlog(db::commitlog::config::from_db_config(_cfg, _dbcfg.commitlog_scheduling_group, _dbcfg.available_memory)).then([this](db::commitlog&& log) {
         _commitlog = std::make_unique<db::commitlog>(std::move(log));
         _commitlog->add_flush_handler([this](db::cf_id_type id, db::replay_position pos) {
             if (!_column_families.contains(id)) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1254,6 +1254,7 @@ struct database_config {
     seastar::scheduling_group statement_scheduling_group;
     seastar::scheduling_group streaming_scheduling_group;
     seastar::scheduling_group gossip_scheduling_group;
+    seastar::scheduling_group commitlog_scheduling_group;
     size_t available_memory;
     std::optional<sstables::sstable_version_types> sstables_format;
 };

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -226,7 +226,7 @@ int main(int argc, char** argv) {
             cfg.max_flush_delay_in_ms = cfg.min_flush_delay_in_ms;
         }
 
-        db::commitlog::config cl_cfg = db::commitlog::config::from_db_config(*db_cfg,  memory::stats().total_memory());
+        db::commitlog::config cl_cfg = db::commitlog::config::from_db_config(*db_cfg, current_scheduling_group(), memory::stats().total_memory());
         tmpdir tmp;
         cl_cfg.commit_log_location = tmp.path().string();
 


### PR DESCRIPTION
Nowadays all commitlog code runs in whatever sched group it's kicked from. Since IO prio classes are going to be inherited from the current sched group the commitlog IO loops should be moved into commitlog sched group, not inherit a "random" one.

There are currently two places that need correct context for IO -- the .cycle() method and segments replenisher.

ref: #13963 

`$ perf-simple-query --write -c2` results

--- Before the patch ---
194898.36 tps ( 56.3 allocs/op,  12.7 tasks/op,   54307 insns/op,        0 errors)
199286.23 tps ( 56.2 allocs/op,  12.7 tasks/op,   54375 insns/op,        0 errors)
199815.84 tps ( 56.2 allocs/op,  12.7 tasks/op,   54377 insns/op,        0 errors)
198260.98 tps ( 56.3 allocs/op,  12.7 tasks/op,   54380 insns/op,        0 errors)
198572.86 tps ( 56.2 allocs/op,  12.7 tasks/op,   54371 insns/op,        0 errors)

median 198572.86 tps ( 56.2 allocs/op,  12.7 tasks/op,   54371 insns/op,        0 errors)
median absolute deviation: 713.36
maximum: 199815.84
minimum: 194898.36

--- After the patch ---
194751.80 tps ( 56.3 allocs/op,  12.7 tasks/op,   54331 insns/op,        0 errors)
199084.70 tps ( 56.2 allocs/op,  12.7 tasks/op,   54389 insns/op,        0 errors)
195551.47 tps ( 56.3 allocs/op,  12.7 tasks/op,   54385 insns/op,        0 errors)
197953.47 tps ( 56.3 allocs/op,  12.7 tasks/op,   54386 insns/op,        0 errors)
198710.00 tps ( 56.3 allocs/op,  12.7 tasks/op,   54387 insns/op,        0 errors)

median 197953.47 tps ( 56.3 allocs/op,  12.7 tasks/op,   54386 insns/op,        0 errors)
median absolute deviation: 1131.24
maximum: 199084.70
minimum: 194751.80