### PR TITLE
repair: optimise  repair reader with different shard count

### DIFF
--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "repair/decorated_key_with_hash.hh"
+#include "readers/evictable.hh"
+#include "dht/sharder.hh"
+#include "reader_permit.hh"
+#include "utils/phased_barrier.hh"
+#include "mutation/mutation_fragment.hh"
+#include "readers/mutation_fragment_v1_stream.hh"
+
+class repair_reader {
+public:
+    enum class read_strategy {
+        local,
+        multishard_split,
+        multishard_filter
+    };
+
+    friend std::ostream& operator<<(std::ostream& out, read_strategy s) {
+        switch (s) {
+            case read_strategy::local:
+                return out << "local";
+            case read_strategy::multishard_split:
+                return out << "multishard_split";
+            case read_strategy::multishard_filter:
+                return out << "multishard_filter";
+        };
+        return out << "unknown";
+    }
+private:
+    schema_ptr _schema;
+    reader_permit _permit;
+    dht::partition_range _range;
+    // Used to find the range that repair master will work on
+    dht::selective_token_range_sharder _sharder;
+    // Seed for the repair row hashing
+    uint64_t _seed;
+    // Pin the table while the reader is alive.
+    // Only needed for local readers, the multishard reader takes care
+    // of pinning tables on used shards.
+    std::optional<utils::phased_barrier::operation> _local_read_op;
+    std::optional<evictable_reader_handle_v2> _reader_handle;
+    // Fragment stream of either local or multishard reader for the range
+    mutation_fragment_v1_stream _reader;
+    // Current partition read from disk
+    lw_shared_ptr<const decorated_key_with_hash> _current_dk;
+    uint64_t _reads_issued = 0;
+    uint64_t _reads_finished = 0;
+
+    flat_mutation_reader_v2 make_reader(
+        seastar::sharded<replica::database>& db,
+        replica::column_family& cf,
+        read_strategy strategy,
+        const dht::sharder& remote_sharder,
+        unsigned remote_shard);
+
+public:
+    repair_reader(
+        seastar::sharded<replica::database>& db,
+        replica::column_family& cf,
+        schema_ptr s,
+        reader_permit permit,
+        dht::token_range range,
+        const dht::sharder& remote_sharder,
+        unsigned remote_shard,
+        uint64_t seed,
+        read_strategy strategy);
+
+    future<mutation_fragment_opt>
+    read_mutation_fragment();
+
+    future<> on_end_of_stream() noexcept;
+
+    future<> close() noexcept;
+
+    lw_shared_ptr<const decorated_key_with_hash>& get_current_dk() {
+        return _current_dk;
+    }
+
+    void set_current_dk(const dht::decorated_key& key);
+
+    void clear_current_dk();
+
+    void check_current_dk();
+
+    void pause();
+};

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -966,8 +966,8 @@ public:
     }
 
 private:
