### PR TITLE
build: preserve $libs when linking a single testing executable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2008,7 +2008,6 @@ with open(buildfile, 'w') as f:
                     rust_headers[hh] = src
                 else:
                     raise Exception('No rule for ' + src)
-        f.write('   libs = $seastar_libs_{}\n'.format(mode))
         f.write(
             'build {mode}-objects: phony {objs}\n'.format(
                 mode=mode,


### PR DESCRIPTION
if we just want to build a single test and scylla executables, we might want to use `configure.py` like:
```bash
./configure.py --mode debug --compiler clang++ --with scylla --with test/boost/database_test
```
which generates `build.ninja` for us, with following rules:
```ninja
build $builddir/debug/test/boost/database_test_g: link.debug ... | $builddir/debug/seastar/libseastar.so $builddir/debug/seastar/libseastar_testing.so
   libs = $seastar_libs_debug $libs -lthrift -lboost_system $seastar_testing_libs_debug
   libs = $seastar_libs_debug
```
but the last line prevents `database_test_g` from linking against the third-party libraries like libabsl, which could have been pulled in by $libs.  the second assignment expression just makes the value of `libs` identical to that of `seastar_libs_debug`.  that library does not include the libraries which are only used by scylla. so we could run into link failure with the `build.ninja` generated with this command line. like:
```
FAILED: build/debug/test/boost/database_test_g
...
ld.lld: error: undefined symbol: seastar::testing::entry_point(int, char**)
>>> referenced by scylla_test_case.hh:22 (./test/lib/scylla_test_case.hh:22)
>>>               build/debug/test/boost/database_test.o:(main)
...
ld.lld: error: undefined symbol: boost::unit_test::unit_test_log_t::set_checkpoint(boost::unit_test::basic_cstring<char const>, unsigned long, boost::unit_tes
t::basic_cstring<char const>)
>>> referenced by database_test.cc:298 (test/boost/database_test.cc:298)
>>>               build/debug/test/boost/database_test.o:(require_exist(seastar::basic_sstring<char, unsigned int, 15u, true> const&, bool))
...
```

with this change, the extra assignment expression is dropped. this should not cause any regression. as f'$seastar_libs_{mode}' as been included as a part of `local_libs` before the grand if-the-else block in the for loop before this `f.write()` statement.