### PR TITLE
cql3: expr: avoid separating column_mutation_attribute from its column_value when levellizing aggregation depth

### DIFF
--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -355,7 +355,7 @@ data_type column_mutation_attribute_type(const column_mutation_attribute& e);
 // How deep aggregations are nested. e.g. sum(avg(count(col))) == 3
 unsigned aggregation_depth(const cql3::expr::expression& e);
 
-// Make sure evey column_value is nested in exactly `depth` aggregations, by adding
+// Make sure evey column_value or column_mutation_attribute is nested in exactly `depth` aggregations, by adding
 // first() calls at the deepest level. e.g. if depth=3, then
 //
 //    my_agg(sum(x), y)


### PR DESCRIPTION
Since ec77172b4b9249279e43b1debb77e9ba596c1597 (" Merge 'cql3: convert the SELECT clause evaluation phase to expressions' from Avi Kivity"), we rewrite non-aggregating selectors to include an aggregation, in order to have the rest of the code either deal with no aggregation, or all selectors aggregating, with nothing in between. This is done
by wrapping column selectors with "first" function calls: col ->
first(col).

This broke non-aggregating selectors that included the ttl() or writetime() pseudo functions. This is because we rewrote them as writetime(first(col)), and writetime() isn't a function that operates on any values; it operates on mutations and so must have access to a column, not an expression.

Fix by detecting this scenario and rewriting the expression as first(writetime(col)).

Unit and integration tests are added.

Fixes #14715.