### PR TITLE
Introduce tablet load balancer

### DIFF
--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -273,9 +273,9 @@ future<> range_streamer::stream_async() {
                             nr_ranges_streamed, nr_ranges_streamed + ranges_to_stream.size(), nr_ranges_total);
                     auto ranges_streamed = ranges_to_stream.size();
                     if (_nr_rx_added) {
-                        sp.request_ranges(source, keyspace, std::move(ranges_to_stream));
+                        sp.request_ranges(source, keyspace, std::move(ranges_to_stream), _tables);
                     } else if (_nr_tx_added) {
-                        sp.transfer_ranges(source, keyspace, std::move(ranges_to_stream));
+                        sp.transfer_ranges(source, keyspace, std::move(ranges_to_stream), _tables);
                     }
                     sp.execute().discard_result().get();
                     // Update finished percentage

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -77,7 +77,8 @@ public:
     };
 
     range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
-            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason)
+            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
+            std::vector<sstring> tables = {})
         : _db(db)
         , _stream_manager(sm)
         , _token_metadata_ptr(std::move(tmptr))
@@ -87,13 +88,14 @@ public:
         , _dr(std::move(dr))
         , _description(std::move(description))
         , _reason(reason)
+        , _tables(std::move(tables))
     {
         _abort_source.check();
     }
 
     range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
