### PR TITLE
forward_service: fix forgetting case-sensitivity in aggregates 

### DIFF
--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -333,7 +333,7 @@ static shared_ptr<cql3::selection::selection> mock_selection(
     ) {
         auto name_as_expression = [] (const sstring& name) -> cql3::expr::expression {
             return cql3::expr::unresolved_identifier {
-                make_shared<cql3::column_identifier_raw>(name, false)
+                make_shared<cql3::column_identifier_raw>(name, true)
             };
         };
 

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -332,8 +332,9 @@ static shared_ptr<cql3::selection::selection> mock_selection(
         const std::optional<query::forward_request::aggregation_info>& info
     ) {
         auto name_as_expression = [] (const sstring& name) -> cql3::expr::expression {
+            constexpr bool keep_case = true;
             return cql3::expr::unresolved_identifier {
-                make_shared<cql3::column_identifier_raw>(name, true)
+                make_shared<cql3::column_identifier_raw>(name, keep_case)
             };
         };
 


### PR DESCRIPTION
There was a bug that caused aggregates to fail when used on column-sensitive columns.
    
For example:
```cql
SELECT SUM("SomeColumn") FROM ks.table;
```
would fail, with a message saying that there is no column "somecolumn".

This is because the case-sensitivity got lost on the way.

For non case-sensitive column names we convert them to lowercase, but for case sensitive names we have to preserve the name as originally written.

The problem was in `forward_service` - we took a column name and created a non case-sensitive `column_identifier` out of it.
This converted the name to lowercase, and later such column couldn't be found.

To fix it, let's make the `column_identifier` case-sensitive.
It will preserve the name, without converting it to lowercase.

Fixes: https://github.com/scylladb/scylladb/issues/14307