### PR TITLE
Simplify `system_keyspace` initialization

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3747,17 +3747,12 @@ sstring system_keyspace_name() {
     return system_keyspace::NAME;
 }
 
-system_keyspace::system_keyspace(cql3::query_processor& qp, replica::database& db) noexcept
-        : _qp(qp)
-        , _db(db)
-        , _cache(std::make_unique<local_cache>())
+system_keyspace::system_keyspace(
+        cql3::query_processor& qp, replica::database& db, const locator::snitch_ptr& snitch) noexcept
+    : _qp(qp)
+    , _db(db)
+    , _cache(std::make_unique<local_cache>())
 {
-}
-
-system_keyspace::~system_keyspace() {
-}
-
-future<> system_keyspace::start(const locator::snitch_ptr& snitch) {
     if (this_shard_id() == 0) {
         qctx = std::make_unique<query_context>(_qp.container());
     }
@@ -3770,16 +3765,13 @@ future<> system_keyspace::start(const locator::snitch_ptr& snitch) {
     // but it doesn't call system_keyspace::setup() and thus ::setup_version() either
     _cache->_local_dc_rack_info.dc = snitch->get_datacenter();
     _cache->_local_dc_rack_info.rack = snitch->get_rack();
+}
 
-    co_return;
+system_keyspace::~system_keyspace() {
 }
 
 future<> system_keyspace::shutdown() {
     _db.unplug_system_keyspace();
-    co_return;
-}
-
-future<> system_keyspace::stop() {
     co_return;
 }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2960,7 +2960,7 @@ future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::
                     std::map<sstring, sstring>{},
                     durable
                     );
-            co_await db.create_keyspace(ksm, dist_ss.local().get_erm_factory(), true, replica::database::system_keyspace::yes);
+            co_await db.create_keyspace(ksm, dist_ss.local().get_erm_factory(), replica::database::system_keyspace::yes);
         }
         auto& ks = db.find_keyspace(ks_name);
         auto cfg = ks.make_column_family_config(*table, db);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2960,10 +2960,6 @@ future<> system_keyspace::make(
         co_await db.create_local_system_table(
             table, maybe_write_in_user_memory(table), dist_ss.local().get_erm_factory());
     }
-
-    if (phase == system_table_load_phase::phase1) {
-        co_await initialize_virtual_tables(dist_db, dist_ss, dist_gossiper, dist_raft_gr, cfg);
-    }
 }
 
 future<> system_keyspace::initialize_virtual_tables(

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2941,7 +2941,10 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
             || s == system_keyspace::raft();
 }
 
-future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr, db::config& cfg, system_table_load_phase phase) {
+future<> system_keyspace::make(
+        distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
+        sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr,
+        db::config& cfg, system_table_load_phase phase) {
     if (phase == system_table_load_phase::phase1) {
         register_virtual_tables(dist_db, dist_ss, dist_gossiper, dist_raft_gr, cfg);
     }
@@ -2957,12 +2960,8 @@ future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::
     }
 
     if (phase == system_table_load_phase::phase1) {
-        install_virtual_readers(sys_ks, db);
+        install_virtual_readers(*this, db);
     }
-}
-
-future<> system_keyspace::make(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, distributed<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase) {
-    return system_keyspace_make(*this, db, ss, g, raft_gr, cfg, phase);
 }
 
 future<locator::host_id> system_keyspace::load_local_host_id() {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2948,17 +2948,14 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
 }
 
 future<> system_keyspace::make(
-        distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
-        sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr,
-        db::config& cfg, system_table_load_phase phase) {
-    auto& db = dist_db.local();
+        locator::effective_replication_map_factory& erm_factory,
+        replica::database& db, db::config& cfg, system_table_load_phase phase) {
     for (auto&& table : system_keyspace::all_tables(db.get_config())) {
         if (table->static_props().load_phase != phase) {
             continue;
         }
 
-        co_await db.create_local_system_table(
-            table, maybe_write_in_user_memory(table), dist_ss.local().get_erm_factory());
+        co_await db.create_local_system_table(table, maybe_write_in_user_memory(table), erm_factory);
     }
 }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -101,8 +101,8 @@ struct compaction_history_entry {
 };
 
 class system_keyspace : public seastar::peering_sharded_service<system_keyspace>, public seastar::async_sharded_service<system_keyspace> {
-    sharded<cql3::query_processor>& _qp;
-    sharded<replica::database>& _db;
+    cql3::query_processor& _qp;
+    replica::database& _db;
     std::unique_ptr<local_cache> _cache;
 
     static schema_ptr raft_snapshot_config();
@@ -488,7 +488,7 @@ public:
     future<bool> get_must_synchronize_topology();
     future<> set_must_synchronize_topology(bool);
 
-    system_keyspace(sharded<cql3::query_processor>& qp, sharded<replica::database>& db) noexcept;
+    system_keyspace(cql3::query_processor& qp, replica::database& db) noexcept;
     ~system_keyspace();
     future<> start(const locator::snitch_ptr&);
     future<> stop();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -276,6 +276,14 @@ public:
                          db::config& cfg,
                          system_table_load_phase phase);
 
