### PR TITLE
Make SSTable cleanup more efficient by fast forwarding to next owned range

### DIFF
--- a/dht/partition_filter.hh
+++ b/dht/partition_filter.hh
@@ -39,6 +39,13 @@ public:
         return _it != _sorted_owned_ranges.end() && _it->contains(t, dht::token_comparator());
     }
 
+    const dht::token_range* next_owned_range() const noexcept {
+        if (_it == _sorted_owned_ranges.end()) {
+            return nullptr;
+        }
+        return &*_it++;
+    }
+
     static flat_mutation_reader_v2::filter make_partition_filter(const dht::token_range_vector& sorted_owned_ranges);
 };
 

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -532,6 +532,7 @@ public:
                     return make_ready_future<>();
                 }
                 if (auto r = next()) {
+                    mrlog.trace("flat_multi_range_mutation_reader {}: fast forwarding to range {}", fmt::ptr(this), *r);
                     return _reader.fast_forward_to(*r);
                 } else {
                     _end_of_stream = true;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1511,6 +1511,9 @@ private:
             }
         });
     }
+    bool has_sstable_attached() const noexcept {
+        return bool(_sst);
+    }
     bool is_initialized() const {
         return bool(_context);
     }
@@ -1518,6 +1521,14 @@ private:
     future<bool> maybe_initialize() {
         if (is_initialized()) {
             co_return true;
+        }
+        // If the reader has no SSTable attached, the reader was proactively closed in the
+        // context of fast-forward calls. The higher level code has no way to know that
+        // underlying reader is really exhausted, so reader is responsible for releasing
+        // its resources beforehand. From there on, the reader has the same semantics
+        // as that of an empty reader.
+        if (!has_sstable_attached()) {
+            co_return false;
         }
         if (_single_partition_read) {
             _sst->get_stats().on_single_partition_read();
@@ -1612,6 +1623,15 @@ public:
                     }
                     _index_in_current_partition = false;
                     _read_enabled = false;
+                    if (_index_reader->eof()) {
+                        // Close the SSTable reader proactively, if the index is completely exhausted
+                        // and no partition was found in the current fast-forward call. This allows
+                        // disk space of SSTables to be reclaimed earlier if they take part in a
+                        // long-living read and they're deleted midway.
+                        sstlog.trace("Closing reader {} for {} after fast-forward call found that index reached EOF and there's nothing left to read",
+                                     fmt::ptr(this), _sst->get_filename());
+                        return close();
+                    }
                     return make_ready_future<>();
                 });
             }
@@ -1699,7 +1719,7 @@ public:
             close_index_reader = _index_reader->close().finally([_ = std::move(_index_reader)] {});
         }
 
-        return when_all_succeed(std::move(close_context), std::move(close_index_reader)).discard_result().handle_exception([] (std::exception_ptr ep) {
+        return when_all_succeed(std::move(close_context), std::move(close_index_reader)).discard_result().handle_exception([sst = std::move(_sst)] (std::exception_ptr ep) {
             // close can not fail as it is called either from the destructor or from flat_mutation_reader::close
             sstlog.warn("Failed closing of sstable_mutation_reader: {}. Ignored since the reader is already done.", ep);
         });

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1643,6 +1643,19 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream()
             .fast_forward_to(dht::partition_range::make({ dht::ring_position(keys[8]), false }, { dht::ring_position(keys[9]), false }))
             .produces_end_of_stream();
+
+        pr = dht::partition_range::make(dht::ring_position(keys[0]), dht::ring_position(keys[1]));
+        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
+            .fast_forward_to(dht::partition_range::make(dht::ring_position::starting_at(keys[0].token()), dht::ring_position::ending_at(keys[1].token())))
+            .produces(keys[0])
+            .produces(keys[1])
+            .fast_forward_to(dht::partition_range::make(dht::ring_position::starting_at(keys[3].token()), dht::ring_position::ending_at(keys[4].token())))
+            .produces(keys[3])
+            .produces(keys[4])
+            .fast_forward_to(dht::partition_range::make_starting_with(dht::ring_position::starting_at(keys[8].token())))
+            .produces(keys[8])
+            .produces(keys[9])
+            .produces_end_of_stream();
       }
     });
 }


### PR DESCRIPTION
Today, SSTable cleanup skips to the next partition, one at a time, when it finds that the current partition is no longer owned by this node.

That's very inefficient because when a cluster is growing in size, existing nodes lose multiple sequential tokens in its owned ranges. Another inefficiency comes from fetching index pages spanning all unowned tokens, which was described in https://github.com/scylladb/scylladb/issues/14317.

To solve both problems, cleanup will now use multi range reader, to guarantee that it will only process the owned data and as a result skip unowned data. This results in cleanup scanning an owned range and then fast forwarding to the next one, until it's done with them all. This reduces significantly the amount of data in the index caching, as index will only be invoked at each range boundary instead.

Without further ado,

before:

`INFO  2023-07-01 07:10:26,281 [shard 0] compaction - [Cleanup keyspace2.standard1 701af580-17f7-11ee-8b85-a479a1a77573] Cleaned 1 sstables to [./tmp/1/keyspace2/standard1-b490ee20179f11ee9134afb16b3e10fd/me-3g7a_0s8o_06uww24drzrroaodpv-big-Data.db:level=0]. 2GB to 1GB (~50% of original) in 26248ms = 81MB/s. ~9443072 total partitions merged to 4750028.`

after:

`INFO  2023-07-01 07:07:52,354 [shard 0] compaction - [Cleanup keyspace2.standard1 199dff90-17f7-11ee-b592-b4f5d81717b9] Cleaned 1 sstables to [./tmp/1/keyspace2/standard1-b490ee20179f11ee9134afb16b3e10fd/me-3g7a_0s4m_5hehd2rejj8w15d2nt-big-Data.db:level=0]. 2GB to 1GB (~50% of original) in 17424ms = 123MB/s. ~9443072 total partitions merged to 4750028.`


Fixes #12998.
Fixes #14317.