### PR TITLE
Compaction group major compaction task

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -291,11 +291,11 @@ compaction_task_executor::compaction_task_executor(compaction_manager& mgr, tabl
     , _compacting_table(t)
     , _compaction_state(_cm.get_compaction_state(t))
     , _type(type)
-    , _gate_holder(_compaction_state.gate.hold())
     , _description(std::move(desc))
 {}
 
 future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task) {
+    gate::holder gate_holder = task->_compaction_state.gate.hold();
     _tasks.push_back(task);
     auto unregister_task = defer([this, task] {
         _tasks.remove(task);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -470,7 +470,7 @@ protected:
 
 }
 
-future<> compaction_manager::perform_major_compaction(table_state& t) {
+future<> compaction_manager::perform_major_compaction(table_state& t, tasks::task_info info) {
     if (_state != state::enabled) {
         return make_ready_future<>();
     }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -462,7 +462,6 @@ private:
     exponential_backoff_retry _compaction_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(300));
     sstables::compaction_type _type;
     sstables::run_id _output_run_identifier;
-    gate::holder _gate_holder;
     sstring _description;
 
 public:
@@ -551,6 +550,8 @@ public:
     sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
 
     std::string describe() const;
+
+    friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task);
 };
 
 std::ostream& operator<<(std::ostream& os, compaction::compaction_task_executor::state s);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -505,13 +505,13 @@ protected:
         return ct == sstables::compaction_type::Compaction;
     }
 public:
-    future<compaction_manager::compaction_stats_opt> run() noexcept;
+    future<compaction_manager::compaction_stats_opt> run_compaction() noexcept;
 
     const ::compaction::table_state* compacting_table() const noexcept {
         return _compacting_table;
     }
 
-    sstables::compaction_type type() const noexcept {
+    sstables::compaction_type compaction_type() const noexcept {
         return _type;
     }
 
@@ -546,7 +546,7 @@ public:
         return _compaction_data.abort.abort_requested();
     }
 
-    void stop(sstring reason) noexcept;
+    void stop_compaction(sstring reason) noexcept;
 
     sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -317,7 +317,7 @@ public:
     future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);
 
     // Submit a table for major compaction.
-    future<> perform_major_compaction(compaction::table_state& t);
+    future<> perform_major_compaction(compaction::table_state& t, tasks::task_info info = {});
 
 
     // Run a custom job for a given table, defined by a function

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -122,8 +122,9 @@ tasks::is_internal table_major_keyspace_compaction_task_impl::is_internal() cons
 
 future<> table_major_keyspace_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
-    co_await run_on_table("force_keyspace_compaction", _db, _status.keyspace, _ti, [] (replica::table& t) {
-        return t.compact_all_sstables();
+    tasks::task_info info{_status.id, _status.shard};
+    co_await run_on_table("force_keyspace_compaction", _db, _status.keyspace, _ti, [info] (replica::table& t) {
+        return t.compact_all_sstables(info);
     });
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1342,7 +1342,7 @@ future<> repair::data_sync_repair_task_impl::run() {
                 auto hosts = std::vector<sstring>();
                 auto ignore_nodes = std::unordered_set<gms::inet_address>();
                 bool hints_batchlog_flushed = false;
-                auto task_impl_ptr = std::make_unique<repair::shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
+                auto task_impl_ptr = seastar::make_shared<repair::shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
                         local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, hints_batchlog_flushed);
                 task_impl_ptr->neighbors = std::move(neighbors);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -836,7 +836,7 @@ public:
     // Start a compaction of all sstables in a process known as major compaction
     // Active memtable is flushed first to guarantee that data like tombstone,
     // sitting in the memtable, will be compacted with shadowed data.
-    future<> compact_all_sstables();
+    future<> compact_all_sstables(tasks::task_info info = {});
 
     future<bool> snapshot_exists(sstring name);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1217,10 +1217,10 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 }
 
 future<>
-table::compact_all_sstables() {
+table::compact_all_sstables(tasks::task_info info) {
     co_await flush();
-    co_await parallel_foreach_compaction_group([this] (compaction_group& cg) {
-        return _compaction_manager.perform_major_compaction(cg.as_table_state());
+    co_await parallel_foreach_compaction_group([this, info] (compaction_group& cg) {
+        return _compaction_manager.perform_major_compaction(cg.as_table_state(), info);
     });
 }
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -178,7 +178,7 @@ protected:
 future<> compaction_manager_test::run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job) {
     auto task = make_shared<compaction_manager_test_task>(_cm, table_s, output_run_id, std::move(job));
     auto& cdata = register_compaction(task);
-    return task->run().discard_result().finally([this, &cdata] {
+    return task->run_compaction().discard_result().finally([this, &cdata] {
         deregister_compaction(cdata);
     });
 }

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -173,12 +173,15 @@ protected:
             return make_ready_future<compaction_manager::compaction_stats_opt>(std::nullopt);
         });
     }
+
+    friend class compaction_manager_test;
 };
 
 future<> compaction_manager_test::run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job) {
     auto task = make_shared<compaction_manager_test_task>(_cm, table_s, output_run_id, std::move(job));
+    gate::holder gate_holder = task->_compaction_state.gate.hold();
     auto& cdata = register_compaction(task);
-    return task->run_compaction().discard_result().finally([this, &cdata] {
+    co_await task->run_compaction().discard_result().finally([this, &cdata] {
         deregister_compaction(cdata);
     });
 }

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -35,19 +35,23 @@ def check_compaction_task(cql, this_dc, rest_api, run_compaction, compaction_typ
                     check_child_parent_relationship(rest_api, top_level_task, depth)
 
 def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
+    task_tree_depth = 2
     # keyspace major compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_compaction/{keyspace}"), "major compaction", 2)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_compaction/{keyspace}"), "major compaction", task_tree_depth)
     # column family major compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}"), "major compaction", 2)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}"), "major compaction", task_tree_depth)
 
 def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", 2)
+    task_tree_depth = 2
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", task_tree_depth)
 
 def test_offstrategy_keyspace_compaction_task(cql, this_dc, rest_api):
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"), "offstrategy compaction", 2)
+    task_tree_depth = 2
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"), "offstrategy compaction", task_tree_depth)
 
 def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
+    task_tree_depth = 2
     # upgrade sstables compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "rewrite sstables compaction", 2)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "rewrite sstables compaction", task_tree_depth)
     # scrub sstables compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "rewrite sstables compaction", 2)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "rewrite sstables compaction", task_tree_depth)

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -35,7 +35,7 @@ def check_compaction_task(cql, this_dc, rest_api, run_compaction, compaction_typ
                     check_child_parent_relationship(rest_api, top_level_task, depth)
 
 def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 2
+    task_tree_depth = 3
     # keyspace major compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_compaction/{keyspace}"), "major compaction", task_tree_depth)
     # column family major compaction


### PR DESCRIPTION
Task manager task covering compaction group major 
compaction.

Uses multiple inheritance on already existing
major_compaction_task_executor to keep track of
the operation with task manager.
 