### PR TITLE
test: wait until there is no pending tasks in compaction_manager_basic_test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -173,8 +173,11 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
 
     BOOST_REQUIRE(cf->sstables_count() == idx.size());
     cf->trigger_compaction();
-    // wait for submitted job to finish.
-    do_until([&cm] { return cm.get_stats().completed_tasks > 0; }, [] {
+    // wait for submitted job to finish and there is no pending tasks
+    do_until([&cm] {
+        return (cm.get_stats().completed_tasks > 0 &&
+                cm.get_stats().pending_tasks == 0);
+    }, [] {
         return sleep(std::chrono::milliseconds(100));
     }).wait();
     // test no more running compactions


### PR DESCRIPTION
before this change, after triggering the compaction, compaction_manager_basic_test waits until the triggered compaction completes. and the regular compaction is run in a loop which does not stop until either the daemon is stopping, or there is no more sstables to be compacted, or the compaction is disabled.

but we only get the input sstables for compaction after swiching to the "pending" state, and acquiring the read lock of the compaction_state, and acquiring the read lock is implemented as a coroutine, so there is chance that coroutine is suspended, and the execution switches to the test. in this case, the test will find that even after the triggered compaction completes, there are still one or more pending compactions. hence the test fails.

to address this problem, instead of just waiting for the compaction to complete, we also wait until the number of pending compaction tasks is 0. so that even if the test manages to sneak into the time window, it won't proceed and start checking the compaction manager's stats.

Fixes #14865
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>