### PR TITLE
main: Ignore sleep_aborted exception in main

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1857,6 +1857,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             stop_signal.wait().get();
             startlog.info("Signal received; shutting down");
 	    // At this point, all objects destructors and all shutdown hooks registered with defer() are executed
+          } catch (const sleep_aborted&) {
+            startlog.info("Startup interrupted");
+            // This happens when scylla gets SIGINT in the middle of join_cluster(), so
+            // just ignore it and exit normally
+            _exit(0);
+            return 0;
           } catch (...) {
             startlog.error("Startup failed: {}", std::current_exception());
             // We should be returning 1 here, but the system is not yet prepared for orderly rollback of main() objects


### PR DESCRIPTION
When scylla starts it may go to sleep along the way before the "serving" message appears. If SIGINT is sent at that time the whole thing unrolls and the main code ends up catching the sleep_aborted exception, printing the error in logs and exiting with non-zero code. However, that's not an error, just the start was interrupted earlier than it was expected by the stop_signal thing.

fixes: #12898