### PR TITLE
test: mutation_test: unflake test_external_memory_usage

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2360,8 +2360,14 @@ SEASTAR_THREAD_TEST_CASE(test_external_memory_usage) {
         auto m = mutation(s.schema(), s.make_pkey("pk"));
 
         auto row_count = tests::random::get_int(1, 16);
+        auto ck_values = std::set<sstring>();
         for (auto i = 0; i < row_count; i++) {
             auto ck_value = to_hex(tests::random::get_bytes(tests::random::get_int(1023) + 1));
+            if (!ck_values.insert(ck_value).second) {
+                // This clustering key was already added. Retry.
+                --i;
+                continue;
+            }
             data_size += ck_value.size();
             auto ck = s.make_ckey(ck_value);
 
@@ -2402,8 +2408,14 @@ SEASTAR_THREAD_TEST_CASE(test_external_memory_usage_v2) {
         auto m = mutation(s.schema(), s.make_pkey("pk"));
 
         auto row_count = tests::random::get_int(1, 16);
+        auto ck_values = std::set<sstring>();
         for (auto i = 0; i < row_count; i++) {
             auto ck_value = to_hex(tests::random::get_bytes(tests::random::get_int(1023) + 1));
+            if (!ck_values.insert(ck_value).second) {
+                // This clustering key was already added. Retry.
+                --i;
+                continue;
+            }
             data_size += ck_value.size();
             auto ck = s.make_ckey(ck_value);
 


### PR DESCRIPTION
The test has about 1/2500000 chance to fail due to a conflict of random values. And it recently did, just to spite us.

Fight back.

Fixes #14563