### PR TITLE
raft: server: throw fewer `commit_status_unknown`s from `wait_for_entry`

### DIFF
--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -950,6 +950,13 @@ future<> raft_cluster<Clock>::add_entry(size_t val, std::optional<size_t> server
             co_await at->add_entry(create_command(val), raft::wait_type::committed);
             break;
         } catch (raft::commit_status_unknown& e) {
+            // FIXME: in some cases when we get `commit_status_unknown` the entry may have been applied.
+            // Retrying it could lead to double application which causes hard to debug failures, e.g. #14029.
+            // For now we leave a warning so the logs give a hint if such a failure happens and we need
+            // to debug it. Ideally we would never have to handle `commit_status_unknown` but some replication
+            // tests rely on retrying it during leader changes etc.
+            tlogger.warn("replication_test: got `commit_status_unknown` from `add_entry`"
+                    ", val: {}, server: {}", val, server);
         } catch (raft::dropped_entry& e) {
             // retry if an entry is dropped because the leader have changed after it was submitted
         }


### PR DESCRIPTION
There are some cases where we can deduce that the entry was committed,
but we were throwing `commit_status_unknown`. Handle one more such case.
The added comment explains it in detail.

Also add a FIXME for another case where we throw `commit_status_unknown`
but we could do better.

Fixes: #14029
Fixes: #14072

