### PR TITLE
test/boost/database_test: split mutation sub-tests

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -291,20 +291,72 @@ static void test_database(void (*run_tests)(populate_fn_ex, bool), unsigned cgs)
     }).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_cg0) {
-    test_database(run_mutation_source_tests_plain, 0);
+// plain cg0
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_basic_cg0) {
+    test_database(run_mutation_source_tests_plain_basic, 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_cg1) {
-    test_database(run_mutation_source_tests_plain, 1);
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_reader_conversion_cg0) {
+    test_database(run_mutation_source_tests_plain_reader_conversion, 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_cg0) {
-    test_database(run_mutation_source_tests_reverse, 0);
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_fragments_monotonic_cg0) {
+    test_database(run_mutation_source_tests_plain_fragments_monotonic, 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_cg1) {
-    test_database(run_mutation_source_tests_reverse, 1);
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_read_back_cg0) {
+    test_database(run_mutation_source_tests_plain_read_back, 0);
+}
+
+// plain cg1
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_basic_cg1) {
+    test_database(run_mutation_source_tests_plain_basic, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_reader_conversion_cg1) {
+    test_database(run_mutation_source_tests_plain_reader_conversion, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_fragments_monotonic_cg1) {
+    test_database(run_mutation_source_tests_plain_fragments_monotonic, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_plain_read_back_cg1) {
+    test_database(run_mutation_source_tests_plain_read_back, 1);
+}
+
+// reverse cg0
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_basic_cg0) {
+    test_database(run_mutation_source_tests_reverse_basic, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_reader_conversion_cg0) {
+    test_database(run_mutation_source_tests_reverse_reader_conversion, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_fragments_monotonic_cg0) {
+    test_database(run_mutation_source_tests_reverse_fragments_monotonic, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_read_back_cg0) {
+    test_database(run_mutation_source_tests_reverse_read_back, 0);
+}
+
+// reverse cg1
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_basic_cg1) {
+    test_database(run_mutation_source_tests_reverse_basic, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_reader_conversion_cg1) {
+    test_database(run_mutation_source_tests_reverse_reader_conversion, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_fragments_monotonic_cg1) {
+    test_database(run_mutation_source_tests_reverse_fragments_monotonic, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_database_with_data_in_sstables_is_a_mutation_source_reverse_read_back_cg1) {
+    test_database(run_mutation_source_tests_reverse_read_back, 1);
 }
 
 static void require_exist(const sstring& filename, bool should) {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -127,12 +127,38 @@ static future<> test_memtable(void (*run_tests)(populate_fn_ex, bool)) {
     });
 }
 
-SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_plain) {
-    return test_memtable(run_mutation_source_tests_plain);
+// plain
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_basic) {
+    return test_memtable(run_mutation_source_tests_plain_basic);
 }
 
-SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_reverse) {
-    return test_memtable(run_mutation_source_tests_reverse);
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_plain_reader_conversion) {
+    return test_memtable(run_mutation_source_tests_plain_reader_conversion);
+}
+
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_plain_fragments_monotonic) {
+    return test_memtable(run_mutation_source_tests_plain_fragments_monotonic);
+}
+
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_plain_read_back) {
+    return test_memtable(run_mutation_source_tests_plain_read_back);
+}
+
+// reverse
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_reverse_basic) {
+    return test_memtable(run_mutation_source_tests_reverse_basic);
+}
+
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_reverse_reader_conversion) {
+    return test_memtable(run_mutation_source_tests_reverse_reader_conversion);
+}
+
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_reverse_fragments_monotonic) {
+    return test_memtable(run_mutation_source_tests_reverse_fragments_monotonic);
+}
+
+SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source_reverse_read_back) {
+    return test_memtable(run_mutation_source_tests_reverse_read_back);
 }
 
 SEASTAR_TEST_CASE(test_memtable_flush_reader) {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1594,19 +1594,15 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
 
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper&, populate_fn_ex);
 
