### PR TITLE
build: cmake: add missing source file

### DIFF
--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(scylla_auth
     allow_all_authorizer.cc
     authenticated_user.cc
     authenticator.cc
+    certificate_authenticator.cc
     common.cc
     default_authorizer.cc
     password_authenticator.cc


### PR DESCRIPTION
TLS certificate authenticator registers itself using a `class_registrator`. that's why CMake is able to build without compiling this source file. but for the sake of completeness, and to be sync with configure.py, let's add it to CMake.