### PR TITLE
view_update_generator: Increase the registration_queue_size

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -50,7 +50,7 @@ using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 
 class view_update_generator : public async_sharded_service<view_update_generator> {
 public:
-    static constexpr size_t registration_queue_size = 5;
+    static constexpr size_t registration_queue_size = 100;
 
 private:
     replica::database& _db;

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -463,17 +463,17 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
 
         BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
 
-        parallel_for_each(ssts.begin(), ssts.begin() + 10, [&] (shared_sstable& sst) {
-            return view_update_generator.register_staging_sstable(sst, t);
-        }).get();
-
-        BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
-
-        parallel_for_each(ssts.begin() + 10, ssts.end(), [&] (shared_sstable& sst) {
-            return view_update_generator.register_staging_sstable(sst, t);
-        }).get();
-
-        BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
+        auto register_and_check_semaphore = [&view_update_generator, t] (std::vector<shared_sstable>::iterator b, std::vector<shared_sstable>::iterator e) {
+            std::vector<future<>> register_futures;
+            for (auto it = b; it != e; ++it) {
+                register_futures.emplace_back(view_update_generator.register_staging_sstable(*it, t));
+            }
+            const auto qsz = db::view::view_update_generator::registration_queue_size;
+            when_all(register_futures.begin(), register_futures.end()).get();
+            REQUIRE_EVENTUALLY_EQUAL(view_update_generator.available_register_units(), qsz);
+        };
+        register_and_check_semaphore(ssts.begin(), ssts.begin() + 10);
+        register_and_check_semaphore(ssts.begin() + 10, ssts.end());
 
         auto select_by_p_id = e.prepare("SELECT * FROM t WHERE p = ?").get();
         auto select_by_p_and_c_id = e.prepare("SELECT * FROM t WHERE p = ? and c = ?").get();


### PR DESCRIPTION
When repair writes a sstable to disk, we check if the sstable needs view update processing. If yes, the sstable will be registered into the view update processing logic with the _registration_sem semaphore. However, the semaphore is not very useful because it is too late to add the back pressure since the sstable is already written.

We have seen multiple cases in the field where the _registration_sem is stuck so that repair is stuck since repair could not register any more sstables for view update processing. Or view update processing is too slow which blocks repair to finish on time.

This patch increases the registration_queue_size to a big number so that the view update processing won't block repair in practice. A follow up patch is planned to remove the semaphore completely. This patch is a simpler version for easier backport to fix issue in the field.