### PR TITLE
test/topology/test_cluster_features: workaround for the python driver not reconnecting after full cluster restart in test_downgrade_after_successful_upgrade_fails

### DIFF
--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -130,6 +130,10 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     await change_support_for_test_feature_and_restart(manager, servers, enable=True)
 
+    # Workaround for scylladb/python-driver#230 - the driver might not
+    # reconnect after all nodes are stopped at once.
+    cql = await reconnect_driver(manager)
+
     # Wait until the feature is considered enabled by all nodes
     cql = manager.cql
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)


### PR DESCRIPTION
Followup to 9bfa63fe3719f5a82518a9c42b7d3a039f73dd0d. Like in `test_downgrade_after_successful_upgrade_fails`, the test `test_joining_old_node_fails` also restarts all nodes at once and is prone to a bug in the Python driver which can prevent the session from reconnecting to any of the nodes. This commit applies the same workaround to the other test (manual reconnect by recreating the Python driver session).