### PR TITLE
streaming: cast the progress to a float before formatting it

### DIFF
--- a/streaming/progress_info.cc
+++ b/streaming/progress_info.cc
@@ -14,8 +14,9 @@ namespace streaming {
 
 std::ostream& operator<<(std::ostream& os, const progress_info& x) {
     sstring dir = x.dir == progress_info::direction::OUT ? "sent to " : "received from ";
-    return os << format("{} {:d}/({:f}%) {} {}", x.file_name, x.current_bytes,
-            x.current_bytes * 100 / x.total_bytes, dir, x.peer);
+    fmt::print(os, "{} {:d}/({:f}%) {} {}", x.file_name, x.current_bytes,
+            x.current_bytes * 100.F / x.total_bytes, dir, x.peer);
+    return os;
 }
 
 }


### PR DESCRIPTION
before this change, we format a `long` using `{:f}`. fmtlib would throw an exception when actually formatting it.

so, let's make the percentage a float before formatting it.

Fixes #14587
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>