### PR TITLE
Remove qctx from system.paxos table access methods

### DIFF
--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -31,34 +31,6 @@ struct query_context {
         return _qp.local().execute_internal(req, { data_value(std::forward<Args>(args))... }, cql3::query_processor::cache_internal::yes);
     }
 
-    template <typename... Args>
-    future<::shared_ptr<cql3::untyped_result_set>> execute_cql_with_timeout(sstring req,
-            db::timeout_clock::time_point timeout,
-            Args&&... args) {
-        const db::timeout_clock::time_point now = db::timeout_clock::now();
-        const db::timeout_clock::duration d =
-            now < timeout ?
-                timeout - now :
-                // let the `storage_proxy` time out the query down the call chain
-                db::timeout_clock::duration::zero();
-
-        struct timeout_context {
-            std::unique_ptr<service::client_state> client_state;
-            service::query_state query_state;
-            timeout_context(db::timeout_clock::duration d)
-                    : client_state(std::make_unique<service::client_state>(service::client_state::internal_tag{}, timeout_config{d, d, d, d, d, d, d}))
-                    , query_state(*client_state, empty_service_permit())
-            {}
-        };
-        return do_with(timeout_context(d), [this, req = std::move(req), &args...] (auto& tctx) {
-            return _qp.local().execute_internal(req,
-                cql3::query_options::DEFAULT.get_consistency(),
-                tctx.query_state,
-                { data_value(std::forward<Args>(args))... },
-                cql3::query_processor::cache_internal::yes);
-        });
-    }
-
     cql3::query_processor& qp() {
         return _qp.local();
     }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -421,12 +421,12 @@ public:
     future<std::vector<view_build_progress>> load_view_build_progress();
 
     // Paxos related functions
-    static future<service::paxos::paxos_state> load_paxos_state(partition_key_view key, schema_ptr s, gc_clock::time_point now,
+    future<service::paxos::paxos_state> load_paxos_state(partition_key_view key, schema_ptr s, gc_clock::time_point now,
             db::timeout_clock::time_point timeout);
-    static future<> save_paxos_promise(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);
-    static future<> save_paxos_proposal(const schema& s, const service::paxos::proposal& proposal, db::timeout_clock::time_point timeout);
-    static future<> save_paxos_decision(const schema& s, const service::paxos::proposal& decision, db::timeout_clock::time_point timeout);
-    static future<> delete_paxos_decision(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);
+    future<> save_paxos_promise(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);
+    future<> save_paxos_proposal(const schema& s, const service::paxos::proposal& proposal, db::timeout_clock::time_point timeout);
+    future<> save_paxos_decision(const schema& s, const service::paxos::proposal& decision, db::timeout_clock::time_point timeout);
+    future<> delete_paxos_decision(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);
 
     // CDC related functions
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -502,6 +502,8 @@ public:
 
 private:
     future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const std::initializer_list<data_value>& values);
+    template <typename... Args>
+    future<::shared_ptr<cql3::untyped_result_set>> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
 
 public:
     template <typename... Args>

--- a/main.cc
+++ b/main.cc
@@ -1446,7 +1446,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("initializing migration manager RPC verbs");
             mm.invoke_on_all(&service::migration_manager::init_messaging_service).get();
             supervisor::notify("initializing storage proxy RPC verbs");
-            proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(messaging), std::ref(gossiper), std::ref(mm)).get();
+            proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(messaging), std::ref(gossiper), std::ref(mm), std::ref(sys_ks)).get();
             auto stop_proxy_handlers = defer_verbose_shutdown("storage proxy RPC verbs", [&proxy] {
                 proxy.invoke_on_all(&service::storage_proxy::stop_remote).get();
             });

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -18,6 +18,7 @@
 namespace service {
 class storage_proxy;
 }
