### PR TITLE
Introduce a scylla-native nodetool

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1245,7 +1245,7 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
 
-scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
+scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
 scylla_perfs = ['test/perf/perf_fast_forward.cc',
                 'test/perf/perf_row_cache_update.cc',
                 'test/perf/perf_simple_query.cc',

--- a/main.cc
+++ b/main.cc
@@ -1944,6 +1944,7 @@ int main(int ac, char** av) {
         {"server", scylla_main, "the scylladb server"},
         {"types", tools::scylla_types_main, "a command-line tool to examine values belonging to scylla types"},
         {"sstable", tools::scylla_sstable_main, "a multifunctional command-line tool to examine the content of sstables"},
+        {"nodetool", tools::scylla_nodetool_main, "a command-line tool to administer local or remote ScyllaDB nodes"},
         {"perf-fast-forward", perf::scylla_fast_forward_main, "run performance tests by fast forwarding the reader on this server"},
         {"perf-row-cache-update", perf::scylla_row_cache_update_main, "run performance tests by updating row cache on this server"},
         {"perf-tablets", perf::scylla_tablets_main, "run performance tests of tablet metadata management"},

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -1,0 +1,172 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import os
+import pytest
+import random
+import rest_api_mock
+import subprocess
+import sys
+import requests.exceptions
+import time
+
+from rest_api_mock import expected_request
+
+
+def pytest_addoption(parser):
+    parser.addoption('--mode', action='store', default='dev',
+                     help='Scylla build mode to use')
+    parser.addoption('--nodetool', action='store', choices=["scylla", "cassandra"], default="scylla",
+                     help="Which nodetool implementation to run the tests against")
+    parser.addoption('--nodetool-path', action='store', default=None,
+                     help="Path to the nodetool binary,"
+                     " with --nodetool=scylla, this should be the scylla binary,"
+                     " with --nodetool=cassandra, this should be the nodetool binary")
+    parser.addoption('--jmx-path', action='store', default=None,
+                     help="Path to the jmx binary, only used with --nodetool=cassandra")
+
+
+@pytest.fixture(scope="session")
+def rest_api_mock_server():
+    ip = f"127.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}"
+    port = random.randint(10000, 65535)
+
+    server_process = subprocess.Popen([
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "rest_api_mock.py"),
+        ip,
+        str(port)])
+
+    server = (ip, port)
+
+    i = 0
+    while True:
+        try:
+            rest_api_mock.get_expected_requests(server)
+            break
+        except requests.exceptions.ConnectionError:
+            if i == 50:  # 5 seconds
+                raise
+            time.sleep(0.1)
+            i += 1
+
+    try:
+        yield server
+    finally:
+        server_process.terminate()
+        server_process.wait()
+
+
+@pytest.fixture(scope="session")
+def jmx(request, rest_api_mock_server):
+    if request.config.getoption("nodetool") == "scylla":
+        yield
+        return
+
+    jmx_path = request.config.getoption("jmx_path")
+    if jmx_path is None:
+        jmx_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "scylla-jmx", "scripts",
+                                                "scylla-jmx"))
+    else:
+        jmx_path = os.path.abspath(jmx_path)
+
+    workdir = os.path.join(os.path.dirname(jmx_path), "..")
+    ip, api_port = rest_api_mock_server
+    expected_requests = [
+            expected_request(
+                "GET",
+                "/column_family/",
+                response=[{"ks": "system_schema",
+                           "cf": "columns",
+                           "type": "ColumnFamilies"},
+                          {"ks": "system_schema",
+                           "cf": "computed_columns",
+                           "type": "ColumnFamilies"}]),
+            expected_request(
+                "GET",
+                "/stream_manager/",
+                response=[])]
+    rest_api_mock.set_expected_requests(rest_api_mock_server, expected_requests)
+
+    # Our nodetool launcher script ignores the host param, so this has to be 127.0.0.1, matching the internal default.
+    jmx_ip = "127.0.0.1"
+    jmx_port = random.randint(10000, 65535)
+    while jmx_port == api_port:
+        jmx_port = random.randint(10000, 65535)
+
+    jmx_process = subprocess.Popen(
+            [
+                jmx_path,
+                "-a", ip,
+                "-p", str(api_port),
+                "-ja", jmx_ip,
+                "-jp", str(jmx_port),
+            ],
+            cwd=workdir, text=True)
+
+    # Wait until jmx starts up
+    # We rely on the expected requests being consumed for this
+    i = 0
+    while len(rest_api_mock.get_expected_requests(rest_api_mock_server)) > 0:
+        if i == 50:  # 5 seconds
+            raise RuntimeError("timed out waiting for JMX to start")
+        time.sleep(0.1)
+        i += 1
+
+    yield jmx_ip, jmx_port
+
+    jmx_process.terminate()
+    jmx_process.wait()
+
+
+@pytest.fixture(scope="session")
+def nodetool_path(request):
+    if request.config.getoption("nodetool") == "scylla":
+        mode = request.config.getoption("mode")
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "build", mode, "scylla"))
+
+    path = request.config.getoption("nodetool_path")
+    if path is not None:
+        return os.path.abspath(path)
+
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "tools", "java", "bin", "nodetool"))
+
+
+@pytest.fixture(scope="function")
+def scylla_only(request):
+    if request.config.getoption("nodetool") != "scylla":
+        pytest.skip('Scylla-only test skipped')
+
+
+@pytest.fixture(scope="module")
+def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
+    def invoker(method, *args, expected_requests=None):
+        if expected_requests is not None:
+            rest_api_mock.set_expected_requests(rest_api_mock_server, expected_requests)
+
+        if request.config.getoption("nodetool") == "scylla":
+            api_ip, api_port = rest_api_mock_server
+            cmd = [nodetool_path, "nodetool", method,
+                   "--logger-log-level", "scylla-nodetool=trace",
+                   "-h", api_ip,
+                   "-p", str(api_port)]
+        else:
+            jmx_ip, jmx_port = jmx
+            cmd = [nodetool_path, "-h", jmx_ip, "-p", str(jmx_port), method]
+        cmd += list(args)
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(res.stdout)
+        sys.stderr.write(res.stderr)
+
+        unconsumed_expected_requests = rest_api_mock.get_expected_requests(rest_api_mock_server)
+        # Clear up any unconsumed requests, so the next test starts with a clean slate
+        rest_api_mock.clear_expected_requests(rest_api_mock_server)
+
+        # Check the return-code first, if the command failed probably not all requests were consumed
+        res.check_returncode()
+        assert len(unconsumed_expected_requests) == 0
+
+    return invoker

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -1,0 +1,220 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import aiohttp
+import aiohttp.web
+import asyncio
+import json
+import logging
+import requests
+import sys
+import traceback
+
+from typing import Any, Dict, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+class expected_request:
+    def __init__(self, method: str, path: str, params: dict = {}, multiple: bool = False,
+                 response: Dict[str, Any] = None):
+        self.method = method
+        self.path = path
+        self.params = {}
+        self.multiple = multiple
+        self.response = response
+
+        self.hit = 0
+
+    def as_json(self):
+        return {
+                "method": self.method,
+                "path": self.path,
+                "multiple": self.multiple,
+                "params": self.params,
+                "response": self.response}
+
+    def __eq__(self, o):
+        return self.method == o.method and self.path == o.path and self.params == o.params
+
+    def __str__(self):
+        return json.dumps(self.as_json())
+
+
+def _make_expected_request(req_json):
+    return expected_request(
+            req_json["method"],
+            req_json["path"],
+            params=req_json.get("params", dict()),
+            multiple=req_json.get("multiple", False),
+            response=req_json.get("response"))
+
+
+class handler_match_info(aiohttp.abc.AbstractMatchInfo):
+    def __init__(self, handler):
+        self.handler = handler
+        self._apps = list()
+
+    async def handler(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Catch all exceptions and return them to the client.
+           Without this, the client would get an 'Internal server error' message
+           without any details. Thanks to this the test log shows the actual error.
+        """
+        try:
+            return await self.handler(request)
+        except Exception as e:
+            tb = traceback.format_exc()
+            logger.error(f'Exception when executing {self.handler.__name__}: {e}\n{tb}')
+            return aiohttp.web.Response(status=500, text=str(e))
+
+    async def expect_handler(self) -> None:
+        return None
+
+    async def http_exception(self) -> None:
+        return None
+
+    def get_info(self) -> Dict[str, Any]:
+        return {}
+
+    def apps(self) -> Tuple[aiohttp.web.Application, ...]:
+        return tuple(self._apps)
+
+    def add_app(self, app: aiohttp.web.Application):
+        self._apps.append(app)
+
+    def freeze(self) -> None:
+        pass
+
+
+class rest_server(aiohttp.abc.AbstractRouter):
+    EXPECTED_REQUESTS_PATH = "__expected_requests__"
+
+    def __init__(self):
+        self.expected_requests = []
+
+    async def resolve(self, request: aiohttp.web.Request) -> aiohttp.abc.AbstractMatchInfo:
+        if request.path == f"/{self.EXPECTED_REQUESTS_PATH}":
+            return handler_match_info(getattr(self, f"{request.method.lower()}_expected_requests"))
+
+        for req in self.expected_requests:
+            if req.path == request.path and req.method == request.method:
+                return handler_match_info(self.handle_generic_request)
+
+        raise aiohttp.web.HTTPNotFound()
+
+    async def get_expected_requests(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        return aiohttp.web.json_response([r.as_json() for r in self.expected_requests])
+
+    async def post_expected_requests(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        payload = await request.json()
+        self.expected_requests = list(map(_make_expected_request, payload))
+        logger.info(f"expected_requests: {list(map(str, self.expected_requests))}")
+        return aiohttp.web.json_response({})
+
+    async def delete_expected_requests(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        self.expected_requests = []
+        return aiohttp.web.json_response({})
+
+    async def handle_generic_request(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        this_req = expected_request(request.method, request.path, params=dict(request.query))
+
+        if len(self.expected_requests) == 0:
+            logger.error(f"unexpected request, expected no request, got {this_req}")
+            return aiohttp.web.Response(status=500, text="Expected no requests, got {this_req}")
+
+        expected_req = self.expected_requests[0]
+        if this_req != expected_req:
+            if expected_req.multiple and expected_req.hit > 0 and \
+                    len(self.expected_requests) > 1 and self.expected_requests[1] == this_req:
+                del self.expected_requests[0]
+                expected_req = self.expected_requests[0]
+            else:
+                logger.error(f"unexpected request, expected {expected_req}, got {this_req}")
+                return aiohttp.web.Response(status=500, text="Expected {expected_req}, got {this_req}")
+
+        if not expected_req.multiple:
+            del self.expected_requests[0]
+
+        expected_req.hit += 1
+
+        if expected_req.response is None:
+            logger.info(f"expected_request: {expected_req}, no response")
+            return aiohttp.web.json_response({})
+        else:
+            logger.info(f"expected_request: {expected_req}, response: {expected_req.response}")
+            return aiohttp.web.json_response(expected_req.response)
+
+
+async def run_server(ip, port):
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s.%(msecs)03d %(levelname)s %(name)s - %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    server = rest_server()
+    app = aiohttp.web.Application(router=server)
+
+    logger.info("start serving")
+
+    runner = aiohttp.web.AppRunner(app)
+    await runner.setup()
+    site = aiohttp.web.TCPSite(runner, ip, port)
+    await site.start()
+
+    try:
+        while True:
+            await asyncio.sleep(3600)  # sleep forever
+    except asyncio.exceptions.CancelledError:
+        pass
+
+    logger.info("stopping")
+
+    await runner.cleanup()
+
+
+def get_expected_requests(server):
+    """Get the expected requests list from the server.
+
+    This will contain all the unconsumed expected request currently on the
+    server. Can be used to check whether all expected requests arrived.
+
+    Params:
+    * server - resolved `rest_api_mock_server` fixture (see conftest.py).
+    """
+    ip, port = server
+    r = requests.get(f"http://{ip}:{port}/{rest_server.EXPECTED_REQUESTS_PATH}")
+    r.raise_for_status()
+    return [_make_expected_request(r) for r in r.json()]
+
+
+def clear_expected_requests(server):
+    """Clear the expected requests list on the server.
+
+    Params:
+    * server - resolved `rest_api_mock_server` fixture (see conftest.py).
+    """
+    ip, port = server
+    r = requests.delete(f"http://{ip}:{port}/{rest_server.EXPECTED_REQUESTS_PATH}")
+    r.raise_for_status()
+
+
+def set_expected_requests(server, expected_requests):
+    """Set the expected requests list on the server.
+
+    Params:
+    * server - resolved `rest_api_mock_server` fixture (see conftest.py).
+    * requests - a list of request objects
+    """
+    ip, port = server
+    payload = json.dumps([r.as_json() for r in expected_requests])
+    r = requests.post(f"http://{ip}:{port}/{rest_server.EXPECTED_REQUESTS_PATH}", data=payload)
+    r.raise_for_status()
+
+
+if __name__ == '__main__':
+    sys.exit(asyncio.run(run_server(sys.argv[1], int(sys.argv[2]))))

--- a/test/nodetool/suite.yaml
+++ b/test/nodetool/suite.yaml
@@ -1,0 +1,1 @@
+type: Tool

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -1,0 +1,84 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+import subprocess
+
+from rest_api_mock import expected_request
+
+
+def test_all_keyspaces(nodetool):
+    nodetool("compact", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+        expected_request("POST", "/storage_service/keyspace_compaction/system"),
+        expected_request("POST", "/storage_service/keyspace_compaction/system_schema")])
+
+
+def test_keyspace(nodetool):
+    nodetool("compact", "system_schema", expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")])
+
+
+def test_nonexistent_keyspace(nodetool):
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        nodetool("compact", "non_existent_ks", expected_requests=[
+                expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system"]),
+                expected_request("POST", "/storage_service/keyspace_compaction/non_existent_ks")])
+
+    err_lines = e.value.stderr.rstrip().split('\n')
+    out_lines = e.value.stdout.rstrip().split('\n')
+    cassandra_error = "nodetool: Keyspace [non_existent_ks] does not exist."
+    scylla_error = "error processing arguments: keyspace non_existent_ks does not exist"
+    assert cassandra_error in err_lines or cassandra_error in out_lines or \
+        scylla_error in err_lines or scylla_error in out_lines
+
+
+def test_table(nodetool):
+    nodetool("compact", "system_schema", "columns", expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema", params={"cf": "columns"})])
+
+    nodetool("compact", "system_schema", "columns", "computed_columns", expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST",
+                             "/storage_service/keyspace_compaction/system_schema",
+                             params={"cf": "columns,computed_columns"})])
+
+
+def test_split_output_compatibility_argument(nodetool):
+    dummy_request = [
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")]
+
+    nodetool("compact", "system_schema", "-s", expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "--split-output", expected_requests=dummy_request)
+
+
+def test_token_range_compatibility_argument(nodetool):
+    dummy_request = [
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")]
+
+    nodetool("compact", "system_schema", "-st", "0", "-et", "1000", expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "--start-token", "0", "--end-token", "1000", expected_requests=dummy_request)
+
+
+def test_partition_compatibility_argument(nodetool):
+    dummy_request = [
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")]
+
+    nodetool("compact", "system_schema", "--partition", "0", expected_requests=dummy_request)
+
+
+def test_user_defined(nodetool, scylla_only):
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        nodetool("compact", "--user-defined", "/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/"
+                 "me-3g8w_11cg_4317k2ppfb6d5vgp0w-big-Data.db")
+
+    err_lines = e.value.stderr.rstrip().split('\n')
+    "error processing arguments: --user-defined flag is unsupported" in err_lines

--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_jmx_compatibility_args(nodetool, scylla_only):
+    """Check that all JMX arguments inherited to nodetool are ignored.
+
+    These arguments are unused in the scylla-native nodetool and should be
+    silently ignored.
+    """
+    dummy_request = [
+            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")]
+
+    nodetool("compact", "system_schema", "-u", "us3r", "-pw", "secr3t",
+             expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "--username", "us3r", "--password", "secr3t",
+             expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "-u", "us3r", "-pwf", "/tmp/secr3t_file",
+             expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "--username", "us3r", "--password-file", "/tmp/secr3t_file",
+             expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "-pp",
+             expected_requests=dummy_request)
+    nodetool("compact", "system_schema", "--print-port",
+             expected_requests=dummy_request)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(tools
   PRIVATE
     scylla-types.cc
     scylla-sstable.cc
+    scylla-nodetool.cc
     schema_loader.cc
     utils.cc
     lua_sstable_consumer.cc)

--- a/tools/entry_point.hh
+++ b/tools/entry_point.hh
@@ -10,5 +10,6 @@ namespace tools {
 
 int scylla_types_main(int argc, char** argv);
 int scylla_sstable_main(int argc, char** argv);
+int scylla_nodetool_main(int argc, char** argv);
 
 } // namespace tools

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -9,9 +9,13 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <seastar/core/thread.hh>
+#include <seastar/http/request.hh>
+#include <seastar/util/short_streams.hh>
 
 #include "log.hh"
 #include "tools/utils.hh"
+#include "utils/http.hh"
+#include "utils/rjson.hh"
 
 namespace bpo = boost::program_options;
 
@@ -24,21 +28,127 @@ const auto app_name = "scylla-nodetool";
 logging::logger nlog(app_name);
 
 class scylla_rest_client {
+    sstring _host;
+    uint16_t _port;
+    sstring _host_name;
+
+    rjson::value do_request(sstring type, sstring path, std::unordered_map<sstring, sstring> params) {
+        auto req = http::request::make(type, _host_name, path);
+        req.query_parameters = std::move(params);
+
+        nlog.trace("Making {} request to {} with parameters {}", type, req.get_url(), req.query_parameters);
+
+        sstring res;
+
+        http::experimental::client api_client(std::make_unique<utils::http::dns_connection_factory>(_host, _port, false, nlog), 1);
+        try {
+            api_client.make_request(std::move(req), seastar::coroutine::lambda([&] (const http::reply&, input_stream<char> body) -> future<> {
+                res = co_await util::read_entire_stream_contiguous(body);
+            })).get();
+        } catch (...) {
+            api_client.close().get();
+            throw;
+        }
+        api_client.close().get();
+
+        if (res.empty()) {
+            return rjson::null_value();
+        } else {
+            return rjson::parse(res);
+        }
+    }
+
+public:
+    scylla_rest_client(sstring host, uint16_t port)
+        : _host(std::move(host))
+        , _port(port)
+        , _host_name(format("{}:{}", _host, _port))
+    { }
+
+    rjson::value post(sstring path, std::unordered_map<sstring, sstring> params = {}) {
+        return do_request("POST", std::move(path), std::move(params));
+    }
+
+    rjson::value get(sstring path, std::unordered_map<sstring, sstring> params = {}) {
+        return do_request("GET", std::move(path), std::move(params));
+    }
 };
 
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
 
 const std::vector<operation_option> global_options{
+    typed_option<sstring>("host,h", "localhost", "the hostname or ip address of the ScyllaDB node"),
+    typed_option<uint16_t>("port,p", 10000, "the port of the REST API of the ScyllaDB node"),
+    typed_option<sstring>("password", "Remote jmx agent password (unused)"),
+    typed_option<sstring>("password-file", "Path to the JMX password file (unused)"),
+    typed_option<sstring>("username,u", "Remote jmx agent username (unused)"),
+    typed_option<>("print-port", "Operate in 4.0 mode with hosts disambiguated by port number (unused)"),
+};
+
+const std::map<std::string_view, std::string_view> option_substitutions{
+    {"-h", "--host"},
+    {"-pw", "--password"},
+    {"-pwf", "--password-file"},
+    {"-pp", "--print-port"},
 };
 
 const std::map<operation, operation_func> operations_with_func{
 };
+
+// boost::program_options doesn't allow multi-char option short-form,
+// e.g. -pw, that C*'s nodetool uses. We silently map these to the
+// respective long-form and pass the transformed argv to tool_app_template.
+// Furthermore, C* nodetool allows for assigning values to short-form
+// arguments with =, e.g. -h=localhost, something which boost::program_options
+// also doesn't support. We silently replace all = with space to support this.
+// So, e.g. "-h=localhost" becomes "-h localhost".
+std::vector<char*> massage_argv(int argc, char** argv) {
+    static std::vector<std::string> argv_holder;
+    argv_holder.reserve(argc);
+
+    for (size_t i = 0; i < argc; ++i) {
+        if (argv[i][0] != '-') {
+            argv_holder.push_back(argv[i]);
+            continue;
+        }
+
+        std::string arg = argv[i];
+        std::string arg_key;
+        std::optional<std::string> arg_value;
+
+        if (auto pos = arg.find('='); pos == std::string::npos) {
+            arg_key = std::move(arg);
+        } else {
+            arg_key = arg.substr(0, pos);
+            arg_value = arg.substr(pos + 1);
+        }
+
+        const auto it = option_substitutions.find(arg_key);
+        if (it != option_substitutions.end()) {
+            nlog.trace("Substituting cmd-line arg {} with {}", arg_key, it->second);
+            arg_key = it->second;
+        }
+
+        argv_holder.push_back(std::move(arg_key));
+        if (arg_value) {
+            argv_holder.push_back(std::move(*arg_value));
+        }
+    }
+
+    std::vector<char*> new_argv;
+    new_argv.reserve(argv_holder.size());
+    std::ranges::transform(argv_holder, std::back_inserter(new_argv), [] (std::string& arg) -> char* { return arg.data(); });
+    return new_argv;
+}
 
 } // anonymous namespace
 
 namespace tools {
 
 int scylla_nodetool_main(int argc, char** argv) {
+    auto replacement_argv = massage_argv(argc, argv);
+    nlog.debug("replacement argv: {}", replacement_argv);
+
     const auto description_template =
 R"(scylla-nodetool - a command-line tool to administer local or remote ScyllaDB nodes
 
@@ -66,8 +176,8 @@ For more information, see: https://opensource.docs.scylladb.com/stable/operating
             .global_options = &global_options};
     tool_app_template app(std::move(app_cfg));
 
-    return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {
-        scylla_rest_client client;
+    return app.run_async(replacement_argv.size(), replacement_argv.data(), [] (const operation& operation, const bpo::variables_map& app_config) {
+        scylla_rest_client client(app_config["host"].as<sstring>(), app_config["port"].as<uint16_t>());
 
         try {
             operations_with_func.at(operation)(client, app_config);

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <seastar/core/thread.hh>
+
+#include "log.hh"
+#include "tools/utils.hh"
+
+namespace bpo = boost::program_options;
+
+using namespace tools::utils;
+
+namespace {
+
+const auto app_name = "scylla-nodetool";
+
+logging::logger nlog(app_name);
+
+class scylla_rest_client {
+};
+
+using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
+
+const std::vector<operation_option> global_options{
+};
+
+const std::map<operation, operation_func> operations_with_func{
+};
+
+} // anonymous namespace
+
+namespace tools {
+
+int scylla_nodetool_main(int argc, char** argv) {
+    const auto description_template =
+R"(scylla-nodetool - a command-line tool to administer local or remote ScyllaDB nodes
+
+# Operations
+
+The operation to execute is the mandatory, first positional argument.
+Operations write their output to stdout. Logs are written to stderr,
+with a logger called {}.
+
+Supported Nodetool operations:
+{}
+
+For more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool.html
+)";
+
+    const auto operations = boost::copy_range<std::vector<operation>>(operations_with_func | boost::adaptors::map_keys);
+    tool_app_template::config app_cfg{
+            .name = app_name,
+            .description = format(description_template, app_name, boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
+                return format("* {}: {}", op.name(), op.summary());
+            }), "\n")),
+            .logger_name = app_name,
+            .lsa_segment_pool_backend_size_mb = 1,
+            .operations = std::move(operations),
+            .global_options = &global_options};
+    tool_app_template app(std::move(app_cfg));
+
+    return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {
+        scylla_rest_client client;
+
+        try {
+            operations_with_func.at(operation)(client, app_config);
+        } catch (std::invalid_argument& e) {
+            fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
+            return 1;
+        } catch (...) {
+            fmt::print(std::cerr, "error running operation: {}\n", std::current_exception());
+            return 2;
+        }
+
+        return 0;
+    });
+}
+
+} // namespace tools

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -31,6 +31,7 @@ class scylla_rest_client {
     sstring _host;
     uint16_t _port;
     sstring _host_name;
+    http::experimental::client _api_client;
 
     rjson::value do_request(sstring type, sstring path, std::unordered_map<sstring, sstring> params) {
         auto req = http::request::make(type, _host_name, path);
@@ -40,16 +41,9 @@ class scylla_rest_client {
 
         sstring res;
 
-        http::experimental::client api_client(std::make_unique<utils::http::dns_connection_factory>(_host, _port, false, nlog), 1);
-        try {
-            api_client.make_request(std::move(req), seastar::coroutine::lambda([&] (const http::reply&, input_stream<char> body) -> future<> {
-                res = co_await util::read_entire_stream_contiguous(body);
-            })).get();
-        } catch (...) {
-            api_client.close().get();
-            throw;
-        }
-        api_client.close().get();
+        _api_client.make_request(std::move(req), seastar::coroutine::lambda([&] (const http::reply&, input_stream<char> body) -> future<> {
+            res = co_await util::read_entire_stream_contiguous(body);
+        })).get();
 
         if (res.empty()) {
             return rjson::null_value();
@@ -63,7 +57,12 @@ public:
         : _host(std::move(host))
         , _port(port)
         , _host_name(format("{}:{}", _host, _port))
+        , _api_client(std::make_unique<utils::http::dns_connection_factory>(_host, _port, false, nlog), 1)
     { }
+
+    ~scylla_rest_client() {
+        _api_client.close().get();
+    }
 
     rjson::value post(sstring path, std::unordered_map<sstring, sstring> params = {}) {
         return do_request("POST", std::move(path), std::move(params));
@@ -75,6 +74,77 @@ public:
 };
 
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
+
+enum class json_type {
+    null, boolean, object, array, string, number
+};
+
+const rjson::value& check_json_type(const rjson::value& value, json_type type) {
+    bool ok = false;
+    sstring type_name = "unknown";
+    switch (type) {
+        case json_type::null:
+            ok = value.IsNull();
+            type_name = "null";
+            break;
+        case json_type::boolean:
+            ok = value.IsBool();
+            type_name = "bool";
+            break;
+        case json_type::object:
+            ok = value.IsObject();
+            type_name = "object";
+            break;
+        case json_type::array:
+            ok = value.IsArray();
+            type_name = "array";
+            break;
+        case json_type::string:
+            ok = value.IsString();
+            type_name = "string";
+            break;
+        case json_type::number:
+            ok = value.IsNumber();
+            type_name = "number";
+            break;
+        default:
+            throw std::runtime_error(fmt::format("check_json_type(): unknown type: {}", static_cast<int>(type)));
+    }
+    if (!ok) {
+        throw std::runtime_error(fmt::format("check_json_type(): json value is not of the expected type: {}", type_name));
+    }
+    return value;
+}
+
+void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (vm.count("user-defined")) {
+        throw std::invalid_argument("--user-defined flag is unsupported");
+    }
+
+    auto keyspaces_json = client.get("/storage_service/keyspaces", {});
+    std::vector<sstring> all_keyspaces;
+    for (const auto& keyspace_json : check_json_type(keyspaces_json, json_type::array).GetArray()) {
+        all_keyspaces.emplace_back(rjson::to_string_view(check_json_type(keyspace_json, json_type::string)));
+    }
+
+    if (vm.count("compaction_arg")) {
+        auto args = vm["compaction_arg"].as<std::vector<sstring>>();
+        std::unordered_map<sstring, sstring> params;
+        const auto keyspace = args[0];
+        if (std::ranges::find(all_keyspaces, keyspace) == all_keyspaces.end()) {
+            throw std::invalid_argument(fmt::format("keyspace {} does not exist", keyspace));
+        }
+
+        if (args.size() > 1) {
+            params["cf"] = fmt::to_string(fmt::join(args.begin() + 1, args.end(), ","));
+        }
+        client.post(format("/storage_service/keyspace_compaction/{}", keyspace), std::move(params));
+    } else {
+        for (const auto& keyspace : all_keyspaces) {
+            client.post(format("/storage_service/keyspace_compaction/{}", keyspace));
+        }
+    }
+}
 
 const std::vector<operation_option> global_options{
     typed_option<sstring>("host,h", "localhost", "the hostname or ip address of the ScyllaDB node"),
@@ -90,9 +160,36 @@ const std::map<std::string_view, std::string_view> option_substitutions{
     {"-pw", "--password"},
     {"-pwf", "--password-file"},
     {"-pp", "--print-port"},
+    {"-st", "--start-token"},
+    {"-et", "--end-token"},
 };
 
 const std::map<operation, operation_func> operations_with_func{
+    {{"compact",
+            "Force a (major) compaction on one or more tables",
+R"(
+Forces a (major) compaction on one or more tables. Compaction is an optimization
+that reduces the cost of IO and CPU over time by merging rows in the background.
+
+By default, major compaction runs on all the keyspaces and tables. Major
+compactions will take all the SSTables for a column family and merge them into a
+single SSTable per shard. If a keyspace is provided, the compaction will run on
+all of the tables within that keyspace. If one or more tables are provided as
+command-line arguments, the compaction will run on these tables.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/compact.html
+)",
+            {
+                    typed_option<>("split-output,s", "Don't create a single big file (unused)"),
+                    typed_option<>("user-defined", "Submit listed SStable files for user-defined compaction (unused)"),
+                    typed_option<int64_t>("start-token", "Specify a token at which the compaction range starts (unused)"),
+                    typed_option<int64_t>("end-token", "Specify a token at which the compaction range end (unused)"),
+                    typed_option<sstring>("partition", "String representation of the partition key to compact (unused)"),
+            },
+            {
+                    {"compaction_arg", bpo::value<std::vector<sstring>>(), "[<keyspace> <tables>...] or [<SStable files>...] ", -1},
+            }},
+            compact_operation},
 };
 
 // boost::program_options doesn't allow multi-char option short-form,

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -72,7 +72,7 @@ void configure_tool_mode(app_template::seastar_options& opts, const sstring& log
 
 int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int(const operation&, const boost::program_options::variables_map&)> main_func) {
     const operation* found_op = nullptr;
-    if (std::strcmp(argv[1], "--help") != 0 && std::strcmp(argv[1], "-h") != 0) {
+    if (std::strncmp(argv[1], "--help", 6) != 0 && std::strcmp(argv[1], "-h") != 0) {
         found_op = &tools::utils::get_selected_operation(argc, argv, _cfg.operations, "operation");
     }
 

--- a/utils/http.hh
+++ b/utils/http.hh
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/coroutine/all.hh>
+#include <seastar/http/client.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/net/tls.hh>
+
+#include "seastarx.hh"
+#include "log.hh"
+
+namespace utils::http {
+
+class dns_connection_factory : public seastar::http::experimental::connection_factory {
+protected:
+    std::string _host;
+    int _port;
+    logging::logger& _logger;
+    struct state {
+        bool initialized = false;
+        socket_address addr;
+        ::shared_ptr<tls::certificate_credentials> creds;
+    };
+    lw_shared_ptr<state> _state;
+    shared_future<> _done;
+
+    future<> initialize(bool use_https) {
+        auto state = _state;
+
+        co_await coroutine::all(
+            [state, host = _host, port = _port] () -> future<> {
+                auto hent = co_await net::dns::get_host_by_name(host, net::inet_address::family::INET);
+                state->addr = socket_address(hent.addr_list.front(), port);
+            },
+            [state, use_https] () -> future<> {
+                if (use_https) {
+                    tls::credentials_builder cbuild;
+                    co_await cbuild.set_system_trust();
+                    state->creds = cbuild.build_certificate_credentials();
+                }
+            }
+        );
+
+        state->initialized = true;
+        _logger.debug("Initialized factory, address={} tls={}", state->addr, state->creds == nullptr ? "no" : "yes");
+    }
+
+public:
+    dns_connection_factory(std::string host, int port, bool use_https, logging::logger& logger)
+        : _host(std::move(host))
+        , _port(port)
+        , _logger(logger)
+        , _state(make_lw_shared<state>())
+        , _done(initialize(use_https))
+    {
+    }
+
+    virtual future<connected_socket> make() override {
+        if (!_state->initialized) {
+            _logger.debug("Waiting for factory to initialize");
+            co_await _done.get_future();
+        }
+
+        if (_state->creds) {
+            _logger.debug("Making new HTTPS connection addr={} host={}", _state->addr, _host);
+            co_return co_await tls::connect(_state->creds, _state->addr, tls::tls_options{.server_name = _host});
+        } else {
+            _logger.debug("Making new HTTP connection");
+            co_return co_await seastar::connect(_state->addr, {}, transport::TCP);
+        }
+    }
+};
+
+} // namespace utils::http


### PR DESCRIPTION
This series introduces a scylla-native nodetool.  It is invokable via the main scylla executable as the other native tools we have. It uses the seastar's new `http::client` to connect to the specified node and execute the desired commands.
For now a single command is implemented: `nodetool compact`, invokable as `scylla nodetool compact`. Once all the boilerplate is added to create a new tool, implementing a single command is not too bad, in terms of code-bloat. Certainly not as clean as a python implementation would be, but good enough. The advantages of a C++ implementation is that all of us in the core team know C++ and that it is shipped right as part of the scylla executable..