### PR TITLE
Don't export filenames from sstable

### DIFF
--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -133,4 +133,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
 // For tests, can drop after we virtualize sstables.
 flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode, uint64_t& validation_errors);
 
+enum class with_origin { yes, no };
+template <with_origin ORIGIN> std::string cm_format(const shared_sstable& sst);
+
 }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -371,7 +371,8 @@ future<sstables::compaction_result> compaction_task_executor::compact_sstables(s
             }
         }
         if (!sstables_requiring_cleanup.empty()) {
-            cmlog.info("The following SSTables require cleaned up in this compaction: {}", sstables_requiring_cleanup);
+            cmlog.info("The following SSTables require cleaned up in this compaction: {}",
+                    sstables_requiring_cleanup | boost::adaptors::transformed(sstables::cm_format<sstables::with_origin::yes>));
             if (!cs.owned_ranges_ptr) {
                 on_internal_error_noexcept(cmlog, "SSTables require cleanup but compaction state has null owned ranges");
             }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -676,7 +676,7 @@ sstables::shared_sstable sstables_task_executor::consume_sstable() {
     auto sst = _sstables.back();
     _sstables.pop_back();
     --_cm._stats.pending_tasks; // from this point on, switch_state(pending|active) works the same way as any other task
-    cmlog.debug("{}", format("consumed {}", sst->get_filename()));
+    cmlog.debug("{}", format("consumed {:D}", *sst));
     return sst;
 }
 
@@ -1457,7 +1457,7 @@ private:
             // expected, just continue with the other sstables when seeing
             // one.
             _cm._stats.errors++;
-            cmlog.error("Scrubbing in validate mode {} failed due to {}, continuing.", sst->get_filename(), std::current_exception());
+            cmlog.error("Scrubbing in validate mode {:D} failed due to {}, continuing.", *sst, std::current_exception());
         }
 
         co_return sstables::compaction_result{};

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -299,7 +299,7 @@ private:
             for (auto& sstable : get_level(i)) {
                 auto r = ::range<dht::decorated_key>::make(sstable->get_first_decorated_key(), sstable->get_last_decorated_key());
                 if (boundaries.contains(r, dht::ring_position_comparator(*_schema))) {
-                    logger.info("Adding high-level (L{}) {} to candidates", sstable->get_sstable_level(), sstable->get_filename());
+                    logger.info("Adding high-level (L{}) {:D} to candidates", sstable->get_sstable_level(), *sstable);
                     candidates.push_back(sstable);
                     break;
                 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -895,7 +895,7 @@ public:
      * Return a set of the sstables names that contain the given
      * partition key in nodetool format
      */
-    future<std::unordered_set<sstring>> get_sstables_by_partition_key(const sstring& key) const;
+    future<std::unordered_set<sstables::shared_sstable>> get_sstables_by_partition_key(const sstring& key) const;
 
     const sstables::sstable_set& get_sstable_set() const;
     lw_shared_ptr<const sstable_list> get_sstables() const;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -403,7 +403,7 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
 
     co_await dir.do_for_each_sstable([&table, needs_view_update, &new_sstables] (sstables::shared_sstable sst) -> future<> {
         auto gen = table.calculate_generation_for_new_table();
-        dblog.trace("Loading {} into {}, new generation {}", sst->get_filename(), needs_view_update ? "staging" : "base", gen);
+        dblog.trace("Loading {:D} into {}, new generation {}", *sst, needs_view_update ? "staging" : "base", gen);
         co_await sst->pick_up_from_upload(!needs_view_update ? sstables::normal_dir : sstables::staging_dir, gen);
             // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
             sst->set_sstable_level(0);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1413,26 +1413,20 @@ int64_t table::get_unleveled_sstables() const {
 }
 
 future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const sstring& key) const {
-    return do_with(std::unordered_set<sstring>(), make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector()),
-            partition_key(partition_key::from_nodetool_style_string(_schema, key)),
-            [this] (std::unordered_set<sstring>& filenames, lw_shared_ptr<sstables::sstable_set::incremental_selector>& sel, partition_key& pk) {
-        return do_with(dht::decorated_key(dht::decorate_key(*_schema, pk)),
-                [this, &filenames, &sel](dht::decorated_key& dk) mutable {
-            const auto& sst = sel->select(dk).sstables;
-            auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
+    auto pk = partition_key::from_nodetool_style_string(_schema, key);
+    auto dk = dht::decorate_key(*_schema, pk);
+    auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
 
-            return do_for_each(sst, [&filenames, &dk, hk = std::move(hk)] (std::vector<sstables::shared_sstable>::const_iterator::reference s) mutable {
-                auto name = s->get_filename();
-                return s->has_partition_key(hk, dk).then([name = std::move(name), &filenames] (bool contains) mutable {
-                    if (contains) {
-                        filenames.insert(name);
-                    }
-                });
-            });
-        }).then([&filenames] {
-            return make_ready_future<std::unordered_set<sstring>>(filenames);
-        });
-    });
+    auto sel = make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector());
+    const auto& sst = sel->select(dk).sstables;
+
+    std::unordered_set<sstring> filenames;
+    for (auto s : sst) {
+        if (co_await s->has_partition_key(hk, dk)) {
+            filenames.insert(s->get_filename());
+        }
+    }
+    co_return filenames;
 }
 
 const sstables::sstable_set& table::get_sstable_set() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1412,7 +1412,7 @@ int64_t table::get_unleveled_sstables() const {
     return 0;
 }
 
-future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const sstring& key) const {
+future<std::unordered_set<sstables::shared_sstable>> table::get_sstables_by_partition_key(const sstring& key) const {
     auto pk = partition_key::from_nodetool_style_string(_schema, key);
     auto dk = dht::decorate_key(*_schema, pk);
     auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
@@ -1420,13 +1420,13 @@ future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const s
     auto sel = make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector());
     const auto& sst = sel->select(dk).sstables;
 
-    std::unordered_set<sstring> filenames;
+    std::unordered_set<sstables::shared_sstable> ssts;
     for (auto s : sst) {
         if (co_await s->has_partition_key(hk, dk)) {
-            filenames.insert(s->get_filename());
+            ssts.insert(s);
         }
     }
-    co_return filenames;
+    co_return ssts;
 }
 
 const sstables::sstable_set& table::get_sstable_set() const {

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -157,10 +157,10 @@ private:
 public:
     void verify_end_state() const {
         if (this->_remain > 0) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), _sst.index_filename());
