### PR TITLE
repair: set repair state correctly

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2686,7 +2686,7 @@ private:
                 });
 
             } else {
-                ns.state = repair_state::put_row_diff_finished;
+                ns.state = repair_state::put_row_diff_started;
                 return master.put_row_diff(std::move(set_diff), needs_all_rows, _all_live_peer_nodes[idx]).then([&ns] {
                     ns.state = repair_state::put_row_diff_finished;
                 }).handle_exception([this, &node] (std::exception_ptr ep) {


### PR DESCRIPTION
repair_node_state::state is only for debugging purpose, see ab57cea7839ce813d96acf233edf905fc88c2795 which introduced it. so this change does not impact the behavior of scylla, but can improve the debugging experience by reflecting more accurate state of repair when we are actually inspecting it.