### PR TITLE
scylla-sstable: add scrub operation

### DIFF
--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -36,6 +36,11 @@ def pytest_addoption(parser):
         help='CQL server port to connect to')
     parser.addoption('--ssl', action='store_true',
         help='Connect to CQL via an encrypted TLSv1.2 connection')
+    # Used by the wrapper script only, not by pytest, added here so it appears
+    # in --help output and so that pytest's argparser won't protest against its
+    # presence.
+    parser.addoption('--omit-scylla-output', action='store_true',
+        help='Omit scylla\'s output from the test output')
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -26,6 +26,12 @@ if '--raft' in sys.argv:
     run_with_raft.orig_cmd = cmd
     cmd = run_with_raft
 
+if "-h" in sys.argv or "--help" in sys.argv:
+    run.run_pytest(sys.path[0], sys.argv)
+    exit(0)
+
+run.omit_scylla_output = "--omit-scylla-output" in sys.argv
+
 pid = run.run_with_temporary_dir(cmd)
 ip = run.pid_to_ip(pid)
 

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -118,10 +118,12 @@ def abort_run_with_dir(pid, tmpdir):
 def abort_run_with_temporary_dir(pid):
     return abort_run_with_dir(pid, pid_to_dir(pid))
 
+omit_scylla_output = False
 summary=''
 run_pytest_pids = set()
 
 def cleanup_all():
+    global omit_scylla_output
     global summary
     global run_with_temporary_dir_pids
     global run_pytest_pids
@@ -136,9 +138,10 @@ def cleanup_all():
             pass
     for pid in run_with_temporary_dir_pids:
         f = abort_run_with_temporary_dir(pid)
-        print('\nSubprocess output:\n')
-        sys.stdout.flush()
-        shutil.copyfileobj(f, sys.stdout.buffer)
+        if not omit_scylla_output:
+            print('\nSubprocess output:\n')
+            sys.stdout.flush()
+            shutil.copyfileobj(f, sys.stdout.buffer)
     scylla_set = set()
     print(summary)
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2538,19 +2538,19 @@ public:
     typed_option(const char* name, const char* description) : basic_option(name, description) { }
 };
 
-class option {
+class operation_option {
     shared_ptr<basic_option> _opt; // need copy to support convenient range declaration of std::vector<option>
 
 public:
     template <typename T>
-    option(typed_option<T> opt) : _opt(make_shared<typed_option<T>>(std::move(opt))) { }
+    operation_option(typed_option<T> opt) : _opt(make_shared<typed_option<T>>(std::move(opt))) { }
 
     const char* name() const { return _opt->name; }
     const char* description() const { return _opt->description; }
     void add_option(bpo::options_description& opts) const { _opt->add_option(opts); }
 };
 
-const std::vector<option> all_options {
+const std::vector<operation_option> all_options {
     typed_option<std::vector<sstring>>("partition", "partition(s) to filter for, partitions are expected to be in the hex format"),
     typed_option<sstring>("partitions-file", "file containing partition(s) to filter for, partitions are expected to be in the hex format"),
     typed_option<>("merge", "merge all sstables into a single mutation fragment stream (use a combining reader over all sstable readers)"),
@@ -2906,7 +2906,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
     if (found_op) {
         bpo::options_description op_desc(found_op->name());
         for (const auto& opt_name : found_op->available_options()) {
-            auto it = std::find_if(all_options.begin(), all_options.end(), [&] (const option& opt) { return opt.name() == opt_name; });
+            auto it = std::find_if(all_options.begin(), all_options.end(), [&] (const operation_option& opt) { return opt.name() == opt_name; });
             assert(it != all_options.end());
             it->add_option(op_desc);
         }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2711,6 +2711,7 @@ for more information on this operation.
 )",
             {},
             validate_operation},
+/* validate-checksums */
     {"validate-checksums",
             "Validate the checksums of the sstable(s)",
 R"(
@@ -2721,6 +2722,7 @@ See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#valida
 for more information on this operation.
 )",
             validate_checksums_operation},
+/* decompress */
     {"decompress",
             "Decompress sstable(s)",
 R"(
@@ -2734,6 +2736,7 @@ the output will be:
     md-12311-big-Data.db.decompressed
 )",
             decompress_operation},
+/* write */
     {"write",
             "Write an sstable",
 R"(
@@ -2761,6 +2764,7 @@ for more information on this operation, including the schema of the JSON input.
 )",
             {"input-file", "output-dir", "generation", "validation-level"},
             write_operation},
+/* script */
     {"script",
             "Run a script on content of an sstable",
 R"(

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2413,6 +2413,7 @@ public:
 void write_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
         sstables::sstables_manager& manager, const bpo::variables_map& vm) {
     static const std::vector<std::pair<std::string, mutation_fragment_stream_validation_level>> valid_validation_levels{
+        {"none", mutation_fragment_stream_validation_level::none},
         {"partition_region", mutation_fragment_stream_validation_level::partition_region},
         {"token", mutation_fragment_stream_validation_level::token},
         {"partition_key", mutation_fragment_stream_validation_level::partition_key},


### PR DESCRIPTION
Exposing scrub compaction to the command-line. Allows for offline scrub of sstables, in cases where online scrubbing (via scylla itself) is not possible or not desired. One such case recently was an sstable from a backup which turned out to be corrupt, `nodetool refresh --load-and-stream` refusing to load it.

Fixes: #14203