### PR TITLE
Revert "Revert "view_update_generator: Increase the registration_queue_size""

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -50,7 +50,7 @@ using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 
 class view_update_generator : public async_sharded_service<view_update_generator> {
 public:
-    static constexpr size_t registration_queue_size = 5;
+    static constexpr size_t registration_queue_size = 100;
 
 private:
     replica::database& _db;

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -464,17 +464,17 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
 
         BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
 
-        parallel_for_each(ssts.begin(), ssts.begin() + 10, [&] (shared_sstable& sst) {
-            return view_update_generator.register_staging_sstable(sst, t);
-        }).get();
-
-        BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
-
-        parallel_for_each(ssts.begin() + 10, ssts.end(), [&] (shared_sstable& sst) {
-            return view_update_generator.register_staging_sstable(sst, t);
-        }).get();
-
-        BOOST_REQUIRE_EQUAL(view_update_generator.available_register_units(), db::view::view_update_generator::registration_queue_size);
+        auto register_and_check_semaphore = [&view_update_generator, t] (std::vector<shared_sstable>::iterator b, std::vector<shared_sstable>::iterator e) {
+            std::vector<future<>> register_futures;
+            for (auto it = b; it != e; ++it) {
+                register_futures.emplace_back(view_update_generator.register_staging_sstable(*it, t));
+            }
+            const auto qsz = db::view::view_update_generator::registration_queue_size;
+            when_all(register_futures.begin(), register_futures.end()).get();
+            REQUIRE_EVENTUALLY_EQUAL(view_update_generator.available_register_units(), qsz);
+        };
+        register_and_check_semaphore(ssts.begin(), ssts.begin() + 10);
+        register_and_check_semaphore(ssts.begin() + 10, ssts.end());
 
         auto select_by_p_id = e.prepare("SELECT * FROM t WHERE p = ?").get();
         auto select_by_p_and_c_id = e.prepare("SELECT * FROM t WHERE p = ? and c = ?").get();


### PR DESCRIPTION
This reverts commit 4cee8206f860ab776e570d45ee512045995e3fa9.

The test is now fixed.

```
bash-5.2# ./test.py --mode=debug --repeat=20 view_build_test
Found 320 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[320/320]   boost    debug  [ PASS ] boost.view_build_test.test_builder_with_concurrent_drop.20                                      
------------------------------------------------------------------------------
```