### PR TITLE
Call storage_service notifications only after keyspace schema changes are applied on all shards

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -259,6 +259,11 @@ keyspace_metadata::new_keyspace(std::string_view name,
     return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, durables_writes, cf_defs, user_types_metadata{}, storage_opts);
 }
 
+lw_shared_ptr<keyspace_metadata>
+keyspace_metadata::new_keyspace(const keyspace_metadata& ksm) {
+    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.durable_writes(), std::vector<schema_ptr>{}, ksm.get_storage_options());
+}
+
 void keyspace_metadata::add_user_type(const user_type ut) {
     _user_types.add_type(ut);
 }

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -56,6 +56,8 @@ public:
                  bool durables_writes,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
+    static lw_shared_ptr<keyspace_metadata>
+    new_keyspace(const keyspace_metadata& ksm);
     void validate(const gms::feature_service&, const locator::topology&) const;
     const sstring& name() const {
         return _name;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1360,19 +1360,18 @@ future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& p
         slogger.info("Altering keyspace {}", key);
         altered.emplace_back(key);
     }
-    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
+    auto& sharded_db = proxy.local().get_db();
+    co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
         for (auto&& val : created) {
             auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, val);
             auto ksm = create_keyspace_from_schema_partition(val, std::move(scylla_specific_rs));
             co_await db.create_keyspace(ksm, proxy.local().get_erm_factory());
             co_await db.get_notifier().create_keyspace(ksm);
         }
-        {
-            for (auto& name : altered) {
-                co_await db.update_keyspace(proxy, name);
-            };
-        }
     });
+    for (auto& name : altered) {
+        co_await replica::database::update_keyspace_on_all_shards(sharded_db, proxy, name);
+    }
     co_return dropped;
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1307,13 +1307,11 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std:
     co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates), std::move(old_scylla_aggregates), std::move(new_scylla_aggregates));
     co_await types_to_drop.drop();
 
-    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-        // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
-        for (auto keyspace_to_drop : keyspaces_to_drop) {
-            db.drop_keyspace(keyspace_to_drop);
-            co_await db.get_notifier().drop_keyspace(keyspace_to_drop);
-        }
-    });
+    auto& sharded_db = proxy.local().get_db();
+    // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
+    for (auto keyspace_to_drop : keyspaces_to_drop) {
+        co_await replica::database::drop_keyspace_on_all_shards(sharded_db, keyspace_to_drop);
+    }
 }
 
 future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition) {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1361,14 +1361,11 @@ future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& p
         altered.emplace_back(key);
     }
     auto& sharded_db = proxy.local().get_db();
-    co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
-        for (auto&& val : created) {
-            auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, val);
-            auto ksm = create_keyspace_from_schema_partition(val, std::move(scylla_specific_rs));
-            co_await db.create_keyspace(ksm, proxy.local().get_erm_factory());
-            co_await db.get_notifier().create_keyspace(ksm);
-        }
-    });
+    for (auto&& val : created) {
+        auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, val);
+        auto ksm = create_keyspace_from_schema_partition(val, std::move(scylla_specific_rs));
+        co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
+    }
     for (auto& name : altered) {
         co_await replica::database::update_keyspace_on_all_shards(sharded_db, proxy, name);
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1367,7 +1367,10 @@ future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& p
         co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
     }
     for (auto& name : altered) {
-        co_await replica::database::update_keyspace_on_all_shards(sharded_db, proxy, name);
+        auto v = co_await db::schema_tables::read_schema_partition_for_keyspace(proxy, db::schema_tables::KEYSPACES, name);
+        auto scylla_specific_rs = co_await db::schema_tables::extract_scylla_specific_keyspace_info(proxy, v);
+        auto tmp_ksm = db::schema_tables::create_keyspace_from_schema_partition(v, scylla_specific_rs);
+        co_await replica::database::update_keyspace_on_all_shards(sharded_db, proxy, *tmp_ksm);
     }
     co_return dropped;
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -874,13 +874,9 @@ database::init_commitlog() {
     });
 }
 
