### PR TITLE
test.py: Terminate clusters gracefully

### DIFF
--- a/test.py
+++ b/test.py
@@ -406,7 +406,7 @@ class PythonTestSuite(TestSuite):
             cluster = ScyllaCluster(logger, self.hosts, cluster_size, create_server)
 
             async def stop() -> None:
-                await cluster.stop()
+                await cluster.stop_gracefully()
 
             # Suite artifacts are removed when
             # the entire suite ends successfully.


### PR DESCRIPTION
When test.py terminates, on-exit artifacts call .stop() on clusters which, in turn, kills scylla processes with SIGKILL thus preventing scylla from stopping normally. This keeps scylla shutdown paths completely untested.