### PR TITLE
partitioned_sstable_set: erase empty runs

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -364,7 +364,12 @@ void partitioned_sstable_set::insert(shared_sstable sst) {
 }
 
 void partitioned_sstable_set::erase(shared_sstable sst) {
-    _all_runs[sst->run_identifier()].erase(sst);
+    if (auto it = _all_runs.find(sst->run_identifier()); it != _all_runs.end()) {
+        it->second.erase(sst);
+        if (it->second.empty()) {
+            _all_runs.erase(it);
+        }
+    }
     _all->erase(sst);
     if (store_as_unleveled(sst)) {
         _unleveled_sstables.erase(std::remove(_unleveled_sstables.begin(), _unleveled_sstables.end(), sst), _unleveled_sstables.end());

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -41,6 +41,9 @@ public:
     // Returns false if sstable being inserted cannot satisfy the disjoint invariant. Then caller should pick another run for it.
     bool insert(shared_sstable sst);
     void erase(shared_sstable sst);
+    bool empty() const noexcept {
+        return _all.empty();
+    }
     // Data size of the whole run, meaning it's a sum of the data size of all its fragments.
     uint64_t data_size() const;
     const sstable_set& all() const { return _all; }


### PR DESCRIPTION
When erasing a sstable first check if its run_id
exists in _all_runs, otherwise do nothing with
that respect, and then if the run becomes empty
when erasing the last sstable (and it could have been a single-sstable run from get go), erase the run
from `_all_runs`.

Fixes #14052