### PR TITLE
Concurrent tablet migration and balancing

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -75,6 +75,20 @@ tablet_transition_info::tablet_transition_info(tablet_transition_stage stage, ta
     , reads(get_selector_for_reads(stage))
 { }
 
+tablet_migration_streaming_info get_migration_streaming_info(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
+    tablet_migration_streaming_info result = {
+        .read_from = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end()),
+        .written_to = std::unordered_set<tablet_replica>(trinfo.next.begin(), trinfo.next.end())
+    };
+    for (auto&& r : trinfo.next) {
+        result.read_from.erase(r);
+    }
+    for (auto&& r : tinfo.replicas) {
+        result.written_to.erase(r);
+    }
+    return result;
+}
+
 tablet_replica get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
     std::unordered_set<tablet_replica> leaving(tinfo.replicas.begin(), tinfo.replicas.end());
     for (auto&& r : trinfo.next) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -190,6 +190,10 @@ future<> tablet_map::for_each_tablet(seastar::noncopyable_function<void(tablet_i
     }
 }
 
+void tablet_map::clear_transitions() {
+    _transitions.clear();
+}
+
 std::optional<shard_id> tablet_map::get_shard(tablet_id tid, host_id host) const {
     auto&& info = get_tablet_info(tid);
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -75,6 +75,20 @@ tablet_transition_info::tablet_transition_info(tablet_transition_stage stage, ta
     , reads(get_selector_for_reads(stage))
 { }
 
+tablet_replica get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
+    std::unordered_set<tablet_replica> leaving(tinfo.replicas.begin(), tinfo.replicas.end());
+    for (auto&& r : trinfo.next) {
+        leaving.erase(r);
+    }
+    if (leaving.empty()) {
+        throw std::runtime_error(format("No leaving replicas"));
+    }
+    if (leaving.size() > 1) {
+        throw std::runtime_error(format("More than one leaving replica"));
+    }
+    return *leaving.begin();
+}
+
 const tablet_map& tablet_metadata::get_tablet_map(table_id id) const {
     try {
         return _tablets.at(id);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -293,6 +293,7 @@ public:
 public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
+    void clear_transitions();
 
     // Destroys gently.
     // The tablet map is not usable after this call and should be destroyed.
@@ -326,6 +327,7 @@ private:
 public:
     const tablet_map& get_tablet_map(table_id id) const;
     const table_to_tablet_map& all_tables() const { return _tablets; }
+    table_to_tablet_map& all_tables() { return _tablets; }
     size_t external_memory_usage() const;
 public:
     void set_tablet_map(table_id, tablet_map);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -168,6 +168,9 @@ struct tablet_transition_info {
     bool operator==(const tablet_transition_info&) const = default;
 };
 
+// Returns the leaving replica for a given transition.
+tablet_replica get_leaving_replica(const tablet_info&, const tablet_transition_info&);
+
 /// Stores information about tablets of a single table.
 ///
 /// The map contains a constant number of tablets, tablet_count().

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -171,6 +171,14 @@ struct tablet_transition_info {
 // Returns the leaving replica for a given transition.
 tablet_replica get_leaving_replica(const tablet_info&, const tablet_transition_info&);
 
+/// Describes streaming required for a given tablet transition.
+struct tablet_migration_streaming_info {
+    std::unordered_set<tablet_replica> read_from;
+    std::unordered_set<tablet_replica> written_to;
+};
+
+tablet_migration_streaming_info get_migration_streaming_info(const tablet_info&, const tablet_transition_info&);
+
 /// Stores information about tablets of a single table.
 ///
 /// The map contains a constant number of tablets, tablet_count().

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1744,6 +1744,11 @@ class topology_coordinator {
 
     // Returns true if the state machine was transitioned into tablet migration path.
     future<bool> maybe_start_tablet_migration(group0_guard);
+
+    future<> await_event() {
+        _as.check();
+        co_await _topo_sm.event.when();
+    }
 public:
     topology_coordinator(
             sharded<db::system_distributed_keyspace>& sys_dist_ks,
@@ -1817,7 +1822,7 @@ future<> topology_coordinator::run() {
             if (!had_work) {
                 // Nothing to work on. Wait for topology change event.
                 slogger.trace("raft topology: topology coordinator fiber has nothing to do. Sleeping.");
-                co_await _topo_sm.event.when();
+                co_await await_event();
                 slogger.trace("raft topology: topology coordinator fiber got an event");
             }
         } catch (raft::request_aborted&) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -65,6 +65,13 @@ seastar::logger lblogger("load_balancer");
 /// means that many under-loaded nodes can be driven forward to balance concurrently because the load balancer
 /// will alternate between them across make_plan() calls.
 ///
+/// If the algorithm is called with active tablet migrations in tablet metadata, those are treated
+/// by load balancer as if they were already completed. This allows the algorithm to incrementally
+/// make decision which when executed with active migrations will produce the desired result.
+/// Overload of shards which still contain migrated-away tablets is limited by the fact
+/// that the algorithm tracks streaming concurrency on both source and target shards of active
+/// migrations and takes concurrency limit into account when producing new migrations.
+///
 /// The cost of make_plan() is relatively heavy in terms of preparing data structures, so the current
 /// implementation is not efficient if the scheduler would like to call make_plan() multiple times
 /// to parallelize execution. This will be addressed in the future by keeping the data structures
@@ -79,7 +86,13 @@ class load_balancer {
     using load_type = double;
 
     struct shard_load {
-        size_t tablet_count;
+        size_t tablet_count = 0;
+
+        // Number of tablets which are streamed from this shard.
+        size_t streaming_read_load = 0;
+
+        // Number of tablets which are streamed to this shard.
+        size_t streaming_write_load = 0;
 
         // Tablets which still have a replica on this shard which are candidates for migrating away from this shard.
         std::unordered_set<global_tablet_id> candidates;
@@ -120,7 +133,65 @@ class load_balancer {
         }
     };
 
+    // Per-shard limits for active tablet streaming sessions.
+    //
+    // There is no hard reason for these values being what they are other than
+    // the guidelines below.
+    //
+    // We want to limit concurrency of active streaming for several reasons.
+    // One is that we want to prevent over-utilization of memory required to carry out streaming,
+    // as that may lead to OOM or excessive cache eviction.
+    //
+    // There is no network scheduler yet, so we want to avoid over-utilization of network bandwidth.
+    // Limiting per-shard concurrency is a lame way to achieve that, but it's better than nothing.
+    //
+    // Scheduling groups should limit impact of streaming on other kinds of processes on the same node,
+    // so this aspect is not the reason for limiting concurrency.
+    //
+    // We don't want too much parallelism because it means that we have plenty of migrations
+    // which progress slowly. It's better to have fewer which complete faster because
+    // less user requests suffer from double-quorum overhead, and under-loaded nodes can take
+    // the load sooner. At the same time, we want to have enough concurrency to fully utilize resources.
+    //
+    // Streaming speed is supposed to be I/O bound and writes are more expensive in terms of IO than reads,
+    // so we allow more read concurrency.
+    //
+    // We allow at least two sessions per shard so that there is less chance for idling until load balancer
+    // makes the next decision after streaming is finished.
+    const size_t max_write_streaming_load = 2;
+    const size_t max_read_streaming_load = 4;
+
     token_metadata_ptr _tm;
+private:
+    tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
+        // We reflect migrations in the load as if they already happened,
+        // optimistically assuming that they will succeed.
+        return trinfo ? trinfo->next : ti.replicas;
+    }
+
+    // Whether to count the tablet as putting streaming load on the system.
+    // Tablets which are streaming or are yet-to-stream are counted.
+    bool is_streaming(const tablet_transition_info* trinfo) {
+        if (!trinfo) {
+            return false;
+        }
+        switch (trinfo->stage) {
+            case tablet_transition_stage::allow_write_both_read_old:
+                return true;
+            case tablet_transition_stage::write_both_read_old:
+                return true;
+            case tablet_transition_stage::streaming:
+                return true;
+            case tablet_transition_stage::write_both_read_new:
+                return false;
+            case tablet_transition_stage::use_new:
+                return false;
+            case tablet_transition_stage::cleanup:
+                return false;
+        }
+        on_internal_error(lblogger, format("Invalid transition stage: {}", static_cast<int>(trinfo->stage)));
+    }
+
 public:
     load_balancer(token_metadata_ptr tm)
         : _tm(std::move(tm)) {
@@ -162,9 +233,14 @@ public:
 
         // Compute tablet load on nodes.
 
-        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
+        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
+            auto& tmap = tmap_;
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) {
-                for (auto&& replica : ti.replicas) {
+                auto trinfo = tmap.get_tablet_transition_info(tid);
+
+                // We reflect migrations in the load as if they already happened,
+                // optimistically assuming that they will succeed.
+                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
                     if (nodes.contains(replica.host)) {
                         nodes[replica.host].tablet_count += 1;
                         // This invariant is assumed later.
@@ -209,45 +285,50 @@ public:
         // We want to saturate the target node so we migrate several tablets in parallel, one for each shard
         // on the target node. This assumes that the target node is well-balanced and that tablet migrations
         // complete at the same time. Both assumptions are not generally true in practice, which we currently ignore.
-        // If target node is not balanced across shards, we will overload some shards.
-        // If tablets are not balanced in size, throughput will suffer because some shards will be idle sooner than others.
+        // But they will be true typically, because we fill shards starting from least-loaded shards,
+        // so we naturally strive towards balance between shards.
         //
-        // FIXME: To handle the above, we should (1) rebalance the target node
-        // before migrating tablets from other nodes. If shards are balanced on the target node, the balancer
-        // will naturally distribute tablets to different shards. Also, (2) we should change this algorithm
-        // to be a generator for migrations and have a scheduler in the execution layer which pulls migrations
-        // from this algorithm, batches them and decides how many to execute.
-        //
-        // The scheduler decides in which order to execute the plan based on current activity in the system.
-        // We cannot just ask the planner for the next migration and stop when we hit overload on some shard,
-        // because that can lead to underutilization of the cluster. Just because the next migration is blocked
-        // by the target shard being busy doesn't mean we could not proceed with migrations for other shards
-        // which would be produced by the planner subsequently.
+        // If target node is not balanced across shards, we will overload some shards. Streaming concurrency
+        // will suffer because more loaded shards will not participate, which will under-utilize the node.
+        // FIXME: To handle the above, we should rebalance the target node before migrating tablets from other nodes.
 
         auto target_node = topo.find_node(target);
         auto batch_size = target_node->get_shard_count();
 
         // Compute per-shard load and candidate tablets.
 
-        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
-            if (!tmap.transitions().empty()) {
-                // FIXME: The algorithm doesn't support balancing with active transitions yet. They must finish first.
-                lblogger.warn("Pending transitions active.");
-                co_return migration_plan();
-            }
-
+        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
+            auto& tmap = tmap_;
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) {
-                for (auto&& replica : ti.replicas) {
+                auto trinfo = tmap.get_tablet_transition_info(tid);
+
+                if (is_streaming(trinfo)) {
+                    auto streaming_info = get_migration_streaming_info(ti, *trinfo);
+                    for (auto&& replica : streaming_info.read_from) {
+                        if (nodes.contains(replica.host)) {
+                            nodes[replica.host].shards[replica.shard].streaming_read_load += 1;
+                        }
+                    }
+                    for (auto&& replica : streaming_info.written_to) {
+                        if (nodes.contains(replica.host)) {
+                            nodes[replica.host].shards[replica.shard].streaming_write_load += 1;
+                        }
+                    }
+                }
+
+                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
                     if (!nodes.contains(replica.host)) {
                         continue;
                     }
                     auto& node_load_info = nodes[replica.host];
-                    auto&& shard_load_info = node_load_info.shards[replica.shard];
+                    shard_load& shard_load_info = node_load_info.shards[replica.shard];
                     if (shard_load_info.tablet_count == 0) {
                         node_load_info.shards_by_load.push_back(replica.shard);
                     }
                     shard_load_info.tablet_count += 1;
-                    shard_load_info.candidates.emplace(global_tablet_id{table, tid});
+                    if (!trinfo) { // migrating tablets are not candidates
+                        shard_load_info.candidates.emplace(global_tablet_id {table, tid});
+                    }
                 }
             });
         }
@@ -283,6 +364,8 @@ public:
         const tablet_metadata& tmeta = _tm->tablets();
         load_type max_off_candidate_load = 0; // max load among nodes which ran out of candidates.
         auto& target_info = nodes[target];
+        const size_t max_skipped_migrations = target_info.shards.size() * 2;
+        size_t skipped_migrations = 0;
         while (plan.size() < batch_size && !nodes_by_load.empty()) {
             co_await coroutine::maybe_yield();
 
@@ -385,8 +468,30 @@ public:
             }
 
             auto dst = global_shard_id {target, target_load.next_shard(target)};
-            lblogger.debug("Select {} to move from {} to {}", source_tablet, src, dst);
-            plan.push_back(tablet_migration_info {source_tablet, src, dst});
+            auto mig = tablet_migration_info {source_tablet, src, dst};
+
+            if (target_info.shards[dst.shard].streaming_write_load < max_write_streaming_load
+                    && src_node_info.shards[src_shard].streaming_read_load < max_read_streaming_load) {
+                target_info.shards[dst.shard].streaming_write_load += 1;
+                src_node_info.shards[src_shard].streaming_read_load += 1;
+                lblogger.debug("Adding migration: {}", mig);
+                plan.push_back(std::move(mig));
+            } else {
+                // Shards are overloaded with streaming. Do not include the migration in the plan, but
+                // continue as if it was in the hope that we will find a migration which can be executed without
+                // violating the load. Next make_plan() invocation will notice that the migration was not executed.
+                // We should not just stop here because that can lead to underutilization of the cluster.
+                // Just because the next migration is blocked doesn't mean we could not proceed with migrations
+                // for other shards which are produced by the planner subsequently.
+                lblogger.debug("Migration {} skipped because of load limit: src_load={}, dst_load={}", mig,
+                               src_node_info.shards[src_shard].streaming_read_load,
+                               target_info.shards[dst.shard].streaming_write_load);
+                skipped_migrations++;
+                if (skipped_migrations >= max_skipped_migrations) {
+                    lblogger.debug("Too many migrations skipped, aborting balancing");
+                    break;
+                }
+            }
 
             target_info.tablet_count += 1;
             target_info.update();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -502,3 +502,8 @@ tablet_allocator_impl& tablet_allocator::impl() {
 }
 
 }
+
+auto fmt::formatter<service::tablet_migration_info>::format(const service::tablet_migration_info& mig, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{tablet: {}, src: {}, dst: {}}}", mig.tablet, mig.src, mig.dst);
+}

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -398,7 +398,6 @@ public:
                 // If balance is not achieved, still consider migrating from candidate nodes which have higher load than the target.
                 // max_off_candidate_load may be higher than the load of current candidate.
                 if (src_node_info.avg_load <= target_info.avg_load) {
-                    lblogger.debug("No more candidate nodes.");
                     lblogger.debug("No more candidate nodes. Next candidate is {} with avg_load={}, target's avg_load={}",
                             src_host, src_node_info.avg_load, target_info.avg_load);
                     break;

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -41,6 +41,13 @@ using migration_plan = utils::chunked_vector<tablet_migration_info>;
 ///        co_await execute(plan);
 ///    }
 ///
+/// It is ok to invoke the algorithm with already active tablet migrations. The algorithm will take them into account
+/// when balancing the load as if they already succeeded. This means that applying a series of migration plans
+/// produced by this function will give the same result regardless of whether applying they are fully executed or
+/// only initiated by creating corresponding transitions in tablet metadata.
+///
+/// The algorithm takes care of limiting the streaming load on the system, also by taking active migrations into account.
+///
 future<migration_plan> balance_tablets(locator::token_metadata_ptr);
 
 class tablet_allocator_impl;

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -61,3 +61,8 @@ public:
 };
 
 }
+
+template <>
+struct fmt::formatter<service::tablet_migration_info> : fmt::formatter<std::string_view> {
+    auto format(const service::tablet_migration_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -45,12 +45,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::publish_cdc_generation, "publish cdc generation"},
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
-    {topology::transition_state::tablet_allow_write_both_read_old, "tablet allow write both read old"},
-    {topology::transition_state::tablet_write_both_read_old, "tablet write both read old"},
-    {topology::transition_state::tablet_write_both_read_new, "tablet write both read new"},
-    {topology::transition_state::tablet_streaming, "tablet streaming"},
-    {topology::transition_state::tablet_use_new, "tablet use new"},
-    {topology::transition_state::tablet_cleanup, "tablet cleanup"},
+    {topology::transition_state::tablet_migration, "tablet migration"},
 };
 
 std::ostream& operator<<(std::ostream& os, topology::transition_state s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -73,14 +73,7 @@ struct topology {
         publish_cdc_generation,
         write_both_read_old,
         write_both_read_new,
-
-        // Tablet migration steps
-        tablet_allow_write_both_read_old,
-        tablet_write_both_read_old,
-        tablet_write_both_read_new,
-        tablet_streaming,
-        tablet_use_new,
-        tablet_cleanup,
+        tablet_migration,
     };
 
     std::optional<transition_state> tstate;


### PR DESCRIPTION
This change makes tablet load balancing more efficient by performing
migrations independently for different tablets, and making new load
balancing plans concurrently with active migrations. 

The migration track is interrupted by pending topology change operations.

The coordinator executes the load balancer on edges of tablet state
machine transitions. This allows new migrations to be started as soon
as tablets finish streaming.

The load balancer is also continuously invoked as long as it produces
a non-empty plan. This is in order to saturate the cluster with
streaming. A single make_plan() call is still not saturating, due
to the way algorithm is implemented.

Overload of shards is limited by the fact that load balancer algorithm tracks
streaming concurrency on both source and target shards of active
migrations and takes concurrency limit into account when producing new
migrations.
