### PR TITLE
Update seastar submodule

### DIFF
--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -88,8 +88,8 @@ future<sstring> azure_snitch::azure_api_call(sstring path) {
 
         // Read HTTP response header first
         auto rsp = parser.get_parsed_response();
-        if (rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status_code));
+        if (rsp->_status != http::reply::status_type::ok) {
+            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status));
         }
 
         auto it = rsp->_headers.find("Content-Length");

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -119,13 +119,13 @@ future<sstring> ec2_snitch::aws_api_call_once(sstring addr, uint16_t port, sstri
 
             // Read HTTP response header first
             auto _rsp = _parser.get_parsed_response();
-            auto rc = _rsp->_status_code;
+            auto rc = _rsp->_status;
             // Verify EC2 instance metadata access
-            if (rc == 403) {
+            if (rc == http::reply::status_type(403)) {
                 return make_exception_future<sstring>(std::runtime_error("Error: Unauthorized response received when trying to communicate with instance metadata service."));
             }
-            if (_rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-                return make_exception_future<sstring>(std::runtime_error(format("Error: HTTP response status {}", _rsp->_status_code)));
+            if (_rsp->_status != http::reply::status_type::ok) {
+                return make_exception_future<sstring>(std::runtime_error(format("Error: HTTP response status {}", _rsp->_status)));
             }
 
             auto it = _rsp->_headers.find("Content-Length");

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -102,8 +102,8 @@ future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
 
         // Read HTTP response header first
         auto rsp = parser.get_parsed_response();
-        if (rsp->_status_code != static_cast<int>(http::reply::status_type::ok)) {
-            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status_code));
+        if (rsp->_status != http::reply::status_type::ok) {
+            throw std::runtime_error(format("Error: HTTP response status {}", rsp->_status));
         }
 
         auto it = rsp->_headers.find("Content-Length");


### PR DESCRIPTION
locator/*_snitch.cc updated for http::reply losing the _status_code member without a deprecation notice.

* seastar 99d28ff057...2b7a341210 (23):
  > Merge 'Prefault memory when --lock-memory 1 is specified' from Avi Kivity
Fixes #8828.
  > reactor: use structured binding when appropriate
  > Simplify payload length and mask parsing.
  > memcached: do not used deprecated API
  > build: serialize calls to openssl certificate generation
  > reactor: epoll backend: initialize _highres_timer_pending
  > shared_ptr: deprecate lw_shared_ptr operator=(T&&)
  > tests: fail spawn_test if output is empty
  > Support specifying the "build root" in configure
  > Merge 'Cleanup RPC request/response frames maintenance' from Pavel Emelyanov
  > build: correct the syntax error in comment
  > util: print_safe: fix hex print functions
  > Add code examples for handling exceptions
  > smp: warn if --memory parameter is not supported
  > Merge 'gate: track holders' from Benny Halevy
  > file: call lambda with std::invoke()
  > deleter: Delete move and copy constructors
  > file: fix the indent
  > file: call close() without the syscall thread
  > reactor: use s/::free()/::io_uring_free_probe()/
  > Merge 'seastar-json2code: generate better-formatted code' from Kefu Chai
  > reactor: Don't re-evaliate local reactor for thread_pool
  > Merge 'Improve http::reply re-allocations and copying in client' from Pavel Emelyanov