### PR TITLE
sstable: switch to uuid identifier for naming S3 sstable objects

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2737,18 +2737,6 @@ future<> system_keyspace::sstables_registry_create_entry(sstring location, sstri
     co_await execute_cql(req, location, desc.generation, status, fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_lookup_entry(sstring location, sstables::generation_type gen) {
-    static const auto req = format("SELECT generation FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Looking up {}.{} in {}", location, gen, SSTABLES_REGISTRY);
-    auto msg = co_await execute_cql(req, location, gen);
-    if (msg->empty() || !msg->one().has("generation")) {
-        slogger.trace("ERROR: Cannot find {}.{} in {}", location, gen, SSTABLES_REGISTRY);
-        co_await coroutine::return_exception(std::runtime_error("No entry in sstables registry"));
-    }
-
-    slogger.trace("Found {}.{} in {}", location, gen, SSTABLES_REGISTRY);
-}
-
 future<> system_keyspace::sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status) {
     static const auto req = format("UPDATE system.{} SET status = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Updating {}.{} -> {} in {}", location, gen, status, SSTABLES_REGISTRY);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1053,7 +1053,6 @@ schema_ptr system_keyspace::sstables_registry() {
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
             .with_column("location", utf8_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
-            .with_column("uuid", uuid_type)
             .with_column("status", utf8_type)
             .with_column("version", utf8_type)
             .with_column("format", utf8_type)
@@ -2732,24 +2731,22 @@ mutation system_keyspace::make_cleanup_candidate_mutation(std::optional<cdc::gen
     return m;
 }
 
-future<> system_keyspace::sstables_registry_create_entry(sstring location, utils::UUID uuid, sstring status, sstables::entry_descriptor desc) {
-    static const auto req = format("INSERT INTO system.{} (location, generation, uuid, status, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
-    slogger.trace("Inserting {}.{}:{} into {}", location, desc.generation, uuid, SSTABLES_REGISTRY);
-    co_await execute_cql(req, location, desc.generation, uuid, status, fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+future<> system_keyspace::sstables_registry_create_entry(sstring location, sstring status, sstables::entry_descriptor desc) {
+    static const auto req = format("INSERT INTO system.{} (location, generation, status, version, format) VALUES (?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    slogger.trace("Inserting {}.{} into {}", location, desc.generation, SSTABLES_REGISTRY);
+    co_await execute_cql(req, location, desc.generation, status, fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<utils::UUID> system_keyspace::sstables_registry_lookup_entry(sstring location, sstables::generation_type gen) {
-    static const auto req = format("SELECT uuid FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
+future<> system_keyspace::sstables_registry_lookup_entry(sstring location, sstables::generation_type gen) {
+    static const auto req = format("SELECT generation FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Looking up {}.{} in {}", location, gen, SSTABLES_REGISTRY);
     auto msg = co_await execute_cql(req, location, gen);
-    if (msg->empty() || !msg->one().has("uuid")) {
+    if (msg->empty() || !msg->one().has("generation")) {
         slogger.trace("ERROR: Cannot find {}.{} in {}", location, gen, SSTABLES_REGISTRY);
         co_await coroutine::return_exception(std::runtime_error("No entry in sstables registry"));
     }
 
-    auto uuid = msg->one().get_as<utils::UUID>("uuid");
-    slogger.trace("Found {}.{}:{} in {}", location, gen, uuid, SSTABLES_REGISTRY);
-    co_return uuid;
+    slogger.trace("Found {}.{} in {}", location, gen, SSTABLES_REGISTRY);
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status) {
@@ -2765,17 +2762,16 @@ future<> system_keyspace::sstables_registry_delete_entry(sstring location, sstab
 }
 
 future<> system_keyspace::sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer) {
-    static const auto req = format("SELECT uuid, status, generation, version, format FROM system.{} WHERE location = ?", SSTABLES_REGISTRY);
+    static const auto req = format("SELECT status, generation, version, format FROM system.{} WHERE location = ?", SSTABLES_REGISTRY);
     slogger.trace("Listing {} entries from {}", location, SSTABLES_REGISTRY);
 
     co_await _qp.query_internal(req, db::consistency_level::ONE, { location }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
-        auto uuid = row.get_as<utils::UUID>("uuid");
         auto status = row.get_as<sstring>("status");
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
         sstables::entry_descriptor desc(gen, ver, fmt, sstables::component_type::TOC);
-        co_await consumer(std::move(uuid), std::move(status), std::move(desc));
+        co_await consumer(std::move(status), std::move(desc));
         co_return stop_iteration::no;
     });
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -499,7 +499,6 @@ public:
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::entry_descriptor desc);
-    future<> sstables_registry_lookup_entry(sstring location, sstables::generation_type gen);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
     using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring state, sstables::entry_descriptor desc)>;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -498,11 +498,11 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
-    future<> sstables_registry_create_entry(sstring location, utils::UUID uuid, sstring status, sstables::entry_descriptor desc);
-    future<utils::UUID> sstables_registry_lookup_entry(sstring location, sstables::generation_type gen);
+    future<> sstables_registry_create_entry(sstring location, sstring status, sstables::entry_descriptor desc);
+    future<> sstables_registry_lookup_entry(sstring location, sstables::generation_type gen);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
-    using sstable_registry_entry_consumer = noncopyable_function<future<>(utils::UUID uuid, sstring state, sstables::entry_descriptor desc)>;
+    using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring state, sstables::entry_descriptor desc)>;
     future<> sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -63,7 +63,7 @@ public:
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
-    virtual future<> remove_by_registry_entry(utils::UUID uuid, entry_descriptor desc) = 0;
+    virtual future<> remove_by_registry_entry(entry_descriptor desc) = 0;
 
     virtual sstring prefix() const  = 0;
 };

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -146,7 +146,10 @@ SEASTAR_TEST_CASE(sstable_resharding_test) {
 SEASTAR_TEST_CASE(sstable_resharding_over_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
     return sstables::test_env::do_with_async([] (auto& env) {
         run_sstable_resharding_test(env);
-    }, test_env_config{ .storage = make_test_object_storage_options() });
+    }, test_env_config{
+        .storage = make_test_object_storage_options(),
+        .use_uuid = true,
+    });
 }
 
 SEASTAR_TEST_CASE(sstable_is_shared_correctness) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -206,6 +206,9 @@ test_env::impl::impl(test_env_config cfg, sstables::storage_manager* sstm)
     , use_uuid(cfg.use_uuid)
     , storage(std::move(cfg.storage))
 {
+    if (cfg.use_uuid) {
+        feature_service.uuid_sstable_identifiers.enable();
+    }
     if (!storage.is_local_type()) {
         // remote storage requires uuid-based identifier for naming sstables
         assert(use_uuid == uuid_identifiers::yes);

--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -198,8 +198,8 @@ async def test_garbage_collect(test_tempdir, s3_server, ssl):
         # Mark the sstables as "removing" to simulate the problem
         res = conn.execute("SELECT * FROM system.sstables;")
         for row in res:
-            sstable_entries.append(tuple((row.location, row.generation, row.uuid)))
-        print(f'Found entries: {[ str(ent[2]) for ent in sstable_entries ]}')
+            sstable_entries.append(tuple((row.location, row.generation)))
+        print(f'Found entries: {[ str(ent[1]) for ent in sstable_entries ]}')
         for sst in sstable_entries:
             conn.execute(f"UPDATE system.sstables SET status = 'removing' WHERE location = '{sst[0]}' AND generation = {sst[1]};")
 
@@ -215,4 +215,4 @@ async def test_garbage_collect(test_tempdir, s3_server, ssl):
         print(f'Found objects: {[ objects ]}')
         for o in objects:
             for ent in sstable_entries:
-                assert not o.startswith(str(ent[2])), f'Sstable object not cleaned, found {o}'
+                assert not o.startswith(str(ent[1])), f'Sstable object not cleaned, found {o}'


### PR DESCRIPTION
before this change, we create a new UUID for a new sstable managed by the s3_storage, and we use the string representation of UUID defined by RFC4122 like "0aa490de-7a85-46e2-8f90-38b8f496d53b" for naming the objects stored on s3_storage. but this representation is not what we are using for storing sstables on local filesystem when the option of "uuid_sstable_identifiers_enabled" is enabled. instead, we are using a base36-based representation which is shorter.

to be consistent with the naming of the sstables created for local filesystem, and more importantly, to simplify the interaction between the local copy of sstables and those stored on object storage, we should use the same string representation of the sstable identifier.

so, in this change:

1. instead of creating a new UUID, just reuse the generation of the sstable for the object's key.
2. do not store the uuid in the sstable_registry system table. As we already have the generation of the sstable for the same purpose.
3. switch the sstable identifier representation from the one defined by the RFC4122 (implemented by fmt::formatter<utils::UUID>) to the base36-based one (implemented by fmt::formatter<sstables::generation_type>)

Fixes #14175
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>