### PR TITLE
Backport 'Allow tombstone GC in compaction to be disabled on user request' to branch-5.2

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -438,6 +438,68 @@
          ]
       },
       {
+         "path":"/column_family/tombstone_gc/{name}",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Check if tombstone GC is enabled for a given table",
+               "type":"boolean",
+               "nickname":"get_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"POST",
+               "summary":"Enable tombstone GC for a given table",
+               "type":"void",
+               "nickname":"enable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable tombstone GC for a given table",
+               "type":"void",
+               "nickname":"disable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/column_family/estimate_keys/{name}",
          "operations":[
             {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2111,6 +2111,65 @@
          ]
       },
       {
+         "path":"/storage_service/tombstone_gc/{keyspace}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Enable tombstone GC",
+               "type":"void",
+               "nickname":"enable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-separated column family names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable tombstone GC",
+               "type":"void",
+               "nickname":"disable_tombstone_gc",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-separated column family names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/deliver_hints",
          "operations":[
             {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -892,6 +892,30 @@ void set_column_family(http_context& ctx, routes& r) {
         });
     });
 
+    cf::get_tombstone_gc.set(r, [&ctx] (const_req req) {
+        auto uuid = get_uuid(req.param["name"], ctx.db.local());
+        replica::table& t = ctx.db.local().find_column_family(uuid);
+        return t.tombstone_gc_enabled();
+    });
+
+    cf::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
+        apilog.info("column_family/enable_tombstone_gc: name={}", req->param["name"]);
+        return foreach_column_family(ctx, req->param["name"], [](replica::table& t) {
+            t.set_tombstone_gc_enabled(true);
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
+
+    cf::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
+        apilog.info("column_family/disable_tombstone_gc: name={}", req->param["name"]);
+        return foreach_column_family(ctx, req->param["name"], [](replica::table& t) {
+            t.set_tombstone_gc_enabled(false);
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
+
     cf::get_built_indexes.set(r, [&ctx](std::unique_ptr<request> req) {
         auto ks_cf = parse_fully_qualified_cf_name(req->param["name"]);
         auto&& ks = std::get<0>(ks_cf);

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -169,6 +169,10 @@ std::ostream& operator<<(std::ostream& os, pretty_printed_throughput tp) {
 
 static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_s, sstable_set::incremental_selector& selector,
         const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk) {
+    if (!table_s.tombstone_gc_enabled()) [[unlikely]] {
+        return api::min_timestamp;
+    }
+
     auto timestamp = table_s.min_memtable_timestamp();
     std::optional<utils::hashed_key> hk;
     for (auto&& sst : boost::range::join(selector.select(dk).sstables, table_s.compacted_undeleted_sstables())) {
@@ -570,7 +574,7 @@ protected:
     // Tombstone expiration is enabled based on the presence of sstable set.
     // If it's not present, we cannot purge tombstones without the risk of resurrecting data.
     bool tombstone_expiration_enabled() const {
-        return bool(_sstable_set);
+        return bool(_sstable_set) && _table_s.tombstone_gc_enabled();
     }
 
     compaction_writer create_gc_compaction_writer() const {

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -31,6 +31,10 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
         return candidate;
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return compaction_descriptor();
+    }
+
     // if there is no sstable to compact in standard way, try compacting based on droppable tombstone ratio
     // unlike stcs, lcs can look for sstable with highest droppable tombstone ratio, so as not to choose
     // a sstable which droppable data shadow data in older sstable, by starting from highest levels which

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -164,6 +164,10 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
         return sstables::compaction_descriptor(std::move(most_interesting), service::get_local_compaction_priority());
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return compaction_descriptor();
+    }
+
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
     // prefer oldest sstables from biggest size tiers because they will be easier to satisfy conditions for

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -43,6 +43,7 @@ public:
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
+    virtual bool tombstone_gc_enabled() const noexcept = 0;
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
 };

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -272,6 +272,10 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
         return most_interesting;
     }
 
+    if (!table_s.tombstone_gc_enabled()) {
+        return {};
+    }
+
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
     auto e = boost::range::remove_if(non_expiring_sstables, [this, compaction_time, &table_s] (const shared_sstable& sst) -> bool {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -436,6 +436,7 @@ private:
     sstables::sstables_manager& _sstables_manager;
     secondary_index::secondary_index_manager _index_manager;
     bool _compaction_disabled_by_user = false;
+    bool _tombstone_gc_enabled = true;
     utils::phased_barrier _flush_barrier;
     std::vector<view_ptr> _views;
 
@@ -961,6 +962,13 @@ public:
 
     void enable_auto_compaction();
     future<> disable_auto_compaction();
+
+    void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
+
+    bool tombstone_gc_enabled() const noexcept {
+        return _tombstone_gc_enabled;
+    }
+
     bool is_auto_compaction_disabled_by_user() const {
       return _compaction_disabled_by_user;
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2438,6 +2438,14 @@ table::disable_auto_compaction() {
     });
 }
 
+void table::set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept {
+    _tombstone_gc_enabled = tombstone_gc_enabled;
+    tlogger.info0("Tombstone GC was {} for {}.{}", tombstone_gc_enabled ? "enabled" : "disabled", _schema->ks_name(), _schema->cf_name());
+    if (_tombstone_gc_enabled) {
+        trigger_compaction();
+    }
+}
+
 flat_mutation_reader_v2
 table::make_reader_v2_excluding_sstables(schema_ptr s,
         reader_permit permit,
@@ -2678,6 +2686,9 @@ public:
     }
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return _t.is_auto_compaction_disabled_by_user();
+    }
+    bool tombstone_gc_enabled() const noexcept override {
+        return _t._tombstone_gc_enabled;
     }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _t.get_compaction_manager().get_tombstone_gc_state();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5117,3 +5117,99 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
         BOOST_REQUIRE(sstables_closed_during_cleanup >= sstables_nr / 2);
     });
 }
+
+SEASTAR_TEST_CASE(tombstone_gc_disabled_test) {
+    return test_env::do_with_async([](test_env &env) {
+        auto builder = schema_builder("tests", "tombstone_purge")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type);
+        builder.set_gc_grace_seconds(0);
+        auto s = builder.build();
+
+        auto tmp = tmpdir();
+        auto sst_gen = [&env, s, &tmp, gen = make_lw_shared<unsigned>(1)] () {
+            return env.make_sstable(s, tmp.path().string(), (*gen)++, sstables::get_highest_sstable_version(), big);
+        };
+
+        auto compact = [&, s](bool tombstone_gc_enabled, bool update_tomb_gc_during_compaction,
+                              std::vector<shared_sstable> all) -> std::vector<shared_sstable> {
+            table_for_tests t(env.manager(), s, tmp.path().string());
+            auto close_cf = deferred_stop(t);
+            std::function<shared_sstable()> my_sst_gen = sst_gen;
+            if (update_tomb_gc_during_compaction) {
+                // update tombstone_gc setting after compaction was initialized,
+                // when it creates the first output SSTable, to stress the
+                // ability of tombstone gc update taking immediate effect
+                // even on ongoing compactions.
+                my_sst_gen = [&]() -> sstables::shared_sstable {
+                    t.set_tombstone_gc_enabled(tombstone_gc_enabled);
+                    return sst_gen();
+                };
+            } else {
+                t.set_tombstone_gc_enabled(tombstone_gc_enabled);
+            }
+            for (auto &sst: all) {
+                column_family_test(t).add_sstable(sst).get();
+            }
+            return compact_sstables(sstables::compaction_descriptor(all, default_priority_class()), t, my_sst_gen).get0().new_sstables;
+        };
+
+        auto next_timestamp = [] {
+            static thread_local api::timestamp_type next = 1;
+            return next++;
+        };
+
+        auto make_insert = [&](partition_key key) {
+            mutation m(s, key);
+            m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)), next_timestamp());
+            return m;
+        };
+
+        auto make_delete = [&](partition_key key) {
+            mutation m(s, key);
+            tombstone tomb(next_timestamp(), gc_clock::now());
+            m.partition().apply(tomb);
+            return m;
+        };
+
+        auto alpha = partition_key::from_exploded(*s, {to_bytes("alpha")});
+        auto beta = partition_key::from_exploded(*s, {to_bytes("beta")});
+
+        auto perform_tombstone_gc_test = [&](bool tombstone_gc_enabled) {
+            auto mut1 = make_insert(alpha);
+            auto mut2 = make_delete(alpha);
+            auto mut3 = make_insert(beta);
+
+            auto sst1 = make_sstable_containing(sst_gen, {mut1});
+            auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+
+            forward_jump_clocks(std::chrono::seconds(1));
+
+            auto do_perform_tombstone_gc_test = [&](bool update_tomb_gc_during_compaction) {
+                auto result = compact(tombstone_gc_enabled, update_tomb_gc_during_compaction, {sst1, sst2});
+                BOOST_REQUIRE_EQUAL(1, result.size());
+
+                std::set<mutation, mutation_decorated_key_less_comparator> sorted_mut;
+                sorted_mut.insert(mut2);
+                sorted_mut.insert(mut3);
+
+                auto r = assert_that(sstable_reader(result[0], s, env.make_reader_permit()));
+                for (auto &&mut: sorted_mut) {
+                    bool is_tombstone = bool(mut.partition().partition_tombstone());
+                    // if tombstone compaction is enabled, expired tombstone is purged
+                    if (is_tombstone && tombstone_gc_enabled) {
+                        continue;
+                    }
+                    r.produces(mut);
+                }
+                r.produces_end_of_stream();
+            };
+
+            do_perform_tombstone_gc_test(false);
+            do_perform_tombstone_gc_test(true);
+        };
+
+        perform_tombstone_gc_test(false);
+        perform_tombstone_gc_test(true);
+    });
+}

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -112,6 +112,9 @@ public:
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return table().is_auto_compaction_disabled_by_user();
     }
