### PR TITLE
table: s/lw_shared/unique_ptr/ when appropriate

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1408,7 +1408,7 @@ future<std::unordered_set<sstables::shared_sstable>> table::get_sstables_by_part
     auto dk = dht::decorate_key(*_schema, pk);
     auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());
 
-    auto sel = make_lw_shared<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector());
+    auto sel = std::make_unique<sstables::sstable_set::incremental_selector>(get_sstable_set().make_incremental_selector());
     const auto& sst = sel->select(dk).sstables;
 
     std::unordered_set<sstables::shared_sstable> ssts;


### PR DESCRIPTION
sel is a local variable, and it is not shared with anybody else. so make it a unique_ptr<> for better readability.