### PR TITLE
Remove dead replacing_nodes_pending_ranges_updater manipulations

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2746,18 +2746,10 @@ future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_sta
     bool is_normal_token_owner = get_token_metadata().is_normal_token_owner(endpoint);
     if (is_normal_token_owner) {
         co_await notify_up(endpoint);
-    }
-    bool replacing_pending_ranges = false;
-    if (!is_normal_token_owner || replacing_pending_ranges) {
+    } else {
         auto tmlock = co_await get_token_metadata_lock();
         auto tmptr = co_await get_mutable_token_metadata_ptr();
-        if (replacing_pending_ranges) {
-            slogger.info("Trigger pending ranges updater for replacing node {}", endpoint);
-            co_await handle_state_replacing_update_pending_ranges(tmptr, endpoint);
-        }
-        if (!is_normal_token_owner) {
-            tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
-        }
+        tmptr->update_topology(endpoint, get_dc_rack_for(endpoint));
         co_await replicate_to_all_cores(std::move(tmptr));
     }
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2747,11 +2747,7 @@ future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_sta
     if (is_normal_token_owner) {
         co_await notify_up(endpoint);
     }
-    bool replacing_pending_ranges = _replacing_nodes_pending_ranges_updater.contains(endpoint);
-    if (replacing_pending_ranges) {
-        _replacing_nodes_pending_ranges_updater.erase(endpoint);
-    }
-
+    bool replacing_pending_ranges = false;
     if (!is_normal_token_owner || replacing_pending_ranges) {
         auto tmlock = co_await get_token_metadata_lock();
         auto tmptr = co_await get_mutable_token_metadata_ptr();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -488,7 +488,6 @@ private:
     future<> replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept;
     sharded<db::system_keyspace>& _sys_ks;
     locator::snitch_signal_slot_t _snitch_reconfigure;
-    std::unordered_set<gms::inet_address> _replacing_nodes_pending_ranges_updater;
 private:
     /**
      * Handle node bootstrap


### PR DESCRIPTION
The set in question is read-and-delete-only and thus always empty. Originally it was removed by commit c9993f020d (storage_service: get rid of handle_state_replacing), but some dangling ends were left. Consequentially, the on_alive() callback can get rid of few dead if-else branches