### PR TITLE
test/pylib: preserve the minio's log file

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -208,8 +208,8 @@ class MinioServer:
 
     def _unset_environ(self):
         for env in self._get_environs():
-            if self.old_env[env] is not None:
-                os.environ[env] = self.old_env[env]
+            if value := self.old_env.get(env):
+                os.environ[env] = value
             else:
                 del os.environ[env]
 


### PR DESCRIPTION
the log file here holds the output of minio server, and minio client (i.e., mc). before this change, the log file is removed along with the rundir of minio_server.

but the content of this file might be interesting if we have issues when connecting to the minio_server. as after the tests finish, what we have is but the log file.

so, in this change, instead of creating the log file under the rundir, we create it under the specified tempdir, so that it can be preserved and collected as a part of the artifact when the test finishes. this will allow us to perform some postmortem debugging.

Refs #14512
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>