### PR TITLE
sstables-format-selector: Add and use system_keyspace dependency

### DIFF
--- a/db/sstables-format-selector.hh
+++ b/db/sstables-format-selector.hh
@@ -29,6 +29,7 @@ class feature_service;
 
 namespace db {
 
+class system_keyspace;
 class sstables_format_selector;
 
 class feature_enabled_listener : public gms::feature::listener {
@@ -47,6 +48,7 @@ class sstables_format_selector {
     gms::gossiper& _gossiper;
     sharded<gms::feature_service>& _features;
     sharded<replica::database>& _db;
+    db::system_keyspace& _sys_ks;
     seastar::named_semaphore _sem = {1, named_semaphore_exception_factory{"feature listeners"}};
     seastar::gate _sel;
 
@@ -58,7 +60,7 @@ class sstables_format_selector {
     future<> read_sstables_format();
 
 public:
-    sstables_format_selector(gms::gossiper& g, sharded<gms::feature_service>& f, sharded<replica::database>& db);
+    sstables_format_selector(gms::gossiper& g, sharded<gms::feature_service>& f, sharded<replica::database>& db, db::system_keyspace& sys_ks);
 
     future<> start();
     future<> stop();

--- a/main.cc
+++ b/main.cc
@@ -1295,7 +1295,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             bm.start(std::ref(qp), std::ref(sys_ks), bm_cfg).get();
 
-            db::sstables_format_selector sst_format_selector(gossiper.local(), feature_service, db);
+            db::sstables_format_selector sst_format_selector(gossiper.local(), feature_service, db, sys_ks.local());
 
             sst_format_selector.start().get();
             auto stop_format_selector = defer_verbose_shutdown("sstables format selector", [&sst_format_selector] {


### PR DESCRIPTION
The selector keeps selected format in system.local and uses static db::system_keyspace::(get|set)_scylla_local_param() helpers to access it. The helpers are turning into non-static so the selector should call those on system_keyspace object, not class