### PR TITLE
Initialize `query_processor` early, without `messaging_service` or `gossiper`

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -857,6 +857,11 @@ query_processor::execute_broadcast_table_query(const service::broadcast_tables::
     return service::broadcast_tables::execute(get_group0_client(), query);
 }
 
+future<query::forward_result>
+query_processor::forward(query::forward_request req, tracing::trace_state_ptr tr_state) {
+    return forwarder().dispatch(std::move(req), std::move(tr_state));
+}
+
 future<::shared_ptr<messages::result_message>>
 query_processor::execute_schema_statement(const statements::schema_altering_statement& stmt, service::query_state& state, const query_options& options) {
     ::shared_ptr<cql_transport::event::schema_change> ce;

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -852,6 +852,11 @@ query_processor::execute_batch_without_checking_exception_message(
     });
 }
 
+future<service::broadcast_tables::query_result>
+query_processor::execute_broadcast_table_query(const service::broadcast_tables::query& query) {
+    return service::broadcast_tables::execute(get_group0_client(), query);
+}
+
 future<::shared_ptr<messages::result_message>>
 query_processor::execute_schema_statement(const statements::schema_altering_statement& stmt, service::query_state& state, const query_options& options) {
     ::shared_ptr<cql_transport::event::schema_change> ce;

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -404,6 +404,12 @@ public:
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_schema_statement(const statements::schema_altering_statement&, service::query_state& state, const query_options& options);
 
+    future<std::string>
+    execute_thrift_schema_command(
+            std::function<future<std::vector<mutation>>(
+                service::migration_manager&, data_dictionary::database, api::timestamp_type)
+            > prepare_schema_mutations);
+
     std::unique_ptr<statements::prepared_statement> get_statement(
             const std::string_view& query,
             const service::client_state& client_state);

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -149,9 +149,12 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries);
 
-    query_processor(service::storage_proxy& proxy, service::forward_service& forwarder, data_dictionary::database db, service::migration_notifier& mn, service::migration_manager& mm, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, service::raft_group0_client& group0_client, std::optional<wasm::startup_context> wasm_ctx);
+    query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, std::optional<wasm::startup_context> wasm_ctx);
 
     ~query_processor();
