### PR TITLE
build: cmake s/FATAL/FATAL_ERROR/

### DIFF
--- a/cmake/generate_cql_grammar.cmake
+++ b/cmake/generate_cql_grammar.cmake
@@ -1,6 +1,6 @@
 find_program (ANTLR3 antlr3)
 if(NOT ANTLR3)
-  message(FATAL "antlr3 is required")
+  message(FATAL_ERROR "antlr3 is required")
 endif()
 
 # Parse antlr3 grammar files and generate C++ sources

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -16,7 +16,7 @@ function(scylla_generate_thrift)
 
     find_program(THRIFT thrift)
     if(NOT THRIFT)
-      message(FATAL "thrift is required")
+      message(FATAL_ERROR "thrift is required")
     endif()
     execute_process(
         COMMAND "${THRIFT}" -version

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_program(CARGO cargo)
 if(NOT CARGO)
-  message(FATAL "cargo is required")
+  message(FATAL_ERROR "cargo is required")
 endif()
 
 function(add_rust_library name)
@@ -26,7 +26,7 @@ endfunction(add_rust_library)
 
 find_program(CXXBRIDGE cxxbridge)
 if(NOT CXXBRIDGE)
-  message(FATAL "cxxbridge is required")
+  message(FATAL_ERROR "cxxbridge is required")
 endif()
 # Generate cxxbridge header and source
 function(generate_cxxbridge name)


### PR DESCRIPTION
we should have used "FATAL_ERROR" instead of "FATAL", as the first parameter passed to the "message()" command. see
https://cmake.org/cmake/help/v3.0/command/message.html