### PR TITLE
Initialize `storage_proxy` early, without `messaging_service` and `gossiper`

### DIFF
--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -344,15 +344,6 @@ filter_for_query(consistency_level cl,
     return selected_endpoints;
 }
 
-inet_address_vector_replica_set filter_for_query(consistency_level cl,
-        const locator::effective_replication_map& erm,
-        inet_address_vector_replica_set& live_endpoints,
-        const inet_address_vector_replica_set& preferred_endpoints,
-        const gms::gossiper& g,
-        replica::column_family* cf) {
-    return filter_for_query(cl, erm, live_endpoints, preferred_endpoints, read_repair_decision::NONE, g, nullptr, cf);
-}
-
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -56,13 +56,6 @@ filter_for_query(consistency_level cl,
                  std::optional<gms::inet_address>* extra,
                  replica::column_family* cf);
 
-inet_address_vector_replica_set filter_for_query(consistency_level cl,
-        const locator::effective_replication_map& erm,
-        inet_address_vector_replica_set& live_endpoints,
-        const inet_address_vector_replica_set& preferred_endpoints,
-        const gms::gossiper& g,
-        replica::column_family* cf);
-
 struct dc_node_count {
     size_t live = 0;
     size_t pending = 0;

--- a/main.cc
+++ b/main.cc
@@ -1453,10 +1453,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
             supervisor::notify("initializing storage proxy RPC verbs");
             proxy.invoke_on_all([&messaging, &gossiper, &mm] (service::storage_proxy& proxy) {
-                proxy.init_messaging_service(messaging.local(), gossiper.local(), mm.local());
+                proxy.start_remote(messaging.local(), gossiper.local(), mm.local());
             }).get();
             auto stop_proxy_handlers = defer_verbose_shutdown("storage proxy RPC verbs", [&proxy] {
-                proxy.invoke_on_all(&service::storage_proxy::uninit_messaging_service).get();
+                proxy.invoke_on_all(&service::storage_proxy::stop_remote).get();
             });
 
             debug::the_stream_manager = &stream_manager;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -961,6 +961,7 @@ public:
     }
 
     void set_hit_rate(gms::inet_address addr, cache_temperature rate);
+    cache_hit_rate get_my_hit_rate() const;
     cache_hit_rate get_hit_rate(const gms::gossiper& g, gms::inet_address addr);
     void drop_hit_rate(gms::inet_address addr);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2190,9 +2190,13 @@ void table::set_hit_rate(gms::inet_address addr, cache_temperature rate) {
     e.last_updated = lowres_clock::now();
 }
 
