### PR TITLE
compaction_manager: sort sstables when compaction is enabled

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1408,13 +1408,12 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_tas
         // regular compaction runs in between and picks the same files.
         sstables = co_await get_func();
         compacting.register_compacting(sstables);
-
-        // sort sstables by size in descending order, such that the smallest files will be rewritten first
-        // (as sstable to be rewritten is popped off from the back of container), so rewrite will have higher
-        // chance to succeed when the biggest files are reached.
-        std::sort(sstables.begin(), sstables.end(), [](sstables::shared_sstable& a, sstables::shared_sstable& b) {
-            return a->data_size() > b->data_size();
-        });
+    });
+    // sort sstables by size in descending order, such that the smallest files will be rewritten first
+    // (as sstable to be rewritten is popped off from the back of container), so rewrite will have higher
+    // chance to succeed when the biggest files are reached.
+    std::ranges::sort(sstables, [](sstables::shared_sstable& a, sstables::shared_sstable& b) {
+        return a->data_size() > b->data_size();
     });
     co_return co_await perform_task(seastar::make_shared<TaskType>(*this, &t, std::move(options), std::move(owned_ranges_ptr), std::move(sstables), std::move(compacting), std::forward<Args>(args)...));
 }


### PR DESCRIPTION
before this change, we sort sstables with compaction disabled, when we are about to perform the compaction. but the idea of guarding the getting and registering as a transaction is to prevent other compaction from mutating the sstables' state and cause the inconsistency.

but since the state is tracked on per-sstable basis, and is not related to the order in which they are processed by a certain compaction task. we don't need to guard the "sort()" with this mutual exclusive lock.

for better readability, and probably better performance, let's move the sort out of the lock. and take this opportunity to use `std::ranges::sort()` for more concise code.