### PR TITLE
cql3/prepare_expr: fix wrong receiver in field_selection_test_assignment

### DIFF
--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -892,7 +892,8 @@ field_selection_prepare_expression(const field_selection& fs, data_dictionary::d
 
 assignment_testable::test_result
 field_selection_test_assignment(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
-    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, make_lw_shared<column_specification>(receiver));
+    // We can't infer the type of the user defined type from the field being selected
+    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr);
     if (!prepared_structure) {
         throw exceptions::invalid_request_exception(fmt::format("Cannot infer type of {}", fs.structure));
     }


### PR DESCRIPTION
When preparing a `field_selection`, we need to prepare the UDT value, and then verify that it has this field.

`field_selection_test_assignment` prepares the UDT value using the same receiver as the whole `field_selection`. This is wrong, this receiver has the type of the field, and not the UDT.

It's impossible to create a receiver for the UDT. Many different UDTs can produce an `int` value when the field `a` is selected. Therefore the receiver should be `nullptr`.

No unit test is added, as this bug doesn't currently cause any issues. Preparing an `unresolved_identifier` doesn't do any type checks, so nothing fails. Still it's good to fix it, just to be correct.