### PR TITLE
Progress of compaction executors

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -752,6 +752,7 @@ private:
                 continue;
             }
 
+            _cdata.compaction_size += sst->data_size();
             // We also capture the sstable, so we keep it alive while the read isn't done
             ssts->insert(sst);
             // FIXME: If the sstables have cardinality estimation bitmaps, use that
@@ -1783,6 +1784,7 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
     auto permit = table_s.make_compaction_reader_permit();
 
     uint64_t validation_errors = 0;
+    cdata.compaction_size = boost::accumulate(descriptor.sstables | boost::adaptors::transformed([] (auto& sst) { return sst->data_size(); }), int64_t(0));
 
     for (const auto& sst : descriptor.sstables) {
         clogger.info("Scrubbing in validate mode {}", sst->get_filename());

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -121,7 +121,7 @@ compaction_progress_monitor& default_compaction_progress_monitor();
 //
 // compaction_descriptor is responsible for specifying the type of compaction, and influencing
 // compaction behavior through its available member fields.
-future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s);
+future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s, compaction_progress_monitor& progress_monitor = default_compaction_progress_monitor());
 
 // Return list of expired sstables for column family cf.
 // A sstable is fully expired *iff* its max_local_deletion_time precedes gc_before and its

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -100,6 +100,22 @@ struct compaction_result {
     compaction_stats stats;
 };
 
+class read_monitor_generator;
+
+class compaction_progress_monitor {
+    std::unique_ptr<read_monitor_generator> _generator = nullptr;
+    uint64_t _progress = 0;
+public:
+    void set_generator(std::unique_ptr<read_monitor_generator> generator);
+    void reset_generator();
+    // Returns number of bytes processed with _generator.
+    uint64_t get_progress() const;
+
+    friend class compaction;
+};
+
+compaction_progress_monitor& default_compaction_progress_monitor();
+
 // Compact a list of N sstables into M sstables.
 // Returns info about the finished compaction, which includes vector to new sstables.
 //

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -48,6 +48,7 @@ struct compaction_info {
 };
 
 struct compaction_data {
+    uint64_t compaction_size = 0;
     uint64_t total_partitions = 0;
     uint64_t total_keys_written = 0;
     sstring stop_requested;

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -112,6 +112,7 @@ public:
     uint64_t get_progress() const;
 
     friend class compaction;
+    friend future<compaction_result> scrub_sstables_validate_mode(sstables::compaction_descriptor, compaction_data&, table_state&, compaction_progress_monitor&);
 };
 
 compaction_progress_monitor& default_compaction_progress_monitor();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -345,7 +345,7 @@ public:
     // parameter type is the compaction type the operation can most closely be
     //      associated with, use compaction_type::Compaction, if none apply.
     // parameter job is a function that will carry the operation
