### PR TITLE
cql3: prepare selectors

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -428,7 +428,7 @@ unaliasedSelector returns [expression s]
        | K_TTL       '(' c=cident ')'              { tmp = column_mutation_attribute{column_mutation_attribute::attribute_kind::ttl,
                                                                                               unresolved_identifier{std::move(c)}}; }
        | f=functionName args=selectionFunctionArgs { tmp = function_call{std::move(f), std::move(args)}; }
-       | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = cast{std::move(arg), std::move(t)}; }
+       | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = cast{.style = cast::cast_style::sql, .arg = std::move(arg), .type = std::move(t)}; }
        )
        ( '.' fi=cident { tmp = field_selection{std::move(tmp), std::move(fi)}; } )*
     { $s = tmp; }
@@ -1632,7 +1632,7 @@ functionArgs returns [std::vector<expression> a]
 term returns [expression term1]
     : v=value                          { $term1 = std::move(v); }
     | f=functionName args=functionArgs { $term1 = function_call{std::move(f), std::move(args)}; }
-    | '(' c=comparatorType ')' t=term  { $term1 = cast{std::move(t), c}; }
+    | '(' c=comparatorType ')' t=term  { $term1 = cast{.style = cast::cast_style::c, .arg = std::move(t), .type = c}; }
     ;
 
 columnOperation[operations_type& operations]

--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -46,6 +46,8 @@ public:
      */
     virtual test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const = 0;
 
+    virtual std::optional<data_type> assignment_testable_type_opt() const = 0;
+
     // for error reporting
     virtual sstring assignment_testable_source_context() const = 0;
 };

--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -44,7 +44,7 @@ public:
      * Most caller should just call the isAssignable() method on the result, though functions have a use for
      * testing "strong" equality to decide the most precise overload to pick when multiple could match.
      */
