### PR TITLE
Stop task manager compaction module properly

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -931,11 +931,10 @@ future<> compaction_manager::drain() {
 }
 
 future<> compaction_manager::stop() {
+    do_stop();
     if (auto cm = std::exchange(_task_manager_module, nullptr)) {
         co_await cm->stop();
     }
-
-    do_stop();
     if (_state != state::none) {
         co_return co_await std::move(*_stop_future);
     }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -934,11 +934,9 @@ future<> compaction_manager::stop() {
     if (auto cm = std::exchange(_task_manager_module, nullptr)) {
         co_await cm->stop();
     }
-    // never started
-    if (_state == state::none) {
-        co_return;
-    } else {
-        do_stop();
+
+    do_stop();
+    if (_state != state::none) {
         co_return co_await std::move(*_stop_future);
     }
 }
@@ -958,6 +956,7 @@ future<> compaction_manager::really_do_stop() {
     cmlog.info("Stopped");
 }
 
+// Should return immediately when _state == state::none.
 void compaction_manager::do_stop() noexcept {
     if (_state == state::none || _stop_future) {
         return;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -258,8 +258,8 @@ public:
         co_return std::move(res.value());
     }
 
-protected:
     seastar::abort_source& abort_source() noexcept;
+protected:
     std::chrono::seconds get_task_ttl() const noexcept;
 private:
     future<> update_task_ttl() noexcept {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -152,6 +152,9 @@ compaction_manager_for_testing::wrapped_compaction_manager::wrapped_compaction_m
 
 // Must run in a seastar thread
 compaction_manager_for_testing::wrapped_compaction_manager::~wrapped_compaction_manager() {
+    if (!tm.abort_source().abort_requested()) {
+        tm.abort_source().request_abort();
+    }
     cm.stop().get();
 }
 


### PR DESCRIPTION
Due to wrong order of stopping of compaction services, shutdown needs 
to wait until all compactions are complete, which may take really long. 

Moreover, test version of compaction manager does not abort task manager,
which is strictly bounded to it, but stops its compaction module. This results 
in tests waiting for compaction task manager's tasks to be unregistered, 
which never happens.

Stopping and aborting of compaction manager and task manager's compaction 
module are performed in a proper order.