### PR TITLE
install.sh: pass -version to java executable

### DIFF
--- a/unified/install.sh
+++ b/unified/install.sh
@@ -107,7 +107,7 @@ if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     exit 1
 fi
 
-if ! scylla-jmx/select-java --version > /dev/null; then
+if ! scylla-jmx/select-java -version > /dev/null; then
     echo "Please install openjdk-8 or openjdk-11 before running install.sh."
     exit 1
 fi


### PR DESCRIPTION
currently, despite that we are moving from Java-8 to Java-11, we still support both Java versions. and the docker image used for testing Datatax driver has
not been updated to install java-11.

the "java" executable provided by openjdk-java-8 does not support "--version" command line argument. java-11 accept both "-version" and "--version". so to cater the needs of the the outdated docker image, we pass "-version" to the selected java. so the test passes if java-8 is found. a better fix is to update the
docker image to install java-11 though.

the output of "java -version" and "java --version" is attached here as a reference:

```console
$ /usr/lib/jvm/java-1.8.0/bin/java --version
Unrecognized option: --version
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

```console
$ /usr/lib/jvm/java-1.8.0/bin/java -version
openjdk version "1.8.0_362"
OpenJDK Runtime Environment (build 1.8.0_362-b09)
OpenJDK 64-Bit Server VM (build 25.362-b09, mixed mode)
```

```console
/usr/lib/jvm/jre-11/bin/java --version
openjdk 11.0.19 2023-04-18
OpenJDK Runtime Environment (Red_Hat-11.0.19.0.7-2.fc38) (build 11.0.19+7)
OpenJDK 64-Bit Server VM (Red_Hat-11.0.19.0.7-2.fc38) (build 11.0.19+7, mixed mode, sharing)
```

```console
$ /usr/lib/jvm/jre-11/bin/java -version
openjdk version "11.0.19" 2023-04-18
OpenJDK Runtime Environment (Red_Hat-11.0.19.0.7-2.fc38) (build 11.0.19+7)
OpenJDK 64-Bit Server VM (Red_Hat-11.0.19.0.7-2.fc38) (build 11.0.19+7, mixed mode, sharing)
```

Fixes #14253
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>