### PR TITLE
api: prevent non-owner cpu access to shared_ptr

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1017,12 +1017,12 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto key = req->get_query_param("key");
         auto uuid = get_uuid(req->param["name"], ctx.db.local());
 
-        return ctx.db.map_reduce0([key, uuid] (replica::database& db) {
-            return db.find_column_family(uuid).get_sstables_by_partition_key(key);
+        return ctx.db.map_reduce0([key, uuid] (replica::database& db) -> future<std::unordered_set<sstring>> {
+            auto sstables = co_await db.find_column_family(uuid).get_sstables_by_partition_key(key);
+            co_return boost::copy_range<std::unordered_set<sstring>>(sstables | boost::adaptors::transformed([] (auto s) { return s->get_filename(); }));
         }, std::unordered_set<sstring>(),
-        [](std::unordered_set<sstring> a, std::unordered_set<sstables::shared_sstable>&& b) mutable {
-            auto names = b | boost::adaptors::transformed([] (auto s) { return s->get_filename(); });
-            a.insert(names.begin(), names.end());
+        [](std::unordered_set<sstring> a, std::unordered_set<sstring>&& b) mutable {
+            a.merge(b);
             return a;
         }).then([](const std::unordered_set<sstring>& res) {
             return make_ready_future<json::json_return_type>(container_to_vec(res));


### PR DESCRIPTION
In get_sstables_for_key in api/column_family.cc a set of lw_shared_ptrs to sstables is passes to reducer of map_reduce0. Reducer then accesses these shared pointers. As reducer is invoked on the same shard map_reduce0 is called, we have an illegal access to shared pointer on non-owner cpu.

A set of shared pointers to sstables is trasnsformed in map function, which is guaranteed to be invoked on a shard associated with the service.

Fixes: #14515.