### PR TITLE
raft: Populate address mapping from system.peers early

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1603,6 +1603,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 group0_service.abort().get();
             });
 
+            load_address_map(sys_ks.local(), raft_address_map.local()).get();
+
             // Set up group0 service earlier since it is needed by group0 setup just below
             ss.local().set_group0(group0_service);
 

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -24,6 +24,10 @@
 
 namespace bi = boost::intrusive;
 
+namespace db {
+class system_keyspace;
+}
+
 namespace service {
 
 extern seastar::logger rslog;
@@ -331,5 +335,8 @@ public:
 };
 
 using raft_address_map = raft_address_map_t<seastar::lowres_clock>;
+
+// Populates the given raft_address_map from the mapping stored in the system.peers table.
+future<> load_address_map(db::system_keyspace&, raft_address_map&);
 
 } // end of namespace service

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -1616,5 +1616,12 @@ std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {
     return os;
 }
 
+future<> load_address_map(db::system_keyspace& sys_ks, raft_address_map& address_map) {
+    for (auto [ip, host] : co_await sys_ks.load_host_ids()) {
+        address_map.add_or_update_entry(raft::server_id(host.uuid()), ip);
+    }
+}
+
+
 } // end of namespace service
 


### PR DESCRIPTION
Currently, the mapping is initialized from the gossiper state when group0 server is started and updated from a gossiper change listener. Gossiper state is restored from system.peers in storage_service::join_cluster(), which is later than setup_group0_if_exists() is called.

The restarted server will hang in
group0_service.setup_group0_if_exist(), which waits for snapshot loading, which waits for storage_service::topology_state_load(), which waits for IP mapping for servers mentioned in the topology, and produces logs like this:

  WARN  2023-06-12 15:45:21,369 [shard 0] storage_service - (rate limiting dropped 196 similar messages) raft topology: cannot map c94ae68f-869d-4727-8b2f-d40814e395f0 to ip, retrying.

This is a regression after f26179c, where group0 server is initialized before the gossiper is started.

The fix is to load the mapping from system.peers before group0 is started. Gossiper state is not available at this point, so we read the mapping directly from system keyspace. This change will also be needed to implement messaging by host id, even if raft is disabled, where we will need to restore the mapping early.

Fixes #14217