### PR TITLE
build: cmake: set scylla version strings as CACHED strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ find_package(xxHash REQUIRED)
 set(scylla_gen_build_dir "${CMAKE_BINARY_DIR}/gen")
 file(MAKE_DIRECTORY "${scylla_gen_build_dir}")
 
+include(add_version_library)
+generate_scylla_version()
 
 add_library(scylla-main STATIC)
 target_sources(scylla-main
@@ -131,7 +133,6 @@ add_subdirectory(tracing)
 add_subdirectory(transport)
 add_subdirectory(types)
 add_subdirectory(utils)
-include(add_version_library)
 add_version_library(scylla_version
     release.cc)
 

--- a/cmake/add_version_library.cmake
+++ b/cmake/add_version_library.cmake
@@ -1,30 +1,28 @@
 ###
 ### Generate version file and supply appropriate compile definitions for release.cc
 ###
-function(add_version_library name source)
+function(generate_scylla_version)
   set(version_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-VERSION-FILE)
   set(release_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-RELEASE-FILE)
   set(product_file ${CMAKE_CURRENT_BINARY_DIR}/SCYLLA-PRODUCT-FILE)
-  set(scylla_version_files
-    ${version_file}
-    ${release_file}
-    ${product_file})
-  add_custom_command(
-    OUTPUT ${scylla_version_files}
+  execute_process(
     COMMAND ${CMAKE_SOURCE_DIR}/SCYLLA-VERSION-GEN --output-dir "${CMAKE_CURRENT_BINARY_DIR}"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-  add_custom_target(scylla-version
-    DEPENDS ${scylla_version_files})
 
   file(STRINGS ${version_file} scylla_version)
   file(STRINGS ${release_file} scylla_release)
+  file(STRINGS ${product_file} scylla_product)
+  set(Scylla_VERSION "${scylla_version}" CACHE INTERNAL "")
+  set(Scylla_RELEASE "${scylla_release}" CACHE INTERNAL "")
+  set(Scylla_PRODUCT "${scylla_product}" CACHE INTERNAL "")
+endfunction(generate_scylla_version)
 
+function(add_version_library name source)
   add_library(${name} OBJECT ${source})
-  add_dependencies(${name} scylla-version)
   target_compile_definitions(${name}
     PRIVATE
-      SCYLLA_VERSION=\"${scylla_version}\"
-      SCYLLA_RELEASE=\"${scylla_release}\")
+      SCYLLA_VERSION=\"${Scylla_VERSION}\"
+      SCYLLA_RELEASE=\"${Scylla_RELEASE}\")
   target_link_libraries(${name}
     PRIVATE
       Seastar::seastar)

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -1,15 +1,11 @@
 function(build_submodule name dir)
-  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-PRODUCT-FILE scylla_product)
-  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-VERSION-FILE scylla_version_dash)
-  file(STRINGS ${CMAKE_BINARY_DIR}/SCYLLA-RELEASE-FILE scylla_release)
-  string(REPLACE "-" "~" scylla_version_tilde scylla_version_dash)
+  string(REPLACE "-" "~" scylla_version_tilde ${Scylla_VERSION})
   set(scylla_version
-    "${scylla_product}-${scylla_version_dash}-${scylla_release}")
+    "${Scylla_PRODUCT}-${scylla_version_tilde}-${Scylla_RELEASE}")
   set(reloc_pkg "${dir}/build/${name}-${scylla_version}.noarch.tar.gz")
   set(working_dir ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
   add_custom_command(
     OUTPUT ${reloc_pkg}
-    DEPENDS ${version_files}
     COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${ARGN}
     WORKING_DIRECTORY "${working_dir}"
     COMMENT "Generating submodule ${name} in ${dir}"


### PR DESCRIPTION
before this change, add_version_library() is a single function which accomplishes two tasks:

1. build scylla-version target using
2. add an object library

but this has two problems:

1. we should run `SCYLLA-VERSION-GEN` at configure time, instead of at build time. otherwise the targets which read from the SCYLLA-{VERSION, RELEASE, PRODUCT}-FILE cannot access them, unless they are able to read them in their build rules. but they always use `file(STRINGS ..)` to read them, and thsee `file()` command is executed at configure time. so, this is a dead end.
2. we repeat the `file(STRING ..)` multiple places. this is not ideal if we want to minimize the repeatings.

so, to address this problem, in this change:

1. use `execute_process()` instead of `add_custom_command()` for generating these *-FILE files. so they are always ready at build time. this partially reverts bb7d99ad37.
2. extract `generate_scylla_version()` out of `add_version_library()`. so we can call the former much earlier than the latter. this would allow us to reference the variables defined by the `generate_scylla_version()` much earlier.
3. define cached strings in the extracted function, so that they can consumed by other places.
4. reference the cached variables in `build_submodule.cmake`.

also, take this opportunity to fix the version string used in build_submodule.cmake: we should have used `scylla_version_tilde`.