### PR TITLE
s3/test: cleanups to avoid using hardcoded values

### DIFF
--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -54,6 +54,15 @@ def unique_key_int():
     return unique_key_int.i
 unique_key_int.i = 0
 
+def format_tuples(tuples=None, **kwargs):
+    '''format a dict to structured values (tuples) in CQL'''
+    if tuples is None:
+        tuples = {}
+    tuples.update(kwargs)
+    body = ', '.join(f"'{key}': '{value}'" for key, value in tuples.items())
+    return f'{{ {body} }}'
+
+
 # A utility function for creating a new temporary keyspace with given options.
 # It can be used in a "with", as:
 #   with new_test_keyspace(cql, '...') as keyspace:

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -70,12 +70,16 @@ storage_opts = format_tuples(type='S3',
                              bucket=s3_public_bucket)
 ks = 'test_ks'
 cf = 'test_cf'
+rows = [('0', 'zero'),
+        ('1', 'one'),
+        ('2', 'two')]
+
 conn.execute((f"CREATE KEYSPACE {ks} WITH"
               f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 conn.execute(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
-conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('0', 'zero');")
-conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('1', 'one');")
-conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('2', 'two');")
+for row in rows:
+    cql_fmt = "INSERT INTO {}.{} ( name, value ) VALUES ('{}', '{}');"
+    conn.execute(cql_fmt.format(ks, cf, *row))
 res = conn.execute(f"SELECT * FROM {ks}.{cf};")
 
 r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/{ks}', timeout=60)
@@ -103,9 +107,8 @@ run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 cluster = run.get_cql_cluster(ip)
 conn = cluster.connect()
 res = conn.execute(f"SELECT * FROM {ks}.{cf};")
-want_res = { '0': 'zero', '1': 'one', '2': 'two' }
 have_res = { x.name: x.value for x in res }
-if want_res != have_res:
+if have_res != dict(rows):
     print(f'Unexpected table content: {have_res}')
     success = False
 

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -68,15 +68,17 @@ replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
 storage_opts = format_tuples(type='S3',
                              endpoint=s3_server_address,
                              bucket=s3_public_bucket)
-conn.execute(("CREATE KEYSPACE test_ks WITH"
+ks = 'test_ks'
+cf = 'test_cf'
+conn.execute((f"CREATE KEYSPACE {ks} WITH"
               f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
-conn.execute("CREATE TABLE test_ks.test_cf ( name text primary key, value text );")
-conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('0', 'zero');")
-conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('1', 'one');")
-conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('2', 'two');")
-res = conn.execute("SELECT * FROM test_ks.test_cf;")
+conn.execute(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('0', 'zero');")
+conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('1', 'one');")
+conn.execute(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('2', 'two');")
+res = conn.execute(f"SELECT * FROM {ks}.{cf};")
 
-r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/test_ks', timeout=60)
+r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/{ks}', timeout=60)
 if r.status_code != 200:
     print(f'Error flushing keyspace: {r}')
     success = False
@@ -100,7 +102,7 @@ run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 
 cluster = run.get_cql_cluster(ip)
 conn = cluster.connect()
-res = conn.execute("SELECT * FROM test_ks.test_cf;")
+res = conn.execute(f"SELECT * FROM {ks}.{cf};")
 want_res = { '0': 'zero', '1': 'one', '2': 'two' }
 have_res = { x.name: x.value for x in res }
 if want_res != have_res:
@@ -108,7 +110,7 @@ if want_res != have_res:
     success = False
 
 print('Drop table')
-conn.execute("DROP TABLE test_ks.test_cf;")
+conn.execute(f"DROP TABLE {ks}.{cf};")
 # Check that the ownership table is de-populated
 res = conn.execute("SELECT * FROM system.sstables;")
 for row in res:

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -3,6 +3,7 @@
 import sys
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 import run
+from util import format_tuples
 
 import atexit
 import os
@@ -51,6 +52,7 @@ def teardown(pid):
     log = run.abort_run_with_dir(pid, test_tempdir)
     shutil.copyfileobj(log, sys.stdout.buffer)
 
+
 print(f'Start scylla (dir={test_tempdir}')
 pid = run.run_with_generated_dir(run_scylla_cmd, get_tempdir)
 atexit.register(lambda: teardown(pid))
@@ -61,7 +63,13 @@ run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 print(f'Create keyspace (minio listening at {s3_server_address})')
 cluster = run.get_cql_cluster(ip)
 conn = cluster.connect()
-conn.execute("CREATE KEYSPACE test_ks WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': '1' } AND STORAGE = { 'type': 'S3', 'endpoint': '" + f'{s3_server_address}' + "', 'bucket': '" + f'{s3_public_bucket}' + "' };")
+replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                  'replication_factor': '1'})
+storage_opts = format_tuples(type='S3',
+                             endpoint=s3_server_address,
+                             bucket=s3_public_bucket)
+conn.execute(("CREATE KEYSPACE test_ks WITH"
+              f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 conn.execute("CREATE TABLE test_ks.test_cf ( name text primary key, value text );")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('0', 'zero');")
 conn.execute("INSERT INTO test_ks.test_cf ( name, value ) VALUES ('1', 'one');")


### PR DESCRIPTION
this series replaces hard-coded values with variables. will need to expand this test to cover most test cases when working on tiered-storage.