### PR TITLE
Stop using anonymous minio bucket for tests

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -31,11 +31,20 @@
 //   export S3_SERVER_ADDRESS_FOR_TEST=s3.us-east-2.amazonaws.com
 //   export S3_SERVER_PORT_FOR_TEST=443
 //   export S3_BUCKET_FOR_TEST=xemul
+//   export AWS_ACCESS_KEY_ID=${aws_key}
+//   export AWS_SECRET_ACCESS_KEY=${aws_secret}
+//   export AWS_DEFAULT_REGION="us-east-2"
 //   export AWS_S3_EXTRA="${aws_key}:${aws_secret}:us-east-2"
 
 s3::endpoint_config_ptr make_minio_config() {
     s3::endpoint_config cfg = {
         .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
+        .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
+        .aws = {{
+            .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
+            .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+            .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
+        }},
     };
     auto extra = ::getenv("AWS_S3_EXTRA");
     if (extra) {
@@ -46,7 +55,6 @@ s3::endpoint_config_ptr make_minio_config() {
         }
         testlog.info("Adding AWS configuration to endpoint");
         cfg.use_https = true;
-        cfg.aws.emplace();
         cfg.aws->key = items[0];
         cfg.aws->secret = items[1];
         cfg.aws->region = items[2];

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -25,8 +25,8 @@
 #include "gc_clock.hh"
 
 // The test can be run on real AWS-S3 bucket. For that, create a bucket with
-// permissive enough policy and then run the test with AWS_S3_EXTRA env set
-// to key:secret:region string. E.g. like this
+// permissive enough policy and then run the test with env set respectively
+// E.g. like this
 //
 //   export S3_SERVER_ADDRESS_FOR_TEST=s3.us-east-2.amazonaws.com
 //   export S3_SERVER_PORT_FOR_TEST=443
@@ -34,7 +34,6 @@
 //   export AWS_ACCESS_KEY_ID=${aws_key}
 //   export AWS_SECRET_ACCESS_KEY=${aws_secret}
 //   export AWS_DEFAULT_REGION="us-east-2"
-//   export AWS_S3_EXTRA="${aws_key}:${aws_secret}:us-east-2"
 
 s3::endpoint_config_ptr make_minio_config() {
     s3::endpoint_config cfg = {
@@ -46,19 +45,6 @@ s3::endpoint_config_ptr make_minio_config() {
             .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
         }},
     };
-    auto extra = ::getenv("AWS_S3_EXTRA");
-    if (extra) {
-        std::vector<std::string> items;
-        boost::split(items, extra, boost::is_any_of(":"));
-        if (items.size() != 3) {
-            throw std::runtime_error("Invalid endpoint format, expected host:port");
-        }
-        testlog.info("Adding AWS configuration to endpoint");
-        cfg.use_https = true;
-        cfg.aws->key = items[0];
-        cfg.aws->secret = items[1];
-        cfg.aws->region = items[2];
-    }
     return make_lw_shared<s3::endpoint_config>(std::move(cfg));
 }
 

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -30,7 +30,7 @@
 //
 //   export S3_SERVER_ADDRESS_FOR_TEST=s3.us-east-2.amazonaws.com
 //   export S3_SERVER_PORT_FOR_TEST=443
-//   export S3_PUBLIC_BUCKET_FOR_TEST=xemul
+//   export S3_BUCKET_FOR_TEST=xemul
 //   export AWS_S3_EXTRA="${aws_key}:${aws_secret}:us-east-2"
 
 s3::endpoint_config_ptr make_minio_config() {
@@ -56,12 +56,12 @@ s3::endpoint_config_ptr make_minio_config() {
 
 /*
  * Tests below expect minio server to be running on localhost
- * with the bucket named env['S3_PUBLIC_BUCKET_FOR_TEST'] created with
+ * with the bucket named env['S3_BUCKET_FOR_TEST'] created with
  * unrestricted anonymous read-write access
  */
 
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
+    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
@@ -106,7 +106,7 @@ static auto deferred_delete_object(shared_ptr<s3::client> client, sstring name) 
 }
 
 void do_test_client_multipart_upload(bool with_copy_upload) {
-    const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
+    const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
@@ -165,7 +165,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
-    const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
+    const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
@@ -207,7 +207,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
 
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_tagging) {
     const sstring name(fmt::format("/{}/testobject-{}",
-                                   tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid()));
+                                   tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     auto client = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -228,7 +228,7 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
 data_dictionary::storage_options make_test_object_storage_options() {
     data_dictionary::storage_options ret;
     ret.value = data_dictionary::storage_options::s3 {
-        .bucket = tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"),
+        .bucket = tests::getenv_safe("S3_BUCKET_FOR_TEST"),
         .endpoint = tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"),
     };
     return ret;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -174,6 +174,12 @@ std::unordered_map<sstring, s3::endpoint_config> make_storage_options_config(con
         [&cfg] (const data_dictionary::storage_options::s3& os) mutable -> void {
             cfg[os.endpoint] = s3::endpoint_config {
                 .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
+                .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
+                .aws = {{
+                    .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
+                    .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+                    .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
+                }},
             };
         }
     }, so.value);

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -46,7 +46,7 @@ public:
     tester(std::chrono::seconds dur, unsigned prl, size_t obj_size)
             : _duration(dur)
             , _parallel(prl)
-            , _object_name(fmt::format("/{}/perfobject-{}-{}", tests::getenv_safe("S3_PUBLIC_BUCKET_FOR_TEST"), ::getpid(), this_shard_id()))
+            , _object_name(fmt::format("/{}/perfobject-{}-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid(), this_shard_id()))
             , _object_size(obj_size)
             , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config()))
     {}

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -28,7 +28,7 @@ class MinioServer:
     ENV_CONFFILE = 'S3_CONFFILE_FOR_TEST'
     ENV_ADDRESS = 'S3_SERVER_ADDRESS_FOR_TEST'
     ENV_PORT = 'S3_SERVER_PORT_FOR_TEST'
-    ENV_BUCKET = 'S3_PUBLIC_BUCKET_FOR_TEST'
+    ENV_BUCKET = 'S3_BUCKET_FOR_TEST'
 
     log_file: BufferedWriter
 
@@ -245,7 +245,7 @@ async def main():
         await server.start()
         print(f'export S3_SERVER_ADDRESS_FOR_TEST={server.address}')
         print(f'export S3_SERVER_PORT_FOR_TEST={server.port}')
-        print(f'export S3_PUBLIC_BUCKET_FOR_TEST={server.bucket_name}')
+        print(f'export S3_BUCKET_FOR_TEST={server.bucket_name}')
         print(f'Please run scylla with: --object-storage-config-file {server.config_file}')
         try:
             _ = input('server started. press any key to stop: ')

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -22,6 +22,7 @@ import time
 import tempfile
 import socket
 import yaml
+import json
 import random
 import string
 from io import BufferedWriter
@@ -33,6 +34,7 @@ class MinioServer:
     ENV_BUCKET = 'S3_BUCKET_FOR_TEST'
     ENV_ACCESS_KEY = 'AWS_ACCESS_KEY_ID'
     ENV_SECRET_KEY = 'AWS_SECRET_ACCESS_KEY'
+    DEFAULT_REGION = 'local'
 
     log_file: BufferedWriter
 
@@ -93,7 +95,7 @@ class MinioServer:
             else:
                 break
 
-    def _anonymous_public_policy(self):
+    def _bucket_policy(self):
         # the default anonymous public policy does not allow us to access
         # the taggings, so let's add the tagging actions manually.
         #
@@ -148,10 +150,14 @@ class MinioServer:
             yield random.randint(min_port, max_port)
 
     @staticmethod
-    def create_conf_file(address: str, port: int, path: str):
+    def create_conf_file(address: str, port: int, acc_key: str, secret_key: str, region: str, path: str):
         with open(path, 'w', encoding='ascii') as config_file:
             endpoint = {'name': address,
-                        'port': port}
+                        'port': port,
+                        'aws_key': acc_key,
+                        'aws_secret': secret_key,
+                        'aws_region': region,
+                        }
             yaml.dump({'endpoints': [endpoint]}, config_file)
 
     async def _run_server(self, port):
@@ -199,7 +205,7 @@ class MinioServer:
             self.logger.info("Failed to start Minio server")
             return
 
-        self.create_conf_file(self.address, self.port, self.config_file)
+        self.create_conf_file(self.address, self.port, self.access_key, self.secret_key, self.DEFAULT_REGION, self.config_file)
         os.environ[self.ENV_CONFFILE] = f'{self.config_file}'
         os.environ[self.ENV_ADDRESS] = f'{self.address}'
         os.environ[self.ENV_PORT] = f'{self.port}'
@@ -218,9 +224,10 @@ class MinioServer:
             self.log_to_file(f'Configuring bucket {self.bucket_name}')
             await self.mc('mb', f'{alias}/{self.bucket_name}')
             with tempfile.NamedTemporaryFile(mode='w', encoding='UTF-8', suffix='.json') as policy_file:
-                json.dump(self._anonymous_public_policy(), policy_file, indent=2)
+                json.dump(self._bucket_policy(), policy_file, indent=2)
                 policy_file.flush()
-                await self.mc('anonymous', 'set-json', policy_file.name, f'{alias}/{self.bucket_name}')
+                await self.mc('admin', 'policy', 'create', alias, 'test-policy', policy_file.name)
+            await self.mc('admin', 'policy', 'attach', alias, 'test-policy', '--user', self.access_key)
 
         except Exception as e:
             self.logger.info(f'MC failed: {e}')


### PR DESCRIPTION
Currently minio starts with a bucket that has public anonymous access. Respectively, all tests use unsigned S3 requests. That was done for simplicity, and its better to apply some policy to the bucket and, consequentially, make tests sign their requests.

Other than the obvious benefit that we test requests signing in unit tests, another goal of this PR is to make it possible to simulate and test various error paths locally, e.g. #13745 and #13022