### PR TITLE
storage_service: avoid excessive delay in wait_for_ring_to_settle()

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -253,15 +253,15 @@ static future<> set_gossip_tokens(gms::gossiper& g,
  */
 future<> storage_service::wait_for_ring_to_settle(std::chrono::milliseconds delay) {
     // first sleep the delay to make sure we see *at least* one other node
-    for (int i = 0; i < delay.count() && _gossiper.get_live_members().size() < 2; i += 1000) {
-        co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
+    for (int i = 0; i < delay.count() && _gossiper.get_live_members().size() < 2; i += 10) {
+        co_await sleep_abortable(std::chrono::milliseconds(10), _abort_source);
     }
 
     auto t = gms::gossiper::clk::now();
     while (true) {
+        slogger.info("waiting for schema information to complete");
         while (!_migration_manager.local().have_schema_agreement()) {
-            slogger.info("waiting for schema information to complete");
-            co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
+            co_await sleep_abortable(std::chrono::milliseconds(10), _abort_source);
         }
         co_await update_topology_change_info("joining");
 


### PR DESCRIPTION
The function storage_service::wait_for_ring_to_settle() is called when bootstrapping a new node in an existing cluster, and it's supposed to wait until the caller has the right schema - to allow the bootstrap to start (the bootstrap needs to copy all existing tables from other nodes).

The code of this function mostly checks in-memory structures in the gossiper and migration manager, and if they aren't ready, sleeps and tries again (until a timeout of "ring_delay_ms"). Today we sleep a whole second between each try, but that's excessive - the checks are very cheap, and we can do them much more often, so we can stop the loop much closer to when the schema becomes available.

This patch changes the sleep from 1 second to 10 milliseconds.

The benefit of this patch is not huge - on average I measured about 0.25 seconds saving on adding a node to a cluster. But I don't see any downside either.

Noticed while looking into Refs #14073