+table::cache_hit_rate table::get_my_hit_rate() const {
+    return cache_hit_rate { _global_cache_hit_rate, lowres_clock::now()};
+}
+
 table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, gms::inet_address addr) {
     if (utils::fb_utilities::get_broadcast_address() == addr) {
-        return cache_hit_rate { _global_cache_hit_rate, lowres_clock::now()};
+        return get_my_hit_rate();
     }
     auto it = _cluster_cache_hit_rates.find(addr);
     if (it == _cluster_cache_hit_rates.end()) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2736,6 +2736,10 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, gms::gossiper& 
 }
 
 struct storage_proxy::remote& storage_proxy::remote() {
+    return const_cast<struct remote&>(const_cast<const storage_proxy*>(this)->remote());
+}
+
+const struct storage_proxy::remote& storage_proxy::remote() const {
     return *_remote;
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6128,11 +6128,11 @@ future<> storage_proxy::truncate_blocking(sstring keyspace, sstring cfname, std:
     return remote().send_truncate_blocking(std::move(keyspace), std::move(cfname), timeout_in_ms);
 }
 
-void storage_proxy::init_messaging_service(netw::messaging_service& ms, gms::gossiper& g, migration_manager& mm) {
+void storage_proxy::start_remote(netw::messaging_service& ms, gms::gossiper& g, migration_manager& mm) {
     _remote = std::make_unique<struct remote>(*this, ms, g, mm);
 }
 
-future<> storage_proxy::uninit_messaging_service() {
+future<> storage_proxy::stop_remote() {
     co_await _remote->stop();
     _remote = nullptr;
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -188,7 +188,8 @@ public:
         ser::storage_proxy_rpc_verbs::register_paxos_prune(&_ms, std::bind_front(&remote::handle_paxos_prune, this));
     }
 
-    future<> uninit_messaging_service() {
+    // Must call before destroying the `remote` object.
+    future<> stop() {
         co_await ser::storage_proxy_rpc_verbs::unregister(&_ms);
         _mm = nullptr;
     }
@@ -200,6 +201,13 @@ public:
     bool is_alive(const gms::inet_address& ep) const {
         return _gossiper.is_alive(ep);
     }
+
+    // Note: none of the `send_*` functions use `remote` after yielding - by the first yield,
+    // control is delegated to another service (messaging_service). Thus unfinished `send`s
+    // do not make it unsafe to destroy the `remote` object.
+    //
+    // Running handlers prevent the object from being destroyed,
+    // assuming `stop()` is called before destruction.
 
     future<> send_mutation(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, const std::optional<tracing::trace_info>& trace_info,
@@ -2744,7 +2752,25 @@ struct storage_proxy::remote& storage_proxy::remote() {
 }
 
 const struct storage_proxy::remote& storage_proxy::remote() const {
-    return *_remote;
+    if (_remote) {
+        return *_remote;
+    }
+
+    // This error should not appear because the user should not be able to send queries
+    // before `remote` is initialized, and user queries should be drained before `remote`
+    // is destroyed; Scylla code should take care not to perform cluster queries outside
+    // the lifetime of `remote` (it can still perform queries to local tables during
+    // the entire lifetime of `storage_proxy`, which is larger than `remote`).
+    //
+    // If there's a bug though, fail the query.
+    //
+    // In the future we may want to introduce a 'recovery mode' in which Scylla starts
+    // without contacting the cluster and allows the user to perform local queries (say,
+    // to system tables), then this code path would be expected to happen if the user
+    // tries a remote query in this recovery mode, in which case we should change it
+    // from `on_internal_error` to a regular exception.
+    on_internal_error(slogger,
+        "attempted to perform remote query when `storage_proxy::remote` is unavailable");
 }
 
 const data_dictionary::database
@@ -6074,7 +6100,7 @@ storage_proxy::filter_replicas_for_read(
 }
 
 bool storage_proxy::is_alive(const gms::inet_address& ep) const {
-    return _remote->is_alive(ep);
+    return _remote ? _remote->is_alive(ep) : (ep == utils::fb_utilities::get_broadcast_address());
 }
 
 inet_address_vector_replica_set storage_proxy::intersection(const inet_address_vector_replica_set& l1, const inet_address_vector_replica_set& l2) {
@@ -6103,7 +6129,7 @@ void storage_proxy::init_messaging_service(migration_manager* mm) {
 }
 
 future<> storage_proxy::uninit_messaging_service() {
-    return _remote->uninit_messaging_service();
+    return _remote->stop();
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -482,8 +482,10 @@ public:
         }
         return next;
     }
-    void init_messaging_service(netw::messaging_service&, gms::gossiper&, migration_manager&);
-    future<> uninit_messaging_service();
+
+    // Start/stop the remote part of `storage_proxy` that is required for performing distributed queries.
+    void start_remote(netw::messaging_service&, gms::gossiper&, migration_manager&);
+    future<> stop_remote();
 
 private:
     // Throws an error if remote is not initialized.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -448,8 +448,8 @@ private:
         inet_address_vector_replica_set& l2) const;
 
 public:
-    storage_proxy(distributed<replica::database>& db, gms::gossiper& gossiper, config cfg, db::view::node_update_backlog& max_view_update_backlog,
-            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
+    storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
+            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory);
     ~storage_proxy();
 
     const distributed<replica::database>& get_db() const {
@@ -482,7 +482,7 @@ public:
         }
         return next;
     }
-    void init_messaging_service(migration_manager*);
+    void init_messaging_service(netw::messaging_service&, gms::gossiper&, migration_manager&);
     future<> uninit_messaging_service();
 
 private:

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -449,7 +449,8 @@ public:
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
     ~storage_proxy();
 
-    remote& remote();
+    const struct remote& remote() const;
+    struct remote& remote();
 
     const distributed<replica::database>& get_db() const {
         return _db;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -452,9 +452,6 @@ public:
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory, netw::messaging_service& ms);
     ~storage_proxy();
 
-    const struct remote& remote() const;
-    struct remote& remote();
-
     const distributed<replica::database>& get_db() const {
         return _db;
     }
@@ -489,6 +486,10 @@ public:
     future<> uninit_messaging_service();
 
 private:
+    // Throws an error if remote is not initialized.
+    const struct remote& remote() const;
+    struct remote& remote();
+
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
     future<> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -330,6 +330,9 @@ private:
     db::hints::manager& hints_manager_for(db::write_type type);
     void sort_endpoints_by_proximity(const locator::topology& topo, inet_address_vector_replica_set& eps) const;
     inet_address_vector_replica_set get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const;
+    inet_address_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, inet_address_vector_replica_set live_endpoints, const inet_address_vector_replica_set& preferred_endpoints, db::read_repair_decision, std::optional<gms::inet_address>* extra, replica::column_family*) const;
+    // As above with read_repair_decision=NONE, extra=nullptr.
+    inet_address_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set& live_endpoints, const inet_address_vector_replica_set& preferred_endpoints, replica::column_family*) const;
     bool is_alive(const gms::inet_address&) const;
     db::read_repair_decision new_read_repair_decision(const schema& s);
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -573,6 +573,10 @@ public:
 
             auto stop_configurables = defer([&] { notify_set.notify_all(configurable::system_state::stopped).get(); });
 
+            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg, cfg_in.disabled_features);
+            feature_service.start(fcfg).get();
+            auto stop_feature_service = defer([&] { feature_service.stop().get(); });
+
             sharded<locator::snitch_ptr> snitch;
             snitch.start(locator::snitch_config{}).get();
             auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
