### PR TITLE
Revert "build: make gen_headers a dependency of gen/*.o"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2083,7 +2083,7 @@ with open(buildfile, 'w') as f:
                                                                    grammar.source.rsplit('.', 1)[0]))
             for cc in grammar.sources('$builddir/{}/gen'.format(mode)):
                 obj = cc.replace('.cpp', '.o')
-                f.write('build {}: cxx.{} {} || {}\n'.format(obj, mode, cc, ' '.join(gen_headers)))
+                f.write('build {}: cxx.{} {} || {}\n'.format(obj, mode, cc, ' '.join(serializers)))
                 flags = '-Wno-parentheses-equality'
                 if cc.endswith('Parser.cpp'):
                     # Unoptimized parsers end up using huge amounts of stack space and overflowing their stack


### PR DESCRIPTION
This reverts commit 9526258b8912abce733e76ece3ce0eee63935c62. Because the issue (#14213) supposed to be fix only exists in the enterprise branch.