### PR TITLE
Automatically close exhausted SSTable readers for cleanup

### DIFF
--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -532,7 +532,6 @@ public:
                     return make_ready_future<>();
                 }
                 if (auto r = next()) {
-                    mrlog.trace("flat_multi_range_mutation_reader {}: fast forwarding to range {}", fmt::ptr(this), *r);
                     return _reader.fast_forward_to(*r);
                 } else {
                     _end_of_stream = true;


### PR DESCRIPTION
This is a followup to 1545ae2d3be23d9ae8e9

A new reader is introduced that automatically closes the underlying sstable reader once it's exhausted after a fast forward call.

Allowing us to revert 1fefe597e60f7ffa58d97fb1 which is fragile.