### PR TITLE
build: cmake: build api/api-doc/metrics.json

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -14,6 +14,7 @@ set(swagger_files
   api-doc/hinted_handoff.json
   api-doc/lsa.json
   api-doc/messaging_service.json
+  api-doc/metrics.json
   api-doc/storage_proxy.json
   api-doc/storage_service.json
   api-doc/stream_manager.json


### PR DESCRIPTION
metrics.json was added in d694a42745d250187aec0addf241d8292fbbf914, `configure.py` was updated accordingly. this change mirrors this change in CMake building system.