-future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name) {
-    auto v = co_await db::schema_tables::read_schema_partition_for_keyspace(proxy, db::schema_tables::KEYSPACES, name);
-    auto& ks = find_keyspace(name);
-
-    auto scylla_specific_rs = co_await db::schema_tables::extract_scylla_specific_keyspace_info(proxy, v);
-    auto tmp_ksm = db::schema_tables::create_keyspace_from_schema_partition(v, scylla_specific_rs);
-    auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm->name(), tmp_ksm->strategy_name(), tmp_ksm->strategy_options(), tmp_ksm->durable_writes(),
+future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm) {
+    auto& ks = find_keyspace(tmp_ksm.name());
+    auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm.name(), tmp_ksm.strategy_name(), tmp_ksm.strategy_options(), tmp_ksm.durable_writes(),
                     boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()));
 
     bool old_durable_writes = ks.metadata()->durable_writes();
@@ -896,9 +892,9 @@ future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const
     co_await get_notifier().update_keyspace(ks.metadata());
 }
 
-future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const sstring& name) {
+future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm) {
     return sharded_db.invoke_on_all([&] (replica::database& db) {
-        return db.update_keyspace(proxy, name);
+        return db.update_keyspace(proxy, ksm);
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -874,6 +874,10 @@ database::init_commitlog() {
     });
 }
 
+future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func) {
+    co_await sharded_db.invoke_on_all(func);
+}
+
 future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm) {
     auto& ks = find_keyspace(tmp_ksm.name());
     auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm.name(), tmp_ksm.strategy_name(), tmp_ksm.strategy_options(), tmp_ksm.durable_writes(),
@@ -893,7 +897,7 @@ future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const
 }
 
 future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm) {
-    return sharded_db.invoke_on_all([&] (replica::database& db) {
+    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         return db.update_keyspace(proxy, ksm);
     });
 }
@@ -903,7 +907,7 @@ void database::drop_keyspace(const sstring& name) {
 }
 
 future<> database::drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name) {
-    return sharded_db.invoke_on_all([&] (replica::database& db) {
+    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         db.drop_keyspace(name);
         return db.get_notifier().drop_keyspace(name);
     });
@@ -1426,7 +1430,7 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
 }
 
 future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {
-    co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
+    co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
         co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
         co_await db.get_notifier().create_keyspace(ksm);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -896,6 +896,12 @@ future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const
     co_await get_notifier().update_keyspace(ks.metadata());
 }
 
+future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const sstring& name) {
+    return sharded_db.invoke_on_all([&] (replica::database& db) {
+        return db.update_keyspace(proxy, name);
+    });
+}
+
 void database::drop_keyspace(const sstring& name) {
     _keyspaces.erase(name);
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -874,8 +874,9 @@ database::init_commitlog() {
     });
 }
 
-future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func) {
+future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier) {
     co_await sharded_db.invoke_on_all(func);
+    co_await sharded_db.invoke_on_all(notifier);
 }
 
 future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm) {
@@ -893,12 +894,14 @@ future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const
     }
 
     co_await ks.update_from(get_shared_token_metadata(), std::move(new_ksm));
-    co_await get_notifier().update_keyspace(ks.metadata());
 }
 
 future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm) {
     return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         return db.update_keyspace(proxy, ksm);
+    }, [&] (replica::database& db) {
+        const auto& ks = db.find_keyspace(ksm.name());
+        return db.get_notifier().update_keyspace(ks.metadata());
     });
 }
 
@@ -909,6 +912,8 @@ void database::drop_keyspace(const sstring& name) {
 future<> database::drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name) {
     return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         db.drop_keyspace(name);
+        return make_ready_future<>();
+    }, [&] (replica::database& db) {
         return db.get_notifier().drop_keyspace(name);
     });
 }
@@ -1433,7 +1438,9 @@ future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, 
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
         co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
