### PR TITLE
scylla_fstrim_setup: start scylla-fstrim.timer on setup for branch-5.3

### DIFF
--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
-    systemd_unit('scylla-fstrim.timer').unmask()
     systemd_unit('scylla-fstrim.timer').enable()
+    systemd_unit('scylla-fstrim.timer').start()
     if is_redhat_variant() or is_arch() or is_suse_variant():
         systemd_unit('fstrim.timer').disable()


### PR DESCRIPTION
Currently, scylla_fstrim_setup does not start scylla-fstrim.timer and just enables it, so the timer starts only after rebooted. This is incorrect behavior, we start start it during the setup.

Also, unmask is unnecessary for enabling the timer.

Fixes #14249

Closes #14252

(cherry picked from commit c70a9cbffefaa6ce107eaa85fce1866a246e9c59)