### PR TITLE
test.py: remove redundant message in report

### DIFF
--- a/test.py
+++ b/test.py
@@ -1440,7 +1440,7 @@ def summarize_tests(tests):
         test.insert(0, message)
 
         message = ET.Element('Info', file=test.attrib['file'], line=test.attrib['line'])
-        message.text = f'{num_failed} out of {num_total} times failed: failed.'
+        message.text = f'{num_failed} out of {num_total} times failed.'
         test.insert(0, message)
     return test
 


### PR DESCRIPTION
before this change, we would have report in Jenkins like:

```
[Info] - 1 out of 3 times failed: failed.
 == [File] - test/boost/commitlog_test.cc
 == [Line] - 298

[Info] - passed: release=1, dev=1
 == [File] - test/boost/commitlog_test.cc
 == [Line] - 298

[Info] - failed: debug=1
 == [File] - test/boost/commitlog_test.cc
 == [Line] - 298
```

the first section is rendered from the an `Info` tag, created by `test.py`. but the ending "failed" does not help in this context, as we already understand it's failing. so, in this change, it is dropped.