### PR TITLE
s3/client: add tagging ops

### DIFF
--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -22,6 +22,13 @@ struct range {
     size_t len;
 };
 
+struct tag {
+    std::string key;
+    std::string value;
+    auto operator<=>(const tag&) const = default;
+};
+using tag_set = std::vector<tag>;
+
 future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_);
 
 class client : public enable_shared_from_this<client> {
@@ -51,6 +58,9 @@ public:
         std::time_t last_modified;
     };
     future<stats> get_object_stats(sstring object_name);
+    future<tag_set> get_object_tagging(sstring object_name);
+    future<> put_object_tagging(sstring object_name, tag_set tagging);
+    future<> delete_object_tagging(sstring object_name);
     future<temporary_buffer<char>> get_object_contiguous(sstring object_name, std::optional<range> range = {});
     future<> put_object(sstring object_name, temporary_buffer<char> buf);
     future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs);


### PR DESCRIPTION
with tagging ops, we will be able to attach kv pairs to an object. this will allow us to mark sstable components with taggings, and filter them based on them.

* test/pylib/minio_server.py: enable anonymous user to perform more actions. because the tagging related ops are not enabled by "mc anonymous set public", we have to enable them using "set-json" subcommand.
* utils/s3/client: add methods to manipulate taggings.
* test/boost/s3_test: add a simple test accordingly.
