### PR TITLE
raft: stop group0 server during group0 service shutdown

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -370,6 +370,8 @@ future<> raft_group0::abort() {
         return uninit_rpc_verbs(_ms.local());
     });
     co_await _shutdown_gate.close();
+
+    co_await stop_group0();
 }
 
 future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
@@ -729,6 +731,12 @@ future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3
             upgrade_to_group0(ss, qp, mm, cdc_gen_service).get();
         });
     });
+}
+
+future<> raft_group0::stop_group0() {
+    if (auto* group0_id = std::get_if<raft::group_id>(&_group0)) {
+        co_await _raft_gr.stop_server(*group0_id, "raft group0 is stopped");
+    }
 }
 
 bool raft_group0::is_member(raft::server_id id, bool include_voters_only) {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -238,6 +238,9 @@ private:
     static void init_rpc_verbs(raft_group0& shard0_this);
     static future<> uninit_rpc_verbs(netw::messaging_service& ms);
 
+    // Stop the group 0 server and remove it from the raft_group_registry.
+    future<> stop_group0();
+
     bool joined_group0() const;
     future<bool> raft_upgrade_complete() const;
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -335,6 +335,19 @@ static void ensure_aborted(raft_server_for_group& server_for_group, sstring reas
     }
 }
 
+future<> raft_group_registry::stop_server(raft::group_id gid, sstring reason) {
+    auto it = _servers.find(gid);
+
+    if (it == _servers.end()) {
+        throw raft_group_not_found(gid);
+    }
+
+    auto srv = std::move(it->second);
+    _servers.erase(it);
+    ensure_aborted(srv, std::move(reason));
+    co_await std::move(*srv.aborted);
+}
+
 future<> raft_group_registry::stop_servers() noexcept {
     gate g;
     for (auto it = _servers.begin(); it != _servers.end(); it = _servers.erase(it)) {

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -111,6 +111,11 @@ public:
     // Called by sharded<>::stop()
     seastar::future<> stop();
 
+    // Stop the server for the given group and remove it from the registry.
+    // It differs from abort_server in that it waits for the server to stop
+    // and removes it from the registry.
+    seastar::future<> stop_server(raft::group_id gid, sstring reason);
+
     // Must not be called before `start`.
     const raft::server_id& get_my_raft_id();
 


### PR DESCRIPTION
When the `topology_change` command is applied, the topology state is reloaded and `cdc::generation_service::handle_cdc_generation` is called. This creates a dependency of the group0 on `cdc::generation_service`.
Currently, the group0 server is stopped during `raft_group_registry` shutdown. However, it is called after `cdc::generation_service` shutdown, which can result in a segfault.
  
To prevent this issue, this commit stops the group0 server and removes it from the `raft_group_registry` during the `group0_service` shutdown.

Fixes #14397.

Reproducer: https://github.com/margdoc/scylla/commit/97d6946e314a5b5d445b57045d93c57d10494b48.
It creates two nodes. The second one is forced to stop after joining the group0. It sleeps before calling `handle_cdc_generation` and sleeps just before `raft_group_registry` is stopped. It ensures that `handle_cdc_generation` wakes up after starting the second sleep. If the `cdc_generation_service` shutdown waits for `raft_group_registry` to stop, `handle_cdc_generation`  will be called without any issue. Otherwise, it will crash since `cdc_generation_service` won't exist. The test passes always. If the crash happens it can be seen in the log file of the second node.