### PR TITLE
Update seastar submodule

### DIFF
--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -41,7 +41,7 @@ SEASTAR_TEST_CASE(test_abort_server_on_background_error) {
             const auto& value_map = seastar::metrics::impl::get_value_map();
             const auto& metric_family = value_map.at("raft_group0_" + name);
             const auto& registered_metric = metric_family.at({{"shard", "0"}});
-            return (*registered_metric)().ui();
+            return registered_metric->get_function()().ui();
         };
 
         auto get_status = [&] {


### PR DESCRIPTION
* seastar c0e618bbb7...7fe5bdd6d8 (8):
  > coroutine: fix a use-after-free in maybe_yield
Ref #13730.
  > Merge 'sstring: add more accessors' from Kefu Chai
  > Merge 'semaphore: semaphore_units: return units when reassigned' from Benny Halevy
  > metrics: do not define defaulted copy assignment operator
  > HTTP headers in http_response are now case insensitive
  > rpc: Make server._proto a reference
  > Merge 'Cleanup class metrics::registered_metrics' from Pavel Emelyanov
  > core: undefine fallthrough to fix compilation error

Closes #14862

Also includes fix for group0_test in a way it accesses the metrics::impl data that had changed with the seastar update