### PR TITLE
build: make gen_headers a dependency of gen/*.o

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2083,7 +2083,7 @@ with open(buildfile, 'w') as f:
                                                                    grammar.source.rsplit('.', 1)[0]))
             for cc in grammar.sources('$builddir/{}/gen'.format(mode)):
                 obj = cc.replace('.cpp', '.o')
-                f.write('build {}: cxx.{} {} || {}\n'.format(obj, mode, cc, ' '.join(serializers)))
+                f.write('build {}: cxx.{} {} || {}\n'.format(obj, mode, cc, ' '.join(gen_headers)))
                 flags = '-Wno-parentheses-equality'
                 if cc.endswith('Parser.cpp'):
                     # Unoptimized parsers end up using huge amounts of stack space and overflowing their stack


### PR DESCRIPTION
when compiling the generated source files, sometimes, we can run into the FTBFS like:
```
02:18:54  FAILED: build/release/gen/cql3/CqlParser.o 02:18:54  clang++ ... -o build/release/gen/cql3/CqlParser.o build/release/gen/cql3/CqlParser.cpp ...
02:18:54  In file included from build/release/gen/cql3/CqlParser.cpp:44:
02:18:54  In file included from build/release/gen/cql3/CqlParser.hpp:75: 
02:18:54  In file included from ./cql3/statements/create_function_statement.hh:12: 
02:18:54  In file included from ./cql3/functions/user_function.hh:16: 
02:18:54  ./lang/wasm.hh:15:10: fatal error: 'rust/wasmtime_bindings.hh' file not found 
02:18:54  #include "rust/wasmtime_bindings.hh"
02:18:54           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
CqlParser.cc is a source file generated from cql3/Cql.g, this source in turn includes another source file generated from
wasmtime_bindings/src/lib.rs. but we failed to setup this dependency in the build.ninja rules -- we only teach ninja that "to compile the grammer source files, please prepare the`serializers` source files first". but this is not enough.

so, in this change, we just replace `serializers` with `gen_headers`, as the latter is a superset of the former. and should fulfill the needs of CqlParser.cc.

Fixes #14213