### PR TITLE
doc: document nodetool checkAndRepairCdcStreams

### DIFF
--- a/docs/operating-scylla/nodetool-commands/checkandrepaircdcstreams.rst
+++ b/docs/operating-scylla/nodetool-commands/checkandrepaircdcstreams.rst
@@ -1,0 +1,29 @@
+Nodetool checkAndRepairCdcStreams
+===================================
+
+Checks if CDC streams reflect the current cluster topology, and regenerates them if they don't.
+
+
+.. warning::
+
+    Do not use this operation while performing other administrative tasks, such as 
+    bootstrapping or decommissioning a node.
+
+
+Usage
+------
+
+.. code:: console
+
+    nodetool checkAndRepairCdcStreams
+
+   
+See Also
+----------
+
+:doc:`Change Data Capture (CDC) </using-scylla/cdc/index>`
+
+:doc:`Upgrading from experimental CDC </kb/cdc-experimental-upgrade>`
+
+.. include:: nodetool-index.rst
+

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -9,6 +9,7 @@ Nodetool
 
    nodetool-commands/cfhistograms
    nodetool-commands/cfstats
+   nodetool-commands/checkandrepaircdcstreams
    nodetool-commands/cleanup
    nodetool-commands/clearsnapshot
    nodetool-commands/compactionhistory
@@ -76,6 +77,7 @@ Operations that are not listed below are currently not available.
 
 * :doc:`cfhistograms <nodetool-commands/cfhistograms/>` - Provides statistics about a table, including number of SSTables, read/write latency, partition size and column count.
 * :doc:`cfstats </operating-scylla/nodetool-commands/cfstats/>` - Provides in-depth diagnostics regard table.
+* :doc:`checkandrepaircdcstreams </operating-scylla/nodetool-commands/checkandrepaircdcstreams/>` - Checks and fixes CDC streams.
 * :doc:`cleanup </operating-scylla/nodetool-commands/cleanup/>` - Triggers the immediate cleanup of keys no longer belonging to a node.
 * :doc:`clearsnapshot </operating-scylla/nodetool-commands/clearsnapshot/>` - This command removes snapshots.
 * :doc:`compactionhistory </operating-scylla/nodetool-commands/compactionhistory/>` - Provides the history of compactions.


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13783

This commit documents the nodetool checkAndRepairCdcStreams operation, which was missing from the docs.

The description is added in a new file and referenced from the nodetool operations index.