### PR TITLE
Revert "build: cmake: use -O0 for debug build"

### DIFF
--- a/cmake/mode.DEBUG.cmake
+++ b/cmake/mode.DEBUG.cmake
@@ -1,4 +1,9 @@
-set(default_Seastar_OptimizationLevel_DEBUG "0")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
+  set(default_Seastar_OptimizationLevel_DEBUG "0")
+else()
+  set(default_Seastar_OptimizationLevel_DEBUG "g")
+endif()
 set(Seastar_OptimizationLevel_DEBUG
   ${default_Seastar_OptimizationLevel_DEBUG}
   CACHE


### PR DESCRIPTION
This reverts commit 8a54e478bae21305d9a9379ef69b6826962b93c8. As commit 7dadd3816184 ("Revert "configure: Switch debug build from -O0 to -Og") was reverted (by b7627085cb134, "Revert "Revert "configure: Switch debug build from -O0 to -Og""")), we do the same to cmake to keep the two build systems in sync.