### PR TITLE
cql3: grammar: reject intValue with no contents

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1622,8 +1622,7 @@ marker returns [uexpression value]
     ;
 
 intValue returns [uexpression value]
-    :
-    | t=INTEGER     { $value = untyped_constant{untyped_constant::integer, $t.text}; }
+    : t=INTEGER     { $value = untyped_constant{untyped_constant::integer, $t.text}; }
     | e=marker      { $value = std::move(e); }
     ;
 

--- a/test/cql-pytest/test_bad_grammar.py
+++ b/test/cql-pytest/test_bad_grammar.py
@@ -1,0 +1,24 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# A collection of tests for grammar that should be rejected, but wasn't at
+# some point in the past.
+
+import pytest
+from util import new_test_table
+from cassandra.protocol import InvalidRequest, SyntaxException
+
+
+# table1 is just there so we can execute bad queries against it.
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+        yield table
+
+# LIMIT should be followed by an expression (#14705)
+def test_limit_empty(cql, table1):
+    with pytest.raises(SyntaxException):
+        cql.execute(f'SELECT * FROM {table1} LIMIT')
+    with pytest.raises(SyntaxException):
+        cql.execute(f'SELECT * FROM {table1} PER PARTITION LIMIT')


### PR DESCRIPTION
The grammar mistakenly allows nothing to be parsed as an intValue (itself accepted in LIMIT and similar clauses).

Easily fixed by removing the empty alternative. A unit test is added.

Fixes #14705.