### PR TITLE
auth: don't use infinite timeout in `default_role_row_satisfies` query

### DIFF
--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -55,6 +55,7 @@ future<bool> default_role_row_satisfies(
         return qp.execute_internal(
                 query,
                 db::consistency_level::ONE,
+                internal_distributed_query_state(),
                 {meta::DEFAULT_SUPERUSER_NAME},
                 cql3::query_processor::cache_internal::yes).then([&qp, &p](::shared_ptr<cql3::untyped_result_set> results) {
             if (results->empty()) {


### PR DESCRIPTION
A long long time ago there was an issue about removing infinite timeouts from distributed queries: #3603. There was also a fix: 620e950fc84eccce1c9e9bc66f4877e3a1a6563d. But apparently some queries escaped the fix, like the one in `default_role_row_satisfies`.

With the right conditions and timing this query may cause a node to hang indefinitely on shutdown. A node tries to perform this query after it starts. If we kill another node which is required to serve this query right before that moment, the query will hang; when we try to shutdown the querying node, it will wait for the query to finish (it's a background task in auth service), which it never does due to infinite timeout.

Use the same timeout configuration as other queries in this module do.

Fixes #13545.