### PR TITLE
build: cmake: include pretty_printers.cc in util

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(utils
     managed_bytes.cc
     multiprecision_int.cc
     murmur_hash.cc
+    pretty_printers.cc
     rate_limiter.cc
     rjson.cc
     runtime.cc


### PR DESCRIPTION
we added pretty_printers.cc back in
83c70ac04f6782a33d861610b52233781484ad6c, in which configure.py is updated. so let's sync the CMake building system accordingly.