-    future<uint64_t> do_estimate_partitions_on_all_shards() {
-        return estimate_partitions(_db, _schema->ks_name(), _schema->cf_name(), _range);
+    future<uint64_t> do_estimate_partitions_on_all_shards(const dht::token_range& range) {
+        return estimate_partitions(_db, _schema->ks_name(), _schema->cf_name(), range);
     }
 
     future<uint64_t> do_estimate_partitions_on_local_shard() {
@@ -990,7 +990,7 @@ private:
                     auto shard_range = sharder.next();
                     if (shard_range) {
                         ++subranges;
-                        return do_estimate_partitions_on_all_shards().then([&partitions_sum] (uint64_t partitions) mutable {
+                        return do_estimate_partitions_on_all_shards(*shard_range).then([&partitions_sum] (uint64_t partitions) mutable {
                             partitions_sum += partitions;
                             return make_ready_future<stop_iteration>(stop_iteration::no);
                         });

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1767,4 +1767,7 @@ future<> start_large_data_handler(sharded<replica::database>& db);
 flat_mutation_reader_v2 make_multishard_streaming_reader(distributed<replica::database>& db, schema_ptr schema, reader_permit permit,
         std::function<std::optional<dht::partition_range>()> range_generator);
 
+flat_mutation_reader_v2 make_multishard_streaming_reader(distributed<replica::database>& db,
+    schema_ptr schema, reader_permit permit, const dht::partition_range& range);
+
 bool is_internal_keyspace(std::string_view name);

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -12,9 +12,12 @@
 #include "repair/hash.hh"
 #include "repair/row.hh"
 #include "repair/writer.hh"
+#include "repair/reader.hh"
 #include "repair/row_level.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/cql_test_env.hh"
+#include "service/storage_proxy.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
@@ -133,3 +136,105 @@ SEASTAR_TEST_CASE(flush_repair_rows_on_wire_to_sstable) {
     });
 }
 
+SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
+    // The test generates random mutations and persists them into the database.
+    // It then tries to read them back with different repair_reader read_strategies.
+    // Two cases are considered - when remote_sharder is different from
+    // the local one and when it's the same.
+    // In the first case we compare the output of multishard_split and multishard_filter
+    // readers, in the second case we exercise the local read strategy and
+    // compare its output to both multishard_split and multishard_filter.
+
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        random_mutation_generator gen{random_mutation_generator::generate_counters::no, local_shard_only::no};
+        co_await e.db().invoke_on_all([gs = global_schema_ptr(gen.schema())](replica::database& db) -> future<> {
+            co_await db.add_column_family_and_make_directory(gs.get());
+            db.find_column_family(gs.get()).mark_ready_for_writes();
+        });
+        auto& cf = e.local_db().find_column_family(gen.schema());
+        const auto& local_sharder = cf.schema()->get_sharder();
+
+        const auto token_max = std::numeric_limits<int64_t>::max();
+        const auto token_min = std::numeric_limits<int64_t>::min();
+        auto min_token = token_max;
+        auto max_token = token_min;
+        {
+            auto mutations = gen(100);
+            for (const auto& m: mutations) {
+                const auto t = m.token().raw();
+                min_token = std::min(min_token, t);
+                max_token = std::max(max_token, t);
+            }
+            auto& storage_proxy = e.get_storage_proxy().local();
+            co_await storage_proxy.mutate_locally(std::move(mutations), tracing::trace_state_ptr());
+        }
+
+        auto do_check = [&](const dht::sharder& remote_sharder,
+            repair_reader::read_strategy strategy1, repair_reader::read_strategy strategy2) -> future<>
+        {
+            const auto& s = *cf.schema();
+            // local strategy can read only from the current shard
+            const auto remote_shard = strategy1 == repair_reader::read_strategy::local || strategy2 == repair_reader::read_strategy::local
+                ? this_shard_id()
+                : tests::random::get_int(remote_sharder.shard_count() - 1);
+            const auto random_range = std::invoke([&] {
+                const auto left = tests::random::get_int(token_min, max_token);
+                const auto right = tests::random::get_int(left == token_max ? token_max : left + 1, token_max);
+                return dht::token_range::make(
+                    {dht::token::from_int64(left), tests::random::with_probability(0.5)},
+                    {dht::token::from_int64(right), tests::random::with_probability(0.5)});
+            });
+            auto read_all = [&](repair_reader::read_strategy strategy) -> future<std::vector<mutation_fragment>> {
+                auto reader = repair_reader(e.db(), cf, cf.schema(), make_reader_permit(e),
+                    random_range, remote_sharder, remote_shard, 0, strategy);
+                std::vector<mutation_fragment> result;
+                while (auto mf = co_await reader.read_mutation_fragment()) {
+                    result.push_back(std::move(*mf));
+                }
+                co_await reader.on_end_of_stream();
+                co_await reader.close();
+                co_return result;
+            };
+            auto dump = [&](std::ostream& target, const std::vector<mutation_fragment>& fragments) {
+                for (const auto& f: fragments) {
+                    ::fmt::print(target, "\n{}", mutation_fragment::printer(s, f));
+                }
+            };
+
+            const auto data1 = co_await read_all(strategy1);
+            const auto data2 = co_await read_all(strategy2);
+            std::optional<sstring> mismatch;
+            if (data1.size() != data2.size()) {
+                mismatch = ::format("size1 {} != size2 {}", data1.size(), data2.size());
+            } else {
+                for (int i = 0; i < data1.size(); ++i) {
+                    const auto& mf1 = data1[i];
+                    const auto& mf2 = data2[i];
+                    if (!mf1.equal(s, mf2)) {
+                        mismatch = ::format("{} != {}",
+                            mutation_fragment::printer(s, mf1), mutation_fragment::printer(s, mf2));
+                        break;
+                    }
+                }
+            }
+            if (mismatch) {
+                std::cout << "data1:";
+                dump(std::cout, data1);
+                std::cout << "\ndata2:";
+                dump(std::cout, data2);
+                std::cout << std::endl;
+                BOOST_FAIL(::format("s1={}, s2={}, mismatch={}", strategy1, strategy2, *mismatch));
+            }
+        };
+
+        co_await do_check(dht::sharder(local_sharder.shard_count() + 1, local_sharder.sharding_ignore_msb()),
+            repair_reader::read_strategy::multishard_split,
+            repair_reader::read_strategy::multishard_filter);
+        co_await do_check(local_sharder,
+            repair_reader::read_strategy::local,
+            repair_reader::read_strategy::multishard_filter);
+        co_await do_check(local_sharder,
+            repair_reader::read_strategy::local,
+            repair_reader::read_strategy::multishard_split);
+    });
+}


