### PR TITLE
storage_service: raft_check_and_repair_cdc_streams: don't create a new generation if current one is optimal

### DIFF
--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -133,6 +133,12 @@ public:
  */
 bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper&);
 
+/*
+ * Checks if the CDC generation is optimal, which is true if its `topology_description` is consistent
+ * with `token_metadata`.
+*/
+bool is_cdc_generation_optimal(const cdc::topology_description& gen, const locator::token_metadata& tm);
+
 std::pair<utils::UUID, cdc::topology_description> make_new_generation_data(
     const std::unordered_set<dht::token>& bootstrap_tokens,
     const noncopyable_function<std::pair<size_t, uint8_t> (dht::token)>& get_sharding_info,

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -171,7 +171,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     // memory and thus needs to be protected with apply mutex
     auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
     co_await _ss.topology_state_load(_cdc_gen_svc);
-    _ss._topology_state_machine.event.signal();
+    _ss._topology_state_machine.event.broadcast();
 }
 
 future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::snapshot_descriptor snp) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -469,7 +469,7 @@ future<> storage_service::topology_transition(cdc::generation_service& cdc_gen_s
     assert(this_shard_id() == 0);
     co_await topology_state_load(cdc_gen_svc); // reload new state
 
-    _topology_state_machine.event.signal();
+    _topology_state_machine.event.broadcast();
 }
 
 future<> storage_service::merge_topology_snapshot(raft_topology_snapshot snp) {
@@ -1578,7 +1578,7 @@ future<> topology_coordinator::run() {
     slogger.info("raft topology: start topology coordinator fiber");
 
     auto abort = _as.subscribe([this] () noexcept {
-        _topo_sm.event.signal();
+        _topo_sm.event.broadcast();
     });
 
     bool wait_for_event = false;


### PR DESCRIPTION
Fixes #14055

We add the CDC generation optimality check in `storage_service::raft_check_and_repair_cdc_streams` so that it doesn't create new generations when unnecessary. Since `generation_service::check_and_repair_cdc_streams` already has this check, we extract it to the new `is_cdc_generation_optimal` function to not duplicate the code.

After this change, multiple tasks could wait for a single generation change. Calling `signal` on `topology_state_machine.event` would't wake them all. Moreover, we must ensure the topology coordinator wakes when his logic expects it. Therefore, we change all `signal` calls on `topology_state_machine.event` to `broadcast`.

We delay the deletion of the `new_cdc_generation` request to the moment when the topology transition reaches the `publish_cdc_generation` state. We need this change to ensure the added CDC generation optimality check in the next commit has an intended effect. If we didn't make it, it would be possible that a task makes the `new_cdc_generation` request, and then, after this request was removed but before committing the new generation, another task also makes the `new_cdc_generation` request. In such a scenario, two generations are created, but only one should. After delaying the deletion of `new_cdc_generation` requests, the second request would have no effect.

Additionally, we modify the `test_topology_ops.py` test in a way that verifies the new changes. We call `storage_service::raft_check_and_repair_cdc_streams` multiple times concurrently and verify that exactly one generation has been created.