### PR TITLE
build: specify link-args using build script

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1829,11 +1829,7 @@ with open(buildfile, 'w') as f:
             command = clang --target=wasm32 --no-standard-libraries -Wl,--export-all -Wl,--no-entry $in -o $out
             description = C2WASM $out
         rule rust2wasm
-            # The default stack size in Rust is 1MB, which causes oversized allocation warnings,
-            # because it's allocated in a single chunk as a part of a Wasm Linear Memory.
-            # We change the stack size to 128KB using the RUSTFLAGS environment variable
-            # in the command below.
-            command = RUSTFLAGS="-C link-args=-zstack-size=131072" cargo build --target=wasm32-wasi --example=$example --locked --manifest-path=test/resource/wasm/rust/Cargo.toml --target-dir=$builddir/wasm/ $
+            command = cargo build --target=wasm32-wasi --example=$example --locked --manifest-path=test/resource/wasm/rust/Cargo.toml --target-dir=$builddir/wasm/ $
                 && wasm-opt -Oz $builddir/wasm/wasm32-wasi/debug/examples/$example.wasm -o $builddir/wasm/$example.wasm $
                 && wasm-strip $builddir/wasm/$example.wasm
             description = RUST2WASM $out
@@ -1845,7 +1841,7 @@ with open(buildfile, 'w') as f:
         src = wasm_deps[binary]
         wasm = binary[:-4] + '.wasm'
         if src.endswith('.rs'):
-            f.write(f'build $builddir/{wasm}: rust2wasm {src} | test/resource/wasm/rust/Cargo.lock\n')
+            f.write(f'build $builddir/{wasm}: rust2wasm {src} | test/resource/wasm/rust/Cargo.lock test/resource/wasm/rust/build.rs\n')
             example_name = binary[binary.rindex('/')+1:-4]
             f.write(f'   example = {example_name}\n')
         else:

--- a/test/resource/wasm/rust/build.rs
+++ b/test/resource/wasm/rust/build.rs
@@ -1,0 +1,8 @@
+// The default stack size in Rust is 1MB, which causes oversized allocation warnings,
+// because it's allocated in a single chunk as a part of a Wasm Linear Memory.
+// We change the stack size to 128KB using the RUSTFLAGS environment variable
+// in the command below.
+fn main() {
+    println!("cargo:rustc-link-arg=-zstack-size=131072");
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
as an alternative to passing the link-args using the environmental variable, we can also use build script to pass the "-C link-args=<FLAG>" to the compiler. see https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#cargorustc-link-argflag

this change is verified using following command
```
RUSTFLAGS='--print link-args' cargo build \
  --target=wasm32-wasi \
  --example=return_input \
  --locked \
  --manifest-path=Cargo.toml \
  --target-dir=build/cmake/test/resource/wasm/rust
```

the output includes "-zstack-size=131072" in the argument passed to lld:
```
   Compiling examples v0.0.0 (/home/kefu/dev/scylladb/test/resource/wasm/rust)
LC_ALL="C"
PATH="/usr/lib/rustlib/x86_64-unknown-linux-gnu/bin:/usr/lib/rustlib/x86_64-unknown-linux-gnu/bin/self-contained:/home/kefu/.local/bin:/home/kefu/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin"
VSLANG="1033"
"lld"
"-flavor" "wasm" "--rsp-quoting=posix" "--export"
"_scylla_abi" "--export" "_scylla_free" "--export" "_scylla_malloc"
"--export" "return_input" "-z" "stack-size=1048576" "--stack-first"
"--allow-undefined" "--fatal-warnings" "--no-demangle"
...
"-L" "/usr/lib/rustlib/wasm32-wasi/lib"
"-L" "/usr/lib/rustlib/wasm32-wasi/lib/self-contained"
"-o"
"/home/kefu/dev/scylladb/build/cmake/test/resource/wasm/rust/wasm32-wasi/debug/examples/return_input-ef03083560989040.wasm"
"--gc-sections"
"--no-entry"
"-O0"
"-zstack-size=131072"
```

with this change, it'd be easier to build .wat files in CMake, so we don't need to repeat the settings in both configure.py and CMakeLists.txt