### PR TITLE
keys: print non-utf-8 keys in hex

### DIFF
--- a/keys.hh
+++ b/keys.hh
@@ -782,7 +782,7 @@ auto format_pk(const WithSchemaWrapper& pk, FormatContext& ctx) {
         if (utils::utf8::validate((const uint8_t *) key.data(), key.size())) {
             out = fmt::format_to(out, "{}", key);
         } else {
-            out = fmt::format_to(out, "{}", "<non-utf8-key>");
+            out = fmt::format_to(out, "{}", fmt_hex{to_bytes_view(sstring_view(key))});
         }
     }
     return out;


### PR DESCRIPTION
primary keys are not necessarily UTF-8 encoded. before this change, when we cannot decode them with UTF-8, we just print them as `"<non-utf8-key>"`. this is far from being helpful when we need to differentiate one key from another.

so, in this change, we print them in hex, like "20010db8".