-            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason)
-        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason) {
+            inet_address address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason, std::vector<sstring> tables = {})
+        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(tables)) {
     }
 
     void add_source_filter(std::unique_ptr<i_source_filter> filter) {
@@ -155,6 +157,7 @@ private:
     locator::endpoint_dc_rack _dr;
     sstring _description;
     streaming::stream_reason _reason;
+    std::vector<sstring> _tables;
     std::unordered_multimap<sstring, std::unordered_map<inet_address, dht::token_range_vector>> _to_stream;
     std::unordered_set<std::unique_ptr<i_source_filter>> _source_filters;
     // Number of tx and rx ranges added

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -6,6 +6,19 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+namespace locator {
+
+struct tablet_id final {
+    uint64_t value();
+};
+
+struct global_tablet_id final {
+    ::table_id table;
+    locator::tablet_id tablet;
+};
+
+}
+
 namespace service {
 struct fencing_token {
     service::topology::version_t topology_version;
@@ -38,4 +51,5 @@ struct raft_topology_pull_params {};
 
 verb raft_topology_cmd (raft::term_t term, uint64_t cmd_index, service::raft_topology_cmd) -> service::raft_topology_cmd_result;
 verb raft_pull_topology_snapshot (service::raft_topology_pull_params) -> service::raft_topology_snapshot;
+verb [[cancellable]] tablet_stream_data (locator::global_tablet_id);
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -112,10 +112,10 @@ inet_address_vector_topology_change vnode_effective_replication_map::get_pending
     return endpoints;
 }
 
-std::optional<inet_address_vector_replica_set> vnode_effective_replication_map::get_endpoints_for_reading(const token& token) const {
+inet_address_vector_replica_set vnode_effective_replication_map::get_endpoints_for_reading(const token& token) const {
     const auto* endpoints = find_token(_read_endpoints, token);
     if (endpoints == nullptr) {
-        return {};
+        return get_natural_endpoints_without_node_being_replaced(token);
     }
     return inet_address_vector_replica_set(endpoints->begin(), endpoints->end());
 }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -201,9 +201,7 @@ public:
     virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const = 0;
 
     /// Returns a list of nodes to which a read request should be directed.
-    /// Returns not null only during topology changes, if request_read_new was called and
-    /// new set of replicas differs from the old one.
-    virtual std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const = 0;
+    virtual inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const = 0;
 
     /// Returns true if there are any pending ranges for this endpoint.
     /// This operation is expensive, for vnode_erm it iterates
@@ -279,7 +277,7 @@ public: // effective_replication_map
     inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const override;
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
     inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
-    std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override;
+    inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override;
     bool has_pending_ranges(inet_address endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -153,6 +153,15 @@ void tablet_map::set_tablet_transition_info(tablet_id id, tablet_transition_info
     _transitions.insert_or_assign(id, std::move(info));
 }
 
+future<> tablet_map::for_each_tablet(seastar::noncopyable_function<void(tablet_id, const tablet_info&)> func) const {
+    std::optional<tablet_id> tid = first_tablet();
+    for (const tablet_info& ti : tablets()) {
+        co_await coroutine::maybe_yield();
+        func(*tid, ti);
+        tid = next_tablet(*tid);
+    }
+}
+
 std::optional<shard_id> tablet_map::get_shard(tablet_id tid, host_id host) const {
     auto&& info = get_tablet_info(tid);
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -260,8 +260,8 @@ public:
         return {get_endpoint_for_host_id(info->pending_replica.host)};
     }
 
-    virtual std::optional<inet_address_vector_replica_set> get_endpoints_for_reading(const token& search_token) const override {
-        return std::nullopt;
+    virtual inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override {
+        return get_natural_endpoints_without_node_being_replaced(search_token);
     }
 
     virtual bool has_pending_ranges(inet_address endpoint) const override {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -472,6 +472,11 @@ effective_replication_map_ptr tablet_aware_replication_strategy::do_make_replica
 
 }
 
+auto fmt::formatter<locator::global_tablet_id>::format(const locator::global_tablet_id& id, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}:{}", id.table, id.tablet);
+}
+
 auto fmt::formatter<locator::tablet_transition_stage>::format(const locator::tablet_transition_stage& stage, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", locator::tablet_transition_stage_to_string(stage));

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -80,6 +80,22 @@ std::ostream& operator<<(std::ostream&, const tablet_replica&);
 
 using tablet_replica_set = utils::small_vector<tablet_replica, 3>;
 
+/// Creates a new replica set with old_replica replaced by new_replica.
+/// If there is no old_replica, the set is returned unchanged.
+inline
+tablet_replica_set replace_replica(const tablet_replica_set& rs, tablet_replica old_replica, tablet_replica new_replica) {
+    tablet_replica_set result;
+    result.reserve(rs.size());
+    for (auto&& r : rs) {
+        if (r == old_replica) {
+            result.push_back(new_replica);
+        } else {
+            result.push_back(r);
+        }
+    }
+    return result;
+}
+
 /// Stores information about a single tablet.
 struct tablet_info {
     tablet_replica_set replicas;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -34,7 +34,28 @@ using token = dht::token;
 // Different tablets in subsequent token metadata version can have the same tablet_id.
 // When splitting a tablet, one of the new tablets (in the new token metadata version)
 // will have the same tablet_id as the old one.
-enum class tablet_id : size_t;
+struct tablet_id {
+    size_t id;
+    explicit tablet_id(size_t id) : id(id) {}
+    size_t value() const { return id; }
+    explicit operator size_t() const { return id; }
+    bool operator<=>(const tablet_id&) const = default;
+};
+
+}
+
+namespace std {
+
+template<>
+struct hash<locator::tablet_id> {
+    size_t operator()(const locator::tablet_id& id) const {
+        return std::hash<size_t>()(id.value());
+    }
+};
+
+}
+
+namespace locator {
 
 struct tablet_replica {
     host_id host;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -80,12 +80,24 @@ enum class tablet_transition_stage {
 sstring tablet_transition_stage_to_string(tablet_transition_stage);
 tablet_transition_stage tablet_transition_stage_from_string(const sstring&);
 
+enum class write_replica_set_selector {
+    previous, both, next
+};
+
+enum class read_replica_set_selector {
+    previous, next
+};
+
 /// Used for storing tablet state transition during topology changes.
 /// Describes transition of a single tablet.
 struct tablet_transition_info {
     tablet_transition_stage stage;
     tablet_replica_set next;
     tablet_replica pending_replica; // Optimization (next - tablet_info::replicas)
+    write_replica_set_selector writes;
+    read_replica_set_selector reads;
+
+    tablet_transition_info(tablet_transition_stage stage, tablet_replica_set next, tablet_replica pending_replica);
 
     bool operator==(const tablet_transition_info&) const = default;
 };

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -19,6 +19,9 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <vector>
 
@@ -215,6 +218,9 @@ public:
     const tablet_container& tablets() const {
         return _tablets;
     }
+
+    /// Calls a given function for each tablet in the map in token ownership order.
+    future<> for_each_tablet(seastar::noncopyable_function<void(tablet_id, const tablet_info&)> func) const;
 
     const auto& transitions() const {
         return _transitions;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -57,6 +57,14 @@ struct hash<locator::tablet_id> {
 
 namespace locator {
 
+/// Identifies tablet (not be confused with tablet replica) in the scope of the whole cluster.
+struct global_tablet_id {
+    table_id table;
+    tablet_id tablet;
+
+    bool operator<=>(const global_tablet_id&) const = default;
+};
+
 struct tablet_replica {
     host_id host;
     shard_id shard;
@@ -290,9 +298,23 @@ struct hash<locator::tablet_replica> {
     }
 };
 
+template<>
+struct hash<locator::global_tablet_id> {
+    size_t operator()(const locator::global_tablet_id& id) const {
+        return utils::hash_combine(
+                std::hash<table_id>()(id.table),
+                std::hash<locator::tablet_id>()(id.tablet));
+    }
+};
+
 }
 
 template <>
 struct fmt::formatter<locator::tablet_transition_stage> : fmt::formatter<std::string_view> {
     auto format(const locator::tablet_transition_stage&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<locator::global_tablet_id> : fmt::formatter<std::string_view> {
+    auto format(const locator::global_tablet_id&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -85,6 +85,7 @@ private:
     void sort_tokens();
 
     const tablet_metadata& tablets() const { return _tablets; }
+    tablet_metadata& tablets() { return _tablets; }
 
     void set_tablets(tablet_metadata&& tablets) {
         _tablets = std::move(tablets);
@@ -402,6 +403,10 @@ void token_metadata_impl::sort_tokens() {
 }
 
 const tablet_metadata& token_metadata::tablets() const {
+    return _impl->tablets();
+}
+
+tablet_metadata& token_metadata::tablets() {
     return _impl->tablets();
 }
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -114,6 +114,7 @@ public:
     ~token_metadata();
     const std::vector<token>& sorted_tokens() const;
     const tablet_metadata& tablets() const;
+    tablet_metadata& tablets();
     void set_tablets(tablet_metadata);
     // Update token->endpoint mappings for a given \c endpoint.
     // \c tokens are all the tokens that are now owned by \c endpoint.

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -171,6 +171,14 @@ public:
     // Returns a pointer to the node if found, or nullptr otherwise.
     const node* find_node(host_id id) const noexcept;
 
+    const node& get_node(host_id id) const {
+        auto n = find_node(id);
+        if (!n) {
+            throw_with_backtrace<std::runtime_error>(format("Node {} not found in topology", id));
+        }
+        return *n;
+    };
+
     // Looks up a node by its inet_address.
     // Returns a pointer to the node if found, or nullptr otherwise.
     const node* find_node(const inet_address& ep) const noexcept;

--- a/main.cc
+++ b/main.cc
@@ -1242,6 +1242,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             distributed<service::tablet_allocator> tablet_allocator;
             if (cfg->check_experimental(db::experimental_features_t::feature::TABLETS)) {
+                if (!cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
+                    startlog.error("Bad configuration: The consistent-topology-changes feature has to be enabled if tablets feature is enabled");
+                    throw bad_configuration_error();
+                }
                 tablet_allocator.start(std::ref(mm_notifier), std::ref(db)).get();
             }
             auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -18,6 +18,7 @@
 #include "gms/gossip_digest_syn.hh"
 #include "gms/gossip_digest_ack.hh"
 #include "gms/gossip_digest_ack2.hh"
+#include "locator/tablets.hh"
 #include "query-request.hh"
 #include "query-result.hh"
 #include <seastar/rpc/rpc.hh>
@@ -593,6 +594,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::REPAIR_FLUSH_HINTS_BATCHLOG:
     case messaging_verb::NODE_OPS_CMD:
     case messaging_verb::HINT_MUTATION:
+    case messaging_verb::TABLET_STREAM_DATA:
         return 1;
     case messaging_verb::CLIENT_ID:
     case messaging_verb::MUTATION:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -182,7 +182,8 @@ enum class messaging_verb : int32_t {
     DIRECT_FD_PING = 63,
     RAFT_TOPOLOGY_CMD = 64,
     RAFT_PULL_TOPOLOGY_SNAPSHOT = 65,
-    LAST = 66,
+    TABLET_STREAM_DATA = 66,
+    LAST = 67,
 };
 
 } // namespace netw

--- a/mutation_writer/multishard_writer.hh
+++ b/mutation_writer/multishard_writer.hh
@@ -16,6 +16,7 @@
 namespace mutation_writer {
 
 future<uint64_t> distribute_reader_and_consume_on_shards(schema_ptr s,
+    const dht::sharder& sharder,
     flat_mutation_reader_v2 producer,
     std::function<future<> (flat_mutation_reader_v2)> consumer,
     utils::phased_barrier::operation&& op = {});

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -492,7 +492,7 @@ void repair_writer_impl::create_writer(lw_shared_ptr<repair_writer> w) {
     }
     replica::table& t = _db.local().find_column_family(_schema->id());
     rlogger.debug("repair_writer: keyspace={}, table={}, estimated_partitions={}", w->schema()->ks_name(), w->schema()->cf_name(), w->get_estimated_partitions());
-    _writer_done = mutation_writer::distribute_reader_and_consume_on_shards(_schema, std::move(_queue_reader),
+    _writer_done = mutation_writer::distribute_reader_and_consume_on_shards(_schema, _schema->get_sharder(), std::move(_queue_reader),
             streaming::make_streaming_consumer(sstables::repair_origin, _db, _sys_dist_ks, _view_update_generator, w->get_estimated_partitions(), _reason, is_offstrategy_supported(_reason)),
     t.stream_in_progress()).then([w] (uint64_t partitions) {
         rlogger.debug("repair_writer: keyspace={}, table={}, managed to write partitions={} to sstable",

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1302,8 +1302,10 @@ keyspace::create_replication_strategy(const locator::shared_token_metadata& stm,
             abstract_replication_strategy::create_replication_strategy(
                 _metadata->strategy_name(), options);
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}", _metadata->name(), _metadata->strategy_name(), options);
-    auto erm = co_await _erm_factory.create_effective_replication_map(_replication_strategy, stm.get());
-    update_effective_replication_map(std::move(erm));
+    if (!_replication_strategy->is_per_table()) {
+        auto erm = co_await _erm_factory.create_effective_replication_map(_replication_strategy, stm.get());
+        update_effective_replication_map(std::move(erm));
+    }
 }
 
 void

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "mutation/mutation.hh"
+#include "db/system_keyspace.hh"
+#include "replica/tablets.hh"
+
+namespace replica {
+
+class tablet_mutation_builder {
+    api::timestamp_type _ts;
+    schema_ptr _s;
+    mutation _m;
+private:
+    clustering_key get_ck(dht::token last_token) {
+        return clustering_key::from_single_value(*_s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
+    }
+public:
+    tablet_mutation_builder(api::timestamp_type ts, const sstring& keyspace_name, table_id table)
+            : _ts(ts)
+            , _s(db::system_keyspace::tablets())
+            , _m(_s, partition_key::from_exploded(*_s, {
+                    data_value(keyspace_name).serialize_nonnull(),
+                    data_value(table.uuid()).serialize_nonnull()
+            }))
+    { }
+
+    tablet_mutation_builder& set_new_replicas(dht::token last_token, locator::tablet_replica_set replicas);
+    tablet_mutation_builder& set_replicas(dht::token last_token, locator::tablet_replica_set replicas);
+    tablet_mutation_builder& set_stage(dht::token last_token, locator::tablet_transition_stage stage);
+    tablet_mutation_builder& del_transition(dht::token last_token);
+
+    mutation build() {
+        return std::move(_m);
+    }
+};
+
+} // namespace replica

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -15,6 +15,7 @@
 #include "cql3/untyped_result_set.hh"
 #include "replica/database.hh"
 #include "replica/tablets.hh"
+#include "replica/tablet_mutation_builder.hh"
 
 namespace replica {
 
@@ -41,23 +42,23 @@ schema_ptr make_tablets_schema() {
             .build();
 }
 
+static
+std::vector<data_value> replicas_to_data_value(const tablet_replica_set& replicas) {
+    std::vector<data_value> result;
+    result.reserve(replicas.size());
+    for (auto&& replica : replicas) {
+        result.emplace_back(make_tuple_value(replica_type, {
+                data_value(utils::UUID(replica.host.uuid())),
+                data_value(int(replica.shard))
+        }));
+    }
+    return result;
+};
+
 future<mutation>
 tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& keyspace_name, const sstring& table_name,
                        api::timestamp_type ts) {
     auto s = db::system_keyspace::tablets();
-
-    auto replicas_to_data_value = [&] (const tablet_replica_set& replicas) {
-        std::vector<data_value> result;
-        result.reserve(replicas.size());
-        for (auto&& replica : replicas) {
-            result.emplace_back(make_tuple_value(replica_type, {
-                data_value(utils::UUID(replica.host.uuid())),
-                data_value(int(replica.shard))
-            }));
-        }
-        return result;
-    };
-
     auto gc_now = gc_clock::now();
     auto tombstone_ts = ts - 1;
 
@@ -82,6 +83,34 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         co_await coroutine::maybe_yield();
     }
     co_return std::move(m);
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_new_replicas(dht::token last_token, locator::tablet_replica_set replicas) {
+    _m.set_clustered_cell(get_ck(last_token), "new_replicas", make_set_value(replica_set_type, replicas_to_data_value(replicas)), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_replicas(dht::token last_token, locator::tablet_replica_set replicas) {
+    _m.set_clustered_cell(get_ck(last_token), "replicas", make_set_value(replica_set_type, replicas_to_data_value(replicas)), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_stage(dht::token last_token, locator::tablet_transition_stage stage) {
+    _m.set_clustered_cell(get_ck(last_token), "stage", data_value(tablet_transition_stage_to_string(stage)), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::del_transition(dht::token last_token) {
+    auto ck = get_ck(last_token);
+    auto stage_col = _s->get_column_definition("stage");
+    _m.set_clustered_cell(ck, *stage_col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    auto new_replicas_col = _s->get_column_definition("new_replicas");
+    _m.set_clustered_cell(ck, *new_replicas_col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    return *this;
 }
 
 mutation make_drop_tablet_map_mutation(const sstring& keyspace_name, table_id id, api::timestamp_type ts) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -22,6 +22,7 @@
 #include "query_result_merger.hh"
 #include <seastar/core/do_with.hh>
 #include "message/messaging_service.hh"
+#include "locator/tablets.hh"
 #include "gms/gossiper.hh"
 #include <seastar/core/future-util.hh>
 #include "db/read_repair_decision.hh"

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6184,13 +6184,10 @@ void storage_proxy::sort_endpoints_by_proximity(const locator::topology& topo, i
 
 inet_address_vector_replica_set storage_proxy::get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const {
     auto endpoints = erm.get_endpoints_for_reading(token);
-    if (!endpoints) {
-        endpoints = erm.get_natural_endpoints_without_node_being_replaced(token);
-    }
-    auto it = boost::range::remove_if(*endpoints, std::not_fn(std::bind_front(&storage_proxy::is_alive, this)));
-    endpoints->erase(it, endpoints->end());
-    sort_endpoints_by_proximity(erm.get_topology(), *endpoints);
-    return std::move(*endpoints);
+    auto it = boost::range::remove_if(endpoints, std::not_fn(std::bind_front(&storage_proxy::is_alive, this)));
+    endpoints.erase(it, endpoints.end());
+    sort_endpoints_by_proximity(erm.get_topology(), endpoints);
+    return endpoints;
 }
 
 // `live_endpoints` must already contain only replicas for this query; the function only filters out some of them.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5083,6 +5083,7 @@ void storage_service::on_update_tablet_metadata() {
     }
     // FIXME: Avoid reading whole tablet metadata on partial changes.
     load_tablet_metadata().get();
+    _topology_state_machine.event.signal(); // wake up load balancer.
 }
 
 future<> storage_service::load_tablet_metadata() {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -15,6 +15,7 @@
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "locator/tablets.hh"
 #include "inet_address_vectors.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/condition-variable.hh>
@@ -145,6 +146,8 @@ private:
     future<> node_ops_abort(node_ops_id ops_uuid);
     void node_ops_signal_abort(std::optional<node_ops_id> ops_uuid);
     future<> node_ops_abort_thread();
+    future<> stream_tablet(locator::global_tablet_id);
+    inet_address host2ip(locator::host_id);
 public:
     storage_service(abort_source& as, distributed<replica::database>& db,
         gms::gossiper& gossiper,
@@ -759,6 +762,7 @@ private:
     std::optional<shared_future<>> _decomission_result;
     std::optional<shared_future<>> _rebuild_result;
     std::unordered_map<raft::server_id, std::optional<shared_future<>>> _remove_result;
+    std::unordered_map<locator::global_tablet_id, std::optional<shared_future<>>> _tablet_streaming;
     // During decommission, the node waits for the coordinator to tell it to shut down.
     std::optional<promise<>> _shutdown_request_promise;
     struct {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -12,11 +12,425 @@
 #include "replica/database.hh"
 #include "service/migration_manager.hh"
 #include "service/tablet_allocator.hh"
+#include "utils/stall_free.hh"
+#include "locator/load_sketch.hh"
+#include "utils/div_ceil.hh"
 
 using namespace locator;
 using namespace replica;
 
 namespace service {
+
+seastar::logger lblogger("load_balancer");
+
+/// The algorithm aims to equalize tablet count on each shard.
+/// This goal is based on the assumption that every shard has similar processing power and space capacity,
+/// and that each tablet has equal consumption of those resources. So by equalizing tablet count per shard we
+/// equalize resource utilization.
+///
+/// The algorithm produces a migration plan which is a set of instructions about which tablets to move
+/// where. The plan is a small increment, not a complete plan. To achieve balance, the algorithm should
+/// be invoked iteratively until an empty plan is returned.
+///
+/// The algorithm keeps track of load at two levels, per node and per shard. The reason for this is that
+/// we want to equalize the per-node score first, by moving tablets across nodes. Tablets are moved away
+/// from the most loaded node first. We also track load per shard, so that we move tablets from the most
+/// loaded shard on a given node first.
+///
+/// The metric for node load is (number of tablets / shard count) which is the average
+/// per-shard load. If we achieve balance according to this metric, and then rebalance the nodes internally,
+/// we will achieve global balance on all shards in the cluster.
+///
+/// The reason why we focus on nodes first before rebalancing them internally is that this results
+/// in less tablet movements than looking at shards only.
+///
+/// It would be still beneficial to rebalance tablet-receiving nodes internally before moving tablets
+/// to them so that we can distribute load equally without overloading shards which are out of balance,
+/// but this is not implemented yet.
+///
+/// The outline of the algorithm is as follows:
+///
+///   1. Determine the set of nodes whose load should be balanced.
+///   2. Pick the least-loaded node (target)
+///   3. Keep moving tablets to the target until balance is achieved with the highest-loaded node,
+///              or we hit a limit for plan size:
+///      3.1. Pick the most-loaded node (source)
+///      3.2. Pick the most-loaded shard on the source
+///      3.3. Pick one of the candidate tablets on the source shard
+///      3.4. Evaluate collocation constraints for tablet replicas, if they pass:
+///           3.4.1 Pick the least-loaded shard on the target
+///           3.4.2 Generate a migration for the candidate tablet from the source shard to the target shard
+///
+/// Even though the algorithm focuses on a single target, the fact the the produced plan is just an increment
+/// means that many under-loaded nodes can be driven forward to balance concurrently because the load balancer
+/// will alternate between them across make_plan() calls.
+///
+/// The cost of make_plan() is relatively heavy in terms of preparing data structures, so the current
+/// implementation is not efficient if the scheduler would like to call make_plan() multiple times
+/// to parallelize execution. This will be addressed in the future by keeping the data structures
+/// valid across calls and only recalculating them when starting a new round with a new token metadata version.
+///
+class load_balancer {
+    using global_shard_id = tablet_replica;
+    using shard_id = seastar::shard_id;
+
+    // Represents metric for per-node load which we want to equalize between nodes.
+    // It's an average per-shard load in terms of tablet count.
+    using load_type = double;
+
+    struct shard_load {
+        size_t tablet_count;
+
+        // Tablets which still have a replica on this shard which are candidates for migrating away from this shard.
+        std::unordered_set<global_tablet_id> candidates;
+
+        future<> clear_gently() {
+            return utils::clear_gently(candidates);
+        }
+    };
+
+    struct node_load {
+        host_id node;
+        uint64_t shard_count = 0;
+        uint64_t tablet_count = 0;
+
+        // The average shard load on this node.
+        load_type avg_load = 0;
+
+        std::vector<shard_id> shards_by_load; // heap which tracks most-loaded shards using shards_by_load_cmp().
+        std::vector<shard_load> shards; // Indexed by shard_id to which a given shard_load corresponds.
+
+        // Call when tablet_count changes.
+        void update() {
+            avg_load = get_avg_load(tablet_count);
+        }
+
+        load_type get_avg_load(uint64_t tablets) const {
+            return double(tablets) / shard_count;
+        }
+
+        auto shards_by_load_cmp() {
+            return [this] (const auto& a, const auto& b) {
+                return shards[a].tablet_count < shards[b].tablet_count;
+            };
+        }
+
+        future<> clear_gently() {
+            return utils::clear_gently(shards);
+        }
+    };
+
+    token_metadata_ptr _tm;
+public:
+    load_balancer(token_metadata_ptr tm)
+        : _tm(std::move(tm)) {
+    }
+
+    future<migration_plan> make_plan() {
+        const locator::topology& topo = _tm->get_topology();
+        migration_plan plan;
+
+        // Prepare plans for each DC separately and combine them to be executed in parallel.
+        for (auto&& dc : topo.get_datacenters()) {
+            auto dc_plan = co_await make_plan(dc);
+            lblogger.info("Prepared {} migrations in DC {}", dc_plan.size(), dc);
+            std::move(dc_plan.begin(), dc_plan.end(), std::back_inserter(plan));
+        }
+
+        lblogger.info("Prepared {} migrations", plan.size());
+        co_return std::move(plan);
+    }
+
+    future<migration_plan> make_plan(sstring dc) {
+        lblogger.info("Examining DC {}", dc);
+
+        const locator::topology& topo = _tm->get_topology();
+
+        // Select subset of nodes to balance.
+
+        std::unordered_map<host_id, node_load> nodes;
+        topo.for_each_node([&] (const locator::node* node_ptr) {
+            if (node_ptr->get_state() == locator::node::state::normal && node_ptr->dc_rack().dc == dc) {
+                node_load& load = nodes[node_ptr->host_id()];
+                load.shard_count = node_ptr->get_shard_count();
+                load.shards.resize(load.shard_count);
+                if (!load.shard_count) {
+                    throw std::runtime_error(format("Shard count of {} not found in topology", node_ptr->host_id()));
+                }
+            }
+        });
+
+        // Compute tablet load on nodes.
+
+        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
+            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) {
+                for (auto&& replica : ti.replicas) {
+                    if (nodes.contains(replica.host)) {
+                        nodes[replica.host].tablet_count += 1;
+                        // This invariant is assumed later.
+                        if (replica.shard >= nodes[replica.host].shard_count) {
+                            auto gtid = global_tablet_id{table, tid};
+                            on_internal_error(lblogger, format("Tablet {} replica {} targets non-existent shard", gtid, replica));
+                        }
+                    }
+                }
+            });
+        }
+
+        // Compute load imbalance.
+
+        load_type max_load = 0;
+        load_type min_load = 0;
+        std::optional<host_id> min_load_node = std::nullopt;
+        for (auto&& [host, load] : nodes) {
+            load.update();
+            if (!min_load_node || load.avg_load < min_load) {
+                min_load = load.avg_load;
+                min_load_node = host;
+            }
+            if (load.avg_load > max_load) {
+                max_load = load.avg_load;
+            }
+        }
+
+        if (max_load == min_load) {
+            // load is balanced.
+            // TODO: Evaluate and fix intra-node balance.
+            co_return migration_plan();
+        }
+
+        for (auto&& [host, load] : nodes) {
+            lblogger.info("Node {}: rack={} avg_load={}, tablets={}, shards={}",
+                          host, topo.find_node(host)->dc_rack().rack, load.avg_load, load.tablet_count, load.shard_count);
+        }
+        lblogger.info("target node: {}, avg_load: {}, max: {}", *min_load_node, min_load, max_load);
+        auto target = *min_load_node;
+
+        // We want to saturate the target node so we migrate several tablets in parallel, one for each shard
+        // on the target node. This assumes that the target node is well-balanced and that tablet migrations
+        // complete at the same time. Both assumptions are not generally true in practice, which we currently ignore.
+        // If target node is not balanced across shards, we will overload some shards.
+        // If tablets are not balanced in size, throughput will suffer because some shards will be idle sooner than others.
+        //
+        // FIXME: To handle the above, we should (1) rebalance the target node
+        // before migrating tablets from other nodes. If shards are balanced on the target node, the balancer
+        // will naturally distribute tablets to different shards. Also, (2) we should change this algorithm
+        // to be a generator for migrations and have a scheduler in the execution layer which pulls migrations
+        // from this algorithm, batches them and decides how many to execute.
+        //
+        // The scheduler decides in which order to execute the plan based on current activity in the system.
+        // We cannot just ask the planner for the next migration and stop when we hit overload on some shard,
+        // because that can lead to underutilization of the cluster. Just because the next migration is blocked
+        // by the target shard being busy doesn't mean we could not proceed with migrations for other shards
+        // which would be produced by the planner subsequently.
+
+        auto target_node = topo.find_node(target);
+        auto batch_size = target_node->get_shard_count();
+
+        // Compute per-shard load and candidate tablets.
+
+        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
+            if (!tmap.transitions().empty()) {
+                // FIXME: The algorithm doesn't support balancing with active transitions yet. They must finish first.
+                lblogger.warn("Pending transitions active.");
+                co_return migration_plan();
+            }
+
+            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) {
+                for (auto&& replica : ti.replicas) {
+                    if (!nodes.contains(replica.host)) {
+                        continue;
+                    }
+                    auto& node_load_info = nodes[replica.host];
+                    auto&& shard_load_info = node_load_info.shards[replica.shard];
+                    if (shard_load_info.tablet_count == 0) {
+                        node_load_info.shards_by_load.push_back(replica.shard);
+                    }
+                    shard_load_info.tablet_count += 1;
+                    shard_load_info.candidates.emplace(global_tablet_id{table, tid});
+                }
+            });
+        }
+
+        // Prepare candidate nodes and shards for heap-based balancing.
+
+        // heap which tracks most-loaded nodes in terms of avg_load.
+        std::vector<host_id> nodes_by_load;
+        nodes_by_load.reserve(nodes.size());
+        auto nodes_cmp = [&] (const host_id& a, const host_id& b) {
+            return nodes[a].avg_load < nodes[b].avg_load;
+        };
+
+        for (auto&& [host, node_load] : nodes) {
+            if (lblogger.is_enabled(seastar::log_level::debug)) {
+                shard_id shard = 0;
+                for (auto&& shard_load : node_load.shards) {
+                    lblogger.debug("shard {}: all tablets: {}, candidates: {}", tablet_replica{host, shard},
+                                   shard_load.tablet_count, shard_load.candidates.size());
+                    shard++;
+                }
+            }
+
+            nodes_by_load.push_back(host);
+            std::make_heap(node_load.shards_by_load.begin(), node_load.shards_by_load.end(), node_load.shards_by_load_cmp());
+        }
+
+        std::make_heap(nodes_by_load.begin(), nodes_by_load.end(), nodes_cmp);
+
+        locator::load_sketch target_load(_tm);
+        co_await target_load.populate(target);
+        migration_plan plan;
+        const tablet_metadata& tmeta = _tm->tablets();
+        load_type max_off_candidate_load = 0; // max load among nodes which ran out of candidates.
+        auto& target_info = nodes[target];
+        while (plan.size() < batch_size && !nodes_by_load.empty()) {
+            co_await coroutine::maybe_yield();
+
+            std::pop_heap(nodes_by_load.begin(), nodes_by_load.end(), nodes_cmp);
+            auto src_host = nodes_by_load.back();
+            auto& src_node_info = nodes[src_host];
+
+            // Check if all nodes reached the same avg_load. There are three sets of nodes: target, candidates (nodes_by_load)
+            // and off-candidates (removed from nodes_by_load). At any time, the avg_load for target is not greater than
+            // that of any candidate, and avg_load of any candidate is not greater than that of any in the off-candidates set.
+            // This is ensured by the fact that we remove candidates in the order of avg_load from the heap, and
+            // because we prevent load inversion between candidate and target in the next check.
+            // So the max avg_load of candidates is that of the current src_node_info, and max avg_load of off-candidates
+            // is tracked in max_off_candidate_load. If max_off_candidate_load is equal to target's avg_load,
+            // it means that all nodes have equal avg_load. We take the maximum with the current candidate in src_node_info
+            // to handle the case of off-candidates being empty. In that case, max_off_candidate_load is 0.
+            if (std::max(max_off_candidate_load, src_node_info.avg_load) == target_info.avg_load) {
+                lblogger.debug("Balance achieved.");
+                break;
+            }
+
+            // If balance is not achieved, still consider migrating from candidate nodes which have higher load than the target.
+            // max_off_candidate_load may be higher than the load of current candidate.
+            if (src_node_info.avg_load <= target_info.avg_load) {
+                lblogger.debug("No more candidate nodes.");
+                lblogger.debug("No more candidate nodes. Next candidate is {} with avg_load={}, target's avg_load={}",
+                               src_host, src_node_info.avg_load, target_info.avg_load);
+                break;
+            }
+
+            // Prevent load inversion which can lead to oscillations.
+            if (src_node_info.get_avg_load(nodes[src_host].tablet_count - 1) <
+                    target_info.get_avg_load(target_info.tablet_count + 1)) {
+                lblogger.debug("No more candidate nodes, load would be inverted. Next candidate is {} with avg_load={}, target's avg_load={}",
+                               src_host, src_node_info.avg_load, target_info.avg_load);
+                break;
+            }
+
+            if (src_node_info.shards_by_load.empty()) {
+                lblogger.debug("candidate node {} ran out of candidate shards with {} tablets remaining.",
+                               src_host, src_node_info.tablet_count);
+                max_off_candidate_load = std::max(max_off_candidate_load, src_node_info.avg_load);
+                nodes_by_load.pop_back();
+                continue;
+            }
+            auto push_back_node_candidate = seastar::defer([&] {
+                std::push_heap(nodes_by_load.begin(), nodes_by_load.end(), nodes_cmp);
+            });
+
+            std::pop_heap(src_node_info.shards_by_load.begin(), src_node_info.shards_by_load.end(), src_node_info.shards_by_load_cmp());
+            auto src_shard = src_node_info.shards_by_load.back();
+            auto src = tablet_replica{src_host, src_shard};
+            auto&& src_shard_info = src_node_info.shards[src_shard];
+            if (src_shard_info.candidates.empty()) {
+                lblogger.debug("shard {} ran out of candidates with {} tablets remaining.", src, src_shard_info.tablet_count);
+                src_node_info.shards_by_load.pop_back();
+                continue;
+            }
+            auto push_back_shard_candidate = seastar::defer([&] {
+                std::push_heap(src_node_info.shards_by_load.begin(), src_node_info.shards_by_load.end(), src_node_info.shards_by_load_cmp());
+            });
+
+            auto source_tablet = *src_shard_info.candidates.begin();
+            src_shard_info.candidates.erase(source_tablet);
+
+            // Check replication strategy constraints.
+
+            auto same_rack = target_node->dc_rack().rack == topo.get_node(src.host).dc_rack().rack;
+            std::unordered_map<sstring, int> rack_load; // Will be built if !same_rack
+            bool has_replica_on_target = false;
+            auto& tmap = tmeta.get_tablet_map(source_tablet.table);
+            for (auto&& r : tmap.get_tablet_info(source_tablet.tablet).replicas) {
+                if (r.host == target) {
+                    has_replica_on_target = true;
+                    break;
+                }
+                if (!same_rack) {
+                    const locator::node& node = topo.get_node(r.host);
+                    if (node.dc_rack().dc == dc) {
+                        rack_load[node.dc_rack().rack] += 1;
+                    }
+                }
+            }
+
+            if (has_replica_on_target) {
+                lblogger.debug("candidate tablet {} skipped because it has a replica on target node", source_tablet);
+                continue;
+            }
+
+            // Make sure we don't increase level of duplication of racks in the replica list.
+            if (!same_rack) {
+                auto max_rack_load = std::max_element(rack_load.begin(), rack_load.end(),
+                                                 [] (auto& a, auto& b) { return a.second < b.second; })->second;
+                auto new_rack_load = rack_load[target_node->dc_rack().rack] + 1;
+                if (new_rack_load > max_rack_load) {
+                    lblogger.debug("candidate tablet {} skipped because it would increase load on rack {} to {}, max={}",
+                                   source_tablet, target_node->dc_rack().rack, new_rack_load, max_rack_load);
+                    continue;
+                }
+            }
+
+            auto dst = global_shard_id {target, target_load.next_shard(target)};
+            lblogger.debug("Select {} to move from {} to {}", source_tablet, src, dst);
+            plan.push_back(tablet_migration_info {source_tablet, src, dst});
+
+            target_info.tablet_count += 1;
+            target_info.update();
+
+            src_shard_info.tablet_count -= 1;
+            if (src_shard_info.tablet_count == 0) {
+                push_back_shard_candidate.cancel();
+                src_node_info.shards_by_load.pop_back();
+            }
+
+            src_node_info.tablet_count -= 1;
+            src_node_info.update();
+            if (src_node_info.tablet_count == 0) {
+                push_back_node_candidate.cancel();
+                nodes_by_load.pop_back();
+            }
+        }
+
+        if (plan.empty()) {
+            // Due to replica collocation constraints, it may not be possible to balance the cluster evenly.
+            // For example, if nodes have different number of shards. Nodes which have more shards will be
+            // replicas for more tablets which rules out more candidates on other nodes with a higher per-shard load.
+            //
+            // Example:
+            //
+            //   node1: 1 shard
+            //   node2: 1 shard
+            //   node3: 7 shard
+            //
+            // If there are 7 tablets and RF=3, each node must have 1 tablet replica.
+            // So node3 will have average load of 1, and node1 and node2 will have
+            // average shard load of 7.
+            lblogger.info("Not possible to achieve balance.");
+        }
+
+        co_await utils::clear_gently(nodes);
+        co_return std::move(plan);
+    }
+};
+
+future<migration_plan> balance_tablets(token_metadata_ptr tm) {
+    load_balancer lb(tm);
+    co_return co_await lb.make_plan();
+}
 
 class tablet_allocator_impl : public tablet_allocator::impl
                             , public service::migration_listener::empty_listener {

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -45,6 +45,12 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::publish_cdc_generation, "publish cdc generation"},
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
+    {topology::transition_state::tablet_allow_write_both_read_old, "tablet allow write both read old"},
+    {topology::transition_state::tablet_write_both_read_old, "tablet write both read old"},
+    {topology::transition_state::tablet_write_both_read_new, "tablet write both read new"},
+    {topology::transition_state::tablet_streaming, "tablet streaming"},
+    {topology::transition_state::tablet_use_new, "tablet use new"},
+    {topology::transition_state::tablet_cleanup, "tablet cleanup"},
 };
 
 std::ostream& operator<<(std::ostream& os, topology::transition_state s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -73,6 +73,14 @@ struct topology {
         publish_cdc_generation,
         write_both_read_old,
         write_both_read_new,
+
+        // Tablet migration steps
+        tablet_allow_write_both_read_old,
+        tablet_write_both_read_old,
+        tablet_write_both_read_new,
+        tablet_streaming,
+        tablet_use_new,
+        tablet_cleanup,
     };
 
     std::optional<transition_state> tstate;

--- a/streaming/stream_reason.hh
+++ b/streaming/stream_reason.hh
@@ -22,6 +22,7 @@ enum class stream_reason : uint8_t {
     rebuild,
     repair,
     replace,
+    tablet_migration,
 };
 
 }
@@ -46,6 +47,8 @@ struct fmt::formatter<streaming::stream_reason> : fmt::formatter<std::string_vie
             return formatter<std::string_view>::format("repair", ctx);
         case replace:
             return formatter<std::string_view>::format("replace", ctx);
+        case tablet_migration:
+            return formatter<std::string_view>::format("tablet migration", ctx);
         }
         std::abort();
     }

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -80,7 +80,8 @@ struct send_info {
             return do_until(std::move(stop_cond), [this, &found_relevant_range, &ranges_it] {
                 dht::token_range range = *ranges_it++;
                 if (!found_relevant_range) {
-                    auto sharder = dht::selective_token_range_sharder(cf.schema()->get_sharder(), std::move(range), this_shard_id());
+                    auto& table_sharder = cf.get_effective_replication_map()->get_sharder(*cf.schema());
+                    auto sharder = dht::selective_token_range_sharder(table_sharder, std::move(range), this_shard_id());
                     auto range_shard = sharder.next();
                     if (range_shard) {
                         found_relevant_range = true;

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -66,7 +66,7 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                 auto source_reader = partition_nr > 0 ? make_flat_mutation_reader_from_mutations_v2(gen.schema(), make_reader_permit(e), muts) : make_empty_flat_reader_v2(s, make_reader_permit(e));
                 auto close_source_reader = deferred_close(source_reader);
                 auto& sharder = s->get_sharder();
-                size_t partitions_received = distribute_reader_and_consume_on_shards(s,
+                size_t partitions_received = distribute_reader_and_consume_on_shards(s, sharder,
                     std::move(source_reader),
                     [&sharder, &shards_after, error] (flat_mutation_reader_v2 reader) mutable {
                         if (error) {
@@ -137,7 +137,7 @@ SEASTAR_TEST_CASE(test_multishard_writer_producer_aborts) {
             };
             auto& sharder = s->get_sharder();
             try {
-                distribute_reader_and_consume_on_shards(s,
+                distribute_reader_and_consume_on_shards(s, sharder,
                     make_generating_reader_v2(s, make_reader_permit(e), std::move(get_next_mutation_fragment)),
                     [&sharder, error] (flat_mutation_reader_v2 reader) mutable {
                         if (error) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -124,6 +124,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tb = *tmap.next_tablet(tb);
 
                 tmap.set_tablet_transition_info(tb, tablet_transition_info{
+                    tablet_transition_stage::allow_write_both_read_old,
                     tablet_replica_set {
                         tablet_replica {h3, 3},
                         tablet_replica {h1, 7},
@@ -133,6 +134,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
 
                 tb = *tmap.next_tablet(tb);
                 tmap.set_tablet_transition_info(tb, tablet_transition_info{
+                    tablet_transition_stage::use_new,
                     tablet_replica_set {
                         tablet_replica {h1, 4},
                         tablet_replica {h2, 2},
@@ -243,6 +245,7 @@ SEASTAR_TEST_CASE(test_get_shard) {
                 }
             });
             tmap.set_tablet_transition_info(tid, tablet_transition_info {
+                tablet_transition_stage::allow_write_both_read_old,
                 tablet_replica_set {
                     tablet_replica {h1, 0},
                     tablet_replica {h2, 3},
@@ -307,6 +310,7 @@ SEASTAR_TEST_CASE(test_sharder) {
                 }
             });
             tmap.set_tablet_transition_info(tid, tablet_transition_info {
+                tablet_transition_stage::use_new,
                 tablet_replica_set {
                     tablet_replica {h1, 1},
                     tablet_replica {h2, 3},

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -9,6 +9,7 @@
 
 
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/random_utils.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
@@ -17,14 +18,25 @@
 
 #include "replica/tablets.hh"
 #include "locator/tablets.hh"
+#include "service/tablet_allocator.hh"
 #include "locator/tablet_sharder.hh"
+#include "locator/load_sketch.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "utils/fb_utilities.hh"
+#include "utils/UUID_gen.hh"
 
 using namespace locator;
 using namespace replica;
+using namespace service;
 
 static api::timestamp_type next_timestamp = api::new_timestamp();
+
+static utils::UUID next_uuid() {
+    static uint64_t counter = 1;
+    return utils::UUID_gen::get_time_UUID(std::chrono::system_clock::time_point(
+            std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                    std::chrono::seconds(counter++))));
+}
 
 static
 void verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata& tm) {
@@ -428,6 +440,293 @@ SEASTAR_THREAD_TEST_CASE(test_token_ownership_splitting) {
                 BOOST_REQUIRE_EQUAL(dht::next_token(tmap.get_last_token(*prev_tb)), tmap.get_first_token(tb));
             }
             prev_tb = tb;
+        }
+    }
+}
+
+static
+void apply_plan(token_metadata& tm, const migration_plan& plan) {
+    for (auto&& mig : plan) {
+        tablet_map& tmap = tm.tablets().get_tablet_map(mig.tablet.table);
+        auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
+        tinfo.replicas = replace_replica(tinfo.replicas, mig.src, mig.dst);
+        tmap.set_tablet(mig.tablet.tablet, tinfo);
+    }
+}
+
+static
+void rebalance_tablets(shared_token_metadata& stm) {
+    while (true) {
+        auto plan = balance_tablets(stm.get()).get0();
+        if (plan.empty()) {
+            break;
+        }
+        stm.mutate_token_metadata([&] (token_metadata& tm) {
+            apply_plan(tm, plan);
+            return make_ready_future<>();
+        }).get();
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
+    // Tests the scenario of bootstrapping a single node
+    // Verifies that load balancer sees it and moves tablets to that node.
+
+    inet_address ip1("192.168.0.1");
+    inet_address ip2("192.168.0.2");
+    inet_address ip3("192.168.0.3");
+
+    auto host1 = host_id(next_uuid());
+    auto host2 = host_id(next_uuid());
+    auto host3 = host_id(next_uuid());
+
+    auto table1 = table_id(next_uuid());
+
+    unsigned shard_count = 2;
+
+    semaphore sem(1);
+    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
+        locator::topology::config{
+            .this_endpoint = ip1,
+            .local_dc_rack = locator::endpoint_dc_rack::default_location
+        }
+    });
+
+    stm.mutate_token_metadata([&] (auto& tm) {
+        tm.update_host_id(host1, ip1);
+        tm.update_host_id(host2, ip2);
+        tm.update_host_id(host3, ip3);
+        tm.update_topology(ip1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(ip2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(ip3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+
+        tablet_map tmap(4);
+        auto tid = tmap.first_tablet();
+        tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                        tablet_replica {host1, 0},
+                        tablet_replica {host2, 1},
+                }
+        });
+        tid = *tmap.next_tablet(tid);
+        tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                        tablet_replica {host1, 0},
+                        tablet_replica {host2, 1},
+                }
+        });
+        tid = *tmap.next_tablet(tid);
+        tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                        tablet_replica {host1, 0},
+                        tablet_replica {host2, 0},
+                }
+        });
+        tid = *tmap.next_tablet(tid);
+        tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                        tablet_replica {host1, 1},
+                        tablet_replica {host2, 0},
+                }
+        });
+        tablet_metadata tmeta;
+        tmeta.set_tablet_map(table1, std::move(tmap));
+        tm.set_tablets(std::move(tmeta));
+        return make_ready_future<>();
+    }).get();
+
+    // Sanity check
+    {
+        load_sketch load(stm.get());
+        load.populate().get();
+        BOOST_REQUIRE_EQUAL(load.get_load(host1), 4);
+        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+        BOOST_REQUIRE_EQUAL(load.get_load(host2), 4);
+        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+        BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+    }
+
+    rebalance_tablets(stm);
+
+    {
+        load_sketch load(stm.get());
+        load.populate().get();
+
+        for (auto h : {host1, host2, host3}) {
+            testlog.debug("Checking host {}", h);
+            BOOST_REQUIRE(load.get_load(h) <= 3);
+            BOOST_REQUIRE(load.get_load(h) > 1);
+            BOOST_REQUIRE(load.get_avg_shard_load(h) <= 2);
+            BOOST_REQUIRE(load.get_avg_shard_load(h) > 0);
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
+    inet_address ip1("192.168.0.1");
+    inet_address ip2("192.168.0.2");
+    inet_address ip3("192.168.0.3");
+    inet_address ip4("192.168.0.4");
+
+    auto host1 = host_id(next_uuid());
+    auto host2 = host_id(next_uuid());
+    auto host3 = host_id(next_uuid());
+    auto host4 = host_id(next_uuid());
+
+    auto table1 = table_id(next_uuid());
+
+    unsigned shard_count = 2;
+
+    semaphore sem(1);
+    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
+        locator::topology::config{
+            .this_endpoint = ip1,
+            .local_dc_rack = locator::endpoint_dc_rack::default_location
+        }
+    });
+
+    stm.mutate_token_metadata([&] (auto& tm) {
+        tm.update_host_id(host1, ip1);
+        tm.update_host_id(host2, ip2);
+        tm.update_host_id(host3, ip3);
+        tm.update_host_id(host4, ip4);
+        tm.update_topology(ip1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(ip2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(ip3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(ip4, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+
+        tablet_map tmap(16);
+        for (auto tid : tmap.tablet_ids()) {
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica {host1, tests::random::get_int<shard_id>(0, shard_count - 1)},
+                    tablet_replica {host2, tests::random::get_int<shard_id>(0, shard_count - 1)},
+                }
+            });
+        }
+        tablet_metadata tmeta;
+        tmeta.set_tablet_map(table1, std::move(tmap));
+        tm.set_tablets(std::move(tmeta));
+        return make_ready_future<>();
+    }).get();
+
+    rebalance_tablets(stm);
+
+    {
+        load_sketch load(stm.get());
+        load.populate().get();
+
+        for (auto h : {host1, host2, host3, host4}) {
+            testlog.debug("Checking host {}", h);
+            BOOST_REQUIRE(load.get_avg_shard_load(h) == 4);
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
+    const int n_hosts = 6;
+
+    std::vector<host_id> hosts;
+    for (int i = 0; i < n_hosts; ++i) {
+        hosts.push_back(host_id(next_uuid()));
+    }
+
+    std::vector<endpoint_dc_rack> racks = {
+        endpoint_dc_rack{ "dc1", "rack-1" },
+        endpoint_dc_rack{ "dc1", "rack-2" }
+    };
+
+    for (int i = 0; i < 13; ++i) {
+        std::unordered_map<sstring, std::vector<host_id>> hosts_by_rack;
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
+                locator::topology::config {
+                        .this_endpoint = inet_address("192.168.0.1"),
+                        .local_dc_rack = racks[1]
+                }
+        });
+
+        size_t total_tablet_count = 0;
+        stm.mutate_token_metadata([&](auto& tm) {
+            tablet_metadata tmeta;
+
+            int i = 0;
+            for (auto h : hosts) {
+                auto ip = inet_address(format("192.168.0.{}", ++i));
+                auto shard_count = 2;
+                tm.update_host_id(h, ip);
+                auto rack = racks[i % racks.size()];
+                tm.update_topology(ip, rack, std::nullopt, shard_count);
+                if (h != hosts[0]) {
+                    // Leave the first host empty by making it invisible to allocation algorithm.
+                    hosts_by_rack[rack.rack].push_back(h);
+                }
+            }
+
+            size_t tablet_count_bits = 8;
+            int rf = tests::random::get_int<shard_id>(2, 4);
+            for (int log2_tablets = 0; log2_tablets < tablet_count_bits; ++log2_tablets) {
+                if (tests::random::get_bool()) {
+                    continue;
+                }
+                auto table = table_id(next_uuid());
+                tablet_map tmap(1 << log2_tablets);
+                for (auto tid : tmap.tablet_ids()) {
+                    // Choose replicas randomly while loading racks evenly.
+                    std::vector<host_id> replica_hosts;
+                    for (int i = 0; i < rf; ++i) {
+                        auto rack = racks[i % racks.size()];
+                        auto& rack_hosts = hosts_by_rack[rack.rack];
+                        while (true) {
+                            auto candidate_host = rack_hosts[tests::random::get_int<shard_id>(0, rack_hosts.size() - 1)];
+                            if (std::find(replica_hosts.begin(), replica_hosts.end(), candidate_host) == replica_hosts.end()) {
+                                replica_hosts.push_back(candidate_host);
+                                break;
+                            }
+                        }
+                    }
+                    tablet_replica_set replicas;
+                    for (auto h : replica_hosts) {
+                        auto shard_count = tm.get_topology().find_node(h)->get_shard_count();
+                        auto shard = tests::random::get_int<shard_id>(0, shard_count - 1);
+                        replicas.push_back(tablet_replica {h, shard});
+                    }
+                    tmap.set_tablet(tid, tablet_info {std::move(replicas)});
+                }
+                total_tablet_count += tmap.tablet_count();
+                tmeta.set_tablet_map(table, std::move(tmap));
+            }
+            tm.set_tablets(std::move(tmeta));
+            return make_ready_future<>();
+        }).get();
+
+        testlog.debug("tablet metadata: {}", stm.get()->tablets());
+        testlog.info("Total tablet count: {}, hosts: {}", total_tablet_count, hosts.size());
+
+        rebalance_tablets(stm);
+
+        {
+            load_sketch load(stm.get());
+            load.populate().get();
+
+            min_max_tracker<unsigned> min_max_load;
+            for (auto h: hosts) {
+                auto l = load.get_avg_shard_load(h);
+                testlog.info("Load on host {}: {}", h, l);
+                min_max_load.update(l);
+            }
+
+            testlog.debug("tablet metadata: {}", stm.get()->tablets());
+            testlog.debug("Min load: {}, max load: {}", min_max_load.min(), min_max_load.max());
+
+//          FIXME: The algorithm cannot achieve balance in all cases yet, so we only check that it stops.
+//          For example, if we have an overloaded node in one rack and target underloaded node in a different rack,
+//          we won't be able to reduce the load gap by moving tablets between the two. We have to balance the overloaded
+//          rack first, which is unconstrained.
+//          Uncomment the following line when the algorithm is improved.
+//          BOOST_REQUIRE(min_max_load.max() - min_max_load.min() <= 1);
         }
     }
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -225,8 +225,8 @@ SEASTAR_TEST_CASE(test_get_shard) {
         auto table1 = table_id(utils::UUID_gen::get_time_UUID());
 
         tablet_metadata tm;
-        tablet_id tid;
-        tablet_id tid1;
+        tablet_id tid(0);
+        tablet_id tid1(0);
 
         {
             tablet_map tmap(2);

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -5,7 +5,6 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
-    experimental_features: [tablets]
 run_first:
     - test_topology_ip
     - test_topology_remove_decom

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -109,3 +109,40 @@ async def test_scans(manager: ManagerClient):
         assert r.c == r.pk
 
     await cql.run_async("DROP KEYSPACE test;")
+
+
+@pytest.mark.asyncio
+async def test_bootstrap(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
+                  "'replication_factor': 1, 'initial_tablets': 32};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        logger.info("Checking table")
+        rows = await cql.run_async("SELECT * FROM test.test;")
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    logger.info("Adding new server")
+    await manager.server_add()
+
+    await check()
+
+    logger.info("Adding new server")
+    await manager.server_add()
+
+    await check()
+    time.sleep(5) # Give load balancer some time to do work
+    await check()
+
+    await cql.run_async("DROP KEYSPACE test;")


### PR DESCRIPTION
After this series, tablet replication can handle the scenario of bootstrapping new nodes. The ownership is distributed indirectly by the means of a load-balancer which moves tablets around in the background. See docs/dev/topology-over-raft.md for details.

The implementation is by no means meant to be perfect, especially in terms of performance, and will be improved incrementally.

The load balancer will be also kicked by schema changes, so that allocation/deallocation done during table creation/drop will be rebalanced. 

Tablet data is streamed using existing `range_streamer`, which is the infrastructure for "the old streaming". This will be later replaced by sstable transfer once integration of tablets with compaction groups is finished. Also, cleanup is not wired yet, also blocked by compaction group integration.
