### PR TITLE
test/boost/index_with_paging_test: reduce running time

### DIFF
--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -18,7 +18,7 @@ SEASTAR_TEST_CASE(test_index_with_paging) {
         e.execute_cql("CREATE TABLE tab (pk int, ck text, v int, v2 int, v3 text, PRIMARY KEY (pk, ck))").get();
         e.execute_cql("CREATE INDEX ON tab (v)").get();
 
-        sstring big_string(4096, 'j');
+        sstring big_string(100, 'j');
         // There should be enough rows to use multiple pages
         for (int i = 0; i < 64 * 1024; ++i) {
             e.execute_cql(format("INSERT INTO tab (pk, ck, v, v2, v3) VALUES ({}, 'hello{}', 1, {}, '{}')", i % 3, i, i, big_string)).get();


### PR DESCRIPTION
Reduce test string value size, parallelize inserts, and use a prepared statement, 

The debug running time for this tests is reduced from 13:18 to 7:52.

Refs #13905