### PR TITLE
messaging_service: Do TLS init early

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1157,6 +1157,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 messaging.invoke_on_all(&netw::messaging_service::stop).get();
             });
 
+            // #14299 - do early init of messaging_service (or rather its TLS structures)
+            // since other things (failure_detector) might try to send messages vie it
+            // before start_listen is called.
+            messaging.invoke_on_all(&netw::messaging_service::start).get();
+
             supervisor::notify("starting gossiper");
             gms::gossip_config gcfg;
             gcfg.gossip_scheduling_group = dbcfg.gossip_scheduling_group;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -332,6 +332,7 @@ public:
     messaging_service(config cfg, scheduling_config scfg, std::shared_ptr<seastar::tls::credentials_builder>);
     ~messaging_service();
 
+    future<> start();
     future<> start_listen(locator::shared_token_metadata& stm);
     uint16_t port();
     gms::inet_address listen_address();


### PR DESCRIPTION
Fixes #14299

failure_detector can try sending messages to TLS endpoints before start_listen has been called (why?). Need TLS initialized before this. So do on service creation.