### PR TITLE
transport: correct format string when printing logging message

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -668,7 +668,7 @@ future<> cql_server::connection::process_request() {
             ++_server._stats.requests_shed;
             return _read_buf.skip(f.length).then([this, stream = f.stream] {
                 const char* message = "request shed due to coordinator overload";
-                clogger.debug("{}: {}, stream {}", _client_state.get_remote_address(), message);
+                clogger.debug("{}: {}, stream {}", _client_state.get_remote_address(), message, stream);
                 write_response(make_error(stream, exceptions::exception_code::OVERLOADED,
                     message, tracing::trace_state_ptr()));
                 return make_ready_future<>();


### PR DESCRIPTION
we print the stream id in the logging messages, but in this case, we forgot to pass `stream` to `log::debug()`. but the placeholder for `stream` was added. if the underlying fmtlib actually formats the argument with the format string, it would throw.

fortunately, we don't enable debug level logging often, guess that's why we haven't spotted this issue yet.