### PR TITLE
De-static system_keyspace's [gs]et_scylla_local_param(_as)?

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1668,8 +1668,8 @@ future<> system_keyspace::set_scylla_local_param_as(const sstring& key, const T&
     co_await qctx->execute_cql(req, type->to_string_impl(data_value(value)), key).discard_result();
     // Flush the table so that the value is available on boot before commitlog replay.
     // database::maybe_init_schema_commitlog() depends on it.
-    co_await smp::invoke_on_all([] () -> future<> {
-        co_await qctx->qp().db().real_database().flush(db::system_keyspace::NAME, system_keyspace::SCYLLA_LOCAL);
+    co_await container().invoke_on_all([] (auto& sys_ks) -> future<> {
+        co_await sys_ks._db.flush(db::system_keyspace::NAME, system_keyspace::SCYLLA_LOCAL);
     });
 }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1665,7 +1665,7 @@ template <typename T>
 future<> system_keyspace::set_scylla_local_param_as(const sstring& key, const T& value) {
     sstring req = format("UPDATE system.{} SET value = ? WHERE key = ?", system_keyspace::SCYLLA_LOCAL);
     auto type = data_type_for<T>();
-    co_await qctx->execute_cql(req, type->to_string_impl(data_value(value)), key).discard_result();
+    co_await execute_cql(req, type->to_string_impl(data_value(value)), key).discard_result();
     // Flush the table so that the value is available on boot before commitlog replay.
     // database::maybe_init_schema_commitlog() depends on it.
     co_await container().invoke_on_all([] (auto& sys_ks) -> future<> {
@@ -1676,7 +1676,7 @@ future<> system_keyspace::set_scylla_local_param_as(const sstring& key, const T&
 template <typename T>
 future<std::optional<T>> system_keyspace::get_scylla_local_param_as(const sstring& key) {
     sstring req = format("SELECT value FROM system.{} WHERE key = ?", system_keyspace::SCYLLA_LOCAL);
-    return qctx->execute_cql(req, key).then([] (::shared_ptr<cql3::untyped_result_set> res)
+    return execute_cql(req, key).then([] (::shared_ptr<cql3::untyped_result_set> res)
             -> future<std::optional<T>> {
         if (res->empty() || !res->one().has("value")) {
             return make_ready_future<std::optional<T>>(std::optional<T>());

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1662,7 +1662,7 @@ template future<> system_keyspace::update_peer_info<utils::UUID>(gms::inet_addre
 template future<> system_keyspace::update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address);
 
 template <typename T>
-future<> set_scylla_local_param_as(const sstring& key, const T& value) {
+future<> system_keyspace::set_scylla_local_param_as(const sstring& key, const T& value) {
     sstring req = format("UPDATE system.{} SET value = ? WHERE key = ?", system_keyspace::SCYLLA_LOCAL);
     auto type = data_type_for<T>();
     co_await qctx->execute_cql(req, type->to_string_impl(data_value(value)), key).discard_result();
@@ -1674,7 +1674,7 @@ future<> set_scylla_local_param_as(const sstring& key, const T& value) {
 }
 
 template <typename T>
-future<std::optional<T>> get_scylla_local_param_as(const sstring& key) {
+future<std::optional<T>> system_keyspace::get_scylla_local_param_as(const sstring& key) {
     sstring req = format("SELECT value FROM system.{} WHERE key = ?", system_keyspace::SCYLLA_LOCAL);
     return qctx->execute_cql(req, key).then([] (::shared_ptr<cql3::untyped_result_set> res)
             -> future<std::optional<T>> {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -265,8 +265,8 @@ public:
 
     future<> remove_endpoint(gms::inet_address ep);
 
-    static future<> set_scylla_local_param(const sstring& key, const sstring& value);
-    static future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
+    future<> set_scylla_local_param(const sstring& key, const sstring& value);
+    future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
     future<> make(

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -268,6 +268,13 @@ public:
     future<> set_scylla_local_param(const sstring& key, const sstring& value);
     future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
+private:
+    template <typename T>
+    future<> set_scylla_local_param_as(const sstring& key, const T& value);
+    template <typename T>
+    future<std::optional<T>> get_scylla_local_param_as(const sstring& key);
+
+public:
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
     future<> make(
             locator::effective_replication_map_factory&,


### PR DESCRIPTION
Those without `_as` suffix are just marked non-static
The `..._as` ones are made class methods (now they are local to system_keyspace.cc)
After that the `..._as` ones are patched to use `this->` instead of `qctx`