### PR TITLE
combined: mergers: remove recursion in operator()()

### DIFF
--- a/readers/combined.cc
+++ b/readers/combined.cc
@@ -32,6 +32,7 @@ struct mutation_fragment_and_stream_id {
 };
 
 using mutation_fragment_batch = boost::iterator_range<merger_vector<mutation_fragment_and_stream_id>::iterator>;
+using mutation_fragment_batch_opt = std::optional<mutation_fragment_batch>;
 
 template<typename Producer>
 concept FragmentProducer = requires(Producer p, dht::partition_range part_range, position_range pos_range) {
@@ -226,6 +227,7 @@ private:
     streamed_mutation::forwarding _fwd_sm;
     mutation_reader::forwarding _fwd_mr;
 private:
+    future<mutation_fragment_batch_opt> maybe_produce_batch();
     void maybe_add_readers_at_partition_boundary();
     void maybe_add_readers(const std::optional<dht::ring_position_view>& pos);
     void add_readers(std::vector<flat_mutation_reader_v2> new_readers);
@@ -469,15 +471,21 @@ mutation_reader_merger::mutation_reader_merger(schema_ptr schema,
 }
 
 future<mutation_fragment_batch> mutation_reader_merger::operator()() {
+    return repeat_until_value([this] { return maybe_produce_batch(); });
+}
+
+future<mutation_fragment_batch_opt> mutation_reader_merger::maybe_produce_batch() {
     // Avoid merging-related logic if we know that only a single reader owns
     // current partition.
     if (_single_reader.reader != reader_iterator{}) {
         if (_single_reader.reader->is_buffer_empty()) {
             if (_single_reader.reader->is_end_of_stream()) {
                 _current.clear();
-                return make_ready_future<mutation_fragment_batch>(_current, &_single_reader);
+                return make_ready_future<mutation_fragment_batch_opt>(mutation_fragment_batch(_current, &_single_reader));
             }
-            return _single_reader.reader->fill_buffer().then([this] { return operator()(); });
+            return _single_reader.reader->fill_buffer().then([] {
+                return make_ready_future<mutation_fragment_batch_opt>();
+            });
         }
         _current.clear();
         _current.emplace_back(_single_reader.reader->pop_mutation_fragment(), &*_single_reader.reader);
@@ -485,22 +493,22 @@ future<mutation_fragment_batch> mutation_reader_merger::operator()() {
         if (_current.back().fragment.is_end_of_partition()) {
             _next.emplace_back(std::exchange(_single_reader.reader, {}), mutation_fragment_v2::kind::partition_end);
         }
-        return make_ready_future<mutation_fragment_batch>(_current);
+        return make_ready_future<mutation_fragment_batch_opt>(_current);
     }
 
     if (in_gallop_mode()) {
         return advance_galloping_reader().then([this] (needs_merge needs_merge) {
             if (!needs_merge) {
-                return make_ready_future<mutation_fragment_batch>(_current);
+                return make_ready_future<mutation_fragment_batch_opt>(_current);
             }
             // Galloping reader may have lost to some other reader. In that case, we should proceed
             // with standard merging logic.
-            return (*this)();
+            return make_ready_future<mutation_fragment_batch_opt>();
         });
     }
 
     if (!_next.empty()) {
-        return prepare_next().then([this] { return (*this)(); });
+        return prepare_next().then([] { return make_ready_future<mutation_fragment_batch_opt>(); });
     }
 
     _current.clear();
@@ -509,7 +517,7 @@ future<mutation_fragment_batch> mutation_reader_merger::operator()() {
     // readers for the next one.
     if (_fragment_heap.empty()) {
         if (!_halted_readers.empty() || _reader_heap.empty()) {
-            return make_ready_future<mutation_fragment_batch>(_current);
+            return make_ready_future<mutation_fragment_batch_opt>(_current);
         }
 
         auto key = [] (const merger_vector<reader_and_fragment>& heap) -> const dht::decorated_key& {
@@ -529,7 +537,7 @@ future<mutation_fragment_batch> mutation_reader_merger::operator()() {
             _current.emplace_back(std::move(_fragment_heap.back().fragment), &*_single_reader.reader);
             _fragment_heap.clear();
             _gallop_mode_hits = 0;
-            return make_ready_future<mutation_fragment_batch>(_current);
+            return make_ready_future<mutation_fragment_batch_opt>(_current);
         }
     }
 
@@ -555,7 +563,7 @@ future<mutation_fragment_batch> mutation_reader_merger::operator()() {
         _gallop_mode_hits = 1;
     }
 
-    return make_ready_future<mutation_fragment_batch>(_current);
+    return make_ready_future<mutation_fragment_batch_opt>(_current);
 }
 
 future<> mutation_reader_merger::next_partition() {
@@ -918,7 +926,7 @@ class clustering_order_reader_merger {
     //
     // If the galloping reader wins with other readers again, the fragment is returned as the next batch.
     // Otherwise, the reader is pushed onto _peeked_readers and we retry in non-galloping mode.
-    future<mutation_fragment_batch> peek_galloping_reader() {
+    future<mutation_fragment_batch_opt> peek_galloping_reader() {
         return _galloping_reader->reader.peek().then([this] (mutation_fragment_v2* mf) {
             bool erase = false;
             if (mf) {
@@ -943,7 +951,7 @@ class clustering_order_reader_merger {
                                     || _cmp(mf->position(), _peeked_readers.front()->reader.peek_buffer().position()) < 0)) {
                         _current_batch.emplace_back(_galloping_reader->reader.pop_mutation_fragment(), &_galloping_reader->reader);
 
-                        return make_ready_future<mutation_fragment_batch>(_current_batch);
+                        return make_ready_future<mutation_fragment_batch_opt>(_current_batch);
                     }
 
                     // One of the existing readers won with the galloping reader,
@@ -969,7 +977,7 @@ class clustering_order_reader_merger {
           return maybe_erase.then([this] {
             _galloping_reader = {};
             _gallop_mode_hits = 0;
-            return (*this)();
+            return make_ready_future<mutation_fragment_batch_opt>();
           });
         });
     }
@@ -994,6 +1002,10 @@ public:
     // returned by the previous operator() call after calling operator() again
     // (the data from the previous batch is destroyed).
     future<mutation_fragment_batch> operator()() {
+        return repeat_until_value([this] { return maybe_produce_batch(); });
+    }
+
+    future<mutation_fragment_batch_opt> maybe_produce_batch() {
         _current_batch.clear();
 
         if (in_gallop_mode()) {
@@ -1001,7 +1013,7 @@ public:
         }
 
         if (!_unpeeked_readers.empty()) {
-            return peek_readers().then([this] { return (*this)(); });
+            return peek_readers().then([] { return make_ready_future<mutation_fragment_batch_opt>(); });
         }
 
         // Before we return a batch of fragments using currently opened readers we must check the queue
@@ -1026,7 +1038,7 @@ public:
                 _all_readers.push_front(std::move(r));
                 _unpeeked_readers.push_back(_all_readers.begin());
             }
-            return peek_readers().then([this] { return (*this)(); });
+            return peek_readers().then([] { return make_ready_future<mutation_fragment_batch_opt>(); });
         }
 
         if (_peeked_readers.empty()) {
@@ -1040,7 +1052,7 @@ public:
                 }
                 _should_emit_partition_end = false;
             }
-            return make_ready_future<mutation_fragment_batch>(_current_batch);
+            return make_ready_future<mutation_fragment_batch_opt>(_current_batch);
         }
 
         // Take all fragments with the next smallest position (there may be multiple such fragments).
@@ -1074,7 +1086,7 @@ public:
             _gallop_mode_hits = 1;
         }
 
-        return make_ready_future<mutation_fragment_batch>(_current_batch);
+        return make_ready_future<mutation_fragment_batch_opt>(_current_batch);
     }
 
     future<> next_partition() {


### PR DESCRIPTION
In mutation_reader_merger and clustering_order_reader_merger, the operator()() is responsible for producing mutation fragments that will be merged and pushed to the combined reader's buffer. Sometimes, it might have to advance existing readers, open new and / or close some existing ones, which requires calling a helper method and then calling operator()() recursively.

In some unlucky circumstances, a stack overflow can occur:

- Readers have to be opened incrementally,
- Most or all readers must not produce any fragments and need to report end of stream without preemption,
- There has to be enough readers opened within the lifetime of the combined reader (~500),
- All of the above needs to happen within a single task quota.

In order to prevent such a situation, the code of both reader merger classes were modified not to perform recursion at all. Most of the code of the operator()() was moved to maybe_produce_batch which does not recur if it is not possible for it to produce a fragment, instead it returns std::nullopt and operator()() calls this method in a loop via seastar::repeat_until_value.

A regression test is added.

Results from `perf_simple_query`, seed `1148387770`:

Before (a9282103ba622160a71bf1b7ad2fab3a6b8301b3):

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              1148387770

test                                      iterations      median         mad         min         max      allocs       tasks        inst
combined.one_mutation                         462922     1.370us     2.688ns     1.356us     1.375us      19.006       0.011      6767.4
combined.one_row                              451835     1.380us     5.220ns     1.374us     1.399us      19.006       0.012      6766.9
combined.single_active                          5064   161.812us   118.163ns   161.694us   162.003us    2466.786       2.428   1451592.6
combined.many_overlapping                        922   950.217us   128.436ns   950.088us   950.946us    4652.798      17.155   7619794.8
combined.disjoint_interleaved                   4947   164.435us   173.747ns   164.261us   165.033us    2485.805       2.458   1472196.4
combined.disjoint_ranges                        4986   164.597us    90.031ns   164.470us   164.795us    2491.779       2.423   1468859.4
combined.overlapping_partitions_disjoint_rows   4531   186.957us    19.741ns   186.743us   186.988us    2191.215       2.971   1626264.3
clustering_combined.ranges_generic           2041424   401.979ns     0.387ns   401.562ns   403.585ns       4.480       0.006      3363.1
clustering_combined.ranges_specialized       2159542   391.678ns     0.683ns   390.995ns   466.998ns       4.499       0.007      3281.0
memtable.one_partition_one_row                112317     1.729us     4.043ns     1.723us     3.036us      16.023       0.028     13562.4
memtable.one_partition_many_rows                9953    17.959us    44.281ns    17.914us    22.028us     123.260       0.333    146177.0
memtable.one_large_partition                      89     2.515ms    20.959us     2.489ms     3.451ms   16436.081      35.431  21382670.0
memtable.many_partitions_one_row                5525    34.450us    11.517ns    34.439us    67.987us     251.449       0.599    249963.0
memtable.many_partitions_many_rows               688   446.517us   431.721ns   445.744us   701.783us    2835.402       8.262   3818500.3
memtable.many_large_partitions                     4    64.731ms    18.651us    64.540ms    64.754ms  410636.600     836.300 498324765.8
```

After (8ffe9682c7ce7355c65c712c9e1feef1ba2ed967):

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              1148387770

test                                      iterations      median         mad         min         max      allocs       tasks        inst
combined.one_mutation                         454557     1.483us    18.640ns     1.402us     1.501us      19.007       0.012      6768.8
combined.one_row                              407500     1.428us    12.533ns     1.359us     1.497us      19.007       0.012      6767.8
combined.single_active                          4968   165.842us    88.323ns   165.531us   166.280us    2467.149       2.801   1471622.3
combined.many_overlapping                        899   976.916us   578.873ns   975.377us   977.923us    4655.270      19.780   7651241.2
combined.disjoint_interleaved                   4874   168.417us    92.085ns   168.183us   168.712us    2486.207       2.872   1490850.7
combined.disjoint_ranges                        4885   169.559us   504.702ns   168.796us   170.064us    2492.202       2.870   1490598.4
combined.overlapping_partitions_disjoint_rows   4318   194.565us   203.271ns   194.362us   195.208us    2191.559       3.337   1645370.6
clustering_combined.ranges_generic           1995994   411.016ns     0.354ns   410.476ns   412.476ns       4.481       0.007      3408.2
clustering_combined.ranges_specialized       2120734   400.942ns     0.898ns   399.963ns   403.063ns       4.500       0.007      3315.9
memtable.one_partition_one_row                114690     1.726us     2.080ns     1.717us     3.258us      16.024       0.028     13759.5
memtable.one_partition_many_rows               10491    17.796us    70.497ns    17.726us    23.873us     123.261       0.335    149079.4
memtable.one_large_partition                      95     2.496ms     6.832us     2.486ms     3.635ms   16435.987      35.389  21652001.3
memtable.many_partitions_one_row                6320    30.254us    61.787ns    30.156us    41.902us     251.403       0.528    221124.1
memtable.many_partitions_many_rows               668   444.464us   773.994ns   443.684us   703.461us    2835.367       8.222   3820312.1
memtable.many_large_partitions                     4    64.353ms   169.843us    64.103ms    64.536ms  410633.300     832.200 498322581.5
```

Fixes: scylladb/scylladb#14415