### PR TITLE
storage_proxy: adjust duration casting in calculate_delay()

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1442,19 +1442,19 @@ public:
     std::chrono::microseconds calculate_delay(db::view::update_backlog backlog) {
         constexpr auto delay_limit_us = 1000000;
         auto adjust = [] (float x) { return x * x * x; };
-        auto budget = std::max(storage_proxy::clock_type::duration(0),
-            _expire_timer.get_timeout() - storage_proxy::clock_type::now());
         std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
-        // "budget" has millisecond resolution and can potentially be long
-        // in the future so converting it to microseconds may overflow.
-        // So to compare buget and ret we need to convert both to the lower
-        // resolution.
-        if (std::chrono::duration_cast<storage_proxy::clock_type::duration>(ret) < budget) {
-            return ret;
-        } else {
-            // budget is small (< ret) so can be converted to microseconds
-            return std::chrono::duration_cast<std::chrono::microseconds>(budget);
-        }
+
+        // The maximum delay applied to the response is the amount of time left until the request timeouts.
+        // Delaying the response more than the timeout point doesn't make much sense - the request will fail
+        // at the timeout point anyway.
+        std::chrono::nanoseconds budget =
+            std::max(std::chrono::nanoseconds(0), _expire_timer.get_timeout() - storage_proxy::clock_type::now());
+
+        // budget is in nanoseconds, so it can be cast to microseconds without worrying about overflows,
+        // casting from nano to micro means dividing by 1000.
+        std::chrono::microseconds max_delay = std::chrono::duration_cast<std::chrono::microseconds>(budget);
+
+        return std::min(ret, max_delay);
     }
     // Calculates how much to delay completing the request. The delay adds to the request's inherent latency.
     template<typename Func>


### PR DESCRIPTION
The function calculate_delay() is used to calculate the amount of time by which client requests should be throttled to prevent overload.

The function calculates the delay based on an equation, and then compares the result with a maximum allowed value, which is equal to the amount of time left until timeout.

The comparison mentions that the budget is in milliseconds, and thus casting microseconds to milliseconds could overflow, and because of that there's some special code to handle this.

This looks wrong, the budget is actually in nanoseconds, not milliseconds, lowres_clock::duration is an alias for std::chrono::nanoseconds.

Because of this the current logic is wrong, casting nanoseconds to microseconds can't overflow. The code even introduced a possible overflow, because it tried to avoid overflow using:
```
std::chrono::duration_cast<storage_proxy::clock_type::duration>(ret)
```

with storage_proxy::clock_type::duration being nanoseconds, and ret being microseconds this can overflow.

Let's remove the faulty logic and change it to a simple cast from nano to micro.

The new code is also resistant to a possible change of `storage_proxy::clock_type::duration`. If it were changed to e.g `chrono::milliseconds`, the `std::max` will fail because of type mismatch, which will bring the developer's attention to this part of the code.