### PR TITLE
test: set use_uuid to true by default in sstables::test_env 

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2919,7 +2919,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
                 .produces(make_insert(keys[i]))
                 .produces_end_of_stream();
         }
-    });
+    }, test_env_config{ .use_uuid = false });
 }
 
 SEASTAR_TEST_CASE(compaction_strategy_aware_major_compaction_test) {
@@ -3051,7 +3051,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         // make sure partial sstable run has none of its fragments compacted.
         BOOST_REQUIRE(generation_exists(partial_sstable_run_sst->generation()));
-    });
+    }, test_env_config{ .use_uuid = false });
 }
 
 // Make sure that a custom tombstone-gced-only writer will be feeded with gc'able tombstone
@@ -5099,7 +5099,7 @@ static future<> run_incremental_compaction_test(sstables::offstrategy offstrateg
 
         BOOST_REQUIRE(sstables_closed == sstables_nr);
         BOOST_REQUIRE(sstables_closed_during_cleanup >= sstables_nr / 2);
-    });
+    }, test_env_config{ .use_uuid = false });
 }
 
 SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
@@ -5180,7 +5180,6 @@ SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
             for (auto&& sst : ssts) {
                 testlog.info("run id {}", sst->run_identifier());
                 column_family_test(t).add_sstable(sst, sstables::offstrategy::yes).get();
-                column_family_test::update_sstables_known_generation(*t, sst->generation());
                 observers.push_back(sst->add_on_closed_handler([&] (sstable& sst) mutable {
                     auto sstables = t->get_sstables();
                     testlog.info("Closing sstable of generation {}, table set size: {}", sst.generation(), sstables->size());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2766,7 +2766,7 @@ SEASTAR_TEST_CASE(compound_sstable_set_basic_test) {
         }
 
         return make_ready_future<>();
-    });
+    }, test_env_config{ .use_uuid = false });
 }
 
 SEASTAR_TEST_CASE(sstable_reader_with_timeout) {

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -212,7 +212,7 @@ write_and_validate_sst(schema_ptr s, sstring dir, noncopyable_function<future<> 
         auto sst1 = do_write_sst(env, s, dir, env.tempdir().path().native(), env.new_generation()).get();
         auto sst2 = env.make_sstable(s, sst1->get_version());
         func(std::move(sst1), std::move(sst2)).get();
-    });
+    }, test_env_config{ .use_uuid = false });
 }
 
 SEASTAR_TEST_CASE(check_summary_func) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,6 +47,7 @@ public:
 struct test_env_config {
     db::large_data_handler* large_data_handler = nullptr;
     data_dictionary::storage_options storage; // will be local by default
+    bool use_uuid = false;
 };
 
 data_dictionary::storage_options make_test_object_storage_options();
@@ -62,6 +63,7 @@ class test_env {
         test_env_sstables_manager mgr;
         reader_concurrency_semaphore semaphore;
         sstables::sstable_generation_generator gen{0};
+        sstables::uuid_identifiers use_uuid;
         data_dictionary::storage_options storage;
 
         impl(test_env_config cfg, sstables::storage_manager* sstm);
@@ -69,7 +71,7 @@ class test_env {
         impl(const impl&) = delete;
 
         sstables::generation_type new_generation() noexcept {
-            return gen(sstables::uuid_identifiers::no);
+            return gen(use_uuid);
         }
     };
     std::unique_ptr<impl> _impl;

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,7 +47,7 @@ public:
 struct test_env_config {
     db::large_data_handler* large_data_handler = nullptr;
     data_dictionary::storage_options storage; // will be local by default
-    bool use_uuid = false;
+    bool use_uuid = true;
 };
 
 data_dictionary::storage_options make_test_object_storage_options();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -203,8 +203,14 @@ test_env::impl::impl(test_env_config cfg, sstables::storage_manager* sstm)
         feature_service, cache_tracker, memory::stats().total_memory(), dir_sem,
         [host_id = locator::host_id::create_random_id()]{ return host_id; }, sstm)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
+    , use_uuid(cfg.use_uuid)
     , storage(std::move(cfg.storage))
-{ }
+{
+    if (!storage.is_local_type()) {
+        // remote storage requires uuid-based identifier for naming sstables
+        assert(use_uuid == uuid_identifiers::yes);
+    }
+}
 
 future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg) {
     if (!cfg.storage.is_local_type()) {


### PR DESCRIPTION
this series 

1. let sstable tests using test_env to use uuid-based sstable identifiers by default
2. let the test who requires integer-based identifier keep using it

this should enable us to perform the s3 related test after enforcing the uuid-based identifier for s3 backend, otherwise the s3 related test would fail as it also utilize `test_env`.