### PR TITLE
test: use different table names in simple_backlog_controller_test 

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4448,7 +4448,8 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
         };
 
         auto create_table = [&] () {
-            simple_schema ss;
+            auto cf = utils::UUID_gen::get_time_UUID();
+            simple_schema ss{"ks", fmt::to_string(cf)};
             auto s = ss.schema();
 
             auto t = env.make_table_for_tests(s);

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -84,8 +84,9 @@ public:
     }
 
     sstring cql() const {
-        return format("CREATE TABLE ks.cf (pk text, ck text, v text, s1 text{}{}, PRIMARY KEY (pk, ck))", _ws ? " static" : "",
-                _wc ? ", c1 map<text, text>" : "");
+        return format("CREATE TABLE {}.{} (pk text, ck text, v text, s1 text{}{}, PRIMARY KEY (pk, ck))",
+                      _s->keypace_name(), _s->element_name(),
+                      _ws ? " static" : "", _wc ? ", c1 map<text, text>" : "");
     }
 
     clustering_key make_ckey(sstring ck) {


### PR DESCRIPTION
in this series, we use different table names in simple_backlog_controller_test. this test is a test exercising sstables compaction strategies. and it creates and keeps multiple tables in a single test session. but we are going to add metrics on per-table basis, and will use the table's ks and cf as the counter's labels. as the metrics subsystem does not allow multiple counters to share the same label. the test will fail when the metrics are being added.

to address this problem, in this change

1. a new ctor is added for `simple_schema`, so we can create `simple_schema` with different names
2. use the new ctor in simple_backlog_controller_test

Fixes #14767