### PR TITLE
tests: add asynchronous log browsing functionality

### DIFF
--- a/test/pylib/log_browsing.py
+++ b/test/pylib/log_browsing.py
@@ -1,0 +1,102 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import logging
+from typing import Optional
+import pytest
+import os
+import re
+
+
+logger = logging.getLogger(__name__)
+
+class ScyllaLogFile():
+    """
+    Class for browsing a Scylla log file.
+    Based on scylla-ccm implementation of log browsing.
+    """
+    def __init__(self, thread_pool: ThreadPoolExecutor, logfile_path: str):
+        self.thread_pool = thread_pool # used for asynchronous IO operations
+        self.file = logfile_path
+        if not os.path.isfile(self.file):
+            pytest.fail("Log file {} does not exist".format(self.file))
+
+    async def _run_in_executor(self, func, *args, loop=None):
+        if loop is None:
+            loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self.thread_pool, func, *args)
+
+    async def mark(self) -> int:
+        """
+        Returns "a mark" to the current position of this node Scylla log.
+        This is for use with the from_mark parameter of watch_log_for method,
+        allowing to watch the log from the position when this method was called.
+        """
+        with open(self.file, 'r') as f:
+            await self._run_in_executor(f.seek, 0, os.SEEK_END)
+            return await self._run_in_executor(f.tell)
+
+    async def wait_for(self, pattern: str | re.Pattern, from_mark: Optional[int] = None, timeout: int = 600) -> None:
+        """
+        wait_for() checks if the log contains the given message.
+        Because it may take time for the log message to be flushed, and sometimes
+        we may want to look for messages about various delayed events, this
+        function doesn't give up when it reaches the end of file, and rather
+        retries until a given timeout. The timeout may be long, because successful
+        tests will not wait for it. Note, however, that long timeouts will make
+        xfailing tests slow.
+        The timeout is in seconds.
+        If from_mark is given, the log is searched from that position, otherwise
+        from the beginning.
+        """
+        prog = re.compile(pattern)
+        loop = asyncio.get_running_loop()
+        line = ""
+
+        with open(self.file, 'r') as f:
+            if from_mark is not None:
+                await self._run_in_executor(f.seek, from_mark, loop=loop)
+
+            async with asyncio.timeout(timeout):
+                logger.debug("Waiting for log message: %s", pattern)
+                while True:
+                    line += await self._run_in_executor(f.readline, loop=loop)
+                    if line:
+                        if prog.search(line):
+                            logger.debug("Found log message: %s", line)
+                            return
+                        elif line[-1] != '\n':
+                            continue
+                        line = ""
+                    else:
+                        await asyncio.sleep(0.01)
+
+    async def grep(self, expr: str | re.Pattern, filter_expr: Optional[str | re.Pattern] = None,
+             from_mark: Optional[int] = None) -> list[(str, re.Match[str])]:
+        """
+        Returns a list of lines matching the regular expression in the Scylla log.
+        The list contains tuples of (line, match), where line is the full line
+        from the log file, and match is the re.Match object for the matching
+        expression.
+        If filter_expr is given, only lines which do not match it are returned.
+        If from_mark is given, the log is searched from that position, otherwise
+        from the beginning.
+        """
+        matchings = []
+        pattern = re.compile(expr)
+        filter_pattern = re.compile(filter_expr) if filter_expr else None
+        loop = asyncio.get_running_loop()
+
+        with open(self.file) as f:
+            if from_mark:
+                await self._run_in_executor(f.seek, from_mark, loop=loop)
+            line = await self._run_in_executor(f.readline, loop=loop)
+            while line:
+                m = pattern.search(line)
+                if m and not (filter_pattern and re.search(filter_pattern, line)):
+                    matchings.append((line, m))
+                line = await self._run_in_executor(f.readline, loop=loop)
+        return matchings

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1068,6 +1068,7 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/get_config', self._server_get_config)
         add_put('/cluster/server/{server_id}/update_config', self._server_update_config)
         add_put('/cluster/server/{server_id}/change_ip', self._server_change_ip)
+        add_get('/cluster/server/{server_id}/get_log_filename', self._server_get_log_filename)
 
     async def _manager_up(self, _request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text=f"{self.is_running}")
@@ -1277,6 +1278,14 @@ class ScyllaClusterManager:
         server_id = ServerNum(int(request.match_info["server_id"]))
         ip_addr = await self.cluster.change_ip(server_id)
         return aiohttp.web.json_response({"ip_addr": ip_addr})
+
+    async def _server_get_log_filename(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        assert self.cluster
+        server_id = ServerNum(int(request.match_info["server_id"]))
+        server = self.cluster.servers[server_id]
+        if not server:
+            return aiohttp.web.Response(status=404, text=f"Server {server_id} unknown")
+        return aiohttp.web.Response(text=f"{server.log_filename}")
 
 
 @asynccontextmanager


### PR DESCRIPTION
# Motivation

To write certain tests, we need the ability to asynchronously browse node logs inside tests.
For example:
* it can be used to detect segfaults. Reproducer https://github.com/margdoc/scylla/commit/97d6946e314a5b5d445b57045d93c57d10494b48 (issue https://github.com/scylladb/scylladb/issues/14397) could read the log to determine whether there was a segmentation fault or a graceful shutdown of the node.
* wait for some events that happen in the background, for example in the dtest `bootstrap_test.py::test_decommissioned_wiped_node_can_join`, the main thread waits for the first node to notice that the fourth node is down.
* check if we print appropriate errors and warnings to the user. For example tests in the file `cql-pytest/test_logs.py` in test.py (but it has only synchronous wait_for).



# Features
Add a class that handles log file browsing with the following features:
* mark: returns "a mark" to the current position of the log.
* wait_for: asynchronously checks if the log contains the given message.
* grep: returns a list of lines matching the regular expression in the log.

Add a new endpoint in `ManagerClient` to obtain the Scylla logfile path.

# Examples

Real test example: https://github.com/margdoc/scylla/commit/a227cc9ea63e013be019ac09bcc0845d42b00fc4
This is the reproducer for https://github.com/scylladb/scylladb/issues/14397. It uses this feature to enforce a specific order of events.
In the other reproducer of the same issue (https://github.com/margdoc/scylla/commit/97d6946e314a5b5d445b57045d93c57d10494b48) we could read the scylla log to check if there was a segmentation fault or if the node stopped gracefully.

--------

Fixes #14782.