### PR TITLE
doc: update info about cassandra superuser

### DIFF
--- a/docs/operating-scylla/security/authentication.rst
+++ b/docs/operating-scylla/security/authentication.rst
@@ -62,11 +62,17 @@ Procedure
 
     .. include:: /rst_include/scylla-commands-restart-index.rst
 
-#. Start cqlsh with the default superuser username and password. The default username is ``cassandra``, the default password is ``cassandra``. You can change it later if you are enabling authorization.  
+#. Start cqlsh with the default superuser username and password. 
 
     .. code-block:: cql
 
        cqlsh -u cassandra -p cassandra
+
+   .. warning::
+
+      Before proceeding  to the next step, we highly recommend creating a custom superuser 
+      to ensure security and prevent performance degradation.
+      See :doc:`Creating a Custom Superuser </operating-scylla/security/create-superuser/>` for instructions.
 
 #. Run a repair on the ``system_auth`` keyspace on **all** the nodes in the cluster.
 	

--- a/docs/operating-scylla/security/create-superuser.rst
+++ b/docs/operating-scylla/security/create-superuser.rst
@@ -1,0 +1,116 @@
+================================
+Creating a Custom Superuser
+================================
+
+The default ScyllaDB superuser role is ``cassandra`` with password ``cassandra``. 
+Users with the ``cassandra`` role have full access to the database and can run 
+any CQL command on the database resources.
+
+During login, the credentials for the default superuser ``cassandra`` are read with 
+a consistency level of QUORUM, whereas those for all other roles are read at LOCAL_ONE. 
+QUORUM may significantly impact performance, especially in multi-datacenter deployments.
+
+To prevent performance degradation and ensure better secuirty, we highly recommend creating 
+a custom superuser. You should:
+
+#. Use the default ``cassandra`` superuser to log in.
+#. Create a custom superuser.
+#. Log in as the custom superuser.
+#. Remove the ``cassandra`` role.
+
+In the above procedure, you only need to use the ``cassandra`` superuser once, during 
+the initial RBAC set up. 
+To completely eliminate the need to use ``cassandra``, you can :ref:`configure the initial 
+custom superuser in the scylla.yaml configuration file <create-superuser-in-config-file>`. 
+
+.. _create-superuser-procedure:
+
+Procedure
+-----------
+
+#. Start cqlsh with the default superuser settings:
+
+   .. code::
+
+    cqlsh -u cassandra -p cassandra
+
+#. Create a new superuser:
+
+   .. code::
+
+    CREATE ROLE <custom_superuser name>  WITH SUPERUSER = true AND LOGIN = true and PASSWORD = '<custom_superuser_password>';
+
+   For example:
+
+   .. code::
+    :class: hide-copy-button
+
+    CREATE ROLE dba WITH SUPERUSER = true AND LOGIN = true and PASSWORD = '39fksah!';
+
+   .. warning::
+    
+    You must set a PASSWORD when creating a role with LOGIN privileges. 
+    Otherwise, you will not be able to log in to the database using that role.
+
+#. Exit cqlsh:
+
+   .. code::
+
+    EXIT;
+
+#. Log in as the new superuser:
+
+   .. code::
+
+    cqlsh -u <custom_superuser name> -p <custom_superuser_password>
+
+   For example:
+
+   .. code::
+    :class: hide-copy-button
+
+    cqlsh -u dba -p 39fksah!
+
+#. Show all the roles to verify that the new superuser was created:
+
+   .. code::
+
+    LIST ROLES;
+
+#. Remove the cassandra superuser:
+
+   .. code::
+
+    DROP ROLE cassandra;
+
+#. Show all the roles to verify that the cassandra role was deleted:
+
+   .. code::
+
+    LIST ROLES;
+
+.. _create-superuser-in-config-file:
+
+Setting Custom Superuser Credentials in scylla.yaml
+------------------------------------------------------
+
+Operating ScyllaDB using the default superuser ``cassandra`` with password ``cassandra`` 
+is insecure and impacts performance. For this reason, the default should be used only once - 
+to create a custom superuser role, following the CQL :ref:`procedure <create-superuser-procedure>` above. 
+
+To avoid executing with the default credentials for the period before you can make 
+the CQL modifications, you can configure the custom superuser name and password
+in the ``scylla.yaml`` configuration file:
+
+.. code-block:: yaml
+   
+   auth_superuser_name: <superuser name>
+   auth_superuser_salted_password: <superuser salted password as processed by mkpassword or similar - cleartext is not allowed>
+
+.. caution::
+
+    The superuser credentials in the ``scylla.yaml`` file will be ignored:
+
+    * If any superuser other than ``cassandra`` is already defined in the cluster.
+    * After you create a custom superuser with the CQL :ref:`procedure <create-superuser-procedure>`.
+

--- a/docs/operating-scylla/security/enable-authorization.rst
+++ b/docs/operating-scylla/security/enable-authorization.rst
@@ -52,85 +52,20 @@ It is highly recommended to perform this action on a node that is not processing
 .. _superuser:
 
 Set a Superuser
-...............
+.........................
 
