### PR TITLE
Sanitize sstables-making utils in tests

### DIFF
--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -975,13 +975,6 @@ SEASTAR_TEST_CASE(reader_selector_fast_forwarding_test) {
     });
 }
 
-static
-sstables::shared_sstable create_sstable(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations) {
-    return make_sstable_containing([&] {
-        return env.make_sstable(s);
-    }, mutations);
-}
-
 static mutation compacted(const mutation& m) {
     auto result = m;
     result.partition().compact_for_compaction(*result.schema(), always_gc, result.decorated_key(), gc_clock::now(), tombstone_gc_state(nullptr));
@@ -1013,7 +1006,7 @@ SEASTAR_TEST_CASE(test_fast_forwarding_combined_reader_is_consistent_with_slicin
                     combined[j++].apply(m);
                 }
             }
-            mutation_source ds = create_sstable(env, s, muts)->as_mutation_source();
+            mutation_source ds = make_sstable_containing(env.make_sstable(s), muts)->as_mutation_source();
             reader_ranges.push_back(dht::partition_range::make({keys[0]}, {keys[0]}));
             readers.push_back(ds.make_reader_v2(s,
                 permit,
@@ -1083,8 +1076,8 @@ SEASTAR_TEST_CASE(test_combined_reader_slicing_with_overlapping_range_tombstones
 
         std::vector<flat_mutation_reader_v2> readers;
 
-        mutation_source ds1 = create_sstable(env, s, {m1})->as_mutation_source();
-        mutation_source ds2 = create_sstable(env, s, {m2})->as_mutation_source();
+        mutation_source ds1 = make_sstable_containing(env.make_sstable(s), {m1})->as_mutation_source();
+        mutation_source ds2 = make_sstable_containing(env.make_sstable(s), {m2})->as_mutation_source();
 
         // upper bound ends before the row in m2, so that the raw is fetched after next fast forward.
         auto range = ss.make_ckey_range(0, 3);

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -33,13 +33,7 @@ SEASTAR_TEST_CASE(test_schema_changes) {
             shared_sstable created_with_base_schema;
             shared_sstable created_with_changed_schema;
             if (it == cache.end()) {
-                auto mt = make_lw_shared<replica::memtable>(base);
-                for (auto& m : base_mutations) {
-                    mt->apply(m);
-                }
-
-                created_with_base_schema = make_sstable_containing(env.make_sstable(base), mt);
-
+                created_with_base_schema = make_sstable_containing(env.make_sstable(base), base_mutations);
                 cache.emplace(std::tuple { version, base }, created_with_base_schema);
             } else {
                 created_with_base_schema = it->second;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3353,15 +3353,12 @@ static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& t
 
 static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         sstable_version_types version, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    lw_shared_ptr<replica::memtable> mt = make_lw_shared<replica::memtable>(s);
-    mt->apply(mut);
-
     // FIXME This used to `write_and_compare_sstables()` and to
     // additionally call `do_validate_stats_metadata()` on the result,
     // but cannot now because flat reader version tranforms rearrange
     // range tombstones.  Revisit once the reader v2 migration is
     // complete and those version transforms are gone
-    auto sst = write_sstables(env, s, mt, version);
+    auto sst = make_sstable_containing(env.make_sstable(s, version), {mut});
     auto written_sst = validate_read(env, sst, {mut});
     check_min_max_column_names(written_sst, std::move(min_components), std::move(max_components));
 }

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -392,15 +392,9 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 }
 
 static
-mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
-        sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return as_mutation_source(make_sstable(env, s, dir, std::move(mutations), env.manager().configure_writer(), version, query_time));
-}
-
-static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
         sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return make_sstable_mutation_source(env, std::move(s), env.tempdir().path().native(), std::move(mutations), version, query_time);
+    return as_mutation_source(make_sstable(env, s, std::move(mutations), env.manager().configure_writer(), version, query_time));
 }
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -853,10 +853,7 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
         m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-        auto mt = make_lw_shared<replica::memtable>(s);
-        mt->apply(std::move(m));
-
-        auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
+        auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)});
         auto mut = with_closeable(sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice()), [] (auto& mr) {
             return read_mutation_from_flat_mutation_reader(mr);
         }).get0();
