### PR TITLE
cql3: expr: change evaluation_input vector components to take spans

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -110,13 +110,13 @@ managed_bytes_opt
 extract_column_value(const column_definition* cdef, const evaluation_inputs& inputs) {
     switch (cdef->kind) {
         case column_kind::partition_key:
-            return managed_bytes((*inputs.partition_key)[cdef->id]);
+            return managed_bytes(inputs.partition_key[cdef->id]);
         case column_kind::clustering_key:
-            if (cdef->id >= inputs.clustering_key->size()) {
+            if (cdef->id >= inputs.clustering_key.size()) {
                 // partial clustering key, or LWT non-existing row
                 return std::nullopt;
             }
-            return managed_bytes((*inputs.clustering_key)[cdef->id]);
+            return managed_bytes(inputs.clustering_key[cdef->id]);
         case column_kind::static_column:
             [[fallthrough]];
         case column_kind::regular_column: {
@@ -126,7 +126,7 @@ extract_column_value(const column_definition* cdef, const evaluation_inputs& inp
                         format("Column definition {} does not match any column in the query selection",
                         cdef->name_as_text()));
             }
-            return managed_bytes_opt((*inputs.static_and_regular_columns)[index]);
+            return managed_bytes_opt(inputs.static_and_regular_columns[index]);
         }
         default:
             throw exceptions::unsupported_operation_exception("Unknown column kind");

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -472,9 +472,9 @@ extern std::ostream& operator<<(std::ostream&, oper_t);
 // Input data needed to evaluate an expression. Individual members can be
 // null if not applicable (e.g. evaluating outside a row context)
 struct evaluation_inputs {
-    const std::vector<bytes>* partition_key = nullptr;
-    const std::vector<bytes>* clustering_key = nullptr;
-    const std::vector<managed_bytes_opt>* static_and_regular_columns = nullptr; // indexes match `selection` member
+    std::span<const bytes> partition_key;
+    std::span<const bytes> clustering_key;
+    std::span<const managed_bytes_opt> static_and_regular_columns; // indexes match `selection` member
     const cql3::selection::selection* selection = nullptr;
     const query_options* options = nullptr;
     std::span<const api::timestamp_type> static_and_regular_timestamps;  // indexes match `selection` member

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -469,9 +469,9 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         bool multi_col_clustering_satisfied = expr::is_satisfied_by(
                 clustering_columns_restrictions,
                 expr::evaluation_inputs{
-                    .partition_key = &partition_key,
-                    .clustering_key = &clustering_key,
-                    .static_and_regular_columns = &static_and_regular_columns,
+                    .partition_key = partition_key,
+                    .clustering_key = clustering_key,
+                    .static_and_regular_columns = static_and_regular_columns,
                     .selection = &selection,
                     .options = &_options,
                 });
@@ -501,9 +501,9 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             bool regular_restriction_matches = expr::is_satisfied_by(
                     single_col_restriction,
                     expr::evaluation_inputs{
-                        .partition_key = &partition_key,
-                        .clustering_key = &clustering_key,
-                        .static_and_regular_columns = &static_and_regular_columns,
+                        .partition_key = partition_key,
+                        .clustering_key = clustering_key,
+                        .static_and_regular_columns = static_and_regular_columns,
                         .selection = &selection,
                         .options = &_options,
                     });
@@ -526,9 +526,9 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             if (!expr::is_satisfied_by(
                         single_col_restriction,
                         expr::evaluation_inputs{
-                            .partition_key = &partition_key,
-                            .clustering_key = &clustering_key,
-                            .static_and_regular_columns = nullptr, // partition key filtering only
+                            .partition_key = partition_key,
+                            .clustering_key = clustering_key,
+                            .static_and_regular_columns = {}, // partition key filtering only
                             .selection = &selection,
                             .options = &_options,
                         })) {
@@ -554,9 +554,9 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             if (!expr::is_satisfied_by(
                         single_col_restriction,
                         expr::evaluation_inputs{
-                            .partition_key = &partition_key,
-                            .clustering_key = &clustering_key,
-                            .static_and_regular_columns = nullptr, // clustering key checks only
+                            .partition_key = partition_key,
+                            .clustering_key = clustering_key,
+                            .static_and_regular_columns = {}, // clustering key checks only
                             .selection = &selection,
                             .options = &_options,
                         })) {

--- a/cql3/statements/cas_request.cc
+++ b/cql3/statements/cas_request.cc
@@ -174,9 +174,9 @@ cas_request::build_cas_result_set(seastar::shared_ptr<cql3::metadata> metadata,
         auto ckey_bytes = old_row.ckey->explode();
 
         auto eval_inputs = expr::evaluation_inputs{
-            .partition_key = &pkey_bytes,
-            .clustering_key = &ckey_bytes,
-            .static_and_regular_columns = &old_row.row->cells,
+            .partition_key = pkey_bytes,
+            .clustering_key = ckey_bytes,
+            .static_and_regular_columns = old_row.row->cells,
             .selection = _rows.selection.get(),
         };
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -184,7 +184,7 @@ bool modification_statement::applies_to(const selection::selection* selection,
     });
 
     auto inputs = expr::evaluation_inputs{
-        .static_and_regular_columns = static_and_regular_columns,
+        .static_and_regular_columns = *static_and_regular_columns,
         .selection = selection,
         .options = &options,
     };

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -29,9 +29,9 @@ update_parameters::get_prefetched_list(const partition_key& pkey, const clusteri
     auto ckey_bytes = ckey.explode();
 
     auto val = expr::extract_column_value(&column, expr::evaluation_inputs{
-        .partition_key = &pkey_bytes,
-        .clustering_key = &ckey_bytes,
-        .static_and_regular_columns = &row->cells,
+        .partition_key = pkey_bytes,
+        .clustering_key = ckey_bytes,
+        .static_and_regular_columns = row->cells,
         .selection = _prefetched.selection.get(),
     });
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -291,9 +291,9 @@ bool partition_key_matches(data_dictionary::database db, const schema& base, con
     return cql3::expr::is_satisfied_by(
             pk_restrictions,
             cql3::expr::evaluation_inputs{
-                .partition_key = &exploded_pk,
-                .clustering_key = &exploded_ck,
-                .static_and_regular_columns = nullptr, // partition key filtering only
+                .partition_key = exploded_pk,
+                .clustering_key = exploded_ck,
+                .static_and_regular_columns = {}, // partition key filtering only
                 .selection = selection.get(),
                 .options = &dummy_options,
             });
@@ -315,9 +315,9 @@ bool clustering_prefix_matches(data_dictionary::database db, const schema& base,
     return cql3::expr::is_satisfied_by(
             r,
             cql3::expr::evaluation_inputs{
-                .partition_key = &exploded_pk,
-                .clustering_key = &exploded_ck,
-                .static_and_regular_columns = nullptr, // clustering key only filtering here
+                .partition_key = exploded_pk,
+                .clustering_key = exploded_ck,
+                .static_and_regular_columns = {}, // clustering key only filtering here
                 .selection = selection.get(),
                 .options = &dummy_options,
             });
@@ -394,9 +394,9 @@ public:
                 return cql3::expr::is_satisfied_by(
                         r,
                         cql3::expr::evaluation_inputs{
-                            .partition_key = &_pk,
-                            .clustering_key = &ck,
-                            .static_and_regular_columns = &static_and_regular_columns,
+                            .partition_key = _pk,
+                            .clustering_key = ck,
+                            .static_and_regular_columns = static_and_regular_columns,
                             .selection = _selection.get(),
                             .options = &dummy_options,
                         });

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -457,9 +457,9 @@ std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evalu
                                .timestamps = std::move(static_and_regular_column_timestamps),
                                .ttls = std::move(static_and_regular_column_ttls)});
 
-    evaluation_inputs inputs{.partition_key = &data->partition_key,
-                             .clustering_key = &data->clustering_key,
-                             .static_and_regular_columns = &data->static_and_regular_columns,
+    evaluation_inputs inputs{.partition_key = data->partition_key,
+                             .clustering_key = data->clustering_key,
+                             .static_and_regular_columns = data->static_and_regular_columns,
                              .selection = data->selection.get(),
                              .options = &data->options,
                              .static_and_regular_timestamps = data->timestamps,


### PR DESCRIPTION
Spans are slightly cleaner, slightly faster (as they avoid an indirection), and allow for replacing some of the arguments with small_vector:s.