### PR TITLE
combined: mergers: limit operator()() recursion by forcing preemption

### DIFF
--- a/utils/preemptor.hh
+++ b/utils/preemptor.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <seastar/util/later.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/preempt.hh>
+
+/// A helper struct that helps force a preemption every given number of calls.
+/// The main use case for it is limiting the number of recursive calls
+/// that occur when a function calls itself indirectly via .then().
+template<unsigned int PreemptEvery>
+struct preemptor {
+    static_assert(PreemptEvery > 0);
+
+private:
+    unsigned int _counter = 0;
+
+public:
+    /// Increments the internal counter and either calls given function immediately,
+    /// or after a yield, depending on the value of the internal counter.
+    template<typename F, typename... Args>
+    requires std::invocable<F, Args...>
+    seastar::futurize_t<std::invoke_result_t<F>> maybe_after_preemption(F&& f, Args&&... args) {
+        if (++_counter == PreemptEvery) {
+            _counter = 0;
+            return seastar::yield().then(std::forward<F>(f), std::forward<Args>(args)...);
+        } else {
+            return futurize_invoke<F>(std::forward<F>(f), std::forward<Args>(args)...);
+        }
+    }
+};


### PR DESCRIPTION
In mutation_reader_merger and clustering_order_reader_merger, the operator()() is responsible for producing mutation fragments that will be merged and pushed to the combined reader's buffer. Sometimes, it might have to advance existing readers, open new and / or close some existing ones, which requires calling a helper method and then calling operator()() recursively.

In some unlucky circumstances, a stack overflow can occur:

- Readers have to be opened incrementally,
- Most or all readers must not produce any fragments and need to report
  end of stream without preemption,
- There has to be enough readers opened within the lifetime of the
  combined reader (~500),
- All of the above needs to happen within a single task quota.

In order to prevent such a situation, both reader merger classes now use a new preemptor<> helper struct to enforce a yield every 64th time a recursive call occurs.

A regression test is added.

Results from `perf_simple_query`, seed `4176097382`:

_Before_ (8d1dfbf0d97e9600b7a6b4577537ce0f9f76b124):

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              4176097382

test                                      iterations      median         mad         min         max      allocs       tasks        inst
combined.one_mutation                         457638     1.346us     5.062ns     1.341us     1.365us      18.006       0.011      6503.4
combined.one_row                              438021     1.391us     2.567ns     1.389us     1.401us      19.006       0.012      6766.2
combined.single_active                          4935   167.261us   828.542ns   165.403us   168.251us    2451.791       2.447   1447035.8
combined.many_overlapping                        882   990.202us     2.403us   987.799us   994.686us    4605.096      17.688   7606030.9
combined.disjoint_interleaved                   4885   167.688us   276.152ns   167.411us   170.712us    2476.847       2.515   1468156.0
combined.disjoint_ranges                        4910   166.831us    72.517ns   166.530us   167.549us    2468.783       2.442   1463555.9
combined.overlapping_partitions_disjoint_rows   4295   196.356us   407.798ns   195.521us   196.981us    2231.326       3.121   1641106.4
clustering_combined.ranges_generic           1977822   416.279ns     0.294ns   415.528ns   416.995ns       4.447       0.007      3363.0
clustering_combined.ranges_specialized       2078846   411.483ns     0.537ns   410.010ns   412.020ns       4.532       0.007      3287.5
memtable.one_partition_one_row                 33601    24.895us     1.878us    22.040us    26.993us      16.070       0.046     43255.6
memtable.one_partition_many_rows                9189    19.252us    54.132ns    19.156us    42.068us     123.288       0.361    149911.9
memtable.one_large_partition                      81     2.696ms     5.832us     2.664ms     3.976ms   16435.602      38.449  21838713.4
memtable.many_partitions_one_row                6222    30.824us   123.774ns    30.653us    44.453us     255.408       0.536    225958.2
memtable.many_partitions_many_rows               667   478.332us   950.958ns   475.380us   795.519us    2834.783       8.786   3903414.9
memtable.many_large_partitions                     4    69.267ms   118.314us    68.803ms    69.538ms  410686.200     896.900 498378764.1
```

_After_ (6d22e0f4825e69fba48afaa12b79ecd11b3b43d9):

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              4176097382

test                                      iterations      median         mad         min         max      allocs       tasks        inst
combined.one_mutation                         446906     1.415us    11.975ns     1.395us     1.449us      18.006       0.011      6503.8
combined.one_row                              422710     1.438us     3.021ns     1.435us     1.446us      19.007       0.012      6767.1
combined.single_active                          4952   164.793us   649.850ns   164.143us   166.387us    2451.808       2.456   1447525.0
combined.many_overlapping                        877   992.228us   189.568ns   991.671us   992.418us    4675.300     113.061   7634021.4
combined.disjoint_interleaved                   4859   167.828us   648.205ns   166.988us   168.579us    2476.872       2.541   1468635.6
combined.disjoint_ranges                        4936   166.873us   240.471ns   166.286us   167.506us    2468.845       2.506   1463987.1
combined.overlapping_partitions_disjoint_rows   4327   194.935us   361.522ns   194.573us   195.685us    2231.343       3.136   1641970.7
clustering_combined.ranges_generic           2019248   407.841ns     0.400ns   406.640ns   408.353ns       4.447       0.007      3355.7
clustering_combined.ranges_specialized       2103024   401.403ns     0.575ns   400.560ns   401.978ns       4.532       0.007      3287.3
memtable.one_partition_one_row                 42678    20.568us     3.268us     1.766us    24.310us      16.060       0.042     36644.2
memtable.one_partition_many_rows                9732    18.393us   123.843ns    18.139us    27.354us     123.265       0.341    153377.0
memtable.one_large_partition                      88     2.508ms     6.958us     2.502ms     3.936ms   16433.111      35.666  22026319.8
memtable.many_partitions_one_row                6080    31.359us   195.100ns    31.164us    46.210us     255.415       0.546    228214.5
memtable.many_partitions_many_rows               702   451.378us     2.129us   449.249us   794.741us    2834.409       8.323   3908781.5
memtable.many_large_partitions                     4    65.998ms   229.589us    64.545ms    66.228ms  410642.900     846.400 498330728.2
```

The most prominent difference seems to be in the `combined.many_overlapping`, in the number of tasks allocated (`17.688` vs. `113.061`). However, the execution time or the instruction count doesn't seem to differ that much.

Fixes: scylladb/scylladb#14415