### PR TITLE
raft: do not ping self in direct failure detector

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1206,7 +1206,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 fd.stop().get();
             });
 
-            raft_gr.start(cfg->consistent_cluster_management(),
+            raft_gr.start(cfg->consistent_cluster_management(), raft::server_id{cfg->host_id.id},
                 std::ref(raft_address_map), std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();
 
             // group0 client exists only on shard 0.
@@ -1317,10 +1317,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     startlog.error("Bad configuration: consistent_cluster_management requires schema commit log to be enabled");
                     throw bad_configuration_error();
                 }
-                auto my_raft_id = raft::server_id{cfg->host_id.uuid()};
                 supervisor::notify("starting Raft Group Registry service");
-                raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {
-                    return raft_gr.start(my_raft_id);
+                raft_gr.invoke_on_all([] (service::raft_group_registry& raft_gr) {
+                    return raft_gr.start();
                 }).get();
             } else {
                 if (cfg->check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -112,7 +112,10 @@ public:
             _address_map.set_nonexpiring(addr.id);
             // Notify the direct failure detector that it should track
             // (or liveness of a specific raft server id.
-            _direct_fd.add_endpoint(addr.id.id);
+            if (addr != _my_id) {
+                // No need to ping self to know it's alive
+                _direct_fd.add_endpoint(addr.id.id);
+            }
         }
         for (const auto& addr: del) {
             // RPC 'send' may yield before resolving IP address,

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -97,23 +97,17 @@ private:
     std::optional<raft::group_id> _group0_id;
 
     // My Raft ID. Shared between different Raft groups.
-    // Once set, must not be changed.
-    //
-    // FIXME: ideally we'd like this to be passed to the constructor.
-    // However storage_proxy/query_processor/system_keyspace are unavailable
-    // when we start raft_group_registry so we have to set it later,
-    // after system_keyspace is initialized.
-    std::optional<raft::server_id> _my_id;
+    raft::server_id _my_id;
 
 public:
     // `is_enabled` must be `true` iff the local RAFT feature is enabled.
-    raft_group_registry(bool is_enabled, raft_address_map&,
+    raft_group_registry(bool is_enabled, raft::server_id my_id, raft_address_map&,
             netw::messaging_service& ms, gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
     ~raft_group_registry();
 
     // If is_enabled(),
-    // Called manually at start on every shard, after system_keyspace is initialized.
-    seastar::future<> start(raft::server_id my_id);
+    // Called manually at start on every shard.
+    seastar::future<> start();
     // Called by sharded<>::stop()
     seastar::future<> stop();
 

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -25,13 +25,13 @@ class raft_rpc : public raft::rpc {
 protected:
     raft_state_machine& _sm;
     raft::group_id _group_id;
-    raft::server_id _server_id;
+    raft::server_id _my_id;                     // Raft server id of this node.
     netw::messaging_service& _messaging;
     raft_address_map& _address_map;
     seastar::gate _shutdown_gate;
 
     explicit raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
-            raft_address_map& address_map, raft::group_id gid, raft::server_id srv_id);
+            raft_address_map& address_map, raft::group_id gid, raft::server_id my_id);
 
 private:
     template <typename Verb, typename Msg> void

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -792,7 +792,9 @@ public:
             });
 
             raft_gr.start(cfg->consistent_cluster_management(),
-                std::ref(raft_address_map), std::ref(ms), std::ref(gossiper), std::ref(fd)).get();
+                raft::server_id{cfg->host_id.id},
+                std::ref(raft_address_map),
+                std::ref(ms), std::ref(gossiper), std::ref(fd)).get();
             auto stop_raft_gr = deferred_stop(raft_gr);
 
             stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(ms), std::ref(mm), std::ref(gossiper), scheduling_groups.streaming_scheduling_group).get();
@@ -865,9 +867,8 @@ public:
             }).get();
 
             if (raft_gr.local().is_enabled()) {
-                auto my_raft_id = raft::server_id{cfg->host_id.uuid()};
-                raft_gr.invoke_on_all([my_raft_id] (service::raft_group_registry& raft_gr) {
-                    return raft_gr.start(my_raft_id);
+                raft_gr.invoke_on_all([] (service::raft_group_registry& raft_gr) {
+                    return raft_gr.start();
                 }).get();
             }
 


### PR DESCRIPTION
Avoid pinging self in direct failure detector, this adds confusing noise and adds constant overhead.
Fixes #14388