### PR TITLE
Cluster features on raft: add storage for supported and enabled features

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -256,11 +256,13 @@ schema_ptr system_keyspace::topology() {
             .with_column("num_tokens", int32_type)
             .with_column("shard_count", int32_type)
             .with_column("ignore_msb", int32_type)
+            .with_column("supported_features", set_type_impl::get_instance(utf8_type, true))
             .with_column("new_cdc_generation_data_uuid", uuid_type, column_kind::static_column)
             .with_column("transition_state", utf8_type, column_kind::static_column)
             .with_column("current_cdc_generation_uuid", uuid_type, column_kind::static_column)
             .with_column("current_cdc_generation_timestamp", timestamp_type, column_kind::static_column)
             .with_column("global_topology_request", utf8_type, column_kind::static_column)
+            .with_column("enabled_features", set_type_impl::get_instance(utf8_type, true), column_kind::static_column)
             .set_comment("Current state of topology change machine")
             .with_version(generate_schema_version(id))
             .build();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -539,10 +539,8 @@ private:
 public:
     topology_node_mutation_builder(topology_mutation_builder&, raft::server_id);
 
-    template<typename T>
-    topology_node_mutation_builder& set(const char* cell, const T& value) {
-        return set(cell, sstring{::format("{}", value)});
-    }
+    topology_node_mutation_builder& set(const char* cell, node_state value);
+    topology_node_mutation_builder& set(const char* cell, topology_request value);
     topology_node_mutation_builder& set(const char* cell, const sstring& value);
     topology_node_mutation_builder& set(const char* cell, const raft::server_id& value);
     topology_node_mutation_builder& set(const char* cell, const std::unordered_set<dht::token>& value);
@@ -652,6 +650,14 @@ api::timestamp_type topology_node_mutation_builder::timestamp() const {
 
 const schema& topology_node_mutation_builder::schema() const {
     return *_builder._s;
+}
+
+topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, node_state value) {
+    return apply_atomic(cell, sstring{::format("{}", value)});
+}
+
+topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, topology_request value) {
+    return apply_atomic(cell, sstring{::format("{}", value)});
 }
 
 topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, const sstring& value) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -63,6 +63,7 @@ struct replica_state {
     std::optional<ring_slice> ring; // if engaged contain the set of tokens the node owns together with their state
     size_t shard_count;
     uint8_t ignore_msb;
+    std::set<sstring> supported_features;
 };
 
 struct topology {
@@ -102,6 +103,9 @@ struct topology {
     // e.g. when a new node bootstraps, needed in `commit_cdc_generation` transition state.
     // It's used as partition key in CDC_GENERATIONS_V3 table.
     std::optional<utils::UUID> new_cdc_generation_data_uuid;
+
+    // Features that are considered enabled by the cluster
+    std::set<sstring> enabled_features;
 
     // Find only nodes in non 'left' state
     const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;


### PR DESCRIPTION
This PR implements the storage part of the cluster features on raft functionality, as described in the "Cluster features on raft v2" doc. These changes will be useful for later PRs that will implement the remaining parts of the feature.

Two new columns are added to `system.topology`:

- `supported_features set<text>` is a new clustering column which holds the features that given node advertises as supported. It will be first initialized when the node joins the cluster, and then updated every time the node reboots and its supported features set changes.
- `enabled_features set<text>` is a new static column which holds the features that are considered enabled by the cluster. Unlike in the current gossip-based implementation the features will not be enabled implicitly when all nodes support a feature, but rather via an explicit action of the topology coordinator.

These columns are reflected in the `topology_state_machine` structure and are populated when the topology state is loaded. Appropriate methods are added to the `topology_mutation_builder` and `topology_node_mutation_builder` in order to allow setting/modifying those columns.

During startup, nodes update their corresponding `supported_features` column to reflect their current feature set. For now it is done unconditionally, but in the future appropriate checks will be added which will prevent nodes from joining / starting their server for group 0 if they can't guarantee that they support all enabled features.