+    bool tombstone_gc_enabled() const noexcept override {
+        return table().tombstone_gc_enabled();
+    }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {
         return _tombstone_gc_state;
     }
@@ -144,6 +147,10 @@ future<> table_for_tests::stop() {
     auto data = _data;
     co_await data->cm.remove(*data->table_s);
     co_await when_all_succeed(data->cm.stop(), data->semaphore.stop()).discard_result();
+}
+
+void table_for_tests::set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept {
+    _data->cf->set_tombstone_gc_enabled(tombstone_gc_enabled);
 }
 
 namespace sstables {

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -73,6 +73,8 @@ struct table_for_tests {
     future<> stop_and_keep_alive() {
         return stop().finally([cf = *this] {});
     }
+
+    void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
 };
 
 dht::token create_token_from_key(const dht::i_partitioner&, sstring key);

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -1,0 +1,99 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+import sys
+import requests
+import threading
+import time
+
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+from util import new_test_table, new_test_keyspace
+
+def do_test_column_family_attribute_api_table(cql, this_dc, rest_api, api_name):
+    ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
+    with new_test_keyspace(cql, ksdef) as test_keyspace:
+        with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
+            test_table = t.split('.')[1]
+
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+
+            resp = rest_api.send("DELETE", f"column_family/{api_name}/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            assert resp.json() == False
+
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+
+            resp = rest_api.send("GET", f"column_family/{api_name}/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            assert resp.json() == True
+
+            # missing table
+            resp = rest_api.send("POST", f"column_family/{api_name}/")
+            assert resp.status_code == requests.codes.not_found
+
+            # bad syntax 1
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}")
+            assert resp.status_code == requests.codes.bad_request
+            assert resp.json()['message'] == 'Column family name should be in keyspace:column_family format'
+
+            # bad syntax 2
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}.{test_table}")
+            assert resp.status_code == requests.codes.bad_request
+            assert resp.json()['message'] == 'Column family name should be in keyspace:column_family format'
+
+            # non-existing keyspace
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}XXX:{test_table}")
+            assert resp.status_code == requests.codes.bad_request
+            assert "Can't find a column family" in resp.json()['message']
+
+            # non-existing table
+            resp = rest_api.send("POST", f"column_family/{api_name}/{test_keyspace}:{test_table}XXX")
+            assert resp.status_code == requests.codes.bad_request
+            assert "Can't find a column family" in resp.json()['message']
+
+def test_column_family_auto_compaction_table(cql, this_dc, rest_api):
+    do_test_column_family_attribute_api_table(cql, this_dc, rest_api, "autocompaction")
+
+def test_column_family_tombstone_gc_api(cql, this_dc, rest_api):
+    do_test_column_family_attribute_api_table(cql, this_dc, rest_api, "tombstone_gc")
+
+def test_column_family_tombstone_gc_correctness(cql, this_dc, rest_api):
+    ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
+    with new_test_keyspace(cql, ksdef) as test_keyspace:
+        with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
+            test_table = t.split('.')[1]
+
+            # 1 Allow tombstones to be purged by compaction right away
+            cql.execute(f"ALTER TABLE {test_keyspace}.{test_table} with gc_grace_seconds=0")
+
+            # 2 Disable tombstone purge using API
+            resp = rest_api.send("DELETE", f"column_family/tombstone_gc/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+
+            resp = rest_api.send("GET", f"column_family/tombstone_gc/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            assert resp.json() == False
+
+            # 3 Create partition tombstone
+            cql.execute(f"DELETE from {test_keyspace}.{test_table} WHERE a = 1")
+
+            # 4 Flush it into sstable
+            resp = rest_api.send("POST", f"storage_service/keyspace_flush/{test_keyspace}")
+            resp.raise_for_status()
+
+            # 5 Trigger major compaction on that sstable
+            resp = rest_api.send("POST", f"storage_service/keyspace_compaction/{test_keyspace}")
+            resp.raise_for_status()
+
+            # 6 Expect that tombstone was not purged
+            resp = rest_api.send("GET", f"column_family/sstables/by_key/{test_keyspace}:{test_table}?key=1")
+            resp.raise_for_status()
+            assert "-Data.db" in resp.json()[0]

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -41,61 +41,79 @@ def test_storage_service_keyspaces(cql, this_dc, rest_api):
         assert keyspace in resp.json()
 
 
-def test_storage_service_auto_compaction_keyspace(cql, this_dc, rest_api):
+def do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
     # test empty keyspace
-    resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}")
+    resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}")
     resp.raise_for_status()
 
