### PR TITLE
build: cmake: use -O0 for debug build

### DIFF
--- a/cmake/mode.DEBUG.cmake
+++ b/cmake/mode.DEBUG.cmake
@@ -1,9 +1,4 @@
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
-  set(default_Seastar_OptimizationLevel_DEBUG "0")
-else()
-  set(default_Seastar_OptimizationLevel_DEBUG "g")
-endif()
+set(default_Seastar_OptimizationLevel_DEBUG "0")
 set(Seastar_OptimizationLevel_DEBUG
   ${default_Seastar_OptimizationLevel_DEBUG}
   CACHE


### PR DESCRIPTION
per clang's document, -Og is like -O1, which is in turn an optimization level between -O0 and -O2. -O0 "generates the most debuggable code". for instance, with -O0, presumably, the variables are not allocated in the registers and later get overwritten, they are always allocated on the stack. this helps with the debugging.

in this change, -O0 is used for better debugging experience. the downside is that the emitted code size will be greater than the one emitted from -Og, and the executable will be slower.