### PR TITLE
service: storage_proxy: make hint write handlers cancellable

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -501,7 +501,8 @@ private:
 
 public:
     static const std::string FILENAME_PREFIX;
-    static const std::chrono::seconds hints_flush_period;
+    // Non-const - can be modified with an error injection.
+    static std::chrono::seconds hints_flush_period;
     static const std::chrono::seconds hint_file_write_timeout;
 
 private:

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1605,7 +1605,8 @@ static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, gms::in
             std::move(pending_endpoints),
             db::write_type::VIEW,
             std::move(tr_state),
-            allow_hints);
+            allow_hints,
+            service::is_cancellable::yes);
 }
 
 static bool should_update_synchronously(const schema& s) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -470,10 +470,6 @@ public:
         return _cdc;
     }
 
-    view_update_handlers_list& get_view_update_handlers_list() {
-        return *_view_update_handlers_list;
-    }
-
     response_id_type get_next_response_id() {
         auto next = _next_response_id++;
         if (next == 0) { // 0 is reserved for unique_response_handler

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -99,6 +99,8 @@ struct view_update_backlog_timestamped {
 struct allow_hints_tag {};
 using allow_hints = bool_class<allow_hints_tag>;
 
+using is_cancellable = bool_class<struct cancellable_tag>;
+
 struct storage_proxy_coordinator_query_result {
     foreign_ptr<lw_shared_ptr<query::result>> query_result;
     replicas_per_token_range last_replicas;
@@ -307,9 +309,9 @@ private:
     ::shared_ptr<abstract_write_response_handler>& get_write_response_handler(storage_proxy::response_id_type id);
     result<response_id_type> create_write_response_handler_helper(schema_ptr s, const dht::token& token,
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
-            service_permit permit, db::allow_per_partition_rate_limit allow_limit);
+            service_permit permit, db::allow_per_partition_rate_limit allow_limit, is_cancellable);
     result<response_id_type> create_write_response_handler(locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, inet_address_vector_replica_set targets,
-            const inet_address_vector_topology_change& pending_endpoints, inet_address_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info);
+            const inet_address_vector_topology_change& pending_endpoints, inet_address_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable);
     result<response_id_type> create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     result<response_id_type> create_write_response_handler(const read_repair_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
@@ -416,7 +418,8 @@ private:
             db::write_type type,
             tracing::trace_state_ptr tr_state,
             write_stats& stats,
-            allow_hints allow_hints = allow_hints::yes);
+            allow_hints,
+            is_cancellable);
 
     db::view::update_backlog get_view_update_backlog() const;
 
@@ -565,9 +568,9 @@ public:
     // hinted handoff support, and just one target. See also
     // send_to_live_endpoints() - another take on the same original function.
     future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
-            tracing::trace_state_ptr tr_state, write_stats& stats, allow_hints allow_hints = allow_hints::yes);
+            tracing::trace_state_ptr tr_state, write_stats& stats, allow_hints, is_cancellable);
     future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
-            tracing::trace_state_ptr tr_state, allow_hints allow_hints = allow_hints::yes);
+            tracing::trace_state_ptr tr_state, allow_hints, is_cancellable);
 
     // Send a mutation to a specific remote target as a hint.
     // Unlike regular mutations during write operations, hints are sent on the streaming connection

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -273,8 +273,8 @@ private:
     std::unordered_map<gms::inet_address, view_update_backlog_timestamped> _view_update_backlogs;
 
     //NOTICE(sarna): This opaque pointer is here just to avoid moving write handler class definitions from .cc to .hh. It's slow path.
