### PR TITLE
Small improvements after pending_ranges, endpoints_for_reading -> erm PR

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -327,7 +327,7 @@ public:
 
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
-    const inet_address_vector_replica_set& do_get_natural_endpoints(const token& search_token) const;
+    const inet_address_vector_replica_set& do_get_natural_endpoints(const token& tok, bool is_vnode) const;
 
 public:
     static factory_key make_factory_key(const replication_strategy_ptr& rs, const token_metadata_ptr& tmptr);

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -178,7 +178,7 @@ future<> clear_gently(foreign_ptr<T>& o) noexcept {
 
 template <typename... T>
 requires (std::is_rvalue_reference_v<T&&> && ...)
-future<> clear_gently(T&&... o) noexcept {
+future<> clear_gently(T&&... o) {
     return do_with(std::move(o)..., [](auto&... args) {
         return when_all(clear_gently(args)...).discard_result();
     });


### PR DESCRIPTION
This is a small follow-up for [this PR](https://github.com/scylladb/scylladb/pull/13715), it resolves some comments in the initial PR that didn't make their way into it.
* remove `noexcept` from `clear_gently`, since exceptions can be raised from move constructor;
* an optimisation for `vnode_effective_replication_map::get_range_addresses`, avoid redundant binary search.