### PR TITLE
alternator: limit length of expressions to 4096 bytes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1648,7 +1648,7 @@ static parsed::condition_expression get_parsed_condition_expression(rjson::value
         throw api_error::validation("ConditionExpression must not be empty");
     }
     try {
-        return parse_condition_expression(rjson::to_string_view(*condition_expression));
+        return parse_condition_expression(rjson::to_string_view(*condition_expression), "ConditionExpression");
     } catch(expressions_syntax_error& e) {
         throw api_error::validation(e.what());
     }
@@ -3450,7 +3450,7 @@ filter::filter(const rjson::value& request, request_type rt,
             throw api_error::validation("Cannot use both old-style and new-style parameters in same request: FilterExpression and AttributesToGet");
         }
         try {
-            auto parsed = parse_condition_expression(rjson::to_string_view(*expression));
+            auto parsed = parse_condition_expression(rjson::to_string_view(*expression), "FilterExpression");
             const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
             const rjson::value* expression_attribute_values = rjson::find(request, "ExpressionAttributeValues");
             resolve_condition_expression(parsed,
@@ -4078,7 +4078,7 @@ calculate_bounds_condition_expression(schema_ptr schema,
     // sort-key range.
     parsed::condition_expression p;
     try {
-        p = parse_condition_expression(rjson::to_string_view(expression));
+        p = parse_condition_expression(rjson::to_string_view(expression), "KeyConditionExpression");
     } catch(expressions_syntax_error& e) {
         throw api_error::validation(e.what());
     }

--- a/alternator/expressions.hh
+++ b/alternator/expressions.hh
@@ -28,7 +28,7 @@ public:
 
 parsed::update_expression parse_update_expression(std::string_view query);
 std::vector<parsed::path> parse_projection_expression(std::string_view query);
-parsed::condition_expression parse_condition_expression(std::string_view query);
+parsed::condition_expression parse_condition_expression(std::string_view query, const char* caller);
 
 void resolve_update_expression(parsed::update_expression& ue,
         const rjson::value* expression_attribute_names,


### PR DESCRIPTION
DynamoDB limits of all expressions (ConditionExpression, UpdateExpression, ProjectionExpression, FilterExpression, KeyConditionExpression) to just 4096 bytes. Until now, Alternator did not enforce this limit, and we had an xfailing test showing this.

But it turns out that not enforcing this limit can be dangerous: The user can pass arbitrarily-long and arbitrarily nested expressions, such as:

    a<b and (a<b and (a<b and (a<b and (a<b and (a<b and (...))))))

and those can cause recursive algorithms in Alternator to recurse very deeply, overflow the stack, and crash.

This patch includes new tests that demonstrate how Scylla crashes before enforcing the 4096-byte length limit on expressions. The patch then starts to enforce this length limit, and these tests stop crashing. We also verify that deeply-nested expressions shorter than the 4096-byte limit are apparently short enough for our recursion ability, and work as expected.

We also add two xfailing tests for two more restrictions that DynamoDB enforces but Alternator still doesn't, even after this patch:

1. DynamoDB limits the number of operators in an expression to just
   300. An expression with 301 operators (such as "<" and "and") will be rejected even if below 4096 bytes.

2. DynamoDB does not allow "redundant parentheses", such as (((((a<b))))).

Implementing these additional restrictions could have reduced the maximum expression depth even further, but it appears the the 4096-byte limit is already low enough for Scylla's stack size.

Fixes #14473