-    resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}")
+    resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}")
     resp.raise_for_status()
 
     # test non-empty keyspace
     with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
-        resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}")
+        resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}")
         resp.raise_for_status()
 
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}")
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}")
         resp.raise_for_status()
 
         # non-existing keyspace
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/XXX")
+        resp = rest_api.send("POST", f"storage_service/{api_name}/XXX")
+        assert resp.status_code == requests.codes.bad_request
+
+    cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_storage_service_auto_compaction_keyspace(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, "auto_compaction")
+
+def test_storage_service_tombstone_gc_keyspace(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_keyspace(cql, this_dc, rest_api, "tombstone_gc")
+
+def do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, api_name):
+    keyspace = new_keyspace(cql, this_dc)
+    with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
+        test_table = t.split('.')[1]
+        resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}", { "cf": test_table })
+        resp.raise_for_status()
+
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": test_table })
+        resp.raise_for_status()
+
+        # non-existing table
+        resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": "XXX" })
         assert resp.status_code == requests.codes.bad_request
 
     cql.execute(f"DROP KEYSPACE {keyspace}")
 
 def test_storage_service_auto_compaction_table(cql, this_dc, rest_api):
-    keyspace = new_keyspace(cql, this_dc)
-    with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t:
-        test_table = t.split('.')[1]
-        resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}", { "cf": test_table })
-        resp.raise_for_status()
+    do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, "auto_compaction")
 
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": test_table })
-        resp.raise_for_status()
+def test_storage_service_tombstone_gc_table(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_table(cql, this_dc, rest_api, "tombstone_gc")
 
-        # non-existing table
-        resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": "XXX" })
-        assert resp.status_code == requests.codes.bad_request
-
-    cql.execute(f"DROP KEYSPACE {keyspace}")
-
-def test_storage_service_auto_compaction_tables(cql, this_dc, rest_api):
+def do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, api_name):
     keyspace = new_keyspace(cql, this_dc)
     with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t0:
         with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t1:
             test_tables = [t0.split('.')[1], t1.split('.')[1]]
