### PR TITLE
Cluster features on raft: topology coordinator + check on boot

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -130,7 +130,7 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
-    future<> enable_features_on_startup(db::system_keyspace&);
+    future<> enable_features_on_startup(db::system_keyspace&, bool use_raft_cluster_features);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 };
 

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -27,6 +27,7 @@ struct fencing_token {
 struct raft_topology_cmd {
     enum class command: uint8_t {
         barrier,
+        barrier_after_feature_update,
         barrier_and_drain,
         stream_ranges,
         fence

--- a/main.cc
+++ b/main.cc
@@ -1306,6 +1306,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 sst_format_selector.stop().get();
             });
 
+            const bool raft_topology_change_enabled = group0_service.is_raft_enabled()
+                    && cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES);
+
             // Re-enable previously enabled features on node startup.
             // This should be done before commitlog starts replaying
             // since some features affect storage.
@@ -1609,7 +1612,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             load_address_map(sys_ks.local(), raft_address_map.local()).get();
 
             // Set up group0 service earlier since it is needed by group0 setup just below
-            ss.local().set_group0(group0_service);
+            ss.local().set_group0(group0_service, raft_topology_change_enabled);
 
             // Setup group0 early in case the node is bootstrapped already and the group exists.
             // Need to do it before allowing incomming messaging service connections since

--- a/main.cc
+++ b/main.cc
@@ -1312,7 +1312,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Re-enable previously enabled features on node startup.
             // This should be done before commitlog starts replaying
             // since some features affect storage.
-            feature_service.local().enable_features_on_startup(sys_ks.local()).get();
+            feature_service.local().enable_features_on_startup(sys_ks.local(), raft_topology_change_enabled).get();
 
             db.local().maybe_init_schema_commitlog();
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1179,6 +1179,16 @@ class topology_coordinator {
                     " joining nodes or topology operations in progress");
         }
 
+        if (utils::get_local_injector().enter("raft_topology_suppress_enabling_features")) {
+            // Prevent enabling features while the injection is enabled.
+            // The topology coordinator will detect in the next iteration
+            // that there are still some cluster features to enable and will
+            // reach this place again. In order not to spin in a loop, sleep
+            // for a short while.
+            co_await sleep(std::chrono::milliseconds(100));
+            co_return;
+        }
+
         // If we are here, then we noticed that all nodes support some features
         // that are not enabled yet. Perform a global barrier to make sure that:
         //

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2397,7 +2397,10 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     });
     _listeners.emplace_back(make_lw_shared(std::move(schema_change_announce)));
     co_await _gossiper.wait_for_gossip_to_settle();
-    co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local());
+    // TODO: Look at the group 0 upgrade state and use it to decide whether to attach or not
+    if (!_raft_topology_change_enabled) {
+        co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local());
+    }
 
     set_mode(mode::JOINING);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3316,9 +3316,9 @@ future<> storage_service::uninit_messaging_service_part() {
     return container().invoke_on_all(&service::storage_service::uninit_messaging_service);
 }
 
