### PR TITLE
sstables: use sstables_manager::uuid_stable_identifier()

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -221,7 +221,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
 
         auto make_sstable = [&] (shard_id shard) {
             auto& sstm = global_table->get_sstables_manager();
-            bool uuid_sstable_identifiers = db.local().features().uuid_sstable_identifiers;
+            bool uuid_sstable_identifiers = sstm.uuid_sstable_identifiers();
             auto generation = sharded_gen.invoke_on(shard, [uuid_sstable_identifiers] (auto& gen) {
                 return gen(sstables::uuid_identifiers{uuid_sstable_identifiers});
             }).get();


### PR DESCRIPTION
instead of accessing the `feature_service`'s member variable, use the accessor provided by sstable_manager. so we always access the this setting via a single channel. this should helps with the readability.