### PR TITLE
schema_mutations, migration_manager: Ignore empty partitions in per-table digest

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -881,6 +881,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , uuid_sstable_identifiers_enabled(this,
             "uuid_sstable_identifiers_enabled", liveness::LiveUpdate, value_status::Used, true, "If set to true, each newly created sstable will have a UUID "
             "based generation identifier, and such files are not readable by previous Scylla versions.")
+    , table_digest_insensitive_to_expiry(this, "table_digest_insensitive_to_expiry", liveness::MustRestart, value_status::Used, true,
+            "When enabled, per-table schema digest calculation ignores empty partitions.")
     , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "Only turn this option on if you want to import tables from Cassandra containing counters, and you are SURE that no counters in that table were created in a version earlier than Cassandra 2.1."
         " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")

--- a/db/config.hh
+++ b/db/config.hh
@@ -357,6 +357,7 @@ public:
     named_value<bool> enable_sstables_md_format;
     named_value<sstring> sstable_format;
     named_value<bool> uuid_sstable_identifiers_enabled;
+    named_value<bool> table_digest_insensitive_to_expiry;
     named_value<bool> enable_dangerous_direct_import_of_cassandra_counters;
     named_value<bool> enable_shard_aware_drivers;
     named_value<bool> enable_ipv6_dns_lookup;