### PR DESCRIPTION
Consider a cluster with no data, e.g. in tests. When a new node is bootstrapped with repair we iterate over all (shard, table, range), read data from all the peer nodes for the range, look for any discrepancies and heal them. Even for small num_tokens (16 in the tests) the number of affected ranges (those we need to consider) amounts to total number of tokens in the cluster, which is 32 for the second node and 48 for the third. Multiplying this by the number of shards and the number of tables in each keyspace gives thousands of ranges. For each of them we need to follow some row level repair protocol, which includes several RPC exchanges between the peer nodes and creating some data structures on them. These exchanges are processed sequentially for each shard, there are `parallel_for_each` in code, but they are throttled by the choosen memory constraints and in fact execute sequentially.

When the bootstrapping node (master) reaches a peer node and asks for data in the specific range and master shard, two options exist. If sharder parameters (primarily, `--smp`) are the same on the master and on the peer, we can just read one local shard, this is fast. If, on the other hand, `--smp` is different, we need to do a multishard query. The given range from the master can contain data from different peer shards, so we split this range into a number of subranges such that each of them contain data only from the given master shard (`dht::selective_token_range_sharder`). The number of these subranges can be quite big (300 in the tests). For each of these subranges we do `fast_forward_to` on the `multishard_reader`, and this incurs a lot of overhead, mainly becuse of `smp::submit_to`.

In this series we optimize this case. Instead of splitting the master range and reading only what's needed, we read all the data in the range and then apply the filter by the master shard. We do this if the estimated number of partitions is small (<=100).

This is the logs of starting a second node with `--smp 4`, first node was `--smp 3`:

```
with this patch
    20:58:49.644 INFO> [debug/topology_custom.test_topology_smp.1] starting server at host 127.222.46.3 in scylla-2...
    20:59:22.713 INFO> [debug/topology_custom.test_topology_smp.1] started server at host 127.222.46.3 in scylla-2, pid 1132859

without this patch
    21:04:06.424 INFO> [debug/topology_custom.test_topology_smp.1] starting server at host 127.181.31.3 in scylla-2...
    21:06:01.287 INFO> [debug/topology_custom.test_topology_smp.1] started server at host 127.181.31.3 in scylla-2, pid 1134140
```

Fixes: #14093