### PR TITLE
test.py: do not abort if fails to parse an XML logger file

### DIFF
--- a/test.py
+++ b/test.py
@@ -643,12 +643,16 @@ class BoostTest(UnitTest):
             test.attrib['mode'] = self.mode
             return test
 
-        root = ET.parse(self.xmlout).getroot()
-        # only keep the tests which actually ran, the skipped ones do not have
-        # TestingTime tag in the corresponding TestCase tag.
-        self.__test_case_elements = map(attach_path_and_mode,
-                                        root.findall(".//TestCase[TestingTime]"))
-        os.unlink(self.xmlout)
+        try:
+            root = ET.parse(self.xmlout).getroot()
+            # only keep the tests which actually ran, the skipped ones do not have
+            # TestingTime tag in the corresponding TestCase tag.
+            self.__test_case_elements = map(attach_path_and_mode,
+                                            root.findall(".//TestCase[TestingTime]"))
+            os.unlink(self.xmlout)
+        except ET.ParseError as e:
+            message = palette.crit(f"failed to parse XML output '{self.xmlout}': {e}")
+            print(f"error: {self.name}: {message}")
 
     def check_log(self, trim: bool) -> None:
         self.__parse_logger()


### PR DESCRIPTION
there are chances that a Boost::test test fails to generate a valid XML file after the test finishes. and
xml.etree.ElementTree.parse() throws when parsing it. see https://github.com/scylladb/scylla-pkg/issues/3196

before this change, the exception is not handled, and test.py aborts in this case. this does not help and could be misleading.

after this change, the exception is handled and printed.