### PR TITLE
scylla-gdb: Print all clients from all idx's

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4040,13 +4040,16 @@ class scylla_netw(gdb.Command):
         ms = mss.local()
         gdb.write('Dropped messages: %s\n' % ms['_dropped_messages'])
         gdb.write('Outgoing connections:\n')
-        for (addr, shard_info) in unordered_map(std_vector(ms['_clients'])[0]):
-            ip = ip_to_str(int(get_ip(addr['addr'])), byteorder='big')
-            client = shard_info['rpc_client']['_p']
-            rpc_client = std_unique_ptr(client['_p'])
-            gdb.write('IP: %s, (netw::messaging_service::rpc_protocol_client_wrapper*) %s:\n' % (ip, client))
-            gdb.write('  stats: %s\n' % rpc_client['_stats'])
-            gdb.write('  outstanding: %d\n' % int(rpc_client['_outstanding']['_M_h']['_M_element_count']))
+        idx = 0
+        for clients in std_vector(ms['_clients']):
+            for (addr, shard_info) in unordered_map(clients):
+                ip = ip_to_str(int(get_ip(addr['addr'])), byteorder='big')
+                client = shard_info['rpc_client']['_p']
+                rpc_client = std_unique_ptr(client['_p'])
+                gdb.write('[%d] IP: %s, (netw::messaging_service::rpc_protocol_client_wrapper*) %s:\n' % (idx, ip, client))
+                gdb.write('  stats: %s\n' % rpc_client['_stats'])
+                gdb.write('  outstanding: %d\n' % int(rpc_client['_outstanding']['_M_h']['_M_element_count']))
+            idx += 1
 
         servers = [
             std_unique_ptr(ms['_server']['_M_elems'][0]),


### PR DESCRIPTION
The scylla netw command prints clients from [0] index only, but there are more of them on messaging service. Print all