### PR TITLE
Remove qctx from system_keyspace::save_truncation_record()

### DIFF
--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -51,7 +51,6 @@ public:
 
     migrator(sharded<service::storage_proxy>& sp, sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, cql3::query_processor& qp)
                     : _sp(sp), _db(db), _sys_ks(sys_ks), _qp(qp) {
-        (void)_sys_ks;
     }
     migrator(migrator&&) = default;
 
@@ -536,7 +535,7 @@ public:
         mlogger.info("Dropping legacy schema tables");
         auto with_snapshot = !_keyspaces.empty();
         return parallel_for_each(legacy_schema_tables, [this, with_snapshot](const sstring& cfname) {
-            return replica::database::drop_table_on_all_shards(_db, db::system_keyspace::NAME, cfname, with_snapshot);
+            return replica::database::drop_table_on_all_shards(_db, _sys_ks, db::system_keyspace::NAME, cfname, with_snapshot);
         });
     }
 

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -49,8 +49,9 @@ class migrator {
 public:
     static const std::unordered_set<sstring> legacy_schema_tables;
 
-    migrator(sharded<service::storage_proxy>& sp, sharded<replica::database>& db, cql3::query_processor& qp)
-                    : _sp(sp), _db(db), _qp(qp) {
+    migrator(sharded<service::storage_proxy>& sp, sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, cql3::query_processor& qp)
+                    : _sp(sp), _db(db), _sys_ks(sys_ks), _qp(qp) {
+        (void)_sys_ks;
     }
     migrator(migrator&&) = default;
 
@@ -582,6 +583,7 @@ public:
 
     sharded<service::storage_proxy>& _sp;
     sharded<replica::database>& _db;
+    sharded<db::system_keyspace>& _sys_ks;
     cql3::query_processor& _qp;
     std::vector<keyspace> _keyspaces;
 };
@@ -600,7 +602,7 @@ const std::unordered_set<sstring> migrator::legacy_schema_tables = {
 }
 
 future<>
-db::legacy_schema_migrator::migrate(sharded<service::storage_proxy>& sp, sharded<replica::database>& db, cql3::query_processor& qp) {
-    return do_with(migrator(sp, db, qp), std::bind(&migrator::migrate, std::placeholders::_1));
+db::legacy_schema_migrator::migrate(sharded<service::storage_proxy>& sp, sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, cql3::query_processor& qp) {
+    return do_with(migrator(sp, db, sys_ks, qp), std::bind(&migrator::migrate, std::placeholders::_1));
 }
 

--- a/db/legacy_schema_migrator.hh
+++ b/db/legacy_schema_migrator.hh
@@ -27,9 +27,11 @@ class storage_proxy;
 }
 
 namespace db {
+class system_keyspace;
+
 namespace legacy_schema_migrator {
 
-future<> migrate(sharded<service::storage_proxy>&, sharded<replica::database>& db, cql3::query_processor&);
+future<> migrate(sharded<service::storage_proxy>&, sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, cql3::query_processor&);
 
 }
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1512,7 +1512,7 @@ future<> system_keyspace::cache_truncation_record() {
 
 future<> system_keyspace::save_truncation_record(table_id id, db_clock::time_point truncated_at, db::replay_position rp) {
     sstring req = format("INSERT INTO system.{} (table_uuid, shard, position, segment_id, truncated_at) VALUES(?,?,?,?,?)", TRUNCATED);
-    return qctx->qp().execute_internal(req, {id.uuid(), int32_t(rp.shard_id()), int32_t(rp.pos), int64_t(rp.base_id()), truncated_at}, cql3::query_processor::cache_internal::yes).discard_result().then([] {
+    return _qp.execute_internal(req, {id.uuid(), int32_t(rp.shard_id()), int32_t(rp.pos), int64_t(rp.base_id()), truncated_at}, cql3::query_processor::cache_internal::yes).discard_result().then([] {
         return force_blocking_flush(TRUNCATED);
     });
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -348,8 +348,8 @@ public:
 
     typedef std::vector<db::replay_position> replay_positions;
 
-    static future<> save_truncation_record(table_id, db_clock::time_point truncated_at, db::replay_position);
-    static future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
+    future<> save_truncation_record(table_id, db_clock::time_point truncated_at, db::replay_position);
+    future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_position(table_id);
     future<db_clock::time_point> get_truncated_at(table_id);
 

--- a/main.cc
+++ b/main.cc
@@ -1328,7 +1328,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             group0_client.init().get();
 
             // schema migration, if needed, is also done on shard 0
-            db::legacy_schema_migrator::migrate(proxy, db, qp.local()).get();
+            db::legacy_schema_migrator::migrate(proxy, db, sys_ks, qp.local()).get();
 
             // making compaction manager api available, after system keyspace has already been established.
             api::set_server_compaction_manager(ctx).get();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1708,15 +1708,15 @@ private:
 
     struct table_truncate_state;
 
-    static future<> truncate_table_on_all_shards(sharded<database>& db, const global_table_ptr&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
-    future<> truncate(column_family& cf, const table_truncate_state&, db_clock::time_point truncated_at);
+    static future<> truncate_table_on_all_shards(sharded<database>& db, sharded<db::system_keyspace>& sys_ks, const global_table_ptr&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
+    future<> truncate(db::system_keyspace& sys_ks, column_family& cf, const table_truncate_state&, db_clock::time_point truncated_at);
 public:
     /** Truncates the given column family */
     // If truncated_at_opt is not given, it is set to db_clock::now right after flush/clear.
-    static future<> truncate_table_on_all_shards(sharded<database>& db, sstring ks_name, sstring cf_name, std::optional<db_clock::time_point> truncated_at_opt = {}, bool with_snapshot = true, std::optional<sstring> snapshot_name_opt = {});
+    static future<> truncate_table_on_all_shards(sharded<database>& db, sharded<db::system_keyspace>& sys_ks, sstring ks_name, sstring cf_name, std::optional<db_clock::time_point> truncated_at_opt = {}, bool with_snapshot = true, std::optional<sstring> snapshot_name_opt = {});
 
     // drops the table on all shards and removes the table directory if there are no snapshots
-    static future<> drop_table_on_all_shards(sharded<database>& db, sstring ks_name, sstring cf_name, bool with_snapshot = true);
+    static future<> drop_table_on_all_shards(sharded<database>& db, sharded<db::system_keyspace>& sys_ks, sstring ks_name, sstring cf_name, bool with_snapshot = true);
 
     const dirty_memory_manager_logalloc::region_group& dirty_memory_region_group() const {
         return _dirty_memory_manager.region_group();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -750,7 +750,7 @@ private:
     }
 
     future<> handle_truncate(rpc::opt_time_point timeout, sstring ksname, sstring cfname) {
-        return replica::database::truncate_table_on_all_shards(_sp._db, ksname, cfname);
+        return replica::database::truncate_table_on_all_shards(_sp._db, _sys_ks, ksname, cfname);
     }
 
     future<foreign_ptr<std::unique_ptr<service::paxos::prepare_response>>>

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -131,7 +131,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
         };
         assert_query_result(keys_per_shard);
 
-        replica::database::truncate_table_on_all_shards(e.db(), "ks", "cf").get();
+        replica::database::truncate_table_on_all_shards(e.db(), e.get_system_keyspace(), "ks", "cf").get();
 
         for (auto it = keys_per_shard.begin(); it < keys_per_shard.end(); ++it) {
             *it = 0;
@@ -180,7 +180,7 @@ SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
 
         auto f0 = insert_data(0, num_keys);
         auto f1 = do_until([&] { return std::cmp_greater_equal(count, num_keys); }, [&, ts = db_clock::now()] {
-            return replica::database::truncate_table_on_all_shards(e.db(), "ks", "cf", ts, false /* with_snapshot */).then([] {
+            return replica::database::truncate_table_on_all_shards(e.db(), e.get_system_keyspace(), "ks", "cf", ts, false /* with_snapshot */).then([] {
                 return yield();
             });
         });
@@ -777,7 +777,7 @@ SEASTAR_TEST_CASE(clear_multiple_snapshots) {
 
         // existing snapshots expected to remain after dropping the table
         testlog.debug("Dropping table {}.{}", ks_name, table_name);
-        replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name).get();
+        replica::database::drop_table_on_all_shards(e.db(), e.get_system_keyspace(), ks_name, table_name).get();
         BOOST_REQUIRE_EQUAL(fs::exists(snapshots_dir / snapshot_name(num_snapshots)), true);
 
         // clear all tags
@@ -1350,7 +1350,7 @@ SEASTAR_TEST_CASE(database_drop_column_family_clears_querier_cache) {
                 s->full_slice(),
                 nullptr);
 
-        auto f = replica::database::drop_table_on_all_shards(e.db(), "ks", "cf");
+        auto f = replica::database::drop_table_on_all_shards(e.db(), e.get_system_keyspace(), "ks", "cf");
 
         // we add a querier to the querier cache while the drop is ongoing
         auto& qc = db.get_querier_cache();
@@ -1379,7 +1379,7 @@ static future<> test_drop_table_with_auto_snapshot(bool auto_snapshot) {
         // Pass `with_snapshot=true` to drop_table_on_all
         // to allow auto_snapshot (based on the configuration above).
         // The table directory should therefore exist after the table is dropped if auto_snapshot is disabled in the configuration.
-        co_await replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name, true);
+        co_await replica::database::drop_table_on_all_shards(e.db(), e.get_system_keyspace(), ks_name, table_name, true);
         auto cf_dir_exists = co_await file_exists(cf_dir);
         BOOST_REQUIRE_EQUAL(cf_dir_exists, auto_snapshot);
         co_return;
@@ -1404,7 +1404,7 @@ SEASTAR_TEST_CASE(drop_table_with_no_snapshot) {
         // Pass `with_snapshot=false` to drop_table_on_all
         // to disallow auto_snapshot.
         // The table directory should therefore not exist after the table is dropped.
-        co_await replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name, false);
+        co_await replica::database::drop_table_on_all_shards(e.db(), e.get_system_keyspace(), ks_name, table_name, false);
         auto cf_dir_exists = co_await file_exists(cf_dir);
         BOOST_REQUIRE_EQUAL(cf_dir_exists, false);
         co_return;
@@ -1423,7 +1423,7 @@ SEASTAR_TEST_CASE(drop_table_with_explicit_snapshot) {
         // With explicit snapshot and with_snapshot=false
         // dir should still be kept, regardless of the
         // with_snapshot parameter and auto_snapshot config.
-        co_await replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name, false);
+        co_await replica::database::drop_table_on_all_shards(e.db(), e.get_system_keyspace(), ks_name, table_name, false);
         auto cf_dir_exists = co_await file_exists(cf_dir);
         BOOST_REQUIRE_EQUAL(cf_dir_exists, true);
         co_return;


### PR DESCRIPTION
The method is called by db::truncate_table_on_all_shards(), its call-chain, in turn, starts from

- proxy::remote::handle_truncate()
- schema_tables::merge_schema()
- legacy_schema_migrator
- tests

All of the above are easy to get system_keyspace reference from. This, in turn, allows making the method non-static and use query_processor reference from system_keyspace object in stead of global qctx