### PR TITLE
cql3: SELECT CAST column names should match Cassandra's

### DIFF
--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -32,7 +32,7 @@ public:
     }
 
     static bool is_exact_match(test_result tr) {
-        return tr != test_result::EXACT_MATCH;
+        return tr == test_result::EXACT_MATCH;
     }
 
     /**

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1136,8 +1136,15 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
                             } else if (!pr.for_metadata) {
                                 fmt::print(os, "{}({})", fn->name(), fmt::join(fc.args | transformed(to_printer), ", "));
                             } else {
-                                auto args = boost::copy_range<std::vector<sstring>>(fc.args | transformed(to_printer) | transformed(fmt::to_string<expression::printer>));
-                                fmt::print(os, "{}", fn->column_name(args));
+                                const std::string_view fn_name = fn->name().name;
+                                if (fn->name().keyspace == "system" && fn_name.starts_with("castas")) {
+                                    auto cast_type = fn_name.substr(6);
+                                    fmt::print(os, "cast({} as {})", fmt::join(fc.args | transformed(to_printer) | transformed(fmt::to_string<expression::printer>), ", "),
+                                         cast_type);
+                                } else {
+                                    auto args = boost::copy_range<std::vector<sstring>>(fc.args | transformed(to_printer) | transformed(fmt::to_string<expression::printer>));
+                                    fmt::print(os, "{}", fn->column_name(args));
+                                }
                             }
                         },
                     }, fc.func);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -835,6 +835,11 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of cast argument {}", c.arg));
     }
 
+    // cast to the same type should be ommited
+    if (cast_type == type_of(*prepared_arg)) {
+        return prepared_arg;
+    }
+
     // This will throw if a cast is impossible
     auto fun = functions::get_castas_fctn_as_cql3_function(cast_type, type_of(*prepared_arg));
 

--- a/test/cql-pytest/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cql-pytest/cassandra_tests/functions/cast_fcts_test.py
@@ -15,8 +15,6 @@ def testInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b text, c double)") as table:
         assertInvalidMessage(cql, table, "cannot be cast to", "SELECT CAST(a AS boolean) FROM %s")
 
-# Marked cassandra_bug because of CASSANDRA-18647 (see comment below)
-@pytest.mark.xfail(reason="issue #14508")
 def testNumericCastsInSelectionClause(cql, test_keyspace, cassandra_bug):
     with create_table(cql, test_keyspace, "(a tinyint primary key, b smallint, c int, d bigint, e float, f double, g decimal, h varint, i int)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",


### PR DESCRIPTION
When doing a SELECT CAST(b AS int), Cassandra returns a column named cast(b as int).
An application may depend on this specific column name to look at the results.
Currently, Scylla uses a different name - system.castasint(b). For Cassandra compatibility, we should switch to the same name that Cassandra uses

fixes #14508