### PR TITLE
Init messaging service preferred IP cache via config

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1433,7 +1433,7 @@ future<> system_keyspace::build_bootstrap_info() {
     });
 }
 
-future<> system_keyspace::setup(sharded<locator::snitch_ptr>& snitch, sharded<netw::messaging_service>& ms) {
+future<> system_keyspace::setup(sharded<netw::messaging_service>& ms) {
     assert(this_shard_id() == 0);
 
     co_await setup_version(ms);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1444,13 +1444,6 @@ future<> system_keyspace::setup(sharded<locator::snitch_ptr>& snitch, sharded<ne
     // #2514 - make sure "system" is written to system_schema.keyspaces.
     co_await db::schema_tables::save_system_schema(_qp, NAME);
     co_await cache_truncation_record();
-
-    if (snitch.local()->prefer_local()) {
-        auto preferred_ips = co_await get_preferred_ips();
-        co_await ms.invoke_on_all([&preferred_ips] (auto& ms) {
-            return ms.init_local_preferred_ip_cache(preferred_ips);
-        });
-    }
 }
 
 struct truncation_record {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -244,7 +244,7 @@ public:
 
     static table_schema_version generate_schema_version(table_id table_id, uint16_t offset = 0);
 
-    future<> setup(sharded<locator::snitch_ptr>& snitch, sharded<netw::messaging_service>& ms);
+    future<> setup(sharded<netw::messaging_service>& ms);
     future<> update_schema_version(table_schema_version version);
 
     /*

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -257,7 +257,6 @@ public:
      */
     future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens);
 
-private:
     future<std::unordered_map<gms::inet_address, gms::inet_address>> get_preferred_ips();
 
 public:

--- a/main.cc
+++ b/main.cc
@@ -1341,7 +1341,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // 1. messaging is on the way with its preferred ip cache
             // 2. cql_test_env() doesn't do it
             // 3. need to check if it depends on any of the above steps
-            sys_ks.local().setup(snitch, messaging).get();
+            sys_ks.local().setup(messaging).get();
 
             supervisor::notify("starting schema commit log");
 

--- a/main.cc
+++ b/main.cc
@@ -1102,6 +1102,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             mscfg.ssl_port = cfg->ssl_storage_port();
             mscfg.listen_on_broadcast_address = cfg->listen_on_broadcast_address();
             mscfg.rpc_memory_limit = std::max<size_t>(0.08 * memory::stats().total_memory(), mscfg.rpc_memory_limit);
+            if (snitch.local()->prefer_local()) {
+                mscfg.preferred_ips = sys_ks.local().get_preferred_ips().get0();
+            }
 
             const auto& seo = cfg->server_encryption_options();
             auto encrypt = utils::get_or_default(seo, "internode_encryption", "none");

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -435,6 +435,8 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
         ci.attach_auxiliary("max_result_size", max_result_size.value_or(query::result_memory_limiter::maximum_result_size));
         return rpc::no_wait;
     });
+
+    init_local_preferred_ip_cache(_cfg.preferred_ips);
 }
 
 msg_addr messaging_service::get_source(const rpc::client_info& cinfo) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -271,6 +271,7 @@ public:
         tcp_nodelay_what tcp_nodelay = tcp_nodelay_what::all;
         bool listen_on_broadcast_address = false;
         size_t rpc_memory_limit = 1'000'000;
+        std::unordered_map<gms::inet_address, gms::inet_address> preferred_ips;
     };
 
     struct scheduling_config {
@@ -325,6 +326,7 @@ private:
     future<> stop_tls_server();
     future<> stop_nontls_server();
     future<> stop_client();
+    void init_local_preferred_ip_cache(const std::unordered_map<gms::inet_address, gms::inet_address>& ips_cache);
 public:
     using clock_type = lowres_clock;
 
@@ -341,7 +343,6 @@ public:
     static rpc::no_wait_type no_wait();
     bool is_shutting_down() { return _shutting_down; }
     gms::inet_address get_preferred_ip(gms::inet_address ep);
-    void init_local_preferred_ip_cache(const std::unordered_map<gms::inet_address, gms::inet_address>& ips_cache);
     void cache_preferred_ip(gms::inet_address ep, gms::inet_address ip);
     gms::inet_address get_public_endpoint_for(const gms::inet_address&) const;
 


### PR DESCRIPTION
This is to make m.s. initialization more solid and simplify sys.ks.::setup()