### PR TITLE
sstables: Make index reader respect the option to bypass cache

### DIFF
--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -25,7 +25,11 @@
 
 namespace sstables {
 
-using use_caching = bool_class<struct use_caching_tag>;
+enum use_caching {
+    none,
+    local,
+    global
+};
 using promoted_index_block_position_view = std::variant<composite_view, position_in_partition_view>;
 using promoted_index_block_position = std::variant<composite, position_in_partition>;
 

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -501,6 +501,8 @@ private:
             return advance_to_end(bound);
         }
         auto loader = [this, &bound] (uint64_t summary_idx) -> future<index_list> {
+            sstlog.debug("Loading summary_idx {} for {}", summary_idx, _sstable->get_filename());
+
             auto& summary = _sstable->get_summary();
             uint64_t position = summary.entries[summary_idx].position;
             uint64_t quantity = downsampling::get_effective_index_interval_after_index(summary_idx, summary.header.sampling_level,
@@ -760,18 +762,29 @@ private:
         return options;
     }
 
+    std::unique_ptr<partition_index_cache> make_local_index_cache(use_caching caching) const {
+        switch (caching) {
+        case use_caching::global:
+            return nullptr;
+        case use_caching::local:
+            return std::make_unique<partition_index_cache>(_sstable->manager().get_cache_tracker().get_lru(),
+                                                           _sstable->manager().get_cache_tracker().region());
+        case use_caching::none:
+            // No LRU attached, keeps only used entries.
+            return std::make_unique<partition_index_cache>(_sstable->manager().get_cache_tracker().region());
+        }
+        __builtin_unreachable();
+    }
 public:
     index_reader(shared_sstable sst, reader_permit permit,
                  tracing::trace_state_ptr trace_state = {},
-                 use_caching caching = use_caching::yes,
+                 use_caching caching = use_caching::global,
                  bool single_partition_read = false)
         : _sstable(std::move(sst))
         , _permit(std::move(permit))
         , _trace_state(std::move(trace_state))
-        , _local_index_cache(caching ? nullptr
-            : std::make_unique<partition_index_cache>(_sstable->manager().get_cache_tracker().get_lru(),
-                                                      _sstable->manager().get_cache_tracker().region()))
-        , _index_cache(caching ? *_sstable->_index_cache : *_local_index_cache)
+        , _local_index_cache(make_local_index_cache(caching))
+        , _index_cache(caching == use_caching::global ? *_sstable->_index_cache : *_local_index_cache)
         , _region(_sstable->manager().get_cache_tracker().region())
         , _use_caching(caching)
         , _single_page_read(single_partition_read) // all entries for a given partition are within a single page
@@ -779,6 +792,13 @@ public:
         if (sstlog.is_enabled(logging::log_level::trace)) {
             sstlog.trace("index {}: index_reader for {}", fmt::ptr(this), _sstable->get_filename());
         }
+    }
+
+    static use_caching caching_mode(const query::partition_slice& ps) {
+        if (ps.options.contains(query::partition_slice::option::bypass_cache)) {
+            return use_caching::none;
+        }
+        return (global_cache_index_pages) ? use_caching::global : use_caching::local;
     }
 
     // Ensures that partition_data_ready() returns true.

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1184,9 +1184,10 @@ private:
         return (!slice.default_row_ranges().empty() && !slice.default_row_ranges()[0].is_full())
                || slice.get_specific_ranges();
     }
+
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
+            auto caching = index_reader::caching_mode(_slice);
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1349,7 +1349,7 @@ private:
     }
     index_reader& get_index_reader() {
         if (!_index_reader) {
-            auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
+            auto caching = index_reader::caching_mode(_slice);
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(),
                                                            _consumer.trace_state(), caching, _single_partition_read);
         }
@@ -2057,7 +2057,7 @@ future<uint64_t> validate(
     auto context = data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer);
 
     std::optional<sstables::index_reader> idx_reader;
-    idx_reader.emplace(sstable, permit, tracing::trace_state_ptr{}, sstables::use_caching::no, false);
+    idx_reader.emplace(sstable, permit, tracing::trace_state_ptr{}, sstables::use_caching::none, false);
 
     try {
         while (!context->eof() && !abort.abort_requested()) {


### PR DESCRIPTION
Today, index page caching can be disabled either with bypass flag or global config.

Today, turning the index caching off means using the local cache rather than a global one.

But turns out that the local cache will keep the unused pages in a LRU for the duration of the reader or until a reclaiming process evict them in least recently used order.

Single-key reads aren't affected by this problem, because they keep only one page cached.
But range reads, which uses the index, by forwarding to next partition, will potentially have multiple unused pages in the LRU, even though they will not be later required. Think of cleanup or view building, where both use filtering reader.

This issue can potentially disrupt the user workload as lots of memory will be wasted that could be otherwise devoted to serving the user queries.

The solution is about introducing a new caching mode, where partition_index_cache is instantiated with no LRU attached to it, meaning that entries will be removed from the cache as soon as they're no longer referenced by the index reader.

Refs #12378.
Refs #14317.