+
+    void start_remote(service::migration_manager&, service::forward_service&, service::raft_group0_client&);
+    future<> stop_remote();
 
     data_dictionary::database db() {
         return _db;
@@ -424,7 +427,8 @@ public:
     void reset_cache();
 
 private:
-    remote& remote();
+    // Keep the holder until you stop using the `remote` services.
+    std::pair<std::reference_wrapper<remote>, gate::holder> remote();
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -41,6 +41,7 @@ namespace cql3 {
 
 namespace statements {
 class batch_statement;
+class schema_altering_statement;
 
 namespace raw {
 
@@ -399,6 +400,9 @@ public:
             service::query_state& query_state,
             query_options& options,
             std::unordered_map<prepared_cache_key_type, authorized_prepared_statements_cache::value_type> pending_authorization_entries);
+
+    future<::shared_ptr<cql_transport::messages::result_message>>
+    execute_schema_statement(const statements::schema_altering_statement&, service::query_state& state, const query_options& options);
 
     std::unique_ptr<statements::prepared_statement> get_statement(
             const std::string_view& query,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -100,13 +100,13 @@ public:
 private:
     std::unique_ptr<migration_subscriber> _migration_subscriber;
     service::storage_proxy& _proxy;
-    service::forward_service& _forwarder;
     data_dictionary::database _db;
     service::migration_notifier& _mnotifier;
-    service::migration_manager& _mm;
     memory_config _mcfg;
     const cql_config& _cql_config;
-    service::raft_group0_client& _group0_client;
+
+    struct remote;
+    std::unique_ptr<remote> _remote;
 
     struct stats {
         uint64_t prepare_invocations = 0;
@@ -424,9 +424,7 @@ public:
     void reset_cache();
 
 private:
-    service::migration_manager& get_migration_manager() noexcept { return _mm; }
-    service::raft_group0_client& get_group0_client() { return _group0_client; }
-    service::forward_service& forwarder() { return _forwarder; }
+    remote& remote();
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -164,9 +164,6 @@ public:
         return _forwarder;
     }
 
-    const service::migration_manager& get_migration_manager() const noexcept { return _mm; }
-    service::migration_manager& get_migration_manager() noexcept { return _mm; }
-
     cql_stats& get_cql_stats() {
         return _cql_stats;
     }
@@ -423,6 +420,8 @@ public:
     void reset_cache();
 
 private:
+    service::migration_manager& get_migration_manager() noexcept { return _mm; }
+
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,
             const std::initializer_list<data_value>&,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -165,10 +165,6 @@ public:
         return _proxy;
     }
 
-    service::forward_service& forwarder() {
-        return _forwarder;
-    }
-
     cql_stats& get_cql_stats() {
         return _cql_stats;
     }
@@ -402,6 +398,10 @@ public:
     future<service::broadcast_tables::query_result>
     execute_broadcast_table_query(const service::broadcast_tables::query&);
 
+    // Splits given `forward_request` and distributes execution of resulting subrequests across a cluster.
+    future<query::forward_result>
+    forward(query::forward_request, tracing::trace_state_ptr);
+
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_schema_statement(const statements::schema_altering_statement&, service::query_state& state, const query_options& options);
 
@@ -426,6 +426,7 @@ public:
 private:
     service::migration_manager& get_migration_manager() noexcept { return _mm; }
     service::raft_group0_client& get_group0_client() { return _group0_client; }
+    service::forward_service& forwarder() { return _forwarder; }
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -75,12 +75,12 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     try {
         auto old_ksm = qp.db().find_keyspace(_name).metadata();
         const auto& tm = *qp.proxy().get_token_metadata_ptr();
 
-        auto m = qp.get_migration_manager().prepare_keyspace_update_announcement(_attrs->as_ks_metadata_update(old_ksm, tm), ts);
+        auto m = mm.prepare_keyspace_update_announcement(_attrs->as_ks_metadata_update(old_ksm, tm), ts);
 
         using namespace cql_transport;
         auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -33,7 +33,7 @@ public:
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor& qp, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 };

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -386,9 +386,8 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-alter_table_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+alter_table_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
   data_dictionary::database db = qp.db();
-  auto& mm = qp.get_migration_manager();
   auto [cfm, view_updates] = prepare_schema_update(db);
   auto m = co_await mm.prepare_column_family_update_announcement(cfm.build(), false, std::move(view_updates), ts);
 

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -55,7 +55,7 @@ public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 private:
     void add_column(const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void alter_column(const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -104,9 +104,9 @@ future<std::vector<mutation>> alter_type_statement::prepare_announcement_mutatio
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-alter_type_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+alter_type_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     try {
-        auto m = co_await prepare_announcement_mutations(qp.db(), qp.get_migration_manager(), ts);
+        auto m = co_await prepare_announcement_mutations(qp.db(), mm, ts);
 
         using namespace cql_transport;
         auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -16,10 +16,6 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "schema/schema.hh"
 
-namespace service {
-class migration_manager;
-}
-
 namespace cql3 {
 
 class query_processor;
@@ -41,7 +37,7 @@ public:
     virtual const sstring& keyspace() const override;
 
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     class add_or_alter;
     class renames;

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -81,8 +81,8 @@ view_ptr alter_view_statement::prepare_view(data_dictionary::database db) const 
     return view_ptr(builder.build());
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> alter_view_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
-    auto m = co_await qp.get_migration_manager().prepare_view_update_announcement(prepare_view(qp.db()), ts);
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> alter_view_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
+    auto m = co_await mm.prepare_view_update_announcement(prepare_view(qp.db()), ts);
 
     using namespace cql_transport;
     auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -36,7 +36,7 @@ public:
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 };

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -77,13 +77,13 @@ std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dic
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-create_aggregate_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+create_aggregate_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
     auto aggregate = dynamic_pointer_cast<functions::user_aggregate>(co_await validate_while_executing(qp));
     if (aggregate) {
-        m = co_await qp.get_migration_manager().prepare_new_aggregate_announcement(aggregate, ts);
+        m = co_await mm.prepare_new_aggregate_announcement(aggregate, ts);
         ret = create_schema_change(*aggregate, true);
     }
 

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -25,7 +25,7 @@ namespace statements {
 
 class create_aggregate_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -66,14 +66,14 @@ std::unique_ptr<prepared_statement> create_function_statement::prepare(data_dict
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-create_function_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+create_function_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
     auto func = dynamic_pointer_cast<functions::user_function>(co_await validate_while_executing(qp));
 
     if (func) {
-        m = co_await qp.get_migration_manager().prepare_new_function_announcement(func, ts);
+        m = co_await mm.prepare_new_function_announcement(func, ts);
         ret = create_schema_change(*func, true);
     }
 

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -23,7 +23,7 @@ namespace statements {
 
 class create_function_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;
     sstring _language;

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -376,7 +376,7 @@ schema_ptr create_index_statement::build_index_schema(query_processor& qp) const
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-create_index_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+create_index_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     using namespace cql_transport;
     auto schema = build_index_schema(qp);
 
@@ -384,7 +384,7 @@ create_index_statement::prepare_schema_mutations(query_processor& qp, api::times
     std::vector<mutation> m;
 
     if (schema) {
-        m = co_await qp.get_migration_manager().prepare_column_family_update_announcement(std::move(schema), false, {}, ts);
+        m = co_await mm.prepare_column_family_update_announcement(std::move(schema), false, {}, ts);
 
         ret = ::make_shared<event::schema_change>(
                 event::schema_change::change_type::UPDATED,

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -47,7 +47,7 @@ public:
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor&, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -93,14 +93,14 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
 #endif
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     using namespace cql_transport;
     const auto& tm = *qp.proxy().get_token_metadata_ptr();
     ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
-        m = qp.get_migration_manager().prepare_new_keyspace_announcement(_attrs->as_ks_metadata(_name, tm), ts);
+        m = mm.prepare_new_keyspace_announcement(_attrs->as_ks_metadata(_name, tm), ts);
 
         ret = ::make_shared<event::schema_change>(
                 event::schema_change::change_type::CREATED,

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -64,7 +64,7 @@ public:
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -75,12 +75,12 @@ std::vector<column_definition> create_table_statement::get_columns() const
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-create_table_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+create_table_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
-        m = co_await qp.get_migration_manager().prepare_new_column_family_announcement(get_cf_meta_data(qp.db()), ts);
+        m = co_await mm.prepare_new_column_family_announcement(get_cf_meta_data(qp.db()), ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -72,7 +72,7 @@ public:
 
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -118,13 +118,13 @@ std::optional<user_type> create_type_statement::make_type(query_processor& qp) c
     return type;
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_type_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_type_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
     try {
         auto t = make_type(qp);
         if (t) {
-            m = co_await qp.get_migration_manager().prepare_new_type_announcement(*t, ts);
+            m = co_await mm.prepare_new_type_announcement(*t, ts);
             using namespace cql_transport;
 
             ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -37,7 +37,7 @@ public:
 
     virtual const sstring& keyspace() const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -369,12 +369,12 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-create_view_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+create_view_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
     auto [definition, warnings] = prepare_view(qp.db());
     try {
-        m = co_await qp.get_migration_manager().prepare_new_view_announcement(std::move(definition), ts);
+        m = co_await mm.prepare_new_view_announcement(std::move(definition), ts);
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(
                 event::schema_change::change_type::CREATED,

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -58,7 +58,7 @@ public:
     // Functions we need to override to subclass schema_altering_statement
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual void validate(query_processor&, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/drop_aggregate_statement.cc
+++ b/cql3/statements/drop_aggregate_statement.cc
@@ -24,7 +24,7 @@ std::unique_ptr<prepared_statement> drop_aggregate_statement::prepare(data_dicti
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_aggregate_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_aggregate_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
@@ -34,7 +34,7 @@ drop_aggregate_statement::prepare_schema_mutations(query_processor& qp, api::tim
         if (!user_aggr) {
             throw exceptions::invalid_request_exception(format("'{}' is not a user defined aggregate", func));
         }
-        m = co_await qp.get_migration_manager().prepare_aggregate_drop_announcement(user_aggr, ts);
+        m = co_await mm.prepare_aggregate_drop_announcement(user_aggr, ts);
         ret = create_schema_change(*func, false);
     }
 

--- a/cql3/statements/drop_aggregate_statement.hh
+++ b/cql3/statements/drop_aggregate_statement.hh
@@ -15,7 +15,7 @@ class query_processor;
 namespace statements {
 class drop_aggregate_statement final : public drop_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 public:
     drop_aggregate_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -24,7 +24,7 @@ std::unique_ptr<prepared_statement> drop_function_statement::prepare(data_dictio
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_function_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_function_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
@@ -38,7 +38,7 @@ drop_function_statement::prepare_schema_mutations(query_processor& qp, api::time
         if (auto aggregate = functions::functions::used_by_user_aggregate(user_func)) {
             throw exceptions::invalid_request_exception(format("Cannot delete function {}, as it is used by user-defined aggregate {}", func, *aggregate));
         }
-        m = co_await qp.get_migration_manager().prepare_function_drop_announcement(user_func, ts);
+        m = co_await mm.prepare_function_drop_announcement(user_func, ts);
         ret = create_schema_change(*func, false);
     }
 

--- a/cql3/statements/drop_function_statement.hh
+++ b/cql3/statements/drop_function_statement.hh
@@ -15,7 +15,7 @@ class query_processor;
 namespace statements {
 class drop_function_statement final : public drop_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 public:
     drop_function_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -73,13 +73,13 @@ schema_ptr drop_index_statement::make_drop_idex_schema(query_processor& qp) cons
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_index_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_index_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
     auto cfm = make_drop_idex_schema(qp);
 
     if (cfm) {
-        m = co_await qp.get_migration_manager().prepare_column_family_update_announcement(cfm, false, {}, ts);
+        m = co_await mm.prepare_column_family_update_announcement(cfm, false, {}, ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(event::schema_change::change_type::UPDATED,

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -44,7 +44,7 @@ public:
 
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 private:

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -47,12 +47,12 @@ const sstring& drop_keyspace_statement::keyspace() const
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_keyspace_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     std::vector<mutation> m;
     ::shared_ptr<cql_transport::event::schema_change> ret;
 
     try {
-        m = co_await qp.get_migration_manager().prepare_keyspace_drop_announcement(_keyspace, ts);
+        m = co_await mm.prepare_keyspace_drop_announcement(_keyspace, ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -30,7 +30,7 @@ public:
 
     virtual const sstring& keyspace() const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 };

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -45,12 +45,12 @@ void drop_table_statement::validate(query_processor&, const service::client_stat
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_table_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_table_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
-        m = co_await qp.get_migration_manager().prepare_column_family_drop_announcement(keyspace(), column_family(), ts);
+        m = co_await mm.prepare_column_family_drop_announcement(keyspace(), column_family(), ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -28,7 +28,7 @@ public:
 
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -125,7 +125,7 @@ const sstring& drop_type_statement::keyspace() const
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_type_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_type_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     validate_while_executing(qp);
 
     data_dictionary::database db = qp.db();
@@ -141,7 +141,7 @@ drop_type_statement::prepare_schema_mutations(query_processor& qp, api::timestam
 
     // Can happen with if_exists
     if (to_drop != all_types.end()) {
-        m = co_await qp.get_migration_manager().prepare_type_drop_announcement(to_drop->second, ts);
+        m = co_await mm.prepare_type_drop_announcement(to_drop->second, ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -31,7 +31,7 @@ public:
 
     virtual const sstring& keyspace() const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -43,16 +43,16 @@ future<> drop_view_statement::check_access(query_processor& qp, const service::c
 
 void drop_view_statement::validate(query_processor&, const service::client_state& state) const
 {
-    // validated in migration_manager::announce_view_drop()
+    // validated in service::migration_manager::announce_view_drop()
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-drop_view_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
+drop_view_statement::prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
-        m = co_await qp.get_migration_manager().prepare_view_drop_announcement(keyspace(), column_family(), ts);
+        m = co_await mm.prepare_view_drop_announcement(keyspace(), column_family(), ts);
 
         using namespace cql_transport;
         ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -34,7 +34,7 @@ public:
 
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -22,8 +22,6 @@ namespace cql3 {
 
 namespace statements {
 
-static logging::logger mylogger("schema_altering_statement");
-
 schema_altering_statement::schema_altering_statement(timeout_config_selector timeout_selector)
     : cf_statement(cf_name())
     , cql_statement_no_metadata(timeout_selector)
@@ -60,60 +58,6 @@ void schema_altering_statement::prepare_keyspace(const service::client_state& st
 }
 
 future<::shared_ptr<messages::result_message>>
-schema_altering_statement::execute0(query_processor& qp, service::query_state& state, const query_options& options) const {
-    auto& mm = qp.get_migration_manager();
-    ::shared_ptr<cql_transport::event::schema_change> ce;
-
-    if (this_shard_id() != 0) {
-        // execute all schema altering statements on a shard zero since this is where raft group 0 is
-        co_return ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0,
-                    std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()));
-    }
-
-    cql3::cql_warnings_vec warnings;
-
-    auto retries = mm.get_concurrent_ddl_retries();
-    while (true) {
-        try {
-            auto group0_guard = co_await mm.start_group0_operation();
-
-            auto [ret, m, cql_warnings] = co_await prepare_schema_mutations(qp, mm, group0_guard.write_timestamp());
-            warnings = std::move(cql_warnings);
-
-            if (!m.empty()) {
-                auto description = format("CQL DDL statement: \"{}\"", raw_cql_statement);
-                co_await mm.announce(std::move(m), std::move(group0_guard), description);
-            }
-
-            ce = std::move(ret);
-        } catch (const service::group0_concurrent_modification&) {
-            mylogger.warn("Failed to execute DDL statement \"{}\" due to concurrent group 0 modification.{}.",
-                    raw_cql_statement, retries ? " Retrying" : " Number of retries exceeded, giving up");
-            if (retries--) {
-                continue;
-            }
-            throw;
-        }
-        break;
-    }
-
-    // If an IF [NOT] EXISTS clause was used, this may not result in an actual schema change.  To avoid doing
-    // extra work in the drivers to handle schema changes, we return an empty message in this case. (CASSANDRA-7600)
-    ::shared_ptr<messages::result_message> result;
-    if (!ce) {
-        result = ::make_shared<messages::result_message::void_message>();
-    } else {
-        result = ::make_shared<messages::result_message::schema_change>(ce);
-    }
-
-    for (const sstring& warning : warnings) {
-        result->add_warning(warning);
-    }
-
-    co_return result;
-}
-
-future<::shared_ptr<messages::result_message>>
 schema_altering_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
     bool internal = state.get_client_state().is_internal();
     if (internal) {
@@ -129,7 +73,7 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
         }
     }
 
-    return execute0(qp, state, options).then([this, &state, internal](::shared_ptr<messages::result_message> result) {
+    return qp.execute_schema_statement(*this, state, options).then([this, &state, internal](::shared_ptr<messages::result_message> result) {
         auto permissions_granted_fut = internal
                 ? make_ready_future<>()
                 : grant_permissions_to_creator(state.get_client_state());

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -77,7 +77,7 @@ schema_altering_statement::execute0(query_processor& qp, service::query_state& s
         try {
             auto group0_guard = co_await mm.start_group0_operation();
 
-            auto [ret, m, cql_warnings] = co_await prepare_schema_mutations(qp, group0_guard.write_timestamp());
+            auto [ret, m, cql_warnings] = co_await prepare_schema_mutations(qp, mm, group0_guard.write_timestamp());
             warnings = std::move(cql_warnings);
 
             if (!m.empty()) {

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -20,6 +20,10 @@
 
 class mutation;
 
+namespace service {
+class migration_manager;
+}
+
 namespace cql3 {
 
 class query_processor;
@@ -56,7 +60,7 @@ protected:
 
     virtual void prepare_keyspace(const service::client_state& state) override;
 
-    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const = 0;
+    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const = 0;
 
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -39,8 +39,6 @@ class schema_altering_statement : public raw::cf_statement, public cql_statement
 private:
     const bool _is_column_family_level;
 
-    future<::shared_ptr<messages::result_message>>
-    execute0(query_processor& qp, service::query_state& state, const query_options& options) const;
 protected:
     explicit schema_altering_statement(timeout_config_selector timeout_selector = &timeout_config::other_timeout);
 
@@ -60,10 +58,11 @@ protected:
 
     virtual void prepare_keyspace(const service::client_state& state) override;
 
-    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const = 0;
-
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+public:
+    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::migration_manager& mm, api::timestamp_type) const = 0;
 };
 
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -45,7 +45,6 @@
 #include "utils/result.hh"
 #include "utils/result_combinators.hh"
 #include "utils/result_loop.hh"
-#include "service/forward_service.hh"
 #include "replica/database.hh"
 
 template<typename T = void>
@@ -1574,7 +1573,7 @@ parallelized_select_statement::do_execute(
     };
 
     // dispatch execution of this statement to other nodes
-    return qp.forwarder().dispatch(req, state.get_trace_state()).then([this] (query::forward_result res) {
+    return qp.forward(req, state.get_trace_state()).then([this] (query::forward_result res) {
         auto meta = make_shared<metadata>(*_selection->get_result_metadata());
         auto rs = std::make_unique<result_set>(std::move(meta));
         rs->add_row(res.query_results);

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -62,15 +62,14 @@ evaluate_prepared(
             : std::nullopt
     };
 }
-    
+
 future<::shared_ptr<cql_transport::messages::result_message>>
 strongly_consistent_modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
     if (this_shard_id() != 0) {
         co_return ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0, cql3::computed_function_values{});
     }
 
-    auto result = co_await service::broadcast_tables::execute(
-        qp.get_group0_client(),
+    auto result = co_await qp.execute_broadcast_table_query(
         { evaluate_prepared(_query, options) }
     );
     

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -65,7 +65,7 @@ evaluate_prepared(
     
 future<::shared_ptr<cql_transport::messages::result_message>>
 strongly_consistent_modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
-        if (this_shard_id() != 0) {
+    if (this_shard_id() != 0) {
         co_return ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0, cql3::computed_function_values{});
     }
 

--- a/cql3/statements/strongly_consistent_select_statement.cc
+++ b/cql3/statements/strongly_consistent_select_statement.cc
@@ -98,8 +98,7 @@ strongly_consistent_select_statement::execute_without_checking_exception_message
         co_return ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0, cql3::computed_function_values{});
     }
 
-    auto result = co_await service::broadcast_tables::execute(
-        qp.get_group0_client(),
+    auto result = co_await qp.execute_broadcast_table_query(
         { evaluate_prepared(_query, options) }
     );
     

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -58,6 +58,11 @@ keyspace::get_replication_strategy() const {
     return _ops->get_replication_strategy(*this);
 }
 
+const table_schema_version&
+database::get_version() const {
+    return _ops->get_version(*this);
+}
+
 std::optional<keyspace>
 database::try_find_keyspace(std::string_view name) const {
     return _ops->try_find_keyspace(*this, name);

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -99,6 +99,7 @@ private:
     friend class impl;
     database(const impl* ops, const void* database);
 public:
+    const table_schema_version& get_version() const;
     keyspace find_keyspace(std::string_view name) const;
     std::optional<keyspace> try_find_keyspace(std::string_view name) const;
     bool has_keyspace(std::string_view name) const;  // throws no_keyspace

--- a/data_dictionary/impl.hh
+++ b/data_dictionary/impl.hh
@@ -17,6 +17,7 @@ namespace data_dictionary {
 class impl {
 public:
     virtual ~impl();
+    virtual const table_schema_version& get_version(database) const = 0;
     virtual std::optional<keyspace> try_find_keyspace(database db, std::string_view name) const = 0;
     virtual std::vector<keyspace> get_keyspaces(database db) const = 0;
     virtual std::vector<sstring> get_user_keyspaces(database db) const = 0;

--- a/main.cc
+++ b/main.cc
@@ -1014,6 +1014,27 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // #293 - do not stop anything
             // engine().at_exit([&proxy] { return proxy.stop(); });
 
+            static sharded<cql3::cql_config> cql_config;
+            cql_config.start(std::ref(*cfg)).get();
+
+            supervisor::notify("starting query processor");
+            cql3::query_processor::memory_config qp_mcfg = {memory::stats().total_memory() / 256, memory::stats().total_memory() / 2560};
+            debug::the_query_processor = &qp;
+            auto local_data_dict = seastar::sharded_parameter([] (const replica::database& db) { return db.as_data_dictionary(); }, std::ref(db));
+
+            utils::loading_cache_config auth_prep_cache_config;
+            auth_prep_cache_config.max_size = qp_mcfg.authorized_prepared_cache_size;
+            auth_prep_cache_config.expiry = std::min(std::chrono::milliseconds(cfg->permissions_validity_in_ms()),
+                                                     std::chrono::duration_cast<std::chrono::milliseconds>(cql3::prepared_statements_cache::entry_expiry));
+            auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
+
+            std::optional<wasm::startup_context> wasm_ctx;
+            if (cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF)) {
+                wasm_ctx.emplace(*cfg, dbcfg);
+            }
+
+            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notifier), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::move(wasm_ctx)).get();
+
             supervisor::notify("starting lifecycle notifier");
             lifecycle_notifier.start().get();
             // storage_service references this notifier and is not stopped yet
@@ -1118,9 +1139,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             static sharded<db::system_distributed_keyspace> sys_dist_ks;
             static sharded<db::system_keyspace> sys_ks;
             static sharded<db::view::view_update_generator> view_update_generator;
-            static sharded<cql3::cql_config> cql_config;
             static sharded<cdc::generation_service> cdc_generation_service;
-            cql_config.start(std::ref(*cfg)).get();
 
             supervisor::notify("starting system keyspace");
             // FIXME -- the query processor is not started yet and is thus not usable. It starts later
@@ -1204,11 +1223,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.stop().get();
             });
 
-            std::optional<wasm::startup_context> wasm_ctx;
-            if (cfg->enable_user_defined_functions() && cfg->check_experimental(db::experimental_features_t::feature::UDF)) {
-                wasm_ctx.emplace(*cfg, dbcfg);
-            }
-
             // Initialization of a keyspace is done by shard 0 only. For system
             // keyspace, the procedure  will go through the hardcoded column
             // families, and in each of them, it will load the sstables for all
@@ -1245,19 +1259,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_raft = defer_verbose_shutdown("Raft", [&raft_gr] {
                 raft_gr.stop().get();
             });
-
-            supervisor::notify("starting query processor");
-            cql3::query_processor::memory_config qp_mcfg = {memory::stats().total_memory() / 256, memory::stats().total_memory() / 2560};
-            debug::the_query_processor = &qp;
-            auto local_data_dict = seastar::sharded_parameter([] (const replica::database& db) { return db.as_data_dictionary(); }, std::ref(db));
-
-            utils::loading_cache_config auth_prep_cache_config;
-            auth_prep_cache_config.max_size = qp_mcfg.authorized_prepared_cache_size;
-            auth_prep_cache_config.expiry = std::min(std::chrono::milliseconds(cfg->permissions_validity_in_ms()),
-                                                     std::chrono::duration_cast<std::chrono::milliseconds>(cql3::prepared_statements_cache::entry_expiry));
-            auth_prep_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
-
-            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notifier), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::move(wasm_ctx)).get();
 
             supervisor::notify("initializing query processor remote part");
             // TODO: do this together with proxy.start_remote(...)

--- a/main.cc
+++ b/main.cc
@@ -1631,7 +1631,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("starting tracing");
-            tracing::tracing::start_tracing(qp).get();
+            tracing::tracing::start_tracing(qp, mm).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [] {
                 tracing::tracing::stop_tracing().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1100,6 +1100,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             scfg.streaming = dbcfg.streaming_scheduling_group;
             scfg.gossip = dbcfg.gossip_scheduling_group;
 
+            supervisor::notify("starting messaging service");
             debug::the_messaging_service = &messaging;
 
             std::shared_ptr<seastar::tls::credentials_builder> creds;

--- a/replica/data_dictionary_impl.hh
+++ b/replica/data_dictionary_impl.hh
@@ -38,6 +38,10 @@ public:
         return *static_cast<const replica::table*>(extract(t));
     }
 public:
+    virtual const table_schema_version& get_version(data_dictionary::database db) const override {
+        return unwrap(db).get_version();
+    }
+
     virtual std::optional<data_dictionary::keyspace> try_find_keyspace(data_dictionary::database db, std::string_view name) const override {
         try {
             return wrap(unwrap(db).find_keyspace(name));

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -12,6 +12,10 @@
 #include "cql3/statements/prepared_statement.hh"
 #include "service/query_state.hh"
 
+namespace service {
+class migration_manager;
+}
+
 namespace cql3 {
 class query_processor;
 namespace statements {
@@ -52,13 +56,13 @@ public:
      * @return A future that resolves when the operation is complete. Any
      *         possible errors are ignored.
      */
-    static future<> setup_table(cql3::query_processor& qp, const sstring& create_cql);
+    static future<> setup_table(cql3::query_processor& qp, service::migration_manager& mm, const sstring& create_cql);
 
     /**
      * @return a future that resolves when the given t_helper is ready to be used for
      * data insertion.
      */
-    future<> cache_table_info(cql3::query_processor& qp, service::query_state&);
+    future<> cache_table_info(cql3::query_processor& qp, service::migration_manager& mm, service::query_state&);
 
     /**
      * @return The table name
@@ -84,15 +88,15 @@ public:
      */
     template <typename OptMaker, typename... Args>
     requires seastar::CanInvoke<OptMaker, Args...>
-    future<> insert(cql3::query_processor& qp, service::query_state& qs, OptMaker opt_maker, Args... opt_maker_args) {
-        return insert(qp, qs, noncopyable_function<cql3::query_options ()>([opt_maker = std::move(opt_maker), args = std::make_tuple(std::move(opt_maker_args)...)] () mutable {
+    future<> insert(cql3::query_processor& qp, service::migration_manager& mm, service::query_state& qs, OptMaker opt_maker, Args... opt_maker_args) {
+        return insert(qp, mm, qs, noncopyable_function<cql3::query_options ()>([opt_maker = std::move(opt_maker), args = std::make_tuple(std::move(opt_maker_args)...)] () mutable {
             return apply(opt_maker, std::move(args));
         }));
     }
 
-    future<> insert(cql3::query_processor& qp, service::query_state& qs, noncopyable_function<cql3::query_options ()> opt_maker);
+    future<> insert(cql3::query_processor& qp, service::migration_manager& mm, service::query_state& qs, noncopyable_function<cql3::query_options ()> opt_maker);
 
-    static future<> setup_keyspace(cql3::query_processor& qp, std::string_view keyspace_name, sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables);
+    static future<> setup_keyspace(cql3::query_processor& qp, service::migration_manager& mm, std::string_view keyspace_name, sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables);
 
     /**
      * Makes a monotonically increasing value in 100ns ("nanos") based on the given time

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -18,7 +18,7 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
     return do_with_cql_env_thread([func](auto &env) {
         tracing::tracing::create_tracing("trace_keyspace_helper").get();
 
-        tracing::tracing::start_tracing(env.qp()).get();
+        tracing::tracing::start_tracing(env.qp(), env.migration_manager()).get();
 
         func(env).finally([]() {
             return tracing::tracing::tracing_instance().invoke_on_all([](tracing::tracing &local_tracing) {

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -496,6 +496,10 @@ public:
         return std::pair(std::move(db), std::move(mock_db));
     }
 
+    virtual const table_schema_version& get_version(data_dictionary::database db) const override {
+        throw std::bad_function_call();
+    }
+
     virtual std::optional<data_dictionary::keyspace> try_find_keyspace(data_dictionary::database db,
                                                                        std::string_view name) const override {
         if (_table_schema->ks_name() == name) {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -94,6 +94,9 @@ public:
     }
 
 private:
+    virtual const table_schema_version& get_version(data_dictionary::database) const override {
+        throw std::bad_function_call();
+    }
     virtual std::optional<data_dictionary::keyspace> try_find_keyspace(data_dictionary::database db, std::string_view name) const override {
         auto& keyspaces = unwrap(db).keyspaces;
         auto it = std::find_if(keyspaces.begin(), keyspaces.end(), [name] (const keyspace& ks) { return ks.metadata->name() == name; });

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -101,7 +101,7 @@ private:
      * @note A caller must ensure that @param events_records is alive till the
      * returned future resolves.
      */
-    future<> apply_events_mutation(cql3::query_processor& qp, lw_shared_ptr<one_session_records> records, std::deque<event_record>& events_records);
+    future<> apply_events_mutation(cql3::query_processor& qp, service::migration_manager& mm, lw_shared_ptr<one_session_records> records, std::deque<event_record>& events_records);
 
     /**
      * Create a mutation data for a new session record

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -36,6 +36,8 @@ private:
     service::query_state _dummy_query_state;
 
     cql3::query_processor* _qp_anchor;
+    service::migration_manager* _mm_anchor;
+
     table_helper _sessions;
     table_helper _sessions_time_idx;
     table_helper _events;
@@ -58,10 +60,13 @@ public:
     //
     // TODO: Create a stub_tracing_session object to discard the traces
     // requested during the initialization phase.
-    virtual future<> start(cql3::query_processor& qp) override;
+    virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) override;
 
     virtual future<> stop() override {
-        return _pending_writes.close().then([this] { _qp_anchor = nullptr; });
+        return _pending_writes.close().then([this] {
+            _qp_anchor = nullptr;
+            _mm_anchor = nullptr;
+        });
     };
 
     virtual void write_records_bulk(records_bulk& bulk) override;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -22,6 +22,10 @@
 #include "log.hh"
 #include "seastarx.hh"
 
+namespace service {
+class migration_manager;
+}
+
 namespace cql3 { class query_processor; }
 
 namespace tracing {
@@ -151,7 +155,7 @@ public:
 
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
-    virtual future<> start(cql3::query_processor& qp) = 0;
+    virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) = 0;
     virtual future<> stop() = 0;
 
     /**
@@ -417,12 +421,12 @@ public:
     }
 
     static future<> create_tracing(sstring tracing_backend_helper_class_name);
-    static future<> start_tracing(sharded<cql3::query_processor>& qp);
+    static future<> start_tracing(sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm);
     static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)
-    future<> start(cql3::query_processor& qp);
+    future<> start(cql3::query_processor& qp, service::migration_manager& mm);
 
     future<> stop();
 


### PR DESCRIPTION
In https://github.com/scylladb/scylladb/pull/14231 we split `storage_proxy` initialization into two phases: for local and remote parts. Here we do the same with `query_processor`. This allows performing queries for local tables early in the Scylla startup procedure, before we initialize services used for cluster communication such as `messaging_service` or `gossiper`.

Fixes: #14202

As a follow-up we will simplify `system_keyspace` initialization, making it available earlier as well.