### PR TITLE
doc: improve the Unified Installer page

### DIFF
--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -8,10 +8,9 @@ If you have root privileges, it is recommended to download the OS specific packa
 Supported distros
 =================
 
-* CentOS 7 (Only support root offline install)
-* CentOS 8
-* Ubuntu 18.04 (developer-mode is used if NOFILE rlimit is too low)
-* Debian 10
+See :doc:`OS Support </getting-started/os-support>` for information about supported Linux distributions and versions.
+
+Note that if you're on CentOS 7, only root offline install is supported.
 
 Download and install
 ====================

--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -2,30 +2,34 @@
 ScyllaDB Unified Installer (relocatable executable)
 ====================================================
 
-This document covers how to install, uninstall, and upgrade using the Scylla Unified Installer. The Unified Installer is recommended to be used when you do not have root privileges to the server.
-If you have root privileges, it is recommended to download the OS specific packages (RPMs and DEBs) and install them with the package manager (dnf and apt).
+This document covers installing, uninstalling, and upgrading ScyllaDB using Unified Installer. 
+Unified Installer is recommended when you do not have root privileges to the server.
+If you have root privileges, we recommend installing ScyllaDB with 
+:doc:`ScyllaDB Web Installer </getting-started/installation-common/scylla-web-installer/>`
+or by downloading the OS-specific packages (RPMs and DEBs) and installing them with 
+the package manager (dnf and apt).
 
-Supported distros
-=================
-
+Prerequisites
+---------------
+Ensure your platform is supported by the ScyllaDB version you want to install. 
 See :doc:`OS Support </getting-started/os-support>` for information about supported Linux distributions and versions.
 
-Note that if you're on CentOS 7, only root offline install is supported.
+Note that if you're on CentOS 7, only root offline installation is supported.
 
-Download and install
-====================
+Download and Install
+-----------------------
 
-For installation without root privileges, follow the instructions on `Scylla Download Center <https://www.scylladb.com/download/?platform=tar>`_
+For installation without root privileges, follow the instructions on `Scylla Download Center <https://www.scylladb.com/download/?platform=tar>`_.
 
-Upgrade / Downgrade/ Uninstall
-==============================
+Upgrade/ Downgrade/ Uninstall
+---------------------------------
 
 .. _unified-installed-upgrade:
 
 Upgrade
--------
+=========
 
-The unified package is based on a binary package; it’s not a RPM / DEB packages, so it doesn’t upgrade or downgrade by yum / apt. Currently, only install.sh of scylla supports the upgrade.
+The unified package is based on a binary package; it’s not a RPM / DEB packages, so it doesn’t upgrade or downgrade by yum / apt. To upgrade ScyllaDB, run the ``install.sh`` script.
 
 Root install:
 
@@ -39,10 +43,10 @@ Nonroot install
 
     ./install.sh --upgrade --nonroot
 
-.. note:: the installation script does not upgrade scylla-jmx and scylla-tools. You will have to do this separately. 
+.. note:: The installation script does not upgrade scylla-jmx and scylla-tools. You will have to upgrade them separately. 
 
 Uninstall
----------
+===========
 
 Root uninstall:
 
@@ -58,6 +62,6 @@ Nonroot uninstall
 
 
 Downgrade
----------
+===========
 
-To downgrade to your original Scylla version, use the Uninstall_ procedure above and then install the original Scylla packages. 
+To downgrade to your original ScyllaDB version, use the Uninstall_ procedure, then install the original ScyllaDB version. 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/14033

This PR:
- replaces the OUTDATED list of platforms supported by Unified Installer with a link to the "OS Support" page. In this way, the list of supported OSes will be documented in one place, preventing outdated documentation.
- improves the language and syntax, including:
    - Improving the wording.
    - Replacing "Scylla" with "ScyllaDB"
    - Fixing language mistakes
    - Fixing heading underline so that the headings render correctly.