### PR TITLE
storage_service: wait for schema agreement during initial boot

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1383,6 +1383,26 @@ class scylla_databases(gdb.Command):
             gdb.write('{:5} (replica::database*){}\n'.format(shard, db))
 
 
+class scylla_commitlog(gdb.Command):
+    """Prints info about commitlog segment manager and managed segments
+    """
+
+    def __init__(self):
+        gdb.Command.__init__(self, 'scylla commitlog', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
+
+    def invoke(self, arg, from_tty):
+        db = find_db()
+        cmtlog = std_unique_ptr(db['_commitlog']).get()
+        gdb.write('(db::commitlog*){}\n'.format(cmtlog))
+        segmgr = seastar_shared_ptr(cmtlog['_segment_manager']).get()
+        gdb.write('(db::commitlog::segment_manager*){}\n'.format(segmgr))
+        segs = std_vector(segmgr['_segments'])
+        gdb.write('segments ({}):\n'.format(len(segs)))
+        for seg_p in segs:
+            seg = seastar_shared_ptr(seg_p).get()
+            gdb.write('(db::commitlog::segment*){}\n'.format(seg))
+
+
 class scylla_keyspaces(gdb.Command):
     def __init__(self):
         gdb.Command.__init__(self, 'scylla keyspaces', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
@@ -5652,6 +5672,7 @@ class scylla_gdb_func_variant_member(gdb.Function):
 # Commands
 scylla()
 scylla_databases()
+scylla_commitlog()
 scylla_keyspaces()
 scylla_tables()
 scylla_memory()

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -253,15 +253,15 @@ static future<> set_gossip_tokens(gms::gossiper& g,
  */
 future<> storage_service::wait_for_ring_to_settle(std::chrono::milliseconds delay) {
     // first sleep the delay to make sure we see *at least* one other node
-    for (int i = 0; i < delay.count() && _gossiper.get_live_members().size() < 2; i += 1000) {
-        co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
+    for (int i = 0; i < delay.count() && _gossiper.get_live_members().size() < 2; i += 10) {
+        co_await sleep_abortable(std::chrono::milliseconds(10), _abort_source);
     }
 
     auto t = gms::gossiper::clk::now();
     while (true) {
+        slogger.info("waiting for schema information to complete");
         while (!_migration_manager.local().have_schema_agreement()) {
-            slogger.info("waiting for schema information to complete");
-            co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
+            co_await sleep_abortable(std::chrono::milliseconds(10), _abort_source);
         }
         co_await update_topology_change_info("joining");
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -295,7 +295,7 @@ private:
 
     future<std::unordered_set<gms::inet_address>> get_nodes_to_sync_with(
             const std::unordered_set<gms::inet_address>& ignore_dead_nodes);
-    future<> wait_for_ring_to_settle(std::chrono::milliseconds delay);
+    future<> wait_for_ring_to_settle();
 
 public:
 

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -613,6 +613,20 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(VALUES  (l1))").get(), ire, duplicate);
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         l1 )").get(), ire, duplicate);
 
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         s2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (s2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (s2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         m2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (m2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (m2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         l2 )").get(), ire, non_full);
+        e.execute_cql(                        "create index on t(FULL    (l2))").get();
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (l2))").get(), ire, duplicate);
+
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t where m2[1] = '1'").get(), ire, entry_eq);
+
         const sstring insert_into = "insert into t(p, s1, m1, l1, s2, m2, l2) values ";
         e.execute_cql(insert_into + "(1, {1},    {1: 'one', 2: 'two'},                [2],       {1}, {1: 'one', 2: 'two'},    [2])").get();
         e.execute_cql(insert_into + "(2, {2},    {3: 'three', 7: 'five'},             [3, 4, 5], {2}, {3: 'three'},            [3, 4, 5])").get();
@@ -648,20 +662,6 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(1)}}}, {{{int32_type->decompose(3)}}}});
         res = e.execute_cql("SELECT p from t where l1 CONTAINS 1").get0();
         assert_that(res).is_rows().with_size(0);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         s2 )").get(), ire, non_full);
-        e.execute_cql(                        "create index on t(FULL    (s2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (s2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         m2 )").get(), ire, non_full);
-        e.execute_cql(                        "create index on t(FULL    (m2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (m2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(         l2 )").get(), ire, non_full);
-        e.execute_cql(                        "create index on t(FULL    (l2))").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("create index on t(FULL    (l2))").get(), ire, duplicate);
-
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t where m2[1] = '1'").get(), ire, entry_eq);
 
         res = e.execute_cql("SELECT p from t where s2 = {2}").get0();
         assert_that(res).is_rows().with_rows({{{int32_type->decompose(2)}}});

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5058,3 +5058,99 @@ SEASTAR_TEST_CASE(compaction_optimization_to_avoid_bloom_filter_checks) {
         BOOST_REQUIRE_EQUAL(1, result.stats.bloom_filter_checks);
     });
 }
