### PR TITLE
repair: Add aborted_by_user to repair status report

### DIFF
--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -115,12 +115,14 @@ public:
     uint64_t nr_ranges_finished = 0;
     uint64_t nr_ranges_total;
     size_t nr_failed_ranges = 0;
-    bool aborted = false;
     int ranges_index = 0;
     repair_stats _stats;
     std::unordered_set<sstring> dropped_tables;
     bool _hints_batchlog_flushed = false;
     std::unordered_set<gms::inet_address> nodes_down;
+private:
+    bool _aborted = false;
+    bool _failed = false;
 public:
     shard_repair_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,


### PR DESCRIPTION
Add the aborted_by_user flag to the repair status report, for example:

INFO  [shard 0] repair - repair[4342512b-5a5f-48fc-a840-934100264cbc]: starting user-requested repair for keyspace ks2a, repair id 1,
      options {{trace -> false}, {columnFamilies -> tb5}, {jobThreads -> 1}, {incremental -> false}, {parallelism -> parallel}, {primaryRange -> false}}
INFO  [shard 0] repair - Started to aborting repair jobs={4342512b-5a5f-48fc-a840-934100264cbc}, nr_jobs=1 WARN  [shard 0] repair - repair[4342512b-5a5f-48fc-a840-934100264cbc]: Repair job aborted by user, job=4342512b-5a5f-48fc-a840-934100264cbc, keyspace=ks2a, tables={tb5} WARN  [shard 0] repair - repair[4342512b-5a5f-48fc-a840-934100264cbc]: 3 out of 513 ranges failed, keyspace=ks2a, tables={tb5}, repair_reason=repair, nodes_down_during_repair={}, aborted_by_user=true WARN  [shard 1] repair - repair[4342512b-5a5f-48fc-a840-934100264cbc]: 3 out of 513 ranges failed, keyspace=ks2a, tables={tb5}, repair_reason=repair, nodes_down_during_repair={}, aborted_by_user=true WARN  [shard 0] repair - repair[4342512b-5a5f-48fc-a840-934100264cbc]: user-requested repair failed: std::runtime_error ({
      shard 0: std::runtime_error (repair[4342512b-5a5f-48fc-a840-934100264cbc]: 3 out of 513 ranges failed, keyspace=ks2a, tables={tb5}, repair_reason=repair, nodes_down_during_repair={}, aborted_by_user=true),
      shard 1: std::runtime_error (repair[4342512b-5a5f-48fc-a840-934100264cbc]: 3 out of 513 ranges failed, keyspace=ks2a, tables={tb5}, repair_reason=repair, nodes_down_during_repair={}, aborted_by_user=true)})

In addition, change the log

from

"Aborted {} repair job(s), aborted={}"

to

"Started to aborting repair jobs={}, nr_jobs={}"

to reflect the fact the user requested abort api is async.