@@ -593,6 +597,62 @@ public:
             sharded<service::migration_notifier> mm_notif;
             mm_notif.start().get();
             auto stop_mm_notify = defer([&mm_notif] { mm_notif.stop().get(); });
+
+            sharded<sstables::directory_semaphore> sst_dir_semaphore;
+            sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
+            auto stop_sst_dir_sem = defer([&sst_dir_semaphore] {
+                sst_dir_semaphore.stop().get();
+            });
+
+            replica::database_config dbcfg;
+            if (cfg_in.dbcfg) {
+                dbcfg = std::move(*cfg_in.dbcfg);
+            } else {
+                dbcfg.available_memory = memory::stats().total_memory();
+            }
+
+            dbcfg.compaction_scheduling_group = scheduling_groups.compaction_scheduling_group;
+            dbcfg.memory_compaction_scheduling_group = scheduling_groups.memory_compaction_scheduling_group;
+            dbcfg.streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
+            dbcfg.statement_scheduling_group = scheduling_groups.statement_scheduling_group;
+            dbcfg.memtable_scheduling_group = scheduling_groups.memtable_scheduling_group;
+            dbcfg.memtable_to_cache_scheduling_group = scheduling_groups.memtable_to_cache_scheduling_group;
+            dbcfg.gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
+            dbcfg.sstables_format = sstables::version_from_string(cfg->sstable_format());
+
+            auto get_tm_cfg = sharded_parameter([&] {
+                return tasks::task_manager::config {
+                    .task_ttl = cfg->task_ttl_seconds,
+                };
+            });
+            task_manager.start(std::move(get_tm_cfg), std::ref(abort_sources)).get();
+            auto stop_task_manager = defer([&task_manager] {
+                task_manager.stop().get();
+            });
+
+            // get_cm_cfg is called on each shard when starting a sharded<compaction_manager>
+            // we need the getter since updateable_value is not shard-safe (#7316)
+            auto get_cm_cfg = sharded_parameter([&] {
+                return compaction_manager::config {
+                    .compaction_sched_group = compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group},
+                    .maintenance_sched_group = compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group},
+                    .available_memory = dbcfg.available_memory,
+                    .static_shares = cfg->compaction_static_shares,
+                    .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
+                };
+            });
+            cm.start(std::move(get_cm_cfg), std::ref(abort_sources), std::ref(task_manager)).get();
+            auto stop_cm = deferred_stop(cm);
+
+            sstm.start(std::ref(*cfg)).get();
+            auto stop_sstm = deferred_stop(sstm);
+
+            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notif), std::ref(feature_service), std::ref(token_metadata), std::ref(cm), std::ref(sstm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+            auto stop_db = defer([&db] {
+                db.stop().get();
+            });
+
+            db.invoke_on_all(&replica::database::start).get();
 
             sharded<service::endpoint_lifecycle_notifier> elc_notif;
             elc_notif.start().get();
@@ -624,10 +684,6 @@ public:
             });
 
             auto stop_sys_dist_ks = defer([&sys_dist_ks] { sys_dist_ks.stop().get(); });
