### PR TITLE
gms: move fmt::formatter<gms::inet_address>::format() to .cc

### DIFF
--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -10,6 +10,7 @@
 
 #include <iomanip>
 #include <boost/io/ios_state.hpp>
+#include <fmt/core.h>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/core/print.hh>
@@ -33,6 +34,30 @@ future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family fam
         return gms::inet_address(h.addr_list.front());
     });
 }
+
+template <typename FormatContext>
+auto fmt::formatter<gms::inet_address>::format(const gms::inet_address& x,
+                                               FormatContext& ctx) const -> decltype(ctx.out()) {
+    if (x.addr().is_ipv4()) {
+        return fmt::format_to(ctx.out(), "{}", x.addr());
+    }
+    // print 2 bytes in a group, and use ':' as the delimeter
+    fmt::format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
+    if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
+        return fmt::format_to(ctx.out(), "%{}", x.addr().scope());
+    }
+    return ctx.out();
+}
+
+template
+auto fmt::formatter<gms::inet_address>::format<fmt::format_context>(
+    const gms::inet_address&,
+    fmt::format_context& ctx) const -> decltype(ctx.out());
+template
+auto fmt::formatter<gms::inet_address>::format<fmt::basic_format_context<std::back_insert_iterator<std::string>, char>>(
+    const gms::inet_address&,
+    fmt::basic_format_context<std::back_insert_iterator<std::string>, char>& ctx) const
+    -> decltype(ctx.out());
 
 std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
     fmt::print(os, "{}", x);

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -87,15 +87,5 @@ struct hash<gms::inet_address> {
 template <>
 struct fmt::formatter<gms::inet_address> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
-    auto format(const ::gms::inet_address& x, FormatContext& ctx) const {
-        if (x.addr().is_ipv4()) {
-            return fmt::format_to(ctx.out(), "{}", x.addr());
-        }
-        // print 2 bytes in a group, and use ':' as the delimeter
-        fmt::format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
-        if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
-            return fmt::format_to(ctx.out(), "%{}", x.addr().scope());
-        }
-        return ctx.out();
-    }
+    auto format(const ::gms::inet_address& x, FormatContext& ctx) const -> decltype(ctx.out());
 };


### PR DESCRIPTION
to reduce the size of header file, in hope to speed the compilation. let's implement the implementation of format() function into .cc file.

please note, `fmt::to_string()` uses another context type: `fmt::basic_format_context<std::back_insert_iterator<std::string>>`. and we do use `fmt::to_string()` to format `gms::inet_address`, so in this change, the template is defined in the .cc file but we also explicit instantiate both specializations in .cc file.

Refs #13245