### PR TITLE
test: specify junit_suite_name for all pytests

### DIFF
--- a/test/alternator/pytest.ini
+++ b/test/alternator/pytest.ini
@@ -2,3 +2,4 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+junit_suite_name = alternator

--- a/test/broadcast_tables/pytest.ini
+++ b/test/broadcast_tables/pytest.ini
@@ -4,3 +4,4 @@
 [pytest]
 log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
 log_date_format = %H:%M:%S
+junit_suite_name = broadcast_tables

--- a/test/cql-pytest/pytest.ini
+++ b/test/cql-pytest/pytest.ini
@@ -2,3 +2,4 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+junit_suite_name = cql-pytest

--- a/test/pylib_test/pytest.ini
+++ b/test/pylib_test/pytest.ini
@@ -7,3 +7,4 @@ asyncio_mode = auto
 log_cli = true
 log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
 log_date_format = %H:%M:%S
+junit_suite_name = pylib_test

--- a/test/redis/pytest.ini
+++ b/test/redis/pytest.ini
@@ -2,3 +2,4 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+junit_suite_name = redis

--- a/test/rest_api/pytest.ini
+++ b/test/rest_api/pytest.ini
@@ -2,3 +2,4 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+junit_suite_name = rest_api

--- a/test/scylla-gdb/pytest.ini
+++ b/test/scylla-gdb/pytest.ini
@@ -2,3 +2,4 @@
 # pytest will look for one in our ancestor directories, and may find
 # something irrelevant. So we should have one here, even if empty.
 [pytest]
+junit_suite_name = scylla-gdb

--- a/test/topology/pytest.ini
+++ b/test/topology/pytest.ini
@@ -8,3 +8,5 @@ log_date_format = %H:%M:%S
 markers =
     slow: tests that take more than 30 seconds to run
     replication_factor: replication factor for RandomTables
+
+junit_suite_name = topology

--- a/test/topology_custom/pytest.ini
+++ b/test/topology_custom/pytest.ini
@@ -8,3 +8,5 @@ log_date_format = %H:%M:%S
 markers =
     slow: tests that take more than 30 seconds to run
     replication_factor: replication factor for RandomTables
+
+junit_suite_name = topology_custom

--- a/test/topology_experimental_raft/pytest.ini
+++ b/test/topology_experimental_raft/pytest.ini
@@ -7,3 +7,5 @@ log_date_format = %H:%M:%S
 
 markers =
     slow: tests that take more than 30 seconds to run
+
+junit_suite_name = topology_experimental_raft

--- a/test/topology_raft_disabled/pytest.ini
+++ b/test/topology_raft_disabled/pytest.ini
@@ -10,3 +10,5 @@ log_date_format = %H:%M:%S
 
 markers =
     replication_factor: replication factor for RandomTables
+
+junit_suite_name = topology_raft_disabled


### PR DESCRIPTION
we drive the pytest based tests in two ways:

- if a test suite claims to be a "Run" suite, it is launched by a "run" script. this test suite is likely to use run.run_pytest() so the latter can setup the environment and do the cleanup.
- if a test suite claims to be a "Python" suite, it is considered as a native pytest based tests. hence all *_test.py and test_*.py are collected recursively.

when Jenkins performs the gating tests, they are launched using test.py. but the former is tested by running `<path-to>/run`, while the latter is exercised by running each individual test separately.

but either way, we fails to instruct pytest that where these tests belong to -- the test suite, even if these tests are structured under test suites. for instance, ideally, all alternator tests / test suites should grouped under "alternator". but when jenkins collects the JUnit's logger file, these tests are flattened under the root of the test result hierarchical.

as the first step to improve this situation, let's set the "junit_suite_name" for all these pytest based tests.

please note, this does not change how test.py consolidate them -- it always collects the JUnit logger file into xml/junit.xml, where the test names are still flattened.