### PR TITLE
[Backport 5.1] Merge 'atomic_cell: compare value last' from Benny Halevy

### DIFF
--- a/docs/dev/timestamp-conflict-resolution.md
+++ b/docs/dev/timestamp-conflict-resolution.md
@@ -1,0 +1,37 @@
+# Timestamp conflict resolution
+
+The fundamental rule for ordering cells that insert, update, or delete data in a given row and column
+is that the cell with the highest timestamp wins.
+
+However, it is possible that multiple such cells will carry the same `TIMESTAMP`.
+In this case, conflicts must be resolved in a consistent way by all nodes.
+Otherwise, if nodes would have picked an arbitrary cell in case of a conflict and they would
+reach different results, reading from different replicas would detect the inconsistency and trigger
+read-repair that will generate yet another cell that would still conflict with the existing cells,
+with no guarantee for convergence.
+
+The first tie-breaking rule when two cells have the same write timestamp is that
+dead cells win over live cells; and if both cells are deleted, the one with the later deletion time prevails.
+
+If both cells are alive, their expiration time is examined.
+Cells that are written with a non-zero TTL (either implicit, as determined by
+the table's default TTL, or explicit, `USING TTL`) are due to expire
+TTL seconds after the time they were written (as determined by the coordinator,
+and rounded to 1 second resolution). That time is the cell's expiration time.
+When cells expire, they become tombstones, shadowing any data written with a write timestamp
+less than or equal to the timestamp of the expiring cell.
+Therefore, cells that have an expiration time win over cells with no expiration time.
+
+If both cells have an expiration time, the one with the latest expiration time wins;
+and if they have the same expiration time (in whole second resolution),
+their write time is derived from the expiration time less the original time-to-live value
+and the one that was written at a later time prevails.
+
+Finally, if both cells are live and have no expiration, or have the same expiration time and time-to-live,
+the cell with the lexicographically bigger value prevails.
+
+Note that when multiple columns are INSERTed or UPDATEed using the same timestamp,
+SELECTing those columns might return a result that mixes cells from either upsert.
+This may happen when both upserts have no expiration time, or both their expiration time and TTL are the
+same, respectively (in whole second resolution). In such a case, cell selection would be based on the cell values
+in each column, independently of each other.

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1139,20 +1139,34 @@ operator<<(std::ostream& os, const mutation_partition::printer& p) {
 constexpr gc_clock::duration row_marker::no_ttl;
 constexpr gc_clock::duration row_marker::dead;
 
+// Note: the ordering algorithm for rows is the same as for cells,
+// except that there is no cell value to break a tie in case all other attributes are equal.
+// See compare_atomic_cell_for_merge.
 int compare_row_marker_for_merge(const row_marker& left, const row_marker& right) noexcept {
+    // Largest write timestamp wins.
     if (left.timestamp() != right.timestamp()) {
         return left.timestamp() > right.timestamp() ? 1 : -1;
     }
+    // Tombstones always win reconciliation with live rows of the same timestamp
     if (left.is_live() != right.is_live()) {
         return left.is_live() ? -1 : 1;
     }
     if (left.is_live()) {
+        // Prefer expiring rows (which will become tombstones at some future date) over live rows.
+        // See https://issues.apache.org/jira/browse/CASSANDRA-14592
         if (left.is_expiring() != right.is_expiring()) {
             // prefer expiring cells.
             return left.is_expiring() ? 1 : -1;
         }
-        if (left.is_expiring() && left.expiry() != right.expiry()) {
-            return left.expiry() < right.expiry() ? -1 : 1;
+        // If both are expiring, choose the cell with the latest expiry or derived write time.
+        if (left.is_expiring()) {
+            if (left.expiry() != right.expiry()) {
+                return left.expiry() < right.expiry() ? -1 : 1;
+            } else if (left.ttl() != right.ttl()) {
+                // The cell write time is derived by (expiry - ttl).
+                // Prefer row that was written later (and has a smaller ttl).
+                return left.ttl() < right.ttl() ? 1 : -1;
+            }
         }
     } else {
         // Both are either deleted or missing

--- a/test/cql-pytest/test-timestamp.py
+++ b/test/cql-pytest/test-timestamp.py
@@ -17,9 +17,19 @@ import pytest
 @pytest.fixture(scope="session")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute(f"CREATE TABLE {table} (k int PRIMARY KEY, v int)")
+    cql.execute(f"CREATE TABLE {table} (k int PRIMARY KEY, v int, w int)")
     yield table
     cql.execute("DROP TABLE " + table)
+
+# sync with wall-clock on exact second so that expiration won't cross the whole-second boundary
+# 100 milliseconds should be enough to execute 2 inserts at the same second in debug mode
+# sleep until the next whole second mark if there is not enough time left on the clock
+def ensure_sync_with_tick(millis = 100):
+    t = time.time()
+    while t - int(t) >= 1 - millis / 1000:
+        time.sleep(1 - (t - int(t)))
+        t = time.time()
+    return t
 
 # In Cassandra, timestamps can be any *signed* 64-bit integer, not including
 # the most negative 64-bit integer (-2^63) which for deletion times is
@@ -44,3 +54,151 @@ def test_negative_timestamp(cql, table1):
     # in the deletion time of cells.
     with pytest.raises(InvalidRequest, match='bound'):
         cql.execute(write, [p, 1, -2**63])
+
+def test_rewrite_different_values_using_same_timestamp(cql, table1):
+    """
+    Rewriting cells more than once with the same timestamp
+    requires tie-breaking to decide which of the cells prevails.
+    When the two inserts are non-expiring or when they have the same expiration time,
+    cells are selected based on the higher value.
+    Otherwise, expiring cells are preferred over non-expiring ones,
+    and if both are expiring, the one with the later expiration time wins.
+    """
+    table = table1
+    ts = 1000
+    values = [[1, 2], [2, 1]]
+    for i in range(len(values)):
+        v1, v2 = values[i]
+
+        def assert_value(k, expected):
+            select = f"SELECT k, v FROM {table} WHERE k = {k}"
+            res = list(cql.execute(select))
+            assert len(res) == 1
+            assert res[0].v == expected
+
+        # With no TTL, highest value wins
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts}")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts}")
+        assert_value(k, max(v1, v2))
+
+        # Expiring cells are preferred over non-expiring
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts}")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts} and TTL 1")
+        assert_value(k, v2)
+
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts} and TTL 1")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts}")
+        assert_value(k, v1)
+
+        # When both are expiring, the one with the later expiration time wins
+        ensure_sync_with_tick()
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts} and TTL 1")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts} and TTL 2")
+        assert_value(k, v2)
+
+        ensure_sync_with_tick()
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts} and TTL 2")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts} and TTL 1")
+        assert_value(k, v1)
+
+def test_rewrite_different_values_using_same_timestamp_and_expiration(scylla_only, cql, table1):
+    """
+    Rewriting cells more than once with the same timestamp
+    requires tie-breaking to decide which of the cells prevails.
+    When the two inserts are expiring and have the same expiration time,
+    scylla selects the cells with the lower ttl.
+    """
+    table = table1
+    ts = 1000
+    values = [[1, 2], [2, 1]]
+    for i in range(len(values)):
+        v1, v2 = values[i]
+
+        def assert_value(k, expected):
+            select = f"SELECT k, v FROM {table} WHERE k = {k}"
+            res = list(cql.execute(select))
+            assert len(res) == 1
+            assert res[0].v == expected
+
+        # When both have the same expiration, the one with the lower TTL wins (as it has higher derived write time = expiration - ttl)
+        ensure_sync_with_tick()
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts} and TTL 3")
+        time.sleep(1)
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts} and TTL 2")
+        assert_value(k, v2)
+
+def test_rewrite_using_same_timestamp_select_after_expiration(cql, table1):
+    """
+    Reproducer for https://github.com/scylladb/scylladb/issues/14182
+
+    Rewrite a cell using the same timestamp and ttl.
+    Due to #14182, after the first insert expires,
+    the first write would have been selected when it has a lexicographically larger
+    value, and that results in a null value in the select query result.
+    With the fix, we expect to get the cell with the higher expiration time.
+    """
+    table = table1
+    ts = 1000
+    values = [[2, 1], [1, 2]]
+    for i in range(len(values)):
+        v1, v2 = values[i]
+
+        def assert_value(k, expected):
+            select = f"SELECT k, v FROM {table} WHERE k = {k}"
+            res = list(cql.execute(select))
+            assert len(res) == 1
+            assert res[0].v == expected
+
+        ensure_sync_with_tick()
+        k = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v1}) USING TIMESTAMP {ts} AND TTL 1")
+        cql.execute(f"INSERT INTO {table} (k, v) VALUES ({k}, {v2}) USING TIMESTAMP {ts} AND TTL 2")
+
+        # wait until first insert expires, and expect 2nd value.
+        # Null value was returned due to #14182 when v1 > v2
+        time.sleep(1)
+        assert_value(k, v2)
+
+def test_rewrite_multiple_cells_using_same_timestamp(cql, table1):
+    """
+    Reproducer for https://github.com/scylladb/scylladb/issues/14182:
+
+    Inserts multiple cells in two insert queries that use the same timestamp and different expiration.
+    Due to #14182, the select query result contained a mixture
+    of the inserts that is based on the value in each cell,
+    rather than on the (different) expiration times on the
+    two inserts.
+    """
+    table = table1
+    ts = 1000
+    ttl1 = 10
+    ttl2 = 20
+    values = [{'v':1, 'w':2}, {'v':2, 'w':1}]
+
+    def assert_values(k, expected):
+        select = f"SELECT * FROM {table} WHERE k = {k}"
+        res = list(cql.execute(select))
+        assert len(res) == 1
+        assert res[0].k == k and res[0].v == expected['v'] and res[0].w == expected['w']
+
+    # rewrite values once with and once without TTL
+    # if reconciliation is done by value, the result will be a mix of the two writes
+    # while if reconciliation is based first on the expiration time, the second write should prevail.
+    k = unique_key_int()
+    cql.execute(f"INSERT INTO {table} (k, v, w) VALUES ({k}, {values[0]['v']}, {values[0]['w']}) USING TIMESTAMP {ts} AND TTL {ttl1}")
+    cql.execute(f"INSERT INTO {table} (k, v, w) VALUES ({k}, {values[1]['v']}, {values[1]['w']}) USING TIMESTAMP {ts}")
+    assert_values(k, values[0])
+
+    # rewrite values using the same write time and different ttls, so they get different expiration times
+    # if reconciliation is done by value, the result will be a mix of the two writes
+    # while if reconciliation is based first on the expiration time, the second write should prevail.
+    k = unique_key_int()
+    cql.execute(f"INSERT INTO {table} (k, v, w) VALUES ({k}, {values[0]['v']}, {values[0]['w']}) USING TIMESTAMP {ts} AND TTL {ttl1}")
+    cql.execute(f"INSERT INTO {table} (k, v, w) VALUES ({k}, {values[1]['v']}, {values[1]['w']}) USING TIMESTAMP {ts} AND TTL {ttl2}")
+    assert_values(k, values[1])


