### PR TITLE
build: remove duplicated test

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -424,7 +424,6 @@ scylla_tests = set([
     'test/boost/data_listeners_test',
     'test/boost/database_test',
     'test/boost/dirty_memory_manager_test',
-    'test/boost/double_decker_test',
     'test/boost/duration_test',
     'test/boost/dynamic_bitset_test',
     'test/boost/enum_option_test',


### PR DESCRIPTION
this change has no impact on `build.ninja` generated by `configure.py`. as we are using a `set` for tracking the tests to be built. but it's still an improvement, as we should not add duplicated entries in a set when initializing it.

there are two occurrences of `test/boost/double_decker_test`, the one which increases the number of inversion is removed, if we sort the tests alphabetically.