### PR TITLE
treewide: enable -Wsign-compare and address the warnings from this option

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -579,7 +579,7 @@ system_distributed_keyspace::read_cdc_generation(utils::UUID id) {
     // Paranoic sanity check. Partial reads should not happen since generations should be retrieved only after they
     // were written successfully with CL=ALL. But nobody uses EverywhereStrategy tables so they weren't ever properly
     // tested, so just in case...
-    if (entries.size() != num_ranges) {
+    if (std::cmp_not_equal(entries.size(), num_ranges)) {
         throw std::runtime_error(format(
                 "read_cdc_generation: wrong number of rows. The `num_ranges` column claimed {} rows,"
                 " but reading the partition returned {}.", num_ranges, entries.size()));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2699,7 +2699,7 @@ system_keyspace::read_cdc_generation(utils::UUID id) {
             "read_cdc_generation: data for CDC generation {} not present", id));
     }
 
-    if (entries.size() != num_ranges) {
+    if (std::cmp_not_equal(entries.size(), num_ranges)) {
         throw std::runtime_error(format(
             "read_cdc_generation: wrong number of rows. The `num_ranges` column claimed {} rows,"
             " but reading the partition returned {}.", num_ranges, entries.size()));

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -802,7 +802,7 @@ class clients_table : public streaming_virtual_table {
         decorated_ip::compare cmp(*_s);
         std::set<decorated_ip, decorated_ip::compare> ips(cmp);
         std::unordered_map<net::inet_address, client_data_vec> cd_map;
-        for (int i = 0; i < smp::count; i++) {
+        for (unsigned i = 0; i < smp::count; i++) {
             for (auto&& ps_cdc : *cd_vec[i]) {
                 for (auto&& cd : ps_cdc) {
                     if (cd_map.contains(cd.ip)) {

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <utility>
 
 #include "log.hh"
 #include "locator/topology.hh"
@@ -394,7 +395,7 @@ node_holder topology::pop_node(const node* node) {
 
     // shrink _nodes if the last node is popped
     // like when failing to index a newly added node
-    if (node->idx() == _nodes.size() - 1) {
+    if (std::cmp_equal(node->idx(), _nodes.size() - 1)) {
         _nodes.resize(node->idx());
     }
 
@@ -424,7 +425,7 @@ const node* topology::find_node(const inet_address& ep) const noexcept {
 // Finds a node by its index
 // Returns nullptr if not found
 const node* topology::find_node(node::idx_type idx) const noexcept {
-    if (idx >= _nodes.size()) {
+    if (std::cmp_greater_equal(idx, _nodes.size())) {
         return nullptr;
     }
     return _nodes.at(idx).get();

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -274,7 +274,7 @@ SEASTAR_TEST_CASE(test_correctness_when_crossing_chunk_boundary) {
         as(region, [&] {
             size_t max_chunk_size = lsa::chunked_managed_vector<int>::max_chunk_capacity();
 
-            lsa::chunked_managed_vector<int> v;
+            lsa::chunked_managed_vector<size_t> v;
             for (size_t i = 0; i < (max_chunk_size + 1); i++) {
                 v.push_back(i);
             }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1237,7 +1237,7 @@ SEASTAR_TEST_CASE(populate_from_quarantine_works) {
         });
         auto shard = tests::random::get_int<unsigned>(0, smp::count);
         auto found = false;
-        for (auto i = 0; i < smp::count && !found; i++) {
+        for (unsigned i = 0; i < smp::count && !found; i++) {
             found = co_await db.invoke_on((shard + i) % smp::count, [] (replica::database& db) -> future<bool> {
                 auto& cf = db.find_column_family("ks", "cf");
                 bool found = false;
@@ -1286,7 +1286,7 @@ SEASTAR_TEST_CASE(snapshot_with_quarantine_works) {
         // move a random sstable to quarantine
         auto shard = tests::random::get_int<unsigned>(0, smp::count);
         auto found = false;
-        for (auto i = 0; i < smp::count; i++) {
+        for (unsigned i = 0; i < smp::count; i++) {
             co_await db.invoke_on((shard + i) % smp::count, [&] (replica::database& db) -> future<> {
                 auto& cf = db.find_column_family("ks", "cf");
                 co_await cf.parallel_foreach_table_state([&] (compaction::table_state& ts) -> future<> {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -15,6 +15,7 @@
 
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
+#include <utility>
 
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/result_set_assertions.hh"
@@ -177,7 +178,7 @@ SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
         uint32_t num_keys = 1000;
 
         auto f0 = insert_data(0, num_keys);
-        auto f1 = do_until([&] { return count >= num_keys; }, [&, ts = db_clock::now()] {
+        auto f1 = do_until([&] { return std::cmp_greater_equal(count, num_keys); }, [&, ts = db_clock::now()] {
             return replica::database::truncate_table_on_all_shards(e.db(), "ks", "cf", ts, false /* with_snapshot */).then([] {
                 return yield();
             });

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -259,23 +259,23 @@ SEASTAR_THREAD_TEST_CASE(test_load_sketch) {
         std::vector<unsigned> node2_shards(node2_shard_count, 0);
         std::vector<unsigned> node3_shards(node3_shard_count, 0);
 
-        for (int i = 0; i < node1_shard_count * 3; ++i) {
+        for (unsigned i = 0; i < node1_shard_count * 3; ++i) {
             node1_shards[load.next_shard(host1)] += 1;
         }
-        for (int i = 0; i < node2_shard_count * 3; ++i) {
+        for (unsigned i = 0; i < node2_shard_count * 3; ++i) {
             node2_shards[load.next_shard(host2)] += 1;
         }
-        for (int i = 0; i < node3_shard_count * 3; ++i) {
+        for (unsigned i = 0; i < node3_shard_count * 3; ++i) {
             node3_shards[load.next_shard(host3)] += 1;
         }
 
-        for (int i = 1; i < node1_shard_count; ++i) {
+        for (unsigned i = 1; i < node1_shard_count; ++i) {
             BOOST_REQUIRE_EQUAL(node1_shards[i], node1_shards[0]);
         }
-        for (int i = 1; i < node2_shard_count; ++i) {
+        for (unsigned i = 1; i < node2_shard_count; ++i) {
             BOOST_REQUIRE_EQUAL(node2_shards[i], node2_shards[0]);
         }
-        for (int i = 1; i < node3_shard_count; ++i) {
+        for (unsigned i = 1; i < node3_shard_count; ++i) {
             BOOST_REQUIRE_EQUAL(node3_shards[i], node3_shards[0]);
         }
     }
@@ -330,7 +330,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_sketch) {
             node3_shards[s] += 1;
         }
 
-        for (int i = 1; i < node3_shard_count; ++i) {
+        for (unsigned i = 1; i < node3_shard_count; ++i) {
             BOOST_REQUIRE_EQUAL(node3_shards[i], node3_shards[0]);
         }
     }

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -27,6 +27,7 @@
 #include <source_location>
 
 #include <boost/range/algorithm/sort.hpp>
+#include <utility>
 
 const sstring KEYSPACE_NAME = "ks";
 
@@ -692,7 +693,7 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
         auto [results2, npages] = read_all_partitions_with_paged_scan(env.db(), s, 4, stateful_query::yes, [&] (size_t page) {
             const auto new_lookups = aggregate_querier_cache_stat(env.db(), &query::querier_cache::stats::lookups);
             if (page) {
-                tests::require(new_lookups > lookups, seastar::compat::source_location::current());
+                tests::require(std::cmp_greater(new_lookups, lookups), seastar::compat::source_location::current());
             }
             lookups = new_lookups;
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3078,7 +3078,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_rebuilder_v2_flush) {
     frags.emplace_back(*s, p, partition_end());
 
     mutation_rebuilder_v2 rebuilder_without_flush(s);
-    for (int i = 0; i < frags.size(); ++i) {
+    for (unsigned i = 0; i < frags.size(); ++i) {
         rebuilder_without_flush.consume(mutation_fragment_v2(*s, p, frags[i]));
     }
     auto m_expected = std::move(*rebuilder_without_flush.consume_end_of_stream());
@@ -3087,13 +3087,13 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_rebuilder_v2_flush) {
     // including no flush).
     // This is to test that the first flush doesn't break the rebuilder in
     // a way that prevents another flush.
-    for (int first_flush = 0; first_flush < frags.size(); ++first_flush) {
-        for (int second_flush = first_flush; second_flush < frags.size(); ++second_flush) {
+    for (unsigned first_flush = 0; first_flush < frags.size(); ++first_flush) {
+        for (unsigned second_flush = first_flush; second_flush < frags.size(); ++second_flush) {
             mutation_rebuilder_v2 rebuilder(s);
             auto m1 = mutation(s, pk); // Contents of flush 1.
             auto m2 = mutation(s, pk); // Contents of flush 2.
             auto m3 = mutation(s, pk); // Contents of final flush. 
-            for (int i = 0; i < frags.size(); ++i) {
+            for (unsigned i = 0; i < frags.size(); ++i) {
                 rebuilder.consume(mutation_fragment_v2(*s, p, frags[i]));
                 if (i == first_flush) {
                     m1 = rebuilder.flush();

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -703,7 +703,7 @@ SEASTAR_THREAD_TEST_CASE(test_split_token_range_msb) {
         BOOST_REQUIRE_EQUAL(ranges.size(), 1 << msb);
 
         std::optional<dht::token> prev_last_token;
-        for (int i = 0; i < ranges.size(); i++) {
+        for (unsigned i = 0; i < ranges.size(); i++) {
             auto t = dht::last_token_of_compaction_group(msb, i);
             testlog.debug("msb: {}, t: {}, range: {}", msb, t, ranges[i]);
             BOOST_REQUIRE(ranges[i].contains(t, cmp));

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -207,7 +207,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
             if (data1.size() != data2.size()) {
                 mismatch = ::format("size1 {} != size2 {}", data1.size(), data2.size());
             } else {
-                for (int i = 0; i < data1.size(); ++i) {
+                for (unsigned i = 0; i < data1.size(); ++i) {
                     const auto& mf1 = data1[i];
                     const auto& mf2 = data2[i];
                     if (!mf1.equal(s, mf2)) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5032,7 +5032,7 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
 
                     testlog.info("Closing sstable of generation {}, table set size: {}", sst.generation(), input_sstable_count);
                     sstables_closed++;
-                    if (input_sstable_count < last_input_sstable_count) {
+                    if (std::cmp_less(input_sstable_count, last_input_sstable_count)) {
                         sstables_closed_during_cleanup++;
                         last_input_sstable_count = input_sstable_count;
                     }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -321,7 +321,7 @@ static future<compact_sstables_result> compact_sstables(test_env& env, std::vect
         std::vector<sstables::shared_sstable> created;
 
         if (create_sstables) {
-            for (auto i = 0; i < create_sstables; i++) {
+            for (unsigned i = 0; i < create_sstables; i++) {
                 const column_definition& r1_col = *s->get_column_definition("r1");
 
                 auto sst = sst_gen();
@@ -459,7 +459,7 @@ SEASTAR_TEST_CASE(compact_02) {
 
         static constexpr size_t num_rounds = 4;
         static constexpr size_t sstables_in_round = 4;
-        for (auto i = 0; i < num_rounds; ++i) {
+        for (unsigned i = 0; i < num_rounds; ++i) {
             compact_and_verify(sstables_in_round);
         }
 
@@ -3843,7 +3843,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
 
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
-            for (auto i = 0; i < disjoint_sstable_count; i++) {
+            for (unsigned i = 0; i < disjoint_sstable_count; i++) {
                 auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(i))});
                 sstables.push_back(std::move(sst));
             }
@@ -3858,7 +3858,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
 
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
-            for (auto i = 0; i < disjoint_sstable_count; i++) {
+            for (unsigned i = 0; i < disjoint_sstable_count; i++) {
                 auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i))});
                 sstables.push_back(std::move(sst));
                 i++;
@@ -3890,7 +3890,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
             mutations_for_small_files.push_back(make_row(0, std::chrono::hours(1)));
 
             std::vector<mutation> mutations_for_big_files;
-            for (auto i = 0; i < keys.size(); i++) {
+            for (unsigned i = 0; i < keys.size(); i++) {
                 mutations_for_big_files.push_back(make_row(i, std::chrono::hours(1)));
             }
 
@@ -4100,7 +4100,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
         });
 
         // Make tables
-        for (auto idx = 0; idx < num_tables; idx++) {
+        for (unsigned idx = 0; idx < num_tables; idx++) {
             auto s = make_schema(idx);
             schemas.push_back(s);
 
@@ -4130,7 +4130,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             column_family_test(cf).add_sstable(sst).get();
         };
 
-        for (auto i = 0; i < num_tables; i++) {
+        for (unsigned i = 0; i < num_tables; i++) {
             add_single_fully_expired_sstable_to_table(i);
         }
 
@@ -4809,7 +4809,7 @@ SEASTAR_TEST_CASE(test_print_shared_sstables_vector) {
         mut1.partition().apply_insert(*s, ss.make_ckey(1), ss.new_timestamp());
         ssts[1] = make_sstable_containing(sst_gen, {std::move(mut1)});
 
-        std::string msg = format("{}", ssts);
+        std::string msg = seastar::format("{}", ssts);
         for (const auto& sst : ssts) {
             auto gen_str = format("{}", sst->generation());
             BOOST_REQUIRE(msg.find(gen_str) != std::string::npos);
@@ -4988,14 +4988,14 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
         dht::token_range_vector owned_token_ranges;
 
         std::set<mutation, mutation_decorated_key_less_comparator> merged;
-        for (auto i = 0; i < sstables_nr * 2; i++) {
+        for (unsigned i = 0; i < sstables_nr * 2; i++) {
             merged.insert(make_insert(partition_key::from_exploded(*s, {to_bytes(to_sstring(i))})));
         }
 
         std::unordered_set<sstables::generation_type> gens; // input sstable generations
         run_id run_identifier = run_id::create_random_id();
         auto merged_it = merged.begin();
-        for (auto i = 0; i < sstables_nr; i++) {
+        for (unsigned i = 0; i < sstables_nr; i++) {
             auto mut1 = std::move(*merged_it);
             merged_it++;
             auto mut2 = std::move(*merged_it);

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -83,7 +83,7 @@ static future<> test_basic_operations(app_template& app) {
                 for (int k = 0; k < rf; ++k) {
                     replicas.push_back({h1, 0});
                 }
-                assert(replicas.size() == rf);
+                assert(std::cmp_equal(replicas.size(), rf));
                 tmap.set_tablet(j, tablet_info{std::move(replicas)});
                 ++total_tablets;
             }

--- a/test/raft/etcd_test.cc
+++ b/test/raft/etcd_test.cc
@@ -751,7 +751,7 @@ void handle_proposal(unsigned nodes, std::vector<int> accepting_int) {
     output1 = fsm1.get_output();
     BOOST_CHECK(output1.messages.size() >= nodes - 1);
     BOOST_CHECK(output1.term_and_vote);
-    for (int i = 2; i < nodes + 1; ++i) {
+    for (unsigned i = 2; i < nodes + 1; ++i) {
         fsm1.step(raft::server_id{utils::UUID(0, i)}, raft::vote_reply{output1.term_and_vote->first, true, false});
     }
     BOOST_CHECK(fsm1.is_leader());


### PR DESCRIPTION
in order to identify the problems caused by integer type promotion when comparing unsigned and signed integers, in this series, we 

- address the warnings raised by `-Wsign-compare` compiler option
- add `-Wsign-compare` compiler option to the building systems