### PR TITLE
cql.g: make the parser reject INSERT JSON without a JSON value

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -479,8 +479,7 @@ orderByClause[raw::select_statement::parameters::orderings_type& orderings]
     ;
 
 jsonValue returns [uexpression value]
-    :
-    | s=STRING_LITERAL { $value = untyped_constant{untyped_constant::string, $s.text}; }
+    : s=STRING_LITERAL { $value = untyped_constant{untyped_constant::string, $s.text}; }
     | m=marker         { $value = std::move(m); }
     ;
 

--- a/test/cql-pytest/test_bad_grammar.py
+++ b/test/cql-pytest/test_bad_grammar.py
@@ -22,3 +22,9 @@ def test_limit_empty(cql, table1):
         cql.execute(f'SELECT * FROM {table1} LIMIT')
     with pytest.raises(SyntaxException):
         cql.execute(f'SELECT * FROM {table1} PER PARTITION LIMIT')
+
+# INSERT JSON should require a JSON value
+# Reproduces https://github.com/scylladb/scylladb/issues/14709
+def test_json_empty(cql, table1):
+    with pytest.raises(SyntaxException):
+        cql.execute(f'INSERT INTO {table1} JSON')


### PR DESCRIPTION
We allow inserting column values using a JSON value, eg:
```cql
INSERT INTO mytable JSON '{ "\"myKey\"": 0, "value": 0}';
```

When no JSON value is specified, the query should be rejected.

Scylla used to crash in such cases. A recent change fixed the crash (https://github.com/scylladb/scylladb/pull/14706), it now fails on unwrapping an uninitialized value, but really it should be rejected at the parsing stage, so let's fix the grammar so that it doesn't allow JSON queries without JSON values.

A unit test is added to prevent regressions.

Refs: https://github.com/scylladb/scylladb/pull/14707
Fixes: https://github.com/scylladb/scylladb/issues/14709