### PR TITLE
test: use BOOST_CHECK_EQUAL when appropriate in compaction_manager_ba…

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -178,13 +178,14 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
         return sleep(std::chrono::milliseconds(100));
     }).wait();
     // test no more running compactions
-    BOOST_REQUIRE(cm.get_stats().pending_tasks == 0 && cm.get_stats().active_tasks == 0);
+    BOOST_CHECK_EQUAL(cm.get_stats().pending_tasks, 0);
+    BOOST_CHECK_EQUAL(cm.get_stats().active_tasks, 0);
     // test compaction successfully finished
-    BOOST_REQUIRE(cm.get_stats().completed_tasks == 1);
-    BOOST_REQUIRE(cm.get_stats().errors == 0);
+    BOOST_CHECK_EQUAL(cm.get_stats().completed_tasks, 1);
+    BOOST_CHECK_EQUAL(cm.get_stats().errors, 0);
 
     // expect sstables of cf to be compacted.
-    BOOST_REQUIRE(cf->sstables_count() == 1);
+    BOOST_CHECK_EQUAL(cf->sstables_count(), 1);
   });
 }
 


### PR DESCRIPTION
…sic_test

compaction_manager_basic_test checks the stats of compaction_manager to verify that there are no ongoing or pending compactions after the triggering the compaction and waiting for its completion. but in #14865, there are still active compaction(s) after the compaction_manager's stats shows there is at least one task completed.

to understand this issue better, let's use `BOOST_CHECK_EQUAL()` instead of `BOOST_REQUIRE()`, so that the test does not error out when the check fails, and we can have better understanding of the status when the test fails.

Refs #14865
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>