### PR TITLE
Backport "Make off-strategy compaction wait for view building completion" to branch-5.1

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2346,6 +2346,11 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
     co_await coroutine::parallel_for_each(dirs_to_sync, [] (sstring dir) {
         return sync_directory(dir);
     });
+    // Off-strategy timer will be rearmed, so if there's more incoming data through repair / streaming,
+    // the timer can be updated once again. In practice, it allows off-strategy compaction to kick off
+    // at the end of the node operation on behalf of this table, which brings more efficiency in terms
+    // of write amplification.
+    do_update_off_strategy_trigger();
 }
 
 /**


### PR DESCRIPTION
Prior to off-strategy compaction, streaming / repair would place staging files into main sstable set, and wait for view building completion before they could be selected for regular compaction.

The reason for that is that view building relies on table providing a mutation source without data in staging files. Had regular compaction mixed staging data with non-staging one, table would have a hard time providing the required mutation source.

After off-strategy compaction, staging files can be compacted in parallel to view building. If off-strategy completes first, it will place the output into the main sstable set. So a parallel view building (on sstables used for off-strategy) may potentially get a mutation source containing staging data from the off-strategy output. That will mislead view builder as it won't be able to detect changes to data in main directory.

To fix it, we'll do what we did before. Filter out staging files from compaction, and trigger the operation only after we're done with view building. We're piggybacking on off-strategy timer for still allowing the off-strategy to only run at the end of the node operation, to reduce the amount of compaction rounds on the data introduced by repair / streaming.

Fixes #11882.



Closes #11919

(cherry picked from commit a57724e711849f472a57d968fe07520ba6fac06e)