### PR TITLE
raft topology: fixes after #13884

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1192,13 +1192,22 @@ void shared_token_metadata::set(mutable_token_metadata_ptr tmptr) noexcept {
 
 void shared_token_metadata::update_fence_version(token_metadata::version_t version) {
     if (const auto current_version = _shared->get_version(); version > current_version) {
+        // The token_metadata::version under no circumstance can go backwards.
+        // Even in case of topology change coordinator moving to another node
+        // this condition must hold, that is why we treat its violation
+        // as an internal error.
         on_internal_error(tlogger,
             format("shared_token_metadata: invalid new fence version, can't be greater than the current version, "
                    "current version {}, new fence version {}", current_version, version));
     }
     if (version < _fence_version) {
-        on_internal_error(tlogger,
-            format("shared_token_metadata: must not set decreasing fence version: {} -> {}", _fence_version, version));
+        // If topology change coordinator moved to another node,
+        // it can get ahead and increment the fence version
+        // while we are handling raft_topology_cmd::command::fence,
+        // so we just throw an error in this case.
+        throw std::runtime_error(
+            format("shared_token_metadata: can't set decreasing fence version: {} -> {}",
+                _fence_version, version));
     }
     _fence_version = version;
 }

--- a/main.cc
+++ b/main.cc
@@ -1554,10 +1554,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.local().uninit_messaging_service_part().get();
             });
 
-            // It's essential to load fencing_version prior to starting the messaging service,
-            // since incoming messages may require fencing.
-            ss.local().update_fence_version(sys_ks.local().get_topology_fence_version().get()).get();
-
             api::set_server_messaging_service(ctx, messaging).get();
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
@@ -1628,6 +1624,15 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Need to do it before allowing incomming messaging service connections since
             // storage proxy's and migration manager's verbs may access group0
             group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local(), cdc_generation_service.local()).get();
+
+            // It's essential to load fencing_version prior to starting the messaging service,
+            // since incoming messages may require fencing.
+            // It is also necessary that token_metadata be initialized by this point and
+            // token_metadata::version to be up to date, since when assigning fence_version we
+            // validate it cannot be greater than token_metadata::version.
+            // The setup_group0_if_exist call above waits for the raft log for group0 to be applied,
+            // which ensures this.
+            ss.local().update_fence_version(sys_ks.local().get_topology_fence_version().get()).get();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return messaging.invoke_on_all([&token_metadata] (auto& netw) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1139,6 +1139,7 @@ class topology_coordinator {
                                       f.get_exception());
                         break;
                     }
+                    node = std::move(f).get();
                 }
 
                 raft_topology_cmd cmd{raft_topology_cmd::command::stream_ranges};

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -34,6 +34,10 @@ async def test_topology_ops(request, manager: ManagerClient):
     logger.info("Bootstrapping other nodes")
     servers += [await manager.server_add(), await manager.server_add()]
 
+    logger.info(f"Restarting node {servers[0]} when other nodes have bootstrapped")
+    await manager.server_stop_gracefully(servers[0].server_id)
+    await manager.server_start(servers[0].server_id)
+
     logger.info(f"Stopping node {servers[0]}")
     await manager.server_stop_gracefully(servers[0].server_id)
 


### PR DESCRIPTION
This PR fixes some problems found after the PR was merged:
  * missed `node_to_work_on` assignment in `handle_topology_transition`;
  * change error reporting in `update_fence_version` from `on_internal_error` to regular exceptions, since that exceptions can happen during normal operation.
  * `update_fence_version` has beed moved  after `group0_service.setup_group0_if_exist` in `main.cc`, otherwise we use uninitialized `token_metadata::version` and get an error.

Fixes: #14303