### PR TITLE
Update sstable_requiring_cleanup on compaction completion

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1724,6 +1724,11 @@ bool compaction_manager::requires_cleanup(table_state& t, const sstables::shared
     return cs.sstables_requiring_cleanup.contains(sst);
 }
 
+const std::unordered_set<sstables::shared_sstable>& compaction_manager::sstables_requiring_cleanup(table_state& t) const {
+    const auto& cs = get_compaction_state(&t);
+    return cs.sstables_requiring_cleanup;
+}
+
 future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, std::optional<tasks::task_info> info) {
     constexpr auto sleep_duration = std::chrono::seconds(10);
     constexpr auto max_idle_duration = std::chrono::seconds(300);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -316,6 +316,8 @@ private:
 
     // Add sst to or remove it from the respective compaction_state.sstables_requiring_cleanup set.
     bool update_sstable_cleanup_state(table_state& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);
+
+    future<> on_compaction_completion(table_state& t, sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy);
 public:
     // Submit a table to be upgraded and wait for its termination.
     future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::table_state& t, bool exclude_current_version, std::optional<tasks::task_info> info = std::nullopt);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -422,6 +422,7 @@ public:
 
     // checks if the sstable is in the respective compaction_state.sstables_requiring_cleanup set.
     bool requires_cleanup(table_state& t, const sstables::shared_sstable& sst) const;
+    const std::unordered_set<sstables::shared_sstable>& sstables_requiring_cleanup(table_state& t) const;
 
     friend class compacting_sstable_registration;
     friend class compaction_weight_registration;

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -155,6 +155,8 @@ leveled_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> input
 
     auto max_sstable_size_in_bytes = _max_sstable_size_in_mb * 1024 * 1024;
 
+    clogger.debug("get_reshaping_job: mode={} input.size={} max_sstable_size_in_bytes={}", mode == reshape_mode::relaxed ? "relaxed" : "strict", input.size(), max_sstable_size_in_bytes);
+
     for (auto& sst : input) {
         auto sst_level = sst->get_sstable_level();
         if (sst_level > leveled_manifest::MAX_LEVELS - 1) {
@@ -237,6 +239,9 @@ leveled_compaction_strategy::get_cleanup_compaction_jobs(table_state& table_s, s
 }
 
 unsigned leveled_compaction_strategy::ideal_level_for_input(const std::vector<sstables::shared_sstable>& input, uint64_t max_sstable_size) {
+    if (!max_sstable_size) {
+        return 1;
+    }
     auto log_fanout = [fanout = leveled_manifest::leveled_fan_out] (double x) {
         double inv_log_fanout = 1.0f / std::log(fanout);
         return log(x) * inv_log_fanout;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2796,6 +2796,8 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 
 future<>
 sstable::unlink(storage::sync_dir sync) noexcept {
+    _on_delete(*this);
+
     auto remove_fut = _storage->wipe(*this, sync);
 
     try {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -412,6 +412,10 @@ public:
         return _on_closed.observe(on_closed_handler);
     }
 
+    utils::observer<sstable&> add_on_delete_handler(std::function<void (sstable&)> on_delete_handler) noexcept {
+        return _on_delete.observe(on_delete_handler);
+    }
+
     template<typename Func, typename... Args>
     requires std::is_nothrow_move_constructible_v<Func>
     auto sstable_write_io_check(Func&& func, Args&&... args) const noexcept {
@@ -503,6 +507,7 @@ private:
     std::optional<dht::decorated_key> _last;
     run_id _run_identifier;
     utils::observable<sstable&> _on_closed;
+    utils::observable<sstable&> _on_delete;
 
     lw_shared_ptr<file_input_stream_history> _single_partition_history = make_lw_shared<file_input_stream_history>();
     lw_shared_ptr<file_input_stream_history> _partition_range_history = make_lw_shared<file_input_stream_history>();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5015,6 +5015,7 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
         size_t last_input_sstable_count = sstables_nr;
         {
             auto t = env.make_table_for_tests(s);
+            auto& cm = t->get_compaction_manager();
             auto stop = deferred_stop(t);
             t->disable_auto_compaction().get();
             const dht::token_range_vector empty_owned_ranges;
@@ -5039,6 +5040,7 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
             ssts = {}; // releases references
             auto owned_ranges_ptr = make_lw_shared<const dht::token_range_vector>(std::move(owned_token_ranges));
             t->perform_cleanup_compaction(std::move(owned_ranges_ptr)).get();
+            BOOST_REQUIRE(cm.sstables_requiring_cleanup(t->as_table_state()).empty());
             testlog.info("Cleanup has finished");
         }
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -32,14 +32,18 @@ class column_family_test {
 public:
     column_family_test(lw_shared_ptr<replica::column_family> cf) : _cf(cf) {}
 
-    future<> add_sstable(sstables::shared_sstable sstable) {
+    future<> add_sstable(sstables::shared_sstable sstable, sstables::offstrategy offstrategy = sstables::offstrategy::no) {
+        if (offstrategy) {
+            // Otherwise, on_compaction_completion always adds the new_sstabes to the main set
+            return _cf->add_sstable_and_update_cache(sstable, offstrategy);
+        }
         auto new_sstables = { sstable };
         return _cf->as_table_state().on_compaction_completion(sstables::compaction_completion_desc{ .new_sstables = new_sstables }, sstables::offstrategy::no);
     }
 
     future<> rebuild_sstable_list(compaction::table_state& table_s, const std::vector<sstables::shared_sstable>& new_sstables,
-            const std::vector<sstables::shared_sstable>& sstables_to_remove) {
-        return table_s.on_compaction_completion(sstables::compaction_completion_desc{ .old_sstables = sstables_to_remove, .new_sstables = new_sstables }, sstables::offstrategy::no);
+            const std::vector<sstables::shared_sstable>& sstables_to_remove, sstables::offstrategy offstrategy = sstables::offstrategy::no) {
+        return table_s.on_compaction_completion(sstables::compaction_completion_desc{ .old_sstables = sstables_to_remove, .new_sstables = new_sstables }, offstrategy);
     }
 
     static void update_sstables_known_generation(replica::column_family& cf, sstables::generation_type generation) {


### PR DESCRIPTION
Currently `sstable_requiring_cleanup` is updated using `compacting_sstable_registration`, but that mechanism is not used by offstrategy compaction, leading to #14304.

This series introduces `compaction_manager::on_compaction_completion` that intercepts the call
to the table::on_compaction_completion. This allows us to update `sstable_requiring_cleanup` right before the compacted sstables are deleted, making sure they are no leaked to `sstable_requiring_cleanup`, which would hold a reference to them until cleanup attempts to clean them up.

`cleanup_incremental_compaction_test` was adjusted to observe the sstables `on_delete` (by adding a new observer event) to detect the case where cleanup attempts to delete the leaked sstables and fails since they were already deleted from the file system by offstrategy compaction. The test fails with the fix and passes with it.

Fixes #14304
