### PR TITLE
utils: avoid using out-of-range index in pretty_printers

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -381,6 +381,7 @@ modes = {
 
 scylla_tests = set([
     'test/boost/UUID_test',
+    'test/boost/pretty_printers_test',
     'test/boost/cdc_generation_test',
     'test/boost/aggregate_fcts_test',
     'test/boost/allocation_strategy_test',

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -352,3 +352,5 @@ add_scylla_test(wasm_alloc_test
   KIND SEASTAR)
 add_scylla_test(wasm_test
   KIND SEASTAR)
+add_scylla_test(pretty_printers_test
+  KIND BOOST)

--- a/test/boost/pretty_printers_test.cc
+++ b/test/boost/pretty_printers_test.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#define BOOST_TEST_MODULE utils
+
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+#include "utils/pretty_printers.hh"
+
+BOOST_AUTO_TEST_CASE(test_print_data_size) {
+    struct {
+        size_t n;
+        std::string_view formatted;
+    } sizes[] = {
+        {0ULL, "0 bytes"},
+        {42ULL, "42 bytes"},
+        {10'000ULL, "10kB"},
+        {10'000'000ULL, "10MB"},
+        {10'000'000'000ULL, "10GB"},
+        {10'000'000'000'000ULL, "10TB"},
+        {10'000'000'000'000'000ULL, "10PB"},
+        {10'000'000'000'000'000'000ULL, "10000PB"},
+    };
+    for (auto [n, expected] : sizes) {
+        std::stringstream out;
+        out << utils::pretty_printed_data_size{n};
+        auto actual = out.str();
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_print_throughput) {
+    struct {
+        size_t n;
+        float seconds;
+        std::string_view formatted;
+    } sizes[] = {
+        {0ULL, 0.F, "0 bytes/s"},
+        {42ULL, 0.F, "0 bytes/s"},
+        {42ULL, 1.F, "42 bytes/s"},
+        {42ULL, 0.5F, "84 bytes/s"},
+        {10'000'000ULL, 1.F, "10MB/s"},
+        {10'000'000ULL, 0.5F, "20MB/s"},
+    };
+    for (auto [n, seconds, expected] : sizes) {
+        std::stringstream out;
+        out << utils::pretty_printed_throughput{n, std::chrono::duration<float>(seconds)};
+        auto actual = out.str();
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}

--- a/utils/pretty_printers.cc
+++ b/utils/pretty_printers.cc
@@ -11,16 +11,20 @@
 namespace utils {
 
 std::ostream& operator<<(std::ostream& os, pretty_printed_data_size data) {
-    static constexpr const char *suffixes[] = {" bytes", "kB", "MB", "GB", "TB", "PB"};
+    static constexpr const char * suffixes[] = {" bytes", "kB", "MB", "GB", "TB", "PB"};
 
-    unsigned exp = 0;
-    while ((data._size >= 1000) && (exp < sizeof(suffixes))) {
-        exp++;
-        data._size /= 1000;
+    const char* suffix = nullptr;
+    uint64_t size = data._size;
+    uint64_t next_size = size;
+    for (auto s : suffixes) {
+        suffix = s;
+        size = next_size;
+        next_size = size / 1000;
+        if (next_size == 0) {
+            break;
+        }
     }
-
-    os << data._size << suffixes[exp];
-    return os;
+    return os << size << suffix;
 }
 
 std::ostream& operator<<(std::ostream& os, pretty_printed_throughput tp) {


### PR DESCRIPTION
before this change, if the formatter size is greater than a pettabyte, `exp` would be 6. but we still use it as the index to find the suffix in `suffixes`, but the array's size is 6. so we would be referencing random bits after "PB" for the suffix of the formatted size.

in this change

* instead of defining `suffixes` using `static constexpr const char* suffixes[]`, use plain list initialisation. simpler this way.
* loop in the suffix for better readability. and to avoid the off-by-one errors.
* add tests for both pretty printers

Branches: 5.1,5.2,5.3
Fixes #14702