### PR TITLE
repair: use fmt::join to print ks_erms|boost::adaptors::map_keys

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1356,7 +1356,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             rs.get_metrics().bootstrap_finished_ranges = 0;
             rs.get_metrics().bootstrap_total_ranges = nr_ranges_total;
         }).get();
-        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", ks_erms | boost::adaptors::map_keys, nr_ranges_total);
+        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", fmt::join(ks_erms | boost::adaptors::map_keys, ","), nr_ranges_total);
         for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.has_keyspace(keyspace_name)) {
                 rlogger.info("bootstrap_with_repair: keyspace={} does not exist any more, ignoring it", keyspace_name);
@@ -1501,7 +1501,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             sync_data_using_repair(keyspace_name, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges);
         }
-        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | boost::adaptors::map_keys);
+        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", fmt::join(ks_erms | boost::adaptors::map_keys, ","));
     });
 }
 
@@ -1538,7 +1538,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             static std::list<gms::inet_address> no_ignore_nodes;
             return ops ? ops->ignore_nodes : no_ignore_nodes;
         };
-        rlogger.info("{}: started with keyspaces={}, leaving_node={}, ignore_nodes={}", op, ks_erms | boost::adaptors::map_keys, leaving_node, get_ignore_nodes());
+        rlogger.info("{}: started with keyspaces={}, leaving_node={}, ignore_nodes={}", op, fmt::join(ks_erms | boost::adaptors::map_keys, ","), leaving_node, get_ignore_nodes());
         for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.has_keyspace(keyspace_name)) {
                 rlogger.info("{}: keyspace={} does not exist any more, ignoring it", op, keyspace_name);
@@ -1696,7 +1696,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
                 op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced, nr_ranges_skipped);
         }
-        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, ks_erms | boost::adaptors::map_keys, leaving_node);
+        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, fmt::join(ks_erms | boost::adaptors::map_keys, ","), leaving_node);
     });
 }
 
@@ -1747,7 +1747,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
                 rs.get_metrics().replace_total_ranges = nr_ranges_total;
             }).get();
         }
-        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={}", op, ks_erms | boost::adaptors::map_keys, source_dc, nr_ranges_total, ignore_nodes);
+        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={}", op, fmt::join(ks_erms | boost::adaptors::map_keys, ","), source_dc, nr_ranges_total, ignore_nodes);
         for (const auto& [keyspace_name, erm] : ks_erms) {
             size_t nr_ranges_skipped = 0;
             if (!db.has_keyspace(keyspace_name)) {
@@ -1798,7 +1798,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
             sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc, nr_ranges);
         }
-        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | boost::adaptors::map_keys, source_dc);
+        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, fmt::join(ks_erms | boost::adaptors::map_keys, ","), source_dc);
     });
 }
 


### PR DESCRIPTION
This is a minimal fix for #13146 for branch-5.2