### PR TITLE
Coroutinize and change return type for table::get_sstables_by_partition_key()

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -889,7 +889,7 @@ public:
      * Return a set of the sstables names that contain the given
      * partition key in nodetool format
      */
-    future<std::unordered_set<sstring>> get_sstables_by_partition_key(const sstring& key) const;
+    future<std::unordered_set<sstables::shared_sstable>> get_sstables_by_partition_key(const sstring& key) const;
 
     const sstables::sstable_set& get_sstable_set() const;
     lw_shared_ptr<const sstable_list> get_sstables() const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1404,26 +1404,20 @@ int64_t table::get_unleveled_sstables() const {
 }
 
 future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const sstring& key) const {
-    return do_with(std::unordered_set<sstring>(), make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector()),
-            partition_key(partition_key::from_nodetool_style_string(_schema, key)),
-            [this] (std::unordered_set<sstring>& filenames, lw_shared_ptr<sstables::sstable_set::incremental_selector>& sel, partition_key& pk) {
-        return do_with(dht::decorated_key(dht::decorate_key(*_schema, pk)),
-                [this, &filenames, &sel](dht::decorated_key& dk) mutable {
-            const auto& sst = sel->select(dk).sstables;
-            auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
+    auto pk = partition_key::from_nodetool_style_string(_schema, key);
+    auto dk = dht::decorate_key(*_schema, pk);
+    auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
 
-            return do_for_each(sst, [&filenames, &dk, hk = std::move(hk)] (std::vector<sstables::shared_sstable>::const_iterator::reference s) mutable {
-                auto name = s->get_filename();
-                return s->has_partition_key(hk, dk).then([name = std::move(name), &filenames] (bool contains) mutable {
-                    if (contains) {
-                        filenames.insert(name);
-                    }
-                });
-            });
-        }).then([&filenames] {
-            return make_ready_future<std::unordered_set<sstring>>(filenames);
-        });
-    });
+    auto sel = make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector());
+    const auto& sst = sel->select(dk).sstables;
+
+    std::unordered_set<sstring> filenames;
+    for (auto s : sst) {
+        if (co_await s->has_partition_key(hk, dk)) {
+            filenames.insert(s->get_filename());
+        }
+    }
+    co_return filenames;
 }
 
 const sstables::sstable_set& table::get_sstable_set() const {


### PR DESCRIPTION
The helper if huge in the form of then-chain. Also it's generic enough not to limit itself in returning sstables' Data file names only.

refs: #14122 (detached from the one that needs more thinking about)