### PR TITLE
view_update_generator: Decouple repair and view update processing

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -59,8 +59,6 @@ private:
     future<> _started = make_ready_future<>();
     seastar::condition_variable _pending_sstables;
     named_semaphore _registration_sem{registration_queue_size, named_semaphore_exception_factory{"view update generator"}};
-    std::unordered_map<lw_shared_ptr<replica::table>, std::vector<sstables::shared_sstable>> _sstables_with_tables;
-    std::unordered_map<lw_shared_ptr<replica::table>, std::vector<sstables::shared_sstable>> _sstables_to_move;
     metrics::metric_groups _metrics;
     class progress_tracker;
     std::unique_ptr<progress_tracker> _progress_tracker;
@@ -89,6 +87,7 @@ private:
     bool should_throttle() const;
     void setup_metrics();
     void discover_staging_sstables();
+    std::unordered_map<lw_shared_ptr<replica::table>, std::vector<sstables::shared_sstable>> get_sstables_to_process();
 };
 
 }


### PR DESCRIPTION
When repair writes a sstable to disk, we check if the sstable needs view update processing. If yes, the sstable will be registered into the view update processing logic with the _registration_sem semaphore. However, the semaphore is not very useful because it is too late to add the back pressure since the sstable is already written.

We have seen multiple cases in the field where the _registration_sem is stuck so that repair is stuck since repair could not register any more sstables for view update processing.

This patch decouples repair and view update generator, so repair and view update processing can work independently.

After this, view update processing is a true background process which picks sstables in the staging directory and processes.

This makes it easier to reason about which operation is slow or stuck in the field. It also will make repair significantly faster because repair now does not wait for view update processing to finish.