### PR TITLE
cql3, secondary index: consistently choose index to use in a query

### DIFF
--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -66,8 +66,9 @@ def test_partition_order_with_si(cql, test_keyspace):
 # The order tested in this case was decided as a good first step in issue
 # #7969, but it's possible that it will eventually be implemented another
 # way, e.g. dynamically based on estimated query selectivity statistics.
+# In any case, the order must be consistent across coordinators and time
+# (and upgrades...) to allow paged queries that use an index to continue.
 # Ref: #7969
-@pytest.mark.xfail(reason="The order of picking indexes is currently arbitrary. Issue #7969")
 def test_order_of_indexes(scylla_only, cql, test_keyspace):
     schema = 'p int primary key, v1 int, v2 int, v3 int'
     with new_test_table(cql, test_keyspace, schema) as table:


### PR DESCRIPTION
When a table has secondary indexes on *multiple* columns, and several such columns are used for filtering in a query, Scylla chooses one of these indexes as the main driver of the query, and the second column's restriction is implemented as filtering.

Before this patch, the index to use was chosen fairly randomly, based on the order of the indexes in the schema. This order may be different in different coordinators, and may even change across restarts on the same coordinators. This is not only inconsistent, it can cause outright wrong results when using *paging* and switching (or restarting) coordinates in the middle of a paged scan... One coordinator saves one index's key in the paging state, and then the other coordinator gets this paging state and wrongly believes it is supposed to be a key of a *different* index.

The fix in this patch is to pick the index suitable for the first indexed column mentioned in the query. This has two benefits over the situation before the patch:

1. The decision of which index to use no longer changes between coordinators or across restarts - it just depends on the schema and the specific query.

2. Different indexes can have different "specificity" so using one or the other can change the query's performance. After this patch, the user is in control over which index is used by changing the order of terms in the query. A curious user can use tracing to check which index was used to implement a particular query.

An xfailing test we had for this issue no longer fails, so the "xfail" marker is removed.

Fixes #7969