### PR TITLE
reloc: raise if rmtree fails

### DIFF
--- a/dist/debuginfo/scripts/create-relocatable-package.py
+++ b/dist/debuginfo/scripts/create-relocatable-package.py
@@ -56,7 +56,10 @@ gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.P
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
 # relocatable package format version = 2.1
-shutil.rmtree(f'build/{SCYLLA_DIR}', ignore_errors=True)
+try:
+    shutil.rmtree(f'build/{SCYLLA_DIR}')
+except FileNotFoundError:
+    pass
 os.makedirs(f'build/{SCYLLA_DIR}')
 with open(f'build/{SCYLLA_DIR}/.relocatable_package_version', 'w') as f:
     f.write('2.1\n')


### PR DESCRIPTION
occasionally, we are observing build failures like:
```
17:20:54  FAILED: build/release/dist/tar/scylla-debuginfo-5.4.0~dev-0.20230522.5b2687e11800.x86_64.tar.gz
17:20:54  dist/debuginfo/scripts/create-relocatable-package.py --mode release 'build/release/dist/tar/scylla-debuginfo-5.4.0~dev-0.20230522.5b2687e11800.x86_64.tar.gz'
17:20:54  Traceback (most recent call last):
17:20:54    File "/jenkins/workspace/scylla-master/scylla-ci/scylla/dist/debuginfo/scripts/create-relocatable-package.py", line 60, in <module>
17:20:54      os.makedirs(f'build/{SCYLLA_DIR}')
17:20:54    File "<frozen os>", line 225, in makedirs
17:20:54  FileExistsError: [Errno 17] File exists: 'build/scylla-debuginfo-package'
```

to understand the root cause better, instead of swallowing the error, let's raise the exception it is not caused by non-existing directory.

a similar change was applied to scripts/create-relocatable-package.py in a0b8aa9b13fcf2ca9145b18c3658839222cf3099. which was correct per-se. but the original intention was to understand the root cause of the failure when packaging scylla-debuginfo-*.tar.gz, which is created by the dist/debuginfo/scripts/create-relocatable-package.py.

so, in this change, the change is ported to this script.