### PR TITLE
test/lib: test_reader_conversions: always close reader

### DIFF
--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1597,8 +1597,8 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
 
         {
             auto rd = ms.make_fragment_v1_stream(m.schema(), semaphore.make_permit());
+            auto close_rd = deferred_close(rd);
             match_compacted_mutation(read_mutation_from_flat_mutation_reader(rd).get0(), m_compacted, query_time);
-            rd.close().get();
         }
     });
 }


### PR DESCRIPTION
read_mutation_from_flat_mutation_reader might throw so we need to close the reader returned from
ms.make_fragment_v1_stream also on the error
path to avoid the internal error abort when the
reader is destroyed while opened.

Fixes #14098