### PR TITLE
sstable_set: add clone_excluding

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2562,15 +2562,7 @@ table::make_reader_v2_excluding_sstables(schema_ptr s,
         readers.reserve(memtable_count + 1);
     });
 
-    auto excluded_ssts = boost::copy_range<std::unordered_set<sstables::shared_sstable>>(excluded);
-    auto effective_sstables = make_lw_shared(_compaction_strategy.make_sstable_set(_schema));
-    _sstables->for_each_sstable([&excluded_ssts, &effective_sstables] (const sstables::shared_sstable& sst) mutable {
-        if (excluded_ssts.contains(sst)) {
-            return;
-        }
-        effective_sstables->insert(sst);
-    });
-
+    auto effective_sstables = make_lw_shared(_sstables->clone_excluding(excluded));
     readers.emplace_back(make_sstable_reader(s, permit, std::move(effective_sstables), range, slice, std::move(trace_state), fwd, fwd_mr));
     return make_combined_reader(s, std::move(permit), std::move(readers), fwd, fwd_mr);
 }

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -59,6 +59,8 @@ class sstable_set_impl {
 public:
     virtual ~sstable_set_impl() {}
     virtual std::unique_ptr<sstable_set_impl> clone() const = 0;
+    virtual std::unique_ptr<sstable_set_impl> clone_empty() const = 0;
+    virtual std::unique_ptr<sstable_set_impl> clone_excluding(const std::vector<shared_sstable>& excluded_sstables) const;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range) const = 0;
     virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const;
     virtual lw_shared_ptr<const sstable_list> all() const = 0;
@@ -121,6 +123,8 @@ public:
     void insert(shared_sstable sst);
     void erase(shared_sstable sst);
     size_t size() const noexcept;
+    sstable_set clone_empty() const;
+    sstable_set clone_excluding(const std::vector<shared_sstable>& excluded_sstables) const;
 
     // Used to incrementally select sstables from sstable set using ring-position.
     // sstable set must be alive during the lifetime of the selector.

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -60,6 +60,7 @@ public:
         bool use_level_metadata);
 
     virtual std::unique_ptr<sstable_set_impl> clone() const override;
+    virtual std::unique_ptr<sstable_set_impl> clone_empty() const override;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range) const override;
     virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;
@@ -89,6 +90,7 @@ public:
     time_series_sstable_set(const time_series_sstable_set& s);
 
     virtual std::unique_ptr<sstable_set_impl> clone() const override;
+    virtual std::unique_ptr<sstable_set_impl> clone_empty() const override;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range = query::full_partition_range) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
@@ -125,9 +127,11 @@ class compound_sstable_set : public sstable_set_impl {
     schema_ptr _schema;
     std::vector<lw_shared_ptr<sstable_set>> _sets;
 public:
-    compound_sstable_set(schema_ptr schema, std::vector<lw_shared_ptr<sstable_set>> sets);
+    compound_sstable_set(schema_ptr schema, std::vector<lw_shared_ptr<sstable_set>> sets = {});
 
     virtual std::unique_ptr<sstable_set_impl> clone() const override;
+    virtual std::unique_ptr<sstable_set_impl> clone_empty() const override;
+    virtual std::unique_ptr<sstable_set_impl> clone_excluding(const std::vector<shared_sstable>& excluded_sstables) const override;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range = query::full_partition_range) const override;
     virtual std::vector<sstable_run> select_sstable_runs(const std::vector<shared_sstable>& sstables) const override;
     virtual lw_shared_ptr<const sstable_list> all() const override;


### PR DESCRIPTION
Used by table::make_reader_v2_excluding_sstables to create a sstable_set based on the current one
that includes all non-excluded sstables.

It checks if the majority of the sstables is included or excluded and picks one of 2 strategies:
either cloning the existing set and erasing the
excluded sstables out of it, if they are the minority, or making a new set and inserting to it all the non-excluded sstables if the included sstables are the minority.

We do that especially for partitioned_sstable_set
since inserting to or erasing from its _leveled_sstables interval_map is expensive and we want to avoid that as much as possible to prevent reactor stalls.

Refs https://github.com/scylladb/scylladb/issues/14244

The reason this change doesn't fix the issue entirely is that it will deal with a typical case where the number of excluded sstables (that are staging and processed by the view update generator) is relatively small.

But when we have many of them, say about about half of the total number of sstables, calling partitioned_sstable_set::insert or erase enough times without preemption might still stall.