### PR TITLE
dist: sysctl: increase vm.vfs_cache_pressure

### DIFF
--- a/dist/common/sysctl.d/99-scylla-vm.conf
+++ b/dist/common/sysctl.d/99-scylla-vm.conf
@@ -6,3 +6,10 @@
 # swap anonymous memory any more, which puts the server at the risk
 # of OOM).
 vm.swappiness = 1
+
+# Give a high preference to evicting inodes/dcache over swapping.
+# Our use of inodes is to either pin them (keeping open Data.db
+# and Index.db components) or to use them once and never touch them
+# again until deletion (all other components). Therefore evicting
+# them early is preferable to keeping them around.
+vm.vfs_cache_pressure = 2000


### PR DESCRIPTION
Our usage of inodes is dual:

 - the Index.db and Data.db components are pinned in memory as the files are open
 - all other components are read once and never looked at again

As such, tune the kernel to prefer evicting dcache/inodes to memory pages. The default is 100, so the value of 2000 increases it by a factor of 20.

Ref https://github.com/scylladb/scylladb/issues/14506