### PR TITLE
sstable: do not call into sstable in filesystem_storage::open()

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -133,7 +133,12 @@ void filesystem_storage::open(sstable& sst) {
     // sstable being created in parallel with the same generation.
     file_output_stream_options options;
     options.buffer_size = 4096;
-    auto w = sst.make_component_file_writer(component_type::TemporaryTOC, std::move(options)).get0();
+    auto sink = make_component_sink(sst, component_type::TemporaryTOC,
+                                    open_flags::wo |
+                                    open_flags::create |
+                                    open_flags::exclusive,
+                                    options).get0();
+    auto w = file_writer(output_stream<char>(std::move(sink)), std::move(file_path));
 
     bool toc_exists = file_exists(sst.filename(component_type::TOC)).get0();
     if (toc_exists) {


### PR DESCRIPTION
before this change, filesystem_storage::open() reuses
`sstable::make_component_file_writer()` to create the
temporary toc, it will rename the temporary toc to the
real TOC when sealing the sstable.

but this prevents us from reusing filesystem_storage in
yet another storage backend. as the

1. create temporary
2. rename temporary to toc

dance only applies to filesystem_storage. when
filesystem_storage calls into sstable, it calls `sst.make_component_file_writer()`,
which in turn calls the `_storage->make_component_sink()`.
but at this moment, `_storage` is not necessarily `filesystem_storage`
anymore. it could be a wrapper around `filesystem_storage`,
which is not aware of the create-rename dance. and could do
a lot more than create a temporary file when asked to
"make_component_sink()".

if we really want to go this way by reusing sstable's API
in `filesystem_storage` to create a temporary toc, we will
have to rename the whatever temporary toc component created
by the wrapper backend to the toc with the seal() func. but
again, this rename op is only implemented in the
filesystem_storage backend. to mirror this operation in
the wrapper backend does not make sense at all -- it
does not have to be aware of the filesystem_storage's internals.

so in this change, instead of reusing the
`sstable::make_component_file_writer()`, we just inline
its implementation in filesystem_storage to avoid this
problem. this is also an improvement from the design
perspective, as the storage should not call into its
the higher abstraction -- sstable.