### PR TITLE
Task manager tasks covering compaction group compaction

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -526,12 +526,12 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_com
     co_return co_await perform_task(std::move(task_executor));
 }
 
-future<> compaction_manager::perform_major_compaction(table_state& t, tasks::task_info info) {
+future<> compaction_manager::perform_major_compaction(table_state& t, std::optional<tasks::task_info> info) {
     if (_state != state::enabled) {
         co_return;
     }
 
-    co_await perform_compaction<major_compaction_task_executor>(info ? std::make_optional(info) : std::nullopt, &t, info.id).discard_result();
+    co_await perform_compaction<major_compaction_task_executor>(info, &t, info.value_or(tasks::task_info{}).id).discard_result();
 }
 
 namespace compaction {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -530,14 +530,8 @@ future<> compaction_manager::perform_major_compaction(table_state& t, tasks::tas
     if (_state != state::enabled) {
         co_return;
     }
-    auto task_executor = make_shared<major_compaction_task_executor>(*this, &t, info.id);
-    if (info) {
-        auto task = co_await _task_manager_module->make_task(task_executor, info);
-        task->start();
-        // We do not need to wait for the task to be done as compaction_task_executor side will take care of that.
-    }
 
-    co_await perform_task(std::move(task_executor)).discard_result();
+    co_await perform_compaction<major_compaction_task_executor>(info ? std::make_optional(info) : std::nullopt, &t, info.id).discard_result();
 }
 
 namespace compaction {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -323,7 +323,7 @@ public:
     future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);
 
     // Submit a table for major compaction.
-    future<> perform_major_compaction(compaction::table_state& t, tasks::task_info info = {});
+    future<> perform_major_compaction(compaction::table_state& t, std::optional<tasks::task_info> info = std::nullopt);
 
 
     // Run a custom job for a given table, defined by a function

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -225,10 +225,6 @@ private:
     // Guarantees that a maintenance task, e.g. cleanup, will be performed on all files available at the time
     // by retrieving set of candidates only after all compactions for table T were stopped, if any.
     template<typename TaskType, typename... Args>
-    requires std::derived_from<TaskType, compaction::compaction_task_executor>
-    future<compaction_stats_opt> perform_task_on_all_files(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, Args... args);
-
-    template<typename TaskType, typename... Args>
     requires std::derived_from<TaskType, compaction_task_executor> &&
             std::derived_from<TaskType, compaction_task_impl>
     future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(std::optional<tasks::task_info> info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -228,6 +228,11 @@ private:
     requires std::derived_from<TaskType, compaction::compaction_task_executor>
     future<compaction_stats_opt> perform_task_on_all_files(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, Args... args);
 
+    template<typename TaskType, typename... Args>
+    requires std::derived_from<TaskType, compaction_task_executor> &&
+            std::derived_from<TaskType, compaction_task_impl>
+    future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(std::optional<tasks::task_info> info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args);
+
     future<compaction_stats_opt> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
     // Stop all fibers, without waiting. Safe to be called multiple times.
@@ -309,9 +314,9 @@ public:
     // Cleanup is about discarding keys that are no longer relevant for a
     // given sstable, e.g. after node loses part of its token range because
     // of a newly added node.
-    future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t);
+    future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, std::optional<tasks::task_info> info);
 private:
-    future<> try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t);
+    future<> try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, std::optional<tasks::task_info> info);
 
     // Add sst to or remove it from the respective compaction_state.sstables_requiring_cleanup set.
     bool update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -217,7 +217,7 @@ private:
     // similar-sized compaction.
     void postpone_compaction_for_table(compaction::table_state* t);
 
-    future<compaction_stats_opt> perform_sstable_scrub_validate_mode(compaction::table_state& t);
+    future<compaction_stats_opt> perform_sstable_scrub_validate_mode(compaction::table_state& t, std::optional<tasks::task_info> info);
     future<> update_static_shares(float shares);
 
     using get_candidates_func = std::function<future<std::vector<sstables::shared_sstable>>()>;
@@ -233,7 +233,7 @@ private:
             std::derived_from<TaskType, compaction_task_impl>
     future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(std::optional<tasks::task_info> info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args);
 
-    future<compaction_stats_opt> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
+    future<compaction_stats_opt> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, std::optional<tasks::task_info> info, can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
     // Stop all fibers, without waiting. Safe to be called multiple times.
     void do_stop() noexcept;
@@ -322,10 +322,10 @@ private:
     bool update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);
 public:
     // Submit a table to be upgraded and wait for its termination.
