### PR TITLE
test/pylib: allow run minio_server.py as a stand-alone tool

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 #
 # Copyright (C) 2022-present ScyllaDB
 #


### PR DESCRIPTION
this would allow developer to run a minio server for testing, for instance, s3_test.