### PR TITLE
s3/test: restructure object_store test into a pytest based test suite

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import logging
+import pytest
+import shutil
+import tempfile
+from dataclasses import dataclass
+
+# use minio_server
+sys.path.insert(1, sys.path[0] + '/../..')
+from test.pylib.minio_server import MinioServer
+from test.pylib.host_registry import HostRegistry
+from test.pylib.cql_repl import conftest
+
+hosts = HostRegistry()
+
+
+def pytest_addoption(parser):
+    conftest.pytest_addoption(parser)
+    # reserved for tests with real S3
+    s3_options = parser.getgroup("s3-server", description="S3 Server settings")
+    s3_options.addoption('--s3-server-address')
+    s3_options.addoption('--s3-server-port', type=int)
+    s3_options.addoption('--s3-server-bucket')
+
+
+@dataclass
+class S3_Server:
+    address: str
+    port: int
+    bucket_name: str
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def ssl(request):
+    yield request.config.getoption('--ssl')
+
+
+@pytest.fixture(scope="function")
+def test_tempdir(tmpdir):
+    tempdir = tmpdir.strpath
+    yield tempdir
+    with open(os.path.join(tempdir, 'log'), 'rb') as log:
+        shutil.copyfileobj(log, sys.stdout.buffer)
+
+
+@pytest.fixture(scope="function")
+async def s3_server(pytestconfig, tmpdir):
+    server = None
+    s3_server_address = pytestconfig.getoption('--s3-server-address')
+    s3_server_port = pytestconfig.getoption('--s3-server-port')
+    s3_server_bucket = pytestconfig.getoption('--s3-server-bucket')
+
+    default_address = os.environ.get('S3_SERVER_ADDRESS_FOR_TEST')
+    default_port = os.environ.get('S3_SERVER_PORT_FOR_TEST')
+    default_bucket = os.environ.get('S3_PUBLIC_BUCKET_FOR_TEST')
+
+    if s3_server_address:
+        server = S3_Server(s3_server_address,
+                           s3_server_port,
+                           s3_server_bucket)
+    elif default_address:
+        server = S3_Server(default_address,
+                           int(default_port),
+                           default_bucket)
+    else:
+        tempdir = tmpdir.strpath
+        server = MinioServer(tempdir,
+                             hosts,
+                             logging.getLogger('minio'))
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()

--- a/test/object_store/pytest.ini
+++ b/test/object_store/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -12,45 +12,48 @@ import shutil
 import signal
 import yaml
 from contextlib import contextmanager
+from dataclasses import dataclass
 
-print('Scylla is: ' + run.find_scylla() + '.')
 success = True
 
 ssl = '--ssl' in sys.argv
-if ssl:
-    cmd = run.run_scylla_ssl_cql_cmd
-    check_cql = run.check_ssl_cql
-else:
-    cmd = run.run_scylla_cmd
-    check_cql = run.check_cql
 
 test_tempdir = run.pid_to_dir(os.getpid())
 os.mkdir(test_tempdir)
-s3_server_address = os.environ['S3_SERVER_ADDRESS_FOR_TEST']
-s3_server_port = int(os.environ['S3_SERVER_PORT_FOR_TEST'])
-s3_public_bucket = os.environ['S3_PUBLIC_BUCKET_FOR_TEST']
 
 
-with open(test_tempdir + '/object_storage.yaml', 'w') as config_file:
-    yaml.dump({ 'endpoints': [
-            {
-                'name': s3_server_address,
-                'port': s3_server_port,
-            }
-        ]
-    }, config_file)
+@dataclass
+class S3_Server:
+    address: str
+    port: int
+    bucket_name: str
 
-def run_scylla_cmd(pid, dir):
-    global cmd
-    (c, e) = cmd(pid, dir)
-    c += ['--object-storage-config-file', test_tempdir + '/object_storage.yaml']
-    return (c, e)
 
 def teardown():
     sys.stdout.flush()
     log = open(os.path.join(test_tempdir, 'log'), 'rb')
     shutil.copyfileobj(log, sys.stdout.buffer)
     shutil.rmtree(test_tempdir)
