### PR TITLE
doc: fix rollback in the 5.2-to-2023.1 upgrade guide

### DIFF
--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/upgrade-guide-from-5.2-to-2023.1-generic.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/upgrade-guide-from-5.2-to-2023.1-generic.rst
@@ -346,8 +346,11 @@ Restore system tables
 
 Restore all tables of **system** and **system_schema** from the previous snapshot because |NEW_VERSION| uses a different set of system tables. See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` for reference.
 
-.. code:: sh
+.. code:: console
 
+    
+    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/
+    sudo find . -maxdepth 1 -type f  -exec sudo rm -f "{}" +
     cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
     sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
     sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/


### PR DESCRIPTION
This PR fixes the Restore System Tables section in the 5.2-to-2023.1 upgrade guide by adding a command to clean upgraded SStables during rollback.

This PR fixes is a bug (an incomplete command) and must be backported to branch-5.3 and branch-5.2.

Refs: https://github.com/scylladb/scylla-enterprise/issues/3046