### PR TITLE
[RFC] db/system_keyspace: add data_source virtual table 

### DIFF
--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -16,15 +16,19 @@
 
 namespace db {
 
-void virtual_table::set_cell(row& cr, const bytes& column_name, data_value value) {
+void virtual_table::set_cell(const ::schema& schema, row& cr, const bytes& column_name, data_value value) {
     auto ts = api::new_timestamp();
-    auto cdef = schema()->get_column_definition(column_name);
+    auto cdef = schema.get_column_definition(column_name);
     if (!cdef) {
         throw_with_backtrace<std::runtime_error>(format("column not found: {}", column_name));
     }
     if (!value.is_null()) {
         cr.apply(*cdef, atomic_cell::make_live(*cdef->type, ts, value.serialize_nonnull()));
     }
+}
+
+void virtual_table::set_cell(row& cr, const bytes& column_name, data_value value) {
+    return set_cell(*schema(), cr, column_name, std::move(value));
 }
 
 bool virtual_table::this_shard_owns(const dht::decorated_key& dk) const {

--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -27,6 +27,7 @@ protected: // opt-ins
     bool _shard_aware = false;
 
 protected:
+    static void set_cell(const ::schema&, row&, const bytes& column_name, data_value);
     void set_cell(row&, const bytes& column_name, data_value);
     bool contains_key(const dht::partition_range&, const dht::decorated_key&) const;
     bool this_shard_owns(const dht::decorated_key&) const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -712,6 +712,10 @@ public:
     flat_mutation_reader_v2 make_memtable_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
             const query::partition_slice& slice);
 
+    // Make a reader which reads only from the sstable(s).
+    flat_mutation_reader_v2 make_sstable_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
+            const query::partition_slice& slice);
+
     sstables::shared_sstable make_streaming_sstable_for_write(std::optional<sstring> subdir = {});
     sstables::shared_sstable make_streaming_staging_sstable();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -708,6 +708,10 @@ public:
     flat_mutation_reader_v2 make_streaming_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
             lw_shared_ptr<sstables::sstable_set> sstables) const;
 
+    // Make a reader which reads only from the memtable(s).
+    flat_mutation_reader_v2 make_memtable_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
+            const query::partition_slice& slice);
+
     sstables::shared_sstable make_streaming_sstable_for_write(std::optional<sstring> subdir = {});
     sstables::shared_sstable make_streaming_staging_sstable();
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -358,6 +358,12 @@ flat_mutation_reader_v2 table::make_memtable_reader(schema_ptr schema, reader_pe
     return make_combined_reader(std::move(schema), std::move(permit), std::move(readers), streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
 }
 
+flat_mutation_reader_v2 table::make_sstable_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
+        const query::partition_slice& slice) {
+    return make_sstable_reader(std::move(schema), std::move(permit), _sstables, range, slice, default_priority_class(), {},
+            streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
+}
+
 future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout) {
     assert(m.schema() == _counter_cell_locks->schema());
     return _counter_cell_locks->lock_cells(m.decorated_key(), partition_cells_range(m.partition()), timeout);


### PR DESCRIPTION
Allows querying the mutation-level content of any table, from any of the
mutation sources (memtable, sstables, row-cache).
The table supports reading only a single partition from the given table.
The content is presented in the mutation-fragment level, separately for
all mutation sources. The content of individual mutation sources are
merged, e.g. even if there are multiple memtables/sstables, the contents
of these will be merged into a single per mutation-source stream.

This virtual table provides us a long needed peak into the content of
memtables and cache, something we could only do in coredumps until now.

Fixes: https://github.com/scylladb/scylladb/issues/11130

Example:

given a table:

    CREATE TABLE ks.tbl (
	pk int,
	ck int,
	s int static,
	v text,
	PRIMARY KEY (pk, ck)
    )

with the following content:

    cqlsh> select * from ks.tbl where pk = 100;

     pk  | ck  | s    | v
    -----+-----+------+-----
     100 | 200 | null | www
     100 | 300 | null | vvv
     100 | 400 | null | www

we can query the underlying mutation fragments:

    cqlsh> select * from system.data_source where keyspace_name = 'ks' and table_name = 'tbl' and partition_key = ['100'];

     keyspace_name | table_name | partition_key | source   | partition_region | clustering_key | position_weight | kind            | value
    ---------------+------------+---------------+----------+------------------+----------------+-----------------+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
		ks |        tbl |       ['100'] | memtable |                0 |               [] |               0 | partition start |                                                                                                                                                                                                                                             null
		ks |        tbl |       ['100'] | memtable |                2 |        ['200'] |               0 |  clustering row | {mutation_fragment: clustering row {position: clustered, ckp{0004000000c8}, 0} {clustering_row: ck 0004000000c8 dr {deletable_row: {row_marker: 1685427018668474 0 0} {{row:\n    v{ atomic_cell{www,ts=1685427018668474,expiry=-1,ttl=0} }}}}}}
		ks |        tbl |       ['100'] | memtable |                2 |        ['400'] |               0 |  clustering row | {mutation_fragment: clustering row {position: clustered, ckp{000400000190}, 0} {clustering_row: ck 000400000190 dr {deletable_row: {row_marker: 1685427016170123 0 0} {{row:\n    v{ atomic_cell{www,ts=1685427016170123,expiry=-1,ttl=0} }}}}}}
		ks |        tbl |       ['100'] | memtable |                3 |               [] |               0 |   partition end |                                                                                                                                                                                                                                             null
		ks |        tbl |       ['100'] |  sstable |                0 |               [] |               0 | partition start |                                                                                                                                                                                                                                             null
		ks |        tbl |       ['100'] |  sstable |                2 |        ['200'] |               0 |  clustering row | {mutation_fragment: clustering row {position: clustered, ckp{0004000000c8}, 0} {clustering_row: ck 0004000000c8 dr {deletable_row: {row_marker: 1685364217042150 0 0} {{row:\n    v{ atomic_cell{vvv,ts=1685364217042150,expiry=-1,ttl=0} }}}}}}
		ks |        tbl |       ['100'] |  sstable |                2 |        ['300'] |               0 |  clustering row | {mutation_fragment: clustering row {position: clustered, ckp{00040000012c}, 0} {clustering_row: ck 00040000012c dr {deletable_row: {row_marker: 1685364217047564 0 0} {{row:\n    v{ atomic_cell{vvv,ts=1685364217047564,expiry=-1,ttl=0} }}}}}}
		ks |        tbl |       ['100'] |  sstable |                2 |        ['400'] |               0 |  clustering row | {mutation_fragment: clustering row {position: clustered, ckp{000400000190}, 0} {clustering_row: ck 000400000190 dr {deletable_row: {row_marker: 1685364217050305 0 0} {{row:\n    v{ atomic_cell{vvv,ts=1685364217050305,expiry=-1,ttl=0} }}}}}}
		ks |        tbl |       ['100'] |  sstable |                3 |               [] |               0 |   partition end |                                                                                                                                                                                                                                             null