### PR TITLE
system_keyspace: Remove qctx usage from load_topology_state()

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2493,7 +2493,7 @@ static std::set<sstring> decode_features(const set_type_impl::native_type& featu
 }
 
 future<service::topology> system_keyspace::load_topology_state() {
-    auto rs = co_await qctx->execute_cql(
+    auto rs = co_await execute_cql(
         format("SELECT * FROM system.{} WHERE key = '{}'", TOPOLOGY, TOPOLOGY));
     assert(rs);
 
@@ -2653,7 +2653,7 @@ future<service::topology> system_keyspace::load_topology_state() {
 
             // Sanity check for CDC generation data consistency.
             {
-                auto gen_rows = co_await qctx->execute_cql(
+                auto gen_rows = co_await execute_cql(
                     format("SELECT count(range_end) as cnt, num_ranges FROM system.{} WHERE id = ?",
                            CDC_GENERATIONS_V3),
                     gen_uuid);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -461,7 +461,7 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<bool> group0_history_contains(utils::UUID state_id);
 
-    static future<service::topology> load_topology_state();
+    future<service::topology> load_topology_state();
     future<int64_t> get_topology_fence_version();
     future<> update_topology_fence_version(int64_t value);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -305,7 +305,7 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
 
     slogger.debug("raft topology: reload raft topology state");
     // read topology state from disk and recreate token_metadata from it
-    _topology_state_machine._topology = co_await db::system_keyspace::load_topology_state();
+    _topology_state_machine._topology = co_await _sys_ks.local().load_topology_state();
 
     const auto& am = _group0->address_map();
     auto id2ip = [this, &am] (raft::server_id id) -> future<gms::inet_address> {


### PR DESCRIPTION
Fortunately, this is pretty simple -- the only caller is storage_service that has sharded<system_keysace> dependency reference