### PR TITLE
build: relax the regex to detect clang version

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -187,7 +187,7 @@ class OptimizationLevel:
                               capture_output=True,
                               check=True,
                               text=True)
-        matched = re.match(r'clang version (\d+\.\d+.\d+)', proc.stdout)
+        matched = re.search(r'clang version (\d+\.\d+.\d+)', proc.stdout)
         if matched is None:
             raise Exception(f'Unable to tell version of {cxx_compiler}')
         if parse_version(matched.group(1)) < parse_version('16.0.0'):


### PR DESCRIPTION
it turns out that the clang redistributed by Debian packager prints something like
```
Debian clang version 14.0.6
Debian clang version 16.0.6 (3)
Debian clang version 16.0.5 (1~exp1)
```
so instead of matching the output of `clang --version`, so the current regular expression fails to match with "Debian clang version 14.0.6" because of the "Debian" prefix. so just search for it.

Refs #14549
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>