### PR TITLE
cql3: expr: remove the default constructor

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -116,6 +116,7 @@ struct uninitialized {
     uninitialized(uninitialized&&) = default;
     uninitialized(const T& val) : _val(val) {}
     uninitialized(T&& val) : _val(std::move(val)) {}
+    uninitialized(std::convertible_to<T> auto&& x) : _val(std::forward<decltype(x)>(x)) {}
     uninitialized& operator=(const uninitialized&) = default;
     uninitialized& operator=(uninitialized&&) = default;
     operator T&&() && { return check(), std::move(*_val); }

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -64,8 +64,8 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
     }
 }
 
-void
-constants::setter::prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update& query) const {
-    query.new_value = *_e;
+expr::expression
+constants::setter::prepare_new_value_for_broadcast_tables() const {
+    return *_e;
 }
 }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -40,7 +40,7 @@ public:
 
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, cql3::raw_value_view value);
 
-        virtual void prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update& query) const override;
+        virtual expr::expression prepare_new_value_for_broadcast_tables() const override;
     };
 
     struct adder final : operation_skip_if_unset {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -143,7 +143,6 @@ class expression final {
     struct impl;                 
     std::unique_ptr<impl> _v;
 public:
-    expression(); // FIXME: remove
     expression(ExpressionElement auto e);
 
     expression(const expression&);
@@ -435,10 +434,6 @@ struct expression::impl final {
 
 expression::expression(ExpressionElement auto e)
         : _v(std::make_unique<impl>(std::move(e))) {
-}
-
-inline expression::expression()
-        : expression(conjunction{}) {
 }
 
 template <invocable_on_expression Visitor>

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -127,10 +127,8 @@ usertype_constructor_prepare_expression(const usertype_constructor& u, data_dict
     for (size_t i = 0; i < ut->size(); ++i) {
         auto&& field = column_identifier(to_bytes(ut->field_name(i)), utf8_type);
         auto iraw = u.elements.find(field);
-        expression raw;
-        if (iraw == u.elements.end()) {
-            raw = expr::make_untyped_null();
-        } else {
+        expression raw = expr::make_untyped_null();
+        if (iraw != u.elements.end()) {
             raw = iraw->second;
             ++found_values;
         }

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -388,8 +388,8 @@ operation::element_deletion::prepare(data_dictionary::database db, const sstring
     abort();
 }
 
-void
-operation::prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update&) const {
+expr::expression
+operation::prepare_new_value_for_broadcast_tables() const {
     // FIXME: implement for every type of `operation`.
     throw service::broadcast_tables::unsupported_operation_error{};
 }

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -23,10 +23,6 @@
 
 namespace cql3 {
 
-namespace statements::broadcast_tables {
-    struct prepared_update;
-}
-
 class update_parameters;
 
 /**
@@ -95,7 +91,7 @@ public:
         return _unset_guard.is_unset(qo);
     }
 
-    virtual void prepare_for_broadcast_tables(statements::broadcast_tables::prepared_update&) const;
+    virtual expr::expression prepare_new_value_for_broadcast_tables() const;
 
     /**
      * A parsed raw UPDATE operation.

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -120,11 +120,9 @@ static std::vector<expr::expression> extract_partition_range(
             auto s = &cv;
             with_current_binary_operator(*this, [&] (const binary_operator& b) {
                 if (s->col->is_partition_key() && (b.op == oper_t::EQ || b.op == oper_t::IN)) {
-                    const auto found = single_column.find(s->col);
-                    if (found == single_column.end()) {
-                        single_column[s->col] = b;
-                    } else {
-                        found->second = make_conjunction(std::move(found->second), b);
+                    const auto [it, inserted] = single_column.try_emplace(s->col, b);
+                    if (!inserted) {
+                        it->second = make_conjunction(std::move(it->second), b);
                     }
                 }
             });
@@ -139,11 +137,9 @@ static std::vector<expr::expression> extract_partition_range(
 
             with_current_binary_operator(*this, [&] (const binary_operator& b) {
                 if (cval.col->is_partition_key() && (b.op == oper_t::EQ || b.op == oper_t::IN)) {
-                    const auto found = single_column.find(cval.col);
-                    if (found == single_column.end()) {
-                        single_column[cval.col] = b;
-                    } else {
-                        found->second = make_conjunction(std::move(found->second), b);
+                    const auto [it, inserted] = single_column.try_emplace(cval.col, b);
+                    if (!inserted) {
+                        it->second = make_conjunction(std::move(it->second), b);
                     }
                 }
             });
@@ -247,11 +243,9 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
             auto s = &cv;
             with_current_binary_operator(*this, [&] (const binary_operator& b) {
                 if (s->col->is_clustering_key()) {
-                    const auto found = single.find(s->col);
-                    if (found == single.end()) {
-                        single[s->col] = b;
-                    } else {
-                        found->second = make_conjunction(std::move(found->second), b);
+                    const auto [it, inserted] = single.try_emplace(s->col, b);
+                    if (!inserted) {
+                        it->second = make_conjunction(std::move(it->second), b);
                     }
                 }
             });
@@ -262,11 +256,9 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
             with_current_binary_operator(*this, [&] (const binary_operator& b) {
                 if (cval.col->is_clustering_key()) {
-                    const auto found = single.find(cval.col);
-                    if (found == single.end()) {
-                        single[cval.col] = b;
-                    } else {
-                        found->second = make_conjunction(std::move(found->second), b);
+                    const auto [it, inserted] = single.try_emplace(cval.col, b);
+                    if (!inserted) {
+                        it->second = make_conjunction(std::move(it->second), b);
                     }
                 }
             });

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -530,7 +530,7 @@ int statement_restrictions::score(const secondary_index::index& index) const {
 std::pair<std::optional<secondary_index::index>, expr::expression> statement_restrictions::find_idx(const secondary_index::secondary_index_manager& sim) const {
     std::optional<secondary_index::index> chosen_index;
     int chosen_index_score = 0;
-    expr::expression chosen_index_restrictions;
+    expr::expression chosen_index_restrictions = expr::conjunction({});
 
     for (const auto& index : sim.list_indexes()) {
         auto cdef = _schema->get_column_definition(to_bytes(index.target_column()));
@@ -1849,7 +1849,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
 
     // If we're here, it means the index cannot be on a partition column: process_partition_key_restrictions()
     // avoids indexing when _partition_range_is_simple.  See _idx_tbl_ck_prefix blurb for its composition.
-    _idx_tbl_ck_prefix = std::vector<expr::expression>(1 + _schema->partition_key_size());
+    _idx_tbl_ck_prefix = std::vector<expr::expression>(1 + _schema->partition_key_size(), expr::conjunction({}));
     _idx_tbl_ck_prefix->reserve(_idx_tbl_ck_prefix->size() + idx_tbl_schema.clustering_key_size());
     for (const auto& e : _partition_range_restrictions) {
         const auto col = expr::as<column_value>(find(e, oper_t::EQ)->lhs).col;

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -36,21 +36,21 @@ private:
     /**
      * Restrictions on partitioning columns
      */
-    expr::expression _partition_key_restrictions;
+    expr::expression _partition_key_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_partition_key_restrictions;
 
     /**
      * Restrictions on clustering columns
      */
-    expr::expression _clustering_columns_restrictions;
+    expr::expression _clustering_columns_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_clustering_key_restrictions;
 
     /**
      * Restriction on non-primary key columns (i.e. secondary index restrictions)
      */
-    expr::expression _nonprimary_key_restrictions;
+    expr::expression _nonprimary_key_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_nonprimary_key_restrictions;
 

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -29,7 +29,7 @@ namespace util {
 
 void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
 
-template <typename Func, typename Result = std::result_of_t<Func(cql3_parser::CqlParser&)>>
+template <typename Func, typename Result = cql3_parser::unwrap_uninitialized_t<std::result_of_t<Func(cql3_parser::CqlParser&)>>>
 Result do_with_parser(const sstring_view& cql, Func&& f) {
     std::optional<Result> ret;
     do_with_parser_impl(cql, [&] (cql3_parser::CqlParser& parser) {

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2421,7 +2421,7 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_bind_variable) {
     BOOST_REQUIRE(prepared_constructor->elements.contains(column_identifier("field2", true)));
 
     bind_variable* prepared_bind_var =
-        as_if<bind_variable>(&prepared_constructor->elements[column_identifier("field2", true)]);
+        as_if<bind_variable>(&prepared_constructor->elements.at(column_identifier("field2", true)));
     BOOST_REQUIRE(prepared_bind_var != nullptr);
 
     ::lw_shared_ptr<column_specification> bind_var_receiver = prepared_bind_var->receiver;
@@ -2466,7 +2466,7 @@ BOOST_AUTO_TEST_CASE(prepare_usertype_constructor_with_bind_variable_and_missing
     BOOST_REQUIRE(prepared_constructor->elements.contains(column_identifier("field2", true)));
 
     bind_variable* prepared_bind_var =
-        as_if<bind_variable>(&prepared_constructor->elements[column_identifier("field2", true)]);
+        as_if<bind_variable>(&prepared_constructor->elements.at(column_identifier("field2", true)));
     BOOST_REQUIRE(prepared_bind_var != nullptr);
 
     ::lw_shared_ptr<column_specification> bind_var_receiver = prepared_bind_var->receiver;


### PR DESCRIPTION
`expression`'s default constructor is dangerous as an it can leak
into computations and generate surprising results. Fix that by
removing the default constructor.

This is made somewhat difficult by the parser generator's reliance
on default construction, and we need to expand our workaround
(`uninitialized<>`) capabilities to do so.

We also remove some incidental uses of default-constructed expressions.