### PR TITLE
db: config: add live_cql_updates_enabled option

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -598,3 +598,10 @@ consistent_cluster_management: true
 # New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
 # to make sure that trying to create an invalid view causes an error.
 strict_is_not_null_in_views: true
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true

--- a/db/config.cc
+++ b/db/config.cc
@@ -1013,7 +1013,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , relabel_config_file(this, "relabel_config_file", value_status::Used, "", "Optionally, read relabel config from file")
     , object_storage_config_file(this, "object_storage_config_file", value_status::Used, "", "Optionally, read object-storage endpoints config from file")
     , minimum_keyspace_rf(this, "minimum_keyspace_rf", liveness::LiveUpdate, value_status::Used, 0, "The minimum allowed replication factor when creating or altering a keyspace.")
-    , auth_superuser_name(this, "auth_superuser_name", value_status::Used, "", 
+    , live_updatable_config_params_changeable_via_cql(this, "live_updatable_config_params_changeable_via_cql", liveness::MustRestart, value_status::Used, true, "If set to true, configuration parameters defined with LiveUpdate can be updated in runtime via CQL (by updating system.config virtual table), otherwise they can't.")
+    , auth_superuser_name(this, "auth_superuser_name", value_status::Used, "",
         "Initial authentication super username. Ignored if authentication tables already contain a super user")
     , auth_superuser_salted_password(this, "auth_superuser_salted_password", value_status::Used, "", 
         "Initial authentication super user salted password. Create using mkpassword or similar. The hashing algorithm used must be available on the node host. "

--- a/db/config.hh
+++ b/db/config.hh
@@ -445,6 +445,10 @@ public:
     static constexpr size_t wasm_udf_reserved_memory = 50 * 1024 * 1024;
 
     named_value<unsigned> minimum_keyspace_rf;
+    named_value<bool> live_updatable_config_params_changeable_via_cql;
+    bool are_live_updatable_config_params_changeable_via_cql() const override {
+        return live_updatable_config_params_changeable_via_cql();
+    }
 
     // authenticator options
     named_value<std::string> auth_superuser_name;

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -287,6 +287,10 @@ public:
     }
     future<> broadcast_to_all_shards();
 private:
+    virtual bool are_live_updatable_config_params_changeable_via_cql() const {
+        return false;
+    }
+
     configs
         _cfgs;
 };

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -27,7 +27,7 @@ namespace YAML {
 /*
  * Add converters as needed here...
  *
- * TODO: Maybe we should just define all node conversionas as "lexical_cast".
+ * TODO: Maybe we should just define all node conversions as "lexical_cast".
  * However, vanilla yamp-cpp does some special treatment of scalar types,
  * mainly inf handling etc. Hm.
  */
@@ -181,7 +181,7 @@ sstring hyphenate(const std::string_view&);
 template<typename T>
 void utils::config_file::named_value<T>::add_command_line_option(boost::program_options::options_description_easy_init& init) {
     const auto hyphenated_name = hyphenate(name());
-    // NOTE. We are not adding default values. We could, but must in that case manually (in some way) geenrate the textual
+    // NOTE. We are not adding default values. We could, but must in that case manually (in some way) generate the textual
     // version, since the available ostream operators for things like pairs and collections don't match what we can deal with parser-wise.
     // See removed ostream operators above.
     init(hyphenated_name.data(), value_ex<T>()->notifier([this](T new_val) { set(std::move(new_val), config_source::CommandLine); }), desc().data());
@@ -204,7 +204,7 @@ void utils::config_file::named_value<T>::set_value(const YAML::Node& node) {
 
 template<typename T>
 bool utils::config_file::named_value<T>::set_value(sstring value, config_source src) {
-    if (_liveness != liveness::LiveUpdate) {
+    if ((_liveness != liveness::LiveUpdate) || (src == config_source::CQL && !_cf->are_live_updatable_config_params_changeable_via_cql())) {
         return false;
     }
 
@@ -226,7 +226,7 @@ future<> utils::config_file::named_value<T>::set_value_on_all_shards(const YAML:
 
 template<typename T>
 future<bool> utils::config_file::named_value<T>::set_value_on_all_shards(sstring value, config_source src) {
-    if (_liveness != liveness::LiveUpdate) {
+    if ((_liveness != liveness::LiveUpdate) || (src == config_source::CQL && !_cf->are_live_updatable_config_params_changeable_via_cql())) {
         co_return false;
     }
 


### PR DESCRIPTION
If `live_cql_updates_enabled` is set to true, configuration parameters defined with `liveness::LiveUpdate` option can be updated in the runtime with CQL, i.e. by updating `system.config` virtual table.
If we don't want any configuration parameter to be changed in the
runtime by updating `system.config` virtual table, this option should be
set to false. This option should be set to false for e.g. cloud users,
who can only perform CQL queries, and should not be able to change
scylla's configuration on the fly.

Current implemenatation is generic, but has a small drawback - messages
returned to the user can be not fully accurate, consider:
```
cqlsh> UPDATE system.config SET value='2' WHERE name='task_ttl_in_seconds';
WriteFailure: Error from server: code=1500 [Replica(s) failed to execute write] message="option is not live-updateable" info={'failures': 1, 'received_responses': 0, 'required_responses': 1, 'consistency': 'ONE'}
```
where `task_ttl_in_seconds` has been defined with
`liveness::LiveUpdate`, but because `live_cql_updates_enabled` is set to
`false` in `scylla.yaml,` `task_ttl_in_seconds` cannot be modified in the
runtime by updating `system.config` virtual table.

Fixes https://github.com/scylladb/scylladb/issues/14355