### PR TITLE
test/topology/test_cluster_features: workaround for python driver not reconnecting after full cluster restart

### DIFF
--- a/test/topology_raft_disabled/test_raft_upgrade_basic.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_basic.py
@@ -14,7 +14,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import inject_error_one_shot
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_feature
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
         delete_raft_data, log_run_time
 

--- a/test/topology_raft_disabled/test_raft_upgrade_majority_loss.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_majority_loss.py
@@ -11,7 +11,8 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft_and_restart, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft_and_restart, \
         wait_until_upgrade_finishes, delete_raft_data, log_run_time
 
 

--- a/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_no_schema.py
@@ -11,7 +11,8 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft, \
         enable_raft_and_restart, wait_for_upgrade_state, wait_until_upgrade_finishes, \
         delete_raft_data, log_run_time
 

--- a/test/topology_raft_disabled/test_raft_upgrade_stuck.py
+++ b/test/topology_raft_disabled/test_raft_upgrade_stuck.py
@@ -12,7 +12,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.rest_client import inject_error_one_shot
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology_raft_disabled.util import reconnect_driver, restart, enable_raft_and_restart, \
+from test.topology.util import reconnect_driver
+from test.topology_raft_disabled.util import restart, enable_raft_and_restart, \
         wait_for_upgrade_state, wait_until_upgrade_finishes, delete_raft_data, log_run_time
 
 

--- a/test/topology_raft_disabled/util.py
+++ b/test/topology_raft_disabled/util.py
@@ -17,18 +17,6 @@ from test.pylib.manager_client import ManagerClient, IPAddress, ServerInfo
 from test.pylib.util import wait_for
 
 
-async def reconnect_driver(manager: ManagerClient) -> Session:
-    """Workaround for scylladb/python-driver#170:
-       the existing driver session may not reconnect, create a new one.
-    """
-    logging.info(f"Reconnecting driver")
-    manager.driver_close()
-    await manager.driver_connect()
-    cql = manager.cql
-    assert(cql)
-    return cql
-
-
 async def restart(manager: ManagerClient, server: ServerInfo) -> None:
     logging.info(f"Stopping {server} gracefully")
     await manager.server_stop_gracefully(server.server_id)


### PR DESCRIPTION
The test `test_downgrade_after_successful_upgrade_fails` shuts down the whole cluster, reconfigures the nodes and then restarts. Apparently, the python driver sometimes does not handle this correctly; in one test run we observed that the driver did not manage to reconnect to any of the nodes, even though the nodes managed to start successfully.

More context can be found on the python driver issue.

This PR works around this issue by using the existing `reconnect_driver` function (which is a workaround for a _different_ python driver issue already) to help the driver reconnect after the full cluster restart.

Refs: scylladb/python-driver#230