### PR TITLE
Initialize/destroy ks/cf directories with explicit class methods

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1318,15 +1318,11 @@ keyspace::column_family_directory(const sstring& base_path, const sstring& name,
 }
 
 future<> table::init_storage() {
-    std::vector<sstring> cfdirs;
-    for (auto& extra : _config.all_datadirs) {
-        cfdirs.push_back(extra);
-    }
-    co_await coroutine::parallel_for_each(cfdirs, [] (sstring cfdir) {
+    co_await coroutine::parallel_for_each(_config.all_datadirs, [] (sstring cfdir) {
         return io_check([cfdir] { return recursive_touch_directory(cfdir); });
     });
-    co_await io_check([cfdirs0 = cfdirs[0]] { return touch_directory(cfdirs0 + "/upload"); });
-    co_await io_check([cfdirs0 = cfdirs[0]] { return touch_directory(cfdirs0 + "/staging"); });
+    co_await io_check([this] { return touch_directory(_config.datadir + "/upload"); });
+    co_await io_check([this] { return touch_directory(_config.datadir + "/staging"); });
 }
 
 column_family& database::find_column_family(const schema_ptr& schema) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1322,13 +1322,11 @@ future<> table::init_storage() {
     for (auto& extra : _config.all_datadirs) {
         cfdirs.push_back(extra);
     }
-    return parallel_for_each(cfdirs, [] (sstring cfdir) {
+    co_await coroutine::parallel_for_each(cfdirs, [] (sstring cfdir) {
         return io_check([cfdir] { return recursive_touch_directory(cfdir); });
-    }).then([cfdirs0 = cfdirs[0]] {
-        return io_check([cfdirs0] { return touch_directory(cfdirs0 + "/upload"); });
-    }).then([cfdirs0 = cfdirs[0]] {
-        return io_check([cfdirs0] { return touch_directory(cfdirs0 + "/staging"); });
     });
+    co_await io_check([cfdirs0 = cfdirs[0]] { return touch_directory(cfdirs0 + "/upload"); });
+    co_await io_check([cfdirs0 = cfdirs[0]] { return touch_directory(cfdirs0 + "/staging"); });
 }
 
 column_family& database::find_column_family(const schema_ptr& schema) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1277,7 +1277,9 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     const db::config& db_config = db.get_config();
 
     for (auto& extra : _config.all_datadirs) {
-        cfg.all_datadirs.push_back(column_family_directory(extra, s.cf_name(), s.id()));
+        auto uuid_sstring = s.id().to_sstring();
+        boost::erase_all(uuid_sstring, "-");
+        cfg.all_datadirs.push_back(format("{}/{}-{}", extra, s.cf_name(), uuid_sstring));
     }
     cfg.datadir = cfg.all_datadirs[0];
     cfg.enable_disk_reads = _config.enable_disk_reads;
@@ -1307,13 +1309,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.x_log2_compaction_groups = db_config.x_log2_compaction_groups();
 
     return cfg;
-}
-
-sstring
-keyspace::column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const {
-    auto uuid_sstring = uuid.to_sstring();
-    boost::erase_all(uuid_sstring, "-");
-    return format("{}/{}-{}", base_path, name, uuid_sstring);
 }
 
 future<> table::init_storage() {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -626,6 +626,7 @@ public:
 
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }
+    future<> init_storage();
 
     seastar::gate& async_gate() { return _async_gate; }
 
@@ -1225,7 +1226,6 @@ public:
     locator::vnode_effective_replication_map_ptr get_effective_replication_map() const;
 
     column_family::config make_column_family_config(const schema& s, const database& db) const;
-    future<> make_directory_for_column_family(const sstring& name, table_id uuid);
     void add_or_update_column_family(const schema_ptr& s);
     void add_user_type(const user_type ut);
     void remove_user_type(const user_type ut);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1242,8 +1242,6 @@ public:
     const sstring& datadir() const {
         return _config.datadir;
     }
-
-    sstring column_family_directory(const sstring& base_path, const sstring& name, table_id uuid) const;
 };
 
 using no_such_keyspace = data_dictionary::no_such_keyspace;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -627,6 +627,7 @@ public:
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }
     future<> init_storage();
+    future<> destroy_storage();
 
     seastar::gate& async_gate() { return _async_gate; }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1204,6 +1204,8 @@ public:
 
     future<> update_from(const locator::shared_token_metadata& stm, lw_shared_ptr<keyspace_metadata>);
 
+    future<> init_storage();
+
     /** Note: return by shared pointer value, since the meta data is
      * semi-volatile. I.e. we could do alter keyspace at any time, and
      * boom, it is replaced.

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -723,7 +723,6 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         }
 
         sstring cfname = cf->schema()->cf_name();
-        auto sstdir = ks.column_family_directory(ksdir, cfname, uuid);
         dblog.info("Keyspace {}: Reading CF {} id={} version={} storage={}", ks_name, cfname, uuid, s->version(), cf->get_storage_options().type_string());
 
         auto gtable = co_await get_table_on_all_shards(db, ks_name, cfname);
@@ -738,9 +737,9 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
             std::exception_ptr eptr = std::current_exception();
             std::string msg =
                 format("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
-                        ks_name, cfname, sstdir, eptr);
+                        ks_name, cfname, cf->dir(), eptr);
             dblog.error("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
-                        ks_name, cfname, sstdir, eptr);
+                        ks_name, cfname, cf->dir(), eptr);
             try {
                 std::rethrow_exception(eptr);
             } catch (sstables::compaction_stopped_exception& e) {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -730,7 +730,7 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         std::exception_ptr ex;
 
         try {
-            co_await ks.make_directory_for_column_family(cfname, uuid);
+            co_await cf->init_storage();
 
             co_await metadata.start();
         } catch (...) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -843,11 +843,6 @@ public:
                 replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, p).get();
             }
 
-            auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
-            parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {
-                auto cfm = pair.second;
-                return ks.make_directory_for_column_family(cfm->cf_name(), cfm->id());
-            }).get();
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
             db.invoke_on_all([] (replica::database& db) {


### PR DESCRIPTION
This set encapsulates ks/cf directories creation and deletion into keyspace and table classes methods. This is needed to facilitate making the storage initialization storage-type aware in the future. Also this makes the replica/ code less involved in formatting sstables' directory path by hand.

refs: #13020
refs: #12707