### PR TITLE
cql3: statements: select_statement: reuse to_selectable() computation in SELECT JSON

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1631,7 +1631,7 @@ void select_statement::maybe_jsonize_select_clause(data_dictionary::database db,
         selector_names.reserve(_select_clause.size());
         selector_types.reserve(_select_clause.size());
         auto selectables = selection::raw_selector::to_selectables(_select_clause, *schema);
-        selection::selector_factories factories(selection::raw_selector::to_selectables(_select_clause, *schema), db, schema, defs);
+        selection::selector_factories factories(selectables, db, schema, defs);
         auto selectors = factories.new_instances();
         for (size_t i = 0; i < selectors.size(); ++i) {
             if (_select_clause[i]->alias) {


### PR DESCRIPTION

We store the result of to_selectables() in a local variable, then compute it again in the next line. Fix by reusing the variable.