### PR TITLE
dbuild:Add docker login if credentials are available

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -16,6 +16,9 @@ EOF
     exit 1
 }
 
+if env | grep DOCKER_USERNAME > /dev/null ; then
+  echo $DOCKER_PASSWORD | docker login --username=$DOCKER_USERNAME --password-stdin
+fi
 if which docker >/dev/null 2>&1 ; then
   tool=${DBUILD_TOOL-docker}
 elif which podman >/dev/null 2>&1 ; then


### PR DESCRIPTION
next started to fail to pull the dbuild image with the following error:

```
09:09:11  + bash -c 'set -o pipefail; /jenkins/workspace/scylla-master/next/scylla/tools/toolchain/dbuild  -v /var/cache/ccache:/var/cache/ccache:z -e CCACHE_DIR=/var/cache/ccache -e CCACHE_UMASK=002 -e PATH=/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin  -- ./configure.py  --debuginfo 1 --tests-debuginfo 1 2>&1 | tee output-build-x86_64.txt'
09:09:11  Unable to find image 'scylladb/scylla-toolchain:fedora-37-20230424' locally
09:09:13  docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
09:09:13  See 'docker run --help'.
09:09:13  Error: No such container:
```

We should login to docker hub before pulling our images, this is a preparation for https://github.com/scylladb/scylla-pkg/pull/3432