### PR TITLE
migration_manager: correct format string when printing warning

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -981,7 +981,7 @@ future<group0_guard> migration_manager::start_group0_operation() {
 void migration_manager::passive_announce(table_schema_version version) {
     _schema_version_to_publish = version;
     (void)_schema_push.trigger().handle_exception([version = std::move(version)] (std::exception_ptr ex) {
-        mlogger.warn("Passive announcing of version {} failed: {}. Ignored.", version);
+        mlogger.warn("Passive announcing of version {} failed: {}. Ignored.", version, ex);
     });
 }
 


### PR DESCRIPTION
we intent to print the error message. but failed to pass it to the formatter. if we actually run into this case, fmtlib would throw.

so in this change, we also print the error when
announcing schema change fails.