-void storage_service::set_group0(raft_group0& group0) {
+void storage_service::set_group0(raft_group0& group0, bool raft_topology_change_enabled) {
     _group0 = &group0;
-    _raft_topology_change_enabled = _group0->is_raft_enabled() && _db.local().get_config().check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES);
+    _raft_topology_change_enabled = raft_topology_change_enabled;
 }
 
 future<> storage_service::join_cluster(cdc::generation_service& cdc_gen_service,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -335,7 +335,7 @@ public:
     future<> join_cluster(cdc::generation_service& cdc_gen_service,
             sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy, cql3::query_processor& qp);
 
-    void set_group0(service::raft_group0&);
+    void set_group0(service::raft_group0&, bool raft_topology_change_enabled);
 
     future<> drain_on_shutdown();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -780,6 +780,10 @@ private:
     future<> raft_rebuild(sstring source_dc);
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
+    future<> do_update_topology_with_local_metadata(raft::server&);
+
+    // Set to true after successful `update_topology_with_local_metadata` call
+    bool _topology_updated_with_local_metadata = false;
 
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -36,6 +36,30 @@ bool topology::contains(raft::server_id id) {
            left_nodes.contains(id);
 }
 
+std::set<sstring> topology::calculate_not_yet_enabled_features() const {
+    std::set<sstring> to_enable;
+    bool first = true;
+
+    for (const auto& [_, rs] : normal_nodes) {
+        if (!first && to_enable.empty()) {
+            break;
+        }
+
+        if (first) {
+            // This is the first node that we process.
+            // Calculate the set of features that this node understands
+            // but are not enabled yet.
+            std::ranges::set_difference(rs.supported_features, enabled_features, std::inserter(to_enable, to_enable.begin()));
+            first = false;
+        } else {
+            // Erase the elements that this node doesn't support
+            std::erase_if(to_enable, [&rs = rs] (const sstring& f) { return !rs.supported_features.contains(f); });
+        }
+    }
+
+    return to_enable;
+}
+
 std::ostream& operator<<(std::ostream& os, const fencing_token& fencing_token) {
     return os << "{" << fencing_token.topology_version << "}";
 }

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -167,6 +167,9 @@ std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd
         case raft_topology_cmd::command::barrier:
             os << "barrier";
             break;
+        case raft_topology_cmd::command::barrier_after_feature_update:
+            os << "barrier_after_feature_update";
+            break;
         case raft_topology_cmd::command::barrier_and_drain:
             os << "barrier_and_drain";
             break;

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -60,6 +60,14 @@ std::set<sstring> topology::calculate_not_yet_enabled_features() const {
     return to_enable;
 }
 
+size_t topology::size() const {
+    return normal_nodes.size() + transition_nodes.size() + new_nodes.size();
+}
+
+bool topology::is_empty() const {
+    return size() == 0;
+}
+
 std::ostream& operator<<(std::ostream& os, const fencing_token& fencing_token) {
     return os << "{" << fencing_token.topology_version << "}";
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -117,6 +117,8 @@ struct topology {
     const std::pair<const raft::server_id, replica_state>* find(raft::server_id id) const;
     // Return true if node exists in any state including 'left' one
     bool contains(raft::server_id id);
+    // Calculates a set of features that are supported by all normal nodes but not yet enabled
+    std::set<sstring> calculate_not_yet_enabled_features() const;
 };
 
 struct raft_topology_snapshot {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -143,6 +143,8 @@ struct topology_state_machine {
 struct raft_topology_cmd {
       enum class command: uint16_t {
           barrier,              // request to wait for the latest topology
+          barrier_after_feature_update, // same as `barrier` but only succeeds after
+                                        // supported features were updated by the node
           barrier_and_drain,    // same + drain requests which use previous versions
           stream_ranges,        // reqeust to stream data, return when streaming is
                                 // done

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -119,6 +119,10 @@ struct topology {
     bool contains(raft::server_id id);
     // Calculates a set of features that are supported by all normal nodes but not yet enabled
     std::set<sstring> calculate_not_yet_enabled_features() const;
+    // Number of nodes that are not in the 'left' state
+    size_t size() const;
+    // Are there any non-left nodes?
+    bool is_empty() const;
 };
 
 struct raft_topology_snapshot {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -939,7 +939,10 @@ public:
                 group0_service.abort().get();
             });
 
-            ss.local().set_group0(group0_service);
+            const bool raft_topology_change_enabled = group0_service.is_raft_enabled()
+                    && cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES);
+
+            ss.local().set_group0(group0_service, raft_topology_change_enabled);
 
             try {
                 ss.local().join_cluster(cdc_generation_service.local(), sys_dist_ks, proxy, qp.local()).get();

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -192,6 +192,7 @@ async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerC
         await manager.server_sees_others(srv.server_id, len(servers) - 1)
 
     # The feature should not be enabled yet on any node
+    cql = manager.get_cql()
     for srv in servers:
         host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
         assert TEST_FEATURE_NAME not in await get_enabled_features(cql, host)
@@ -202,7 +203,6 @@ async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerC
     await manager.remove_node(servers[0].server_id, servers[-1].server_id)
 
     # The feature should eventually become enabled
-    cql = manager.cql
     hosts = await wait_for_cql_and_get_hosts(cql, servers[:-1], time.time() + 60)
     logging.info(f"Waiting until {TEST_FEATURE_NAME} is enabled on all nodes")
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 300) for h in hosts))

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -8,3 +8,4 @@ extra_scylla_config_options:
     experimental_features: ['consistent-topology-changes', 'tablets']
 skip_in_release:
   - test_blocked_bootstrap
+  - test_raft_cluster_features

--- a/test/topology_experimental_raft/test_raft_cluster_features.py
+++ b/test/topology_experimental_raft/test_raft_cluster_features.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Tests that are specific to the raft-based cluster feature implementation.
+"""
+import logging
+import asyncio
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from test.topology import test_cluster_features
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
+    for _ in range(3):
+        await manager.server_add()
+    await test_cluster_features.test_rolling_upgrade_happy_path(manager)
+
+
+@pytest.mark.asyncio
+async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
+    for _ in range(3):
+        await manager.server_add()
+    await test_cluster_features.test_downgrade_after_partial_upgrade(manager)
+
+
+@pytest.mark.asyncio
+async def test_joining_old_node_fails(manager: ManagerClient) -> None:
+    for _ in range(3):
+        await manager.server_add()
+    await test_cluster_features.test_joining_old_node_fails(manager)
+
+
+@pytest.mark.asyncio
+async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) -> None:
+    for _ in range(3):
+        await manager.server_add()
+    await test_cluster_features.test_downgrade_after_successful_upgrade_fails(manager)
+
+
+@pytest.mark.asyncio
+async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
+    for _ in range(3):
+        await manager.server_add()
+    await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
+
+
+@pytest.mark.asyncio
+async def test_cannot_disable_cluster_feature_after_all_declare_support(manager: ManagerClient) -> None:
+    """Upgrade all nodes to support the test cluster feature, but suppress
+       the topology coordinator and prevent it from enabling the feature.
+       Try to downgrade one of the nodes - it should fail because of the
+       mising feature. Unblock the topology coordinator, restart the node
+       and observe that the feature was enabled.
+    """
+    servers = [await manager.server_add() for _ in range(3)]
+
+    # Rolling restart so that all nodes support the feature - but do not
+    # allow enabling yet
+    for srv in servers:
+        await manager.server_update_config(srv.server_id, 'error_injections_at_startup', [
+            'raft_topology_suppress_enabling_features',
+            'features_enable_test_feature',
+        ])
+        await manager.server_restart(srv.server_id)
+
+    # Try to downgrade one node
+    await manager.server_update_config(servers[0].server_id, 'error_injections_at_startup', [])
+    await manager.server_stop_gracefully(servers[0].server_id)
+    await manager.server_start(servers[0].server_id,
+                               expected_error="Feature 'TEST_ONLY_FEATURE' was previously supported by all nodes in the cluster")
+    
+    # Unblock enabling features on nodes
+    for srv in servers[1:]:
+        await manager.api.disable_injection(srv.ip_addr, 'raft_topology_suppress_enabling_features')
+    
+    # Re-enable the feature again and restart
+    await manager.server_update_config(servers[0].server_id, 'error_injections_at_startup', [
+        'features_enable_test_feature',
+    ])
+    await manager.server_start(servers[0].server_id)
+
+    # Nodes should start supporting the feature
+    cql = cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await asyncio.gather(*(wait_for_feature('TEST_ONLY_FEATURE', cql, h, time.time() + 60) for h in hosts))


### PR DESCRIPTION
This PR implements the functionality of the raft-based cluster features needed to safely manage and enable cluster features, according to the cluster features on raft design doc.

Enabling features is a two phase process, performed by the topology coordinator when it notices that there are no topology changes in progress and there are some not-yet enabled features that are declared to be supported by all nodes:

1. First, a global barrier is performed to make sure that all nodes saw and persisted the same state of the `system.topology` table as the coordinator and see the same supported features of all nodes. When booting, nodes are now forbidden to revoke support for a feature if all nodes declare support for it, a successful barrier this makes sure that no node will restart and disable the features.
2. After a successful barrier, the features are marked as enabled in the `system.topology` table.

The whole procedure is a group 0 operation and fails if the topology table is modified in the meantime (e.g. some node changes its supported features set).

For now, the implementation relies on gossip shadow round check to protect from nodes without all features joining the cluster. In a followup, a new joining procedure will be implemented which involves the topology coordinator and lets it verify joining node's cluster features before the new node is added to group 0 and to the cluster.

A set of tests for the new implementation is introduced, containing the same tests as for the non-raft-based cluster feature implementation plus one additional test, specific to this implementation.