+    future<> initialize_virtual_tables(
+                         distributed<replica::database>&,
+                         distributed<service::storage_service>&,
+                         sharded<gms::gossiper>&,
+                         sharded<service::raft_group_registry>&,
+                         db::config&);
+
+
     /// overloads
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -496,10 +496,8 @@ public:
     future<bool> get_must_synchronize_topology();
     future<> set_must_synchronize_topology(bool);
 
-    system_keyspace(cql3::query_processor& qp, replica::database& db) noexcept;
+    system_keyspace(cql3::query_processor& qp, replica::database& db, const locator::snitch_ptr&) noexcept;
     ~system_keyspace();
-    future<> start(const locator::snitch_ptr&);
-    future<> stop();
     future<> shutdown();
 
 private:

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -59,6 +59,7 @@ namespace gms {
 }
 
 namespace locator {
+    class effective_replication_map_factory;
     class endpoint_dc_rack;
     class snitch_ptr;
 } // namespace locator
@@ -269,12 +270,11 @@ public:
     static future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
-    future<> make(distributed<replica::database>& db,
-                         distributed<service::storage_service>& ss,
-                         sharded<gms::gossiper>& g,
-                         sharded<service::raft_group_registry>& raft_gr,
-                         db::config& cfg,
-                         system_table_load_phase phase);
+    future<> make(
+            locator::effective_replication_map_factory&,
+            replica::database&,
+            db::config&,
+            system_table_load_phase phase);
 
     future<> initialize_virtual_tables(
                          distributed<replica::database>&,

--- a/main.cc
+++ b/main.cc
@@ -1231,7 +1231,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // done only by shard 0, so we'll no longer face race conditions as
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, system_table_load_phase::phase1).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
             supervisor::notify("initializing virtual tables");
             sys_ks.invoke_on_all([&db, &ss, &gossiper, &raft_gr, &cfg] (db::system_keyspace& sys_ks) {
                 return sys_ks.initialize_virtual_tables(db, ss, gossiper, raft_gr, *cfg);
@@ -1319,7 +1319,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // because table construction consults enabled features.
             // Needs to be before system_keyspace::setup(), which writes to schema tables.
             supervisor::notify("loading system_schema sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, system_table_load_phase::phase2).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase2).get();
 
             if (raft_gr.local().is_enabled()) {
                 if (!db.local().uses_schema_commitlog()) {

--- a/main.cc
+++ b/main.cc
@@ -1142,13 +1142,19 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             static sharded<cdc::generation_service> cdc_generation_service;
 
             supervisor::notify("starting system keyspace");
-            // FIXME -- the query processor is not started yet and is thus not usable. It starts later
-            // on (look up the qp.start() thing) and cannot be started earlier, before proxy does. The
-            // plan is to equip system keyspace with its own instance of the query processor that doesn't
-            // need storage proxy to work, but uses some other local replica access mechanism. Similar
-            // thing for database -- it's not yet started and should be replaced with the aforementioned
-            // replica accessor.
-            sys_ks.start(std::ref(qp), std::ref(db)).get();
+            sys_ks.start(std::ref(qp), std::ref(db), std::ref(snitch)).get();
+            // TODO: stop()?
+
+            // Initialization of a keyspace is done by shard 0 only. For system
+            // keyspace, the procedure  will go through the hardcoded column
+            // families, and in each of them, it will load the sstables for all
+            // shards using distributed database object.
+            // Iteration through column family directory for sstable loading is
+            // done only by shard 0, so we'll no longer face race conditions as
+            // described here: https://github.com/scylladb/scylla/issues/1014
+            supervisor::notify("loading system sstables");
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
+            cfg->host_id = sys_ks.local().load_local_host_id().get0();
 
             supervisor::notify("starting gossiper");
             gms::gossip_config gcfg;
@@ -1222,16 +1228,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();
             });
-
-            // Initialization of a keyspace is done by shard 0 only. For system
-            // keyspace, the procedure  will go through the hardcoded column
-            // families, and in each of them, it will load the sstables for all
-            // shards using distributed database object.
-            // Iteration through column family directory for sstable loading is
-            // done only by shard 0, so we'll no longer face race conditions as
-            // described here: https://github.com/scylladb/scylla/issues/1014
-            supervisor::notify("loading system sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
             supervisor::notify("initializing virtual tables");
             sys_ks.invoke_on_all([&db, &ss, &gossiper, &raft_gr, &cfg] (db::system_keyspace& sys_ks) {
                 return sys_ks.initialize_virtual_tables(db, ss, gossiper, raft_gr, *cfg);
@@ -1282,12 +1278,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // engine().at_exit([&qp] { return qp.stop(); });
             sstables::init_metrics().get();
 
-            // FIXME -- this sys_ks start should really be up above, where its instance
-            // start, but we only have query processor started that late
-            sys_ks.invoke_on_all([&snitch] (auto& sys_ks) {
-                return sys_ks.start(snitch.local());
-            }).get();
-            cfg->host_id = sys_ks.local().load_local_host_id().get0();
             shared_token_metadata::mutate_on_all_shards(token_metadata, [hostid = cfg->host_id, endpoint = utils::fb_utilities::get_broadcast_address()] (locator::token_metadata& tm) {
                 tm.get_topology().add_or_update_endpoint(endpoint, hostid);
                 return make_ready_future<>();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -797,7 +797,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await db::schema_tables::extract_scylla_specific_keyspace_info(proxy, v);
         auto ksm = create_keyspace_from_schema_partition(v, scylla_specific_rs);
-        co_return co_await create_keyspace(ksm, proxy.local().get_erm_factory(), true /* bootstrap. do not mark populated yet */, system_keyspace::no);
+        co_return co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto& ks = this->find_keyspace(v.first);
@@ -1383,11 +1383,11 @@ future<> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metada
 
 future<>
 database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory) {
-    return create_keyspace(ksm, erm_factory, false, system_keyspace::no);
+    return create_keyspace(ksm, erm_factory, system_keyspace::no);
 }
 
 future<>
-database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, bool is_bootstrap, system_keyspace system) {
+database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
     if (_keyspaces.contains(ksm->name())) {
         co_return;
     }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1246,7 +1246,7 @@ keyspace::create_replication_strategy(const locator::shared_token_metadata& stm,
             abstract_replication_strategy::create_replication_strategy(
                 _metadata->strategy_name(), options);
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}", _metadata->name(), _metadata->strategy_name(), options);
-    auto erm = co_await get_erm_factory().create_effective_replication_map(_replication_strategy, stm.get());
+    auto erm = co_await _erm_factory.create_effective_replication_map(_replication_strategy, stm.get());
     update_effective_replication_map(std::move(erm));
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -119,8 +119,6 @@ class large_data_handler;
 class system_keyspace;
 class table_selector;
 
-future<> system_keyspace_make(db::system_keyspace& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase);
-
 namespace view {
 class view_update_generator;
 }
@@ -1412,7 +1410,6 @@ private:
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    friend future<> db::system_keyspace_make(db::system_keyspace& sys_ks, distributed<database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1426,7 +1426,7 @@ private:
     template<typename Future>
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
-    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, bool is_bootstrap, system_keyspace system);
+    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
     void remove(table&) noexcept;
 public:
     static table_schema_version empty_version;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1180,14 +1180,6 @@ private:
     config _config;
     locator::effective_replication_map_factory& _erm_factory;
 
-    locator::effective_replication_map_factory& get_erm_factory() noexcept {
-        return _erm_factory;
-    }
-
-    const locator::effective_replication_map_factory& get_erm_factory() const noexcept {
-        return _erm_factory;
-    }
-
 public:
     explicit keyspace(lw_shared_ptr<keyspace_metadata> metadata, config cfg, locator::effective_replication_map_factory& erm_factory);
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1456,7 +1456,10 @@ public:
         }
     };
 
+    // Load the schema definitions kept in schema tables from disk and initialize in-memory schema data structures
+    // (keyspace/table definitions, column mappings etc.)
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
+
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
             compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -47,13 +47,11 @@ class foreign_sstable_open_info;
 namespace service {
 
 class storage_proxy;
-class storage_service;
-class raft_group_registry;
 
 }
 
-namespace gms {
-class gossiper;
+namespace locator {
+class effective_replication_map_factory;
 }
 
 class distributed_loader_for_tests;
@@ -78,7 +76,7 @@ class distributed_loader {
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<service::raft_group_registry>& raft_gr, db::config& cfg, system_table_load_phase phase);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&, db::config& cfg, system_table_load_phase phase);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -847,7 +847,7 @@ public:
             }).get();
 
             for (const auto p: all_system_table_load_phases) {
-                replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, p).get();
+                replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, p).get();
             }
             sys_ks.invoke_on_all([&db, &ss, &gossiper, &raft_gr, &cfg] (db::system_keyspace& sys_ks) {
                 return sys_ks.initialize_virtual_tables(db, ss, gossiper, raft_gr, *cfg);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -849,6 +849,9 @@ public:
             for (const auto p: all_system_table_load_phases) {
                 replica::distributed_loader::init_system_keyspace(sys_ks, db, ss, gossiper, raft_gr, *cfg, p).get();
             }
+            sys_ks.invoke_on_all([&db, &ss, &gossiper, &raft_gr, &cfg] (db::system_keyspace& sys_ks) {
+                return sys_ks.initialize_virtual_tables(db, ss, gossiper, raft_gr, *cfg);
+            }).get();
 
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 


### PR DESCRIPTION
Initialization of `system_keyspace` is now done in a single place instead of
being spread out through the entire procedure. `system_keyspace` is also
available for queries much earlier which allows, for example, to load our Host
ID before we initialize any of the distributed services (like gossiper,
messaging_service etc.) This is doable because `query_processor` is now
available early. A couple of FIXMEs have been resolved.

Refs: #14202