+
+
+def get_scylla_with_s3_cmd(tempdir, ssl, s3_server):
+    '''return the command args and environmental variables for running scylla'''
+    scylla = run.find_scylla()
+    print('Scylla under test:', scylla)
+    def make_run_cmd(pid, d):
+        if ssl:
+            cmd, env = run.run_scylla_ssl_cql_cmd(pid, d)
+        else:
+            cmd, env = run.run_scylla_cmd(pid, d)
+
+        os_conf_path = os.path.join(tempdir, 'object_storage.yaml')
+        with open(os_conf_path, 'w', encoding='utf-8') as os_config_file:
+            s3_endpoint = {'name': s3_server.address,
+                           'port': s3_server.port}
+            yaml.dump({'endpoints': [s3_endpoint]}, os_config_file)
+        cmd += ['--object-storage-config-file', os_conf_path]
+        return cmd, env
+    return make_run_cmd
 
 
 def check_with_cql(ip, ssl):
@@ -100,8 +103,9 @@ def kill_with_dir(old_pid, run_dir):
 
 
 @contextmanager
-def managed_cluster(run_dir, ssl):
+def managed_cluster(run_dir, ssl, s3_server):
     '''return scylla's pid, IP and a connection to it'''
+    run_scylla_cmd = get_scylla_with_s3_cmd(run_dir, ssl, s3_server)
     pid = run_with_dir(run_scylla_cmd, run_dir)
     ip = run.pid_to_ip(pid)
     run.wait_for_services(pid, [check_with_cql(ip, ssl)])
@@ -121,15 +125,19 @@ rows = [('0', 'zero'),
         ('2', 'two')]
 
 
-with managed_cluster(test_tempdir, ssl) \
+s3_server = S3_Server(os.environ['S3_SERVER_ADDRESS_FOR_TEST'],
+                      int(os.environ['S3_SERVER_PORT_FOR_TEST']),
+                      os.environ['S3_PUBLIC_BUCKET_FOR_TEST'])
+
+with managed_cluster(test_tempdir, ssl, s3_server) \
      as (ip, cluster):
     atexit.register(teardown)
