### PR TITLE
storage_service: refresh_sync_nodes: restrict to normal token owners

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -47,11 +47,14 @@ node_holder node::clone() const {
 
 std::string node::to_string(node::state s) {
     switch (s) {
-    case state::none:       return "none";
-    case state::joining:    return "joining";
-    case state::normal:     return "normal";
-    case state::leaving:    return "leaving";
-    case state::left:       return "left";
+    case state::none:           return "none";
+    case state::bootstrapping:  return "bootstrapping";
+    case state::replacing:      return "replacing";
+    case state::normal:         return "normal";
+    case state::being_decommissioned: return "being_decommissioned";
+    case state::being_removed:        return "being_removed";
+    case state::being_replaced:       return "being_replaced";
+    case state::left:           return "left";
     }
     __builtin_unreachable();
 }
@@ -311,9 +314,9 @@ void topology::index_node(const node* node) {
     if (node->endpoint() != inet_address{}) {
         auto eit = _nodes_by_endpoint.find(node->endpoint());
         if (eit != _nodes_by_endpoint.end()) {
-            if (eit->second->get_state() == node::state::leaving || eit->second->get_state() == node::state::left) {
+            if (eit->second->is_leaving() || eit->second->left()) {
                 _nodes_by_endpoint.erase(node->endpoint());
-            } else if (node->get_state() != node::state::leaving && node->get_state() != node::state::left) {
+            } else if (!node->is_leaving() && !node->left()) {
                 if (node->host_id()) {
                     _nodes_by_host_id.erase(node->host_id());
                 }

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -47,9 +47,12 @@ public:
 
     enum class state {
         none = 0,
-        joining,    // while bootstrapping, replacing
+        bootstrapping,  // (joining)
+        replacing,      // (joining)
         normal,
-        leaving,    // while decommissioned, removed, replaced
+        being_decommissioned, // (leaving)
+        being_removed,        // (leaving)
+        being_replaced,       // (leaving)
         left        // after decommissioned, removed, replaced
     };
 
@@ -101,6 +104,35 @@ public:
     idx_type idx() const noexcept { return _idx; }
 
     state get_state() const noexcept { return _state; }
+
+    bool is_joining() const noexcept {
+        switch (_state) {
+        case state::bootstrapping:
+        case state::replacing:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool is_normal() const noexcept {
+        return _state == state::normal;
+    }
+
+    bool is_leaving() const noexcept {
+        switch (_state) {
+        case state::being_decommissioned:
+        case state::being_removed:
+        case state::being_replaced:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool left() const noexcept {
+        return _state == state::left;
+    }
 
     shard_id get_shard_count() const noexcept { return _shard_count; }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1425,7 +1425,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
 
             //Pending ranges
-            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack(), locator::node::state::joining);
+            metadata_clone.update_topology(myip, _sys_ks.local().local_dc_rack(), locator::node::state::bootstrapping);
             metadata_clone.update_normal_tokens(tokens, myip).get();
             auto pending_range_addresses = strat.get_range_addresses(metadata_clone).get0();
             metadata_clone.clear_gently().get();
@@ -1882,7 +1882,7 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     // update a cloned version of tmptr
     // no need to set the original version
     auto cloned_tmptr = make_token_metadata_ptr(std::move(cloned_tm));
-    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::joining);
+    cloned_tmptr->update_topology(utils::fb_utilities::get_broadcast_address(), _sys_ks.local().local_dc_rack(), locator::node::state::replacing);
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, utils::fb_utilities::get_broadcast_address());
     co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3790,7 +3790,7 @@ public:
             throw std::runtime_error(msg);
         }
 
-        slogger.info("{}[{}]: sync_nodes={}, ignore_nodes={}", desc, uuid(), desc, host_id, endpoint, sync_nodes, ignore_nodes);
+        slogger.info("{}[{}]: sync_nodes={}, ignore_nodes={}", desc, uuid(), sync_nodes, ignore_nodes);
     }
 
     future<> stop() noexcept {

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -144,15 +144,15 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     BOOST_REQUIRE(topo.get_location(id1) == dc_rack2);
     BOOST_REQUIRE(topo.get_location(ep1) == dc_rack2);
 
-    BOOST_REQUIRE_NE(node->get_state(), locator::node::state::leaving);
-    node = topo.update_node(mutable_node, std::nullopt, std::nullopt, std::nullopt, locator::node::state::leaving);
+    BOOST_REQUIRE_NE(node->get_state(), locator::node::state::being_decommissioned);
+    node = topo.update_node(mutable_node, std::nullopt, std::nullopt, std::nullopt, locator::node::state::being_decommissioned);
     mutable_node = const_cast<locator::node*>(node);
-    BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::leaving);
+    BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::being_decommissioned);
 
     auto dc_rack3 = endpoint_dc_rack{"DC3", "RACK3"};
     // Note: engage state option, but keep node::state value the same
     // to reproduce #13502
-    node = topo.update_node(mutable_node, std::nullopt, ep3, dc_rack3, locator::node::state::leaving);
+    node = topo.update_node(mutable_node, std::nullopt, ep3, dc_rack3, locator::node::state::being_decommissioned);
     mutable_node = const_cast<locator::node*>(node);
     BOOST_REQUIRE_EQUAL(topo.find_node(id1), node);
     BOOST_REQUIRE_EQUAL(topo.find_node(ep1), nullptr);
@@ -161,7 +161,7 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     BOOST_REQUIRE(topo.get_location(id1) == dc_rack3);
     BOOST_REQUIRE(topo.get_location(ep2) == endpoint_dc_rack::default_location);
     BOOST_REQUIRE(topo.get_location(ep3) == dc_rack3);
-    BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::leaving);
+    BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::being_decommissioned);
 
     // In state::left the ndoe will remain indexed only by its host_id
     node = topo.update_node(mutable_node, std::nullopt, std::nullopt, std::nullopt, locator::node::state::left);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -954,7 +954,7 @@ SEASTAR_THREAD_TEST_CASE(test_topology_tracks_local_node) {
 
     stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
         co_await tm.clear_gently();
-        tm.get_topology().add_or_update_endpoint(ip1, host1, ip1_dc_rack_v2, node::state::leaving);
+        tm.get_topology().add_or_update_endpoint(ip1, host1, ip1_dc_rack_v2, node::state::being_decommissioned);
     }).get();
 
     n1 = stm.get()->get_topology().find_node(host1);


### PR DESCRIPTION
It is possible that topology will contain nodes that are no longer normal token owners, so they don't need to be sync'ed with.

Fixes scylladb/scylladb#14793