### PR TITLE
Base node liveliness consistently on gossiper::is_alive

### DIFF
--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -22,7 +22,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
         for (auto i : g.get_endpoint_states()) {
             fd::endpoint_state val;
             val.addrs = fmt::to_string(i.first);
-            val.is_alive = i.second.is_alive();
+            val.is_alive = g.is_alive(i.first);
             val.generation = i.second.get_heart_beat_state().get_generation().value();
             val.version = i.second.get_heart_beat_state().get_heart_beat_version().value();
             val.update_time = i.second.get_update_timestamp().time_since_epoch().count();
@@ -57,7 +57,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     fd::get_simple_states.set(r, [&g] (std::unique_ptr<request> req) {
         std::map<sstring, sstring> nodes_status;
         for (auto& entry : g.get_endpoint_states()) {
-            nodes_status.emplace(entry.first.to_sstring(), entry.second.is_alive() ? "UP" : "DOWN");
+            nodes_status.emplace(entry.first.to_sstring(), g.is_alive(entry.first) ? "UP" : "DOWN");
         }
         return make_ready_future<json::json_return_type>(map_to_key_value<fd::mapper>(nodes_status));
     });

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -555,8 +555,7 @@ bool manager::end_point_hints_manager::sender::can_send() noexcept {
     }
 
     try {
-        auto ep_state_ptr = _gossiper. get_endpoint_state_for_endpoint_ptr(end_point_key());
-        if (ep_state_ptr && ep_state_ptr->is_alive()) {
+        if (_gossiper.is_alive(end_point_key())) {
             _state.remove(state::ep_state_left_the_ring);
             return true;
         } else {

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -31,28 +31,26 @@ private:
     std::map<application_state, versioned_value> _application_state;
     /* fields below do not get serialized */
     clk::time_point _update_timestamp;
-    bool _is_alive;
     bool _is_normal = false;
 
 public:
     bool operator==(const endpoint_state& other) const {
         return _heart_beat_state  == other._heart_beat_state &&
                _application_state == other._application_state &&
-               _update_timestamp  == other._update_timestamp &&
-               _is_alive          == other._is_alive;
+               _update_timestamp  == other._update_timestamp;
     }
 
     endpoint_state() noexcept
         : _heart_beat_state()
         , _update_timestamp(clk::now())
-        , _is_alive(true) {
+    {
         update_is_normal();
     }
 
     endpoint_state(heart_beat_state initial_hb_state) noexcept
         : _heart_beat_state(initial_hb_state)
         , _update_timestamp(clk::now())
-        , _is_alive(true) {
+    {
         update_is_normal();
     }
 
@@ -61,7 +59,7 @@ public:
         : _heart_beat_state(std::move(initial_hb_state))
         , _application_state(application_state)
         , _update_timestamp(clk::now())
-        , _is_alive(true) {
+    {
         update_is_normal();
     }
 
@@ -118,23 +116,6 @@ public:
         _update_timestamp = clk::now();
     }
 
-private:
-    bool is_alive() const noexcept {
-        return _is_alive;
-    }
-
-    void set_alive(bool alive) noexcept {
-        _is_alive = alive;
-    }
-
-    void mark_alive() noexcept {
-        set_alive(true);
-    }
-
-    void mark_dead() noexcept {
-        set_alive(false);
-    }
-
 public:
     std::string_view get_status() const noexcept {
         constexpr std::string_view empty = "";
@@ -168,7 +149,6 @@ public:
     bool is_cql_ready() const noexcept;
 
     friend std::ostream& operator<<(std::ostream& os, const endpoint_state& x);
-    friend class gossiper;
 };
 
 // The endpoint state is protected with an endpoint lock

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -118,6 +118,7 @@ public:
         _update_timestamp = clk::now();
     }
 
+private:
     bool is_alive() const noexcept {
         return _is_alive;
     }
@@ -134,6 +135,7 @@ public:
         set_alive(false);
     }
 
+public:
     std::string_view get_status() const noexcept {
         constexpr std::string_view empty = "";
         auto* app_state = get_application_state_ptr(application_state::STATUS);
@@ -166,6 +168,7 @@ public:
     bool is_cql_ready() const noexcept;
 
     friend std::ostream& operator<<(std::ostream& os, const endpoint_state& x);
+    friend class gossiper;
 };
 
 // The endpoint state is protected with an endpoint lock

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -583,7 +583,7 @@ future<> gossiper::do_apply_state_locally(gms::inet_address node, const endpoint
                     logger.debug("Ignoring remote version {} <= {} for {}", remote_max_version, local_max_version, node);
                 }
                 if (!is_alive(node) && !this->is_dead_state(local_state)) { // unless of course, it was dead
-                    this->mark_alive(node, local_state);
+                    this->mark_alive(node);
                 }
             } else {
                 for (const auto& item : remote_state.get_application_state_map()) {
@@ -1529,7 +1529,7 @@ void gossiper::update_timestamp_for_nodes(const std::map<inet_address, endpoint_
     }
 }
 
-void gossiper::mark_alive(inet_address addr, endpoint_state& local_state) {
+void gossiper::mark_alive(inet_address addr) {
     // Enter the _background_msg gate so stop() would wait on it
     auto inserted = _pending_mark_alive_endpoints.insert(addr).second;
     if (inserted) {
@@ -1672,7 +1672,7 @@ future<> gossiper::handle_major_state_change(inet_address ep, const endpoint_sta
 
     auto& ep_state = _endpoint_state_map.at(ep);
     if (!is_dead_state(ep_state)) {
-        mark_alive(ep, ep_state);
+        mark_alive(ep);
     } else {
         logger.debug("Not marking {} alive due to dead state {}", ep, get_gossip_status(eps));
         co_await mark_dead(ep, ep_state, pid);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1169,6 +1169,7 @@ future<> gossiper::evict_from_membership(inet_address endpoint, permit_id pid) {
     verify_permit(endpoint, pid);
     co_await mutate_live_and_unreachable_endpoints([endpoint] (gossiper& g) {
         g._unreachable_endpoints.erase(endpoint);
+        g._live_endpoints.erase(endpoint);
     });
     co_await container().invoke_on_all([endpoint] (auto& g) {
         g._endpoint_state_map.erase(endpoint);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1400,6 +1400,8 @@ future<> gossiper::reset_endpoint_state_map() {
         g._unreachable_endpoints.clear();
         g._live_endpoints.clear();
         g._live_endpoints_version = version;
+        g._shadow_unreachable_endpoints.clear();
+        g._shadow_live_endpoints.clear();
         g._endpoint_state_map.clear();
     });
 }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1064,12 +1064,6 @@ void gossiper::run() {
 
                 do_status_check().get();
             }
-
-            {
-                auto lock = lock_endpoint_update_semaphore().get();
-                replicate_live_endpoints_on_change().get();
-            }
-
     }).then_wrapped([this] (auto&& f) {
         try {
             f.get();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -404,7 +404,8 @@ public:
     const versioned_value* get_application_state_ptr(inet_address endpoint, application_state appstate) const noexcept;
     sstring get_application_state_value(inet_address endpoint, application_state appstate) const;
 
-    // removes ALL endpoint states; should only be called after shadow gossip
+    // removes ALL endpoint states; should only be called after shadow gossip.
+    // Must be called on shard 0
     future<> reset_endpoint_state_map();
 
     const std::unordered_map<inet_address, endpoint_state>& get_endpoint_states() const noexcept;
@@ -637,6 +638,7 @@ public:
 private:
     future<> failure_detector_loop();
     future<> failure_detector_loop_for_node(gms::inet_address node, generation_type gossip_generation, uint64_t live_endpoints_version);
+    // Must be called on shard 0
     future<> update_live_endpoints_version();
 };
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -651,8 +651,6 @@ public:
 private:
     future<> failure_detector_loop();
     future<> failure_detector_loop_for_node(gms::inet_address node, generation_type gossip_generation, uint64_t live_endpoints_version);
-    // Must be called on shard 0
-    future<> update_live_endpoints_version();
 };
 
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -247,6 +247,9 @@ private:
     std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
     std::unordered_set<inet_address> _shadow_live_endpoints;
 
+    // Must be called on shard 0.
+    future<semaphore_units<>> lock_endpoint_update_semaphore();
+
     // replicate shard 0 live endpoints across all other shards.
     // _endpoint_update_semaphore must be held for the whole duration
     future<> replicate_live_endpoints_on_change();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -447,7 +447,7 @@ public:
 private:
     void update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map);
 
-    void mark_alive(inet_address addr, endpoint_state& local_state);
+    void mark_alive(inet_address addr);
 
     future<> real_mark_alive(inet_address addr);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -244,8 +244,8 @@ private:
 
     bool _in_shadow_round = false;
 
-    std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
-    std::unordered_set<inet_address> _shadow_live_endpoints;
+    uint64_t _shadow_live_endpoints_version = 0;
+    uint64_t _shadow_unreachable_endpoints_version = 0;
 
     // Must be called on shard 0.
     future<semaphore_units<>> lock_endpoint_update_semaphore();
@@ -263,7 +263,7 @@ private:
     // they all shards are consistent with each other.
     future<> mutate_live_and_unreachable_endpoints(std::function<void(gossiper&)>);
 
-    // replicate shard 0 live endpoints across all other shards.
+    // replicate shard 0 live and unreachable endpoints sets across all other shards.
     // _endpoint_update_semaphore must be held for the whole duration
     future<> replicate_live_endpoints_on_change();
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -220,7 +220,7 @@ private:
     std::list<std::vector<inet_address>> _endpoints_to_talk_with;
 
     /* live member set */
-    utils::chunked_vector<inet_address> _live_endpoints;
+    std::unordered_set<inet_address> _live_endpoints;
     uint64_t _live_endpoints_version = 0;
 
     /* nodes are being marked as alive */
@@ -245,7 +245,7 @@ private:
     bool _in_shadow_round = false;
 
     std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
-    utils::chunked_vector<inet_address> _shadow_live_endpoints;
+    std::unordered_set<inet_address> _shadow_live_endpoints;
 
     // replicate shard 0 live endpoints across all other shards.
     // _endpoint_update_semaphore must be held for the whole duration

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -232,7 +232,7 @@ bool migration_manager::have_schema_agreement() {
     for (auto& x : known_endpoints) {
         auto& endpoint = x.first;
         auto& eps = x.second;
-        if (endpoint == utils::fb_utilities::get_broadcast_address() || !eps.is_alive()) {
+        if (endpoint == utils::fb_utilities::get_broadcast_address() || !_gossiper.is_alive(endpoint)) {
             continue;
         }
         mlogger.debug("Checking schema state for {}.", endpoint);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3310,7 +3310,7 @@ future<> storage_service::on_dead(gms::inet_address endpoint, gms::endpoint_stat
 future<> storage_service::on_restart(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id pid) {
     slogger.debug("endpoint={} on_restart: permit_id={}", endpoint, pid);
     // If we have restarted before the node was even marked down, we need to reset the connection pool
-    if (state.is_alive()) {
+    if (endpoint != get_broadcast_address() && _gossiper.is_alive(endpoint)) {
         return on_dead(endpoint, state, pid);
     }
     return make_ready_future();


### PR DESCRIPTION
Currently he gossiper marks endpoint_state objects as alive/dead.
I some cases the endpoint_state::is_alive function is checked but in many other cases
gossiper::is_alive(endpoint) is used to determine if the endpoint is alive.

This series removed the endpoint_state::is_alive state and moves all the logic to gossiper::is_alive
that bases its decision on the endpoint having an endpoint_state and being in the _live_endpoints set.

For that, the _live_endpoints is made sure to be replicated to all shards when changed
and the endpoint_state changes are serialized under lock_endpoint, and also making sure that the
endpoint_state in the _endpoint_states_map is never updated in place, but rather a temporary copy is changed
and then safely replicated using gossiper::replicate

Refs https://github.com/scylladb/scylladb/issues/14794