+namespace db { class system_keyspace; }
 
 namespace service::paxos {
 
@@ -111,16 +112,16 @@ public:
         , _accepted_proposal(std::move(accepted))
         , _most_recent_commit(std::move(commit)) {}
     // Replica RPC endpoint for Paxos "prepare" phase.
-    static future<prepare_response> prepare(storage_proxy& sp, tracing::trace_state_ptr tr_state, schema_ptr schema,
+    static future<prepare_response> prepare(storage_proxy& sp, db::system_keyspace& sys_ks, tracing::trace_state_ptr tr_state, schema_ptr schema,
             const query::read_command& cmd, const partition_key& key, utils::UUID ballot,
             bool only_digest, query::digest_algorithm da, clock_type::time_point timeout);
     // Replica RPC endpoint for Paxos "accept" phase.
-    static future<bool> accept(storage_proxy& sp, tracing::trace_state_ptr tr_state, schema_ptr schema, dht::token token, const proposal& proposal,
+    static future<bool> accept(storage_proxy& sp, db::system_keyspace& sys_ks, tracing::trace_state_ptr tr_state, schema_ptr schema, dht::token token, const proposal& proposal,
             clock_type::time_point timeout);
     // Replica RPC endpoint for Paxos "learn".
-    static future<> learn(storage_proxy& sp, schema_ptr schema, proposal decision, clock_type::time_point timeout, tracing::trace_state_ptr tr_state);
+    static future<> learn(storage_proxy& sp, db::system_keyspace& sys_ks, schema_ptr schema, proposal decision, clock_type::time_point timeout, tracing::trace_state_ptr tr_state);
     // Replica RPC endpoint for pruning Paxos table
-    static future<> prune(schema_ptr schema, const partition_key& key, utils::UUID ballot, clock_type::time_point timeout,
+    static future<> prune(db::system_keyspace& sys_ks, schema_ptr schema, const partition_key& key, utils::UUID ballot, clock_type::time_point timeout,
             tracing::trace_state_ptr tr_state);
 };
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -487,7 +487,7 @@ public:
     }
 
     // Start/stop the remote part of `storage_proxy` that is required for performing distributed queries.
-    void start_remote(netw::messaging_service&, gms::gossiper&, migration_manager&);
+    void start_remote(netw::messaging_service&, gms::gossiper&, migration_manager&, sharded<db::system_keyspace>& sys_ks);
     future<> stop_remote();
 
 private:

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4682,6 +4682,8 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
 }
 
 SEASTAR_TEST_CASE(test_null_value_tuple_floating_types_and_uuids) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto test_for_single_type = [&e] (const shared_ptr<const abstract_type>& type, auto update_value) {
             cquery_nofail(e, format("CREATE TABLE IF NOT EXISTS t (k int PRIMARY KEY, test {})", type->cql3_type_name()));
@@ -4703,10 +4705,12 @@ SEASTAR_TEST_CASE(test_null_value_tuple_floating_types_and_uuids) {
         test_for_single_type(float_type, 1.0f);
         test_for_single_type(uuid_type, utils::make_random_uuid());
         test_for_single_type(timeuuid_type, utils::UUID("00000000-0000-1000-0000-000000000000"));
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_like_parameter_marker) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE t (pk int PRIMARY KEY, col text)");
         cquery_nofail(e, "INSERT INTO  t (pk, col) VALUES (1, 'aaa')");
@@ -4720,10 +4724,12 @@ SEASTAR_TEST_CASE(test_like_parameter_marker) {
         prepared_on_shard(e, query, {T("err"), I(1), T("a%")}, {{B(false), "chg"}});
         prepared_on_shard(e, query, {T("chg"), I(2), T("b%")}, {{B(true),  "bbb"}});
         prepared_on_shard(e, query, {T("err"), I(1), T("a%")}, {{B(false), "chg"}});
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_list_parameter_marker) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE t (k int PRIMARY KEY, v list<int>)");
         cquery_nofail(e, "INSERT INTO  t (k, v) VALUES (1, [10, 20, 30])");
@@ -4742,10 +4748,12 @@ SEASTAR_TEST_CASE(test_list_parameter_marker) {
         prepared_on_shard(e, query,
             {list_of({100, 200, 300}), I(1), list_of({20, 21, 22})},
             {{B(true), list_of({10, 20, 30})}});
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_select_serial_consistency) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE t (a int, b int, primary key (a,b))");
         cquery_nofail(e, "INSERT INTO t (a, b) VALUES (1, 1)");
@@ -4769,7 +4777,7 @@ SEASTAR_TEST_CASE(test_select_serial_consistency) {
         check_fails("select * from t where  b > 0 allow filtering");
         check_fails("select * from t where  a in (1, 3)");
         prepared_on_shard(e, "select * from t where a = 1", {}, {{I(1), I(1)}, {I(1), I(2)}}, db::consistency_level::SERIAL);
-    });
+    }, std::move(cfg));
 }
 
 