-
-            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg, cfg_in.disabled_features);
-            feature_service.start(fcfg).get();
-            auto stop_feature_service = defer([&] { feature_service.stop().get(); });
 
             sharded<gms::gossiper> gossiper;
 
@@ -695,62 +751,6 @@ public:
 
             stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(ms), std::ref(mm), std::ref(gossiper), scheduling_groups.streaming_scheduling_group).get();
             auto stop_streaming = defer([&stream_manager] { stream_manager.stop().get(); });
-
-            sharded<sstables::directory_semaphore> sst_dir_semaphore;
-            sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
-            auto stop_sst_dir_sem = defer([&sst_dir_semaphore] {
-                sst_dir_semaphore.stop().get();
-            });
-
-            replica::database_config dbcfg;
-            if (cfg_in.dbcfg) {
-                dbcfg = std::move(*cfg_in.dbcfg);
-            } else {
-                dbcfg.available_memory = memory::stats().total_memory();
-            }
-
-            dbcfg.compaction_scheduling_group = scheduling_groups.compaction_scheduling_group;
-            dbcfg.memory_compaction_scheduling_group = scheduling_groups.memory_compaction_scheduling_group;
-            dbcfg.streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
-            dbcfg.statement_scheduling_group = scheduling_groups.statement_scheduling_group;
-            dbcfg.memtable_scheduling_group = scheduling_groups.memtable_scheduling_group;
-            dbcfg.memtable_to_cache_scheduling_group = scheduling_groups.memtable_to_cache_scheduling_group;
-            dbcfg.gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
-            dbcfg.sstables_format = sstables::version_from_string(cfg->sstable_format());
-
-            auto get_tm_cfg = sharded_parameter([&] {
-                return tasks::task_manager::config {
-                    .task_ttl = cfg->task_ttl_seconds,
-                };
-            });
-            task_manager.start(std::move(get_tm_cfg), std::ref(abort_sources)).get();
-            auto stop_task_manager = defer([&task_manager] {
-                task_manager.stop().get();
-            });
-
-            // get_cm_cfg is called on each shard when starting a sharded<compaction_manager>
-            // we need the getter since updateable_value is not shard-safe (#7316)
-            auto get_cm_cfg = sharded_parameter([&] {
-                return compaction_manager::config {
-                    .compaction_sched_group = compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group},
-                    .maintenance_sched_group = compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group},
-                    .available_memory = dbcfg.available_memory,
-                    .static_shares = cfg->compaction_static_shares,
-                    .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
-                };
-            });
-            cm.start(std::move(get_cm_cfg), std::ref(abort_sources), std::ref(task_manager)).get();
-            auto stop_cm = deferred_stop(cm);
-
-            sstm.start(std::ref(*cfg)).get();
-            auto stop_sstm = deferred_stop(sstm);
-
-            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notif), std::ref(feature_service), std::ref(token_metadata), std::ref(cm), std::ref(sstm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
-            auto stop_db = defer([&db] {
-                db.stop().get();
-            });
-
-            db.invoke_on_all(&replica::database::start).get();
 
             feature_service.invoke_on_all([] (auto& fs) {
                 return fs.enable(fs.supported_feature_set());

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -767,7 +767,7 @@ public:
             db::view::node_update_backlog b(smp::count, 10ms);
             scheduling_group_key_config sg_conf =
                     make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
-            proxy.start(std::ref(db), std::ref(gossiper), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory), std::ref(ms)).get();
+            proxy.start(std::ref(db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
             auto stop_proxy = defer([&proxy] { proxy.stop().get(); });
 
             forward_service.start(std::ref(ms), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();


### PR DESCRIPTION
Move the initialization of `storage_proxy` early in the startup procedure, before starting
`system_keyspace`, `messaging_service`, `gossiper`, `storage_service` and more.

As a follow-up, we'll be able to move initialization of `query_processor` right
after `storage_proxy` (but this requires a bit of refactoring in
`query_processor` too).

Local queries through `storage_proxy` can be done after the early initialization step.
In a follow-up, when we do a similar thing for `query_processor`, we'll be able
to perform local CQL queries early as well. (Before starting `gossiper` etc.)