-    print(f'Create keyspace (minio listening at {s3_server_address})')
+    print(f'Create keyspace (minio listening at {s3_server.address})')
     replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
                                       'replication_factor': '1'})
     storage_opts = format_tuples(type='S3',
-                                 endpoint=s3_server_address,
-                                 bucket=s3_public_bucket)
+                                 endpoint=s3_server.address,
+                                 bucket=s3_server.bucket_name)
 
     conn = cluster.connect()
     conn.execute((f"CREATE KEYSPACE {ks} WITH"
@@ -156,7 +164,7 @@ with managed_cluster(test_tempdir, ssl) \
             success = False
 
 print('Restart scylla')
-with managed_cluster(test_tempdir, ssl) \
+with managed_cluster(test_tempdir, ssl, s3_server) \
      as (ip, cluster):
     conn = cluster.connect()
     res = conn.execute(f"SELECT * FROM {ks}.{cf};")

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -29,8 +29,6 @@ s3_server_address = os.environ['S3_SERVER_ADDRESS_FOR_TEST']
 s3_server_port = int(os.environ['S3_SERVER_PORT_FOR_TEST'])
 s3_public_bucket = os.environ['S3_PUBLIC_BUCKET_FOR_TEST']
 
-def get_tempdir(pid):
-    return test_tempdir
 
 with open(test_tempdir + '/object_storage.yaml', 'w') as config_file:
     yaml.dump({ 'endpoints': [
@@ -84,7 +82,7 @@ rows = [('0', 'zero'),
         ('2', 'two')]
 
 print(f'Start scylla (dir={test_tempdir}')
-with managed_cluster(run.run_with_generated_dir(run_scylla_cmd, get_tempdir), ssl) \
+with managed_cluster(run.run_with_generated_dir(run_scylla_cmd, lambda _: test_tempdir), ssl) \
      as (pid, ip, cluster):
     old_pid = pid
     atexit.register(lambda: teardown(old_pid))

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -10,6 +10,7 @@ import os
 import requests
 import shutil
 import yaml
+from contextlib import contextmanager
 
 print('Scylla is: ' + run.find_scylla() + '.')
 success = True
@@ -53,73 +54,87 @@ def teardown(pid):
     shutil.copyfileobj(log, sys.stdout.buffer)
 
 
-print(f'Start scylla (dir={test_tempdir}')
-pid = run.run_with_generated_dir(run_scylla_cmd, get_tempdir)
-atexit.register(lambda: teardown(pid))
+def check_with_cql(ip, ssl):
+    '''return a checker which checks the readiness of scylla'''
+    def checker():
+        if ssl:
+            return run.check_ssl_cql(ip)
+        else:
+            return run.check_cql(ip)
+    return checker
 
-ip = run.pid_to_ip(pid)
-run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 
-print(f'Create keyspace (minio listening at {s3_server_address})')
-cluster = run.get_cql_cluster(ip)
-conn = cluster.connect()
-replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
-                                  'replication_factor': '1'})
-storage_opts = format_tuples(type='S3',
-                             endpoint=s3_server_address,
-                             bucket=s3_public_bucket)
+@contextmanager
+def managed_cluster(pid, ssl):
+    '''return scylla's pid, IP and a connection to it'''
+    ip = run.pid_to_ip(pid)
+    run.wait_for_services(pid, [check_with_cql(ip, ssl)])
+    cluster = run.get_cql_cluster(ip)
+    try:
+        yield pid, ip, cluster
+    finally:
+        cluster.shutdown()
+
+
+old_pid = None
 ks = 'test_ks'
 cf = 'test_cf'
 rows = [('0', 'zero'),
         ('1', 'one'),
         ('2', 'two')]
 
-conn.execute((f"CREATE KEYSPACE {ks} WITH"
-              f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
-conn.execute(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
-for row in rows:
-    cql_fmt = "INSERT INTO {}.{} ( name, value ) VALUES ('{}', '{}');"
-    conn.execute(cql_fmt.format(ks, cf, *row))
-res = conn.execute(f"SELECT * FROM {ks}.{cf};")
+print(f'Start scylla (dir={test_tempdir}')
+with managed_cluster(run.run_with_generated_dir(run_scylla_cmd, get_tempdir), ssl) \
+     as (pid, ip, cluster):
+    old_pid = pid
+    atexit.register(lambda: teardown(old_pid))
+    print(f'Create keyspace (minio listening at {s3_server_address})')
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+    storage_opts = format_tuples(type='S3',
+                                 endpoint=s3_server_address,
+                                 bucket=s3_public_bucket)
 
-r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/{ks}', timeout=60)
-if r.status_code != 200:
-    print(f'Error flushing keyspace: {r}')
-    success = False
+    conn = cluster.connect()
+    conn.execute((f"CREATE KEYSPACE {ks} WITH"
+                  f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
+    conn.execute(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+    for row in rows:
+        cql_fmt = "INSERT INTO {}.{} ( name, value ) VALUES ('{}', '{}');"
+        conn.execute(cql_fmt.format(ks, cf, *row))
+    res = conn.execute(f"SELECT * FROM {ks}.{cf};")
 
-# Check that the ownership table is populated properly
-res = conn.execute("SELECT * FROM system.sstables;")
-for row in res:
-    if not row.location.startswith(test_tempdir):
-        print(f'Unexpected entry location in registry: {row.location}')
+    r = requests.post(f'http://{ip}:10000/storage_service/keyspace_flush/{ks}', timeout=60)
+    if r.status_code != 200:
+        print(f'Error flushing keyspace: {r}')
         success = False
-    if row.status != 'sealed':
-        print(f'Unexpected entry status in registry: {row.status}')
-        success = False
 
-cluster.shutdown()
+    # Check that the ownership table is populated properly
+    res = conn.execute("SELECT * FROM system.sstables;")
+    for row in res:
+        if not row.location.startswith(test_tempdir):
+            print(f'Unexpected entry location in registry: {row.location}')
+            success = False
+        if row.status != 'sealed':
+            print(f'Unexpected entry status in registry: {row.status}')
+            success = False
 
 print('Restart scylla')
-pid = run.restart_with_dir(pid, run_scylla_cmd, test_tempdir)
-ip = run.pid_to_ip(pid)
-run.wait_for_services(pid, [ lambda: check_cql(ip) ])
+with managed_cluster(run.restart_with_dir(old_pid, run_scylla_cmd, test_tempdir), ssl) \
+     as (pid, ip, cluster):
+    conn = cluster.connect()
+    res = conn.execute(f"SELECT * FROM {ks}.{cf};")
+    have_res = { x.name: x.value for x in res }
+    if have_res != dict(rows):
+        print(f'Unexpected table content: {have_res}')
+        success = False
 
-cluster = run.get_cql_cluster(ip)
-conn = cluster.connect()
-res = conn.execute(f"SELECT * FROM {ks}.{cf};")
-have_res = { x.name: x.value for x in res }
-if have_res != dict(rows):
-    print(f'Unexpected table content: {have_res}')
-    success = False
-
-print('Drop table')
-conn.execute(f"DROP TABLE {ks}.{cf};")
-# Check that the ownership table is de-populated
-res = conn.execute("SELECT * FROM system.sstables;")
-for row in res:
-    print(f'Unexpected entry in registry: {row.location} {row.status}')
-    success = False
-
-cluster.shutdown()
+    print('Drop table')
+    conn.execute(f"DROP TABLE {ks}.{cf};")
+    # Check that the ownership table is de-populated
+    res = conn.execute("SELECT * FROM system.sstables;")
+    for row in res:
+        print(f'Unexpected entry in registry: {row.location} {row.status}')
+        success = False
 
 sys.exit(0 if success else 1)

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -9,6 +9,7 @@ import atexit
 import os
 import requests
 import shutil
+import signal
 import yaml
 from contextlib import contextmanager
 
@@ -62,6 +63,42 @@ def check_with_cql(ip, ssl):
     return checker
 
 
+def run_with_dir(run_cmd_gen, run_dir):
+    print(f'Start scylla (dir={run_dir}')
+    mask = signal.pthread_sigmask(signal.SIG_BLOCK, {})
+    signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGQUIT, signal.SIGTERM})
+    sys.stdout.flush()
+    sys.stderr.flush()
+    pid = os.fork()
+    if pid == 0:
+        # child
+        cmd, env = run_cmd_gen(os.getpid(), run_dir)
+        log = os.path.join(run_dir, 'log')
+        log_fd = os.open(log, os.O_WRONLY | os.O_CREAT | os.O_APPEND, mode=0o666)
+        # redirect stdout and stderr to log file
+        for output in [sys.stdout, sys.stderr]:
+            output.flush()
+            output_fd = output.fileno()
+            os.close(output_fd)
+            os.dup2(log_fd, output_fd)
+        os.setsid()
+        os.execve(cmd[0], cmd, dict(os.environ, **env))
+    # parent
+    signal.pthread_sigmask(signal.SIG_SETMASK, mask)
+    return pid
+
+
+def restart_with_dir(old_pid, run_cmd_gen, run_dir):
+    try:
+        os.killpg(old_pid, 2)
+        os.waitpid(old_pid, 0)
+    except ProcessLookupError:
+        pass
+    scylla_link = os.path.join(run_dir, 'test_scylla')
+    os.unlink(scylla_link)
+    return run_with_dir(run_cmd_gen, run_dir)
+
+
 @contextmanager
 def managed_cluster(pid, ssl):
     '''return scylla's pid, IP and a connection to it'''
@@ -81,8 +118,8 @@ rows = [('0', 'zero'),
         ('1', 'one'),
         ('2', 'two')]
 
-print(f'Start scylla (dir={test_tempdir}')
-with managed_cluster(run.run_with_generated_dir(run_scylla_cmd, lambda _: test_tempdir), ssl) \
+
+with managed_cluster(run_with_dir(run_scylla_cmd, test_tempdir), ssl) \
      as (pid, ip, cluster):
     old_pid = pid
     atexit.register(lambda: teardown(old_pid))
@@ -118,7 +155,7 @@ with managed_cluster(run.run_with_generated_dir(run_scylla_cmd, lambda _: test_t
             success = False
 
 print('Restart scylla')
-with managed_cluster(run.restart_with_dir(old_pid, run_scylla_cmd, test_tempdir), ssl) \
+with managed_cluster(restart_with_dir(old_pid, run_scylla_cmd, test_tempdir), ssl) \
      as (pid, ip, cluster):
     conn = cluster.connect()
     res = conn.execute(f"SELECT * FROM {ks}.{cf};")

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -46,11 +46,11 @@ def run_scylla_cmd(pid, dir):
     c += ['--object-storage-config-file', test_tempdir + '/object_storage.yaml']
     return (c, e)
 
-def teardown(pid):
-    print('Kill scylla')
+def teardown():
     sys.stdout.flush()
-    log = run.abort_run_with_dir(pid, test_tempdir)
+    log = open(os.path.join(test_tempdir, 'log'), 'rb')
     shutil.copyfileobj(log, sys.stdout.buffer)
+    shutil.rmtree(test_tempdir)
 
 
 def check_with_cql(ip, ssl):
@@ -88,27 +88,29 @@ def run_with_dir(run_cmd_gen, run_dir):
     return pid
 
 
-def restart_with_dir(old_pid, run_cmd_gen, run_dir):
+def kill_with_dir(old_pid, run_dir):
     try:
+        print('Kill scylla')
         os.killpg(old_pid, 2)
         os.waitpid(old_pid, 0)
     except ProcessLookupError:
         pass
     scylla_link = os.path.join(run_dir, 'test_scylla')
     os.unlink(scylla_link)
-    return run_with_dir(run_cmd_gen, run_dir)
 
 
 @contextmanager
-def managed_cluster(pid, ssl):
+def managed_cluster(run_dir, ssl):
     '''return scylla's pid, IP and a connection to it'''
+    pid = run_with_dir(run_scylla_cmd, run_dir)
     ip = run.pid_to_ip(pid)
     run.wait_for_services(pid, [check_with_cql(ip, ssl)])
     cluster = run.get_cql_cluster(ip)
     try:
-        yield pid, ip, cluster
+        yield ip, cluster
     finally:
         cluster.shutdown()
+        kill_with_dir(pid, run_dir)
 
 
 old_pid = None
@@ -119,10 +121,9 @@ rows = [('0', 'zero'),
         ('2', 'two')]
 
 
-with managed_cluster(run_with_dir(run_scylla_cmd, test_tempdir), ssl) \
-     as (pid, ip, cluster):
-    old_pid = pid
-    atexit.register(lambda: teardown(old_pid))
+with managed_cluster(test_tempdir, ssl) \
+     as (ip, cluster):
+    atexit.register(teardown)
     print(f'Create keyspace (minio listening at {s3_server_address})')
     replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
                                       'replication_factor': '1'})
@@ -155,8 +156,8 @@ with managed_cluster(run_with_dir(run_scylla_cmd, test_tempdir), ssl) \
             success = False
 
 print('Restart scylla')
-with managed_cluster(restart_with_dir(old_pid, run_scylla_cmd, test_tempdir), ssl) \
-     as (pid, ip, cluster):
+with managed_cluster(test_tempdir, ssl) \
+     as (ip, cluster):
     conn = cluster.connect()
     res = conn.execute(f"SELECT * FROM {ks}.{cf};")
     have_res = { x.name: x.value for x in res }

--- a/test/object_store/suite.yaml
+++ b/test/object_store/suite.yaml
@@ -1,1 +1,1 @@
-type: Run
+type: Python


### PR DESCRIPTION
in this series, test/object_storage is restructured into a pytest based test. this paves the road to a test suites covers more use cases. so we can some more lower-level tests for tiered/caching-store.