### PR TITLE
install.sh: force default umask to 022

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ export LD_LIBRARY_PATH="$prefix/libreloc"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}suppressions=$prefix/libexec/ubsan-suppressions.supp"
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"
 EOF
-    chmod 755 "$root/$prefix/bin/$bin"
+    chmod +x "$root/$prefix/bin/$bin"
 }
 
 relocate_python3() {
@@ -178,11 +178,11 @@ relocate_python3() {
     local pythonpath="$(dirname "$pythoncmd")"
 
     if [ ! -x "$script" ]; then
-        install -m755 "$script" "$install"
+        cp "$script" "$install"
         return
     fi
-    install -d -m755 "$relocateddir"
-    install -m755 "$script" "$relocateddir"
+    mkdir -p "$relocateddir"
+    cp "$script" "$relocateddir"
     cat > "$install"<<EOF
 #!/usr/bin/env bash
 [[ -z "\$LD_PRELOAD" ]] || { echo "\$0: not compatible with LD_PRELOAD" >&2; exit 110; }
@@ -199,7 +199,7 @@ if [ -f "\${DEBIAN_SSL_CERT_FILE}" ]; then
 fi
 PYTHONPATH="\${d}:\${d}/libexec:\$PYTHONPATH" PATH="\${d}/../bin:\${d}/$pythonpath:\${PATH}" SSL_CERT_FILE="\${c}" exec -a "\$0" "\${d}/libexec/\${b}" "\$@"
 EOF
-    chmod 755 "$install"
+    chmod +x "$install"
 }
 
 install() {
@@ -424,7 +424,6 @@ install -d -m755 -d "$rprefix"/scyllatop
 cp -r tools/scyllatop/* "$rprefix"/scyllatop
 install -d -m755 -d "$rprefix"/scripts
 cp -r dist/common/scripts/* "$rprefix"/scripts
-chmod 755 "$rprefix"/scripts/*
 ln -srf "$rprefix/scyllatop/scyllatop.py" "$rprefix/bin/scyllatop"
 if $supervisor; then
     install -d -m755 "$rprefix"/supervisor

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,9 @@ supervisor_conf() {
     fi
 }
 
+# force default umask to 022
+umask 022
+
 if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     echo "systemd is not detected, unsupported distribution."
     exit 1


### PR DESCRIPTION
To fix all strict umask related issues, we should force applying umask
as 022 in install.sh.

We should revert previous patch since we don't need to specify
permission explicitly for each files anymore, so the patch is not needed
now.

Fixes #10752
Closes #10840
Fixes #14383