### PR TITLE
Fix `test_node_isolation` flakiness

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -33,7 +33,7 @@ class ManagerClient():
     # pylint: disable=too-many-public-methods
 
     def __init__(self, sock_path: str, port: int, use_ssl: bool,
-                 con_gen: Optional[Callable[[List[IPAddress], int, bool], CassandraSession]]) \
+                 con_gen: Callable[[List[IPAddress], int, bool], CassandraSession]) \
                          -> None:
         self.port = port
         self.use_ssl = use_ssl
@@ -50,12 +50,11 @@ class ManagerClient():
 
     async def driver_connect(self, server: Optional[ServerInfo] = None) -> None:
         """Connect to cluster"""
-        if self.con_gen is not None:
-            targets = [server] if server else await self.running_servers()
-            servers = [s_info.ip_addr for s_info in targets]
-            logger.debug("driver connecting to %s", servers)
-            self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
-            self.cql = self.ccluster.connect()
+        targets = [server] if server else await self.running_servers()
+        servers = [s_info.ip_addr for s_info in targets]
+        logger.debug("driver connecting to %s", servers)
+        self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
+        self.cql = self.ccluster.connect()
 
     def driver_close(self) -> None:
         """Disconnect from cluster"""


### PR DESCRIPTION
The test isolates a node and then connects to it through CQL.
The `connect()` step would often timeout on ARM debug builds. This was
already dealt with in the past in the context of other tests: #11289.

The `ManagerClient.con_gen` function creates a connection in a way that
avoids the problem -- connection timeout settings are adjusted to
account for the slowness. Use it in this test to fix the flakiness.

At the same time, reduce the timeout used for the actual CQL request
(after the driver has already connected), because the test expects this
request to timeout and waiting for 200 seconds here is just a waste of
time.

