### PR TITLE
keys: Move exploded_clustering_prefix's operator<< to keys.cc

### DIFF
--- a/keys.cc
+++ b/keys.cc
@@ -101,3 +101,11 @@ int32_t weight(bound_kind k) {
 }
 
 const thread_local clustering_key_prefix bound_view::_empty_prefix = clustering_key::make_empty();
+
+std::ostream&
+operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
+    // Can't pass to_hex() to transformed(), since it is overloaded, so wrap:
+    auto enhex = [] (auto&& x) { return fmt_hex(x); };
+    fmt::print(os, "prefix{{{}}}", fmt::join(ecp._v | boost::adaptors::transformed(enhex), ":"));
+    return os;
+}

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2283,14 +2283,6 @@ std::ostream& operator<<(std::ostream& os, operation_type op_type) {
 
 }
 
-std::ostream&
-operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
-    // Can't pass to_hex() to transformed(), since it is overloaded, so wrap:
-    auto enhex = [] (auto&& x) { return fmt_hex(x); };
-    fmt::print(os, "prefix{{{}}}", fmt::join(ecp._v | boost::adaptors::transformed(enhex), ":"));
-    return os;
-}
-
 namespace replica {
 
 sstring database::get_available_index_name(const sstring &ks_name, const sstring &cf_name,


### PR DESCRIPTION
Now it sits in replicate/database.cc, but the latter is overloaded with code, worth keeping less, all the more so the ..._prefix itself lives in the keys.hh header.