+            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), fmt::format("{:I}", _sst));
         }
         if (_state != state::KEY_SIZE && _state != state::START) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), _sst.index_filename());
+            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), fmt::format("{:I}", _sst));
         }
     }
 
@@ -308,7 +308,7 @@ inline file make_tracked_index_file(sstable& sst, reader_permit permit, tracing:
     if (!trace_state) {
         return f;
     }
-    return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.index_filename()));
+    return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{:I}:", sst));
 }
 
 inline
@@ -519,7 +519,7 @@ private:
                     std::exception_ptr ex;
                     if (f.failed()) {
                         ex = f.get_exception();
-                        sstlog.error("failed reading index for {}: {}", _sstable->get_filename(), ex);
+                        sstlog.error("failed reading index for {:D}: {}", *_sstable, ex);
                     }
                     if (ex) {
                         return make_exception_future<index_list>(std::move(ex));
@@ -541,7 +541,7 @@ private:
             bound.current_index_idx = 0;
             bound.current_pi_idx = 0;
             if (bound.current_list->empty()) {
-                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->index_filename());
+                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), format("{:I}", *_sstable));
             }
             bound.data_file_position = bound.current_list->_entries[0]->position();
             bound.element = indexable_element::partition;
@@ -781,7 +781,7 @@ public:
         , _single_page_read(single_partition_read) // all entries for a given partition are within a single page
     {
         if (sstlog.is_enabled(logging::log_level::trace)) {
-            sstlog.trace("index {}: index_reader for {}", fmt::ptr(this), _sstable->get_filename());
+            sstlog.trace("index {}: index_reader for {:D}", fmt::ptr(this), *_sstable);
         }
     }
 

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1254,7 +1254,7 @@ private:
 
         if (!_consumer.is_mutation_end()) {
             throw malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
-                                                     position_in_partition_view::printer(*_schema, _consumer.position())), _sst->get_filename());
+                                                     position_in_partition_view::printer(*_schema, _consumer.position())), format("{:D}", *_sst));
         }
 
         // It's better to obtain partition information from the index if we already have it.
