### PR TITLE
gossiper: mark_alive: enter background_msg gate

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1476,8 +1476,9 @@ void gossiper::mark_alive(inet_address addr, endpoint_state& local_state) {
     local_state.mark_dead();
     msg_addr id = get_msg_addr(addr);
     auto generation = _endpoint_state_map[get_broadcast_address()].get_heart_beat_state().get_generation();
+    // Enter the _background_msg gate so stop() would wait on it
+    auto gh = _background_msg.hold();
     logger.debug("Sending a EchoMessage to {}, with generation_number={}", id, generation);
-    // Do it in the background.
     (void)_messaging.send_gossip_echo(id, generation.value(), std::chrono::milliseconds(15000)).then([this, addr] {
         logger.trace("Got EchoMessage Reply");
         // After sending echo message, the Node might not be in the
@@ -1494,7 +1495,7 @@ void gossiper::mark_alive(inet_address addr, endpoint_state& local_state) {
         return make_ready_future();
     }).finally([this, addr] {
         _pending_mark_alive_endpoints.erase(addr);
-    }).handle_exception([addr] (auto ep) {
+    }).handle_exception([addr, gh = std::move(gh)] (auto ep) {
         logger.warn("Fail to send EchoMessage to {}: {}", addr, ep);
     });
 }


### PR DESCRIPTION
The function dispatch a background operation that must be waited on in stop().

While at it, bundle cleanup of _pending_mark_alive_endpoints and releasing the gate holder in a deferred action which life is extended until the background fiber completes.

Fixes scylladb/scylladb#14791