### PR TITLE
cache_flat_mutation_reader: use the correct schema in prepare_hash

### DIFF
--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -894,7 +894,7 @@ void cache_flat_mutation_reader::add_to_buffer(const partition_snapshot_row_curs
     if (!row.dummy()) {
         _read_context.cache().on_row_hit();
         if (_read_context.digest_requested()) {
-            row.latest_row().cells().prepare_hash(table_schema(), column_kind::regular_column);
+            row.latest_row_prepare_hash();
         }
         add_clustering_row_to_buffer(mutation_fragment_v2(*_schema, _permit, row.row()));
     } else {

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -565,8 +565,8 @@ public:
     }
 
     // Can be called only when cursor is valid and pointing at a row.
-    deletable_row& latest_row() const noexcept {
-        return _current_row[0].it->row();
+    void latest_row_prepare_hash() const {
+        _current_row[0].it->row().cells().prepare_hash(*_current_row[0].schema, column_kind::regular_column);
     }
 
     // Can be called only when cursor is valid and pointing at a row.


### PR DESCRIPTION
Since `mvcc: make schema upgrades gentle` (https://github.com/scylladb/scylladb/commit/51e3b9321b2e7a5ae95e028287644db729f33968),
rows pointed to by the cursor can have different (older) schema
than the schema of the cursor's snapshot.

However, one place in the code wasn't updated accordingly,
causing a row to be processed with the wrong schema in the right
circumstances.

This passed through unit testing because it requires
a digest-computing cache read after a schema change,
and no test exercised this.

This series fixes the bug and adds a unit test which reproduces the issue.

Fixes #14110