### PR TITLE
 reader_concurrency_semaphore: disable CPU based admission for streaming semaphore

### DIFF
--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -186,6 +186,7 @@ private:
     size_t _max_queue_length = std::numeric_limits<size_t>::max();
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
+    bool _cpu_based_admission_enabled = true;
     stats _stats;
     bool _stopped = false;
     bool _evicting = false;
@@ -274,7 +275,8 @@ public:
             sstring name,
             size_t max_queue_length,
             utils::updateable_value<uint32_t> serialize_limit_multiplier,
-            utils::updateable_value<uint32_t> kill_limit_multiplier);
+            utils::updateable_value<uint32_t> kill_limit_multiplier,
+            bool cpu_based_admission_enabled);
 
     /// Create a semaphore with practically unlimited count and memory.
     ///
@@ -291,8 +293,10 @@ public:
             ssize_t memory = std::numeric_limits<ssize_t>::max(),
             size_t max_queue_length = std::numeric_limits<size_t>::max(),
             utils::updateable_value<uint32_t> serialize_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()),
-            utils::updateable_value<uint32_t> kill_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()))
-        : reader_concurrency_semaphore(count, memory, std::move(name), max_queue_length, std::move(serialize_limit_multipler), std::move(kill_limit_multipler))
+            utils::updateable_value<uint32_t> kill_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+            bool cpu_based_admission_enabled = true)
+        : reader_concurrency_semaphore(count, memory, std::move(name), max_queue_length, std::move(serialize_limit_multipler),
+                std::move(kill_limit_multipler), cpu_based_admission_enabled)
     {}
 
     virtual ~reader_concurrency_semaphore();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -332,7 +332,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
         "_read_concurrency_sem",
         max_inactive_queue_length(),
         _cfg.reader_concurrency_semaphore_serialize_limit_multiplier,
-        _cfg.reader_concurrency_semaphore_kill_limit_multiplier)
+        _cfg.reader_concurrency_semaphore_kill_limit_multiplier,
+        true)
     // No timeouts or queue length limits - a failure here can kill an entire repair.
     // Trust the caller to limit concurrency.
     , _streaming_concurrency_sem(
@@ -341,7 +342,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             "_streaming_concurrency_sem",
             std::numeric_limits<size_t>::max(),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
-            utils::updateable_value(std::numeric_limits<uint32_t>::max()))
+            utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+            false)
     // No limits, just for accounting.
     , _compaction_concurrency_sem(reader_concurrency_semaphore::no_limits{}, "compaction")
     , _system_read_concurrency_sem(
@@ -351,7 +353,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             "_system_read_concurrency_sem",
             std::numeric_limits<size_t>::max(),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
-            utils::updateable_value(std::numeric_limits<uint32_t>::max()))
+            utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+            true)
     , _row_cache_tracker(cache_tracker::register_metrics::yes)
     , _apply_stage("db_apply", &database::do_apply)
     , _version(empty_version)

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -30,7 +30,8 @@ sstables_manager::sstables_manager(
         "sstable_metadata_concurrency_sem",
         std::numeric_limits<size_t>::max(),
         utils::updateable_value(std::numeric_limits<uint32_t>::max()),
-        utils::updateable_value(std::numeric_limits<uint32_t>::max()))
+        utils::updateable_value(std::numeric_limits<uint32_t>::max()),
+        false)
     , _dir_semaphore(dir_sem)
 {
 }


### PR DESCRIPTION
CPU based amdmission was introduced to allow moving the semaphore in front of the cache. Cache reads don't benefit from concurrency, on the contrary, concurrency can actually and up making latencies of individual reads worse, even if the overall throughput is preserved. To acomodate this use-case, the CPU based admission was introduced, keeping concurrency at 1, until the current read misses and has to go to disk, at which point conncurrency is beneficial and a new read is admitted. This admission criteria is only beneficial for workloads that go through the cache, like the user and system semaphore. For the streaming semaphore whoever, it is actively damaging throughput, artificially reducing concurrency of maintenance operations, which all bypass the cache.
To accomodate both workloads, this patch adds a new option to the concurrency semaphore, which allows opting in or out of the CPU based scheduling. The streaming semaphore then opts out of it. A test is also added to confirm the option works as intended.

Fixes: #14425