-    virtual test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const column_specification& receiver) const = 0;
+    virtual test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const = 0;
 
     // for error reporting
     virtual sstring assignment_testable_source_context() const = 0;

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -121,14 +121,17 @@ std::unique_ptr<attributes> attributes::raw::prepare(data_dictionary::database d
 
     if (timestamp.has_value()) {
         ts = prepare_expression(*timestamp, db, ks_name, nullptr, timestamp_receiver(ks_name, cf_name));
+        verify_no_aggregate_functions(*ts, "USING clause");
     }
 
     if (time_to_live.has_value()) {
         ttl = prepare_expression(*time_to_live, db, ks_name, nullptr, time_to_live_receiver(ks_name, cf_name));
+        verify_no_aggregate_functions(*time_to_live, "USING clause");
     }
 
     if (timeout.has_value()) {
         to = prepare_expression(*timeout, db, ks_name, nullptr, timeout_receiver(ks_name, cf_name));
+        verify_no_aggregate_functions(*timeout, "USING clause");
     }
 
     return std::unique_ptr<attributes>{new attributes{std::move(ts), std::move(ttl), std::move(to)}};

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2648,5 +2648,25 @@ bool is_partition_token_for_schema(const expression& maybe_token, const schema& 
 
     return is_partition_token_for_schema(*fun_call, table_schema);
 }
+
+void
+verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors) {
+    auto find_agg = overloaded_functor{
+            [] (const functions::function_name& f) -> bool {
+                on_internal_error(expr_logger, "verify_no_aggregate_functions: unprepared function_call");
+            },
+            [] (const shared_ptr<functions::function> f) -> bool {
+                return f->is_aggregate();
+            }
+        };
+    bool found_agg = find_in_expression<function_call>(expr, [find_agg] (const function_call& fc) {
+        return std::visit(find_agg, fc.func);
+    });
+    if (found_agg) {
+        throw exceptions::invalid_request_exception(fmt::format("Aggregation function are not supported in the {}", context_for_errors));
+    }
+}
+
+
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1089,7 +1089,7 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
             },
             [&] (const column_mutation_attribute& cma)  {
                 fmt::print(os, "{}({})",
-                        cma.kind == column_mutation_attribute::attribute_kind::ttl ? "TTL" : "WRITETIME",
+                        cma.kind,
                         to_printer(cma.column));
             },
             [&] (const function_call& fc)  {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2243,6 +2243,17 @@ size_t count_if(const expression& e, const noncopyable_function<bool (const bina
 }
 
 data_type
+column_mutation_attribute_type(const column_mutation_attribute& e) {
+    switch (e.kind) {
+    case column_mutation_attribute::attribute_kind::writetime:
+        return long_type;
+    case column_mutation_attribute::attribute_kind::ttl:
+        return int32_type;
+    }
+    on_internal_error(expr_logger, "evaluating type of illegal column mutation attribute kind");
+}
+
+data_type
 type_of(const expression& e) {
     return visit(overloaded_functor{
         [] (const conjunction& e) {
@@ -2259,13 +2270,7 @@ type_of(const expression& e) {
             on_internal_error(expr_logger, "evaluating type of unresolved_identifier");
         },
         [] (const column_mutation_attribute& e) {
-            switch (e.kind) {
-            case column_mutation_attribute::attribute_kind::writetime:
-                return long_type;
-            case column_mutation_attribute::attribute_kind::ttl:
-                return int32_type;
-            }
-            on_internal_error(expr_logger, "evaluating type of illegal column mutation attribute kind");
+            return column_mutation_attribute_type(e);
         },
         [] (const function_call& e) {
             return std::visit(overloaded_functor{

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -316,6 +316,8 @@ struct function_call {
 };
 
 struct cast {
+    enum class cast_style { c, sql };
+    cast_style style;
     expression arg;
     std::variant<data_type, shared_ptr<cql3_type::raw>> type;
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -327,6 +327,7 @@ struct cast {
 struct field_selection {
     expression structure;
     shared_ptr<column_identifier_raw> field;
+    size_t field_idx = 0; // invalid before prepare
     data_type type; // may be null before prepare
 
     friend bool operator==(const field_selection&, const field_selection&) = default;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -881,3 +881,17 @@ struct fmt::formatter<cql3::expr::expression::printer> {
 template <cql3::expr::ExpressionElement E>
 struct fmt::formatter<E> : public fmt::formatter<cql3::expr::expression> {
 };
+
+template <>
+struct fmt::formatter<cql3::expr::column_mutation_attribute::attribute_kind> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(cql3::expr::column_mutation_attribute::attribute_kind k, FormatContext& ctx) const {
+        switch (k) {
+            case cql3::expr::column_mutation_attribute::attribute_kind::writetime:
+                return fmt::format_to(ctx.out(), "WRITETIME");
+            case cql3::expr::column_mutation_attribute::attribute_kind::ttl:
+                return fmt::format_to(ctx.out(), "TTL");
+        }
+        return fmt::format_to(ctx.out(), "unrecognized_attribute_kind({})", static_cast<int>(k));
+    }
+};

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -701,6 +701,9 @@ expression adjust_for_collection_as_maps(const expression& e);
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 
+// Check that a prepared expression has no aggregate functions. Throws on error.
+void verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors);
+
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.
 extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -721,11 +721,11 @@ expression optimize_like(const expression& e);
  * Most caller should just call the is_assignable() method on the result, though functions have a use for
  * testing "strong" equality to decide the most precise overload to pick when multiple could match.
  */
-extern assignment_testable::test_result test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver);
+extern assignment_testable::test_result test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver);
 
 // Test all elements of exprs for assignment. If all are exact match, return exact match. If any is not assignable,
 // return not assignable. Otherwise, return weakly assignable.
-extern assignment_testable::test_result test_assignment_all(const std::vector<expression>& exprs, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver);
+extern assignment_testable::test_result test_assignment_all(const std::vector<expression>& exprs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver);
 
 extern shared_ptr<assignment_testable> as_assignment_testable(expression e);
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -823,6 +823,11 @@ bytes_opt value_for(const column_definition&, const expression&, const query_opt
 bool contains_multi_column_restriction(const expression&);
 
 bool has_only_eq_binops(const expression&);
+
+/// Finds the data type of writetime(x) or ttl(x)
+data_type column_mutation_attribute_type(const column_mutation_attribute& e);
+
+
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -730,7 +730,7 @@ extern assignment_testable::test_result test_assignment(const expression& expr, 
 // return not assignable. Otherwise, return weakly assignable.
 extern assignment_testable::test_result test_assignment_all(const std::vector<expression>& exprs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver);
 
-extern shared_ptr<assignment_testable> as_assignment_testable(expression e);
+extern shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt);
 
 inline oper_t pick_operator(statements::bound b, bool inclusive) {
     return is_start(b) ?

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1033,7 +1033,7 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
 
 static assignment_testable::test_result expression_test_assignment(const data_type& expr_type,
                                                                    const column_specification& receiver) {
-    if (receiver.type->underlying_type() == expr_type->underlying_type()) {
+    if (receiver.type->underlying_type() == expr_type->underlying_type() || (receiver.type == long_type && expr_type->is_counter())) {
         return assignment_testable::test_result::EXACT_MATCH;
     } else if (receiver.type->is_value_compatible_with(*expr_type)) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1183,7 +1183,10 @@ public:
     virtual sstring assignment_testable_source_context() const override {
         return fmt::format("{}", _e);
     }
-
+    virtual std::optional<data_type> assignment_testable_type_opt() const override {
+        // FIXME: we could try to prepare the expression and see if we get a type
+        return std::nullopt;
+    }
 };
 
 ::shared_ptr<assignment_testable> as_assignment_testable(expression e) {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -996,7 +996,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
         .args = std::move(parameters),
         .lwt_cache_id = fc.lwt_cache_id
     };
-    if (all_terminal && fun->is_pure() && !fun->is_aggregate()) {
+    if (all_terminal && fun->is_pure() && !fun->is_aggregate() && !fun->requires_thread()) {
         return constant(expr::evaluate(fun_call, query_options::DEFAULT), fun->return_type());
     } else {
         return fun_call;

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1229,6 +1229,13 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
 
 static
 assignment_testable::test_result
+unresolved_identifier_test_assignment(const unresolved_identifier& ui, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+    auto prepared = prepare_expression(ui, db, keyspace, schema_opt, make_lw_shared<column_specification>(receiver));
+    return test_assignment(prepared, db, keyspace, schema_opt, receiver);
+}
+
+static
+assignment_testable::test_result
 column_mutation_attribute_test_assignment(const column_mutation_attribute& cma, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
     auto type = column_mutation_attribute_type(cma);
     return expression_test_assignment(std::move(type), std::move(receiver));
@@ -1253,8 +1260,8 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
         [&] (const subscript&) -> test_result {
             on_internal_error(expr_logger, "subscripts are not yet reachable via test_assignment()");
         },
-        [&] (const unresolved_identifier&) -> test_result {
-            on_internal_error(expr_logger, "unresolved_identifiers are not yet reachable via test_assignment()");
+        [&] (const unresolved_identifier& ui) -> test_result {
+            return unresolved_identifier_test_assignment(ui, db, keyspace, schema_opt, receiver);
         },
         [&] (const column_mutation_attribute& cma) -> test_result {
             return column_mutation_attribute_test_assignment(cma, db, keyspace, schema_opt, receiver);

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -184,6 +184,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
 
     // Prepare the restriction
     binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema);
+    expr::verify_no_aggregate_functions(prepared_binop, "where clause");
 
     // Fill prepare context
     const column_value* lhs_pk_col_search_res = find_in_expression<column_value>(prepared_binop.lhs,

--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -374,6 +374,12 @@ castas_fctn get_castas_fctn(data_type to_type, data_type from_type) {
     throw exceptions::invalid_request_exception(format("{} cannot be cast to {}", from_type->name(), to_type->name()));
 }
 
+shared_ptr<function>
+get_castas_fctn_as_cql3_function(data_type to_type, data_type from_type) {
+    auto f = get_castas_fctn(to_type, from_type->without_reversed().shared_from_this());
+    return make_castas_function(to_type, from_type, f);
+}
+
 shared_ptr<function> castas_functions::get(data_type to_type, const std::vector<shared_ptr<cql3::selection::selector>>& provided_args) {
     if (provided_args.size() != 1) {
         throw exceptions::invalid_request_exception("Invalid CAST expression");

--- a/cql3/functions/castas_fcts.hh
+++ b/cql3/functions/castas_fcts.hh
@@ -30,6 +30,7 @@ namespace functions {
 using castas_fctn = data_value(*)(data_value);
 
 castas_fctn get_castas_fctn(data_type to_type, data_type from_type);
+::shared_ptr<function> get_castas_fctn_as_cql3_function(data_type to_type, data_type from_type);
 
 class castas_functions {
 public:

--- a/cql3/functions/error_injection_fcts.cc
+++ b/cql3/functions/error_injection_fcts.cc
@@ -84,7 +84,7 @@ shared_ptr<function> make_disable_injection_function() {
 
 shared_ptr<function> make_enabled_injections_function() {
     const auto list_type_inst = list_type_impl::get_instance(ascii_type, false);
-    return make_failure_injection_function<true>("enabled_injections", list_type_inst, {},
+    return make_failure_injection_function<false>("enabled_injections", list_type_inst, {},
         [list_type_inst] (std::span<const bytes_opt>) -> bytes {
             return seastar::map_reduce(smp::all_cpus(), [] (unsigned) {
                 return make_ready_future<std::vector<sstring>>(utils::get_local_injector().enabled_injections());

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -328,6 +328,14 @@ functions::get(data_dictionary::database db,
     static const function_name TO_JSON_FUNCTION_NAME = function_name::native_function("tojson");
     static const function_name FROM_JSON_FUNCTION_NAME = function_name::native_function("fromjson");
 
+    auto schema = std::invoke([&] () -> schema_ptr {
+        if (receiver_cf.has_value() && db.has_schema(receiver_ks, *receiver_cf)) {
+            return db.find_schema(receiver_ks, *receiver_cf);
+        } else {
+            return nullptr;
+        }
+    });
+
     if (name.has_keyspace()
                 ? name == TOKEN_FUNCTION_NAME
                 : name.name == TOKEN_FUNCTION_NAME.name) {
@@ -335,8 +343,8 @@ functions::get(data_dictionary::database db,
         if (!receiver_cf.has_value()) {
             throw exceptions::invalid_request_exception("functions::get for token doesn't have a known column family");
         }
-        auto fun = ::make_shared<token_fct>(db.find_schema(receiver_ks, *receiver_cf));
-        validate_types(db, keyspace, fun, provided_args, receiver_ks, receiver_cf);
+        auto fun = ::make_shared<token_fct>(schema);
+        validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
         return fun;
     }
 
@@ -393,13 +401,13 @@ functions::get(data_dictionary::database db,
     // Fast path if there is only one choice
     if (candidates.size() == 1) {
         auto fun = std::move(candidates[0]);
-        validate_types(db, keyspace, fun, provided_args, receiver_ks, receiver_cf);
+        validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
         return fun;
     }
 
     std::vector<shared_ptr<function>> compatibles;
     for (auto&& to_test : candidates) {
-        auto r = match_arguments(db, keyspace, to_test, provided_args, receiver_ks, receiver_cf);
+        auto r = match_arguments(db, keyspace, schema.get(), to_test, provided_args, receiver_ks, receiver_cf);
         switch (r) {
             case assignment_testable::test_result::EXACT_MATCH:
                 // We always favor exact matches
@@ -504,6 +512,7 @@ functions::mock_get(const function_name &name, const std::vector<data_type>& arg
 void
 functions::validate_types(data_dictionary::database db,
                           const sstring& keyspace,
+                          const schema* schema_opt,
                           shared_ptr<function> fun,
                           const std::vector<shared_ptr<assignment_testable>>& provided_args,
                           const sstring& receiver_ks,
@@ -524,7 +533,7 @@ functions::validate_types(data_dictionary::database db,
         }
 
         auto&& expected = make_arg_spec(receiver_ks, receiver_cf, *fun, i);
-        if (!is_assignable(provided->test_assignment(db, keyspace, *expected))) {
+        if (!is_assignable(provided->test_assignment(db, keyspace, schema_opt, *expected))) {
             throw exceptions::invalid_request_exception(
                     format("Type error: {} cannot be passed as argument {:d} of function {} of type {}",
                             provided, i, fun->name(), expected->type->as_cql3_type()));
@@ -534,6 +543,7 @@ functions::validate_types(data_dictionary::database db,
 
 assignment_testable::test_result
 functions::match_arguments(data_dictionary::database db, const sstring& keyspace,
+        const schema* schema_opt,
         shared_ptr<function> fun,
         const std::vector<shared_ptr<assignment_testable>>& provided_args,
         const sstring& receiver_ks,
@@ -551,7 +561,7 @@ functions::match_arguments(data_dictionary::database db, const sstring& keyspace
             continue;
         }
         auto&& expected = make_arg_spec(receiver_ks, receiver_cf, *fun, i);
-        auto arg_res = provided->test_assignment(db, keyspace, *expected);
+        auto arg_res = provided->test_assignment(db, keyspace, schema_opt, *expected);
         if (arg_res == assignment_testable::test_result::NOT_ASSIGNABLE) {
             return assignment_testable::test_result::NOT_ASSIGNABLE;
         }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -22,6 +22,7 @@
 #include "cql3/column_identifier.hh"
 #include "utils/to_string.hh"
 #include "log.hh"
+#include "schema/schema.hh"
 #include <unordered_map>
 
 namespace cql3 {
@@ -84,11 +85,13 @@ private:
     // case where there is no override for a given function. This is thus probably worth the minor code duplication.
     static void validate_types(data_dictionary::database db,
                               const sstring& keyspace,
+                              const schema* schema_opt,
                               shared_ptr<function> fun,
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
                               std::optional<const std::string_view> receiver_cf);
     static assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
+            const schema* schema_opt,
             shared_ptr<function> fun,
             const std::vector<shared_ptr<assignment_testable>>& provided_args,
             const sstring& receiver_ks,

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -87,10 +87,6 @@ public:
     const functions::function_name& name() const {
         return _tfun->name();
     }
-
-    virtual sstring assignment_testable_source_context() const override {
-        return format("{}", this->name());
-    }
 };
 
 }

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -78,12 +78,6 @@ public:
         _selected->reset();
     }
 
-    virtual sstring assignment_testable_source_context() const override {
-        auto&& name = _type->field_name(_field);
-        auto sname = std::string_view(reinterpret_cast<const char*>(name.data()), name.size());
-        return format("{}.{}", _selected, sname);
-    }
-
     field_selector(user_type type, size_t field, shared_ptr<selector> selected)
             : _type(std::move(type)), _field(field), _selected(std::move(selected)) {
     }

--- a/cql3/selection/raw_selector.hh
+++ b/cql3/selection/raw_selector.hh
@@ -14,6 +14,7 @@
 #include "cql3/selection/selectable-expr.hh"
 #include "cql3/expr/expression.hh"
 #include "cql3/column_identifier.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 namespace cql3 {
 
@@ -36,11 +37,11 @@ public:
      * @return a list of <code>Selectable</code>s
      */
     static std::vector<::shared_ptr<selectable>> to_selectables(const std::vector<::shared_ptr<raw_selector>>& raws,
-            const schema& schema) {
+            const schema& schema, data_dictionary::database db, const sstring& ks) {
         std::vector<::shared_ptr<selectable>> r;
         r.reserve(raws.size());
         for (auto&& raw : raws) {
-            r.emplace_back(prepare_selectable(schema, raw->selectable_));
+            r.emplace_back(prepare_selectable(schema, raw->selectable_, db, ks));
         }
         return r;
     }

--- a/cql3/selection/selectable-expr.hh
+++ b/cql3/selection/selectable-expr.hh
@@ -11,11 +11,12 @@
 
 #include "selectable.hh"
 #include "cql3/expr/expression.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 namespace cql3::selection {
 
 expr::expression make_count_rows_function_expression();
-shared_ptr<selectable> prepare_selectable(const schema& s, const expr::expression& raw_selectable);
+shared_ptr<selectable> prepare_selectable(const schema& s, const expr::expression& raw_selectable, data_dictionary::database db, const sstring& keyspace);
 bool selectable_processes_selection(const expr::expression& raw_selectable);
 
 }

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -40,28 +40,12 @@ protected:
 public:
     class writetime_or_ttl;
 
-    class with_function;
     class with_anonymous_function;
 
     class with_field_selection;
-
-    class with_cast;
 };
 
 std::ostream & operator<<(std::ostream &os, const selectable& s);
-
-class selectable::with_function : public selectable {
-    functions::function_name _function_name;
-    std::vector<shared_ptr<selectable>> _args;
-public:
-    with_function(functions::function_name fname, std::vector<shared_ptr<selectable>> args)
-        : _function_name(std::move(fname)), _args(std::move(args)) {
-    }
-
-    virtual sstring to_string() const override;
-
-    virtual shared_ptr<selector::factory> new_selector_factory(data_dictionary::database db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-};
 
 class selectable::with_anonymous_function : public selectable {
     shared_ptr<functions::function> _function;
@@ -69,19 +53,6 @@ class selectable::with_anonymous_function : public selectable {
 public:
     with_anonymous_function(::shared_ptr<functions::function> f, std::vector<shared_ptr<selectable>> args)
         : _function(f), _args(std::move(args)) {
-    }
-
-    virtual sstring to_string() const override;
-
-    virtual shared_ptr<selector::factory> new_selector_factory(data_dictionary::database db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-};
-
-class selectable::with_cast : public selectable {
-    ::shared_ptr<selectable> _arg;
-    data_type _type;
-public:
-    with_cast(::shared_ptr<selectable> arg, data_type type)
-        : _arg(std::move(arg)), _type(std::move(type)) {
     }
 
     virtual sstring to_string() const override;

--- a/cql3/selection/selectable_with_field_selection.hh
+++ b/cql3/selection/selectable_with_field_selection.hh
@@ -22,9 +22,10 @@ class selectable::with_field_selection : public selectable {
 public:
     shared_ptr<selectable> _selected;
     shared_ptr<column_identifier> _field;
+    size_t _field_idx;
 public:
-    with_field_selection(shared_ptr<selectable> selected, shared_ptr<column_identifier> field)
-            : _selected(std::move(selected)), _field(std::move(field)) {
+    with_field_selection(shared_ptr<selectable> selected, shared_ptr<column_identifier> field, size_t field_idx)
+            : _selected(std::move(selected)), _field(std::move(field)), _field_idx(field_idx) {
     }
 
     virtual sstring to_string() const override;

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -295,12 +295,12 @@ uint32_t selection::add_column_for_post_processing(const column_definition& c) {
     return _columns.size() - 1;
 }
 
-::shared_ptr<selection> selection::from_selectors(data_dictionary::database db, schema_ptr schema, const std::vector<::shared_ptr<raw_selector>>& raw_selectors) {
+::shared_ptr<selection> selection::from_selectors(data_dictionary::database db, schema_ptr schema, const sstring& ks, const std::vector<::shared_ptr<raw_selector>>& raw_selectors) {
     std::vector<const column_definition*> defs;
 
     ::shared_ptr<selector_factories> factories =
         selector_factories::create_factories_and_collect_column_definitions(
-            raw_selector::to_selectables(raw_selectors, *schema), db, schema, defs);
+            raw_selector::to_selectables(raw_selectors, *schema, db, ks), db, schema, defs);
 
     auto metadata = collect_metadata(*schema, raw_selectors, *factories);
     if (processes_selection(raw_selectors) || raw_selectors.size() != defs.size()) {

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -128,7 +128,7 @@ private:
     static std::vector<lw_shared_ptr<column_specification>> collect_metadata(const schema& schema,
         const std::vector<::shared_ptr<raw_selector>>& raw_selectors, const selector_factories& factories);
 public:
-    static ::shared_ptr<selection> from_selectors(data_dictionary::database db, schema_ptr schema, const std::vector<::shared_ptr<raw_selector>>& raw_selectors);
+    static ::shared_ptr<selection> from_selectors(data_dictionary::database db, schema_ptr schema, const sstring& ks, const std::vector<::shared_ptr<raw_selector>>& raw_selectors);
 
     virtual std::unique_ptr<selectors> new_selectors() const = 0;
 

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -90,6 +90,10 @@ public:
             return assignment_testable::test_result::NOT_ASSIGNABLE;
         }
     }
+
+    virtual std::optional<data_type> assignment_testable_type_opt() const override {
+        return get_type();
+    }
 };
 
 /**

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -75,7 +75,7 @@ public:
      */
     virtual void reset() = 0;
 
-    virtual assignment_testable::test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const column_specification& receiver) const override {
+    virtual assignment_testable::test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const override {
         auto t1 = receiver.type->underlying_type();
         auto t2 = get_type()->underlying_type();
         // We want columns of `counter_type' to be served by underlying type's overloads

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <vector>
-#include "cql3/assignment_testable.hh"
 #include "query-request.hh"
 #include "types/types.hh"
 #include "schema/schema_fwd.hh"
@@ -29,7 +28,7 @@ class result_set_builder;
  * <p>Since the introduction of aggregation, <code>selector</code>s cannot be called anymore by multiple threads
  * as they have an internal state.</p>
  */
-class selector : public assignment_testable {
+class selector {
 public:
     class factory;
 
@@ -74,26 +73,6 @@ public:
      * Reset the internal state of this <code>selector</code>.
      */
     virtual void reset() = 0;
-
-    virtual assignment_testable::test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const override {
-        auto t1 = receiver.type->underlying_type();
-        auto t2 = get_type()->underlying_type();
-        // We want columns of `counter_type' to be served by underlying type's overloads
-        // (here: `counter_cell_view::total_value_type()') with an `EXACT_MATCH'.
-        // Weak assignability between the two would lead to ambiguity because
-        // `WEAKLY_ASSIGNABLE' counter->blob conversion exists and would compete.
-        if (t1 == t2 || (t1 == counter_cell_view::total_value_type() && t2->is_counter())) {
-            return assignment_testable::test_result::EXACT_MATCH;
-        } else if (t1->is_value_compatible_with(*t2)) {
-            return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-        } else {
-            return assignment_testable::test_result::NOT_ASSIGNABLE;
-        }
-    }
-
-    virtual std::optional<data_type> assignment_testable_type_opt() const override {
-        return get_type();
-    }
 };
 
 /**

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <vector>
 #include "cql3/selection/selector.hh"
+#include "data_dictionary/data_dictionary.hh"
 #include "schema/schema.hh"
 #include "query-request.hh"
 

--- a/cql3/selection/simple_selector.hh
+++ b/cql3/selection/simple_selector.hh
@@ -87,10 +87,6 @@ public:
         return _type;
     }
 
-    virtual sstring assignment_testable_source_context() const override {
-        return _column_name;
-    }
-
 #if 0
     @Override
     public String toString()

--- a/cql3/selection/writetime_or_ttl_selector.hh
+++ b/cql3/selection/writetime_or_ttl_selector.hh
@@ -92,10 +92,6 @@ public:
         return _is_writetime ? long_type : int32_type;
     }
 
-    virtual sstring assignment_testable_source_context() const override {
-        return _column_name;
-    }
-
 #if 0
     @Override
     public String toString()

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -65,7 +65,9 @@ seastar::future<shared_ptr<db::functions::function>> create_aggregate_statement:
     if (_ival) {
         auto dummy_ident = ::make_shared<column_identifier>("", true);
         auto column_spec = make_lw_shared<column_specification>("", "", dummy_ident, state_type);
-        auto initcond_term = expr::evaluate(prepare_expression(_ival.value(), db, _name.keyspace, nullptr, {column_spec}), query_options::DEFAULT);
+        auto initcond_expr = prepare_expression(_ival.value(), db, _name.keyspace, nullptr, {column_spec});
+        expr::verify_no_aggregate_functions(initcond_expr, "INITCOND clause");
+        auto initcond_term = expr::evaluate(initcond_expr, query_options::DEFAULT);
         initcond = std::move(initcond_term).to_bytes_opt();
     }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -524,6 +524,7 @@ static
 expr::expression
 column_condition_prepare(const expr::expression& expr, data_dictionary::database db, const sstring& keyspace, const schema& schema){
     auto prepared = expr::prepare_expression(expr, db, keyspace, &schema, make_lw_shared<column_specification>("", "", make_shared<column_identifier>("IF condition", true), boolean_type));
+    expr::verify_no_aggregate_functions(prepared, "IF clause");
 
     expr::for_each_expression<expr::column_value>(prepared, [] (const expr::column_value& cval) {
       auto def = cval.col;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1631,7 +1631,7 @@ void select_statement::maybe_jsonize_select_clause(data_dictionary::database db,
         selector_names.reserve(_select_clause.size());
         selector_types.reserve(_select_clause.size());
         auto selectables = selection::raw_selector::to_selectables(_select_clause, *schema);
-        selection::selector_factories factories(selection::raw_selector::to_selectables(_select_clause, *schema), db, schema, defs);
+        selection::selector_factories factories(selectables, db, schema, defs);
         auto selectors = factories.new_instances();
         for (size_t i = 0; i < selectors.size(); ++i) {
             if (_select_clause[i]->alias) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1630,7 +1630,7 @@ void select_statement::maybe_jsonize_select_clause(data_dictionary::database db,
         std::vector<const column_definition*> defs;
         selector_names.reserve(_select_clause.size());
         selector_types.reserve(_select_clause.size());
-        auto selectables = selection::raw_selector::to_selectables(_select_clause, *schema);
+        auto selectables = selection::raw_selector::to_selectables(_select_clause, *schema, db, keyspace());
         selection::selector_factories factories(selectables, db, schema, defs);
         auto selectors = factories.new_instances();
         for (size_t i = 0; i < selectors.size(); ++i) {
@@ -1664,7 +1664,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
 
     auto selection = _select_clause.empty()
                      ? selection::selection::wildcard(schema)
-                     : selection::selection::from_selectors(db, schema, _select_clause);
+                     : selection::selection::from_selectors(db, schema, keyspace(), _select_clause);
 
     auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering());
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1815,6 +1815,7 @@ select_statement::prepare_limit(data_dictionary::database db, prepare_context& c
     }
 
     expr::expression prep_limit = prepare_expression(*limit, db, keyspace(), nullptr, limit_receiver());
+    expr::verify_no_aggregate_functions(prep_limit, "LIMIT clause");
     expr::fill_prepare_context(prep_limit, ctx);
     return prep_limit;
 }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -435,6 +435,7 @@ insert_json_statement::prepare_internal(data_dictionary::database db, schema_ptr
     assert(expr::is<cql3::expr::untyped_constant>(_json_value) || expr::is<cql3::expr::bind_variable>(_json_value));
     auto json_column_placeholder = ::make_shared<column_identifier>("", true);
     auto prepared_json_value = prepare_expression(_json_value, db, "", nullptr, make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
+    expr::verify_no_aggregate_functions(prepared_json_value, "JSON clause");
     expr::fill_prepare_context(prepared_json_value, ctx);
     auto stmt = ::make_shared<cql3::statements::insert_prepared_json_statement>(ctx.bound_variables_size(), schema, std::move(attrs), stats, std::move(prepared_json_value), _default_unset);
     prepare_conditions(db, *schema, ctx, *stmt);

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -359,7 +359,7 @@ static shared_ptr<cql3::selection::selection> mock_selection(
         raw_selectors.emplace_back(mock_singular_selection(functions[i], request.reduction_types[i], info));
     }
 
-    return cql3::selection::selection::from_selectors(db.as_data_dictionary(), schema, std::move(raw_selectors));
+    return cql3::selection::selection::from_selectors(db.as_data_dictionary(), schema, schema->ks_name(), std::move(raw_selectors));
 }
 
 future<query::forward_result> forward_service::dispatch_to_shards(

--- a/test/cql-pytest/test_aggregate.py
+++ b/test/cql-pytest/test_aggregate.py
@@ -11,6 +11,7 @@ import math
 from decimal import Decimal
 from util import new_test_table, unique_key_int, project, new_type
 from cassandra.util import Date
+from cassandra_tests.porting import assert_invalid_message
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
@@ -212,3 +213,7 @@ def test_avg_decimal_2(cql, table1, cassandra_bug):
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 4, 3)")
     # Reproduces CASSANDRA-18470:
     assert [(Decimal('2'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+
+def test_reject_aggregates_in_where_clause(cql, table1):
+    assert_invalid_message(cql, table1, 'Aggregation',
+                           f'SELECT * FROM {table1} WHERE p = sum((int)4)')


### PR DESCRIPTION
CQL statements carry expressions in many contexts: the SELECT, WHERE, SET, and IF clauses, plus various attributes. Previously, each of these contexts had its own representation for an expression, and another one for the same expression but before preparation. We have been gradually moving towards a uniform representation of expressions.

This series tackles SELECT clause elements (selectors), in their unprepared phase. It's relatively simple since there are only five types of expression components (column references, writetime/ttl modifiers, function calls, casts, and field selections). Nevertheless, there isn't much commonality with previously converted expression elements so quite a lot of code is involved.

After the series, we are still left with a custom post-prepare representation of expressions. It's quite complicated since it deals with two passes, for aggregation, so it will be left for another series.