### PR TITLE
test/boost/schema_changes_test: split long-running test

### DIFF
--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -22,41 +22,63 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
-SEASTAR_TEST_CASE(test_schema_changes) {
+constexpr std::array<sstable_version_types, 3> expected_writable_sstable_versions = {
+sstable_version_types::mc,
+sstable_version_types::md,
+sstable_version_types::me,
+};
+
+// Add/remove test cases if writable_sstable_versions changes
+static_assert(writable_sstable_versions.size() == expected_writable_sstable_versions.size(), "writable_sstable_versions changed");
+static_assert(writable_sstable_versions[0] == expected_writable_sstable_versions[0], "writable_sstable_versions changed");
+static_assert(writable_sstable_versions[1] == expected_writable_sstable_versions[1], "writable_sstable_versions changed");
+static_assert(writable_sstable_versions[2] == expected_writable_sstable_versions[2], "writable_sstable_versions changed");
+
+future <> test_schema_changes_int(sstable_version_types sstable_vtype) {
   return sstables::test_env::do_with_async([] (sstables::test_env& env) {
-    std::map<std::tuple<sstables::sstable::version_types, schema_ptr>, shared_sstable> cache;
+    std::map<schema_ptr, shared_sstable> cache;
     for_each_schema_change([&] (schema_ptr base, const std::vector<mutation>& base_mutations,
                                 schema_ptr changed, const std::vector<mutation>& changed_mutations) {
-        for (auto version : writable_sstable_versions) {
-            auto it = cache.find(std::tuple { version, base });
+        auto it = cache.find(base);
 
-            shared_sstable created_with_base_schema;
-            shared_sstable created_with_changed_schema;
-            if (it == cache.end()) {
-                created_with_base_schema = make_sstable_containing(env.make_sstable(base), base_mutations);
-                cache.emplace(std::tuple { version, base }, created_with_base_schema);
-            } else {
-                created_with_base_schema = it->second;
-            }
-
-            created_with_changed_schema = env.reusable_sst(changed, created_with_base_schema).get();
-
-            const auto pr = dht::partition_range::make_open_ended_both_sides();
-
-            auto mr = assert_that(created_with_base_schema->as_mutation_source()
-                        .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
-            for (auto& m : changed_mutations) {
-                mr.produces(m);
-            }
-            mr.produces_end_of_stream();
-
-            mr = assert_that(created_with_changed_schema->as_mutation_source()
-                    .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
-            for (auto& m : changed_mutations) {
-                mr.produces(m);
-            }
-            mr.produces_end_of_stream();
+        shared_sstable created_with_base_schema;
+        shared_sstable created_with_changed_schema;
+        if (it == cache.end()) {
+            created_with_base_schema = make_sstable_containing(env.make_sstable(base), base_mutations);
+            cache.emplace(base, created_with_base_schema);
+        } else {
+            created_with_base_schema = it->second;
         }
+
+        created_with_changed_schema = env.reusable_sst(changed, created_with_base_schema).get();
+
+        const auto pr = dht::partition_range::make_open_ended_both_sides();
+
+        auto mr = assert_that(created_with_base_schema->as_mutation_source()
+                    .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
+        for (auto& m : changed_mutations) {
+            mr.produces(m);
+        }
+        mr.produces_end_of_stream();
+
+        mr = assert_that(created_with_changed_schema->as_mutation_source()
+                .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
+        for (auto& m : changed_mutations) {
+            mr.produces(m);
+        }
+        mr.produces_end_of_stream();
     });
   });
+}
+
+SEASTAR_TEST_CASE(test_schema_changes_mc) {
+    return test_schema_changes_int(sstable_version_types::mc);
+}
+
+SEASTAR_TEST_CASE(test_schema_changes_md) {
+    return test_schema_changes_int(sstable_version_types::md);
+}
+
+SEASTAR_TEST_CASE(test_schema_changes_me) {
+    return test_schema_changes_int(sstable_version_types::me);
 }


### PR DESCRIPTION
Split long running test `test_schema_changes` in 3 parts, one for each `writable_sstable_versions` so it can be run in parallel by `test.py`.

Add static checks to alert if the array of types changed.

Original test takes around 24 minutes in debug mode, and each new split test takes around 8 minutes.

Refs #13905