### PR TITLE
Canonicalize tracing start/shutdown/stop sequence

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1626,7 +1626,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("starting tracing");
-            tracing::tracing::start_tracing(qp).get();
+            tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp)).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [] {
                 tracing::tracing::stop_tracing().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -896,7 +896,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // });
 
             supervisor::notify("creating tracing");
-            tracing::tracing::create_tracing("trace_keyspace_helper").get();
+            sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
+            tracing.start(sstring("trace_keyspace_helper")).get();
             auto destroy_tracing = defer_verbose_shutdown("tracing instance", [] {
                 tracing::tracing::tracing_instance().stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1627,8 +1627,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting tracing");
             tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp)).get();
-            auto stop_tracing = defer_verbose_shutdown("tracing", [] {
-                tracing::tracing::stop_tracing().get();
+            auto stop_tracing = defer_verbose_shutdown("tracing", [&tracing] {
+                tracing.invoke_on_all(&tracing::tracing::shutdown).get();
             });
 
             startlog.info("SSTable data integrity checker is {}.",

--- a/main.cc
+++ b/main.cc
@@ -1626,7 +1626,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("starting tracing");
-            tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp)).get();
+            tracing.invoke_on_all(&tracing::tracing::start).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [&tracing] {
                 tracing.invoke_on_all(&tracing::tracing::shutdown).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1254,7 +1254,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("creating tracing");
             sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-            tracing.start(sstring("trace_keyspace_helper")).get();
+            tracing.start(std::ref(qp), sstring("trace_keyspace_helper")).get();
             auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
                 tracing.stop().get();
             });

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -18,8 +18,7 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
         tracing.start(sstring("trace_keyspace_helper")).get();
-
-        tracing::tracing::start_tracing(env.qp()).get();
+        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp())).get();
 
         func(env).finally([]() {
             return tracing::tracing::tracing_instance().invoke_on_all([](tracing::tracing &local_tracing) {

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -18,15 +18,9 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
         tracing.start(sstring("trace_keyspace_helper")).get();
+        auto stop = defer([&tracing] { tracing.stop().get(); });
         tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp())).get();
-
-        func(env).finally([]() {
-            return tracing::tracing::tracing_instance().invoke_on_all([](tracing::tracing &local_tracing) {
-                return local_tracing.shutdown();
-            }).finally([]() {
-                return tracing::tracing::tracing_instance().stop();
-            });
-        }).get();
+        func(env).get();
     }, std::move(cfg_in));
 }
 

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -16,7 +16,8 @@
 
 future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
     return do_with_cql_env_thread([func](auto &env) {
-        tracing::tracing::create_tracing("trace_keyspace_helper").get();
+        sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
+        tracing.start(sstring("trace_keyspace_helper")).get();
 
         tracing::tracing::start_tracing(env.qp()).get();
 

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -17,7 +17,7 @@
 future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-        tracing.start(sstring("trace_keyspace_helper")).get();
+        tracing.start(std::ref(env.qp()), sstring("trace_keyspace_helper")).get();
         auto stop = defer([&tracing] { tracing.stop().get(); });
         tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp())).get();
         func(env).get();

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -19,7 +19,7 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
         tracing.start(std::ref(env.qp()), sstring("trace_keyspace_helper")).get();
         auto stop = defer([&tracing] { tracing.stop().get(); });
-        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp())).get();
+        tracing.invoke_on_all(&tracing::tracing::start).get();
         func(env).get();
     }, std::move(cfg_in));
 }

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -208,8 +208,8 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
     });
 }
 