-    future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, bool exclude_current_version);
+    future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, bool exclude_current_version, std::optional<tasks::task_info> info = std::nullopt);
 
     // Submit a table to be scrubbed and wait for its termination.
-    future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts);
+    future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts, std::optional<tasks::task_info> info = std::nullopt);
 
     // Submit a table for major compaction.
     future<> perform_major_compaction(compaction::table_state& t, std::optional<tasks::task_info> info = std::nullopt);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -334,7 +334,7 @@ public:
     // parameter type is the compaction type the operation can most closely be
     //      associated with, use compaction_type::Compaction, if none apply.
     // parameter job is a function that will carry the operation
-    future<> run_custom_job(compaction::table_state& s, sstables::compaction_type type, const char *desc, noncopyable_function<future<>(sstables::compaction_data&)> job);
+    future<> run_custom_job(compaction::table_state& s, sstables::compaction_type type, const char *desc, noncopyable_function<future<>(sstables::compaction_data&)> job, std::optional<tasks::task_info> info);
 
     class compaction_reenabler {
         compaction_manager& _cm;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -305,7 +305,7 @@ public:
 
     // Submit a table to be off-strategy compacted.
     // Returns true iff off-strategy compaction was required and performed.
-    future<bool> perform_offstrategy(compaction::table_state& t);
+    future<bool> perform_offstrategy(compaction::table_state& t, std::optional<tasks::task_info> info);
 
     // Submit a table to be cleaned up and wait for its termination.
     //

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -360,8 +360,9 @@ tasks::is_internal table_offstrategy_keyspace_compaction_task_impl::is_internal(
 
 future<> table_offstrategy_keyspace_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
-    co_await run_on_table("perform_keyspace_offstrategy_compaction", _db, _status.keyspace, _ti, [this] (replica::table& t) -> future<> {
-        _needed |= co_await t.perform_offstrategy_compaction();
+    tasks::task_info info{_status.id, _status.shard};
+    co_await run_on_table("perform_keyspace_offstrategy_compaction", _db, _status.keyspace, _ti, [this, info] (replica::table& t) -> future<> {
+        _needed |= co_await t.perform_offstrategy_compaction(info);
     });
 }
 

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -323,7 +323,7 @@ future<> table_cleanup_keyspace_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
     auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(_status.keyspace));
     co_await run_on_table("force_keyspace_cleanup", _db, _status.keyspace, _ti, [&] (replica::table& t) {
-        return t.perform_cleanup_compaction(owned_ranges_ptr);
+        return t.perform_cleanup_compaction(owned_ranges_ptr, tasks::task_info{_status.id, _status.shard});
     });
 }
 

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -322,7 +322,7 @@ public:
     }
 
     virtual std::string type() const override {
-        return "rewrite sstables compaction";
+        return "sstables compaction";
     }
 protected:
     virtual future<> run() override = 0;
@@ -344,6 +344,10 @@ public:
         , _table_infos(std::move(table_infos))
         , _exclude_current_version(exclude_current_version)
     {}
+
+    virtual std::string type() const override {
+        return "upgrade " + sstables_compaction_task_impl::type();
+    }
 protected:
     virtual future<> run() override;
 };
@@ -365,6 +369,10 @@ public:
         , _table_infos(std::move(table_infos))
         , _exclude_current_version(exclude_current_version)
     {}
+
+    virtual std::string type() const override {
+        return "upgrade " + sstables_compaction_task_impl::type();
+    }
 
     virtual tasks::is_internal is_internal() const noexcept override;
 protected:
@@ -396,6 +404,10 @@ public:
         , _exclude_current_version(exclude_current_version)
     {}
 
+    virtual std::string type() const override {
+        return "upgrade " + sstables_compaction_task_impl::type();
+    }
+
     virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
@@ -420,6 +432,10 @@ public:
         , _opts(opts)
         , _stats(stats)
     {}
+
+    virtual std::string type() const override {
+        return "scrub " + sstables_compaction_task_impl::type();
+    }
 protected:
     virtual future<> run() override;
 };
@@ -445,6 +461,10 @@ public:
         , _stats(stats)
     {}
 
+    virtual std::string type() const override {
+        return "scrub " + sstables_compaction_task_impl::type();
+    }
+
     virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
@@ -468,6 +488,10 @@ public:
         , _opts(opts)
         , _stats(stats)
     {}
