### PR TITLE
token_metadata::get_endpoint_to_host_id_map_for_reading: restrict to token owners

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -465,7 +465,7 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"Retrieve the mapping of endpoint to host ID",
+               "summary":"Retrieve the mapping of endpoint to host ID of all nodes that own tokens",
                "type":"array",
                "items":{
                   "type":"mapper"

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -561,7 +561,15 @@ std::unordered_map<inet_address, host_id> token_metadata_impl::get_endpoint_to_h
     std::unordered_map<inet_address, host_id> map;
     map.reserve(nodes.size());
     for (const auto& [endpoint, node] : nodes) {
-        map[endpoint] = node->host_id();
+        // Restrict to token-owners
+        if (!(node->is_normal() || node->is_leaving())) {
+            continue;
+        }
+        if (const auto& host_id = node->host_id()) {
+            map[endpoint] = host_id;
+        } else {
+            on_internal_error_noexcept(tlogger, fmt::format("get_endpoint_to_host_id_map_for_reading: endpoint {} has null host_id", endpoint));
+        }
     }
     return map;
 }


### PR DESCRIPTION
And verify the they returned host_id isn't null.
Call on_internal_error_noexcept in that case
since all token owners are expected to have their
host_id set. Aborting in testing would help fix
issues in this area.

Fixes scylladb/scylladb#14843
Refs scylladb/scylladb#14793