### PR TITLE
build: cmake: build: cmake: build submodules 

### DIFF
--- a/cmake/add_version_library.cmake
+++ b/cmake/add_version_library.cmake
@@ -4,13 +4,23 @@
 function(add_version_library name source)
   set(version_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-VERSION-FILE)
   set(release_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-RELEASE-FILE)
-  execute_process(
+  set(product_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-PRODUCT-FILE)
+  set(scylla_version_files
+    ${version_file}
+    ${release_file}
+    ${product_file})
+  add_custom_command(
+    OUTPUT ${scylla_version_files}
     COMMAND ${CMAKE_SOURCE_DIR}/SCYLLA-VERSION-GEN --output-dir "${CMAKE_CURRENT_BINARY_DIR}"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  add_custom_target(scylla-version
+    DEPENDS ${scylla_version_files})
+
   file(STRINGS ${version_file} scylla_version)
   file(STRINGS ${release_file} scylla_release)
 
   add_library(${name} OBJECT ${source})
+  add_dependencies(${name} scylla-version)
   target_compile_definitions(${name}
     PRIVATE
       SCYLLA_VERSION=\"${scylla_version}\"

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -1,0 +1,27 @@
+function(build_submodule name dir)
+  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-PRODUCT-FILE scylla_product)
+  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-VERSION-FILE scylla_version_dash)
+  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-RELEASE-FILE scylla_release)
+  string(REPLACE "-" "~" scylla_version_tilde scylla_version_dash)
+  set(scylla_version
+    "${scylla_product}-${scylla_version_dash}-${scylla_release}")
+  set(reloc_pkg "${dir}/build/${name}-${scylla_version}.noarch.tar.gz")
+  set(working_dir ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+  add_custom_command(
+    OUTPUT ${reloc_pkg}
+    DEPENDS ${version_files}
+    COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${ARGN}
+    WORKING_DIRECTORY "${working_dir}"
+    COMMENT "Generating submodule ${name} in ${dir}"
+    JOB_POOL submodule_pool)
+  add_custom_target(dist-${name}-tar
+    DEPENDS ${reloc_pkg})
+  add_custom_target(dist-${name}-rpm
+    COMMAND reloc/build_rpm.sh --reloc-pkg ${reloc_pkg}
+    WORKING_DIRECTORY "${working_dir}")
+  add_custom_target(dist-${name}-deb
+    COMMAND reloc/build_deb.sh --reloc-pkg ${reloc_pkg}
+    WORKING_DIRECTORY "${working_dir}")
+  add_custom_target(dist-${name}
+    DEPENDS dist-${name}-tar dist-${name}-rpm dist-${name}-deb)
+endfunction()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -18,3 +18,14 @@ target_link_libraries(tools
     xxHash::xxhash
   PRIVATE
     db)
+
+include(build_submodule)
+build_submodule(tools java)
+build_submodule(jmx jmx)
+build_submodule(python3 python3
+  --packages
+  "python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro python3-click python3-six"
+  --pip-packages
+  "scylla-driver geomet traceback-with-variables scylla-api-client"
+  --pip-symlinks
+  "scylla-api-client")


### PR DESCRIPTION
this series enables CMake to build submodules. it helps developers to build, for instance, the java tools on demand.