### PR TITLE
compaction_manager: pass const reference to ctor

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -40,7 +40,7 @@ public:
         , _cs(cs)
     { }
 
-    compacting_sstable_registration(compaction_manager& cm, compaction::compaction_state& cs, std::vector<sstables::shared_sstable> compacting)
+    compacting_sstable_registration(compaction_manager& cm, compaction::compaction_state& cs, const std::vector<sstables::shared_sstable>& compacting)
         : compacting_sstable_registration(cm, cs)
     {
         register_compacting(compacting);


### PR DESCRIPTION
the callers of the constructor does not move variable into this parameter, and the constructor itself is not able to consume it. as the parameter is a vector while `compaction_sstable_registration` use an `unordered_set` for tracking the sstables being compacted.

so, to avoid creating a temporary copy of the vector, let's just pass by reference.