### PR TITLE
estimated_histogram: do not use dynamic format_string

### DIFF
--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -626,7 +626,6 @@ public:
             max_name_len = std::max(max_name_len, names.back().size());
         }
 
-        sstring formatstr = format("{{:{:d}s}}: {{:d}}\n", max_name_len);
         for (size_t i = 0; i < name_count; i++) {
             int64_t count = h.buckets[i];
             // sort-of-hack to not print empty ranges at the start that are only used to demarcate the
@@ -635,7 +634,7 @@ public:
             if (i == 0 && count == 0) {
                 continue;
             }
-            out << format(formatstr.c_str(), names[i], count);
+            fmt::print(out, "{:{}s}: {:d}", names[i], max_name_len, count);
         }
         return out;
     }


### PR DESCRIPTION
fmtlib allows us to specify the field width dynamically, so specify the field width in the same statement formatting the argument improves the readability. and use the constexpr fmt string allows us to switch to compile-time formatter supported by fmtlib v8.

this change also use `fmt::print()` to format the argument right to the output ostream, instead of creating a temporary sstring, and copy it to the output ostream.