### PR TITLE
build: cmake: remove nonexistent test

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -315,8 +315,6 @@ add_scylla_test(transport_test
   KIND SEASTAR)
 add_scylla_test(types_test
   KIND SEASTAR)
-add_scylla_test(type_json_test
-  KIND SEASTAR)
 add_scylla_test(utf8_test
   KIND BOOST
   LIBRARIES utils)


### PR DESCRIPTION
the test of "type_json_test" was added locally, and has not landed on master. but it somehow was spilled into 87170bf07a9 by accident.

so, let's drop it.