### PR TITLE
Add option to test/alternator/run to run tests concurrently

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -93,7 +93,15 @@ cluster.connect().execute("INSERT INTO system_auth.roles (role, salted_hash) VAL
 cluster.shutdown()
 
 # Finally run pytest:
-success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
+if len(sys.argv) >= 3 and sys.argv[1] == '-j':
+    # Use "run -j 10" to run up to 10 test files in parallel (against the one
+    # Scylla process). Without "-j", one pytest is invoked to run all tests.
+    # Don't combine "-j" and a test file or function name - it is pointless
+    # and currently doesn't work.
+    # Note that we run Scylla itself on two shards, and -j doesn't chage that.
+    success = run.run_pytest_parallel(sys.path[0], int(sys.argv[2]), ['--url', alternator_url] + sys.argv[3:])
+else:
+    success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
 
 run.summary = 'Alternator tests pass' if success else 'Alternator tests failure'
 

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -11,7 +11,7 @@
 import pytest
 import time
 from botocore.exceptions import ClientError
-from util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table
+from util import create_test_table, random_string, full_scan, full_query, multiset, list_tables, new_test_table, unique_table_name
 
 # GSIs only support eventually consistent reads, so tests that involve
 # writing to a table and then expect to read something from it cannot be
@@ -1191,7 +1191,7 @@ def test_gsi_non_scylla_name(dynamodb):
 # (compare test_create_and_delete_table_very_long_name()).
 def test_gsi_very_long_name(dynamodb):
     #create_gsi(dynamodb, 'n' * 255)   # works on DynamoDB, but not on Scylla
-    create_gsi(dynamodb, 'n' * 190)
+    create_gsi(dynamodb, 'n' * (211-len(unique_table_name())-1))
 
 # Verify that ListTables does not list materialized views used for indexes.
 # This is hard to test, because we don't really know which table names

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -9,6 +9,7 @@ import random
 import collections
 import time
 import re
+import os
 import requests
 import pytest
 from contextlib import contextmanager
@@ -123,8 +124,11 @@ def multiset(items):
     return collections.Counter([freeze(item) for item in items])
 
 # NOTE: alternator_Test prefix contains a capital letter on purpose,
-#in order to validate case sensitivity in alternator
-test_table_prefix = 'alternator_Test_'
+# in order to validate case sensitivity in alternator.
+# We also add the process id, in case two independent pytest invocations
+# run in parallel and happen to try to create a table at exactly the same
+# time.
+test_table_prefix = 'alternator_Test_' + str(os.getpid()) + '_'
 def unique_table_name():
     current_ms = int(round(time.time() * 1000))
     # If unique_table_name() is called twice in the same millisecond...


### PR DESCRIPTION
This is a draft for the second idea suggested in https://github.com/scylladb/scylladb/issues/14387 - it adds a "-j N" option to test/alternator/run, which runs up to N parallel "pytest" invocations, one invocation per test source file.

This is a draft because:
1. The output of the different pytest invocations is mixed up in the output of test/alternator/run. It needs to be saved while the test runs and printed out separately.
2. The junit xml files from the different pytest invocations runs over one another, instead of being merged into one result file.