### PR TITLE
Fix stack-use-after-return in mutation source excluding staging

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2536,7 +2536,7 @@ table::make_reader_v2_excluding_staging(schema_ptr s,
         readers.reserve(memtable_count + 1);
     });
 
-    static std::predicate<const sstable&> auto excl_staging_predicate = [] (const sstable& sst) {
+    static const sstables::sstable_predicate excl_staging_predicate = [] (const sstable& sst) {
         return !sst.requires_view_building();
     };
 


### PR DESCRIPTION
The new test detected a stack-use-after-return when using table's as_mutation_source_excluding_staging() for range reads.

This doesn't really affect view updates that generate single key reads only. So the problem was only stressed in the recently added test. Otherwise, we'd have seen it when running dtests (in debug mode) that stress the view update path from staging.

The problem happens because the closure was feeded into a noncopyable_function that was taken by reference. For range reads, we defer before subsequent usage of the predicate. For single key reads, we only defer after finished using the predicate.

Fix is about using sstable_predicate type, so there won't be a need to construct a temporary object on stack.

Fixes #14812.