### PR TITLE
test: pylib: ensure ScyllaCluster.add_server does not start a second cluster

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -669,6 +669,11 @@ class ScyllaCluster:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
+        # If the cluster isn't empty and all servers are stopped,
+        # adding a new server would create a new cluster.
+        if self.servers and not self.running:
+            raise RuntimeError("Can't add the server: all servers in the cluster are stopped")
+
         extra_config: dict[str, Any] = config.copy() if config else {}
         if replace_cfg:
             replaced_id = replace_cfg.replaced_id


### PR DESCRIPTION
Fixes #12438 

If the cluster isn't empty and all servers are stopped, calling `ScyllaCluster.add_server` can start a new cluster. That's because `ScyllaCluster._seeds` uses the running servers to calculate the seed node list, so if all nodes are down, the new node would select only itself as a seed, starting a new cluster.

As a single `ScyllaCluster` should describe a single cluster, we make `ScyllaCluster.add_server` fail when called on a non-empty cluster with all its nodes stopped.