### PR TITLE
sstables: stop warning when auto-snapshot leaves non-empty directory

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3064,7 +3064,7 @@ static future<int> remove_dir(fs::path dir, bool recursive) {
             // Ignore missing directories
             co_return 0;
         }
-        if (error_code == EEXIST && !recursive) {
+        if ((error_code == EEXIST || error_code == ENOTEMPTY) && !recursive) {
             // Just return failure if the directory is not empty
             // Let the caller decide what to do about it.
             co_return error_code;


### PR DESCRIPTION
When a table is dropped, we delete its sstables, and finally try to delete the table's top-level directory with the rmdir system call. When the auto-snapshot feature is enabled (this is still Scylla's default), the snapshot will remain in that directory so it won't be empty and will cannot be removed. Today, this results in a long, ugly and scary warning in the log:

```
WARN  2023-07-06 20:48:04,995 [shard 0] sstable - Could not remove table directory "/tmp/scylla-test-198265/data/alternator_alternator_Test_1688665684546/alternator_Test_1688665684546-4238f2201c2511eeb15859c589d9be4d/snapshots": std::filesystem::__cxx11::filesystem_error (error system:39, filesystem error: remove failed: Directory not empty [/tmp/scylla-test-198265/data/alternator_alternator_Test_1688665684546/alternator_Test_1688665684546-4238f2201c2511eeb15859c589d9be4d/snapshots]). Ignored.
```

It is bad to log as a warning something which is completely normal - it happens every time a table is dropped with the perfectly valid (and even default) auto-snapshot mode. We should only log a warning if the deletion failed because of some unexpected reason.

And in fact, this is exactly what the code **tried** to do - it does not log a warning if the rmdir failed with EEXIST. It even had a comment saying why it was doing this. But the problem is that in Linux, deleting a non-empty directory does not return EEXIST, it returns ENOTEMPTY... Posix actually allows both. So we need to check both, and this is the only change in this patch.

To confirm this that this patch works, edit test/cql-pytest/run.py and change auto-snapshot from 0 to 1, run test/alternator/run (for example) and see many "Directory not empty" warnings as above. With this patch, none of these warnings appear.

Fixes #13538