### PR TITLE
alternator: correct format string

### DIFF
--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -662,7 +662,7 @@ static rjson::value extract_path(const rjson::value* item,
             // objects. But today Alternator does not validate the structure
             // of nested documents before storing them, so this can happen on
             // read.
-            throw api_error::validation(format("{}: malformed item read: {}", *item));
+            throw api_error::validation(format("{}: malformed item read: {}", caller, *item));
         }
         const char* type = v->MemberBegin()->name.GetString();
         v = &(v->MemberBegin()->value);


### PR DESCRIPTION
when formatting the error message for `api_error::validation`, we always include the caller in the error message, but in this case, forgot to pass the `caller` to `seastar::format()`. if fmtlib actually formats them, it would throw.

so let's pass `caller` to `seastar::format()`.