### PR TITLE
Prepare sstable_directory lister to garbage_collect() s3 stuff

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -95,7 +95,7 @@ public:
 
         void handle(sstables::entry_descriptor desc, std::filesystem::path filename);
 
-        directory_lister _lister;
+        fs::path _directory;
         std::unique_ptr<scan_state> _state;
 
     public:

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -71,7 +71,7 @@ public:
 
     class components_lister {
     public:
-        virtual future<> process(sstable_directory& directory, fs::path location, process_flags flags) = 0;
+        virtual future<> process(sstable_directory& directory, process_flags flags) = 0;
         virtual future<> commit() = 0;
         virtual ~components_lister() {}
     };
@@ -101,7 +101,7 @@ public:
     public:
         filesystem_components_lister(std::filesystem::path dir);
 
-        virtual future<> process(sstable_directory& directory, fs::path location, process_flags flags) override;
+        virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
     };
 
@@ -112,7 +112,7 @@ public:
     public:
         system_keyspace_components_lister(db::system_keyspace& sys_ks, sstring location);
 
-        virtual future<> process(sstable_directory& directory, fs::path location, process_flags flags) override;
+        virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
     };
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -98,9 +98,6 @@ public:
         directory_lister _lister;
         std::unique_ptr<scan_state> _state;
 
-        future<sstring> get();
-        future<> close();
-
     public:
         filesystem_components_lister(std::filesystem::path dir);
 


### PR DESCRIPTION
When scylla starts it collects dangling sstables from the datadir. It includes temporary sstable directories and pending-deletion log. S3-backed sstables cannot be garbage-collected like that, instead "garbage" entries from the ownership table should be processed. Currently the g.c. code is unaware of storage and scans datadir for whatever sstable it's called for.

This PR prepares the garbage_collect() call to become virtual, but no-op for ownership-table lister. Proper S3 garbage-collecting is not yet here, it needs an extra patch to seastar http client.

refs: #13024