### PR TITLE
replica,sstable: do not assign a value to a shared_ptr

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1503,7 +1503,7 @@ future<> compaction_group::stop() noexcept {
 }
 
 void compaction_group::clear_sstables() {
-    _main_sstables = _t._compaction_strategy.make_sstable_set(_t._schema);
+    _main_sstables = make_lw_shared<sstables::sstable_set>(_t._compaction_strategy.make_sstable_set(_t._schema));
     _maintenance_sstables = _t.make_maintenance_sstable_set();
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -63,15 +63,13 @@ future<> storage_manager::stop() {
 
 void storage_manager::update_config(const db::config& cfg) {
     for (auto [ep, ecfg] : cfg.object_storage_config()) {
-        auto it = _s3_endpoints.find(ep);
         auto s3_cfg = make_lw_shared<s3::endpoint_config>(std::move(ecfg));
-        if (it != _s3_endpoints.end()) {
-            it->second.cfg = std::move(s3_cfg);
+        auto [it, added] = _s3_endpoints.try_emplace(ep, std::move(s3_cfg));
+        if (!added) {
             if (it->second.client != nullptr) {
-                it->second.client->update_config(it->second.cfg);
+                it->second.client->update_config(s3_cfg);
             }
-        } else {
-            _s3_endpoints.emplace(std::make_pair(std::move(ep), std::move(s3_cfg)));
+            it->second.cfg = std::move(s3_cfg);
         }
     }
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -64,13 +64,14 @@ future<> storage_manager::stop() {
 void storage_manager::update_config(const db::config& cfg) {
     for (auto [ep, ecfg] : cfg.object_storage_config()) {
         auto it = _s3_endpoints.find(ep);
+        auto s3_cfg = make_lw_shared<s3::endpoint_config>(std::move(ecfg));
         if (it != _s3_endpoints.end()) {
-            it->second.cfg = std::move(ecfg);
+            it->second.cfg = std::move(s3_cfg);
             if (it->second.client != nullptr) {
                 it->second.client->update_config(it->second.cfg);
             }
         } else {
-            _s3_endpoints.emplace(std::make_pair(std::move(ep), make_lw_shared<s3::endpoint_config>(std::move(ecfg))));
+            _s3_endpoints.emplace(std::make_pair(std::move(ep), std::move(s3_cfg)));
         }
     }
 }


### PR DESCRIPTION
instead using the operator=(T&&) to assign an instance of `T` to a
shared_ptr, assign a new instance of shared_ptr to it.

unlike std::shared_ptr, seastar::shared_ptr allows us to move a value
into the existing value pointed by shared_ptr with operator=(). the
corresponding change in seastar is
https://github.com/scylladb/seastar/commit/319ae0b530107dce510c27f45d21b4ad696ef07d.
but this is a little bit confusing, as the behavior of a shared_ptr
should look like a pointer instead the value pointed by it. and this
could be error-prune, because user could use something like
```c++
p = std::string();
```
by accident, and expect that the value pointed by `p` is cleared.
and all copies of this shared_ptr are updated accordingly. what
he/she really wants is:
```c++
*p = std::string();
```
and the code compiles, while the outcome of the statement is that
the pointee of `p` is destructed, and `p` now points to a new
instance of string with a new address. the copies of this
instance of shared_ptr still hold the old value.

this behavior is not expected. so before deprecating and removing
this operator. let's stop using it.

in this change, we update two caller sites of the
`lw_shared_ptr::operator=(T&&)`. instead of creating a new instance
pointee of the pointer in-place, a new instance of lw_shared_ptr is
created, and is assigned to the existing shared_ptr.
