### PR TITLE
scripts/coverage.py: --run: swallow KeyboardInterrupt

### DIFF
--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -61,7 +61,10 @@ def run(args, executable=None, distinct_id=None):
         extra_env = env(executable, distinct_id)
     else:
         extra_env = env(args[0], distinct_id)
-    subprocess.check_call(args, env=dict(os.environ, **extra_env))
+    try:
+        subprocess.check_call(args, env=dict(os.environ, **extra_env))
+    except KeyboardInterrupt:
+        pass # allow process to be shut down with ^C
 
 
 def generate_coverage_report(path="build/coverage/test", name="tests", input_files=None, verbose=0):


### PR DESCRIPTION
It is quite common to stop a tested scylla process with ^C, which will raise KeyboardInterrupt from subprocess.run(). Catch and swallow this exception, allowing the post-processing to continue. The interrupted process has to handle the interrupt correctly too -- flush the coverage data even on premature exit -- but this is for another patch.