### PR TITLE
Update seastar submodule and locator/*_snitch.cc

### DIFF
--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -85,8 +85,8 @@ future<sstring> azure_snitch::azure_api_call(sstring path) {
 
         // Read HTTP response header first
         auto rsp = parser.get_parsed_response();
-        if (rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status_code));
+        if (rsp->_status != http::reply::status_type::ok) {
+            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status));
         }
 
         auto it = rsp->_headers.find("Content-Length");

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -119,13 +119,13 @@ future<sstring> ec2_snitch::aws_api_call_once(sstring addr, uint16_t port, sstri
 
             // Read HTTP response header first
             auto _rsp = _parser.get_parsed_response();
-            auto rc = _rsp->_status_code;
+            auto rc = _rsp->_status;
             // Verify EC2 instance metadata access
-            if (rc == 403) {
+            if (rc == http::reply::status_type::forbidden) {
                 return make_exception_future<sstring>(std::runtime_error("Error: Unauthorized response received when trying to communicate with instance metadata service."));
             }
-            if (_rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-                return make_exception_future<sstring>(std::runtime_error(format("Error: HTTP response status {}", _rsp->_status_code)));
+            if (_rsp->_status != http::reply::status_type::ok) {
+                return make_exception_future<sstring>(std::runtime_error(format("Error: HTTP response status {}", _rsp->_status)));
             }
 
             auto it = _rsp->_headers.find("Content-Length");

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -99,8 +99,8 @@ future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
 
         // Read HTTP response header first
         auto rsp = parser.get_parsed_response();
-        if (rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status_code));
+        if (rsp->_status != http::reply::status_type::ok) {
+            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status));
         }
 
         auto it = rsp->_headers.find("Content-Length");


### PR DESCRIPTION
this change also includes change to locator/*_snitch.cc, to make this commit compile. see below:

* seastar 99d28ff0...8038c131 (32):
  > shared_ptr: deprecate lw_shared_ptr operator=(T&&)
  > tests: fail spawn_test if output is empty
  > Support specifying the "build root" in configure
  > build: correct the syntax error in comment
  > util: print_safe: fix hex print functions
  > Add code examples for handling exceptions
  > smp: warn if --memory parameter is not supported
  > file: call lambda with std::invoke()
  > deleter: Delete move and copy constructors
  > file: fix the indent
  > file: call close() without the syscall thread
  > gate: use gate::holder for with_gate helpers
  > gate: keep holders on a boost intrusive list
  > reactor: use s/::free()/::io_uring_free_probe()/
  > reactor: Don't re-evaliate local reactor for thread_pool
  > request_frame: Use constants instead of magic numbers
  > response_frame: Use constants instead of magic numbers
  > client: Wrap request encoding into encode_header()
  > rpc: Move request_frame* classes up
  > client: Write request header in client method
  > server: Wrap response encoding into encode_header()
  > client: Remove unused read_response_frame()
  > server: Dont pass this->_read_buf into this->negotiate_protocol()
  > client: Keep protocol negotiation sequence in one method
  > http: Less http::reply re-allocations in handling
  > http: Carry unique_ptr<reply> in connection private methods
  > http: Use http::reply in parser
  > seastar-json2code: use Template in create_h_file
  > seastar-json2code: let print_comment() accept a single param
  > seastar-json2code: use textwrap for proper indent enum class
  > seastar-json2code: have less spaces in "enum class"
  > seastar-json2code: remove redundant spaces and trailing spaces

along with the Seastar submodule change, we have to update `locator/*_snitch.cc` to adapt to the changes of
"http: Use http::reply in parser" where we dropped the type of `http_response`, and use `http::reply` in place of the it. the latter use `_status` to represent the http status code instead. and unlike `http_response::_status_code`, `http::reply::_status` is a scoped enum. that's why we need to change the caller sites in locator/*_snitch.cc` accordingly.