### PR TITLE
sstables: format using format string

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -950,7 +950,7 @@ thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> dow
 future<> sstable::do_read_simple(component_type type,
                                  noncopyable_function<future<> (version_types, file&&, uint64_t sz)> read_component) {
     auto file_path = filename(type);
-    sstlog.debug(("Reading " + sstable_version_constants::get_component_map(_version).at(type) + " file {} ").c_str(), file_path);
+    sstlog.debug("Reading {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
     try {
         file fi = co_await new_sstable_component_file(_read_error_handler, type, open_flags::ro);
         uint64_t size = co_await fi.size();
@@ -1008,7 +1008,7 @@ void sstable::do_write_simple(file_writer&& writer,
 void sstable::do_write_simple(component_type type,
         noncopyable_function<void (version_types version, file_writer& writer)> write_component, unsigned buffer_size) {
     auto file_path = filename(type);
-    sstlog.debug(("Writing " + sstable_version_constants::get_component_map(_version).at(type) + " file {} ").c_str(), file_path);
+    sstlog.debug("Writing {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
 
     file_output_stream_options options;
     options.buffer_size = buffer_size;


### PR DESCRIPTION
instead of concatenating strings, let's format using the builtin support of `log::debug()`. for two reasons:

1. better performance, after this change, we don't need to materialize the concatenated string, if the "debug" level logging is not enabled. seasetar::log only formats when a certain log level is enabled.
2. better readability. with the format string, it is clear what is the fixed part, and which arguments are to be formatted. this also helps us to move to compile-time formatting check, as fmtlib requires the caller to be explicit when it wants to use runtime format string.