### PR TITLE
db: do not use std::cmp_not_equal() when appropriate

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -553,7 +553,7 @@ system_distributed_keyspace::insert_cdc_generation(
 future<std::optional<cdc::topology_description>>
 system_distributed_keyspace::read_cdc_generation(utils::UUID id) {
     std::vector<cdc::token_range_description> entries;
-    auto num_ranges = 0;
+    size_t num_ranges = 0;
     co_await _qp.query_internal(
             // This should be a local read so 20s should be more than enough
             format("SELECT range_end, streams, ignore_msb, num_ranges FROM {}.{} WHERE id = ? USING TIMEOUT 20s", NAME_EVERYWHERE, CDC_GENERATIONS_V2),
@@ -579,7 +579,7 @@ system_distributed_keyspace::read_cdc_generation(utils::UUID id) {
     // Paranoic sanity check. Partial reads should not happen since generations should be retrieved only after they
     // were written successfully with CL=ALL. But nobody uses EverywhereStrategy tables so they weren't ever properly
     // tested, so just in case...
-    if (std::cmp_not_equal(entries.size(), num_ranges)) {
+    if (entries.size() != num_ranges) {
         throw std::runtime_error(format(
                 "read_cdc_generation: wrong number of rows. The `num_ranges` column claimed {} rows,"
                 " but reading the partition returned {}.", num_ranges, entries.size()));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2675,7 +2675,7 @@ future<> system_keyspace::update_topology_fence_version(int64_t value) {
 future<cdc::topology_description>
 system_keyspace::read_cdc_generation(utils::UUID id) {
     std::vector<cdc::token_range_description> entries;
-    auto num_ranges = 0;
+    size_t num_ranges = 0;
     co_await _qp.query_internal(
             format("SELECT range_end, streams, ignore_msb, num_ranges FROM {}.{} WHERE id = ?",
                    NAME, CDC_GENERATIONS_V3),
@@ -2699,7 +2699,7 @@ system_keyspace::read_cdc_generation(utils::UUID id) {
             "read_cdc_generation: data for CDC generation {} not present", id));
     }
 
-    if (std::cmp_not_equal(entries.size(), num_ranges)) {
+    if (entries.size() != num_ranges) {
         throw std::runtime_error(format(
             "read_cdc_generation: wrong number of rows. The `num_ranges` column claimed {} rows,"
             " but reading the partition returned {}.", num_ranges, entries.size()));


### PR DESCRIPTION
this change is a follow-up of 3129ae3c8c665af934d356027a3392c6544a181b. since in both cases in this change, the `num_ranges` should always be greater than zero, there is no need to use `int` for its type, and "num_ranges" returned by the CQL query should always be greater or equal to zero, so there is no need to check if it is positive.

in this change, we change the type of `num_ranges` to `size_t` to avoid using the verbose `std::cmp_not_equal()` helper, for better readability.