-By default, the superuser credentials are username cassandra, password cassandra. This is not secure. It is highly advised to change this to a unique username and password combination.
+The default ScyllaDB superuser role is ``cassandra`` with password ``cassandra``. Using the default
+superuser is unsafe and may significantly impact performance. 
 
-**Procedure**
+If you haven't created a custom superuser while enablint authentication, you should create a custom superuser
+before creating additional roles. 
+See :doc:`Creating a Custom Superuser </operating-scylla/security/create-superuser/>` for instructions.
 
-1. Start cqlsh with the default superuser settings.
-
-.. code-block:: cql
-
-   cqlsh -u cassandra -p cassandra
-
-.. note:: The cassandra user is special. When you try to login with this username, it is required to usen QUORUM consistency level(CL) for replies. On the other hand, your own user requires LOCAL_ONE consistency level.
-          This can be a problematic in certain situations, such as adding or removing DCs. In such cases the cassandra user won't be able to login.
-          Creating a superuser role and assigning yourself to the role is definitely the best way forward. Refer to :doc:`RBAC </operating-scylla/security/rbac-usecase>` for an example of how to create roles and refer to :doc:`Grant Authorization </operating-scylla/security/authorization>` for information on using the grant clause.
-
-
-2. Create a role for the superuser which has all privileges
-
-.. code-block:: cql
-
-   CREATE ROLE <role-name> WITH SUPERUSER = true;
-
-.. code-block:: cql
-
-   CREATE ROLE DBA WITH SUPERUSER = true;
-
-.. note:: This role already has complete read and write permissions on all tables and keyspaces and does not need to be granted anything else. The superuser permission setting is by default, disabled. Only for the administrator does it need to be enabled.
-
-3. Assign that role to yourself and grant login privileges
-
-.. code-block:: cql
-
-   CREATE ROLE <user> WITH PASSWORD = 'password' AND SUPERUSER = true AND LOGIN = true;
-
-.. include:: /operating-scylla/security/_common/warning-no-pwd.rst 
+.. warning::
    
-For example (John is the DBA)
-
-.. code-block:: cql
-
-   CREATE ROLE john WITH PASSWORD = '39fksah!' AND LOGIN = true;
-   GRANT DBA TO john;
-
-4. Exit cqlsh and login again with the new credentials
-
-.. code-block:: none
-  
-   cqlsh> exit
-   cqlsh -u new-username -p new-password
-
-For example:
-
-.. code-block:: none
-  
-   cqlsh> exit
-   cqlsh -u john -p 39fksah!
-
-
-.. note:: To guarantee new authorization values (like a password) are visible across the cluster, make sure to run a repair on table `system_auth` after updating or adding users.
+   We highly recommend creating a custom superuser to ensure security and avoid performance degradation.
 
 .. _roles:
-
-Setting default initial superuser credentials using the config file
-...................................................................
-
-The default super username/password in ScyllaDB is 'cassandra'/'cassandra'. This is very insecure and should be altered using the above CQL procedure. However, to avoid 
-executing with known defaults for the period before the CQL modifications can be done, the default superuser name and password can be configured in the ``scylla.yaml`` configuration file instead.
-
-.. code-block:: yaml
-   
-   auth_superuser_name: <super user name>
-   auth_superuser_salted_password: <super user salted password as processed by mkpassword or similar - not cleartext>
-
-This will set the initial values of the super user credentials. 
-
-.. note:: The password entered here must be salted, i.e. pre-hashed. Cleartext passwords are not allowed. 
-.. note:: If you alter the password of the super user using CQL (like above), the value here is ignored.
-.. note:: If any super user is already defined in the cluster, the value here is ignored.
 
 Create Additional Roles
 .......................

--- a/docs/operating-scylla/security/index.rst
+++ b/docs/operating-scylla/security/index.rst
@@ -7,6 +7,7 @@ Security
    security-checklist
    authentication
    runtime-authentication
+   create-superuser
    gen-cqlsh-file
    Reset Authenticator Password </troubleshooting/password-reset>
    enable-authorization
@@ -33,6 +34,7 @@ Security
 
   * :doc:`Enable Authentication </operating-scylla/security/authentication/>`
   * :doc:`Enable and Disable Authentication Without Downtime </operating-scylla/security/runtime-authentication/>`
+  * :doc:`Creating a Custom Superuser </operating-scylla/security/create-superuser/>`
   * :doc:`Generate a cqlshrc File <gen-cqlsh-file>`
   * :doc:`Enable Authorization</operating-scylla/security/enable-authorization/>`
   * :doc:`Role Based Access Control (RBAC) </operating-scylla/security/rbac-usecase/>`


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-docs/issues/4028

The goal of this update is to discourage the use of the default `cassandra` superuser in favor of a custom super user - and explain why it's a good practice.

The scope of this commit:
- Adding a new page on creating a custom superuser. The page collects and clarifies the information about the `cassandra` superuser from other pages.
- Remove the (incomplete) information about superuser from the Authorization and Authentication pages, and add the link to the new page instead.

Additionally, this update will result in better searchability and ensures language clarity.