### PR TITLE
tracing: drop trace(.., std::string&&) overload

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -424,7 +424,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     co_await client_state.maybe_update_per_service_level_params();
 
     tracing::trace_state_ptr trace_state = maybe_trace_query(client_state, username, op, content);
-    tracing::trace(trace_state, std::move(op));
+    tracing::trace(trace_state, "{}", op);
     rjson::value json_request = co_await _json_parser.parse(std::move(content));
     co_return co_await callback_it->second(_executor, client_state, trace_state,
             make_service_permit(std::move(units)), std::move(json_request), std::move(req));

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -454,15 +454,6 @@ private:
         }
     }
 
-    void trace(const char* msg) noexcept {
-        try {
-            trace_internal(std::string(msg));
-        } catch (...) {
-            // Bump up an error counter and ignore
-            ++_local_tracing_ptr->stats.trace_errors;
-        }
-    }
-
     /**
      * Add a single trace entry - printf-like version
      *
@@ -713,12 +704,6 @@ template <typename... T>
 inline void trace(const trace_state_ptr& p, fmt::format_string<T...> fmt, T&&... args) noexcept {
     if (p && !p->ignore_events()) {
         p->trace(fmt, std::forward<T>(args)...);
-    }
-}
-
-inline void trace(const trace_state_ptr& p, std::string&& msg) noexcept {
-    if (p && !p->ignore_events()) {
-        p->trace(std::move(msg));
     }
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1099,7 +1099,7 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
         const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",
                 stmt->get_bound_terms(),
                 options.get_values_count());
-        tracing::trace(query_state.get_trace_state(), msg);
+        tracing::trace(query_state.get_trace_state(), "{}", msg);
         throw exceptions::invalid_request_exception(msg);
     }
 


### PR DESCRIPTION
this change is a follow-up of 4f5fcb02fdf40244b13f908334081212c581a1e6, the goal is to avoid the programming oversights like

```c++
trace(trace_ptr, "foo {} with {} but {} is {}");
```

as `trace(const trace_state_ptr& p, const std::string& msg)` is a better match than the templated one, i.e.,
`trace(const trace_state_ptr& p, fmt::format_string<T...> fmt, T&&... args)`. so we cannot detect this with the compile-time format checking.

so let's just drop this overload, and update its callers to use the other overload.

The change was suggested by Avi. the example also came from him.