### PR TITLE
feature_service: handle deprecated features correctly in feature check

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -98,9 +98,6 @@ void feature_service::unregister_feature(feature& f) {
 
 
 std::set<std::string_view> feature_service::supported_feature_set() const {
-    // Add features known by this local node. When a new feature is
-    // introduced in scylla, update it here, e.g.,
-    // return sstring("FEATURE1,FEATURE2")
     std::set<std::string_view> features = {
         // Deprecated features - sent to other nodes via gossip, but assumed true in the code
         "RANGE_TOMBSTONES"sv,
@@ -122,7 +119,6 @@ std::set<std::string_view> feature_service::supported_feature_set() const {
         "CORRECT_STATIC_COMPACT_IN_MC"sv,
         "UNBOUNDED_RANGE_TOMBSTONES"sv,
         "MC_SSTABLE_FORMAT"sv,
-        "LARGE_COLLECTION_DETECTION"sv,
     };
 
     for (auto& [name, f_ref] : _registered_features) {
@@ -238,7 +234,7 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     for (auto&& f : persisted_features) {
         logger.debug("Enabling persisted feature '{}'", f);
         const bool is_registered_feat = _registered_features.contains(sstring(f));
-        if (!is_registered_feat || !known_features.contains(f)) {
+        if (!known_features.contains(f)) {
             if (is_registered_feat) {
                 throw std::runtime_error(format(
                     "Feature '{}' was previously enabled in the cluster but its support is disabled by this node. "

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -26,6 +26,12 @@ namespace gms {
 
 static logging::logger logger("features");
 
+static const char* enable_test_feature_error_injection_name = "features_enable_test_feature";
+
+static bool is_test_only_feature_enabled() {
+    return utils::get_local_injector().enter(enable_test_feature_error_injection_name);
+}
+
 feature_config::feature_config() {
 }
 
@@ -76,7 +82,7 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
         fcfg._disabled_features.insert("UUID_SSTABLE_IDENTIFIERS"s);
     }
 
-    if (!utils::get_local_injector().enter("features_enable_test_feature")) {
+    if (!is_test_only_feature_enabled()) {
         fcfg._disabled_features.insert("TEST_ONLY_FEATURE"s);
     }
 

--- a/test/topology_custom/test_deprecating_cluster_features.py
+++ b/test/topology_custom/test_deprecating_cluster_features.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import time
+
+from test.pylib.manager_client import ManagerClient
+import pytest
+
+
+TEST_FEATURE_ENABLE_ERROR_INJECTION = "features_enable_test_feature"
+TEST_FEATURE_ENABLE_AS_DEPRECATED_ERROR_INJECTION = "features_enable_test_feature_as_deprecated"
+ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
+
+
+@pytest.mark.asyncio
+async def test_feature_deprecation_works(manager: ManagerClient) -> None:
+    """Simulate a very old node which, long ago, has enabled some features,
+       persisted them in system.scylla_local, and now some of them became
+       deprecated.
+    """
+
+    # Start the node, enable the feature
+    srv = await manager.server_add(config={
+        ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY: [TEST_FEATURE_ENABLE_ERROR_INJECTION]
+    })
+    await manager.server_start(srv.server_id)
+
+    # Restart the node, but this time the feature is deprecated
+    await manager.server_stop_gracefully(srv.server_id)
+    await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY,
+                                       [TEST_FEATURE_ENABLE_AS_DEPRECATED_ERROR_INJECTION])
+    await manager.server_start(srv.server_id)
+
+    # The node should restart successfully


### PR DESCRIPTION
The feature check in `enable_features_on_startup` loads the list
of features that were enabled previously, goes over every one of them
and checks whether each feature is considered supported and whether
there is a corresponding `gms::feature` object for it (i.e. the feature
is "registered"). The second part of the check is unnecessary
and wrong. A feature can be marked as supported but its `gms::feature`
object not be present anymore: after a feature is supported for long
enough (i.e. we only support upgrades from versions that support the
feature), we can consider such a feature to be deprecated.

When a feature is deprecated, its `gms::feature` object is removed and
the feature is always considered enabled which allows to remove some
legacy code. We still consider this feature to be supported and
advertise it in gossip, for the sake of the old nodes which, even
though they always support the feature, they still check whether other
nodes support it.

The problem with the check as it is now is that it disallows moving
features to the disabled list. If one tries to do it, they will find
out that upgrading the node to the new version does not work:
`enable_features_on_startup` will load the feature, notice that it is
not "registered" (there is no `gms::feature` object for it) and fail
to boot.

This commit fixes the problem by modifying `enable_features_on_startup`
not to look at the registered features list at all. In addition to
this, some other small cleanups are performed:

- "LARGE_COLLECTION_DETECTION" is removed from the deprecated features
  list. For some reason, it was put there when the feature was being
  introduced. It does not break anything because there is
  a `gms::feature` object for it, but it's slightly confusing
  and therefore is removed.
- The comment in `supported_feature_set` that invites developers to add
  features there as they are introduced is removed. It is no longer
  necessary to do so because registered features are put there
  automatically. Deprecated features should still be put there,
  as indicated as another comment.

Fortunately, this issue does not break any upgrades as of now - since
we added enabled cluster feature persisting, no features were
deprecated, and we only add registered features to the persisted feature
list.

An error injection and a regression test is added.