### PR TITLE
build: add -Wimplicit-fallthrough to cmake

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -15,6 +15,7 @@ string(JOIN " " CMAKE_CXX_FLAGS
   "-Wall"
   "-Werror"
   "-Wno-error=deprecated-declarations"
+  "-Wimplicit-fallthrough"
   ${_supported_warnings})
 
 function(default_target_arch arch)


### PR DESCRIPTION
In 0cabf4eeb91794f4 ("build: disable implicit fallthrough"), we added -Wimplicit-fallthrough to configure.py, but forgot to add it to cmake.