### PR TITLE
docs: compaction: correct min_sstable_size default value

### DIFF
--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -116,7 +116,7 @@ The following options only apply to SizeTieredCompactionStrategy:
 
 =====
 
-``min_sstable_size`` (default: 50)
+``min_sstable_size`` (default: 52,428,800)
    All SSTables smaller than this number of bytes are put into the same bucket.
 
 =====


### PR DESCRIPTION
DEFAULT_MIN_SSTABLE_SIZE is defined as `50L * 1024L * 1024L` which is 50 MB, not 50 bytes.

Fixes #14413