### PR TITLE
cql: fix column name in writetime() error message

### DIFF
--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -61,7 +61,7 @@ selectable::writetime_or_ttl::new_selector_factory(data_dictionary::database db,
         throw exceptions::invalid_request_exception(
                 format("Cannot use selection function {} on PRIMARY KEY part {}",
                               _is_writetime ? "writeTime" : "ttl",
-                              def->name()));
+                              def->name_as_text()));
     }
     if (def->type->is_multi_cell()) {
         throw exceptions::invalid_request_exception(format("Cannot use selection function {} on non-frozen collections",

--- a/test/cql-pytest/test-timestamp.py
+++ b/test/cql-pytest/test-timestamp.py
@@ -78,3 +78,15 @@ def test_futuristic_timestamp(cql, table1):
         print('checking with restrict_future_timestamp=false')
         cql.execute(f'INSERT INTO {table1} (k, v) VALUES ({p}, 1) USING TIMESTAMP {futuristic_ts}')
         assert [(futuristic_ts,)] == cql.execute(f'SELECT writetime(v) FROM {table1} where k = {p}')
+
+# Currently, writetime(k) is not allowed for a key column. Neither is ttl(k).
+# Scylla issue #14019 and CASSANDRA-9312 consider allowing it - with the
+# meaning that it should return the timestamp and ttl of a row marker.
+# If this issue is ever implemented in Scylla or Cassandra, the following
+# test will need to be replaced by a test for the new feature instead of
+# expecting an error message.
+def test_key_writetime(cql, table1):
+    with pytest.raises(InvalidRequest, match='PRIMARY KEY part k'):
+        cql.execute(f'SELECT writetime(k) FROM {table1}')
+    with pytest.raises(InvalidRequest, match='PRIMARY KEY part k'):
+        cql.execute(f'SELECT ttl(k) FROM {table1}')


### PR DESCRIPTION
Found and fixed yet another place where an error message prints a column name as "bytes" type which causes it to be printed as hexadecimal codes instead of the actual characters of the name.

The specific error message fixed here is "Cannot use selection function writeTime on PRIMARY KEY part k" which happens when you try to use writetime() or ttl() on a key column (which isn't allowed today - see issue #14019). Before this patch we got "6b" in the error message instead of "k".

The patch also includes a regression test that verifies that this error condition is recognized and the real name of the column is printed. This test fails before this patch, and passes after it. As usual, the test also passes on Cassandra.