### PR TITLE
test.py: test suite order

### DIFF
--- a/test.py
+++ b/test.py
@@ -38,12 +38,14 @@ from test.pylib.pool import Pool
 from test.pylib.util import LogPrefixAdapter
 from test.pylib.scylla_cluster import ScyllaServer, ScyllaCluster, get_cluster_manager, merge_cmdline_options
 from test.pylib.minio_server import MinioServer
-from typing import Dict, List, Callable, Any, Iterable, Optional, Awaitable, Union
+from typing import Dict, List, Callable, Any, Iterable, Optional, Awaitable, Union, Tuple
 
 output_is_a_tty = sys.stdout.isatty()
 
 all_modes = set(['debug', 'release', 'dev', 'sanitize', 'coverage'])
 debug_modes = set(['debug', 'sanitize'])
+# Slow modes to run firs
+mode_run_order = ["debug", "release"]
 
 
 def create_formatter(*decorators) -> Callable[[Any], str]:
@@ -98,6 +100,8 @@ class TestSuite(ABC):
         # The number of failed tests
         self.n_failed = 0
 
+        # Relative load of suite, higher values will be scheduled to run first
+        self.load = cfg.get("suite_load", 1)
         self.run_first_tests = set(cfg.get("run_first", []))
         self.no_parallel_cases = set(cfg.get("no_parallel_cases", []))
         # Skip tests disabled in suite.yaml
@@ -173,6 +177,16 @@ class TestSuite(ABC):
             assert suite is not None
             TestSuite.suites[suite_key] = suite
         return suite
+
+    @staticmethod
+    def sort_tests() -> None:
+        """Reorder suites by configured slowness factor"""
+        mode_index = {key: i for i, key in enumerate(mode_run_order)}
+        def key_mode_load(i: Tuple[str, TestSuite]):
+            """Order suites by mode (debug/release/dev) and load (config)"""
+            # Note: flip sign so higher load values go first
+            return mode_index.get(i[1].mode, len(mode_index)), - i[1].load
+        TestSuite.suites = dict(sorted(TestSuite.suites.items(), key=key_mode_load))
 
     @staticmethod
     def all_tests() -> Iterable['Test']:
@@ -1391,6 +1405,9 @@ async def main() -> int:
     open_log(options.tmpdir, f"test.py.{'-'.join(options.modes)}.log", options.log_level)
 
     await find_tests(options)
+
+    TestSuite.sort_tests()
+
     if options.list_tests:
         print('\n'.join([f"{t.suite.mode:<8} {type(t.suite).__name__[:-9]:<11} {t.name}"
                          for t in TestSuite.all_tests()]))

--- a/test.py
+++ b/test.py
@@ -1392,7 +1392,8 @@ async def main() -> int:
 
     await find_tests(options)
     if options.list_tests:
-        print('\n'.join([t.name for t in TestSuite.all_tests()]))
+        print('\n'.join([f"{t.suite.mode:<8} {type(t.suite).__name__[:-9]:<11} {t.name}"
+                         for t in TestSuite.all_tests()]))
         return 0
 
     signaled = asyncio.Event()

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -1,4 +1,6 @@
 type: boost
+# Relative load of this suite, higher values will be scheduled first
+suite_load: 10
 # A list of long tests, which should be started early
 run_first:
     - index_with_paging_test

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -1,4 +1,6 @@
 type: Topology
+# Relative load of this suite, higher values will be scheduled first
+suite_load: 12
 pool_size: 4
 cluster:
   initial_size: 3

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -1,4 +1,6 @@
 type: Topology
+# Relative load of this suite, higher values will be scheduled first
+suite_load: 11
 pool_size: 4
 cluster:
   initial_size: 0

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -1,4 +1,6 @@
 type: Topology
+# Relative load of this suite, higher values will be scheduled first
+suite_load: 5
 pool_size: 4
 cluster:
   initial_size: 0

--- a/test/topology_raft_disabled/suite.yaml
+++ b/test/topology_raft_disabled/suite.yaml
@@ -1,4 +1,6 @@
 type: Topology
+# Relative load of this suite, higher values will be scheduled first
+suite_load: 11
 pool_size: 4
 cluster:
   initial_size: 3


### PR DESCRIPTION
The order to schedule was one suite at a time but without any specific order of which suites would run first. There is a difference in running time across modes (debug -> release -> dev). And some suites take very long time to run.
    
It's often the case where only a handful of long running tests are left running late, leaving many cores unused and stretching total run time.
    
Add an optional suite configuration option suite_load to mark suites taking long to run. Higher values will be scheduled earlier.
    
Sort suites by mode and then by load.