### PR TITLE
Backport to branch-5.3: Revert "Merge 'cql: update permissions when creating/altering a function/keyspace' from Wojciech Mitros"

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -120,20 +120,13 @@ cql3::statements::create_keyspace_statement::prepare(data_dictionary::database d
     return std::make_unique<prepared_statement>(make_shared<create_keyspace_statement>(*this));
 }
 
-future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
-    return do_with(auth::make_data_resource(keyspace()), auth::make_functions_resource(keyspace()), [&cs](const auth::resource& r, const auth::resource& fr) {
+future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creator(const service::client_state& cs) const {
+    return do_with(auth::make_data_resource(keyspace()), [&cs](const auth::resource& r) {
         return auth::grant_applicable_permissions(
                 *cs.get_auth_service(),
                 *cs.user(),
                 r).handle_exception_type([](const auth::unsupported_authorization_operation&) {
             // Nothing.
-        }).then([&cs, &fr] {
-            return auth::grant_applicable_permissions(
-                    *cs.get_auth_service(),
-                    *cs.user(),
-                    fr).handle_exception_type([](const auth::unsupported_authorization_operation&) {
-                // Nothing.
-            });
         });
     });
 }

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -68,7 +68,7 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const override;
+    virtual future<> grant_permissions_to_creator(const service::client_state&) const override;
 
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -39,7 +39,7 @@ public:
 
     std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const;
+    future<> grant_permissions_to_creator(const service::client_state&) const;
 
     void validate(query_processor&, const service::client_state&) const override;
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -146,7 +146,7 @@ create_table_statement::prepare(data_dictionary::database db, cql_stats& stats) 
     abort();
 }
 
-future<> create_table_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
+future<> create_table_statement::grant_permissions_to_creator(const service::client_state& cs) const {
     return do_with(auth::make_data_resource(keyspace(), column_family()), [&cs](const auth::resource& r) {
         return auth::grant_applicable_permissions(
                 *cs.get_auth_service(),

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -77,7 +77,7 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const override;
+    virtual future<> grant_permissions_to_creator(const service::client_state&) const override;
 
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -22,29 +22,13 @@ namespace statements {
 future<> function_statement::check_access(query_processor& qp, const service::client_state& state) const { return make_ready_future<>(); }
 
 future<> create_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const {
-    create_arg_types(qp);
-    if (!functions::functions::find(_name, _arg_types)) {
-        co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
-    } else if (_or_replace) {
-        _altering = true;
-        co_await state.has_function_access(qp.db(), _name.keyspace, auth::encode_signature(_name.name, _arg_types), auth::permission::ALTER);
-    }
-}
+    co_await state.has_functions_access(qp.db(), _name.keyspace, auth::permission::CREATE);
+    if (_or_replace) {
+        create_arg_types(qp);
+        sstring encoded_signature = auth::encode_signature(_name.name, _arg_types);
 
-future<> create_function_statement_base::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
-    if (_altering) {
-        return make_ready_future<>();
+        co_await state.has_function_access(qp.db(), _name.keyspace, encoded_signature, auth::permission::ALTER);
     }
-    std::string_view keyspace = _name.has_keyspace() ? _name.keyspace : cs.get_keyspace();
-
-    return do_with(auth::make_functions_resource(keyspace, auth::encode_signature(_name.name, _arg_types)), [&cs](const auth::resource& r) {
-        return auth::grant_applicable_permissions(
-                *cs.get_auth_service(),
-                *cs.user(),
-                r).handle_exception_type([](const auth::unsupported_authorization_operation&) {
-            // Nothing.
-        });
-    });
 }
 
 future<> drop_function_statement_base::check_access(query_processor& qp, const service::client_state& state) const

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -43,11 +43,9 @@ protected:
     virtual void validate(query_processor& qp, const service::client_state& state) const override;
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const = 0;
     virtual seastar::future<shared_ptr<db::functions::function>> validate_while_executing(query_processor&) const override;
-    virtual seastar::future<> grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const override;
 
     bool _or_replace;
     bool _if_not_exists;
-    mutable bool _altering = false;
 
     create_function_statement_base(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types,
             bool or_replace, bool if_not_exists);

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -64,7 +64,7 @@ std::unique_ptr<prepared_statement> create_role_statement::prepare(
     return std::make_unique<prepared_statement>(::make_shared<create_role_statement>(*this));
 }
 
-future<> create_role_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state& cs) const {
+future<> create_role_statement::grant_permissions_to_creator(const service::client_state& cs) const {
     return do_with(auth::make_role_resource(_role), [&cs](const auth::resource& r) {
         return auth::grant_applicable_permissions(
                 *cs.get_auth_service(),
@@ -94,7 +94,7 @@ future<> create_role_statement::check_access(query_processor& qp, const service:
 }
 
 future<result_message_ptr>
-create_role_statement::execute(query_processor& qp,
+create_role_statement::execute(query_processor&,
                                service::query_state& state,
                                const query_options&) const {
     auth::role_config config;
@@ -104,12 +104,12 @@ create_role_statement::execute(query_processor& qp,
     return do_with(
             std::move(config),
             extract_authentication_options(_options),
-            [this, &qp, &state](const auth::role_config& config, const auth::authentication_options& authen_options) {
+            [this, &state](const auth::role_config& config, const auth::authentication_options& authen_options) {
         const auto& cs = state.get_client_state();
         auto& as = *cs.get_auth_service();
 
-        return auth::create_role(as, _role, config, authen_options).then([this, &qp, &cs] {
-            return grant_permissions_to_creator(qp, cs);
+        return auth::create_role(as, _role, config, authen_options).then([this, &cs] {
+            return grant_permissions_to_creator(cs);
         }).then([] {
             return void_result_message();
         }).handle_exception_type([this](const auth::role_already_exists& e) {

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -38,7 +38,7 @@ schema_altering_statement::schema_altering_statement(cf_name name, timeout_confi
 {
 }
 
-future<> schema_altering_statement::grant_permissions_to_creator(query_processor& qp, const service::client_state&) const {
+future<> schema_altering_statement::grant_permissions_to_creator(const service::client_state&) const {
     return make_ready_future<>();
 }
 
@@ -119,10 +119,10 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
         }
     }
 
-    return execute0(qp, state, options).then([this, &qp, &state, internal](::shared_ptr<messages::result_message> result) {
+    return execute0(qp, state, options).then([this, &state, internal](::shared_ptr<messages::result_message> result) {
         auto permissions_granted_fut = internal
                 ? make_ready_future<>()
-                : grant_permissions_to_creator(qp, state.get_client_state());
+                : grant_permissions_to_creator(state.get_client_state());
         return permissions_granted_fut.then([result = std::move(result)] {
            return result;
         });

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -48,7 +48,7 @@ protected:
      *
      * By default, this function does nothing.
      */
-    virtual future<> grant_permissions_to_creator(query_processor& qp, const service::client_state&) const;
+    virtual future<> grant_permissions_to_creator(const service::client_state&) const;
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 


### PR DESCRIPTION
This reverts commit 52e4edfd5e6773ffd53ddf6ccb51be58175613c5, reversing changes made to d2d53fc1dbe6ced778975370b9626b6a9c55f7e2. The associated test fails with about 10% probablity, which blocks other work.

Fixes #14395