### PR TITLE
Find task manager task progress

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -158,8 +158,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         tasks::task_manager::foreign_task_ptr task;
         try {
             task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
-                auto state = task->get_status().state;
-                if (state == tasks::task_manager::task_state::done || state == tasks::task_manager::task_state::failed) {
+                if (task->is_complete()) {
                     task->unregister_task();
                 }
                 co_return std::move(task);
@@ -214,8 +213,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         try {
             // Get requested task.
             task = co_await tasks::task_manager::invoke_on_task(_ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
-                auto state = task->get_status().state;
-                if (state == tasks::task_manager::task_state::done || state == tasks::task_manager::task_state::failed) {
+                if (task->is_complete()) {
                     task->unregister_task();
                 }
                 co_return task;

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -36,11 +36,46 @@ task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_
     }
 }
 
+future<std::optional<double>> task_manager::task::impl::expected_total_workload() const {
+    return make_ready_future<std::optional<double>>(std::nullopt);
+}
+
+std::optional<double> task_manager::task::impl::expected_children_number() const {
+    return std::nullopt;
+}
+
+task_manager::task::progress task_manager::task::impl::get_binary_progress() const {
+    return tasks::task_manager::task::progress{
+        .completed = is_complete(),
+        .total = 1.0
+    };
+}
+
 future<task_manager::task::progress> task_manager::task::impl::get_progress() const {
-    if (!_children.empty()) {
-        co_return progress{};
+    auto children_num = _children.size();
+    if (children_num == 0) {
+        co_return get_binary_progress();
     }
-    co_return _progress;
+
+    std::optional<double> expected_workload = std::nullopt;
+    auto expected_children_num = expected_children_number();
+    // When get_progress is called, the task can have some of its children unregistered yet.
+    // Then if total workload is not known, progress obtained from children may be deceiving.
+    // In such a situation it's safer to return binary progress value.
+    if (expected_children_num.value_or(0) != children_num && !(expected_workload = co_await expected_total_workload())) {
+        co_return get_binary_progress();
+    }
+
+    tasks::task_manager::task::progress progress{};
+    // _children vector may be modified in the meantime. Do not use foreach loop as the iterators may get invalidated.
+    for (unsigned i = 0; i < _children.size(); ++i) {
+        auto& child = _children[i];
+        progress += co_await smp::submit_to(child.get_owner_shard(), [&child] {
+            return child->get_progress();
+        });
+    }
+    progress.total = expected_workload.value_or(progress.total);
+    co_return progress;
 }
 
 is_abortable task_manager::task::impl::is_abortable() const noexcept {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -72,6 +72,10 @@ future<> task_manager::task::impl::abort() noexcept {
     }
 }
 
+bool task_manager::task::impl::is_complete() const noexcept {
+    return _status.state == tasks::task_manager::task_state::done || _status.state == tasks::task_manager::task_state::failed;
+}
+
 void task_manager::task::impl::run_to_completion() {
     (void)run().then_wrapped([this] (auto f) {
         if (f.failed()) {
@@ -202,6 +206,10 @@ void task_manager::task::unregister_task() noexcept {
 
 const task_manager::foreign_task_vector& task_manager::task::get_children() const noexcept {
     return _impl->_children;
+}
+
+bool task_manager::task::is_complete() const noexcept {
+    return _impl->is_complete();
 }
 
 task_manager::module::module(task_manager& tm, std::string name) noexcept : _tm(tm), _name(std::move(name)) {}

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -77,6 +77,17 @@ public:
         struct progress {
             double completed = 0.0;         // Number of units completed so far.
             double total = 0.0;             // Total number of units to complete the task.
+
+            progress& operator+=(const progress& rhs) {
+                completed += rhs.completed;
+                total += rhs.total;
+                return *this;
+            }
+
+            friend progress operator+(progress lhs, const progress& rhs) {
+                lhs += rhs;
+                return lhs;
+            }
         };
 
         struct status {
@@ -119,6 +130,9 @@ public:
             void finish() noexcept;
             void finish_failed(std::exception_ptr ex, std::string error) noexcept;
             void finish_failed(std::exception_ptr ex);
+            future<std::optional<double>> expected_total_workload() const;
+            std::optional<double> expected_children_number() const;
+            task_manager::task::progress get_binary_progress() const;
 
             friend task;
         };

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -107,7 +107,6 @@ public:
         class impl {
         protected:
             status _status;
-            progress _progress;             // Reliable only for tasks with no descendants.
             task_id _parent_id;
             foreign_task_vector _children;
             shared_promise<> _done;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -112,6 +112,7 @@ public:
             virtual tasks::is_abortable is_abortable() const noexcept;
             virtual tasks::is_internal is_internal() const noexcept;
             virtual future<> abort() noexcept;
+            bool is_complete() const noexcept;
         protected:
             virtual future<> run() = 0;
             void run_to_completion();
@@ -146,6 +147,7 @@ public:
         void register_task();
         void unregister_task() noexcept;
         const foreign_task_vector& get_children() const noexcept;
+        bool is_complete() const noexcept;
 
         friend class test_task;
         friend class ::repair::task_manager_module;


### PR DESCRIPTION
Modify task_manager::task::impl::get_progress method so that,
whenever relevant, progress is calculated based on children's
progress. Otherwise progress indicates only whether the task
is finished or not. 

The method may be overriden in inheriting classes.