### PR TITLE
scylla-gdb: Format IPs with network byte order

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4041,7 +4041,7 @@ class scylla_netw(gdb.Command):
         gdb.write('Dropped messages: %s\n' % ms['_dropped_messages'])
         gdb.write('Outgoing connections:\n')
         for (addr, shard_info) in unordered_map(std_vector(ms['_clients'])[0]):
-            ip = ip_to_str(int(get_ip(addr['addr'])), byteorder=sys.byteorder)
+            ip = ip_to_str(int(get_ip(addr['addr'])), byteorder='big')
             client = shard_info['rpc_client']['_p']
             rpc_client = std_unique_ptr(client['_p'])
             gdb.write('IP: %s, (netw::messaging_service::rpc_protocol_client_wrapper*) %s:\n' % (ip, client))


### PR DESCRIPTION
The scylla netw command prints connections IPs reversed:

(gdb) scylla netw
Dropped messages: {0, 0, 0, 1, 0 <repeats 15 times>, 1, 0 <repeats 41 times>} Outgoing connections:
IP: 31.0.142.10, (netw::messaging_service::rpc_protocol_client_wrapper*) 0x600008d6d490:
  stats: {replied = 0, pending = 0, exception_received = 0, sent_messages = 1192, wait_reply = 0, timeout = 0}
  outstanding: 0

It should unpack the address as if it was in big-endian to have it like

(gdb) scylla netw
Dropped messages: {0, 0, 0, 1, 0 <repeats 15 times>, 1, 0 <repeats 41 times>} Outgoing connections:
IP: 10.142.0.31, (netw::messaging_service::rpc_protocol_client_wrapper*) 0x600008d6d490:
  stats: {replied = 0, pending = 0, exception_received = 0, sent_messages = 1192, wait_reply = 0, timeout = 0}
  outstanding: 0