-        co_await db.get_notifier().create_keyspace(ksm);
+    }, [&] (replica::database& db) -> future<> {
+        const auto& ks = db.find_keyspace(ks_metadata.name());
+        co_await db.get_notifier().create_keyspace(ks.metadata());
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -875,7 +875,16 @@ database::init_commitlog() {
 }
 
 future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier) {
-    co_await sharded_db.invoke_on_all(func);
+    // Run func first on shard 0
+    // to allow "seeding" of the effective_replication_map
+    // with a new e_r_m instance.
+    co_await sharded_db.invoke_on(0, func);
+    co_await sharded_db.invoke_on_all([&] (replica::database& db) {
+        if (this_shard_id() == 0) {
+            return make_ready_future<>();
+        }
+        return func(db);
+    });
     co_await sharded_db.invoke_on_all(notifier);
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -900,6 +900,13 @@ void database::drop_keyspace(const sstring& name) {
     _keyspaces.erase(name);
 }
 
+future<> database::drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name) {
+    return sharded_db.invoke_on_all([&] (replica::database& db) {
+        db.drop_keyspace(name);
+        return db.get_notifier().drop_keyspace(name);
+    });
+}
+
 static bool is_system_table(const schema& s) {
     return s.ks_name() == db::system_keyspace::NAME || s.ks_name() == db::system_distributed_keyspace::NAME
         || s.ks_name() == db::system_distributed_keyspace::NAME_EVERYWHERE;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1438,6 +1438,7 @@ private:
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
     void remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
+    future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
 public:
     static table_schema_version empty_version;
 
@@ -1536,7 +1537,7 @@ public:
     bool has_keyspace(std::string_view name) const;
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
-    future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
+    static future<> update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const sstring& name);
     static future<> drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1439,7 +1439,7 @@ private:
     void remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm);
-    static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
+    static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier);
 public:
     static table_schema_version empty_version;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1438,7 +1438,7 @@ private:
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
     void remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
-    future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
+    future<> update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm);
 public:
     static table_schema_version empty_version;
 
@@ -1537,7 +1537,7 @@ public:
     bool has_keyspace(std::string_view name) const;
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
-    static future<> update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const sstring& name);
+    static future<> update_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
     static future<> drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1439,6 +1439,7 @@ private:
     void remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(sharded<service::storage_proxy>& proxy, const keyspace_metadata& tmp_ksm);
+    static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
 public:
     static table_schema_version empty_version;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1437,6 +1437,7 @@ private:
     void update_write_metrics_for_timed_out_write();
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
     void remove(table&) noexcept;
+    void drop_keyspace(const sstring& name);
 public:
     static table_schema_version empty_version;
 
@@ -1536,7 +1537,7 @@ public:
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
     future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
-    void drop_keyspace(const sstring& name);
+    static future<> drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1530,7 +1530,7 @@ public:
      *
      * @return ready future when the operation is complete
      */