+
+SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        auto builder = schema_builder("tests", "test")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type);
+        builder.set_gc_grace_seconds(10000);
+        builder.set_compaction_strategy(sstables::compaction_strategy_type::leveled);
+        std::map<sstring, sstring> opts = {
+            { "sstable_size_in_mb", "0" }, // makes sure that every mutation produces one fragment, to trigger incremental compaction
+        };
+        builder.set_compaction_strategy_options(std::move(opts));
+        auto s = builder.build();
+        auto sst_gen = env.make_sst_factory(s);
+
+        auto make_insert = [&] (partition_key key) {
+            mutation m(s, key);
+            m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)), api::new_timestamp());
+            return m;
+        };
+
+        std::vector<utils::observer<sstable&>> observers;
+        std::vector<shared_sstable> ssts;
+        size_t sstables_closed = 0;
+        size_t sstables_closed_during_cleanup = 0;
+        static constexpr size_t sstables_nr = 10;
+
+        dht::token_range_vector owned_token_ranges;
+
+        std::set<mutation, mutation_decorated_key_less_comparator> merged;
+        for (auto i = 0; i < sstables_nr * 2; i++) {
+            merged.insert(make_insert(partition_key::from_exploded(*s, {to_bytes(to_sstring(i))})));
+        }
+
+        std::unordered_set<sstables::generation_type> gens; // input sstable generations
+        run_id run_identifier = run_id::create_random_id();
+        auto merged_it = merged.begin();
+        for (auto i = 0; i < sstables_nr; i++) {
+            auto mut1 = std::move(*merged_it);
+            merged_it++;
+            auto mut2 = std::move(*merged_it);
+            merged_it++;
+            auto sst = make_sstable_containing(sst_gen, {
+                std::move(mut1),
+                std::move(mut2)
+            });
+            sstables::test(sst).set_run_identifier(run_identifier); // in order to produce multi-fragment run.
+            sst->set_sstable_level(1);
+
+            // every sstable will be eligible for cleanup, by having both an owned and unowned token.
+            owned_token_ranges.push_back(dht::token_range::make_singular(sst->get_last_decorated_key().token()));
+
+            gens.insert(sst->generation());
+            ssts.push_back(std::move(sst));
+        }
+
+        size_t last_input_sstable_count = sstables_nr;
+        {
+            auto t = env.make_table_for_tests(s);
+            auto stop = deferred_stop(t);
+            t->disable_auto_compaction().get();
+            const dht::token_range_vector empty_owned_ranges;
+            for (auto&& sst : ssts) {
+                testlog.info("run id {}", sst->run_identifier());
+                column_family_test(t).add_sstable(sst).get();
+                column_family_test::update_sstables_known_generation(*t, sst->generation());
+                observers.push_back(sst->add_on_closed_handler([&] (sstable& sst) mutable {
+                    auto sstables = t->get_sstables();
+                    auto input_sstable_count = std::count_if(sstables->begin(), sstables->end(), [&] (const shared_sstable& sst) {
+                        return gens.count(sst->generation());
+                    });
+
+                    testlog.info("Closing sstable of generation {}, table set size: {}", sst.generation(), input_sstable_count);
+                    sstables_closed++;
+                    if (input_sstable_count < last_input_sstable_count) {
+                        sstables_closed_during_cleanup++;
+                        last_input_sstable_count = input_sstable_count;
+                    }
+                }));
+            }
+            ssts = {}; // releases references
+            auto owned_ranges_ptr = make_lw_shared<const dht::token_range_vector>(std::move(owned_token_ranges));
+            t->perform_cleanup_compaction(std::move(owned_ranges_ptr)).get();
+            testlog.info("Cleanup has finished");
+        }
+
+        while (sstables_closed != sstables_nr) {
+            yield().get();
+        }
+
+        testlog.info("Closed sstables {}, Closed during cleanup {}", sstables_closed, sstables_closed_during_cleanup);
+
+        BOOST_REQUIRE(sstables_closed == sstables_nr);
+        BOOST_REQUIRE(sstables_closed_during_cleanup >= sstables_nr / 2);
+    });
+}

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1597,8 +1597,8 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
 
         {
             auto rd = ms.make_fragment_v1_stream(m.schema(), semaphore.make_permit());
+            auto close_rd = deferred_close(rd);
             match_compacted_mutation(read_mutation_from_flat_mutation_reader(rd).get0(), m_compacted, query_time);
-            rd.close().get();
         }
     });
 }

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -27,6 +27,9 @@ def test_compaction_tasks(gdb):
 def test_databases(gdb):
     scylla(gdb, 'databases')
 
