### PR TITLE
test/boost/view_build_test: improve test_view_update_generator_register_semaphore_unit_leak

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -85,6 +85,7 @@ public:
             wait_for_all_updates wait_for_all);
 
     ssize_t available_register_units() const { return _registration_sem.available_units(); }
+    size_t queued_batches_count() const { return _sstables_with_tables.size(); }
 private:
     bool should_throttle() const;
     void setup_metrics();


### PR DESCRIPTION
By making it independent of the number of units the view update generator's registration semaphore is created with. We want to increase this number significantly and that would destabilize this test significantly. To prevent this, detach the test from the number of units completely, while stil preserving the original intent behind it, as best as it could be determined.