### PR TITLE
query_context: do not include unused header

### DIFF
--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -14,7 +14,6 @@
 #include "cql3/query_processor.hh"
 #include "cql3/query_options.hh"
 #include "db/timeout_clock.hh"
-#include "exceptions/exceptions.hh"
 #include "timeout_config.hh"
 
 namespace service {


### PR DESCRIPTION
in this header, none of the exceptions defined by
`exceptions/exceptions.hh` is used. so let's drop the `#include`.