-void run_mutation_reader_tests(populate_fn_ex populate, bool with_partition_range_forwarding) {
+void run_mutation_reader_tests_basic(tests::reader_concurrency_semaphore_wrapper& semaphore,
+        populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
 
-    tests::reader_concurrency_semaphore_wrapper semaphore;
-
     test_range_tombstones_v2(semaphore, populate);
-    test_reader_conversions(semaphore, populate);
     test_time_window_clustering_slicing(semaphore, populate);
     test_clustering_slices(semaphore, populate);
-    test_mutation_reader_fragments_have_monotonic_positions(semaphore, populate);
     test_streamed_mutation_forwarding_across_range_tombstones(semaphore, populate);
     test_streamed_mutation_forwarding_guarantees(semaphore, populate);
-    test_all_data_is_read_back(semaphore, populate);
     test_streamed_mutation_slicing_returns_only_relevant_tombstones(semaphore, populate);
     test_streamed_mutation_forwarding_is_consistent_with_slicing(semaphore, populate);
     test_range_queries(semaphore, populate);
@@ -1620,6 +1616,18 @@ void run_mutation_reader_tests(populate_fn_ex populate, bool with_partition_rang
         test_fast_forwarding_across_partitions_to_empty_range(semaphore, populate);
         test_slicing_and_fast_forwarding(semaphore, populate);
     }
+}
+
+void run_mutation_reader_tests_all(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    run_mutation_reader_tests_basic(semaphore, populate, with_partition_range_forwarding);
+
+    // Most of the time is spent in the following tests
+    test_reader_conversions(semaphore, populate);
+    test_mutation_reader_fragments_have_monotonic_positions(semaphore, populate);
+    test_all_data_is_read_back(semaphore, populate);
 }
 
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
@@ -1673,36 +1681,97 @@ void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_rang
 
 void run_mutation_source_tests_plain(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
-    run_mutation_reader_tests(populate, with_partition_range_forwarding);
+    run_mutation_reader_tests_all(populate, with_partition_range_forwarding);
+}
+
+void run_mutation_source_tests_plain_basic(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    run_mutation_reader_tests_basic(semaphore, populate, with_partition_range_forwarding);
+}
+
+void run_mutation_source_tests_plain_reader_conversion(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_reader_conversions(semaphore, populate);
+}
+
+void run_mutation_source_tests_plain_fragments_monotonic(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_mutation_reader_fragments_have_monotonic_positions(semaphore, populate);
+}
+
+void run_mutation_source_tests_plain_read_back(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_all_data_is_read_back(semaphore, populate);
+}
+
+// read in reverse
+static mutation_source make_mutation_source(populate_fn_ex populate, schema_ptr s,
+        const std::vector<mutation>& m, gc_clock::time_point t) {
+    auto table_schema = s->make_reversed();
+
+    std::vector<mutation> reversed_mutations;
+    reversed_mutations.reserve(m.size());
+    for (const auto& mut : m) {
+        reversed_mutations.emplace_back(reverse(mut));
+    }
+    auto ms = populate(table_schema, reversed_mutations, t);
+
+    return mutation_source([table_schema, ms = std::move(ms), reversed_slices = std::list<query::partition_slice>()] (
+            schema_ptr query_schema,
+            reader_permit permit,
+            const dht::partition_range& pr,
+            const query::partition_slice& slice,
+            tracing::trace_state_ptr tr,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding mr_fwd) mutable {
+        reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, slice))
+                .with_option<query::partition_slice::option::reversed>()
+                .build());
+        return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), tr, fwd, mr_fwd);
+    });
 }
 
 void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
-    // read in reverse
-    run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
-        auto table_schema = s->make_reversed();
-
-        std::vector<mutation> reversed_mutations;
-        reversed_mutations.reserve(m.size());
-        for (const auto& mut : m) {
-            reversed_mutations.emplace_back(reverse(mut));
-        }
-        auto ms = populate(table_schema, reversed_mutations, t);
-
-        return mutation_source([table_schema, ms = std::move(ms), reversed_slices = std::list<query::partition_slice>()] (
-                schema_ptr query_schema,
-                reader_permit permit,
-                const dht::partition_range& pr,
-                const query::partition_slice& slice,
-                tracing::trace_state_ptr tr,
-                streamed_mutation::forwarding fwd,
-                mutation_reader::forwarding mr_fwd) mutable {
-            reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, slice))
-                    .with_option<query::partition_slice::option::reversed>()
-                    .build());
-            return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), tr, fwd, mr_fwd);
-        });
+    run_mutation_reader_tests_all([&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        return make_mutation_source(populate, s, m, t);
     }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
+}
+
+void run_mutation_source_tests_reverse_basic(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    run_mutation_reader_tests_basic(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        return make_mutation_source(populate, s, m, t);
+    }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
+}
+
+void run_mutation_source_tests_reverse_reader_conversion(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_reader_conversions(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        return make_mutation_source(populate, s, m, t);
+    });
+}
+
+void run_mutation_source_tests_reverse_fragments_monotonic(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_mutation_reader_fragments_have_monotonic_positions(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        return make_mutation_source(populate, s, m, t);
+    });
+}
+
+void run_mutation_source_tests_reverse_read_back(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    test_all_data_is_read_back(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        return make_mutation_source(populate, s, m, t);
+    });
 }
 
 struct mutation_sets {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1822,7 +1822,7 @@ static mutation_sets generate_mutation_sets() {
 
         clustering_key ck1 = clustering_key::from_deeply_exploded(*s1, {data_value(bytes("ck1_0")), data_value(bytes("ck1_1"))});
         clustering_key ck2 = clustering_key::from_deeply_exploded(*s1, {data_value(bytes("ck2_0")), data_value(bytes("ck2_1"))});
-        auto ttl = gc_clock::duration(1);
+        auto ttl = gc_clock::duration(10000);   // Note: large value to avoid deletion on tests ignoring query time
 
         {
             auto tomb = new_tombstone();

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -18,7 +18,15 @@ using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::ve
 void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
 void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 void run_mutation_source_tests_plain(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_plain_basic(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_plain_reader_conversion(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_plain_fragments_monotonic(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_plain_read_back(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_reverse_basic(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_reverse_reader_conversion(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_reverse_fragments_monotonic(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_reverse_read_back(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 
 enum are_equal { no, yes };
 


### PR DESCRIPTION
Split long-runing database mutation tests.

At a trade-off with verbosity, split these sub-tests for the long running tests `database_with_data_in_sstables_is_a_mutation_source_`*.

Refs #13905