### PR TITLE
cql3/prepare_expr: fix partially preparing function arguments

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -928,7 +928,7 @@ prepare_function_args_for_type_inference(std::span<const expression> args, data_
         std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr);
         auto type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
         auto expr = prepared_arg_opt ? std::move(*prepared_arg_opt) : argument;
-        partially_prepared_args.emplace_back(as_assignment_testable(std::move(argument), std::move(type)));
+        partially_prepared_args.emplace_back(as_assignment_testable(std::move(expr), std::move(type)));
     }
     return partially_prepared_args;
 }


### PR DESCRIPTION
Before choosing a function, we prepare the arguments that can be prepared without a receiver. Preparing an argument makes its type known, which allows to choose the best overload among many possible functions.

The function that prepared the argument passes the unprepared argument by mistake. Let's fix it so that it actually uses the prepared argument.