### PR TITLE
tests: Add test for table's mutation source excluding staging

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5053,3 +5053,52 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
         BOOST_REQUIRE(sstables_closed_during_cleanup >= sstables_nr / 2);
     });
 }
+
+SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pks = ss.make_pkeys(2);
+
+        auto make_mut = [&] (auto pkey) {
+            auto mut1 = mutation(s, pkey);
+            mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+            return mut1;
+        };
+        std::set<mutation, mutation_decorated_key_less_comparator> sorted_muts;
+        sorted_muts.insert(make_mut(pks[0]));
+        sorted_muts.insert(make_mut(pks[1]));
+
+        auto t = env.make_table_for_tests(s, env.tempdir().path().string());
+        t->mark_ready_for_writes();
+        auto close_t = deferred_stop(t);
+
+        auto sst_gen = env.make_sst_factory(s);
+
+        auto staging_sst = make_sstable_containing(sst_gen, {*sorted_muts.begin()});
+        staging_sst->change_state(sstables::staging_dir).get();
+        BOOST_REQUIRE(staging_sst->requires_view_building());
+
+        auto regular_sst = make_sstable_containing(sst_gen, {*sorted_muts.rbegin()});
+
+        t->add_sstable_and_update_cache(staging_sst).get();
+        t->add_sstable_and_update_cache(regular_sst).get();
+
+        {
+            testlog.info("table::as_mutation_source_excluding_staging()");
+            auto ms_excluding_staging = t->as_mutation_source_excluding_staging();
+            assert_that(ms_excluding_staging.make_reader_v2(s, env.make_reader_permit(), query::full_partition_range))
+                .produces(*sorted_muts.rbegin())
+                .produces_end_of_stream();
+        }
+
+        {
+            testlog.info("table::as_mutation_source()");
+            auto ms_inclusive = t->as_mutation_source();
+            assert_that(ms_inclusive.make_reader_v2(s, env.make_reader_permit(), query::full_partition_range))
+                    .produces(*sorted_muts.begin())
+                    .produces(*sorted_muts.rbegin())
+                    .produces_end_of_stream();
+        }
+    });
+}


### PR DESCRIPTION
Commit f5e3b8df6d2d5b93e077 introduced an optimization for as_mutation_source_excluding_staging() and added a test that verifies correctness of single key and range reads based on supplied predicates. This new test aims to improve the coverage by testing directly both table::as_mutation_source() and as_mutation_source_excluding_staging(), therefore guaranteeing that both supply the correct predicate to sstable set.