### PR TITLE
doc: remove the dead link to unirestore

### DIFF
--- a/docs/using-scylla/mig-tool-review.rst
+++ b/docs/using-scylla/mig-tool-review.rst
@@ -7,7 +7,6 @@ The following migration tools are available for migrating to Scylla from Compati
 * From SSTable to SSTable
     - Based on Scylla refresh
     - On a large scale, it requires tooling to upload / transfer files from location to location.
-    - For example, `unirestore <https://github.com/scylladb/field-engineering/tree/master/unirestore>`_: SSTable to SSTable
 * From SSTable to CQL.
     - :doc:`sstableloader</operating-scylla/admin-tools/sstableloader/>`
 * From CQL to CQL

--- a/docs/using-scylla/mig-tool-review.rst
+++ b/docs/using-scylla/mig-tool-review.rst
@@ -2,10 +2,11 @@
 ScyllaDB Migration Tools: An Overview
 =======================================
 
-The following migration tools are available for migrating to Scylla from Compatible databases, like Apache Cassandra or other Scylla Clusters (Open Source or Enterprise):
+The following migration tools are available for migrating to ScyllaDB from compatible databases, 
+such as Apache Cassandra, or from other Scylla clusters (ScyllaDB Open Source or Enterprise):
 
 * From SSTable to SSTable
-    - Based on Scylla refresh
+    - Based on ScyllaDB refresh
     - On a large scale, it requires tooling to upload / transfer files from location to location.
 * From SSTable to CQL.
     - :doc:`sstableloader</operating-scylla/admin-tools/sstableloader/>`


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/14459

This PR removes the (dead) link to the unirestore tool in a private repository. In addition, it adds minor language improvements.
