### PR TITLE
cql3: select_statement: don't copy metadata object needlessly

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -833,7 +833,7 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
     if (fast_path) {
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(make_shared<cql_transport::messages::result_message::rows>(result(
             result_generator(_schema, std::move(results), std::move(cmd), _selection, _stats),
-            ::make_shared<metadata>(*_selection->get_result_metadata()))
+            _selection->get_result_metadata())
         ));
     }
     return process_results_complex(std::move(results), std::move(cmd), options, now);
@@ -1607,7 +1607,7 @@ parallelized_select_statement::do_execute(
 
     // dispatch execution of this statement to other nodes
     return qp.forward(req, state.get_trace_state()).then([this] (query::forward_result res) {
-        auto meta = make_shared<metadata>(*_selection->get_result_metadata());
+        auto meta = _selection->get_result_metadata();
         auto rs = std::make_unique<result_set>(std::move(meta));
         rs->add_row(res.query_results);
         update_stats_rows_read(rs->size());


### PR DESCRIPTION
It's a shared_ptr\<const metadata>, so it's safe to pass around.

perf-simple-query:

before:
211989.40 tps ( 62.1 allocs/op,  13.1 tasks/op,   43812 insns/op,        0 errors)
217889.09 tps ( 62.1 allocs/op,  13.1 tasks/op,   43713 insns/op,        0 errors)
211418.75 tps ( 62.1 allocs/op,  13.1 tasks/op,   43782 insns/op,        0 errors)
217388.46 tps ( 62.1 allocs/op,  13.1 tasks/op,   43733 insns/op,        0 errors)
211528.74 tps ( 62.1 allocs/op,  13.1 tasks/op,   43766 insns/op,        0 errors)

after:
215241.86 tps ( 61.1 allocs/op,  13.1 tasks/op,   43563 insns/op,        0 errors)
216172.41 tps ( 61.1 allocs/op,  13.1 tasks/op,   43562 insns/op,        0 errors)
212591.73 tps ( 61.1 allocs/op,  13.1 tasks/op,   43586 insns/op,        0 errors)
212217.28 tps ( 61.1 allocs/op,  13.1 tasks/op,   43553 insns/op,        0 errors)
215863.47 tps ( 61.1 allocs/op,  13.1 tasks/op,   43559 insns/op,        0 errors)

About 200 instructions saved.