### PR TITLE
s3/test: do not keep the tempdir forever

### DIFF
--- a/test/object_store/pytest.ini
+++ b/test/object_store/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 asyncio_mode = auto
+tmp_path_retention_count = 1
+tmp_path_retention_policy = failed


### PR DESCRIPTION
by default, up to 3 temporary directories are kept by pytest. but we run only a single time for each of the $TMPDIR. per our recent observation, it takes a lot more time for jenkins to scan the tempdir if we use it for scylla's rundir.

so, to alleviate this symptom, we just keep up to one failed session in the tempdir. if the test passes, the tempdir created by pytest will be nuked. normally it is located at scylladb/testlog/${mode}/pytest-of-$(whoami).

see also
https://docs.pytest.org/en/7.3.x/reference/reference.html#confval-tmp_path_retention_policy

Refs #14690
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>