### PR TITLE
migration_manager: disable schema pulls when schema is Raft-managed

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1616,9 +1616,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Set up group0 service earlier since it is needed by group0 setup just below
             ss.local().set_group0(group0_service);
 
-            // Setup group0 early in case the node is bootsrapped already and the group exists
+            // Setup group0 early in case the node is bootstrapped already and the group exists.
             // Need to do it before allowing incomming messaging service connections since
-            // storage proxy's and migration manager's verbs may access group0
+            // storage proxy's and migration manager's verbs may access group0.
+            // This will also disable migration manager schema pulls if needed.
             group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local(), cdc_generation_service.local()).get();
 
             // It's essential to load fencing_version prior to starting the messaging service,

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -139,9 +139,12 @@ public:
     future<> setup_group0(db::system_keyspace&, const std::unordered_set<gms::inet_address>& initial_contact_nodes,
                           std::optional<replace_info>, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
 
-    // Call during the startup procedure before networking is enabled during restart
+    // Call during the startup procedure before networking is enabled.
     //
-    // If the local RAFT feature is enabled start existing group 0 server.
+    // If the local RAFT feature is enabled and we're not in RECOVERY mode:
+    // - start group 0 server if it exists,
+    // - disable migration_manager schema pulls if we're bootstrapping
+    //   or Raft is already fully functioning.
     //
     // Cannot be called twice.
     //

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -365,12 +365,6 @@ future<std::pair<rwlock::holder, group0_upgrade_state>> raft_group0_client::get_
     co_return std::pair{rwlock::holder{}, _upgrade_state};
 }
 
-bool raft_group0_client::using_raft() {
-    // No need to take upgrade log since after the state becomes use_post_raft_procedures
-    // it never goes back
-    return _raft_gr.has_group0() && _upgrade_state == group0_upgrade_state::use_post_raft_procedures;
-}
-
 future<> raft_group0_client::set_group0_upgrade_state(group0_upgrade_state state) {
     // We could explicitly handle abort here but we assume that if someone holds the lock,
     // they will eventually finish (say, due to abort) and release it.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -155,11 +155,6 @@ public:
     // the holder does not actually hold any lock.
     future<std::pair<rwlock::holder, group0_upgrade_state>> get_group0_upgrade_state();
 
-    // Returns true iff the upgrade state is `use_post_raft_procedures`
-    // The function does not take upgrade lock since after the state becomes
-    // `use_post_raft_procedures` it can never go back
-    bool using_raft();
-
     // Ensures that nobody holds any `rwlock::holder`s returned from `get_group0_upgrade_state()`
     // then changes the state to `s`.
     //

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -403,10 +403,6 @@ raft::server& raft_group_registry::group0() {
     return get_server(*_group0_id);
 }
 
-bool raft_group_registry::has_group0() {
-    return bool(_group0_id);
-}
-
 future<> raft_group_registry::start_server_for_group(raft_server_for_group new_grp) {
     auto gid = new_grp.gid;
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -141,9 +141,6 @@ public:
     // after boot/upgrade is complete
     raft::server& group0();
 
-    // return ture iff group0 is configured
-    bool has_group0();
-
     // Start raft server instance, store in the map of raft servers and
     // arm the associated timer to tick the server.
     future<> start_server_for_group(raft_server_for_group grp);


### PR DESCRIPTION
We want to disable `migration_manager` schema pulls and make schema
managed only by Raft group 0 if Raft is enabled. This will be important
with Raft-based topology, when schema will depend on topology (e.g. for
tablets).

We solved the problem partially in PR #13695. However, it's still
possible for a bootstrapping node to pull schema in the early part of
bootstrap procedure, before it setups group 0, because of how the
currently used `_raft_gr.using_raft()` check is implemented.

Here's the list of cases:
- If a node is bootstrapping in non-Raft mode, schema pulls must remain
  enabled.
- If a node is bootstrapping in Raft mode, it should never perform a
  schema pull.
- If a bootstrapped node is restarting in non-Raft mode but with Raft
  feature enabled (which means we should start upgrading to use Raft),
  or restarting in the middle of Raft upgrade procedure, schema pulls must
  remain enabled until the Raft upgrade procedure finishes.
  This is also the case of restarting after RECOVERY.
- If a bootstrapped node is restarting in Raft mode, it should never
  perform a schema pull.

The `raft_group0` service is responsible for setting up Raft during boot
and for the Raft upgrade procedure. So this is the most natural place to
make the decision that schema pulls should be disabled. Instead of
trying to come up with a correct condition that fully covers the above
list of cases, store a `bool` inside `migration_manager` and set it from
`raft_group0` function at the right moment - when we decide that we
should boot in Raft mode, or restart with Raft, or upgrade. Most of the
conditions are already checked in `setup_group0_if_exist`, we just need
to set the bool. Also print a log message when schema pulls are
disabled.

Fix a small bug in `migration_manager::get_schema_for_write` - it was
possible for the function to mark schema as synced without actually
syncing it if it was running concurrently to the Raft upgrade procedure.

Correct some typos in comments and update the comments.

Fixes #12870