### PR TITLE
cql3: Specify arguments types in UDA creation errors

### DIFF
--- a/test/cql-pytest/test_uda.py
+++ b/test/cql-pytest/test_uda.py
@@ -107,13 +107,13 @@ def test_incorrect_state_func(scylla_only, cql, test_keyspace):
     div_body = "(state tuple<bigint, bigint>) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state[1]//state[2]'"
     with new_function(cql, test_keyspace, avg_partial_body) as avg_partial, new_function(cql, test_keyspace, div_body) as div_fun:
         custom_avg_body = f"(bigint) SFUNC {avg_partial} STYPE tuple<bigint, bigint> FINALFUNC {div_fun} INITCOND (0,0)"
-        with pytest.raises(InvalidRequest, match="State function not found"):
+        with pytest.raises(InvalidRequest, match="State function .* not found"):
             cql.execute(f"CREATE AGGREGATE {test_keyspace}.{unique_name()} {custom_avg_body}")
     avg2_partial_body = "(state tuple<bigint, bigint>) CALLED ON NULL INPUT RETURNS tuple<bigint, bigint> LANGUAGE lua AS 'return {state[1] + 42, state[2] + 1}'"
     div_body = "(state tuple<bigint, bigint>) CALLED ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return state[1]//state[2]'"
     with new_function(cql, test_keyspace, avg2_partial_body) as avg2_partial, new_function(cql, test_keyspace, div_body) as div_fun:
         custom_avg_body = f"(bigint) SFUNC {avg2_partial} STYPE tuple<bigint, bigint> FINALFUNC {div_fun} INITCOND (0,0)"
-        with pytest.raises(InvalidRequest, match="State function not found"):
+        with pytest.raises(InvalidRequest, match="State function .* not found"):
             cql.execute(f"CREATE AGGREGATE {test_keyspace}.{unique_name()} {custom_avg_body}")
 
 # Test that UDA works without final function and returns accumulator then


### PR DESCRIPTION
Display not only function name but also expected arguments if `state_function` or `final_function` was not found.

Fixes: #12088