### PR TITLE
sstable: Move XFS renamer hack into fs storage

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -126,13 +126,6 @@ read_monitor_generator& default_read_monitor_generator() {
     return noop_read_monitor_generator;
 }
 
-future<> sstable::rename_new_sstable_component_file(sstring from_name, sstring to_name) const {
-    return sstable_write_io_check(rename_file, from_name, to_name).handle_exception([from_name, to_name] (std::exception_ptr ep) {
-        sstlog.error("Could not rename SSTable component {} to {}. Found exception: {}", from_name, to_name, ep);
-        return make_exception_future<>(ep);
-    });
-}
-
 future<file> sstable::new_sstable_component_file(const io_error_handler& error_handler, component_type type, open_flags flags, file_open_options options) noexcept {
   try {
     auto f = _storage->open_component(*this, type, flags, options, _manager.config().enable_sstable_data_integrity_check());

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -567,7 +567,6 @@ private:
     void write_crc(const checksum& c);
     void write_digest(uint32_t full_checksum);
 
-    future<> rename_new_sstable_component_file(sstring from_file, sstring to_file) const;
     future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {}) noexcept;
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,


### PR DESCRIPTION
The method sits on sstable, but is called only from fs storage and it's the only place that really needs it