### PR TITLE
test: use correct timestamp resolution in `test_group0_history_clearing_old_entries`

### DIFF
--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -40,6 +40,7 @@ public:
     // UUID timestamp time component is represented in intervals
     // of 1/10 of a microsecond since the beginning of GMT epoch.
     using decimicroseconds = std::chrono::duration<int64_t, std::ratio<1, 10'000'000>>;
+    using microseconds = std::chrono::microseconds;
     using milliseconds = std::chrono::milliseconds;
 private:
     // A grand day! millis at 00:00:00.000 15 Oct 1582.
@@ -316,11 +317,29 @@ public:
 
     /**
      * @param uuid
+     * @return decimicroseconds since Unix epoch
+     */
+    static decimicroseconds unix_timestamp_decimicros(UUID uuid)
+    {
+        return decimicroseconds(uuid.timestamp()) + START_EPOCH;
+    }
+
+    /**
+     * @param uuid
+     * @return microseconds since Unix epoch
+     */
+    static microseconds unix_timestamp_micros(UUID uuid)
+    {
+        return duration_cast<microseconds>(unix_timestamp_decimicros(uuid));
+    }
+
+    /**
+     * @param uuid
      * @return milliseconds since Unix epoch
      */
     static milliseconds unix_timestamp(UUID uuid)
     {
-        return duration_cast<milliseconds>(decimicroseconds(uuid.timestamp()) + START_EPOCH);
+        return duration_cast<milliseconds>(unix_timestamp_decimicros(uuid));
     }
 
     /**


### PR DESCRIPTION
In 10c1f1dc80afec530dd24bd11ca74cfbe0eb0f99 I fixed `make_group0_history_state_id_mutation` to use correct timestamp resolution (microseconds instead of milliseconds) which was supposed to fix the flakiness of `test_group0_history_clearing_old_entries`.

Unfortunately, the test is still flaky, although now it's failing at a later step -- this is because I was sloppy and I didn't adjust this second part of the test to also use microsecond resolution. The test is counting the number of entries in the `system.group0_history` table that are older than a certain timestamp, but it's doing the counting using millisecond resolution, causing it to give results that are off by one sometimes.

Fix it by using microseconds everywhere.

Fixes #14653