### PR TITLE
test: Don't use empty AWS secret key

### DIFF
--- a/test/alternator/test_authorization.py
+++ b/test/alternator/test_authorization.py
@@ -17,10 +17,10 @@ def test_wrong_key_access(request, dynamodb):
     url = dynamodb.meta.client._endpoint.host
     with pytest.raises(ClientError, match='UnrecognizedClientException'):
         if url.endswith('.amazonaws.com'):
-            boto3.client('dynamodb',endpoint_url=url, aws_access_key_id='wrong_id', aws_secret_access_key='').describe_endpoints()
+            boto3.client('dynamodb',endpoint_url=url, aws_access_key_id='wrong_id', aws_secret_access_key='x').describe_endpoints()
         else:
             verify = not url.startswith('https')
-            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='', verify=verify).describe_endpoints()
+            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='x', verify=verify).describe_endpoints()
 
 # A similar test, but this time the user is expected to exist in the database (for local tests)
 def test_wrong_password(request, dynamodb):


### PR DESCRIPTION
There's a test case that checks in valid credentials (wrong key). However, some boto3 libraries don't like empty secret key values:

request = <FixtureRequest for <Function test_wrong_key_access>> dynamodb = dynamodb.ServiceResource()

    def test_wrong_key_access(request, dynamodb):
        print("Please make sure authorization is enforced in your Scylla installation: alternator_enforce_authorization: true")
        url = dynamodb.meta.client._endpoint.host
        with pytest.raises(ClientError, match='UnrecognizedClientException'):
            if url.endswith('.amazonaws.com'):
                boto3.client('dynamodb',endpoint_url=url, aws_access_key_id='wrong_id', aws_secret_access_key='').describe_endpoints()
            else:
                verify = not url.startswith('https')
>               boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='', verify=verify).describe_endpoints()

test_authorization.py:23:

...

cls = <class 'awscrt.auth.AwsCredentialsProvider'>, access_key_id = 'whatever' secret_access_key = '', session_token = None

    @classmethod
    def new_static(cls, access_key_id, secret_access_key, session_token=None):
        """
        Create a simple provider that just returns a fixed set of credentials.

        Args:
            access_key_id (str): Access key ID
            secret_access_key (str): Secret access key
            session_token (Optional[str]): Optional session token

        Returns:
            AwsCredentialsProvider:
        """
        assert isinstance(access_key_id, str)
        assert isinstance(secret_access_key, str)
        assert isinstance(session_token, str) or session_token is None

>       binding = _awscrt.credentials_provider_new_static(access_key_id, secret_access_key, session_token)
E       RuntimeError: 34 (AWS_ERROR_INVALID_ARGUMENT): An invalid argument was passed to a function.

$ pip3 show boto3
Name: boto3
Version: 1.26.139
Summary: The AWS SDK for Python
Home-page: https://github.com/boto/boto3
Author: Amazon Web Services
Author-email:
License: Apache License 2.0
Location: /home/xemul/.local/lib/python3.11/site-packages Requires: botocore, jmespath, s3transfer
Required-by: