### PR TITLE
compaction_manager: correct comment on compaction_task_executor::state

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -447,7 +447,8 @@ public:
                     // counted in compaction_manager::stats::pending_tasks
         active,     // task initiated active compaction, may alternate with pending
                     // counted in compaction_manager::stats::active_tasks
-        done,       // task completed successfully (may transition only to state::none)
+        done,       // task completed successfully (may transition only to state::none, or
+                    // state::pending for regular compaction)
                     // counted in compaction_manager::stats::completed_tasks
         postponed,  // task was postponed (may transition only to state::none)
                     // represented by the postponed_compactions metric


### PR DESCRIPTION
when it comes to `regular_compaction_task_executor`, we repeat the compaction until the compaction can not proceed, so after an iteration of compaction completes successfully, the task can still continue with yet another round of the compaction as it sees appropriate. so let's update the comment to reflect this fact.