### PR TITLE
doc: Repair system_auth with nodetool repair -pr option

### DIFF
--- a/docs/operating-scylla/security/authentication.rst
+++ b/docs/operating-scylla/security/authentication.rst
@@ -74,7 +74,7 @@ Procedure
 	
     .. code-block:: none
 	
-       nodetool repair system_auth
+       nodetool repair -pr system_auth
 
 6. If you want to create users and roles, continue to :doc:`Enable Authorization </operating-scylla/security/enable-authorization>`.
 


### PR DESCRIPTION
Since repair is performed on all nodes, each node can just repair the primary ranges instead of all owned ranges. This avoids repair ranges more than once.