### PR TITLE
storage_service: reduce timeout in `wait_for_ring_to_settle`

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -257,7 +257,13 @@ static future<> set_gossip_tokens(gms::gossiper& g,
 future<> storage_service::wait_for_ring_to_settle() {
     // Make sure we see at least one other node.
     logger::rate_limit rate_limit{std::chrono::seconds{5}};
-    auto timeout = gms::gossiper::clk::now() + std::chrono::minutes{5};
+#ifdef SEASTAR_DEBUG
+    // Account for debug slowness. 3 minutes is probably overkill but we don't want flaky tests.
+    constexpr auto timeout_delay = std::chrono::minutes{3};
+#else
+    constexpr auto timeout_delay = std::chrono::seconds{30};
+#endif
+    auto timeout = gms::gossiper::clk::now() + timeout_delay;
     while (_gossiper.get_live_members().size() < 2) {
         if (timeout <= gms::gossiper::clk::now()) {
             auto err = ::format("Timed out waiting for other live nodes to show up in gossip during initial boot");


### PR DESCRIPTION
In 297c75c6d82770149cf41dd949ac4c3c8fbd6f01 I set the timeout to 5 minutes mainly due to debug mode which is often quite slow on Jenkins. But 5 minutes is a bit of an overkill. It wouldn't be a problem but there is a dtest that waits for a node to fail bootstrap; it's wasteful for the test to sleep for an entire 5 minutes.

Set it to:
- 3 minutes in debug mode,
- 30 seconds in dev/release modes.

Ref: scylladb/scylla-dtest#3203