+def test_commitlog(gdb):
+    scylla(gdb, 'commitlog')
+
 def test_tables(gdb):
     scylla(gdb, 'tables')
 


### PR DESCRIPTION
In production environments the Scylla boot procedure includes various
sleeps such as 'ring delay' and 'waiting for gossip to settle'. We
disable those sleeps in test.py tests and we'd also like to disable
them, if possible, in dtests.

Unfortunately, disabling the sleeps causes problems with schema: a
bootstrapping node creates its own versions of distributed keyspaces and
tables (such as `system_distributed`) because it doesn't first wait for
gossip to settle, during which it would usually pull existing schemas of
those keyspaces/tables from existing nodes. This may cause schema
disagreement for the whole duration of the bootstrap procedure (the
other nodes don't pull schema from a bootstrapping node; pulls are only
allowed once it becomes NORMAL), which causes the bootstrapping node to
costantly pull schema in attempts to synchronize, which doesn't work
because it's the other nodes which don't have schema mutations, not this
node. Even when the bootstrapping node finishes, the existing nodes
won't automatically pull schema from that node - only once we perform
another schema change a pull will be triggered.

The continuous pulls and the lack of schema synchronization until manual
schema change cause problems in tests. For example we observed the test
timing out in debug mode because bootstrap took too long due to the node
having to perform ~700 schema pulls (it attempts to synchronize schema
on each range repair). There's also potential for permanent schema
divergence, although I haven't seen this yet - in my experiments, once
the existing nodes pull from the new node, schema would always converge.

In any case, the safe and robust solution is to ensure that the
bootstrapping node pulls schema from existing nodes early in the boot
procedure. Then it won't try to create its own versions of the
distributed keyspaces/tables because it'll see they are already present
in the cluster.

In fact there already is `storage_service::wait_for_ring_to_settle`
which is supposed to wait until schema is in agreement before
proceeding.

However, this schema agreement wait relied on an earlier wait at the
beginning of the function - for a node to show up in gossiper
(otherwise, if we're the only node in gossiper, the schema agreement
wait trivially finishes immediately).

Unfortunately, this wait would timeout after `ring_delay` and proceed,
even if no other node was observed, instead of throwing an error...

To make it safe, modify the logic so if we timeout, we refuse to
bootstrap. To make it work in tests which set `ring_delay` to 0, make it
independent of `ring_delay` - just set the timeout to 5 minutes.

Fixes #14065
Fixes #14073