### PR TITLE
Fix test.py with compaction groups

### DIFF
--- a/test/boost/recent_entries_map_test.cc
+++ b/test/boost/recent_entries_map_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include <seastar/core/manual_clock.hh>
 #include <chrono>
 

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -14,8 +14,7 @@
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <seastar/util/closeable.hh>
 
-#include <seastar/testing/test_case.hh>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -16,7 +16,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/util/closeable.hh>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -20,6 +20,8 @@ all_can_run_compaction_groups_except:
     - exceptions_optimized_test
     - rate_limiter_test
     - exceptions_fallback_test
+    - top_k_test
+    - reusable_buffer_test
 # Custom command line arguments for some of the tests
 custom_args:
     mutation_reader_test:

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <seastar/testing/thread_test_case.hh>
+#include "test/lib/scylla_test_case.hh"
 #include "utils/fb_utilities.hh"
 #include "locator/token_metadata.hh"
 #include "locator/simple_strategy.hh"


### PR DESCRIPTION
test.py with --x-log2-compaction-groups option rotted a little bit. Some boost tests added later didn't use the correct header which parses the option or they didn't adjust suite.yaml. Perhaps it's time to set up a weekly (or bi-weekly) job to verify there are no regressions with it. It's important as it stresses the data plane for tablets reusing the existing tests available.