### PR TITLE
doc: add the Rust CDC Connector to the docs

### DIFF
--- a/docs/using-scylla/cdc/cdc-intro.rst
+++ b/docs/using-scylla/cdc/cdc-intro.rst
@@ -82,6 +82,7 @@ The following libraries are available:
 
 * `Go <https://github.com/scylladb/scylla-cdc-go>`_
 * `Java <https://github.com/scylladb/scylla-cdc-java>`_
+* `Rust <https://github.com/scylladb/scylla-cdc-rust>`_
 
 More information
 ----------------

--- a/docs/using-scylla/cdc/cdc-querying-streams.rst
+++ b/docs/using-scylla/cdc/cdc-querying-streams.rst
@@ -25,7 +25,7 @@ With the above approach you can, for instance, build a distributed CDC consumer,
 
    If you use CDC in Scylla 4.3 and your application is constantly querying CDC log tables and using the old description table to learn about new generations and stream IDs, you should upgrade your application before upgrading to 4.4. The upgraded application should dynamically switch from using the old description table to the new description tables when the cluster is upgraded from 4.3 to 4.4. We present an example algorithm that the application can perform in the last section.
 
-   We highly recommend using the newest releases of our client CDC libraries (`Java CDC library <https://github.com/scylladb/scylla-cdc-java>`_, `Go CDC library <https://github.com/scylladb/scylla-cdc-go>`_). They take care of correctly querying the stream description tables and they handle the upgrade procedure for you.
+   We highly recommend using the newest releases of our client CDC libraries (`Java CDC library <https://github.com/scylladb/scylla-cdc-java>`_, `Go CDC library <https://github.com/scylladb/scylla-cdc-go>`_, `Rust CDC library <https://github.com/scylladb/scylla-cdc-rust>`_). They take care of correctly querying the stream description tables and they handle the upgrade procedure for you.
 
 Learning about available streams
 --------------------------------
@@ -216,4 +216,4 @@ You may also decide that it's safe to switch to the new tables even though not a
 Note that after upgrading the cluster to 4.4, all new generations (which are created when bootstrapping new nodes) appear only in the new tables. After upgrading your application and your cluster, and ensuring that either all generations have been rewritten to the new tables or that you're not interested in the data from old generations, it is safe to remove the old description table.
 
 .. note::
-   We highly recommend using the newest releases of our client CDC libraries (`Java CDC library <https://github.com/scylladb/scylla-cdc-java>`_, `Go CDC library <https://github.com/scylladb/scylla-cdc-go>`_). They take care of correctly querying the stream description tables and they handle the upgrade procedure for you.
+   We highly recommend using the newest releases of our client CDC libraries (`Java CDC library <https://github.com/scylladb/scylla-cdc-java>`_, `Go CDC library <https://github.com/scylladb/scylla-cdc-go>`_, `Rust CDC library <https://github.com/scylladb/scylla-cdc-rust>`_). They take care of correctly querying the stream description tables and they handle the upgrade procedure for you.

--- a/docs/using-scylla/drivers/cql-drivers/index.rst
+++ b/docs/using-scylla/drivers/cql-drivers/index.rst
@@ -57,7 +57,7 @@ or include a library for :doc:`CDC </using-scylla/cdc/cdc-intro>`.
    * - :doc:`Rust </using-scylla/drivers/cql-drivers/scylla-rust-driver>`
      - |v|   (preview version)
      - |v|
-     - |x| 
+     - |v| 
 
 
 Third-party Drivers

--- a/docs/using-scylla/drivers/cql-drivers/scylla-rust-driver.rst
+++ b/docs/using-scylla/drivers/cql-drivers/scylla-rust-driver.rst
@@ -15,3 +15,12 @@ Although optimized for ScyllaDB, the driver is also compatible with Apache Cassa
 **To download and install the driver**, visit the `Github project <https://github.com/scylladb/scylla-rust-driver>`_.
 
 Read the `Documentation <https://rust-driver.docs.scylladb.com>`_.
+
+Using CDC with Rust
+----------------------
+
+When writing applications, you can use ScyllaDB's `Rust CDC Library <https://github.com/scylladb/scylla-cdc-rust>`_ 
+to simplify writing applications that read from ScyllaDB's CDC.
+
+Use `Rust CDC Library <https://github.com/scylladb/scylla-cdc-rust>`_ to read 
+:doc:`ScyllaDB's CDC </using-scylla/cdc/index>` update streams.


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13877

This commit adds the information about Rust CDC Connector to the documentation. All relevant pages are updated: the ScyllaDB Rust Driver page, and other places in the docs where Java and Go CDC connectors are mentioned.

In addition, the drivers table is updated to indicate Rust driver support for CDC.