### PR TITLE
data_dictionary: fix forgetting of UDTs on ALTER KEYSPACE

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -216,7 +216,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
                         std::move(strategy_options),
                         durable_writes,
                         std::move(cf_defs),
-                        user_types_metadata{},
+                        std::move(user_types),
                         storage_options{}) { }
 
 keyspace_metadata::keyspace_metadata(std::string_view name,


### PR DESCRIPTION
Due to a simple programming oversight, one of keyspace_metadata constructors is using empty user_types_metadata instead of the passed one. Fix that.

Fixes #14139