-            resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
+            resp = rest_api.send("DELETE", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
             resp.raise_for_status()
 
-            resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
+            resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},{test_tables[1]}" })
             resp.raise_for_status()
 
             # non-existing table
-            resp = rest_api.send("POST", f"storage_service/auto_compaction/{keyspace}", { "cf": f"{test_tables[0]},XXX" })
+            resp = rest_api.send("POST", f"storage_service/{api_name}/{keyspace}", { "cf": f"{test_tables[0]},XXX" })
             assert resp.status_code == requests.codes.bad_request
 
     cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_storage_service_auto_compaction_tables(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, "auto_compaction")
+
+def test_storage_service_tombstone_gc_tables(cql, this_dc, rest_api):
+    do_test_storage_service_attribute_api_tables(cql, this_dc, rest_api, "tombstone_gc")
 
 def test_storage_service_keyspace_offstrategy_compaction(cql, this_dc, rest_api):
     keyspace = new_keyspace(cql, this_dc)


### PR DESCRIPTION
Adding new APIs /column_family/tombstone_gc and /storage_service/tombstone_gc, that will allow for disabling tombstone garbage collection (GC) in compaction.

Mimicks existing APIs /column_family/autocompaction and /storage_service/autocompaction.

column_family variant must specify a single table only, following existing convention.