-    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory);
+    static future<> create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
     /* below, find_keyspace throws no_such_<type> on fail */
     keyspace& find_keyspace(std::string_view name);
     const keyspace& find_keyspace(std::string_view name) const;

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -115,6 +115,7 @@ class migration_notifier {
 private:
     atomic_vector<migration_listener*> _listeners;
 
+    future<> on_schema_change(std::function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error);
 public:
     /// Register a migration listener on current shard.
     void register_listener(migration_listener* listener);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -398,58 +398,59 @@ bool migration_manager::should_pull_schema_from(const gms::inet_address& endpoin
             && !_gossiper.is_gossip_only_member(endpoint);
 }
 
-future<> migration_notifier::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
-    return seastar::async([this, ksm] {
-        const auto& name = ksm->name();
-        _listeners.thread_for_each([&name] (migration_listener* listener) {
+future<> migration_notifier::on_schema_change(std::function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error) {
+    return seastar::async([this, notify = std::move(notify), describe_error = std::move(describe_error)] {
+        std::exception_ptr ex;
+        _listeners.thread_for_each([&] (migration_listener* listener) {
             try {
-                listener->on_create_keyspace(name);
+                notify(listener);
             } catch (...) {
-                mlogger.warn("Create keyspace notification failed {}: {}", name, std::current_exception());
+                ex = std::current_exception();
+                mlogger.error("{}", describe_error(ex));
             }
         });
+        if (ex) {
+            std::rethrow_exception(std::move(ex));
+        }
+    });
+}
+
+future<> migration_notifier::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
+    const auto& name = ksm->name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_create_keyspace(name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Create keyspace notification failed {}: {}", name, ex);
     });
 }
 
 future<> migration_notifier::create_column_family(const schema_ptr& cfm) {
-    return seastar::async([this, cfm] {
-        const auto& ks_name = cfm->ks_name();
-        const auto& cf_name = cfm->cf_name();
-        _listeners.thread_for_each([&ks_name, &cf_name] (migration_listener* listener) {
-            try {
-                listener->on_create_column_family(ks_name, cf_name);
-            } catch (...) {
-                mlogger.warn("Create column family notification failed {}.{}: {}", ks_name, cf_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = cfm->ks_name();
+    const auto& cf_name = cfm->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_create_column_family(ks_name, cf_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Create column family notification failed {}.{}: {}", ks_name, cf_name, ex);
     });
 }
 
 future<> migration_notifier::create_user_type(const user_type& type) {
-    return seastar::async([this, type] {
-        const auto& ks_name = type->_keyspace;
-        const auto& type_name = type->get_name_as_string();
-        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
-            try {
-                listener->on_create_user_type(ks_name, type_name);
-            } catch (...) {
-                mlogger.warn("Create user type notification failed {}.{}: {}", ks_name, type_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = type->_keyspace;
+    const auto& type_name = type->get_name_as_string();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_create_user_type(ks_name, type_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Create user type notification failed {}.{}: {}", ks_name, type_name, ex);
     });
 }
 
 future<> migration_notifier::create_view(const view_ptr& view) {
-    return seastar::async([this, view] {
-        const auto& ks_name = view->ks_name();
-        const auto& view_name = view->cf_name();
-        _listeners.thread_for_each([&ks_name, &view_name] (migration_listener* listener) {
-            try {
-                listener->on_create_view(ks_name, view_name);
-            } catch (...) {
-                mlogger.warn("Create view notification failed {}.{}: {}", ks_name, view_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = view->ks_name();
+    const auto& view_name = view->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_create_view(ks_name, view_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Create view notification failed {}.{}: {}", ks_name, view_name, ex);
     });
 }
 
@@ -468,57 +469,41 @@ public void notifyCreateAggregate(UDAggregate udf)
 #endif
 
 future<> migration_notifier::update_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
-    return seastar::async([this, ksm] {
-        const auto& name = ksm->name();
-        _listeners.thread_for_each([&name] (migration_listener* listener) {
-            try {
-                listener->on_update_keyspace(name);
-            } catch (...) {
-                mlogger.warn("Update keyspace notification failed {}: {}", name, std::current_exception());
-            }
-        });
+    const auto& name = ksm->name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_update_keyspace(name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Update keyspace notification failed {}: {}", name, ex);
     });
 }
 
 future<> migration_notifier::update_column_family(const schema_ptr& cfm, bool columns_changed) {
-    return seastar::async([this, cfm, columns_changed] {
-        const auto& ks_name = cfm->ks_name();
-        const auto& cf_name = cfm->cf_name();
-        _listeners.thread_for_each([&ks_name, &cf_name, columns_changed] (migration_listener* listener) {
-            try {
-                listener->on_update_column_family(ks_name, cf_name, columns_changed);
-            } catch (...) {
-                mlogger.warn("Update column family notification failed {}.{}: {}", ks_name, cf_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = cfm->ks_name();
+    const auto& cf_name = cfm->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_update_column_family(ks_name, cf_name, columns_changed);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Update column family notification failed {}.{}: {}", ks_name, cf_name, ex);
     });
 }
 
 future<> migration_notifier::update_user_type(const user_type& type) {
-    return seastar::async([this, type] {
-        const auto& ks_name = type->_keyspace;
-        const auto& type_name = type->get_name_as_string();
-        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
-            try {
-                listener->on_update_user_type(ks_name, type_name);
-            } catch (...) {
-                mlogger.warn("Update user type notification failed {}.{}: {}", ks_name, type_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = type->_keyspace;
+    const auto& type_name = type->get_name_as_string();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_update_user_type(ks_name, type_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Update user type notification failed {}.{}: {}", ks_name, type_name, ex);
     });
 }
 
 future<> migration_notifier::update_view(const view_ptr& view, bool columns_changed) {
-    return seastar::async([this, view, columns_changed] {
-        const auto& ks_name = view->ks_name();
-        const auto& view_name = view->cf_name();
-        _listeners.thread_for_each([&ks_name, &view_name, columns_changed] (migration_listener* listener) {
-            try {
-                listener->on_update_view(ks_name, view_name, columns_changed);
-            } catch (...) {
-                mlogger.warn("Update view notification failed {}.{}: {}", ks_name, view_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = view->ks_name();
+    const auto& view_name = view->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_update_view(ks_name, view_name, columns_changed);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Update view notification failed {}.{}: {}", ks_name, view_name, ex);
     });
 }
 
@@ -545,84 +530,60 @@ public void notifyUpdateAggregate(UDAggregate udf)
 #endif
 
 future<> migration_notifier::drop_keyspace(const sstring& ks_name) {
-    return seastar::async([this, ks_name] {
-        _listeners.thread_for_each([&ks_name] (migration_listener* listener) {
-            try {
-                listener->on_drop_keyspace(ks_name);
-            } catch (...) {
-                mlogger.warn("Drop keyspace notification failed {}: {}", ks_name, std::current_exception());
-            }
-        });
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_keyspace(ks_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop keyspace notification failed {}: {}", ks_name, ex);
     });
 }
 
 future<> migration_notifier::drop_column_family(const schema_ptr& cfm) {
-    return seastar::async([this, cfm] {
-        const auto& cf_name = cfm->cf_name();
-        const auto& ks_name = cfm->ks_name();
-        _listeners.thread_for_each([&ks_name, &cf_name] (migration_listener* listener) {
-            try {
-                listener->on_drop_column_family(ks_name, cf_name);
-            } catch (...) {
-                mlogger.warn("Drop column family notification failed {}.{}: {}", ks_name, cf_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = cfm->ks_name();
+    const auto& cf_name = cfm->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_column_family(ks_name, cf_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop column family notification failed {}.{}: {}", ks_name, cf_name, ex);
     });
 }
 
 future<> migration_notifier::drop_user_type(const user_type& type) {
-    return seastar::async([this, type] {
-        auto&& ks_name = type->_keyspace;
-        auto&& type_name = type->get_name_as_string();
-        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
-            try {
-                listener->on_drop_user_type(ks_name, type_name);
-            } catch (...) {
-                mlogger.warn("Drop user type notification failed {}.{}: {}", ks_name, type_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = type->_keyspace;
+    const auto& type_name = type->get_name_as_string();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_user_type(ks_name, type_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop user type notification failed {}.{}: {}", ks_name, type_name, ex);
     });
 }
 
 future<> migration_notifier::drop_view(const view_ptr& view) {
-    return seastar::async([this, view] {
-        auto&& ks_name = view->ks_name();
-        auto&& view_name = view->cf_name();
-        _listeners.thread_for_each([&ks_name, &view_name] (migration_listener* listener) {
-            try {
-                listener->on_drop_view(ks_name, view_name);
-            } catch (...) {
-                mlogger.warn("Drop view notification failed {}.{}: {}", ks_name, view_name, std::current_exception());
-            }
-        });
+    const auto& ks_name = view->ks_name();
+    const auto& view_name = view->cf_name();
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_view(ks_name, view_name);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop view notification failed {}.{}: {}", ks_name, view_name, ex);
     });
 }
 
 future<> migration_notifier::drop_function(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types) {
-    return seastar::async([this, &fun_name, &arg_types] {
-        auto&& ks_name = fun_name.keyspace;
-        auto&& sig = auth::encode_signature(fun_name.name, arg_types);
-        _listeners.thread_for_each([&ks_name, &sig] (migration_listener* listener) {
-            try {
-                listener->on_drop_function(ks_name, sig);
-            } catch (...) {
-                mlogger.warn("Drop function notification failed {}.{}: {}", ks_name, sig, std::current_exception());
-            }
-        });
+    auto&& ks_name = fun_name.keyspace;
+    auto&& sig = auth::encode_signature(fun_name.name, arg_types);
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_function(ks_name, sig);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop function notification failed {}.{}: {}", ks_name, sig, ex);
     });
 }
 
 future<> migration_notifier::drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types) {
-    return seastar::async([this, &fun_name, &arg_types] {
-        auto&& ks_name = fun_name.keyspace;
-        auto&& sig = auth::encode_signature(fun_name.name, arg_types);
-        _listeners.thread_for_each([&ks_name, &sig] (migration_listener* listener) {
-            try {
-                listener->on_drop_aggregate(ks_name, sig);
-            } catch (...) {
-                mlogger.warn("Drop aggregate notification failed {}.{}: {}", ks_name, sig, std::current_exception());
-            }
-        });
+    auto&& ks_name = fun_name.keyspace;
+    auto&& sig = auth::encode_signature(fun_name.name, arg_types);
+    co_await on_schema_change([&] (migration_listener* listener) {
+        listener->on_drop_aggregate(ks_name, sig);
+    }, [&] (std::exception_ptr ex) {
+        return fmt::format("Drop aggregate notification failed {}.{}: {}", ks_name, sig, ex);
     });
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5049,13 +5049,20 @@ future<> storage_service::update_topology_change_info(sstring reason, acquire_me
 }
 
 future<> storage_service::keyspace_changed(const sstring& ks_name) {
+    // The keyspace_changed notification is called on all shards
+    // after any keyspace schema change, but we need to mutate_token_metadata
+    // once after all shards are done with database::update_keyspace.
+    // mutate_token_metadata (via update_topology_change_info) will update the
+    // token metadata and effective_replication_map on all shards.
+    if (this_shard_id() != 0) {
+        return make_ready_future<>();
+    }
     // Update pending ranges since keyspace can be changed after we calculate pending ranges.
     sstring reason = ::format("keyspace {}", ks_name);
-    return container().invoke_on(0, [reason = std::move(reason)] (auto& ss) mutable {
-        return ss.update_topology_change_info(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
+    // FIXME: indentation
+        return update_topology_change_info(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
             slogger.warn("Failure to update pending ranges for {} ignored", reason);
         });
-    });
 }
 
 void storage_service::on_update_tablet_metadata() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5059,10 +5059,7 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
     }
     // Update pending ranges since keyspace can be changed after we calculate pending ranges.
     sstring reason = ::format("keyspace {}", ks_name);
-    // FIXME: indentation
-        return update_topology_change_info(reason, acquire_merge_lock::no).handle_exception([reason = std::move(reason)] (auto ep) {
-            slogger.warn("Failure to update pending ranges for {} ignored", reason);
-        });
+    return update_topology_change_info(reason, acquire_merge_lock::no);
 }
 
 void storage_service::on_update_tablet_metadata() {


### PR DESCRIPTION
This series aims at hardening schema merges and preventing inconsistencies across shards by
updating the database shards before calling the notification callback.

As seen in #13137, we don't want to call the notifications on all shards in parallel while the database shards are in flux.

In addition, any error to update the keyspace will cause abort so not to leave the database shards in an inconsistent state .

Other changes optimize this path by:
- updating shard 0 first, to seed the effective_replication_map.
- executing `storage_service::keyspace_changed` only once, on shard 0 to prevent quadratic update of the token_metadata and e_r_m on every keyspace change.

Fixes #13137
