### PR TITLE
compaction_manager: use range in compacting_sstable_registration

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -186,13 +186,13 @@ private:
     requires std::convertible_to<std::ranges::range_value_t<Range>, sstables::shared_sstable>
     std::vector<sstables::shared_sstable> get_candidates(table_state& t, const Range& sstables) const;
 
-    template <typename Iterator, typename Sentinel>
-    requires std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>
-    void register_compacting_sstables(Iterator first, Sentinel last);
+    template <std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, sstables::shared_sstable>
+    void register_compacting_sstables(const Range& range);
 
-    template <typename Iterator, typename Sentinel>
-    requires std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>
-    void deregister_compacting_sstables(Iterator first, Sentinel last);
+    template <std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, sstables::shared_sstable>
+    void deregister_compacting_sstables(const Range& range);
 
     // gets the table's compaction state
     // throws std::out_of_range exception if not found.


### PR DESCRIPTION
simpler than the "begin, end" iterator pair. and also tighten the type constraints, now require the value type to be sstables::shared_sstable. this matches what we are expecting in the implementation.