### PR TITLE
compaction_manager: remove unnecessary include

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -9,6 +9,7 @@
 #include "compaction_manager.hh"
 #include "compaction_strategy.hh"
 #include "compaction_backlog_manager.hh"
+#include "compaction_weight_registration.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <seastar/core/metrics.hh>

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -31,7 +31,6 @@
 #include <functional>
 #include <algorithm>
 #include "compaction.hh"
-#include "compaction_weight_registration.hh"
 #include "compaction_backlog_manager.hh"
 #include "compaction/task_manager_module.hh"
 #include "compaction_state.hh"
@@ -45,8 +44,6 @@ namespace db {
 class system_keyspace;
 class compaction_history_entry;
 }
-
-class compacting_sstable_registration;
 
 class repair_history_map {
 public:
@@ -64,8 +61,6 @@ class rewrite_sstables_compaction_task_executor;
 class cleanup_sstables_compaction_task_executor;
 class validate_sstables_compaction_task_executor;
 }
-class compaction_manager_test_task_executor;
-
 // Compaction manager provides facilities to submit and track compaction jobs on
 // behalf of existing tables.
 class compaction_manager {
@@ -429,7 +424,6 @@ public:
     friend class compaction::rewrite_sstables_compaction_task_executor;
     friend class compaction::cleanup_sstables_compaction_task_executor;
     friend class compaction::validate_sstables_compaction_task_executor;
-    friend class compaction_manager_test_task_executor;
 };
 
 namespace compaction {


### PR DESCRIPTION
also, remove unnecessary forward declarations.

* compaction_manager_test_task_executor is only referenced in the friend declaration. but this declaration does not need a forward declaration of the friend class
* compaction_manager_test_task_executor is not used anywhere.