### PR TITLE
topology: unindex_node: erase dc from datacenters when empty

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -357,6 +357,7 @@ void topology::unindex_node(const node* node) {
                     _dc_rack_nodes.erase(dc);
                     _dc_racks.erase(dc);
                     _dc_endpoints.erase(dit);
+                    _datacenters.erase(dc);
                 } else {
                     _dc_rack_nodes[dc][rack].erase(node);
                     auto& racks = _dc_racks[dc];

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -216,7 +216,7 @@ SEASTAR_THREAD_TEST_CASE(test_remove_endpoint) {
     topo.remove_endpoint(ep1);
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_endpoints(), (dc_endpoints_t{}));
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_racks(), (dc_racks_t{}));
-    BOOST_REQUIRE_EQUAL(topo.get_datacenters(), (dcs_t{"dc1"}));
+    BOOST_REQUIRE_EQUAL(topo.get_datacenters(), (dcs_t{}));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_sketch) {


### PR DESCRIPTION
In branch 5.2 we erase `dc` from `_datacenters` if there are no more endpoints listed in `_dc_endpoints[dc]`.

This was lost unintentionally in f3d5df54482e2867336d4b36b6a979e823c8c5ff and this commit restores that behavior, and fixes test_remove_endpoint.

Fixes scylladb/scylladb#14896