### PR TITLE
Add concurrency control and workload isolation for S3 client

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -301,7 +301,6 @@ class client::upload_sink_base : public data_sink_impl {
 
 protected:
     shared_ptr<client> _client;
-    http::experimental::client& _http;
     sstring _object_name;
     sstring _upload_id;
     utils::chunked_vector<sstring> _part_etags;
@@ -320,7 +319,6 @@ protected:
 public:
     upload_sink_base(shared_ptr<client> cln, sstring object_name)
         : _client(std::move(cln))
-        , _http(_client->_http)
         , _object_name(std::move(object_name))
     {
     }
@@ -670,7 +668,6 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
 
 class client::readable_file : public file_impl {
     shared_ptr<client> _client;
-    http::experimental::client& _http;
     sstring _object_name;
 
     [[noreturn]] void unsupported() {
@@ -680,7 +677,6 @@ class client::readable_file : public file_impl {
 public:
     readable_file(shared_ptr<client> cln, sstring object_name)
         : _client(std::move(cln))
-        , _http(_client->_http)
         , _object_name(std::move(object_name))
     {
     }

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -31,7 +31,7 @@ class client : public enable_shared_from_this<client> {
     class readable_file;
     std::string _host;
     endpoint_config_ptr _cfg;
-    http::experimental::client _http;
+    std::unordered_map<seastar::scheduling_group, http::experimental::client> _https;
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -22,6 +22,8 @@ struct range {
     size_t len;
 };
 
+future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_);
+
 class client : public enable_shared_from_this<client> {
     class upload_sink_base;
     class upload_sink;
@@ -36,6 +38,7 @@ class client : public enable_shared_from_this<client> {
     struct private_tag {};
 
     void authorize(http::request&);
+    future<> make_request(http::request req, http::experimental::client::reply_handler handle = ignore_reply, http::reply::status_type expected = http::reply::status_type::ok);
 
     future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler);
 public:


### PR DESCRIPTION
In its current state s3 client uses a single default-configured http client thus making different sched classes' workload compete with each other for sockets to make requests on. There's an attempt to handle that in upload-sink implementation that limits itself with some small number of concurrent PUT requests, but that doesn't help much as many sinks don't share this limit.

This PR makes S3 client maintain a set of http clients, one per sched-group, configures maximum number of TCP connections proportional to group's shares and removes the artificial limit from sinks thus making them share the group's http concurrency limit.

As a side effect, the upload-sink fixes the no-writes-after-flush protection -- if it's violated, write will result in exception, while currently it just hangs on a semaphore forever.

fixes: #13458
fixes: #13320
fixes: #13021