### PR TITLE
sstables: print generation without {:d}

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -141,7 +141,7 @@ void filesystem_storage::open(sstable& sst) {
         // the generation of a sstable that exists.
         w.close();
         remove_file(file_path).get();
-        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {:d} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
+        throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
     }
 
     sst.write_toc(std::move(w));


### PR DESCRIPTION
the formatter for sstables::generation_type does not support "d" specifier, so we should not use "{:d}" for printing it. this works before d7c90b52396d9f6b508ebfa8a04b4f784f1c88b8, but after that change, generation_type is not an alias of int64_t anymore. and its formatter does not support "d", so we should either specialize fmt::formatter<generation_type> to support it or just drop the specifier.

since seastar::format() is using
```c++
fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<A>(a)...);
```
to print the arguments with given fmt string, we cannot identify these kind of error at compile time.

at runtime, if we have issues like this, {fmt} would throw exception like:
```
terminate called after throwing an instance of 'fmt::v9::format_error'
  what():  invalid format specifier
```
when constructing the `std::runtime_error` instance.

so, in this change, "d" is removed.