### PR TITLE
raft_group0: log gaining and losing leadership on the INFO level

### DIFF
--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -96,6 +96,11 @@ class raft_group0 {
         aborted = 2
     } _status_for_monitoring;
 
+    // Fiber monitoring and logging gaining/losing leadership events in group 0.
+    future<> leadership_monitor_fiber();
+    future<> _leadership_monitor = make_ready_future<>();
+    abort_source _leadership_monitor_as;
+
 public:
     // Passed to `setup_group0` when replacing a node.
     struct replace_info {


### PR DESCRIPTION
Knowing that a server gained or lost leadership is sometimes useful for the purpose of debugging, so we log information about these events on the INFO level.

Gaining and losing leadership are relatively rare events, so this change shouldn't flood the logs.

Fixes #14524