### PR TITLE
utils: error injection: add a string-to-string map of injection's parameters

### DIFF
--- a/api/api-doc/error_injection.json
+++ b/api/api-doc/error_injection.json
@@ -34,6 +34,14 @@
                      "allowMultiple":false,
                      "type":"boolean",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"parameters",
+                     "description":"dict of parameters to pass to the injection (json format)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"dict",
+                     "paramType":"body"
                   }
                ]
             },
@@ -110,5 +118,15 @@
             }
          ]
       }
-   ]
+   ],
+   "components":{
+      "schemas": {
+         "dict": {
+            "type": "object",
+            "additionalProperties": {
+               "type": "string"
+            }
+         }
+      }
+   }
 }

--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -12,7 +12,9 @@
 #include <seastar/http/exception.hh>
 #include "log.hh"
 #include "utils/error_injection.hh"
+#include "utils/rjson.hh"
 #include <seastar/core/future-util.hh>
+#include <seastar/util/short_streams.hh>
 
 namespace api {
 using namespace seastar::httpd;
@@ -24,10 +26,27 @@ void set_error_injection(http_context& ctx, routes& r) {
     hf::enable_injection.set(r, [](std::unique_ptr<request> req) {
         sstring injection = req->param["injection"];
         bool one_shot = req->get_query_param("one_shot") == "True";
-        auto& errinj = utils::get_local_injector();
-        return errinj.enable_on_all(injection, one_shot).then([] {
-            return make_ready_future<json::json_return_type>(json::json_void());
-        });
+        auto params = req->content;
+
+        const size_t max_params_size = 1024 * 1024;
+        if (params.size() > max_params_size) {
+            // This is a hard limit, because we don't want to allocate
+            // too much memory or block the thread for too long.
+            throw httpd::bad_param_exception(format("Injection parameters are too long, max length is {}", max_params_size));
+        }
+
+        try {
+            auto parameters = params.empty()
+                ? utils::error_injection_parameters{}
+                : rjson::parse_to_map<utils::error_injection_parameters>(params);
+
+            auto& errinj = utils::get_local_injector();
+            return errinj.enable_on_all(injection, one_shot, std::move(parameters)).then([] {
+                return make_ready_future<json::json_return_type>(json::json_void());
+            });
+        } catch (const rjson::error& e) {
+            throw httpd::bad_param_exception(format("Failed to parse injections parameters: {}", e.what()));
+        }
     });
 
     hf::get_enabled_injections_on_all.set(r, [](std::unique_ptr<request> req) {

--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -333,6 +333,22 @@ SEASTAR_TEST_CASE(test_inject_message) {
     }
 }
 
+SEASTAR_TEST_CASE(test_inject_with_parameters) {
+    utils::error_injection<true> errinj;
+
+    errinj.enable("injection", false, { { "x", "42" } });
+
+    auto f = errinj.inject_with_handler("injection", [] (auto& handler) {
+        auto x = handler.get("x");
+        auto y = handler.get("y");
+        BOOST_REQUIRE(x && *x == "42");
+        BOOST_REQUIRE(!y);
+        return make_ready_future<>();
+    });
+
+    BOOST_REQUIRE_NO_THROW(co_await std::move(f));
+}
+
 // Test error injection CQL API
 // NOTE: currently since functions can't get terminals an auxiliary table
 //       with error injection names and one shot parameters


### PR DESCRIPTION
Add `parameters` map to `injection_shared_data`. Now tests can attach string data to injections that can be read in injected code via `injection_handler`.

Closes #14521