### PR TITLE
Revert "test: string_format_test: don't compare std::string with sstr…

### DIFF
--- a/test/boost/string_format_test.cc
+++ b/test/boost/string_format_test.cc
@@ -213,11 +213,11 @@ BOOST_AUTO_TEST_CASE(test_vector_format) {
 BOOST_AUTO_TEST_CASE(test_string_format) {
     seastar::sstring sstring = "foo";
     auto formatted = fmt::format("{}", sstring);
-    BOOST_REQUIRE_EQUAL(seastar::sstring(formatted), sstring);
+    BOOST_REQUIRE_EQUAL(formatted, sstring);
 
     std::string std_string = "foo";
     formatted = fmt::format("{}", std_string);
-    BOOST_REQUIRE_EQUAL(seastar::sstring(formatted), std_string);
+    BOOST_REQUIRE_EQUAL(formatted, std_string);
 
     std::string_view std_string_view = std_string;
     formatted = fmt::format("{}", std_string_view);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(test_bytes_format) {
     auto b = to_bytes("f0");
     auto formatted = fmt::format("{}", b);
     auto expected = to_hex(b);
-    BOOST_REQUIRE_EQUAL(seastar::sstring(formatted), expected);
+    BOOST_REQUIRE_EQUAL(formatted, expected);
 }
 
 BOOST_AUTO_TEST_CASE(test_optional_string_format) {


### PR DESCRIPTION
…ing"

This reverts commit 3c54d5ec5e78e9aab3847cb27c8f13bf2623226a.

The reverted change fixed the FTBFS of the test in question with Clang 16, which rightly stopped convert the LHS of `"hello" == sstring{"hello"}` to the type of the type acceptable by the member operator even we have a constructor for this conversion, like

class sstring {
public:
  bar_t(const char*);
  bool operator==(const sstring&) const;
  bool operator!=(const sstring&) const;
};

because we have an operator!=, as per the draft of C++ standard https://eel.is/c++draft/over.match.oper#4 :

> A non-template function or function template F named operator==
> is a rewrite target with first operand o unless a search for the
> name operator!= in the scope S from the instantiation context of
> the operator expression finds a function or function template
> that would correspond ([basic.scope.scope]) to F if its name were
> operator==, where S is the scope of the class type of o if F is a
> class member, and the namespace scope of which F is a member
> otherwise.

in 397f4b51c37fc8e98a6f5be2f6d75ab49ff83b3a, the seastar submodule was updated. in which, we now have a dedicated overload for the `const char*` case. so the compiler is now able to compile the expression like `"hello" == sstring{"hello"}` in C++20 now.

so, in this change, the workaround is reverted.