### PR TITLE
Enlighten messaging_service::shutdown()

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -418,6 +418,14 @@ static future<> do_with_servers(std::string_view what, std::array<std::unique_pt
     mlogger.info("{} server - Done", what);
 }
 
+future<> messaging_service::shutdown_tls_server() {
+    return do_with_servers("Shutting down tls", _server_tls, std::mem_fn(&rpc_protocol_server_wrapper::shutdown));
+}
+
+future<> messaging_service::shutdown_nontls_server() {
+    return do_with_servers("Shutting down nontls", _server, std::mem_fn(&rpc_protocol_server_wrapper::shutdown));
+}
+
 future<> messaging_service::stop_tls_server() {
     return do_with_servers("Stopping tls", _server_tls, std::mem_fn(&rpc_protocol_server_wrapper::stop));
 }
@@ -439,7 +447,7 @@ future<> messaging_service::stop_client() {
 
 future<> messaging_service::shutdown() {
     _shutting_down = true;
-    co_await when_all(stop_nontls_server(), stop_tls_server(), stop_client()).discard_result();
+    co_await when_all(shutdown_nontls_server(), shutdown_tls_server(), stop_client()).discard_result();
     _token_metadata = nullptr;
 }
 
@@ -447,6 +455,7 @@ future<> messaging_service::stop() {
     if (!_shutting_down) {
         co_await shutdown();
     }
+    co_await when_all(stop_nontls_server(), stop_tls_server());
     co_await unregister_handler(messaging_verb::CLIENT_ID);
     if (_rpc->has_handlers()) {
         mlogger.error("RPC server still has handlers registered");

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 
 #include "message/messaging_service.hh"
 #include <seastar/core/distributed.hh>
@@ -410,7 +411,7 @@ gms::inet_address messaging_service::listen_address() {
 }
 
 static future<> stop_servers(std::array<std::unique_ptr<messaging_service::rpc_protocol_server_wrapper>, 2>& servers) {
-    return parallel_for_each(
+    co_await coroutine::parallel_for_each(
             servers | boost::adaptors::filtered([] (auto& ptr) { return bool(ptr); }) | boost::adaptors::indirected,
             std::mem_fn(&messaging_service::rpc_protocol_server_wrapper::stop));
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -449,11 +449,9 @@ future<> messaging_service::shutdown() {
 
 future<> messaging_service::stop() {
     if (!_shutting_down) {
-        return shutdown().then([this] {
-            return stop();
-        });
+        co_await shutdown();
     }
-    return unregister_handler(messaging_verb::CLIENT_ID).then([this] {
+    co_await unregister_handler(messaging_verb::CLIENT_ID);
         if (_rpc->has_handlers()) {
             mlogger.error("RPC server still has handlers registered");
             for (auto verb = messaging_verb::MUTATION; verb < messaging_verb::LAST;
@@ -465,9 +463,6 @@ future<> messaging_service::stop() {
 
             std::abort();
         }
-
-        return make_ready_future<>();
-    });
 }
 
 rpc::no_wait_type messaging_service::no_wait() {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -410,24 +410,20 @@ gms::inet_address messaging_service::listen_address() {
     return _cfg.ip;
 }
 
-static future<> stop_servers(std::array<std::unique_ptr<messaging_service::rpc_protocol_server_wrapper>, 2>& servers) {
+static future<> do_with_servers(std::string_view what, std::array<std::unique_ptr<messaging_service::rpc_protocol_server_wrapper>, 2>& servers, auto method) {
+    mlogger.info("{} server", what);
     co_await coroutine::parallel_for_each(
             servers | boost::adaptors::filtered([] (auto& ptr) { return bool(ptr); }) | boost::adaptors::indirected,
-            std::mem_fn(&messaging_service::rpc_protocol_server_wrapper::stop));
+            method);
+    mlogger.info("{} server - Done", what);
 }
 
 future<> messaging_service::stop_tls_server() {
-    mlogger.info("Stopping tls server");
-    return stop_servers(_server_tls).then( [] {
-        mlogger.info("Stopping tls server - Done");
-    });
+    return do_with_servers("Stopping tls", _server_tls, std::mem_fn(&rpc_protocol_server_wrapper::stop));
 }
 
 future<> messaging_service::stop_nontls_server() {
-    mlogger.info("Stopping nontls server");
-    return stop_servers(_server).then([] {
-        mlogger.info("Stopping nontls server - Done");
-    });
+    return do_with_servers("Stopping nontls", _server, std::mem_fn(&rpc_protocol_server_wrapper::stop));
 }
 
 future<> messaging_service::stop_client() {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -452,17 +452,17 @@ future<> messaging_service::stop() {
         co_await shutdown();
     }
     co_await unregister_handler(messaging_verb::CLIENT_ID);
-        if (_rpc->has_handlers()) {
-            mlogger.error("RPC server still has handlers registered");
-            for (auto verb = messaging_verb::MUTATION; verb < messaging_verb::LAST;
-                    verb = messaging_verb(int(verb) + 1)) {
-                if (_rpc->has_handler(verb)) {
-                    mlogger.error(" - {}", static_cast<int>(verb));
-                }
+    if (_rpc->has_handlers()) {
+        mlogger.error("RPC server still has handlers registered");
+        for (auto verb = messaging_verb::MUTATION; verb < messaging_verb::LAST;
+                verb = messaging_verb(int(verb) + 1)) {
+            if (_rpc->has_handler(verb)) {
+                mlogger.error(" - {}", static_cast<int>(verb));
             }
-
-            std::abort();
         }
+
+        std::abort();
+    }
 }
 
 rpc::no_wait_type messaging_service::no_wait() {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -314,6 +314,8 @@ private:
     std::vector<scheduling_info_for_connection_index> _scheduling_info_for_connection_index;
     std::vector<tenant_connection_index> _connection_index_for_tenant;
 
+    future<> shutdown_tls_server();
+    future<> shutdown_nontls_server();
     future<> stop_tls_server();
     future<> stop_nontls_server();
     future<> stop_client();


### PR DESCRIPTION
Recent seastar update added rpc::server::shutdown() method that only isolates the server from the network, but lets all internal handler callbacks continue running up until stop() is called. This patch makes use of it in messaging service by calling this new shiny shutdown() in its shutdown() and calling good old stop() in its stop().

Intentionally, it will prevent scylla from freezing on drain in case some RPC handler gets stuck. It may later freeze on stop(), but it's less horrible. Also chances are that by stop time some other handler's dependencies would have been drained/shut-down so the handler can wake up and stop normally.

fixes: #14031