### PR TITLE
system_keyspace: Don't update schema version in .setup()

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1437,7 +1437,6 @@ future<> system_keyspace::setup(sharded<locator::snitch_ptr>& snitch, sharded<ne
     assert(this_shard_id() == 0);
 
     co_await setup_version(ms);
-    co_await update_schema_version(_db.get_version());
     co_await build_bootstrap_info();
     co_await check_health();
     co_await db::schema_tables::save_system_keyspace_schema(_qp);


### PR DESCRIPTION
The db.get_version() called that early returns value that database got construction-time, i.e. -- empty_version thing. It makes little sense committing it into the system k.s. all the more so the "real" version is calculated and updated few steps after .setup().