### PR TITLE
test: randomized_nemesis_test: do not perform tautogical comparision

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2905,7 +2905,7 @@ public:
     }
 
     static elem_t digest_append(elem_t d, elem_t x) {
-        assert(0 <= d < magic);
+        assert(0 <= d && d < magic);
 
         auto y = (d + x) % magic;
         assert(digest_remove(y, x) == d);
@@ -2913,7 +2913,7 @@ public:
     }
 
     static elem_t digest_remove(elem_t d, elem_t x) {
-        assert(0 <= d < magic);
+        assert(0 <= d && d < magic);
         auto y = (d - x) % magic;
         return y < 0 ? y + magic : y;
     }


### PR DESCRIPTION
it is not supported by C++, and might not yield expected result. as "0 <= d" evaluates to true, which is always less than "magic".

so let's avoid using it.

```
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:2908:23: error: result of comparison of constant 54313 with expression of type 'bool' is always true [-Werror,-Wtautological-constant-out-of-range-compare]
 2908 |         assert(0 <= d < magic);
      |                ~~~~~~ ^ ~~~~~
```