--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -24,6 +24,10 @@ enum class schema_feature {
     PER_TABLE_PARTITIONERS,
     SCYLLA_KEYSPACES,
     SCYLLA_AGGREGATES,
+
+    // When enabled, schema_mutations::digest() will skip empty mutations (with only tombstones),
+    // so that the digest remains the same after schema tables are compacted.
+    TABLE_DIGEST_INSENSITIVE_TO_EXPIRY,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
@@ -33,7 +37,8 @@ using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::CDC_OPTIONS,
     schema_feature::PER_TABLE_PARTITIONERS,
     schema_feature::SCYLLA_KEYSPACES,
-    schema_feature::SCYLLA_AGGREGATES
+    schema_feature::SCYLLA_AGGREGATES,
+    schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY
     >>;
 
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1067,6 +1067,9 @@ read_tables_for_keyspaces(distributed<service::storage_proxy>& proxy, const std:
 {
     std::map<table_id, schema_mutations> result;
     for (auto&& [keyspace_name, sel] : tables_per_keyspace) {
+        if (!sel.tables.contains(kind)) {
+            continue;
+        }
         for (auto&& table_name : sel.tables.find(kind)->second) {
             auto qn = qualified_name(keyspace_name, table_name);
             auto muts = co_await read_table_mutations(proxy, qn, get_table_holder(kind));

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -189,7 +189,7 @@ future<mutation> read_keyspace_mutation(distributed<service::storage_proxy>&, co
 // Must be called on shard 0.
 future<semaphore_units<>> hold_merge_lock() noexcept;
 
-future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations);
+future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations, bool reload = false);
 
 // Recalculates the local schema version.
 //

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -14,6 +14,7 @@
 #include "schema/schema_fwd.hh"
 #include "schema_features.hh"
 #include "utils/hashing.hh"
+#include "gms/feature_service.hh"
 #include "schema_mutations.hh"
 #include "types/map.hh"
 #include "query-result-set.hh"
@@ -66,7 +67,8 @@ class config;
 
 class schema_ctxt {
 public:
-    schema_ctxt(const config&, std::shared_ptr<data_dictionary::user_types_storage> uts, replica::database* = nullptr);
+    schema_ctxt(const config&, std::shared_ptr<data_dictionary::user_types_storage> uts, const gms::feature_service&,
+                replica::database* = nullptr);
     schema_ctxt(replica::database&);
     schema_ctxt(distributed<replica::database>&);
     schema_ctxt(distributed<service::storage_proxy>&);
@@ -87,11 +89,16 @@ public:
         return *_user_types;
     }
 
-    replica::database* get_db() {
+    const gms::feature_service& features() const {
+        return _features;
+    }
+
+    replica::database* get_db() const {
         return _db;
     }
 private:
     replica::database* _db;
+    const gms::feature_service& _features;
     const db::extensions& _extensions;
     const unsigned _murmur3_partitioner_ignore_msb_bits;
     const uint32_t _schema_registry_grace_period;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -75,6 +75,9 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.uuid_sstable_identifiers_enabled()) {
         fcfg._disabled_features.insert("UUID_SSTABLE_IDENTIFIERS"s);
     }
+    if (!cfg.table_digest_insensitive_to_expiry()) {
+        fcfg._disabled_features.insert("TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"s);
+    }
 
     if (!utils::get_local_injector().enter("features_enable_test_feature")) {
         fcfg._disabled_features.insert("TEST_ONLY_FEATURE"s);
@@ -181,6 +184,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(per_table_partitioners);
     f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);
     f.set_if<db::schema_feature::SCYLLA_AGGREGATES>(aggregate_storage_options);
+    f.set_if<db::schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY>(table_digest_insensitive_to_expiry);
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -118,6 +118,7 @@ public:
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
     gms::feature tablets { *this, "TABLETS"sv };
     gms::feature uuid_sstable_identifiers { *this, "UUID_SSTABLE_IDENTIFIERS"sv };
+    gms::feature table_digest_insensitive_to_expiry { *this, "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -12,6 +12,7 @@
 #include "mutation/mutation.hh"
 #include "schema/schema_fwd.hh"
 #include "mutation/canonical_mutation.hh"
+#include "db/schema_features.hh"
 
 // Commutative representation of table schema
 // Equality ignores tombstones.
@@ -124,7 +125,7 @@ public:
 
     bool is_view() const;
 
-    table_schema_version digest() const;
+    table_schema_version digest(db::schema_features) const;
     std::optional<sstring> partitioner() const;
 
     bool operator==(const schema_mutations&) const;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -368,6 +368,12 @@ future<> migration_manager::merge_schema_from(netw::messaging_service::msg_addr 
     return db::schema_tables::merge_schema(_sys_ks, proxy.container(), _feat, std::move(mutations));
 }
 
+future<> migration_manager::reload_schema() {
+    mlogger.info("Reloading schema");
+    std::vector<mutation> mutations;
+    return db::schema_tables::merge_schema(_sys_ks, _storage_proxy.container(), _feat, std::move(mutations), true);
+}
+
 future<> migration_manager::merge_schema_from(netw::messaging_service::msg_addr src, const std::vector<frozen_mutation>& mutations)
 {
     if (_as.abort_requested()) {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -94,6 +94,7 @@ public:
     // Coalesces requests.
     future<> merge_schema_from(netw::msg_addr);
     future<> do_merge_schema_from(netw::msg_addr);
+    future<> reload_schema();
 
     // Merge mutations received from src.
     // Keep mutations alive around whole async operation.

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -824,7 +824,7 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
     }, cfg_in).then([tmp = std::move(tmp)] {});
 }
 
-SEASTAR_TEST_CASE(test_schema_digest_does_not_change) {
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_without_digest_feature) {
     std::vector<utils::UUID> expected_digests{
         utils::UUID("264f79fc-61bd-3670-8d6e-2794f9787b0a"),
         utils::UUID("d2035515-b299-3265-b920-7dbe5306e72a"),
@@ -842,7 +842,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change) {
             std::move(expected_digests), [] (cql_test_env& e) {});
 }
 
-SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns) {
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns_without_digest_feature) {
     std::vector<utils::UUID> expected_digests{
         utils::UUID("036153ec-4565-34fb-a878-ce347b94f247"),
         utils::UUID("fa2e7735-7604-3202-8ce9-399996305aca"),
@@ -859,7 +859,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns) {
             std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS", "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"}, std::move(expected_digests), [] (cql_test_env& e) {});
 }
 
-SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions) {
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions_without_digest_feature) {
     std::vector<utils::UUID> expected_digests{
         utils::UUID("6fa38d16-bbc4-3da5-bda5-680329789d8f"),
         utils::UUID("649bf7ec-fd64-3ccb-adde-3887fc1432be"),
@@ -882,7 +882,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions) {
         });
 }
 
-SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_cdc_options) {
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_cdc_options_without_digest_feature) {
     auto ext = std::make_shared<db::extensions>();
     ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
     std::vector<utils::UUID> expected_digests{
@@ -907,7 +907,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_cdc_options) {
         std::move(ext));
 }
 
-SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_keyspace_storage_options) {
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_keyspace_storage_options_without_digest_feature) {
     std::vector<utils::UUID> expected_digests{
         utils::UUID("d9f78213-ff9f-3208-9083-47e18cebf06f"),
         utils::UUID("30e2cf99-389d-381f-82b9-3fcdcf66a1fb"),
@@ -923,6 +923,112 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_keyspace_storage_optio
     return test_schema_digest_does_not_change_with_disabled_features(
         "./test/resource/sstables/schema_digest_test_keyspace_storage_options",
         std::set<sstring>{"TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"},
+        std::move(expected_digests),
+        [] (cql_test_env& e) {
+            e.execute_cql("create keyspace tests_s3 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }"
+                    " and storage = { 'type': 'S3', 'bucket': 'b1', 'endpoint': 'localhost' };").get();
+            e.execute_cql("create table tests_s3.table1 (pk int primary key, c1 int, c2 int)").get();
+        });
+}
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change) {
+    std::vector<utils::UUID> expected_digests{
+        utils::UUID("264f79fc-61bd-3670-8d6e-2794f9787b0a"),
+        utils::UUID("d2035515-b299-3265-b920-7dbe5306e72a"),
+        utils::UUID("d2035515-b299-3265-b920-7dbe5306e72a"),
+        utils::UUID("de49e92f-a00d-3f24-8779-d07de26708cb"),
+        utils::UUID("de49e92f-a00d-3f24-8779-d07de26708cb"),
+        utils::UUID("75550bef-3a95-3901-be80-4540f7d8a311"),
+        utils::UUID("aff80a2a-4a72-35bb-9ac3-f851013610d0"),
+        utils::UUID("030100b2-27aa-32f2-8964-0090a1af75f8"),
+        utils::UUID("16ba4b2d-7c61-393b-ba51-0890e25f4e22"),
+        utils::UUID("de49e92f-a00d-3f24-8779-d07de26708cb"),
+    };
+    return test_schema_digest_does_not_change_with_disabled_features("./test/resource/sstables/schema_digest_test",
+            std::set<sstring>{"COMPUTED_COLUMNS", "CDC", "KEYSPACE_STORAGE_OPTIONS"},
+            std::move(expected_digests), [] (cql_test_env& e) {});
+}
+
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns) {
+    std::vector<utils::UUID> expected_digests{
+        utils::UUID("036153ec-4565-34fb-a878-ce347b94f247"),
+        utils::UUID("fa2e7735-7604-3202-8ce9-399996305aca"),
+        utils::UUID("fa2e7735-7604-3202-8ce9-399996305aca"),
+        utils::UUID("94606636-ae43-3e0a-b238-e7f0e33ef600"),
+        utils::UUID("94606636-ae43-3e0a-b238-e7f0e33ef600"),
+        utils::UUID("5a89ff92-9b5c-32eb-ad5a-5def856e3024"),
+        utils::UUID("26808d79-e22a-3d20-88a7-d812301ff342"),
+        utils::UUID("371527f3-2f26-32a6-8b29-bb0ce0735b61"),
+        utils::UUID("02ed06b1-c384-3f83-b116-fe94f5bf647a"),
+        utils::UUID("94606636-ae43-3e0a-b238-e7f0e33ef600"),
+    };
+    return test_schema_digest_does_not_change_with_disabled_features("./test/resource/sstables/schema_digest_test_computed_columns",
+            std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS"}, std::move(expected_digests), [] (cql_test_env& e) {});
+}
+
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions) {
+    std::vector<utils::UUID> expected_digests{
+        utils::UUID("6fa38d16-bbc4-3da5-bda5-680329789d8f"),
+        utils::UUID("649bf7ec-fd64-3ccb-adde-3887fc1432be"),
+        utils::UUID("649bf7ec-fd64-3ccb-adde-3887fc1432be"),
+        utils::UUID("48fd0c1b-9777-34be-8c16-187c6ab55cfc"),
+        utils::UUID("48fd0c1b-9777-34be-8c16-187c6ab55cfc"),
+        utils::UUID("9b842fb8-2b89-3f9f-a344-f648cb27a226"),
+        utils::UUID("e596cbc4-60f8-3788-96e6-fdfb105ba39f"),
+        utils::UUID("0f214b9c-81a5-3771-8722-4763ab8fd0ee"),
+        utils::UUID("08624ebc-c0d2-3e7a-bcd7-4fcb442626e4"),
+        utils::UUID("48fd0c1b-9777-34be-8c16-187c6ab55cfc"),
+    };
+    return test_schema_digest_does_not_change_with_disabled_features(
+        "./test/resource/sstables/schema_digest_with_functions_test",
+        std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS"},
+        std::move(expected_digests),
+        [] (cql_test_env& e) {
+            e.execute_cql("create function twice(val int) called on null input returns int language lua as 'return 2 * val';").get();
+            e.execute_cql("create function my_add(a int, b int) called on null input returns int language lua as 'return a + b';").get();
+        });
+}
+
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_cdc_options) {
+    auto ext = std::make_shared<db::extensions>();
+    ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
+    std::vector<utils::UUID> expected_digests{
+        utils::UUID("ff69e387-64ca-3335-b488-b7a615908148"),
+        utils::UUID("7f1ac621-fc68-3420-bc9b-54520da40418"),
+        utils::UUID("7f1ac621-fc68-3420-bc9b-54520da40418"),
+        utils::UUID("09899769-4e7f-3119-9769-e3db3d99455b"),
+        utils::UUID("09899769-4e7f-3119-9769-e3db3d99455b"),
+        utils::UUID("fdfdea09-fee9-3fd4-945f-b91a7a2e0e39"),
+        utils::UUID("44e79540-5cc5-3617-88c0-267fe7cc2232"),
+        utils::UUID("e2b673e7-04c0-37cb-b076-77951f2f5452"),
+        utils::UUID("089d5e42-065a-3e19-a608-58a960816c51"),
+        utils::UUID("09899769-4e7f-3119-9769-e3db3d99455b"),
+    };
+    return test_schema_digest_does_not_change_with_disabled_features(
+        "./test/resource/sstables/schema_digest_test_cdc_options",
+        std::set<sstring>{"KEYSPACE_STORAGE_OPTIONS"},
+        std::move(expected_digests),
+        [] (cql_test_env& e) {
+            e.execute_cql("create table tests.table_cdc (pk int primary key, c1 int, c2 int) with cdc = {'enabled':'true'};").get();
+        },
+        std::move(ext));
+}
+
+SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_keyspace_storage_options) {
+    std::vector<utils::UUID> expected_digests{
+        utils::UUID("d9f78213-ff9f-3208-9083-47e18cebf06f"),
+        utils::UUID("30e2cf99-389d-381f-82b9-3fcdcf66a1fb"),
+        utils::UUID("30e2cf99-389d-381f-82b9-3fcdcf66a1fb"),
+        utils::UUID("98d63879-6633-3708-880e-8716fcbadda0"),
+        utils::UUID("98d63879-6633-3708-880e-8716fcbadda0"),
+        utils::UUID("1f971ee2-42d1-3564-ae89-0090803d6d58"),
+        utils::UUID("60444aca-708a-387f-b571-e4c0806ab78d"),
+        utils::UUID("11c00de3-d47f-38bd-84f1-0f5e1179a168"),
+        utils::UUID("c495feac-b2a4-3c50-91a5-363630f878d6"),
+        utils::UUID("3fc03c97-8010-3746-8cea-e8b9ac27fe4e"),
+    };
+    return test_schema_digest_does_not_change_with_disabled_features(
+        "./test/resource/sstables/schema_digest_test_keyspace_storage_options",
+        std::set<sstring>{},
         std::move(expected_digests),
         [] (cql_test_env& e) {
             e.execute_cql("create keyspace tests_s3 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }"

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -812,8 +812,6 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
 
         expect_digest(sf, expected_digests[4]);
 
-        // FIXME: schema_mutations::digest() is still sensitive to expiry, so we can check versions only after forward_jump_clocks()
-        // otherwise the results would not be stable.
         expect_version("tests", "table1", expected_digests[5]);
         expect_version("ks", "tbl", expected_digests[6]);
         expect_version("ks", "tbl_view", expected_digests[7]);
@@ -840,7 +838,8 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change) {
         utils::UUID("de49e92f-a00d-3f24-8779-d07de26708cb"),
     };
     return test_schema_digest_does_not_change_with_disabled_features("./test/resource/sstables/schema_digest_test",
-            std::set<sstring>{"COMPUTED_COLUMNS", "CDC", "KEYSPACE_STORAGE_OPTIONS"}, std::move(expected_digests), [] (cql_test_env& e) {});
+            std::set<sstring>{"COMPUTED_COLUMNS", "CDC", "KEYSPACE_STORAGE_OPTIONS", "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"},
+            std::move(expected_digests), [] (cql_test_env& e) {});
 }
 
 SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns) {
@@ -857,7 +856,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_after_computed_columns) {
         utils::UUID("94606636-ae43-3e0a-b238-e7f0e33ef600"),
     };
     return test_schema_digest_does_not_change_with_disabled_features("./test/resource/sstables/schema_digest_test_computed_columns",
-            std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS"}, std::move(expected_digests), [] (cql_test_env& e) {});
+            std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS", "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"}, std::move(expected_digests), [] (cql_test_env& e) {});
 }
 
 SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions) {
@@ -875,7 +874,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_functions) {
     };
     return test_schema_digest_does_not_change_with_disabled_features(
         "./test/resource/sstables/schema_digest_with_functions_test",
-        std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS"},
+        std::set<sstring>{"CDC", "KEYSPACE_STORAGE_OPTIONS", "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"},
         std::move(expected_digests),
         [] (cql_test_env& e) {
             e.execute_cql("create function twice(val int) called on null input returns int language lua as 'return 2 * val';").get();
@@ -900,7 +899,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_cdc_options) {
     };
     return test_schema_digest_does_not_change_with_disabled_features(
         "./test/resource/sstables/schema_digest_test_cdc_options",
-        std::set<sstring>{"KEYSPACE_STORAGE_OPTIONS"},
+        std::set<sstring>{"KEYSPACE_STORAGE_OPTIONS", "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"},
         std::move(expected_digests),
         [] (cql_test_env& e) {
             e.execute_cql("create table tests.table_cdc (pk int primary key, c1 int, c2 int) with cdc = {'enabled':'true'};").get();
@@ -923,7 +922,7 @@ SEASTAR_TEST_CASE(test_schema_digest_does_not_change_with_keyspace_storage_optio
     };
     return test_schema_digest_does_not_change_with_disabled_features(
         "./test/resource/sstables/schema_digest_test_keyspace_storage_options",
-        std::set<sstring>{},
+        std::set<sstring>{"TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"},
         std::move(expected_digests),
         [] (cql_test_env& e) {
             e.execute_cql("create keyspace tests_s3 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }"

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -34,10 +34,12 @@ static schema_ptr random_schema() {
 
 struct dummy_init {
     std::unique_ptr<db::config> config;
+    gms::feature_service fs;
 
-    dummy_init() {
-        config = std::make_unique<db::config>();
-        local_schema_registry().init(db::schema_ctxt(*config,std::make_shared<data_dictionary::dummy_user_types_storage>()));
+    dummy_init()
+            : config(std::make_unique<db::config>())
+            , fs(gms::feature_config_from_db_config(*config)) {
+        local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs));
     }
 };
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -534,7 +534,9 @@ schema_ptr do_load_schema_from_schema_tables(std::filesystem::path scylla_data_p
 
     db::config dbcfg;
     auto user_type_storage = std::make_shared<single_keyspace_user_types_storage>(std::move(utm));
-    db::schema_ctxt ctxt(dbcfg, user_type_storage);
+    gms::feature_service features(gms::feature_config_from_db_config(dbcfg));
+    db::schema_ctxt ctxt(dbcfg, user_type_storage, features);
+
     schema_mutations muts(std::move(*tables), std::move(*columns), std::move(view_virtual_columns), std::move(computed_columns), std::move(indexes),
             std::move(dropped_columns), std::move(scylla_tables));
     return db::schema_tables::create_table_from_mutations(ctxt, muts);


### PR DESCRIPTION
Schema digest is calculated by querying for mutations of all schema
tables, then compacting them so that all tombstones in them are
dropped. However, even if the mutation becomes empty after compaction,
we still feed its partition key. If the same mutations were compacted
prior to the query, because the tombstones expire, we won't get any
mutation at all and won't feed the partition key. So schema digest
will change once an empty partition of some schema table is compacted
away.

Tombstones expire 7 days after schema change which introduces them. If
one of the nodes is restarted after that, it will compute a different
table schema digest on boot. This may cause performance problems. When
sending a request from coordinator to replica, the replica needs
schema_ptr of exact schema version request by the coordinator. If it
doesn't know that version, it will request it from the coordinator and
perform a full schema merge. This adds latency to every such request.
Schema versions which are not referenced are currently kept in cache
for only 1 second, so if request flow has low-enough rate, this
situation results in perpetual schema pulls.

After ae8d2a550d227de2221c310bd38704ad2e078b35 (5.2.0), it is more liekly to
run into this situation, because table creation generates tombstones
for all schema tables relevant to the table, even the ones which
will be otherwise empty for the new table (e.g. computed_columns).

This change inroduces a cluster feature which when enabled will change
digest calculation to be insensitive to expiry by ignoring empty
partitions in digest calculation. When the feature is enabled,
schema_ptrs are reloaded so that the window of discrepancy during
transition is short and no rolling restart is required.

A similar problem was fixed for per-node digest calculation in
c2ba94dc39e4add9db213751295fb17b95e6b962. Per-table digest calculation
was not fixed at that time because we didn't persist enabled features
and they were not enabled early-enough on boot for us to depend on
them in digest calculation. Now they are enabled before non-system
tables are loaded so digest calculation can rely on cluster features.

Fixes #4485.

Manually tested using ccm on cluster upgrade scenarios and node restarts.