### PR TITLE
De-static system_keyspace::*_group0_* methods

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2396,7 +2396,7 @@ future<utils::UUID> system_keyspace::get_last_group0_state_id() {
 }
 
 future<bool> system_keyspace::group0_history_contains(utils::UUID state_id) {
-    auto rs = co_await qctx->execute_cql(
+    auto rs = co_await execute_cql(
         format(
             "SELECT state_id FROM system.{} WHERE key = '{}' AND state_id = ?",
             GROUP0_HISTORY, GROUP0_HISTORY_KEY),

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2384,7 +2384,7 @@ future<> system_keyspace::set_raft_group0_id(utils::UUID uuid) {
 static constexpr auto GROUP0_HISTORY_KEY = "history";
 
 future<utils::UUID> system_keyspace::get_last_group0_state_id() {
-    auto rs = co_await qctx->execute_cql(
+    auto rs = co_await execute_cql(
         format(
             "SELECT state_id FROM system.{} WHERE key = '{}' LIMIT 1",
             GROUP0_HISTORY, GROUP0_HISTORY_KEY));

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -447,7 +447,7 @@ public:
     future<utils::UUID> get_raft_group0_id();
 
     // Persist Raft Group 0 id. Should be a TIMEUUID.
-    static future<> set_raft_group0_id(utils::UUID id);
+    future<> set_raft_group0_id(utils::UUID id);
 
     // Save advertised gossip feature set to system.local
     future<> save_local_supported_features(const std::set<std::string_view>& feats);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -454,7 +454,7 @@ public:
 
     // Get the last (the greatest in timeuuid order) state ID in the group 0 history table.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
-    static future<utils::UUID> get_last_group0_state_id();
+    future<utils::UUID> get_last_group0_state_id();
 
     // Checks whether the group 0 history table contains the given state ID.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -444,7 +444,7 @@ public:
     future<> cdc_set_rewritten(std::optional<cdc::generation_id_v1>);
 
     // Load Raft Group 0 id from scylla.local
-    static future<utils::UUID> get_raft_group0_id();
+    future<utils::UUID> get_raft_group0_id();
 
     // Persist Raft Group 0 id. Should be a TIMEUUID.
     static future<> set_raft_group0_id(utils::UUID id);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -458,7 +458,7 @@ public:
 
     // Checks whether the group 0 history table contains the given state ID.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
-    static future<bool> group0_history_contains(utils::UUID state_id);
+    future<bool> group0_history_contains(utils::UUID state_id);
 
     future<service::topology> load_topology_state();
     future<int64_t> get_topology_fence_version();

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -117,7 +117,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
 
     // max_mutation_size = 1/2 of commitlog segment size, thus max_command_size is set 1/3 of commitlog segment size to leave space for metadata.
     size_t max_command_size = _sp.data_dictionary().get_config().commitlog_segment_size_in_mb() * 1024 * 1024 / 3;
-    group0_state_machine_merger m(co_await db::system_keyspace::get_last_group0_state_id(), std::move(read_apply_mutex_holder),
+    group0_state_machine_merger m(co_await _client.sys_ks().get_last_group0_state_id(), std::move(read_apply_mutex_holder),
                                   max_command_size, _sp.data_dictionary());
 
     for (auto&& c : command) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -394,7 +394,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_
     assert(this_shard_id() == 0);
     assert(!joined_group0());
 
-    auto group0_id = raft::group_id{co_await db::system_keyspace::get_raft_group0_id()};
+    auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID present means we've already joined group 0 before.
         co_return co_await start_server_for_group0(group0_id, ss, qp, mm, cdc_gen_service);
@@ -560,7 +560,7 @@ future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service
         co_return;
     }
 
-    auto group0_id = raft::group_id{co_await db::system_keyspace::get_raft_group0_id()};
+    auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID is present => we've already joined group 0 earlier.
         group0_log.info("setup_group0: group 0 ID present. Starting existing Raft server.");

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -390,7 +390,7 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
 }
 
 future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
-                                  cdc::generation_service& cdc_gen_service) {
+                                  cdc::generation_service& cdc_gen_service, db::system_keyspace& sys_ks) {
     assert(this_shard_id() == 0);
     assert(!joined_group0());
 
@@ -608,7 +608,7 @@ future<> raft_group0::setup_group0(
     }
 
     group0_log.info("setup_group0: joining group 0...");
-    co_await join_group0(std::move(seeds), false /* non-voter */, ss, qp, mm, cdc_gen_service);
+    co_await join_group0(std::move(seeds), false /* non-voter */, ss, qp, mm, cdc_gen_service, sys_ks);
     group0_log.info("setup_group0: successfully joined group 0.");
 
     utils::get_local_injector().inject("stop_after_joining_group0", [&] {
@@ -1562,7 +1562,7 @@ future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state, ser
 
     if (!joined_group0()) {
         upgrade_log.info("Joining group 0...");
-        co_await join_group0(co_await _sys_ks.load_peers(), true, ss, qp, mm, cdc_gen_service);
+        co_await join_group0(co_await _sys_ks.load_peers(), true, ss, qp, mm, cdc_gen_service, _sys_ks);
     } else {
         upgrade_log.info(
             "We're already a member of group 0."

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -470,7 +470,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_
         // Try again after a pause
         co_await seastar::sleep_abortable(std::chrono::milliseconds{1000}, _abort_source);
     }
-    co_await db::system_keyspace::set_raft_group0_id(group0_id.id);
+    co_await sys_ks.set_raft_group0_id(group0_id.id);
     // Allow peer_exchange() RPC to access group 0 only after group0_id is persisted.
 
     _group0 = group0_id;

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -293,7 +293,7 @@ private:
     // Preconditions: Raft local feature enabled
     // and we haven't initialized group 0 yet after last Scylla start (`joined_group0()` is false).
     // Postcondition: `joined_group0()` is true.
-    future<> join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+    future<> join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service, db::system_keyspace& sys_ks);
 
     // Start an existing Raft server for the cluster-wide group 0.
     // Assumes the server was already added to the group earlier so we don't attempt to join it again.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -249,7 +249,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
             // Read barrier may wait for `group0_state_machine::apply` which also takes this mutex.
             auto read_apply_holder = co_await hold_read_apply_mutex();
 
-            auto observed_group0_state_id = co_await db::system_keyspace::get_last_group0_state_id();
+            auto observed_group0_state_id = co_await _sys_ks.get_last_group0_state_id();
             auto new_group0_state_id = generate_group0_state_id(observed_group0_state_id);
 
             co_return group0_guard {

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -197,7 +197,7 @@ future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard g
         // on this node to proceed
     } ();
 
-    if (!(co_await db::system_keyspace::group0_history_contains(new_group0_state_id))) {
+    if (!(co_await _sys_ks.group0_history_contains(new_group0_state_id))) {
         // The command was applied but the history table does not contain the new group 0 state ID.
         // This means `apply` skipped the change due to previous state ID mismatch.
         throw group0_concurrent_modification{};


### PR DESCRIPTION
These are users of global `qctx` variable or call `(get|set)_scylla_local_param(_as)?` which, in turn, also reference the `qctx`. Unfortunately, the latter(s) are still in use by other code and cannot be marked non-static in this PR