### PR TITLE
test/cql-pytest: make run_with_temporary_dir_pids a dict  and s/restart_with_dir/kill_with_generated_dir/

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -74,7 +74,7 @@ def make_new_tempdir(pid, do_create):
 def run_with_temporary_dir(run_cmd_generator):
     return run_with_generated_dir(run_cmd_generator, make_new_tempdir)
 
-def restart_with_dir(old_pid, run_cmd_generator, run_dir_generator):
+def kill_with_generated_dir(old_pid, run_dir_generator):
     try:
         os.killpg(old_pid, 2)
         os.waitpid(old_pid, 0)
@@ -84,7 +84,6 @@ def restart_with_dir(old_pid, run_cmd_generator, run_dir_generator):
     run_dir = run_dir_generator(old_pid, do_create=False)
     scylla_link = os.path.join(run_dir, 'test_scylla')
     os.unlink(scylla_link)
-    return run_with_generated_dir(run_cmd_generator, run_dir_generator)
 
 # run_with_temporary_dir_pids is a dict of process ids and the functions
 # to create their temporary directory, these process ids are previously

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -103,9 +103,10 @@ for row in res:
         success = False
 
 cluster.shutdown()
+run.kill_with_generated_dir(pid, make_run_dir)
 
 print('Restart scylla')
-pid = run.restart_with_dir(pid, run_scylla_cmd, make_run_dir)
+pid = run.run_with_generated_dir(run_scylla_cmd, make_run_dir)
 ip = run.pid_to_ip(pid)
 run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 

--- a/test/object_store/run
+++ b/test/object_store/run
@@ -28,8 +28,11 @@ s3_server_address = os.environ['S3_SERVER_ADDRESS_FOR_TEST']
 s3_server_port = int(os.environ['S3_SERVER_PORT_FOR_TEST'])
 s3_public_bucket = os.environ['S3_PUBLIC_BUCKET_FOR_TEST']
 
-def get_tempdir(pid):
-    return test_tempdir
+def get_make_run_dir(run_dir):
+    '''return a function which returns the run_dir'''
+    def make_run_dir(pid, do_create):
+        return run_dir
+    return make_run_dir
 
 with open(test_tempdir + '/object_storage.yaml', 'w') as config_file:
     yaml.dump({ 'endpoints': [
@@ -53,8 +56,10 @@ def teardown(pid):
     shutil.copyfileobj(log, sys.stdout.buffer)
 
 
+make_run_dir = get_make_run_dir(test_tempdir)
+
 print(f'Start scylla (dir={test_tempdir}')
-pid = run.run_with_generated_dir(run_scylla_cmd, get_tempdir)
+pid = run.run_with_generated_dir(run_scylla_cmd, make_run_dir)
 atexit.register(lambda: teardown(pid))
 
 ip = run.pid_to_ip(pid)
@@ -100,7 +105,7 @@ for row in res:
 cluster.shutdown()
 
 print('Restart scylla')
-pid = run.restart_with_dir(pid, run_scylla_cmd, test_tempdir)
+pid = run.restart_with_dir(pid, run_scylla_cmd, make_run_dir)
 ip = run.pid_to_ip(pid)
 run.wait_for_services(pid, [ lambda: check_cql(ip) ])
 

--- a/test/scylla-gdb/run
+++ b/test/scylla-gdb/run
@@ -38,7 +38,7 @@ def run_pytest_in_gdb(pytest_dir, additional_parameters):
     pid = os.fork()
     if pid == 0:
         # child:
-        run.run_with_temporary_dir_pids = set() # no children to clean up on child
+        run.run_with_temporary_dir_pids = {} # no children to clean up on child
         run.run_pytest_pids = set()
         os.chdir(pytest_dir)
         pytest_args = ['-o', 'junit_family=xunit2'] + additional_parameters


### PR DESCRIPTION
this series includes two changes

- make run_with_temporary_dir_pids a dict: do relax the assumption on the ownership of run_dir
- s/restart_with_dir/kill_with_generated_dir/: do pave the road to a better fixture offering a running scylla instance

both of them were created when reworking the object_storage tests. 