### PR TITLE
Revert "configure: Switch debug build from -O0 to -Og"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -286,7 +286,8 @@ modes = {
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*40,
         # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
-        'optimization-level': ('0' if platform.machine() == 'aarch64' else 'g'),
+        # also, -Og was seen to make all variables "optimized out"
+        'optimization-level': '0',
         'per_src_extra_cxxflags': {},
         'cmake_build_type': 'Debug',
         'can_have_debug_info': True,


### PR DESCRIPTION
This reverts commit 7e68ed6a5de2635dab3e7169a3cc9c2d79e29a88. With -Og simple 'gdb build/debug/scylla -ex start' shows the function parameters as "optimized out" while with -O0 they display fine. This applies to all variables, not just main's parameters.

Bisect revealed that this behavior started with the reverted commit; it's not due to a later toolchain update.

Fixes #14196.