### PR TITLE
docs/operating-scylla: lowercase the name of an option

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
+++ b/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
@@ -12,7 +12,7 @@ Example from scylla.yaml:
 
 .. code:: yaml
    
-   Enable_repair_based_node_ops: true
+   enable_repair_based_node_ops: true
    allowed_repair_based_node_ops: replace
 
 To enable other operations (experimental), add them as a comma-separated list to allowed_repair_based_node_ops. Available operations are:


### PR DESCRIPTION
"Enable_repair_based_node_ops" is the name of an option, and the leading character should be lowecase "e". so fix it.

Fixes #14017
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>