### PR TITLE
build: cmake: link auth against libcrypt

### DIFF
--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(scylla_auth
   PRIVATE
     cql3
     idl
-    wasmtime_bindings)
+    wasmtime_bindings
+    libxcrypt::libxcrypt)
 
 add_whole_archive(auth scylla_auth)


### PR DESCRIPTION
libxcrypt is used by auth subsystem, for instance, `crypt_r()` provided by this library is used by passwords.cc. so let's link against it.