### PR TITLE
use_statement: Convert an exception to a future exception

### DIFF
--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -56,7 +56,11 @@ future<> use_statement::check_access(query_processor& qp, const service::client_
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 use_statement::execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const {
-    state.get_client_state().set_keyspace(qp.db().real_database(), _keyspace);
+    try {
+        state.get_client_state().set_keyspace(qp.db().real_database(), _keyspace);
+    } catch(...) {
+        return make_exception_future<::shared_ptr<cql_transport::messages::result_message>>(std::current_exception());
+    }
     auto result =::make_shared<cql_transport::messages::result_message::set_keyspace>(_keyspace);
     return make_ready_future<::shared_ptr<cql_transport::messages::result_message>>(result);
 }


### PR DESCRIPTION
The use statement execution code can throw if the keyspace is doesn't exist, this can be a problem for code that will use execute in a fiber since the exception will break the fiber even if `then_wrapped` is used.

Fixes #14449 