@@ -881,10 +878,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
             m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-            auto mt = make_lw_shared<replica::memtable>(s);
-            mt->apply(std::move(m));
-
-            auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
+            auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)});
             auto hk = sstables::sstable::make_hashed_key(*s, dk.key());
             auto mr = sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
             auto close_mr = deferred_close(mr);

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -393,14 +393,14 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
-        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return as_mutation_source(make_sstable(env, s, dir, std::move(mutations), cfg, version, query_time));
+        sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
+    return as_mutation_source(make_sstable(env, s, dir, std::move(mutations), env.manager().configure_writer(), version, query_time));
 }
 
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
-        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return make_sstable_mutation_source(env, std::move(s), env.tempdir().path().native(), std::move(mutations), std::move(cfg), version, query_time);
+        sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
+    return make_sstable_mutation_source(env, std::move(s), env.tempdir().path().native(), std::move(mutations), version, query_time);
 }
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
@@ -1245,7 +1245,7 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
             ss.add_row(m2, ss.make_ckey(5), "v");
             ss.add_row(m2, ss.make_ckey(6), "v");
 
-            auto ms = make_sstable_mutation_source(env, s, {m1, m2}, env.manager().configure_writer(), version);
+            auto ms = make_sstable_mutation_source(env, s, {m1, m2}, version);
 
             auto index_accesses = [] {
                 auto&& stats = sstables::partition_index_cache::shard_stats();
@@ -1577,8 +1577,7 @@ SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {
             std::vector<mutation> muts = {m1, m2};
             boost::sort(muts, mutation_decorated_key_less_comparator{});
 
-            sstable_writer_config cfg = env.manager().configure_writer();
-            auto ms = make_sstable_mutation_source(env, s, muts, cfg, version);
+            auto ms = make_sstable_mutation_source(env, s, muts, version);
 
             assert_that(ms.make_reader_v2(s, env.make_reader_permit()))
                 .produces(muts[0])

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -99,9 +99,9 @@ shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, 
 }
 
 shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition) {
+        sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition, gc_clock::time_point query_time) {
     auto s = rd.schema();
-    auto sst = env.make_sstable(s, gen, version, sstable_format_types::big);
+    auto sst = env.make_sstable(s, gen, version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     sst->write_components(std::move(rd), expected_partition, s, cfg, encoding_stats{}).get();
     sst->load().get();
     return sst;
@@ -109,12 +109,7 @@ shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, ssta
 
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
         sstables::generation_type gen, const sstable::version_types v, int estimated_partitions, gc_clock::time_point query_time) {
-    schema_ptr s = mt->schema();
-    auto sst = env.make_sstable(s, gen, v, sstable_format_types::big, default_sstable_buffer_size, query_time);
-    auto mr = mt->make_flat_reader(s, env.make_reader_permit());
-    sst->write_components(std::move(mr), estimated_partitions, s, cfg, mt->get_encoding_stats()).get();
-    sst->load().get();
-    return sst;
+    return make_sstable_easy(env, mt->make_flat_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
 }
 
 future<compaction_result> compact_sstables(compaction_manager& cm, sstables::compaction_descriptor descriptor, table_state& table_s, std::function<shared_sstable()> creator, compaction_sstable_replacer_fn replacer,

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -57,9 +57,8 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, s
             i = 0;
         }
     }
-    write_memtable_to_sstable_for_test(*mt, sst).get();
-    sstable_open_config cfg { .load_first_and_last_position_metadata = true };
-    sst->open_data(cfg).get();
+
+    make_sstable_containing(sst, mt);
 
     std::set<mutation, mutation_decorated_key_less_comparator> merged;
     for (auto&& m : muts) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -293,7 +293,7 @@ future<compaction_result> compact_sstables(compaction_manager& cm, sstables::com
         can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
 shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstables::sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1);
+        sstables::generation_type gen, const sstables::sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, gc_clock::time_point = gc_clock::now());
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
         sstables::generation_type gen, const sstable::version_types v = sstables::get_highest_sstable_version(), int estimated_partitions = 1, gc_clock::time_point = gc_clock::now());
 


### PR DESCRIPTION
There are tons of wrappers that help test cases make sstables for their needs. And lots of code duplication in test cases that do parts of those helpers' work on their own. This set cleans some bits of those