### PR TITLE
test: silence the deprecation warning

### DIFF
--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -391,7 +391,8 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
         // column_definition has to have column_specifiction because to_string uses it for column name
         ::shared_ptr<column_identifier> identifier = ::make_shared<column_identifier>(name, true);
         column_specification specification("ks", "cf", std::move(identifier), int32_type);
-        definition.column_specification = std::move(specification);
+        definition.column_specification = make_lw_shared<column_specification>(
+            std::move(specification));
 
         return definition;
     };


### PR DESCRIPTION
because `lw_shared_ptr::operator=(T&&)` was deprecated. we started to have following waring:

```
/home/kefu/dev/scylladb/test/boost/statement_restrictions_test.cc:394:41: warning: 'operator=' is deprecated: call make_lw_shared<> and assign the result instead [-Wdeprecated-declarations]
  394 |         definition.column_specification = std::move(specification);
      |                                         ^
/home/kefu/dev/scylladb/seastar/include/seastar/core/shared_ptr.hh:346:7: note: 'operator=' has been explicitly marked deprecated here
  346 |     [[deprecated("call make_lw_shared<> and assign the result instead")]]
      |       ^
1 warning generated.
```

so, in this change, we use the recommended way to update a lw_shared_ptr.