### PR TITLE
cql3: expr: improve error message when rejecting aggregation functions in illegal contexts

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2720,7 +2720,7 @@ verify_no_aggregate_functions(const expression& expr, std::string_view context_f
         return std::visit(find_agg, fc.func);
     });
     if (found_agg) {
-        throw exceptions::invalid_request_exception(fmt::format("Aggregation function are not supported in the {}", context_for_errors));
+        throw exceptions::invalid_request_exception(fmt::format("Aggregation functions are not supported in the {}", context_for_errors));
     }
 }
 

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -184,7 +184,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
 
     // Prepare the restriction
     binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema);
-    expr::verify_no_aggregate_functions(prepared_binop, "where clause");
+    expr::verify_no_aggregate_functions(prepared_binop, "WHERE clause");
 
     // Fill prepare context
     const column_value* lhs_pk_col_search_res = find_in_expression<column_value>(prepared_binop.lhs,


### PR DESCRIPTION

Fix a small grammatical error, and capitalize WHERE in accordance with SQL tradition.