### PR TITLE
tools: add cqlsh shortcut

### DIFF
--- a/bin/cqlsh
+++ b/bin/cqlsh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Copyright (C) 2023-present ScyllaDB
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+here=$(dirname "$0")
+exec "$here/../tools/cqlsh/bin/cqlsh" "$@"
+


### PR DESCRIPTION
Add bin/cqlsh as a shortcut to tools/cqlsh/bin/cqlsh, intended for developers.