### PR TITLE
locator: remove this_host_id from topology::config

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -72,8 +72,8 @@ topology::topology(config cfg)
         , _cfg(cfg)
         , _sort_by_proximity(!cfg.disable_proximity_sorting)
 {
-    tlogger.trace("topology[{}]: constructing using config: host_id={} endpoint={} dc={} rack={}", fmt::ptr(this),
-            cfg.this_host_id, cfg.this_endpoint, cfg.local_dc_rack.dc, cfg.local_dc_rack.rack);
+    tlogger.trace("topology[{}]: constructing using config: endpoint={} dc={} rack={}", fmt::ptr(this),
+            cfg.this_endpoint, cfg.local_dc_rack.dc, cfg.local_dc_rack.rack);
 }
 
 topology::topology(topology&& o) noexcept
@@ -137,9 +137,7 @@ const node* topology::add_node(host_id id, const inet_address& ep, const endpoin
 }
 
 bool topology::is_configured_this_node(const node& n) const {
-    if (_cfg.this_host_id) { // Selection by host_id
-        return _cfg.this_host_id == n.host_id();
-    } else if (_cfg.this_endpoint != inet_address()) { // Selection by endpoint
+    if (_cfg.this_endpoint != inet_address()) { // Selection by endpoint
         return _cfg.this_endpoint == n.endpoint();;
     }
     return false; // No selection;
@@ -541,8 +539,7 @@ void topology::for_each_node(std::function<void(const node*)> func) const {
 namespace std {
 
 std::ostream& operator<<(std::ostream& out, const locator::topology& t) {
-    out << "{this_host_id: " << t._cfg.this_host_id
-        << ", this_endpoint: " << t._cfg.this_endpoint
+    out << "{this_endpoint: " << t._cfg.this_endpoint
         << ", dc: " << t._cfg.local_dc_rack.dc
         << ", rack: " << t._cfg.local_dc_rack.rack
         << ", nodes:\n";

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -128,7 +128,6 @@ private:
 class topology {
 public:
     struct config {
-        host_id this_host_id;
         inet_address this_endpoint;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;

--- a/main.cc
+++ b/main.cc
@@ -847,9 +847,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting tokens manager");
             locator::token_metadata::config tm_cfg;
-            // The local node's host_id is updated after loading from system.local
-            // or making a random one for a new node
-            tm_cfg.topo_cfg.this_host_id = host_id::create_null_id();
             tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             if (snitch.local()->get_name() == "org.apache.cassandra.locator.SimpleSnitch") {

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -34,7 +34,6 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
 
     utils::fb_utilities::set_broadcast_address(ep1);
     topology::config cfg = {
-        .this_host_id = id1,
         .this_endpoint = ep1,
         .local_dc_rack = endpoint_dc_rack::default_location,
     };
@@ -73,7 +72,6 @@ SEASTAR_THREAD_TEST_CASE(test_moving) {
 
     utils::fb_utilities::set_broadcast_address(ep1);
     topology::config cfg = {
-        .this_host_id = id1,
         .this_endpoint = ep1,
         .local_dc_rack = endpoint_dc_rack::default_location,
     };
@@ -104,7 +102,6 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
 
     utils::fb_utilities::set_broadcast_address(ep1);
     topology::config cfg = {
-        .this_host_id = host_id::create_null_id(),
         .this_endpoint = ep1,
         .local_dc_rack = endpoint_dc_rack::default_location,
     };
@@ -198,7 +195,6 @@ SEASTAR_THREAD_TEST_CASE(test_remove_endpoint) {
 
     utils::fb_utilities::set_broadcast_address(ep1);
     topology::config cfg = {
-        .this_host_id = id1,
         .this_endpoint = ep1,
         .local_dc_rack = dc_rack1
     };

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -237,7 +237,6 @@ void simple_test() {
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
-    tm_cfg.topo_cfg.this_host_id = host_id::create_random_id();
     tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -399,7 +398,6 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
-    tm_cfg.topo_cfg.this_host_id = host_id::create_random_id();
     tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -28,7 +28,6 @@ namespace {
     mutable_token_metadata_ptr create_token_metadata(inet_address this_endpoint) {
         return make_lw_shared<token_metadata>(token_metadata::config {
             topology::config {
-                .this_host_id = host_id::create_random_id(),
                 .this_endpoint = this_endpoint,
                 .local_dc_rack = get_dc_rack(this_endpoint)
             }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -588,8 +588,6 @@ public:
 
             sharded<locator::shared_token_metadata> token_metadata;
             locator::token_metadata::config tm_cfg;
-            // We assign null ID, the same as main.cc.
-            tm_cfg.topo_cfg.this_host_id = locator::host_id::create_null_id();
             tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
             tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg).get();


### PR DESCRIPTION
The `locator::topology::config::this_host_id` field is redundant in all places that use `locator::topology::config`, so we can safely remove it.

Closes #14638