### PR TITLE
sstable: do not include unused header

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -31,7 +31,6 @@
 #include "compaction/table_state.hh"
 #include "sstables/sstable_directory.hh"
 #include "db/system_keyspace.hh"
-#include "db/query_context.hh"
 #include "query-result-writer.hh"
 #include "db/view/view_update_generator.hh"
 #include <boost/range/adaptor/transformed.hpp>


### PR DESCRIPTION
`db/query_context.hh` contains the declaration of class `db::query_context`. but `replica/table.cc` does not use or need `db::query_context`.

so, in this change, the `#include` is removed.