### PR TITLE
cql3/expression: implement evaluate(field_selection) 

### DIFF
--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -94,6 +94,10 @@ bool column_identifier_raw::operator==(const column_identifier_raw& other) const
     return _text == other._text;
 }
 
+const sstring& column_identifier_raw::text() const {
+    return _text;
+}
+
 sstring column_identifier_raw::to_string() const {
     return _text;
 }

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -88,6 +88,8 @@ public:
 
     bool operator==(const column_identifier_raw& other) const;
 
+    const sstring& text() const;
+
     virtual sstring to_string() const;
     sstring to_cql_string() const;
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1117,7 +1117,11 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
                 }, c.type);
             },
             [&] (const field_selection& fs)  {
-                fmt::print(os, "({}.{})", to_printer(fs.structure), fs.field);
+                if (pr.debug_mode) {
+                    fmt::print(os, "({}.{})", to_printer(fs.structure), fs.field);
+                } else {
+                    fmt::print(os, "{}.{}", to_printer(fs.structure), fs.field);
+                }
             },
             [&] (const bind_variable&) {
                 // FIXME: store and present bind variable name

--- a/types/types.cc
+++ b/types/types.cc
@@ -2023,6 +2023,26 @@ data_value deserialize_aux(const tuple_type_impl& t, View v) {
     return data_value::make(t.shared_from_this(), std::make_unique<tuple_type_impl::native_type>(std::move(ret)));
 }
 
+template <FragmentedView View>
+std::optional<std::optional<View>> read_nth_tuple_element(View serialized_tuple, std::size_t element_index) {
+    for (std::size_t i = 0; serialized_tuple.size_bytes() > 0; i++) {
+        // element being std::nullopt means that its value is NULL.
+        std::optional<View> element = read_tuple_element(serialized_tuple);
+
+        if (i == element_index) {
+            return std::make_optional(element);
+        }
+    }
+
+    return std::nullopt;
+}
+
+template std::optional<std::optional<managed_bytes_view>> read_nth_tuple_element(managed_bytes_view serialized_tuple,
+                                                                              std::size_t element_index);
+template std::optional<std::optional<fragmented_temporary_buffer::view>> read_nth_tuple_element(
+    fragmented_temporary_buffer::view serialized_tuple,
+    std::size_t element_index);
+
 template<FragmentedView View>
 utils::multiprecision_int deserialize_value(const varint_type_impl&, View v) {
     if (v.empty()) {

--- a/types/types.cc
+++ b/types/types.cc
@@ -3000,9 +3000,9 @@ bool abstract_type::is_value_compatible_with(const abstract_type& other) const {
 }
 
 std::optional<size_t>
-user_type_impl::idx_of_field(const bytes& name) const {
+user_type_impl::idx_of_field(const bytes_view& name) const {
     for (size_t i = 0; i < _field_names.size(); ++i) {
-        if (name == _field_names[i]) {
+        if (name == bytes_view(_field_names[i])) {
             return {i};
         }
     }

--- a/types/types.cc
+++ b/types/types.cc
@@ -2043,6 +2043,27 @@ template std::optional<std::optional<fragmented_temporary_buffer::view>> read_nt
     fragmented_temporary_buffer::view serialized_tuple,
     std::size_t element_index);
 
+template <FragmentedView View>
+std::optional<View> read_nth_user_type_field(View serialized_user_type, std::size_t element_index) {
+    // UDT is serialized as a tuple of field values, so we can use read_nth_tuple_element to read
+    // the value of nth UDT field.
+    std::optional<std::optional<View>> read_field = read_nth_tuple_element(serialized_user_type, element_index);
+
+    if (!read_field.has_value()) {
+        // There is no field with this index, assume that this field is NULL.
+        return std::nullopt;
+    }
+
+    // Field value found, return it.
+    return *read_field;
+}
+
+template std::optional<managed_bytes_view> read_nth_user_type_field(managed_bytes_view serialized_user_type,
+                                                                    std::size_t element_index);
+template std::optional<fragmented_temporary_buffer::view> read_nth_user_type_field(
+    fragmented_temporary_buffer::view serialized_user_type,
+    std::size_t element_index);
+
 template<FragmentedView View>
 utils::multiprecision_int deserialize_value(const varint_type_impl&, View v) {
     if (v.empty()) {

--- a/types/types.hh
+++ b/types/types.hh
@@ -972,6 +972,16 @@ std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(V
 template <FragmentedView View>
 std::optional<std::optional<View>> read_nth_tuple_element(View serialized_tuple, std::size_t element_index);
 
+// Given a serialized user defined type value, reads the nth field and returns it.
+// When the field has a NULL value, it returns std::nullopt, otherwise it returns make_optional(nth field bytes...).
+// When there's no field with the requested index, it's assumed that this field has a NULL value.
+// This is standard behavior for UDTs. It could be that a UDT value was serialized in the past,
+// but later new fields were added to the UDT using ALTER TYPE. Old values are not updated on ALTER TYPE,
+// so they contain less fields than the new version of this type. If the serialized value
+// has 3 fields, but the current version of the UDT has 5 fields, we can assume that fields #4 and #5 are NULL.
+template <FragmentedView View>
+std::optional<View> read_nth_user_type_field(View serialized_user_type, std::size_t element_index);
+
 using user_type = shared_ptr<const user_type_impl>;
 using tuple_type = shared_ptr<const tuple_type_impl>;
 

--- a/types/types.hh
+++ b/types/types.hh
@@ -962,6 +962,16 @@ utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(View in)
 template <FragmentedView View>
 std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in);
 
+
+// Given a serialized tuple value, reads the nth element and returns it.
+// Returns std::nullopt when there's no element with such index.
+// The second std::nullopt signifies whether the value is NULL or not.
+// make_optional(make_optional(some bytes...)) - a non-null value with these bytes
+// make_optional(std::nullopt) - a null value
+// std::nullopt - no element with this index
+template <FragmentedView View>
+std::optional<std::optional<View>> read_nth_tuple_element(View serialized_tuple, std::size_t element_index);
+
 using user_type = shared_ptr<const user_type_impl>;
 using tuple_type = shared_ptr<const tuple_type_impl>;
 

--- a/types/user.hh
+++ b/types/user.hh
@@ -40,7 +40,7 @@ public:
     sstring field_name_as_string(size_t i) const { return _string_field_names[i]; }
     const std::vector<bytes>& field_names() const { return _field_names; }
     const std::vector<sstring>& string_field_names() const { return _string_field_names; }
-    std::optional<size_t> idx_of_field(const bytes& name) const;
+    std::optional<size_t> idx_of_field(const bytes_view& name) const;
     bool is_multi_cell() const { return _is_multi_cell; }
     virtual data_type freeze() const override;
     bytes get_name() const { return _name; }


### PR DESCRIPTION
Implement `expr:valuate()` for `expr::field_selection`.

`field_selection` is used to represent access to a struct field.
For example, with a UDT value:
```
CREATE TYPE my_type (a int, b int);
```
The expression `my_type_value.a` would be represented as a `field_selection`, which selects the field `a`.

Evaluating such an expression consists of finding the right element's value in a serialized UDT value and returning it.

Note that it's still not possible to use `field_selection` inside the `WHERE` clause. Enabling it would require changes to the grammar, as well as query planning, Current `statement_restrictions` just reacts with `on_internal_error` when it encounters a `field_selection`.
Nonetheless it's a step towards relaxing the grammar, and now it's finally possible to evaluate all kinds of prepared expressions (#12906)

Fixes: https://github.com/scylladb/scylladb/issues/12906