-    class view_update_handlers_list;
-    std::unique_ptr<view_update_handlers_list> _view_update_handlers_list;
+    class cancellable_write_handlers_list;
+    std::unique_ptr<cancellable_write_handlers_list> _cancellable_write_handlers_list;
 
     /* This is a pointer to the shard-local part of the sharded cdc_service:
      * storage_proxy needs access to cdc_service to augument mutations.
@@ -427,7 +427,8 @@ private:
     template<typename Range>
     future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);
 
-    void retire_view_response_handlers(noncopyable_function<bool(const abstract_write_response_handler&)> filter_fun);
+    // Retires (times out) write response handlers which were constructed as `cancellable` and pass the given filter.
+    void cancel_write_handlers(noncopyable_function<bool(const abstract_write_response_handler&)> filter_fun);
 
     /**
      * Returns whether for a range query doing a query against merged is likely

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -161,7 +161,7 @@ class ManagerClient():
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         self._driver_update()
 
-    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None, start: bool = True) -> ServerInfo:
+    async def server_add(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, Any]] = None, start: bool = True) -> ServerInfo:
         """Add a new server"""
         try:
             data: dict[str, Any] = {'start': start}

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -18,7 +18,7 @@ import shutil
 import tempfile
 import time
 import traceback
-from typing import Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, NamedTuple, Union
+from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, NamedTuple, Union
 import uuid
 from enum import Enum
 from io import BufferedWriter
@@ -203,7 +203,7 @@ class ScyllaServer:
                  logger: Union[logging.Logger, logging.LoggerAdapter],
                  cluster_name: str, ip_addr: str, seeds: List[str],
                  cmdline_options: List[str],
-                 config_options: Dict[str, str]) -> None:
+                 config_options: Dict[str, Any]) -> None:
         # pylint: disable=too-many-arguments
         self.server_id = ServerNum(ScyllaServer.newid())
         self.exe = pathlib.Path(exe).resolve()
@@ -565,7 +565,7 @@ class ScyllaCluster:
         cluster_name: str
         ip_addr: IPAddress
         seeds: List[str]
-        config_from_test: dict[str, str]
+        config_from_test: dict[str, Any]
         cmdline_from_test: List[str]
 
     def __init__(self, logger: Union[logging.Logger, logging.LoggerAdapter],
@@ -652,11 +652,11 @@ class ScyllaCluster:
     def _seeds(self) -> List[str]:
         return [server.ip_addr for server in self.running.values()]
 
-    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, str]] = None, start: bool = True) -> ServerInfo:
+    async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None, cmdline: Optional[List[str]] = None, config: Optional[dict[str, Any]] = None, start: bool = True) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
-        extra_config: dict[str, str] = config.copy() if config else {}
+        extra_config: dict[str, Any] = config.copy() if config else {}
         if replace_cfg:
             replaced_id = replace_cfg.replaced_id
             assert replaced_id in self.servers, \

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -5,3 +5,7 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
+skip_in_release:
+  - test_shutdown_hang
+skip_in_debug:
+  - test_shutdown_hang

--- a/test/topology_custom/test_shutdown_hang.py
+++ b/test/topology_custom/test_shutdown_hang.py
@@ -1,0 +1,63 @@
+import asyncio
+import logging
+import time
+import pytest
+
+from cassandra.query import SimpleStatement # type: ignore
+from cassandra.cluster import ConsistencyLevel # type: ignore
+from cassandra.protocol import WriteTimeout # type: ignore
+
+from test.pylib.manager_client import ManagerClient
+from test.topology.util import wait_for_token_ring_and_group0_consistency
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
+    """Reproducer for #8079"""
+    s1 = await manager.server_add(config={
+        'error_injections_at_startup': ['decrease_hints_flush_period']
+    })
+    s2 = await manager.server_add()
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    cql = manager.get_cql()
+
+    logger.info("Create keyspace and table")
+    await cql.run_async("create keyspace ks with replication = {'class': 'SimpleStrategy', 'replication_factor': 2}")
+    await cql.run_async("create table ks.t (pk int primary key)")
+
+    logger.info(f"Stop {s2}")
+    await manager.server_stop(s2.server_id)
+
+    logger.info("Write data with small timeout")
+    # We're using a small timeout for the insert so it's not unexpected that it would fail on slow
+    # CI machines. To avoid flakiness we disable the test in debug mode (as well as release since
+    # it requires an error injection - so it will run only in dev mode) and we retry the write 10 times.
+    passed = False
+    for _ in range(10):
+        try:
+            await cql.run_async(SimpleStatement("insert into ks.t (pk) values (0) using timeout 500ms",
+                                                consistency_level=ConsistencyLevel.ONE))
+        except WriteTimeout:
+            logger.info("write timeout, retrying")
+        else:
+            passed = True
+            break
+
+    if not passed:
+        pytest.fail("Write timed out on each attempt")
+
+    # The write succeeded but a background task was left to finish the write to the other node
+    # (which is dead but the first node didn't mark it as dead yet).
+    # The background task will timeout shortly because of 'using timeout' in the statement.
+    # This will cause a hint to get created.
+    # The hints manager starts sending the hint soon after (hint flushing happens every
+    # ~1 second with the error injection).
+    logger.info("Sleep")
+    await asyncio.sleep(2)
+
+    logger.info(f"Stop {s1} gracefully")
+    await manager.server_stop_gracefully(s1.server_id)


### PR DESCRIPTION
The `view_update_write_response_handler` class, which is a subclass of
`abstract_write_response_handler`, was created for a single purpose:
to make it possible to cancel a handler for a view update write,
which means we stop waiting for a response to the write, timing out
the handler immediately. This was done to solve issue with node
shutdown hanging because it was waiting for a view update to finish;
view updates were configured with 5 minute timeout. See #3966, #4028.

Now we're having a similar problem with hint updates causing shutdown
to hang in tests (#8079).

`view_update_write_response_handler` implements cancelling by adding
itself to an intrusive list which we then iterate over to timeout each
handler when we shutdown or when gossiper notifies `storage_proxy`
that a node is down.

To make it possible to reuse this algorithm for other handlers, move
the functionality into `abstract_write_response_handler`. We inherit
from `bi::list_base_hook` so it introduces small memory overhead to
each write handler (2 pointers) which was only present for view update
handlers before. But those handlers are already quite large, the
overhead is small compared to their size.

Use this new functionality to also cancel hint write handlers when we
shutdown. This fixes #8079.
