### PR TITLE
database: remove unused header

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -75,8 +75,6 @@
 #include "readers/multi_range.hh"
 #include "readers/multishard.hh"
 
-#include "lang/wasm.hh"
-
 using namespace std::chrono_literals;
 using namespace db;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -64,7 +64,6 @@
 #include "utils/serialized_action.hh"
 #include "compaction/compaction_fwd.hh"
 #include "utils/disk-error-handler.hh"
-#include "rust/wasmtime_bindings.hh"
 
 class cell_locker;
 class cell_locker_stats;


### PR DESCRIPTION
After recent changes, all wasm related logic has been moved from the database class to the query_processor. As a result, the wasm headers no longer need to be included there, and in particular, files that include replica/database.hh no longer need to wait on the generated header rust/wasmtime_bindings.hh to compile.

Before this change, `find build/dev -name '*.d' | xargs grep wasmtime_bindings.hh | wc -l` was returning `206`. After this change, it returns `140`, which would be hard to further reduce, because the `query_processor.hh` depends on `wasmtime_bindings.hh` and `query_processor.hh` appears in `134` depfiles

Fixes  #14224