### PR TITLE
create-relocatable-package.py: package build/node_export only for stripped version

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -171,10 +171,10 @@ ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('build/debian/debian', arcname='debian')
 ar.reloc_add('build/node_exporter', arcname='node_exporter')
-if not args.stripped:
-    ar.reloc_add('build/node_exporter/node_exporter', arcname='node_exporter/node_exporter')
-else:
+if args.stripped:
     ar.reloc_add('build/node_exporter/node_exporter.stripped', arcname='node_exporter/node_exporter')
+else:
+    ar.reloc_add('build/node_exporter/node_exporter', arcname='node_exporter/node_exporter')
 ar.reloc_add('build/node_exporter/LICENSE', arcname='node_exporter/LICENSE')
 ar.reloc_add('build/node_exporter/NOTICE', arcname='node_exporter/NOTICE')
 ar.reloc_add('ubsan-suppressions.supp')

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -170,8 +170,8 @@ ar.reloc_add('api')
 ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('build/debian/debian', arcname='debian')
-ar.reloc_add('build/node_exporter', arcname='node_exporter')
 if args.stripped:
+    ar.reloc_add('build/node_exporter', arcname='node_exporter')
     ar.reloc_add('build/node_exporter/node_exporter.stripped', arcname='node_exporter/node_exporter')
 else:
     ar.reloc_add('build/node_exporter/node_exporter', arcname='node_exporter/node_exporter')


### PR DESCRIPTION
because we build stripped package and non-stripped package in parallel
using ninja. there are chances that the non-stripped build job could
be adding build/node_exporter directory to the tarball while the job
building stripped package is using objcopy to extract the symbols from
the build/node_exporter/node_exporter executable. but objcopy creates
temporary files when processing the executables. and the temporary
files can be spotted by the non-stripped build job. there are two
consequences:

1. non-stripped build job includes the temporary files in its tarball,
   even they are not supposed to be distributed
2. non-stripped build job fails to include the temporary file(s), as
   they are removed after objcopy finishes its job. but the job did spot
   them when preparing the tarball. so when the tarfile python module
   tries to include the previous found temporary file(s), it throws.

neither of these consequences is expected. but fortunately, this only
happens when packaging the non-stripped package. when packaging the
stripped package, the build/node_exported directory is not in flux
anymore. as ninja ensures the dependencies between the jobs.

so, in this change, we do not add the whole directory when packaging
the non-stripped version. as all its ingredients have been added
separately as regular files. and when packaing the stripped version,
we still use the existing step, as we don't have to list all the
files created by strip.sh:

node_exporter{,.debug,.dynsyms,.funcsyms,.keep_symbols,.minidebug.xz}

we could do so in this script, but the repeatings is unnecessary and
error-prune. so, let's keep including the whole directory recursively,
so all the debug symbols are included.

Fixes https://github.com/scylladb/scylladb/issues/14079