### PR TITLE
Add metrics to S3 client

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -76,7 +76,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     BOOST_REQUIRE_EQUAL(sz, 10);
 
     testlog.info("Get object stats\n");
-    s3::client::stats st = cln->get_object_stats(name).get0();
+    s3::stats st = cln->get_object_stats(name).get0();
     BOOST_REQUIRE_EQUAL(st.size, 10);
     // forgive timezone difference as minio server is GMT by default
     BOOST_REQUIRE(std::difftime(st.last_modified, gc_clock::to_time_t(gc_clock::now())) < 24*3600);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -548,10 +548,11 @@ future<> client::upload_sink_base::upload_part(memory_data_sink_buffers bufs) {
     _part_etags.emplace_back();
     s3l.trace("PUT part {} {} bytes in {} buffers (upload id {})", part_number, bufs.size(), bufs.buffers().size(), _upload_id);
     auto req = http::request::make("PUT", _client->_host, _object_name);
-    req._headers["Content-Length"] = format("{}", bufs.size());
+    auto size = bufs.size();
+    req._headers["Content-Length"] = format("{}", size);
     req.query_parameters["partNumber"] = format("{}", part_number + 1);
     req.query_parameters["uploadId"] = _upload_id;
-    req.write_body("bin", bufs.size(), [this, part_number, bufs = std::move(bufs)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs)] (output_stream<char>&& out_) mutable -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         s3l.trace("upload {} part data (upload id {})", part_number, _upload_id);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -224,7 +224,7 @@ static std::time_t parse_http_last_modified_time(const sstring& object_name, sst
     return std::mktime(&tm);
 }
 
-future<client::stats> client::get_object_stats(sstring object_name) {
+future<stats> client::get_object_stats(sstring object_name) {
     struct stats st{};
     co_await get_object_header(object_name, [&] (const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
         st.size = rep.content_length;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -29,6 +29,11 @@ struct tag {
 };
 using tag_set = std::vector<tag>;
 
+struct stats {
+    uint64_t size;
+    std::time_t last_modified;
+};
+
 future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_);
 
 class client : public enable_shared_from_this<client> {
@@ -53,10 +58,6 @@ public:
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf = {});
 
     future<uint64_t> get_object_size(sstring object_name);
-    struct stats {
-        uint64_t size;
-        std::time_t last_modified;
-    };
     future<stats> get_object_stats(sstring object_name);
     future<tag_set> get_object_tagging(sstring object_name);
     future<> put_object_tagging(sstring object_name, tag_set tagging);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -43,7 +43,11 @@ class client : public enable_shared_from_this<client> {
     class readable_file;
     std::string _host;
     endpoint_config_ptr _cfg;
-    std::unordered_map<seastar::scheduling_group, http::experimental::client> _https;
+    struct group_client {
+        http::experimental::client http;
+        group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn);
+    };
+    std::unordered_map<seastar::scheduling_group, group_client> _https;
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -9,6 +9,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/metrics.hh>
 #include <seastar/http/client.hh>
 #include "utils/s3/creds.hh"
 
@@ -45,7 +46,9 @@ class client : public enable_shared_from_this<client> {
     endpoint_config_ptr _cfg;
     struct group_client {
         http::experimental::client http;
+        seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn);
+        void register_metrics(std::string class_name, std::string host);
     };
     std::unordered_map<seastar::scheduling_group, group_client> _https;
     using global_factory = std::function<shared_ptr<client>(std::string)>;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -54,6 +54,7 @@ class client : public enable_shared_from_this<client> {
     struct private_tag {};
 
     void authorize(http::request&);
+    group_client& find_or_create_client();
     future<> make_request(http::request req, http::experimental::client::reply_handler handle = ignore_reply, http::reply::status_type expected = http::reply::status_type::ok);
 
     future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler);


### PR DESCRIPTION
The added metrics include:

- http client metrics, which include the number of connections, the number of active connections and the number of new connections made so far
- IO metrics that mimic those for traditional IO -- total number of object read/write ops, total number of get/put/uploaded bytes and individual IO request delay (round-trip, including body transfer time)

fixes: #13369