whereas the storage_service one can specify an entire keyspace, or a subset of a tables in a keyspace.

column_family API usage
-----

```
    The table name must be in keyspace:name format

    Get status:
    curl -s -X GET "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"

    Enable GC
    curl -s -X POST "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"

    Disable GC
    curl -s -X DELETE "http://127.0.0.1:10000/column_family/tombstone_gc/ks:cf"
```

storage_service API usage
-----

```
    Tables can be specified using a comma-separated list.

    Enable GC on keyspace
    curl -s -X POST "http://127.0.0.1:10000/storage_service/tombstone_gc/ks"

    Disable GC on keyspace
    curl -s -X DELETE "http://127.0.0.1:10000/storage_service/tombstone_gc/ks"

    Enable GC on a subset of tables
    curl -s -X POST
    "http://127.0.0.1:10000/storage_service/tombstone_gc/ks?cf=table1,table2"
```

Closes #13793

* github.com:scylladb/scylladb: test: Test new API for disabling tombstone GC test: rest_api: extract common testing code into generic functions Add API to disable tombstone GC in compaction api: storage_service: restore indentation api: storage_service: extract code to set attribute for a set of tables tests: Test new option for disabling tombstone GC in compaction compaction_strategy: bypass tombstone compaction if tombstone GC is disabled table: Allow tombstone GC in compaction to be disabled on user request

Fixes #14077

(cherry picked from commit 31e820e5a1b0f046f54ac8c954fa0cb8410d9c69)
Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>