### PR TITLE
schema: add scylla specific options to schema description

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -35,6 +35,8 @@
 #include "utils/rjson.hh"
 #include "tombstone_gc_options.hh"
 #include "db/per_partition_rate_limit_extension.hh"
+#include "db/tags/utils.hh"
+#include "db/tags/extension.hh"
 
 constexpr int32_t schema::NAME_LENGTH;
 
@@ -783,6 +785,15 @@ static bool is_index(replica::database& db, const table_id& id, const schema& s)
     return  db.find_column_family(id).get_index_manager().is_index(s);
 }
 
+static bool is_update_synchronously_view(const schema& s) {
+    auto tag_opt = db::find_tag(s, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);
+    if (!tag_opt.has_value()) {
+        return false;
+    }
+
+    return *tag_opt == "true";
+}
+
 sstring schema::element_type(replica::database& db) const {
     if (is_view()) {
         if (is_index(db, view_info()->base_id(), *this)) {
@@ -926,8 +937,20 @@ std::ostream& schema::describe(replica::database& db, std::ostream& os, bool wit
     os << "\n    AND memtable_flush_period_in_ms = " << memtable_flush_period();
     os << "\n    AND min_index_interval = " << min_index_interval();
     os << "\n    AND read_repair_chance = " << read_repair_chance();
-    os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "';";
-    os << "\n";
+    os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
+    os << "\n    AND paxos_grace_seconds = " << paxos_grace_seconds().count();
+
+    auto tombstone_gc_str = tombstone_gc_options().to_sstring();
+    std::replace(tombstone_gc_str.begin(), tombstone_gc_str.end(), '"', '\'');
+    os << "\n    AND tombstone_gc = " << tombstone_gc_str;
+    
+    if (cdc_options().enabled()) {
+        os << "\n    AND cdc = " << cdc_options().to_sstring();
+    }
+    if (is_view() && !is_index(db, view_info()->base_id(), *this)) {
+        os << "\n    AND synchronous_updates = " << std::boolalpha << is_update_synchronously_view(*this);
+    }
+    os << ";\n";
 
     if (with_internals) {
         for (auto& cdef : dropped_columns()) {

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -21,6 +21,11 @@
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
+#include "tombstone_gc_extension.hh"
+#include "db/tags/extension.hh"
+#include "cdc/cdc_extension.hh"
+#include "db/paxos_grace_seconds_extension.hh"
+#include "db/per_partition_rate_limit_extension.hh"
 
 #include "test/lib/scylla_test_case.hh"
 
@@ -31,6 +36,18 @@
 const sstring KEYSPACE_NAME = "ks";
 
 namespace {
+
+static cql_test_config cql_config_with_extensions() {
+    auto ext = std::make_shared<db::extensions>();
+    ext->add_schema_extension<db::tags_extension>(db::tags_extension::NAME);
+    ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
+    ext->add_schema_extension<db::paxos_grace_seconds_extension>(db::paxos_grace_seconds_extension::NAME);
+    ext->add_schema_extension<tombstone_gc_extension>(tombstone_gc_extension::NAME);
+    ext->add_schema_extension<db::per_partition_rate_limit_extension>(db::per_partition_rate_limit_extension::NAME);
+
+    auto cfg = seastar::make_shared<db::config>(ext);
+    return cql_test_config(cfg);
+}
 
 struct generated_table {
     schema_ptr schema;
@@ -200,7 +217,7 @@ SEASTAR_THREAD_TEST_CASE(test_abandoned_read) {
         require_eventually_empty_caches(env.db());
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 static std::vector<mutation> read_all_partitions_one_by_one(distributed<replica::database>& db, schema_ptr s, std::vector<dht::decorated_key> pkeys,
@@ -556,7 +573,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_all) {
         check_results_are_equal(results1, results3);
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
@@ -616,7 +633,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_all_multi_range) {
         require_eventually_empty_caches(env.db());
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
@@ -668,7 +685,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_with_partition_row_limits) {
         } } }
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
@@ -719,7 +736,7 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
         require_eventually_empty_caches(env.db());
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
@@ -774,7 +791,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_reversed) {
         require_eventually_empty_caches(env.db());
 
         return make_ready_future<>();
-    }).get();
+    }, cql_config_with_extensions()).get();
 }
 
 namespace {
@@ -1076,8 +1093,8 @@ run_fuzzy_test_workload(fuzzy_test_config cfg, distributed<replica::database>& d
 } // namespace
 
 SEASTAR_THREAD_TEST_CASE(fuzzy_test) {
-    auto db_cfg = make_shared<db::config>();
-    db_cfg->enable_commitlog(false);
+    auto cql_cfg = cql_config_with_extensions();
+    cql_cfg.db_config->enable_commitlog(false);
 
     do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
         // REPLACE RANDOM SEED HERE.
@@ -1124,5 +1141,5 @@ SEASTAR_THREAD_TEST_CASE(fuzzy_test) {
         }).get();
 
         return make_ready_future<>();
-    }, db_cfg).get();
+    }, cql_cfg).get();
 }

--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -829,6 +829,9 @@ def new_random_table(cql, keyspace, udts=[]):
     extras["min_index_interval"] = min_idx_interval
     extras["max_index_interval"] = random.randrange(min_idx_interval, 10000)
     extras["memtable_flush_period_in_ms"] = random.randrange(0, 10000)
+    extras["paxos_grace_seconds"] = random.randrange(1000, 100000)
+
+    extras["tombstone_gc"] = f"{{'mode': 'timeout', 'propagation_delay_in_seconds': '{random.randrange(100, 100000)}'}}"
 
     extra_options = [f"{k} = {v}" for (k, v) in extras.items()]
     extra_str = " AND ".join(extra_options)


### PR DESCRIPTION
Add `paxos_grace_seconds`, `tombstone_gc`, `cdc` and `synchronous_updates` options to schema description.

Fixes: #12389
Fixes: https://github.com/scylladb/scylla-enterprise/issues/2979