-    future<> run_custom_job(compaction::table_state& s, sstables::compaction_type type, const char *desc, noncopyable_function<future<>(sstables::compaction_data&)> job, std::optional<tasks::task_info> info, throw_if_stopping do_throw_if_stopping);
+    future<> run_custom_job(compaction::table_state& s, sstables::compaction_type type, const char *desc, noncopyable_function<future<>(sstables::compaction_data&, sstables::compaction_progress_monitor&)> job, std::optional<tasks::task_info> info, throw_if_stopping do_throw_if_stopping);
 
     class compaction_reenabler {
         compaction_manager& _cm;
@@ -475,6 +475,7 @@ protected:
     sstables::compaction_data _compaction_data;
     state _state = state::none;
     throw_if_stopping _do_throw_if_stopping;
+    sstables::compaction_progress_monitor _progress_monitor;
 
 private:
     shared_future<compaction_manager::compaction_stats_opt> _compaction_done = make_ready_future<compaction_manager::compaction_stats_opt>();

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -156,7 +156,7 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
     // jobs. But only one will run in parallel at a time
     auto& t = table.as_table_state();
     co_await coroutine::parallel_for_each(buckets, [&] (std::vector<sstables::shared_sstable>& sstlist) mutable {
-        return table.get_compaction_manager().run_custom_job(table.as_table_state(), sstables::compaction_type::Reshard, "Reshard compaction", [&] (sstables::compaction_data& info) -> future<> {
+        return table.get_compaction_manager().run_custom_job(table.as_table_state(), sstables::compaction_type::Reshard, "Reshard compaction", [&] (sstables::compaction_data& info, sstables::compaction_progress_monitor& progress_monitor) -> future<> {
             auto erm = table.get_effective_replication_map(); // keep alive around compaction.
 
             sstables::compaction_descriptor desc(sstlist);
@@ -165,7 +165,7 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
             desc.sharder = &erm->get_sharder(*table.schema());
             desc.owned_ranges = owned_ranges_ptr;
 
-            auto result = co_await sstables::compact_sstables(std::move(desc), info, t);
+            auto result = co_await sstables::compact_sstables(std::move(desc), info, t, progress_monitor);
             // input sstables are moved, to guarantee their resources are released once we're done
             // resharding them.
             co_await when_all_succeed(dir.collect_output_unshared_sstables(std::move(result.new_sstables), sstables::sstable_directory::can_be_remote::yes), dir.remove_sstables(std::move(sstlist))).discard_result();
@@ -452,8 +452,8 @@ future<> shard_reshaping_compaction_task_impl::run() {
 
         std::exception_ptr ex;
         try {
-            co_await table.get_compaction_manager().run_custom_job(table.as_table_state(), sstables::compaction_type::Reshape, "Reshape compaction", [&dir = _dir, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable -> future<> {
-                sstables::compaction_result result = co_await sstables::compact_sstables(std::move(desc), info, table.as_table_state());
+            co_await table.get_compaction_manager().run_custom_job(table.as_table_state(), sstables::compaction_type::Reshape, "Reshape compaction", [&dir = _dir, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info, sstables::compaction_progress_monitor& progress_monitor) mutable -> future<> {
+                sstables::compaction_result result = co_await sstables::compact_sstables(std::move(desc), info, table.as_table_state(), progress_monitor);
                 co_await dir.remove_unshared_sstables(std::move(sstlist));
                 co_await dir.collect_output_unshared_sstables(std::move(result.new_sstables), sstables::sstable_directory::can_be_remote::no);
             }, info, throw_if_stopping::yes);

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -41,6 +41,8 @@ public:
     virtual std::string type() const override = 0;
 protected:
     virtual future<> run() override = 0;
+
+    future<tasks::task_manager::task::progress> get_progress(const sstables::compaction_data& cdata, const sstables::compaction_progress_monitor& progress_monitor) const;
 };
 
 class major_compaction_task_impl : public compaction_task_impl {

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -59,7 +59,8 @@ future<uint64_t> validate(
         shared_sstable sstable,
         reader_permit permit,
         abort_source& abort,
-        std::function<void(sstring)> error_handler);
+        std::function<void(sstring)> error_handler,
+        sstables::read_monitor& monitor);
 
 } // namespace mx
 } // namespace sstables

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1716,12 +1716,12 @@ sstable_writer sstable::get_writer(const schema& s, uint64_t estimated_partition
 }
 
 future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,
-        std::function<void(sstring)> error_handler) {
+        std::function<void(sstring)> error_handler, sstables::read_monitor& monitor) {
     if (_version >= sstable_version_types::mc) {
-        co_return co_await mx::validate(shared_from_this(), std::move(permit), abort, std::move(error_handler));
+        co_return co_await mx::validate(shared_from_this(), std::move(permit), abort, std::move(error_handler), monitor);
     }
 
-    auto reader = make_crawling_reader(_schema, permit, nullptr);
+    auto reader = make_crawling_reader(_schema, permit, nullptr, monitor);
 
     uint64_t errors = 0;
     std::exception_ptr ex;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -305,7 +305,7 @@ public:
     // (e.g. parse error), it will return with validation error count seen up to
     // the abort. In the latter case it will call the error-handler before doing so.
     future<uint64_t> validate(reader_permit permit, abort_source& abort,
-            std::function<void(sstring)> error_handler);
+            std::function<void(sstring)> error_handler, sstables::read_monitor& monitor = default_read_monitor());
 
     encoding_stats get_encoding_stats_for_compaction() const;
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -115,6 +115,10 @@ bool task_manager::task::impl::is_complete() const noexcept {
     return _status.state == tasks::task_manager::task_state::done || _status.state == tasks::task_manager::task_state::failed;
 }
 
+bool task_manager::task::impl::is_done() const noexcept {
+    return _status.state == tasks::task_manager::task_state::done;
+}
+
 void task_manager::task::impl::run_to_completion() {
     (void)run().then_wrapped([this] (auto f) {
         if (f.failed()) {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -127,6 +127,7 @@ public:
             virtual tasks::is_internal is_internal() const noexcept;
             virtual future<> abort() noexcept;
             bool is_complete() const noexcept;
+            bool is_done() const noexcept;
             virtual void release_resources() noexcept {}
         protected:
             virtual future<> run() = 0;


### PR DESCRIPTION
compaction_read_monitor_generator is an existing mechanism
for monitoring progress of sstables reading during compaction.
In this change information gathered by compaction_read_monitor_generator
is utilized by task manager compaction tasks of the lowest level, 
i.e. compaction executors, to calculate task progress.

compaction_read_monitor_generator has a flag, which decides whether
monitored changes will be registered by compaction_backlog_tracker.
This allows us to pass the generator to all compaction readers without
impacting the backlog.

Task executors have access to compaction_read_monitor_generator_wrapper,
which protects the internals of  compaction_read_monitor_generator
and provides only the necessary functionality.
 