### PR TITLE
Establish "erm" as an acronym for fields and getters of effective_replication_map

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -434,11 +434,11 @@ class token_ranges_owned_by_this_shard {
 public:
     token_ranges_owned_by_this_shard(replica::database& db, gms::gossiper& g, schema_ptr s)
         :  _s(s)
-        , _token_ranges(db.find_keyspace(s->ks_name()).get_effective_replication_map(),
+        , _token_ranges(db.find_keyspace(s->ks_name()).erm(),
                 g, utils::fb_utilities::get_broadcast_address())
         , _range_idx(random_offset(0, _token_ranges.size() - 1))
         , _end_idx(_range_idx + _token_ranges.size())
-        , _erm(s->table().get_effective_replication_map())
+        , _erm(s->table().erm())
     {
         tlogger.debug("Generating token ranges starting from base range {} of {}", _range_idx, _token_ranges.size());
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -577,7 +577,7 @@ indexed_table_select_statement::do_execute_base_query(
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     uint32_t queried_ranges_count = partition_ranges.size();
     auto&& table = qp.proxy().local_db().find_column_family(_schema);
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
     query_ranges_to_vnodes_generator ranges_to_vnodes(erm->make_splitter(), _schema, std::move(partition_ranges));
 
     struct base_query_state {

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -244,7 +244,7 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
 
         auto& table = _db.local().find_column_family(uuid);
         const auto& schema = *table.schema();
-        auto shard = table.get_effective_replication_map()->shard_of(schema, fm.token(schema));
+        auto shard = table.erm()->shard_of(schema, fm.token(schema));
         return _db.invoke_on(shard, [this, cer = std::move(cer), &src_cm, rp] (replica::database& db) mutable -> future<> {
             auto& fm = cer.mutation();
             // TODO: might need better verification that the deserialized mutation

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -851,7 +851,7 @@ void manager::end_point_hints_manager::sender::start() {
 }
 
 future<> manager::end_point_hints_manager::sender::send_one_mutation(frozen_mutation_and_schema m) {
-    auto erm = _db.find_column_family(m.s).get_effective_replication_map();
+    auto erm = _db.find_column_family(m.s).erm();
     auto token = dht::get_token(*m.s, m.fm.key());
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints(std::move(token));
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1554,7 +1554,7 @@ static std::optional<gms::inet_address>
 get_view_natural_endpoint(replica::database& db, const sstring& keyspace_name,
         const dht::token& base_token, const dht::token& view_token) {
     auto& ks = db.find_keyspace(keyspace_name);
-    auto erm = ks.get_effective_replication_map();
+    auto erm = ks.erm();
     auto& topology = erm->get_token_metadata_ptr()->get_topology();
     auto my_address = utils::fb_utilities::get_broadcast_address();
     auto my_datacenter = topology.get_datacenter();
@@ -1638,7 +1638,7 @@ future<> view_update_generator::mutate_MV(
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto& keyspace_name = mut.s->ks_name();
         auto target_endpoint = get_view_natural_endpoint(_proxy.local().local_db(), keyspace_name, base_token, view_token);
-        auto remote_endpoints = _proxy.local().local_db().find_keyspace(keyspace_name).get_effective_replication_map()->get_pending_endpoints(view_token);
+        auto remote_endpoints = _proxy.local().local_db().find_keyspace(keyspace_name).erm()->get_pending_endpoints(view_token);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());
 
         const bool update_synchronously = should_update_synchronously(*mut.s);

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -63,7 +63,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
 
         if (!found_source) {
             auto& ks = _db.local().find_keyspace(keyspace);
-            auto rf = ks.get_effective_replication_map()->get_replication_factor();
+            auto rf = ks.erm()->get_replication_factor();
             // When a replacing node replaces a dead node with keyspace of RF
             // 1, it is expected that replacing node could not find a peer node
             // that contains data to stream from.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -618,13 +618,13 @@ future<> global_vnode_effective_replication_map::get_keyspace_erms(sharded<repli
         // all e_r_m:s and clone both on all shards. including the ring version,
         // all under the lock.
         auto lk = co_await db.get_shared_token_metadata().get_lock();
-        auto erm = db.find_keyspace(keyspace_name).get_effective_replication_map();
+        auto erm = db.find_keyspace(keyspace_name).erm();
         auto ring_version = erm->get_token_metadata().get_ring_version();
         _erms[0] = make_foreign(std::move(erm));
         co_await coroutine::parallel_for_each(boost::irange(1u, smp::count), [this, &sharded_db, keyspace_name, ring_version] (unsigned shard) -> future<> {
             _erms[shard] = co_await sharded_db.invoke_on(shard, [keyspace_name, ring_version] (const replica::database& db) {
                 const auto& ks = db.find_keyspace(keyspace_name);
-                auto erm = ks.get_effective_replication_map();
+                auto erm = ks.erm();
                 auto local_ring_version = erm->get_token_metadata().get_ring_version();
                 if (local_ring_version != ring_version) {
                     on_internal_error(rslogger, format("Inconsistent effective_replication_map ring_verion {}, expected {}", local_ring_version, ring_version));

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -86,7 +86,7 @@ get_range_to_address_map_in_local_dc(
 
 // static future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 // get_range_to_address_map(const replica::database& db, const sstring& keyspace) {
-//     return get_range_to_address_map(db.find_keyspace(keyspace).get_effective_replication_map());
+//     return get_range_to_address_map(db.find_keyspace(keyspace).erm());
 // }
 
 static future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
@@ -99,7 +99,7 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
     std::vector<dht::token_range_endpoints> ranges;
     //Token.TokenFactory tf = getPartitioner().getTokenFactory();
 
-    auto erm = db.find_keyspace(keyspace).get_effective_replication_map();
+    auto erm = db.find_keyspace(keyspace).erm();
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> range_to_address_map = co_await (
             include_only_local_dc
                     ? get_range_to_address_map_in_local_dc(erm)

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -771,7 +771,7 @@ future<typename ResultBuilder::result_type> do_query(
         db::timeout_clock::time_point timeout,
         noncopyable_function<ResultBuilder(const compact_for_query_state_v2&)> result_builder_factory) {
     auto& table = db.local().find_column_family(s);
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
     auto ctx = seastar::make_shared<read_context>(db, s, erm, cmd, ranges, trace_state, timeout);
 
     // Use coroutine::as_future to prevent exception on timesout.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -767,7 +767,7 @@ public:
     const schema_ptr& schema() const { return _schema; }
     void set_schema(schema_ptr);
     db::commitlog* commitlog() { return _commitlog; }
-    const locator::effective_replication_map_ptr& get_effective_replication_map() const { return _erm; }
+    const locator::effective_replication_map_ptr& erm() const { return _erm; }
     void update_effective_replication_map(locator::effective_replication_map_ptr);
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_mutation_partition_ptr> find_partition_slow(schema_ptr, reader_permit permit, const partition_key& key) const;
@@ -1219,7 +1219,7 @@ public:
         return _replication_strategy;
     }
 
-    locator::vnode_effective_replication_map_ptr get_effective_replication_map() const;
+    locator::vnode_effective_replication_map_ptr erm() const;
 
     column_family::config make_column_family_config(const schema& s, const database& db) const;
     void add_or_update_column_family(const schema_ptr& s);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2786,7 +2786,7 @@ public:
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
         auto cfg = _t.get_sstables_manager().configure_writer(std::move(origin));
-        cfg.erm = _t.get_effective_replication_map();
+        cfg.erm = _t.erm();
         return cfg;
     }
     api::timestamp_type min_memtable_timestamp() const override {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -154,7 +154,7 @@ const dht::i_partitioner& schema::get_partitioner() const {
 const dht::sharder& schema::get_sharder() const {
     auto t = maybe_table();
     if (t && !t->uses_static_sharding()) {
-        // Use table()->get_effective_replication_map()->get_sharder() instead.
+        // Use table()->erm()->get_sharder() instead.
         on_internal_error(dblog, format("Attempted to obtain static sharder for table {}.{}", ks_name(), cf_name()));
     }
     return _raw._sharder.get();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -830,7 +830,7 @@ public:
     // Returns a sharder for this table.
     // Use only for tables which use vnode-based replication strategy, that is for which
     // table::uses_static_sharding() is true.
-    // To obtain a sharder which is valid for all kinds of tables, use table::get_effective_replication_map()->get_sharder()
+    // To obtain a sharder which is valid for all kinds of tables, use table::erm()->get_sharder()
     const dht::sharder& get_sharder() const;
 
     // Returns a pointer to the table if the local database has a table which this object references by id().

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -220,7 +220,7 @@ public:
         :  _s(s)
         , _partition_ranges(v)
         , _range_idx(0)
-        , _erm(_s->table().get_effective_replication_map())
+        , _erm(_s->table().erm())
     {}
 
     // Return the next partition_range owned by this shard, or nullopt when the
@@ -540,7 +540,7 @@ future<> forward_service::uninit_messaging_service() {
 future<query::forward_result> forward_service::dispatch(query::forward_request req, tracing::trace_state_ptr tr_state) {
     schema_ptr schema = local_schema_registry().get(req.cmd.schema_version);
     replica::table& cf = _db.local().find_column_family(schema);
-    auto erm = cf.get_effective_replication_map();
+    auto erm = cf.erm();
     // next_vnode is used to iterate through all vnodes produced by
     // query_ranges_to_vnodes_generator.
     auto next_vnode = [

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -657,7 +657,7 @@ private:
                     // this function assumes singular queries but doesn't validate
                     throw std::runtime_error("READ_DATA called with wrapping range");
                 }
-                auto erm = s->table().get_effective_replication_map();
+                auto erm = s->table().erm();
                 p->get_stats().replica_data_reads++;
                 auto da = oda.value_or(query::digest_algorithm::MD5);
                 query::result_options opts;
@@ -672,7 +672,7 @@ private:
                     // this function assumes singular queries but doesn't validate
                     throw std::runtime_error("READ_DIGEST called with wrapping range");
                 }
-                auto erm = s->table().get_effective_replication_map();
+                auto erm = s->table().erm();
                 p->get_stats().replica_digest_reads++;
                 auto da = oda.value_or(query::digest_algorithm::MD5);
                 return p->query_result_local_digest(erm, std::move(s), cmd, std::move(pr2.first), trace_state_ptr, timeout, da, rate_limit_info);
@@ -1697,7 +1697,7 @@ paxos_response_handler::paxos_response_handler(shared_ptr<storage_proxy> proxy_a
         , tr_state(tr_state_arg) {
     auto ks_name = _schema->ks_name();
     replica::table& table = _proxy->_db.local().find_column_family(_schema->id());
-    _effective_replication_map_ptr = table.get_effective_replication_map();
+    _effective_replication_map_ptr = table.erm();
     storage_proxy::paxos_participants pp = _proxy->get_paxos_participants(ks_name, *_effective_replication_map_ptr, _key.token(), _cl_for_paxos);
     _live_endpoints = std::move(pp.endpoints);
     _required_participants = pp.required_participants;
@@ -2848,7 +2848,7 @@ storage_proxy::response_id_type storage_proxy::unique_response_handler::release(
 
 future<>
 storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
-    auto erm = _db.local().find_column_family(m.schema()).get_effective_replication_map();
+    auto erm = _db.local().find_column_family(m.schema()).erm();
     auto shard = erm->get_sharder(*m.schema()).shard_of(m.token());
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {smp_grp, timeout},
@@ -2865,7 +2865,7 @@ storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_sta
 future<>
 storage_proxy::mutate_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout,
         smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
-    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto erm = _db.local().find_column_family(s).erm();
     auto shard = erm->get_sharder(*s).shard_of(m.token(*s));
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {smp_grp, timeout},
@@ -2887,7 +2887,7 @@ storage_proxy::mutate_locally(std::vector<mutation> mutation, tracing::trace_sta
 }
 future<>
 storage_proxy::mutate_hint(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout) {
-    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto erm = _db.local().find_column_family(s).erm();
     auto shard = erm->get_sharder(*s).shard_of(m.token(*s));
     get_stats().replica_cross_shard_ops += shard != this_shard_id();
     return _db.invoke_on(shard, {_hints_write_smp_service_group, timeout}, [&m, gs = global_schema_ptr(s), tr_state = std::move(tr_state), timeout] (replica::database& db) mutable -> future<> {
@@ -2938,7 +2938,7 @@ storage_proxy::mutate_counters_on_leader(std::vector<frozen_mutation_and_schema>
 future<>
 storage_proxy::mutate_counter_on_leader_and_replicate(const schema_ptr& s, frozen_mutation fm, db::consistency_level cl, clock_type::time_point timeout,
                                                       tracing::trace_state_ptr trace_state, service_permit permit) {
-    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto erm = _db.local().find_column_family(s).erm();
     auto shard = erm->get_sharder(*s).shard_of(fm.token(*s));
     bool local = shard == this_shard_id();
     get_stats().replica_cross_shard_ops += !local;
@@ -2955,7 +2955,7 @@ result<storage_proxy::response_id_type>
 storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::token& token, std::unique_ptr<mutation_holder> mh,
         db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, is_cancellable cancellable) {
     replica::table& table = _db.local().find_column_family(s->id());
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
     inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(token);
     inet_address_vector_topology_change pending_endpoints = erm->get_pending_endpoints(token);
 
@@ -3073,7 +3073,7 @@ storage_proxy::create_write_response_handler(const std::tuple<lw_shared_ptr<paxo
 
     auto keyspace_name = s->ks_name();
     replica::table& table = _db.local().find_column_family(s->id());
-    auto ermp = table.get_effective_replication_map();
+    auto ermp = table.erm();
 
     // No rate limiting for paxos (yet)
     return create_write_response_handler(std::move(ermp), cl, db::write_type::CAS, std::make_unique<cas_mutation>(std::move(commit), s, nullptr), std::move(endpoints),
@@ -3257,7 +3257,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
 
     for (auto& m : mutations) {
         auto& table = _db.local().find_column_family(m.schema()->id());
-        auto erm = table.get_effective_replication_map();
+        auto erm = table.erm();
         erms.insert(erm);
         auto leader = find_leader_for_counter_update(m, *erm, cl);
         leaders[leader].emplace_back(frozen_mutation_and_schema { freeze(m), m.schema() });
@@ -3302,7 +3302,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
             // - the topology coordinator should prevent incompatible changes while requests
             //   (like this one) are in flight
             auto& table = _db.local().find_column_family(s->id());
-            auto erm = table.get_effective_replication_map();
+            auto erm = table.erm();
             try {
                 std::rethrow_exception(std::move(exp));
             } catch (rpc::timeout_error&) {
@@ -3606,7 +3606,7 @@ storage_proxy::mutate_atomically_result(std::vector<mutation> mutations, db::con
         future<result<>> send_batchlog_mutation(mutation m, db::consistency_level cl = db::consistency_level::ONE) {
             return _p.mutate_prepare<>(std::array<mutation, 1>{std::move(m)}, cl, db::write_type::BATCH_LOG, _permit, [this] (const mutation& m, db::consistency_level cl, db::write_type type, service_permit permit) {
                 auto& table = _p._db.local().find_column_family(m.schema()->id());
-                auto ermp = table.get_effective_replication_map();
+                auto ermp = table.erm();
                 return _p.create_write_response_handler(std::move(ermp), cl, type, std::make_unique<shared_mutation>(m), _batchlog_endpoints, {}, {}, _trace_state, _stats, std::move(permit), std::monostate(), is_cancellable::no);
             }).then(utils::result_wrap([this, cl] (unique_response_handler_vector ids) {
                 _p.register_cdc_operation_result_tracker(ids, _cdc_tracker);
@@ -3738,7 +3738,7 @@ future<> storage_proxy::send_to_endpoint(
                 std::back_inserter(dead_endpoints),
                 std::bind_front(&storage_proxy::is_alive, this));
         auto& table = _db.local().find_column_family(m->schema()->id());
-        auto erm = table.get_effective_replication_map();
+        auto erm = table.erm();
         slogger.trace("Creating write handler with live: {}; dead: {}", targets, dead_endpoints);
         db::assure_sufficient_live_nodes(cl, *erm, targets, pending_endpoints);
         return create_write_response_handler(
@@ -5378,7 +5378,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
     schema_ptr schema = local_schema_registry().get(cmd->schema_version);
 
     replica::table& table = _db.local().find_column_family(schema->id());
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
 
     db::read_repair_decision repair_decision = query_options.read_repair_decision
         ? *query_options.read_repair_decision : new_read_repair_decision(*schema);
@@ -5721,7 +5721,7 @@ storage_proxy::query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
         storage_proxy::coordinator_query_options query_options) {
     schema_ptr schema = local_schema_registry().get(cmd->schema_version);
     replica::table& table = _db.local().find_column_family(schema->id());
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
 
     // when dealing with LocalStrategy and EverywhereStrategy keyspaces, we can skip the range splitting and merging
     // (which can be expensive in clusters with vnodes)
@@ -6235,7 +6235,7 @@ storage_proxy::query_mutations_locally(schema_ptr s, lw_shared_ptr<query::read_c
                                        storage_proxy::clock_type::time_point timeout,
                                        tracing::trace_state_ptr trace_state) {
     auto& table = s->table();
-    auto erm = table.get_effective_replication_map();
+    auto erm = table.erm();
     if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*s), *s, pr)) {
         auto shard = *shard_opt;
         get_stats().replica_cross_shard_ops += shard != this_shard_id();

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -123,7 +123,7 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
     auto s = table.schema();
     const auto cf_id = s->id();
     const auto reason = streaming::stream_reason::repair;
-    auto erm = _db.local().find_column_family(s).get_effective_replication_map();
+    auto erm = _db.local().find_column_family(s).erm();
 
     // By sorting SSTables by their primary key, we allow SSTable runs to be
     // incrementally streamed.

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -55,7 +55,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                 schema_ptr s = reader.schema();
 
                 auto cfg = cf->get_sstables_manager().configure_writer(origin);
-                cfg.erm = cf->get_effective_replication_map();
+                cfg.erm = cf->erm();
                 return sst->write_components(std::move(reader), adjusted_estimated_partitions, s,
                                              cfg, encoding_stats{}).then([sst] {
                     return sst->open_data();

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -613,7 +613,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
         auto& table = db.find_column_family("ks", "t");
         auto& cl = *table.commitlog();
         auto s = table.schema();
-        auto& sharder = table.get_effective_replication_map()->get_sharder(*table.schema());
+        auto& sharder = table.erm()->get_sharder(*table.schema());
         auto memtables = table.active_memtables();
 
         auto add_entry = [&cl, s, &sharder] (const partition_key& key) mutable {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1591,7 +1591,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_reading_empty_table) {
 
         env.execute_cql(s.cql()).get();
         auto& table = env.db().local().find_column_family(s.schema()->ks_name(), s.schema()->cf_name());
-        auto erm = table.get_effective_replication_map();
+        auto erm = table.erm();
 
         auto factory = [&shards_touched] (
                 schema_ptr s,
@@ -1948,7 +1948,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_only_reads_from_needed
 
         env.execute_cql(s.cql()).get();
         auto& table = env.db().local().find_column_family(s.schema()->ks_name(), s.schema()->cf_name());
-        auto erm = table.get_effective_replication_map();
+        auto erm = table.erm();
 
         std::vector<bool> expected_shards_touched(smp::count);
 
@@ -2205,7 +2205,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
         auto reader = make_multishard_combining_reader_v2(
                 seastar::make_shared<test_reader_lifecycle_policy>(std::move(factory)),
                 schema,
-                table.get_effective_replication_map(),
+                table.erm(),
                 make_reader_permit(env),
                 query::full_partition_range,
                 schema->full_slice());
@@ -2281,7 +2281,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
                     streamed_mutation::forwarding::no, fwd_mr);
         };
         auto& table = env.db().local().find_column_family(schema);
-        auto erm = table.get_effective_replication_map();
+        auto erm = table.erm();
         auto reference_reader = make_filtering_reader(
                 make_multishard_combining_reader_v2(seastar::make_shared<test_reader_lifecycle_policy>(std::move(reader_factory)),
                     schema, erm, make_reader_permit(env), partition_range, schema->full_slice()),

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -96,7 +96,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
 
     uint64_t bloom_filter_size_before = filter_size(sst);
 
-    auto erm = cf->get_effective_replication_map();
+    auto erm = cf->erm();
 
     auto descriptor = sstables::compaction_descriptor({sst}, 0, std::numeric_limits<uint64_t>::max());
     descriptor.options = sstables::compaction_type_options::make_reshard();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -350,7 +350,7 @@ public:
         auto ckey = clustering_key::from_deeply_exploded(*schema, ck);
         auto exp = expected.type()->decompose(expected);
         auto dk = dht::decorate_key(*schema, pkey);
-        auto shard = cf.get_effective_replication_map()->shard_of(*schema, dk._token);
+        auto shard = cf.erm()->shard_of(*schema, dk._token);
         return _db.invoke_on(shard, [pkey = std::move(pkey),
                                       ckey = std::move(ckey),
                                       ks_name = std::move(ks_name),


### PR DESCRIPTION
get_effective_replication_map() is verbose, and already abbreviated as "erm" in local variables and some fields. This change standardizes this to other fields and elevates this practice to getters as well.

Helps reduce noise in the code.