### PR TITLE
build: drop the warning on -O0 might fail tests

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -47,8 +47,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION GREATER_
   if(NOT _original_level STREQUAL _safe_level)
     message(WARNING
       "Changing optimization level from -O${_original_level} to -O${_safe_level} "
-      "due to https://github.com/llvm/llvm-project/issues/62842. "
-      "Please note -O0 is very slow that some tests might fail.")
+      "due to https://github.com/llvm/llvm-project/issues/62842.")
     string(REPLACE " -O${_original_level} " " -O${_safe_level} "
       CMAKE_CXX_FLAGS_${build_mode}
       "${CMAKE_CXX_FLAGS_${build_mode}}")

--- a/configure.py
+++ b/configure.py
@@ -174,8 +174,7 @@ class OptimizationLevel:
             return
         print('\033[91mWARN\033[00m: '
               f'Changing optimization level to "-O{safe_level}" '
-              'due to https://github.com/llvm/llvm-project/issues/62842. '
-              'Please note -O0 is so slow that some tests might fail.')
+              'due to https://github.com/llvm/llvm-project/issues/62842.')
         cls.warned = True
 
     def __call__(self, cxx_compiler, default_level):


### PR DESCRIPTION
Michał Chojnowski noted that this is not true. -O0 almost doubles the run time of `./test.py --mode=debug`. but it does not fail any of the tests.