### PR TITLE
tools/scylla-sstable: mark const variable with constexpr

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2742,7 +2742,7 @@ for more information on this operation, including the API documentation.
 namespace tools {
 
 int scylla_sstable_main(int argc, char** argv) {
-    const auto description_template =
+    constexpr auto description_template =
 R"(scylla-sstable - a multifunctional command-line tool to examine the content of sstables.
 
 Usage: scylla sstable {{operation}} [--option1] [--option2] ... [{{sstable_path1}}] [{{sstable_path2}}] ...


### PR DESCRIPTION
this change changes `const` to `constexpr`. because the string literal defined here is not only immutable, but also initialized at compile-time, and can be used by constexpr expressions and functions.

this change is introduced to reduce the size of the change when moving to compile-time format string in future. so far, seastar::format() does not use the compile-time format string, but we have patches pending on review implementing this. and the author of this change has local branches implementing the changes on scylla side to support compile-time format string, which practically replaces most of the `format()` calls with `seastar::format()`.

to reduce the size of the change and the pain of rebasing, some of the less controversial changes are extracted and upstreamed. this one is one of them.

this change also addresses following compilation failure:

```
/home/kefu/dev/scylladb/tools/scylla-sstable.cc:2836:44: error: call to consteval function 'fmt::basic_format_string<char, const char *const &, seastar::basic_sstring<char, unsigned int, 15>>::basic_format_string<const char *, 0>' is not a constant expression
 2836 |             .description = seastar::format(description_template, app_name, boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
      |                                            ^
/usr/include/fmt/core.h:3148:67: note: read of non-constexpr variable 'description_template' is not allowed in a constant expression
 3148 |   FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
      |                                                                   ^
```