### PR TITLE
Update seastar submodule

### DIFF
--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/seastar.hh>
+#include <seastar/core/coroutine.hh>
 #include "init.hh"
 #include "supervisor.hh"
 #include "directories.hh"


### PR DESCRIPTION
Update seastar submodule

* seastar afe39231...99d28ff0 (16):
  > file/util: Include seastar.hh
  > http/exception: Use http::reply explicitly
  > http/client: Include lost condition-variable.hh
  > util: file: drop unnecessary include of reactor.hh
  > tests: perf: add a markdown printer
  > http/client: Introduce unexpected_status_error for client requests
  > sharded: avoid #include <seastar/core/reactor.hh> for run_in_background()
  > code: Use std::is_invocable_r_v instead of InvokeReturns
  > http/client: Add ability to change pool size on the fly
  > http/client: Add getters for active/idle connections counts
  > http/client: Count and limit the number of connections
  > http/client: Add connection->client RAII backref
  > build: use the user-specified compiler when building DPDK
  > build: use proper toolchain based on specified compiler
  > build: only pass CMAKE_C_COMPILER when building ingredients
  > build: use specified compiler when building liburing