--- a/test/boost/extensions_test.cc
+++ b/test/boost/extensions_test.cc
@@ -126,6 +126,8 @@ SEASTAR_TEST_CASE(paxos_grace_seconds_extension) {
     auto ext = std::make_shared<db::extensions>();
     ext->add_schema_extension<db::paxos_grace_seconds_extension>(db::paxos_grace_seconds_extension::NAME);
     auto cfg = ::make_shared<db::config>(ext);
+    cql_test_config cql_cfg(cfg);
+    cql_cfg.need_remote_proxy = true;
 
     return do_with_cql_env([] (cql_test_env& e) {
         // Verify that paxos_grace_seconds extensions gets recognized properly
@@ -156,7 +158,7 @@ SEASTAR_TEST_CASE(paxos_grace_seconds_extension) {
         });
 
         return f;
-    }, cfg);
+    }, std::move(cql_cfg));
 }
 
 SEASTAR_TEST_CASE(test_extension_remove) {

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -202,6 +202,8 @@ auto make_options(clevel cl) {
 } // anonymous namespace
 
 SEASTAR_TEST_CASE(test_query_counters) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
     return do_with_cql_env_thread([](cql_test_env& e) {
         // Executes a query and waits for it to complete.
         auto process_query = [&e](const sstring& query, clevel cl) mutable {
@@ -278,7 +280,7 @@ SEASTAR_TEST_CASE(test_query_counters) {
             clevel::ANY);
         expected["ANY"] += 2;
         BOOST_CHECK_EQUAL(expected, get_query_metrics());
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_select_full_scan_metrics) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -897,6 +897,15 @@ public:
 
             sys_dist_ks.start(std::ref(qp), std::ref(mm), std::ref(proxy)).get();
 
+            if (cfg_in.need_remote_proxy) {
+                proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(ms), std::ref(gossiper), std::ref(mm), std::ref(sys_ks)).get();
+            }
+            auto stop_proxy_remote = defer([&proxy, need = cfg_in.need_remote_proxy] {
+                if (need) {
+                    proxy.invoke_on_all(&service::storage_proxy::stop_remote).get();
+                }
+            });
+
             sl_controller.invoke_on_all([&sys_dist_ks, &sl_controller] (qos::service_level_controller& service) {
                 qos::service_level_controller::service_level_distributed_data_accessor_ptr service_level_data_accessor =
                         ::static_pointer_cast<qos::service_level_controller::service_level_distributed_data_accessor>(

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -90,6 +90,7 @@ public:
     std::optional<replica::database_config> dbcfg;
     std::set<sstring> disabled_features;
     std::optional<cql3::query_processor::memory_config> qp_mcfg;
+    bool need_remote_proxy = false;
 
     cql_test_config();
     cql_test_config(const cql_test_config&);


### PR DESCRIPTION
The "fix" is straightforward -- callers of system_keyspace::*paxos* methods need to get system keyspace from somewhere. This time the only caller is storage_proxy::remote that can have system keyspace via direct dependency reference.