### PR TITLE
storage_proxy: print the expected ex.what()

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6123,7 +6123,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
         write ? get_stats().cas_write_unavailables.mark() :  get_stats().cas_read_unavailables.mark();
         throw;
     } catch (seastar::semaphore_timed_out& ex) {
-        paxos::paxos_state::logger.trace("CAS[{}]: timeout while waiting for row lock {}", handler->id());
+        paxos::paxos_state::logger.trace("CAS[{}]: timeout while waiting for row lock {}", handler->id(), ex.what());
         if (write) {
             get_stats().cas_write_timeouts.mark();
             throw mutation_write_timeout_exception(schema->ks_name(), schema->cf_name(), cl_for_paxos, 0,  handler->block_for(), db::write_type::CAS);


### PR DESCRIPTION
before this change, the format string contains two placeholders, but only one extra argument is passed in. if we actually format this logging message, fmtlib would throw.

after this change, we pass the exception's error message as yet another argument.

this logging message is printed with "trace" level, guess that's why we haven't have the exception thrown by fmtlib.