### PR TITLE
storage_service: Remove dead get_rpc_address()

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2397,17 +2397,6 @@ future<> storage_service::bootstrap(cdc::generation_service& cdc_gen_service, st
     });
 }
 
-sstring
-storage_service::get_rpc_address(const inet_address& endpoint) const {
-    if (endpoint != get_broadcast_address()) {
-        auto* v = _gossiper.get_application_state_ptr(endpoint, gms::application_state::RPC_ADDRESS);
-        if (v) {
-            return v->value();
-        }
-    }
-    return fmt::to_string(endpoint);
-}
-
 future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 storage_service::get_range_to_address_map(const sstring& keyspace) const {
     return get_range_to_address_map(_db.local().find_keyspace(keyspace).get_effective_replication_map());

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -365,12 +365,6 @@ private:
     future<> bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id, const std::optional<replacement_info>& replacement_info);
 
 public:
-    /**
-     * Return the rpc address associated with an endpoint as a string.
-     * @param endpoint The endpoint to get rpc address for
-     * @return the rpc address
-     */
-    sstring get_rpc_address(const inet_address& endpoint) const;
 
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_to_address_map(const sstring& keyspace) const;
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>> get_range_to_address_map(locator::vnode_effective_replication_map_ptr erm) const;


### PR DESCRIPTION
Unused. Locator calls gossiper directly