### PR TITLE
test: Remove sstable_utils' storage_prefix() helper

### DIFF
--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -61,11 +61,11 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
     sstables::sstable_generation_generator gen_generator{0};
 
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), gen_generator());
-    sstring old_path = test(sst).storage_prefix();
+    sstring old_path = sst->get_storage().prefix();
     touch_directory(format("{}/{}", old_path, sstables::staging_dir)).get();
     sst->change_state(sstables::staging_dir).get();
     sst->change_state(sstables::normal_dir).get();
-    BOOST_REQUIRE(sstable_directory::compare_sstable_storage_prefix(old_path, test(sst).storage_prefix()));
+    BOOST_REQUIRE(sstable_directory::compare_sstable_storage_prefix(old_path, sst->get_storage().prefix()));
 
     sst->close_files().get();
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -223,10 +223,6 @@ public:
         co_await _sst->_storage->move(*_sst, std::move(new_dir), new_generation, nullptr);
         _sst->_generation = std::move(new_generation);
     }
-
-    sstring storage_prefix() const {
-        return _sst->_storage->prefix();
-    }
 };
 
 inline auto replacer_fn_no_op() {


### PR DESCRIPTION
It's excessive, test case that needs it can get storage prefix without this fancy wrapper-helper