### PR TITLE
storage_proxy: silence abort_requested_exception on reads and writes

### DIFF
--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -20,11 +20,15 @@ class stale_topology_exception {
     int64_t callee_fence_version();
 };
 
+class abort_requested_exception {
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
             replica::rate_limit_exception,
-            replica::stale_topology_exception
+            replica::stale_topology_exception,
+            replica::abort_requested_exception
     > reason;
 };
 

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -24,6 +24,8 @@ exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
         return rate_limit_exception();
     } catch (const stale_topology_exception& e) {
         return e;
+    } catch (abort_requested_exception&) {
+        return abort_requested_exception();
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -13,6 +13,7 @@
 #include <optional>
 #include <variant>
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/timed_out_error.hh>
 
@@ -66,11 +67,14 @@ public:
     virtual const char* what() const noexcept override { return _message.c_str(); }
 };
 
+using abort_requested_exception = seastar::abort_requested_exception;
+
 struct exception_variant {
     std::variant<unknown_exception,
             no_exception,
             rate_limit_exception,
-            stale_topology_exception
+            stale_topology_exception,
+            abort_requested_exception
     > reason;
 
     exception_variant()

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -482,8 +482,10 @@ private:
                         errors.count++;
                         errors.local = replica::try_encode_replica_exception(eptr);
                         seastar::log_level l = seastar::log_level::warn;
-                        if (is_timeout_exception(eptr) || std::holds_alternative<replica::rate_limit_exception>(errors.local.reason)) {
-                            // ignore timeouts and rate limit exceptions so that logs are not flooded.
+                        if (is_timeout_exception(eptr)
+                                || std::holds_alternative<replica::rate_limit_exception>(errors.local.reason)
+                                || std::holds_alternative<abort_requested_exception>(errors.local.reason)) {
+                            // ignore timeouts, abort requests and rate limit exceptions so that logs are not flooded.
                             // database's total_writes_timedout or total_writes_rate_limited counter was incremented.
                             l = seastar::log_level::debug;
                         }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -596,6 +596,9 @@ private:
                     } else if constexpr(std::is_same_v<Ex, replica::stale_topology_exception>) {
                         msg = e.what();
                         return error::FAILURE;
+                    } else if constexpr (std::is_same_v<Ex, replica::abort_requested_exception>) {
+                        msg = e.what();
+                        return error::FAILURE;
                     }
                 }, exception->reason);
             }


### PR DESCRIPTION
Fixes #10447

This issue is an expected behavior. However, `abort_requested_exception` is not handled properly.

## Why this issue appeared

1. The node is drained.
2. `migration_manager::drain` is called and executes `_as.request_abort();`.
3. The coordinator sends read RPCs to the drained replica. On the replica side, `storage_proxy::handle_read` calls `migration_manager::get_schema_for_read`, which is defined like this:
```cpp
future<schema_ptr> migration_manager::get_schema_for_write(/* ... */) {
    if (_as.abort_requested()) {
        co_return coroutine::exception(std::make_exception_ptr(abort_requested_exception()));
    }
    /* ... */
```
So, `abort_requested_exception` is thrown.
4. RPC doesn't preserve information about its type, and it is converted to a string containing its error message.
5. It is rethrown as `std::runtime_error` on the coordinator side, and `abstract_resolve_reader::error()` logs information about it. However, we don't want to report `abort_requested_exception` there. This exception should be catched and ignored:
```cpp
void error(/* ... */) {
    /* ... */
   else if (try_catch<abort_requested_exception>(eptr)) {
        // do not report aborts, they are trigerred by shutdown or timeouts
    }
    /* ... */
```

## Proposed solution

To fix this issue, we can add `abort_requested_exception` to `replica::exception_variant` and make sure that if it is thrown by `migration_manager::get_schema_for_write`, `storage_proxy::handle_read` correctly  encodes it. Thanks to this change, `abstract_read_resolver::error` can correctly handle `abort_requested_exception` thrown on the replica side by not reporting it.

## Side effect of the proposed solution

If the replica supports it, the coordinator doesn't, and all nodes support `feature_service::typed_errors_in_read_rpc`, the coordinator will fail to decode `abort_requested_exception` and it will be decoded to `unknown_exception`. It will still be rethrown as `std::runtime_error`, however the message will change from *abort requested* to *unknown exception*.

## Another issue

Moreover, `handle_write` reports abort requests for the same reason. This also floods the logs (this time on the replica side) for the same reason. I don't think it is intended, so I've changed it too. This change is in the last commit.