### PR TITLE
code: Reduce tracing/*hh fanout

### DIFF
--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -14,12 +14,13 @@
 #include "mutation/mutation_fragment.hh"
 #include "query-request.hh"
 #include "schema/schema_fwd.hh"
-#include "tracing/tracing.hh"
 
 #include <boost/range/iterator_range.hpp>
 
 #include <iterator>
 #include <memory>
+
+namespace tracing { class trace_state_ptr; }
 
 namespace db::view {
 

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -13,10 +13,11 @@
 #include "query-request.hh"
 #include "schema/schema_fwd.hh"
 #include "secondary_index_manager.hh"
-#include "tracing/tracing.hh"
 #include "view_info.hh"
 
 #include <memory>
+
+namespace tracing { class trace_state_ptr; }
 
 namespace db::index {
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -41,7 +41,6 @@
 #include "compaction/compaction_strategy.hh"
 #include "utils/estimated_histogram.hh"
 #include <seastar/core/metrics_registration.hh>
-#include "tracing/trace_state.hh"
 #include "db/view/view_stats.hh"
 #include "db/view/view_update_backlog.hh"
 #include "db/view/row_locking.hh"
@@ -75,6 +74,7 @@ class mutation;
 class frozen_mutation;
 class reconcilable_result;
 
+namespace tracing { class trace_state_ptr; }
 namespace s3 { struct endpoint_config; }
 
 namespace service {

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -19,7 +19,6 @@
 #include "utils/phased_barrier.hh"
 #include "utils/histogram.hh"
 #include "mutation/partition_version.hh"
-#include "tracing/trace_state.hh"
 #include <seastar/core/metrics_registration.hh>
 #include "mutation/mutation_cleaner.hh"
 #include "utils/double-decker.hh"
@@ -36,6 +35,8 @@ class flat_mutation_reader_v2;
 namespace replica {
 class memtable_entry;
 }
+
+namespace tracing { class trace_state_ptr; }
 
 namespace cache {
 

--- a/service/forward_service.hh
+++ b/service/forward_service.hh
@@ -16,7 +16,11 @@
 #include "message/messaging_service_fwd.hh"
 #include "query-request.hh"
 #include "replica/database_fwd.hh"
-#include "tracing/trace_state.hh"
+
+namespace tracing {
+class trace_state_ptr;
+class trace_info;
+}
 
 namespace service {
 

--- a/sstables/mx/partition_reversing_data_source.hh
+++ b/sstables/mx/partition_reversing_data_source.hh
@@ -13,7 +13,8 @@
 #include "reader_permit.hh"
 #include "sstables/index_reader.hh"
 #include "sstables/shared_sstable.hh"
-#include "tracing/trace_state.hh"
+
+namespace tracing { class trace_state_ptr; }
 
 namespace sstables {
 namespace mx {


### PR DESCRIPTION
There are some headers that include tracing/*.hh ones despite all they need is forward-declared trace_state_ptr