### PR TITLE
compaction: prevent resharding from using compacting reader

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1622,7 +1622,7 @@ public:
     }
 
     bool use_interposer_consumer() const override {
-        return true;
+        return false;
     }
 
     std::string_view report_start_desc() const override {


### PR DESCRIPTION
before this change, resharding_compaction could use compacting_reader when consuming sstables, but the table has multiple fragment runs, and the sstables are not empty. but resharding should only segregate data according its owner shard. to perform the compaction with compacting_reader when resharding_compaction hurts the efficiency. As per Raphael,

> there's some redundant work between reshard and reshape, as reshape
> will pick the work left by reshard, in order to satisfy the LSM-tree
> layout goal. A possible optimization is to tweak resharding to no
> longer apply compacting reader (which deserializes, compact or expire,
> and then serialize the result), removing one layer between producer
> (sstable reader) and consumer (sstable writer), with only a mutation
> writer segregator in between.

so, in this change we disable the interposer_consumer in the resharding_compaction, so that it won't use compacting_reader anymore.

see also 30063943, where we allowed incremental compaction with interposer consumer. but in this change, we chose to avoid using compacting_reader in this very case.

Fixes #14439
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>