### PR TITLE
utils: managed_bytes: optimize memory usage for small buffers

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -37,11 +37,11 @@ private:
     //       and chunk::frag_size refers to the currently occupied space in the chunk.
     //       After building, the first chunk::size is the whole object size, and chunk::frag_size
     //       doesn't change. This fits with managed_bytes interpretation.
-    using chunk = blob_storage;
+    using chunk = multi_chunk_blob_storage;
     static constexpr size_type default_chunk_size{512};
     static constexpr size_type max_alloc_size() { return 128 * 1024; }
 private:
-    blob_storage::ref_type _begin;
+    chunk::ref_type _begin;
     chunk* _current;
     size_type _size;
     size_type _initial_chunk_size = default_chunk_size;
@@ -55,7 +55,7 @@ public:
         using reference = bytes_view&;
 
         struct implementation {
-            blob_storage* current_chunk;
+            chunk* current_chunk;
         };
     private:
         chunk* _current = nullptr;

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -888,10 +888,12 @@ class managed_bytes_printer(gdb.printing.PrettyPrinter):
         def to_bytes(data, size):
             return bytes(inf.read_memory(data, size))
 
-        if self.val['_u']['small']['size'] >= 0:
-            return to_bytes(self.val['_u']['small']['data'], int(self.val['_u']['small']['size']))
+        if self.val['_inline_size'] >= 0:
+            return to_bytes(self.val['_u']['inline_data'], int(self.val['_inline_size']))
+        elif self.val['_inline_size'] == -1:
+            return to_bytes(self.val['_u']['single_chunk_ref']['ptr']['data'], int(self.val['_u']['single_chunk_ref']['size']))
         else:
-            ref = self.val['_u']['ptr']
+            ref = self.val['_u']['multi_chunk_ref']['ptr']
             chunks = list()
             while ref['ptr']:
                 chunks.append(to_bytes(ref['ptr']['data'], int(ref['ptr']['frag_size'])))

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -76,7 +76,7 @@ public:
                             e.promoted_index->promoted_index_size,
                             e.promoted_index->num_blocks);
                 }
-                auto key = managed_bytes(reinterpret_cast<const blob_storage::char_type*>(e.key.get()), e.key.size());
+                auto key = managed_bytes(reinterpret_cast<const bytes::value_type*>(e.key.get()), e.key.size());
                 indexes._entries.emplace_back(make_managed<index_entry>(std::move(key), e.data_file_offset, std::move(pi)));
             });
         });

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -27,18 +27,6 @@ managed_bytes_opt to_managed_bytes_opt(const bytes_opt& bo) {
     return managed_bytes(*bo);
 }
 
-std::unique_ptr<bytes_view::value_type[]>
-managed_bytes::do_linearize_pure() const {
-    auto b = _u.ptr;
-    auto data = std::unique_ptr<bytes_view::value_type[]>(new bytes_view::value_type[b->size]);
-    auto e = data.get();
-    while (b) {
-        e = std::copy_n(b->data, b->frag_size, e);
-        b = b->next;
-    }
-    return data;
-}
-
 sstring to_hex(const managed_bytes& b) {
     return fmt::to_string(managed_bytes_view(b));
 }

--- a/utils/mutable_view.hh
+++ b/utils/mutable_view.hh
@@ -48,8 +48,7 @@ public:
     CharT* data() const { return _begin; }
     size_t size() const { return _end - _begin; }
     bool empty() const { return _begin == _end; }
-    CharT& front() { return *_begin; }
-    const CharT& front() const { return *_begin; }
+    CharT& front() const { return *_begin; }
 
     void remove_prefix(size_t n) {
         _begin += n;


### PR DESCRIPTION
managed_bytes is implemented as chain of blob_storage objects.
Each blob_storage contains 24 bytes of metadata. But in the most
common case -- when there is only a single element in the chain --
16 bytes of this metadata is trivial/unused.

This is regrettable waste because managed_bytes is used for every
database cell in the memtables and cache. It means that every value
of size >= 7 bytes (smaller ones fit in the inline storage of
managed_bytes) receives 16 bytes of useless overhead.

To correct that, this series adds to managed_bytes an alternative storage
layout -- used for buffers small enough to fit in one fragment -- which only
stores the necessary minimum of metadata. (That is: a pointer to the parent,
to facilitate moving the storage during memory defragmentation).

This saves 16 bytes on every cell greater than 15 bytes. Which includes e.g.
every live cell with value bigger than 6 bytes, which likely applies to most cells.

Before:
```
$ build/release/scylla perf-simple-query --duration 10
median 218692.88 tps ( 61.1 allocs/op,  13.1 tasks/op,   41762 insns/op,        0 errors)
$ build/release/scylla perf-simple-query --duration 10 --write
median 173511.46 tps ( 58.3 allocs/op,  13.2 tasks/op,   53258 insns/op,        0 errors)
$ build/release/test/perf/mutation_footprint_test -c1 --row-count=20 --partition-count=100 --data-size=8 --column-count=16
 - in cache:     2580222
 - in memtable:  2549852
```

After:
```
$ build/release/scylla perf-simple-query --duration 10
median 218780.89 tps ( 61.1 allocs/op,  13.1 tasks/op,   41763 insns/op,        0 errors)
$ build/release/scylla perf-simple-query --duration 10 --write
median 173105.78 tps ( 58.3 allocs/op,  13.2 tasks/op,   52913 insns/op,        0 errors)
$ build/release/test/perf/mutation_footprint_test -c1 --row-count=20 --partition-count=100 --data-size=8 --column-count=16
 - in cache:     2068238
 - in memtable:  2037696
```