@@ -1444,7 +1444,7 @@ public:
             try {
                 f.get();
             } catch(sstables::malformed_sstable_exception& e) {
-                throw sstables::malformed_sstable_exception(format("Failed to read partition from SSTable {} due to {}", _sst->get_filename(), e.what()));
+                throw sstables::malformed_sstable_exception(format("Failed to read partition from SSTable {:D} due to {}", *_sst, e.what()));
             }
         });
     }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1419,7 +1419,7 @@ private:
 
         if (!_consumer.is_mutation_end()) {
             throw malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
-                                                     position_in_partition_view::printer(*_schema, _consumer.position())), _sst->get_filename());
+                                                     position_in_partition_view::printer(*_schema, _consumer.position())), format("{:D}", *_sst));
         }
 
         // It's better to obtain partition information from the index if we already have it.
@@ -1667,7 +1667,7 @@ public:
             try {
                 f.get();
             } catch(sstables::malformed_sstable_exception& e) {
-                throw sstables::malformed_sstable_exception(format("Failed to read partition from SSTable {} due to {}", _sst->get_filename(), e.what()));
+                throw sstables::malformed_sstable_exception(format("Failed to read partition from SSTable {:D} due to {}", *_sst, e.what()));
             }
         });
     }

--- a/sstables/shared_sstable.hh
+++ b/sstables/shared_sstable.hh
@@ -38,22 +38,4 @@ namespace sstables {
 using shared_sstable = seastar::lw_shared_ptr<sstable>;
 using sstable_list = std::unordered_set<shared_sstable>;
 
-std::string to_string(const shared_sstable& sst, bool include_origin = true);
-
 } // namespace sstables