### PR DESCRIPTION
Currently, when two cells have the same write timestamp and both are alive or expiring, we compare their value first, before checking if either of them is expiring
and if both are expiring, comparing their expiration time and ttl value to determine which of them will expire later or was written later.

This was based on an early version of Cassandra.
However, the Cassandra implementation rightfully changed in https://github.com/apache/cassandra/commit/e225c88a65f2e8091f8ea6212c291416674882a1 ([CASSANDRA-14592](https://issues.apache.org/jira/browse/CASSANDRA-14592)), where the cell expiration is considered before the cell value.

To summarize, the motivation for this change is three fold:
1. Cassandra compatibility
2. Prevent an edge case where a null value is returned by select query when an expired cell has a larger value than a cell with later expiration.
3. A generalization of the above: value-based reconciliation may cause select query to return a mixture of upserts, if multiple upserts use the same timeastamp but have different expiration times.  If the cell value is considered before expiration, the select result may contain cells from different inserts, while reconciling based the expiration times will choose cells consistently from either upserts, as all cells in the respective upsert will carry the same expiration time.

\Fixes scylladb/scylladb#14182

Also, this series:
- updates dml documentation
- updates internal documentation
- updates and adds unit tests and cql pytest reproducing #14182

\Closes scylladb/scylladb#14183

* github.com:scylladb/scylladb:
  docs: dml: add update ordering section
  cql-pytest: test_using_timestamp: add tests for rewrites using same timestamp
  mutation_partition: compare_row_marker_for_merge: consider ttl in case expiry is the same
  atomic_cell: compare_atomic_cell_for_merge: update and add documentation
  compare_atomic_cell_for_merge: compare value last for live cells
  mutation_test: test_cell_ordering: improve debuggability

(cherry picked from commit 87b4606cd66b76977f360a483c92d2f3e9e441ba)