+
+    virtual std::string type() const override {
+        return "scrub " + sstables_compaction_task_impl::type();
+    }
 
     virtual tasks::is_internal is_internal() const noexcept override;
 protected:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -930,7 +930,7 @@ public:
     // a future<bool> that is resolved when offstrategy_compaction completes.
     // The future value is true iff offstrategy compaction was required.
     future<bool> perform_offstrategy_compaction();
-    future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges);
+    future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges, std::optional<tasks::task_info> info = std::nullopt);
     unsigned estimate_pending_compactions() const;
 
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -857,7 +857,7 @@ public:
     // Start a compaction of all sstables in a process known as major compaction
     // Active memtable is flushed first to guarantee that data like tombstone,
     // sitting in the memtable, will be compacted with shadowed data.
-    future<> compact_all_sstables(tasks::task_info info = {});
+    future<> compact_all_sstables(std::optional<tasks::task_info> info = std::nullopt);
 
     future<bool> snapshot_exists(sstring name);
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -929,7 +929,7 @@ public:
     // Performs offstrategy compaction, if needed, returning
     // a future<bool> that is resolved when offstrategy_compaction completes.
     // The future value is true iff offstrategy compaction was required.
-    future<bool> perform_offstrategy_compaction();
+    future<bool> perform_offstrategy_compaction(std::optional<tasks::task_info> info = std::nullopt);
     future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges, std::optional<tasks::task_info> info = std::nullopt);
     unsigned estimate_pending_compactions() const;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1225,7 +1225,7 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 }
 
 future<>
-table::compact_all_sstables(tasks::task_info info) {
+table::compact_all_sstables(std::optional<tasks::task_info> info) {
     co_await flush();
     co_await parallel_foreach_compaction_group([this, info] (compaction_group& cg) {
         return _compaction_manager.perform_major_compaction(cg.as_table_state(), info);

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -57,9 +57,9 @@ def test_offstrategy_keyspace_compaction_task(cql, this_dc, rest_api):
 def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 2
     # upgrade sstables compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "rewrite sstables compaction", task_tree_depth)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "upgrade sstables compaction", task_tree_depth)
     # scrub sstables compaction
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "rewrite sstables compaction", task_tree_depth)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "scrub sstables compaction", task_tree_depth)
 
 def test_reshaping_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 1

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -10,7 +10,7 @@ module_name = "compaction"
 long_time = 1000000000
 
 # depth parameter means the number of edges in the longest path from root to leaves in task tree.
-def check_compaction_task(cql, this_dc, rest_api, run_compaction, compaction_type, depth):
+def check_compaction_task(cql, this_dc, rest_api, run_compaction, compaction_type, depth, allow_no_children=False):
     drain_module_tasks(rest_api, module_name)
     with set_tmp_task_ttl(rest_api, long_time):
         with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
@@ -35,8 +35,7 @@ def check_compaction_task(cql, this_dc, rest_api, run_compaction, compaction_typ
                 assert not failed, f"tasks with ids {failed} failed"
 
                 for top_level_task in statuses:
-                    if top_level_task["type"] != "resharding compaction":
-                        check_child_parent_relationship(rest_api, top_level_task, depth)
+                    check_child_parent_relationship(rest_api, top_level_task, depth, allow_no_children)
     drain_module_tasks(rest_api, module_name)
 
 def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
@@ -47,27 +46,27 @@ def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}"), "major compaction", task_tree_depth)
 
 def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 2
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", task_tree_depth)
+    task_tree_depth = 3
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", task_tree_depth, True)
 
 def test_offstrategy_keyspace_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 2
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"), "offstrategy compaction", task_tree_depth)
+    task_tree_depth = 3
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"), "offstrategy compaction", task_tree_depth, True)
 
 def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 2
+    task_tree_depth = 3
     # upgrade sstables compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "upgrade sstables compaction", task_tree_depth)
     # scrub sstables compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "scrub sstables compaction", task_tree_depth)
 
 def test_reshaping_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 1
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "reshaping compaction", task_tree_depth)
+    task_tree_depth = 2
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "reshaping compaction", task_tree_depth, True)
 
 def test_resharding_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 1
-    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "resharding compaction", task_tree_depth)
+    task_tree_depth = 2
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "resharding compaction", task_tree_depth, True)
 
 def test_regular_compaction_task(cql, this_dc, rest_api):
     drain_module_tasks(rest_api, module_name)


### PR DESCRIPTION
All compaction task executors, except for regular compaction one, 
become task manager compaction tasks. 

Creating and starting of major_compaction_task_executor is modified
to be consistent with other compaction task executors. 