-
-template <>
-struct fmt::formatter<sstables::shared_sstable> : fmt::formatter<std::string_view> {
-    template <typename FormatContext>
-    auto format(const sstables::shared_sstable& sst, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", sstables::to_string(sst));
-    }
-};
-
-namespace std {
-
-inline std::ostream& operator<<(std::ostream& os, const sstables::shared_sstable& sst) {
-    return os << fmt::format("{}", sst);
-}
-
-} // namespace std

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -745,7 +745,7 @@ class incremental_reader_selector : public reader_selector {
     sstable_reader_factory_type _fn;
 
     flat_mutation_reader_v2 create_reader(shared_sstable sst) {
-        tracing::trace(_trace_state, "Reading partition range {} from sstable {}", *_pr, seastar::value_of([&sst] { return sst->get_filename(); }));
+        tracing::trace(_trace_state, "Reading partition range {} from sstable {:D}", *_pr, *sst);
         return _fn(sst, *_pr);
     }
 
@@ -899,7 +899,7 @@ sstable_set_impl::create_single_key_sstable_reader(
     auto readers = boost::copy_range<std::vector<flat_mutation_reader_v2>>(
         filter_sstable_for_reader_by_ck(std::move(selected_sstables), *cf, schema, slice)
         | boost::adaptors::transformed([&] (const shared_sstable& sstable) {
-            tracing::trace(trace_state, "Reading key {} from sstable {}", pos, seastar::value_of([&sstable] { return sstable->get_filename(); }));
+            tracing::trace(trace_state, "Reading key {} from sstable {:D}", pos, *sstable);
             return sstable->make_reader(schema, permit, pr, slice, pc, trace_state, fwd);
         })
     );

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -351,8 +351,8 @@ void partitioned_sstable_set::insert(shared_sstable sst) {
 
     // If sstable doesn't satisfy disjoint invariant, then place it in a new sstable run.
     while (!_all_runs[sst->run_identifier()].insert(sst)) {
-        sstlog.warn("Generating a new run identifier for SSTable {} as overlapping was detected when inserting it into SSTable run {}",
-                    sst->get_filename(), sst->run_identifier());
+        sstlog.warn("Generating a new run identifier for SSTable {:D} as overlapping was detected when inserting it into SSTable run {}",
+                    *sst, sst->run_identifier());
         sst->generate_new_run_identifier();
     }
     auto undo_all_runs_insert = defer([&] () { _all_runs[sst->run_identifier()].erase(sst); });

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3115,12 +3115,6 @@ future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir) {
     }
 }
 
-std::string to_string(const shared_sstable& sst, bool include_origin) {
-    return include_origin ?
-        fmt::format("{}:level={:d}:origin={}", sst->get_filename(), sst->get_sstable_level(), sst->get_origin()) :
-        fmt::format("{}:level={:d}", sst->get_filename(), sst->get_sstable_level());
-}
-
 } // namespace sstables
 
 namespace seastar {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2783,7 +2783,7 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
     std::exception_ptr ex;
     auto sem = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::has_partition_key()");
     try {
-        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), s->get_filename(), db::no_timeout, {}));
+        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema.get(), format("{:D}", *s), db::no_timeout, {}));
         present = co_await lh_index_ptr->advance_lower_and_check_if_present(dk);
     } catch (...) {
         ex = std::current_exception();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -370,18 +370,6 @@ public:
         return component_basename(_schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 
-    sstring get_filename() const {
-        return filename(component_type::Data);
-    }
-
-    sstring toc_filename() const {
-        return filename(component_type::TOC);
-    }
-
-    sstring index_filename() const {
-        return filename(component_type::Index);
-    }
-
     bool requires_view_building() const;
 
     bool is_quarantined() const noexcept;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -346,6 +346,10 @@ public:
         return _version;
     }
 
+    format_types get_format() const noexcept {
+        return _format;
+    }
+
     // Returns the total bytes of all components.
     uint64_t bytes_on_disk() const;
 
@@ -960,3 +964,36 @@ future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir);
 future<> remove_by_toc_name(sstring sstable_toc_name);
 
 } // namespace sstables
