### PR TITLE
partitioned_sstable_set: insert: return early if sst is already in the set

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -342,7 +342,11 @@ future<stop_iteration> partitioned_sstable_set::for_each_sstable_gently_until(st
 }
 
 void partitioned_sstable_set::insert(shared_sstable sst) {
-    _all->insert(sst);
+    auto [_, inserted] = _all->insert(sst);
+    if (!inserted) {
+        // sst is already in the set, no further handling is required
+        return;
+    }
     auto undo_all_insert = defer([&] () { _all->erase(sst); });
 
     // If sstable doesn't satisfy disjoint invariant, then place it in a new sstable run.


### PR DESCRIPTION
Currently, partitioned_sstable_set::insert may erase a sstable from the set inadvertently, if an exception is thrown while (re-)inserting it.

To prevent that, simply return early after detecting that insertion didn't took place, based on the unordered_set::insert result.

This issue is theoretical, as there are no known case of re-inserting sstables into the partitioned sstable set.

Fixes #14060