-future<> trace_keyspace_helper::start(cql3::query_processor& qp) {
-    return table_helper::setup_keyspace(qp, KEYSPACE_NAME, "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
+future<> trace_keyspace_helper::start() {
+    return table_helper::setup_keyspace(qp(), KEYSPACE_NAME, "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
 }
 
 void trace_keyspace_helper::write_one_session_records(lw_shared_ptr<one_session_records> records) {

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -57,7 +57,7 @@ public:
     //
     // TODO: Create a stub_tracing_session object to discard the traces
     // requested during the initialization phase.
-    virtual future<> start(cql3::query_processor& qp) override;
+    virtual future<> start() override;
 
     virtual future<> shutdown() override {
         return _pending_writes.close();

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -35,7 +35,6 @@ private:
     int64_t _slow_query_last_nanos = 0;
     service::query_state _dummy_query_state;
 
-    cql3::query_processor* _qp_anchor;
     table_helper _sessions;
     table_helper _sessions_time_idx;
     table_helper _events;
@@ -61,7 +60,7 @@ public:
     virtual future<> start(cql3::query_processor& qp) override;
 
     virtual future<> shutdown() override {
-        return _pending_writes.close().then([this] { _qp_anchor = nullptr; });
+        return _pending_writes.close();
     };
 
     virtual void write_records_bulk(records_bulk& bulk) override;

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -60,7 +60,7 @@ public:
     // requested during the initialization phase.
     virtual future<> start(cql3::query_processor& qp) override;
 
-    virtual future<> stop() override {
+    virtual future<> shutdown() override {
         return _pending_writes.close().then([this] { _qp_anchor = nullptr; });
     };
 

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -30,7 +30,6 @@ tracing::tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class
         : _qp(qp)
         , _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", this_shard_id()))
-        , _tracing_backend_helper_class_name(std::move(tracing_backend_helper_class_name))
         , _gen(std::random_device()())
         , _slow_query_duration_threshold(default_slow_query_duraion_threshold)
         , _slow_query_record_ttl(default_slow_query_record_ttl) {
@@ -38,9 +37,9 @@ tracing::tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class
 
     std::unique_ptr<i_tracing_backend_helper> helper;
     try {
-        helper = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
+        helper = create_object<i_tracing_backend_helper>(tracing_backend_helper_class_name, *this);
     } catch (no_such_class& e) {
-        tracing_logger.error("Can't create tracing backend helper {}: not supported", _tracing_backend_helper_class_name);
+        tracing_logger.error("Can't create tracing backend helper {}: not supported", tracing_backend_helper_class_name);
         throw;
     } catch (...) {
         throw;

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -26,8 +26,9 @@ std::vector<sstring> trace_type_names = {
     "REPAIR"
 };
 
-tracing::tracing(sstring tracing_backend_helper_class_name)
-        : _write_timer([this] { write_timer_callback(); })
+tracing::tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name)
+        : _qp(qp)
+        , _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", this_shard_id()))
         , _tracing_backend_helper_class_name(std::move(tracing_backend_helper_class_name))
         , _gen(std::random_device()())

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -67,13 +67,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::stop_tracing() {
-    return tracing_instance().invoke_on_all([] (tracing& local_tracing) {
-        // It might have been shut down while draining
-        return local_tracing.shutdown();
-    });
-}
-
 bool tracing::may_create_new_session(const std::optional<utils::UUID>& session_id) {
     // Don't create a session if its records are likely to be dropped
     if (!have_records_budget(exp_trace_events_per_session) || _active_sessions >= max_pending_sessions + write_event_sessions_threshold) {

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -129,7 +129,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
     }
 }
 
-future<> tracing::start(cql3::query_processor& qp) {
+future<> tracing::start() {
     try {
         _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
     } catch (no_such_class& e) {
@@ -139,7 +139,7 @@ future<> tracing::start(cql3::query_processor& qp) {
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(qp);
+    co_await _tracing_backend_helper_ptr->start(_qp);
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -67,12 +67,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::start_tracing(sharded<cql3::query_processor>& qp) {
-    return tracing_instance().invoke_on_all([&qp] (tracing& local_tracing) {
-        return local_tracing.start(qp.local());
-    });
-}
-
 future<> tracing::stop_tracing() {
     return tracing_instance().invoke_on_all([] (tracing& local_tracing) {
         // It might have been shut down while draining

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -170,7 +170,7 @@ future<> tracing::shutdown() {
     write_pending_records();
     _down = true;
     _write_timer.cancel();
-    return _tracing_backend_helper_ptr->stop().then([] {
+    return _tracing_backend_helper_ptr->shutdown().then([] {
         tracing_logger.info("Tracing is down");
     });
 }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -67,10 +67,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::create_tracing(sstring tracing_backend_class_name) {
-    return tracing_instance().start(std::move(tracing_backend_class_name));
-}
-
 future<> tracing::start_tracing(sharded<cql3::query_processor>& qp) {
     return tracing_instance().invoke_on_all([&qp] (tracing& local_tracing) {
         return local_tracing.start(qp.local());

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -139,7 +139,7 @@ future<> tracing::start() {
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(_qp);
+    co_await _tracing_backend_helper_ptr->start();
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -416,7 +416,6 @@ public:
         return !_down;
     }
 
-    static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -152,7 +152,7 @@ public:
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
     virtual future<> start(cql3::query_processor& qp) = 0;
-    virtual future<> stop() = 0;
+    virtual future<> shutdown() = 0;
 
     /**
      * Write a bulk of tracing records.

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -153,7 +153,7 @@ public:
 
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
-    virtual future<> start(cql3::query_processor& qp) = 0;
+    virtual future<> start() = 0;
     virtual future<> shutdown() = 0;
 
     /**

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -145,6 +145,8 @@ struct i_tracing_backend_helper {
 
 protected:
     tracing& _local_tracing;
+    cql3::query_processor& qp() noexcept;
+    const cql3::query_processor& qp() const noexcept;
 
 public:
     using ptr_type = std::unique_ptr<i_tracing_backend_helper>;
@@ -287,6 +289,7 @@ private:
 };
 
 class tracing : public seastar::async_sharded_service<tracing> {
+    friend class i_tracing_backend_helper;
 public:
     static const gc_clock::duration write_period;
     // maximum number of sessions pending for write per shard
@@ -658,4 +661,13 @@ inline span_id span_id::make_span_id() {
     // make sure the value is always greater than 0
     return 1 + (tracing::get_local_tracing_instance().get_next_rand_uint64() << 1);
 }
+
+inline cql3::query_processor& i_tracing_backend_helper::qp() noexcept {
+    return _local_tracing._qp;
+}
+
+inline const cql3::query_processor& i_tracing_backend_helper::qp() const noexcept {
+    return _local_tracing._qp;
+}
+
 }

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -384,7 +384,6 @@ private:
     bool _ignore_trace_events = false;
     std::unique_ptr<i_tracing_backend_helper> _tracing_backend_helper_ptr;
     sstring _thread_name;
-    sstring _tracing_backend_helper_class_name;
     seastar::metrics::metric_groups _metrics;
     double _trace_probability = 0.0; // keep this one for querying purposes
     uint64_t _normalized_trace_probability = 0;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -416,7 +416,6 @@ public:
         return !_down;
     }
 
-    static future<> create_tracing(sstring tracing_backend_helper_class_name);
     static future<> start_tracing(sharded<cql3::query_processor>& qp);
     static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -313,6 +313,7 @@ public:
     } stats;
 
 private:
+    cql3::query_processor& _qp;
     // A number of currently active tracing sessions
     uint64_t _active_sessions = 0;
 
@@ -416,7 +417,7 @@ public:
         return !_down;
     }
 
-    tracing(sstring tracing_backend_helper_class_name);
+    tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)
     future<> start(cql3::query_processor& qp);

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -416,7 +416,6 @@ public:
         return !_down;
     }
 
-    static future<> start_tracing(sharded<cql3::query_processor>& qp);
     static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -420,7 +420,7 @@ public:
     tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)
-    future<> start(cql3::query_processor& qp);
+    future<> start();
 
     future<> stop();
 


### PR DESCRIPTION
Tracing is one of two global service left out there with its starting and stopping being pretty hairy. In order to de-globalize it and keep its start-stop under control the existing start-stop sequence is worth cleaning. This PR

- removes create_ , start_ and stop_ wrappers to un-hide the global tracing_instance thing
- adds explicit tracing -> query_processor dependency
- makes keyspace helper use this dependency instead of fancy qp_anchor pointer
- renames tracing::stop() to shutdown() as it's in fact shutdown
- coroutinizes start/shutdown/stop while at it