### PR TITLE
Add `scylla table` to scylla-gdb

### DIFF
--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -33,6 +33,9 @@ def test_commitlog(gdb):
 def test_tables(gdb):
     scylla(gdb, 'tables')
 
+def test_table(gdb):
+    scylla(gdb, 'table system.local')
+
 def test_keyspaces(gdb):
     scylla(gdb, 'keyspaces')
 


### PR DESCRIPTION
The command is to print interesting and/or hard-to-get-by-hand info about individual tables