### PR TITLE
Branch 5.1 backport scylla prepare fixes

### DIFF
--- a/dist/common/scripts/scylla_cpuset_setup
+++ b/dist/common/scripts/scylla_cpuset_setup
@@ -36,6 +36,9 @@ if __name__ == '__main__':
     except:
         pass
     if cpuset != args.cpuset or smp != args.smp:
+        if os.path.exists('/etc/scylla.d/perftune.yaml'):
+            os.remove('/etc/scylla.d/perftune.yaml')
+
         cfg.set('CPUSET', '{cpuset}{smp}'.format( \
                 cpuset='--cpuset {} '.format(args.cpuset) if args.cpuset else '', \
                 smp='--smp {} '.format(args.smp) if args.smp else '' \

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -62,16 +62,6 @@ def get_irq_cpu_mask():
 
     return out(hwloc_cmd).strip()
 
-def config_updated():
-    perftune_mtime = os.path.getmtime('/etc/scylla.d/perftune.yaml')
-    cpuset_mtime = os.path.getmtime('/etc/scylla.d/cpuset.conf')
-    sysconfig_mtime = os.path.getmtime(sysconfdir_p() / 'scylla-server')
-    print("perftune_mtime < cpuset_mtime:{}".format(perftune_mtime < cpuset_mtime))
-    print("perftune_mtime < sysconfig_mtime:{}".format(perftune_mtime < sysconfig_mtime))
-    if perftune_mtime < cpuset_mtime or perftune_mtime < sysconfig_mtime:
-        return True
-    return False
-
 def create_perftune_conf(cfg):
     """
     This function checks if a perftune configuration file should be created and
@@ -97,7 +87,7 @@ def create_perftune_conf(cfg):
         params += ' --write-back-cache=false'
 
     if len(params) > 0:
-        if os.path.exists('/etc/scylla.d/perftune.yaml') and not config_updated():
+        if os.path.exists('/etc/scylla.d/perftune.yaml'):
             return True
 
         params += ' --dump-options-file'

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -16,31 +16,51 @@ import distro
 from scylla_util import *
 from subprocess import run
 
-def get_mode_cpuset(nic, mode):
-    mode_cpu_mask = out('/opt/scylladb/scripts/perftune.py --tune net --nic {} --mode {} --get-cpu-mask-quiet'.format(nic, mode))
-    return hex2list(mode_cpu_mask)
-
 def get_cur_cpuset():
     cfg = sysconfig_parser('/etc/scylla.d/cpuset.conf')
     cpuset = cfg.get('CPUSET')
     return re.sub(r'^--cpuset (.+)$', r'\1', cpuset).strip()
 
-def get_tune_mode(nic):
+def get_irq_cpu_mask():
+    """
+    Return an irq_cpu_mask corresponding to a value written in cpuset.conf
+
+    Let's use the "CPU masks invariant": irq_cpu_mask | compute_cpu_mask == cpu_mask.
+
+    This function is called when  we are generating a perftune.yaml meaning that there are no restrictions on
+    cpu_mask defined.
+
+    And this means that in the context of this function call cpu_mask is "all CPUs", or in hwloc-cal lingo - 'all'.
+
+    (For any "special" value of a cpu_mask a user needs to write his/her own perftune.yaml)
+
+    Mentioned above means that in order to calculate an irq_cpu_mask that corresponds to a compute_cpu_mask defined
+    using --cpuset in cpuset.conf and cpu_mask == 'all' we need to invert bits from the compute_cpu_mask in the 'all'
+    mask.
+
+    This can be achieved by running the following hwloc-calc command:
+
+    hwloc-calc --pi all ~PU:X ~PU:Y ~PU:Z ...
+
+    where X,Y,Z,... are either a single CPU index or a CPU range.
+
+    For example, if we have the following cpuset:
+
+    0,2-7,17-24,35
+
+    to get irq_cpu_mask we want to run the following command:
+
+    hwloc-calc --pi all ~PU:0 ~PU:2-7 ~PU:17-24 ~PU:35
+    """
+
     if not os.path.exists('/etc/scylla.d/cpuset.conf'):
         raise Exception('/etc/scylla.d/cpuset.conf not found')
     cur_cpuset = get_cur_cpuset()
-    mq_cpuset = get_mode_cpuset(nic, 'mq')
-    sq_cpuset = get_mode_cpuset(nic, 'sq')
-    sq_split_cpuset = get_mode_cpuset(nic, 'sq_split')
 
-    if cur_cpuset == mq_cpuset:
-        return 'mq'
-    elif cur_cpuset == sq_cpuset:
-        return 'sq'
-    elif cur_cpuset == sq_split_cpuset:
-        return 'sq_split'
-    else:
-        raise Exception('tune mode not found')
+    hwloc_cmd = "/opt/scylladb/bin/hwloc-calc --pi all {}".\
+        format(" ".join(['~PU:{}'.format(c) for c in cur_cpuset.split(",")]))
+
+    return out(hwloc_cmd).strip()
 
 def config_updated():
     perftune_mtime = os.path.getmtime('/etc/scylla.d/perftune.yaml')
@@ -65,8 +85,10 @@ def create_perftune_conf(cfg):
         nic = cfg.get('IFNAME')
         if not nic:
             nic = 'eth0'
-        mode = get_tune_mode(nic)
-        params += '--tune net --nic "{nic}" --mode {mode}'.format(nic=nic, mode=mode)
+        irq_cpu_mask = get_irq_cpu_mask()
+        # Note that 'irq_cpu_mask' is a coma separated list of 32-bits wide masks.
+        # Therefore, we need to put it in quotes.
+        params += '--tune net --nic "{nic}" --irq-cpu-mask "{irq_cpu_mask}"'.format(nic=nic, irq_cpu_mask=irq_cpu_mask)
 
     if cfg.has_option('SET_CLOCKSOURCE') and cfg.get('SET_CLOCKSOURCE') == 'yes':
         params += ' --tune system --tune-clock'

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -21,6 +21,20 @@ def get_cur_cpuset():
     cpuset = cfg.get('CPUSET')
     return re.sub(r'^--cpuset (.+)$', r'\1', cpuset).strip()
 
+def cpu_mask_is_zero(cpu_mask):
+    """
+    The cpu_mask is a comma-separated list of 32-bit hex values with possibly omitted zero components,
+            e.g. 0xffff,,0xffff
+    We want to estimate if the whole mask is all-zeros.
+    :param cpu_mask: hwloc-calc generated CPU mask
+    :return: True if mask is zero, False otherwise
+    """
+    for cur_cpu_mask in cpu_mask.split(','):
+        if cur_cpu_mask and int(cur_cpu_mask, 16) != 0:
+            return False
+
+    return True
+
 def get_irq_cpu_mask():
     """
     Return an irq_cpu_mask corresponding to a value written in cpuset.conf
@@ -60,7 +74,14 @@ def get_irq_cpu_mask():
     hwloc_cmd = "/opt/scylladb/bin/hwloc-calc --pi all {}".\
         format(" ".join(['~PU:{}'.format(c) for c in cur_cpuset.split(",")]))
 
-    return out(hwloc_cmd).strip()
+    irq_cpu_mask = out(hwloc_cmd).strip()
+
+    # If the generated mask turns out to be all-zeros then it means that all present CPUs are used in cpuset.conf.
+    # In such a case irq_cpu_mask has to be all-CPUs too, a.k.a. MQ mode.
+    if cpu_mask_is_zero(irq_cpu_mask):
+        irq_cpu_mask = out("/opt/scylladb/bin/hwloc-calc all").strip()
+
+    return irq_cpu_mask
 
 def create_perftune_conf(cfg):
     """


### PR DESCRIPTION
This PR:
* Switches scylla_prepare to a new perftune.py semantics.
* Fixes a regression introduced during an attempt to make scylla_cpuset_setup idempotent (#11385).
* Makes scylla_cpuset_setup idempotent.