### PR TITLE
sstables: Exorcise assert when sealing summary for empty SSTable

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1504,7 +1504,9 @@ future<> seal_summary(summary& s,
     s.header.size = s.entries.size();
     s.header.size_at_full_sampling = sstable::get_size_at_full_sampling(state.partition_count, s.header.min_index_interval);
 
-    assert(first_key); // assume non-empty sstable
+    if (!first_key) {
+        throw malformed_sstable_exception(format("Cannot seal summary because the SSTable has no keys written to it"));
+    }
     s.first_key.value = first_key->get_bytes();
 
     if (last_key) {


### PR DESCRIPTION
We have bumped into this assert many times, and it's always unclear for the person facing it what it means.

Another reason is multi tenancy, asserts are evil, they shouldn't bring the node down just because some sstable creation failed. A malicious user could craft certain operations in order to bring the node down.

Refs #7871.