### PR TITLE
config: set schema_commitlog_segment_size_in_mb to 128 

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -71,6 +71,13 @@ commitlog_sync_period_in_ms: 10000
 # is reasonable.
 commitlog_segment_size_in_mb: 32
 
+# The size of the individual schema commitlog file segments.
+
+# The segment size puts a limit on the mutation size that can be
+# written at once, and some schema mutation writes are much larger
+# than average.
+schema_commitlog_segment_size_in_mb: 32
+
 # seed_provider class_name is saved for future use.
 # A seed address is mandatory.
 seed_provider:

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -72,11 +72,12 @@ commitlog_sync_period_in_ms: 10000
 commitlog_segment_size_in_mb: 32
 
 # The size of the individual schema commitlog file segments.
-
-# The segment size puts a limit on the mutation size that can be
-# written at once, and some schema mutation writes are much larger
-# than average.
-schema_commitlog_segment_size_in_mb: 32
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
 
 # seed_provider class_name is saved for future use.
 # A seed address is mandatory.

--- a/db/config.cc
+++ b/db/config.cc
@@ -469,8 +469,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_segment_size_in_mb(this, "commitlog_segment_size_in_mb", value_status::Used, 64,
         "Sets the size of the individual commitlog file segments. A commitlog segment may be archived, deleted, or recycled after all its data has been flushed to SSTables. This amount of data can potentially include commitlog segments from every table in the system. The default size is usually suitable for most commitlog archiving, but if you want a finer granularity, 8 or 16 MB is reasonable. See Commit log archive configuration.\n"
         "Related information: Commit log archive configuration")
-    , schema_commitlog_segment_size_in_mb(this, "schema_commitlog_segment_size_in_mb", value_status::Used, 32,
-        "Sets the size of the individual schema commitlog file segments. The segment size puts a limit on the mutation size that can be written at once, and some schema mutation writes are much larger than average.\n"
+    , schema_commitlog_segment_size_in_mb(this, "schema_commitlog_segment_size_in_mb", value_status::Used, 128,
+        "Sets the size of the individual schema commitlog file segments. The default size is larger than the default size of the data commitlog because the segment size puts a limit on the mutation size that can be written at once, and some schema mutation writes are much larger than average.\n"
         "Related information: Commit log archive configuration")
     /* Note: does not exist on the listing page other than in above comment, wtf? */
     , commitlog_sync_period_in_ms(this, "commitlog_sync_period_in_ms", value_status::Used, 10000,

--- a/db/config.cc
+++ b/db/config.cc
@@ -469,6 +469,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_segment_size_in_mb(this, "commitlog_segment_size_in_mb", value_status::Used, 64,
         "Sets the size of the individual commitlog file segments. A commitlog segment may be archived, deleted, or recycled after all its data has been flushed to SSTables. This amount of data can potentially include commitlog segments from every table in the system. The default size is usually suitable for most commitlog archiving, but if you want a finer granularity, 8 or 16 MB is reasonable. See Commit log archive configuration.\n"
         "Related information: Commit log archive configuration")
+    , schema_commitlog_segment_size_in_mb(this, "schema_commitlog_segment_size_in_mb", value_status::Used, 32,
+        "Sets the size of the individual schema commitlog file segments. The segment size puts a limit on the mutation size that can be written at once, and some schema mutation writes are much larger than average.\n"
+        "Related information: Commit log archive configuration")
     /* Note: does not exist on the listing page other than in above comment, wtf? */
     , commitlog_sync_period_in_ms(this, "commitlog_sync_period_in_ms", value_status::Used, 10000,
         "Controls how long the system waits for other writes before performing a sync in \"periodic\" mode.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -199,6 +199,7 @@ public:
     named_value<uint32_t> failure_detector_timeout_in_ms;
     named_value<sstring> commitlog_sync;
     named_value<uint32_t> commitlog_segment_size_in_mb;
+    named_value<uint32_t> schema_commitlog_segment_size_in_mb;
     named_value<uint32_t> commitlog_sync_period_in_ms;
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -951,7 +951,7 @@ void database::maybe_init_schema_commitlog() {
     c.fname_prefix = db::schema_tables::COMMITLOG_FILENAME_PREFIX;
     c.metrics_category_name = "schema-commitlog";
     c.commitlog_total_space_in_mb = 10 << 20;
-    c.commitlog_segment_size_in_mb = _cfg.commitlog_segment_size_in_mb();
+    c.commitlog_segment_size_in_mb = _cfg.schema_commitlog_segment_size_in_mb();
     c.commitlog_sync_period_in_ms = _cfg.commitlog_sync_period_in_ms();
     c.mode = db::commitlog::sync_mode::BATCH;
     c.extensions = &_cfg.extensions();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -952,7 +952,6 @@ void database::maybe_init_schema_commitlog() {
     c.metrics_category_name = "schema-commitlog";
     c.commitlog_total_space_in_mb = 10 << 20;
     c.commitlog_segment_size_in_mb = _cfg.schema_commitlog_segment_size_in_mb();
-    c.commitlog_sync_period_in_ms = _cfg.commitlog_sync_period_in_ms();
     c.mode = db::commitlog::sync_mode::BATCH;
     c.extensions = &_cfg.extensions();
     c.use_o_dsync = _cfg.commitlog_use_o_dsync();


### PR DESCRIPTION
Fixes #14668

In #14668, we have decided to introduce a new `scylla.yaml` variable for the schema commitlog segment size and set it to 128MB. The reason is that segment size puts a limit on the mutation size that can be written at once, and some schema mutation writes are much larger than average, as shown in #13864. This `schema_commitlog_segment_size_in_mb variable` variable is now added to `scylla.yaml` and `db/config`.

Additionally,  we do not derive the commitlog sync period for schema commitlog anymore because schema commitlog runs in batch mode, so it doesn't need this parameter. It has also been discussed in #14668.