+
+template <>
+struct fmt::formatter<sstables::sstable> {
+    std::optional<sstables::component_type> f = std::nullopt;
+
+    constexpr auto parse(format_parse_context& ctx) {
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end) {
+            switch (*it++) {
+            case 'T':
+                f = sstables::component_type::TOC;
+                break;
+            case 'I':
+                f = sstables::component_type::Index;
+                break;
+            case 'D':
+                f = sstables::component_type::Data;
+                break;
+            default:
+                throw format_error("unknown format specifier");
+            }
+        }
+        if (it != end && *it != '}') {
+            throw format_error("invalid format");
+        }
+        return it;
+    }
+
+    template <typename Ctx>
+    auto format(const sstables::sstable& sst, Ctx& ctx) const {
+        return format_to(ctx.out(), "{}", sst.get_storage().location(sst, f));
+    }
+};

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -457,10 +457,7 @@ public:
 
 private:
     sstring filename(component_type f) const {
-        return filename(_storage->prefix(), f);
-    }
-
-    sstring filename(const sstring& dir, component_type f) const {
+        auto dir = _storage->prefix();
         return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -104,7 +104,7 @@ future<file> filesystem_storage::open_component(const sstable& sst, component_ty
     auto create_flags = open_flags::create | open_flags::exclusive;
     auto readonly = (flags & create_flags) != create_flags;
     auto tgt_dir = !readonly && temp_dir ? *temp_dir : dir;
-    auto name = sst.filename(tgt_dir, type);
+    auto name = tgt_dir + "/" + sst.component_basename(type);
 
     auto f = open_sstable_component_file_non_checked(name, flags, options, check_integrity);
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -293,7 +293,7 @@ future<> filesystem_storage::check_create_links_replay(const sstable& sst, const
 /// \param generation - the generation of the destination sstable
 /// \param mark_for_removal - mark the sstable for removal after linking it to the destination dst_dir
 future<> filesystem_storage::create_links_common(const sstable& sst, sstring dst_dir, generation_type generation, mark_for_removal mark_for_removal) const {
-    sstlog.trace("create_links: {} -> {} generation={} mark_for_removal={}", sst.get_filename(), dst_dir, generation, mark_for_removal);
+    sstlog.trace("create_links: {:D} -> {} generation={} mark_for_removal={}", sst, dst_dir, generation, mark_for_removal);
     auto comps = sst.all_components();
     co_await check_create_links_replay(sst, dst_dir, generation, comps);
     // TemporaryTOC is always first, TOC is always last
@@ -319,7 +319,7 @@ future<> filesystem_storage::create_links_common(const sstable& sst, sstring dst
         co_await sst.sstable_write_io_check(remove_file, std::move(dst_temp_toc));
     }
     co_await sst.sstable_write_io_check(sync_directory, dst_dir);
-    sstlog.trace("create_links: {} -> {} generation={}: done", sst.get_filename(), dst_dir, generation);
+    sstlog.trace("create_links: {:D} -> {} generation={}: done", sst, dst_dir, generation);
 }
 
 future<> filesystem_storage::create_links(const sstable& sst, const sstring& dir) const {
@@ -337,8 +337,8 @@ future<> filesystem_storage::snapshot(const sstable& sst, sstring dir, absolute_
 future<> filesystem_storage::move(const sstable& sst, sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {
     co_await touch_directory(new_dir);
     sstring old_dir = dir;
-    sstlog.debug("Moving {} old_generation={} to {} new_generation={} do_sync_dirs={}",
-            sst.get_filename(), sst._generation, new_dir, new_generation, delay_commit == nullptr);
+    sstlog.debug("Moving {:D} old_generation={} to {} new_generation={} do_sync_dirs={}",
+            sst, sst._generation, new_dir, new_generation, delay_commit == nullptr);
     co_await create_links_common(sst, new_dir, new_generation, mark_for_removal::yes);
     dir = new_dir;
     generation_type old_generation = sst._generation;
@@ -380,7 +380,7 @@ future<> filesystem_storage::change_state(const sstable& sst, sstring to, genera
         co_return; // Already there
     }
 
-    sstlog.info("Moving sstable {} to {}", sst.get_filename(), path);
+    sstlog.info("Moving sstable {:D} to {}", sst, path);
     co_await move(sst, path.native(), std::move(new_generation), delay_commit);
 }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -385,12 +385,12 @@ future<> filesystem_storage::change_state(const sstable& sst, sstring to, genera
 }
 
 future<> filesystem_storage::wipe(const sstable& sst) noexcept {
-    // We must be able to generate toc_filename()
+    // We must be able to generate TOC file name
     // in order to delete the sstable.
     // Running out of memory here will terminate.
     auto name = [&sst] () noexcept {
         memory::scoped_critical_alloc_section _;
-        return sst.toc_filename();
+        return sst.filename(component_type::TOC);
     }();
 
     try {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -62,6 +62,7 @@ public:
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
 
     virtual sstring prefix() const  = 0;
+    virtual sstring location(const sstable& sst, std::optional<component_type> f = std::nullopt) const = 0;
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring dir);

--- a/sstables/writer_impl.hh
+++ b/sstables/writer_impl.hh
@@ -33,8 +33,8 @@ struct sstable_writer::writer_impl {
         , _schema(schema)
         , _pc(pc)
         , _cfg(cfg)
-        , _collector(_schema, sst.get_filename(), sst.manager().get_local_host_id())
-        , _validator(format("sstable writer {}", _sst.get_filename()), _schema, _cfg.validation_level)
+        , _collector(_schema, fmt::format("collector {:D}", _sst), sst.manager().get_local_host_id())
+        , _validator(fmt::format("sstable writer {:D}", _sst), _schema, _cfg.validation_level)
     {}
 
     virtual void consume_new_partition(const dht::decorated_key& dk) = 0;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3215,7 +3215,7 @@ static void compare_sstables(test_env& env, sstring table_name, sstable_version_
 
 static sstables::shared_sstable write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<replica::memtable> mt1, lw_shared_ptr<replica::memtable> mt2, sstable_version_types version) {
     auto sst = env.make_sstable(s, version);
-    BOOST_TEST_MESSAGE(format("write_sstable from two memtable: {}", sst->get_filename()));
+    BOOST_TEST_MESSAGE(format("write_sstable from two memtable: {:D}", *sst));
 
     sst->write_components(make_combined_reader(s,
         env.make_reader_permit(),
@@ -3235,7 +3235,7 @@ static sstables::shared_sstable write_and_compare_sstables(test_env& env, schema
 
 static sstables::shared_sstable write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<replica::memtable> mt, sstable_version_types version) {
     auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
-    BOOST_TEST_MESSAGE(format("write_sstable from memtable: {}", sst->get_filename()));
+    BOOST_TEST_MESSAGE(format("write_sstable from memtable: {:D}", *sst));
     return sst;
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2123,7 +2123,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
             auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
             auto sst = env.make_sstable(schema);
 
-            testlog.info("Writing sstable {}", sst->get_filename());
+            testlog.info("Writing sstable {:D}", *sst);
 
             const auto corrupt_fragments = write_corrupt_sstable(env, *sst, permit, [&, mut_builder = mutation_rebuilder_v2(schema)] (mutation_fragment_v2&& mf, bool) mutable {
                 if (mf.is_end_of_partition()) {
@@ -2135,7 +2135,7 @@ SEASTAR_TEST_CASE(sstable_scrub_validate_mode_test) {
 
             sst->load().get();
 
-            testlog.info("Loaded sstable {}", sst->get_filename());
+            testlog.info("Loaded sstable {:D}", *sst);
 
             auto table = env.make_table_for_tests(schema);
             auto close_cf = deferred_stop(table);
@@ -2325,11 +2325,11 @@ SEASTAR_TEST_CASE(sstable_scrub_skip_mode_test) {
                 }
             });
 
-            testlog.info("Writing sstable {}", sst->get_filename());
+            testlog.info("Writing sstable {:D}", *sst);
 
             sst->load().get();
 
-            testlog.info("Loaded sstable {}", sst->get_filename());
+            testlog.info("Loaded sstable {:D}", *sst);
 
             auto table = env.make_table_for_tests(schema);
             auto close_cf = deferred_stop(table);
@@ -2408,7 +2408,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
             auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
             auto sst = env.make_sstable(schema);
 
-            testlog.info("Writing sstable {}", sst->get_filename());
+            testlog.info("Writing sstable {:D}", *sst);
 
             const auto corrupt_fragments = write_corrupt_sstable(env, *sst, permit, [&, mut_builder = mutation_rebuilder_v2(schema)] (mutation_fragment_v2&& mf, bool) mutable {
                 if (mf.is_end_of_partition()) {
@@ -2420,7 +2420,7 @@ SEASTAR_TEST_CASE(sstable_scrub_segregate_mode_test) {
 
             sst->load().get();
 
-            testlog.info("Loaded sstable {}", sst->get_filename());
+            testlog.info("Loaded sstable {:D}", *sst);
 
             auto table = env.make_table_for_tests(schema);
             auto close_cf = deferred_stop(table);
@@ -2514,7 +2514,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
                 auto scrubbed_mt = make_lw_shared<replica::memtable>(schema);
                 auto sst = env.make_sstable(schema);
 
-                testlog.info("Writing sstable {}", sst->get_filename());
+                testlog.info("Writing sstable {:D}", *sst);
 
                 const auto corrupt_fragments = write_corrupt_sstable(env, *sst, permit, [&, mut_builder = mutation_rebuilder_v2(schema)] (mutation_fragment_v2&& mf, bool) mutable {
                     if (mf.is_end_of_partition()) {
@@ -2526,7 +2526,7 @@ SEASTAR_TEST_CASE(sstable_scrub_quarantine_mode_test) {
 
                 sst->load().get();
 
-                testlog.info("Loaded sstable {}", sst->get_filename());
+                testlog.info("Loaded sstable {:D}", *sst);
 
                 auto table = env.make_table_for_tests(schema);
                 auto close_cf = deferred_stop(table);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4892,31 +4892,6 @@ SEASTAR_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
     co_await cm.stop();
 }
 
-SEASTAR_TEST_CASE(test_print_shared_sstables_vector) {
-    return test_env::do_with_async([] (test_env& env) {
-        simple_schema ss;
-        auto s = ss.schema();
-        auto pks = ss.make_pkeys(2);
-        auto sst_gen = env.make_sst_factory(s);
-
-        std::vector<sstables::shared_sstable> ssts(2);
-
-        auto mut0 = mutation(s, pks[0]);
-        mut0.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        ssts[0] = make_sstable_containing(sst_gen, {std::move(mut0)});
-
-        auto mut1 = mutation(s, pks[1]);
-        mut1.partition().apply_insert(*s, ss.make_ckey(1), ss.new_timestamp());
-        ssts[1] = make_sstable_containing(sst_gen, {std::move(mut1)});
-
-        std::string msg = format("{}", ssts);
-        for (const auto& sst : ssts) {
-            auto gen_str = format("{}", sst->generation());
-            BOOST_REQUIRE(msg.find(gen_str) != std::string::npos);
-        }
-    });
-}
-
 SEASTAR_TEST_CASE(tombstone_gc_disabled_test) {
     return test_env::do_with_async([] (test_env& env) {
         auto builder = schema_builder("tests", "tombstone_purge")

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2918,7 +2918,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                 bool valid;
 
-                testlog.info("Validating intact {}", sst->get_filename());
+                testlog.info("Validating intact {:D}", *sst);
 
                 valid = sstables::validate_checksums(sst, permit).get();
                 BOOST_REQUIRE(valid);
@@ -2926,7 +2926,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 auto sst_file = open_file_dma(test(sst).filename(sstables::component_type::Data).native(), open_flags::wo).get();
                 auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
 
-                testlog.info("Validating corrupted {}", sst->get_filename());
+                testlog.info("Validating corrupted {:D}", *sst);
 
                 { // corrupt the sstable
                     const auto size = std::min(sst->ondisk_data_size() / 2, uint64_t(1024));
@@ -2938,7 +2938,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 valid = sstables::validate_checksums(sst, permit).get();
                 BOOST_REQUIRE(!valid);
 
-                testlog.info("Validating truncated {}", sst->get_filename());
+                testlog.info("Validating truncated {:D}", *sst);
 
                 { // truncate the sstable
                     sst_file.truncate(sst->ondisk_data_size() / 2).get();

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -94,7 +94,7 @@ make_sstable_for_all_shards(replica::database& db, replica::table& table, fs::pa
     mt->clear_gently().get();
     // We can't write an SSTable with bad sharding, so pretend
     // it came from Cassandra
-    testlog.debug("make_sstable_for_all_shards: {}: rewriting TOC", sst->get_filename());
+    testlog.debug("make_sstable_for_all_shards: {:D}: rewriting TOC", *sst);
     sstables::test(sst).remove_component(sstables::component_type::Scylla).get();
     sstables::test(sst).rewrite_toc_without_scylla_component();
     return sst;

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -813,3 +813,12 @@ BOOST_AUTO_TEST_CASE(test_empty_key_view_comparison) {
     BOOST_CHECK_EQUAL(0, lf.size());
     BOOST_CHECK(lf.begin() == lf.end());
 }
+
+SEASTAR_TEST_CASE(test_sstable_formatter) {
+    return test_using_reusable_sst(uncompressed_schema(), uncompressed_dir(), 1, [] (auto& env, shared_sstable sstp) {
+        BOOST_CHECK_EQUAL(fmt::format("{}", *sstp), uncompressed_dir() + "/la-1-big-Data.db");
+        BOOST_CHECK_EQUAL(fmt::format("{:T}", *sstp), uncompressed_dir() + "/la-1-big-TOC.txt");
+        BOOST_CHECK_EQUAL(fmt::format("{:I}", *sstp), uncompressed_dir() + "/la-1-big-Index.db");
+        BOOST_CHECK_EQUAL(fmt::format("{:D}", *sstp), uncompressed_dir() + "/la-1-big-Data.db");
+    });
+}

--- a/tools/json_writer.hh
+++ b/tools/json_writer.hh
@@ -74,7 +74,7 @@ public:
         EndObject();
     }
     void SstableKey(const sstables::sstable& sst) {
-        Key(sst.get_filename());
+        Key(sst.get_storage().location(sst));
     }
     void SstableKey(const sstables::sstable* const sst) {
         if (sst) {

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -433,7 +433,7 @@ int sstable_index_l(lua_State* l) {
     auto& sst = pop_userdata_ref<const sstables::sstable>(l, 1);
     lua_pop(l, 2);
     if (strcmp(field, "filename") == 0) {
-        lua::push_sstring(l, sst.get_filename());
+        lua::push_sstring(l, sst.get_storage().location(sst));
         return 1;
     }
     return 0;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1521,8 +1521,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
             continue;
         }
 
-        auto output_filename = sst->get_filename();
-        output_filename += ".decompressed";
+        auto output_filename = sst->get_storage().location(*sst) + ".decompressed";
 
         auto ofile = open_file_dma(output_filename, open_flags::wo | open_flags::create).get();
         file_output_stream_options options;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -562,7 +562,7 @@ class dumping_consumer : public sstable_consumer {
             return make_ready_future<>();
         }
         virtual future<stop_iteration> consume_sstable_start(const sstables::sstable* const sst) override {
-            fmt::print("{{sstable_start{}}}\n", sst ? fmt::format(": filename {}", sst->get_filename()) : "");
+            fmt::print("{{sstable_start{}}}\n", sst ? fmt::format(": filename {:D}", *sst) : "");
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(partition_start&& ps) override {
@@ -949,7 +949,7 @@ void validate_operation(schema_ptr schema, reader_permit permit, const std::vect
     abort_source abort;
     for (const auto& sst : sstables) {
         const auto errors = sst->validate(permit, default_priority_class(), abort, [] (sstring what) { sst_log.info("{}", what); }).get();
-        fmt::print("{}: {}\n", sst->get_filename(), errors == 0 ? "valid" : "invalid");
+        fmt::print("{:D}: {}\n", *sst, errors == 0 ? "valid" : "invalid");
     }
 }
 
@@ -1505,7 +1505,7 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
 
     for (auto& sst : sstables) {
         const auto valid = sstables::validate_checksums(sst, permit).get();
-        sst_log.info("validated the checksums of {}: {}", sst->get_filename(), valid ? "valid" : "invalid");
+        sst_log.info("validated the checksums of {:D}: {}", *sst, valid ? "valid" : "invalid");
     }
 }
 
@@ -1517,7 +1517,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
 
     for (const auto& sst : sstables) {
         if (!sst->get_compression()) {
-            sst_log.info("Sstable {} is not compressed, nothing to do", sst->get_filename());
+            sst_log.info("Sstable {:D} is not compressed, nothing to do", *sst);
             continue;
         }
 
@@ -1540,7 +1540,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
         }).get();
         ostream.flush().get();
 
-        sst_log.info("Sstable {} decompressed into {}", sst->get_filename(), output_filename);
+        sst_log.info("Sstable {:D} decompressed into {}", *sst, output_filename);
     }
 }
 


### PR DESCRIPTION
There are several sstring-returning methods on class sstable that return paths to files. Mostly these are used to print them in logs. Since now sstables can be stored not only on local filesystem these methods become pretty pointless as returned string are not guaranteed to work as filenames (despite their names).

This PR adds formatter for sstable itself that emits sstable "location" reported by storage driver. The location is file path for filessytem storage and a URL for S3 one. The unsafe exporting methods are removed at the end.