### PR TITLE
compound_compat: do not format an sstring with {:d}

### DIFF
--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -568,7 +568,7 @@ public:
             auto marker = it->second;
             ++it;
             if (it != e && marker != composite::eoc::none) {
-                throw runtime_exception(format("non-zero component divider found ({:d}) mid", format("0x{:02x}", composite::eoc_type(marker) & 0xff)));
+                throw runtime_exception(format("non-zero component divider found ({:#02x}) mid", composite::eoc_type(marker) & 0xff));
             }
         }
         return ret;


### PR DESCRIPTION
before this change, we format a sstring with "{:d}", fmtlib would throw `fmt::format_error` at runtime when formatting it. this is not expected.

so, in this change, we just print the int8_t using `seastar::format()` in a single pass. and with the format specifier of `#02x` instead of adding the "0x" prefix manually.

Fixes #14577
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>