### PR TITLE
tools: move operation-options to the operations themselves

### DIFF
--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -108,26 +108,13 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
 
     if (found_op) {
         boost::program_options::options_description op_desc(found_op->name());
-        size_t options_added = 0;
-        for (const auto& opt_name : found_op->available_options()) {
-            if (_cfg.operation_options) {
-                auto it = std::ranges::find_if(*_cfg.operation_options, [&] (const operation_option& opt) { return opt.name() == opt_name; });
-                if (it != _cfg.operation_options->end()) {
-                    it->add_option(op_desc);
-                    ++options_added;
-                    continue;
-                }
-            }
-            if (_cfg.operation_positional_options) {
-                auto it = std::ranges::find_if(*_cfg.operation_positional_options, [&] (const app_template::positional_option& opt) { return opt.name == opt_name; });
-                if (it != _cfg.operation_positional_options->end()) {
-                    app.add_positional_options({*it});
-                    continue;
-                }
-            }
-            std::abort(); // failed to look-up option
+        for (const auto& opt : found_op->options()) {
+            opt.add_option(op_desc);
         }
-        if (options_added) {
+        for (const auto& opt : found_op->positional_options()) {
+            app.add_positional_options({opt});
+        }
+        if (!found_op->options().empty()) {
             app.get_options_description().add(op_desc);
         }
     }

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -67,20 +67,28 @@ class operation {
     std::string _name;
     std::string _summary;
     std::string _description;
-    std::vector<std::string> _available_options;
+    std::vector<operation_option> _options;
+    std::vector<app_template::positional_option> _positional_options;
 
 public:
-    operation(std::string name, std::string summary, std::string description)
-        : _name(std::move(name)), _summary(std::move(summary)), _description(std::move(description)) {
-    }
-    operation(std::string name, std::string summary, std::string description, std::vector<std::string> available_options)
-        : _name(std::move(name)), _summary(std::move(summary)), _description(std::move(description)), _available_options(std::move(available_options)) {
+    operation(
+            std::string name,
+            std::string summary,
+            std::string description,
+            std::vector<operation_option> options = {},
+            std::vector<app_template::positional_option> positional_options = {})
+        : _name(std::move(name))
+        , _summary(std::move(summary))
+        , _description(std::move(description))
+        , _options(std::move(options))
+        , _positional_options(std::move(positional_options)) {
     }
 
     const std::string& name() const { return _name; }
     const std::string& summary() const { return _summary; }
     const std::string& description() const { return _description; }
-    const std::vector<std::string>& available_options() const { return _available_options; }
+    const std::vector<operation_option>& options() const { return _options; }
+    const std::vector<app_template::positional_option>& positional_options() const { return _positional_options; }
 };
 
 inline bool operator<(const operation& a, const operation& b) {
@@ -97,8 +105,6 @@ public:
         std::vector<operation> operations;
         const std::vector<operation_option>* global_options = nullptr;
         const std::vector<app_template::positional_option>* global_positional_options = nullptr;
-        const std::vector<operation_option>* operation_options = nullptr;
-        const std::vector<app_template::positional_option>* operation_positional_options = nullptr;
     };
 
 private:


### PR DESCRIPTION
Currently, operation-options are declared in a single global list, then operations refer to the options they support via name. This system was born at a time, when scylla-sstable had a lot of shared options between its operations, so it was desirable to declare them centrally and only add references to individual operations, to reduce duplication. However, as the dust settled, only 2 options are shared by 2 operations each. This is a very low benefit. Up to now the cost was also very low -- shared options meant the same in all operations that used them. However this is about to change and this system becomes very awkward to use as soon as multiple operations want to have an option with the same name, but sligthly (or very) different meaning/semantics. So this patch changes moves the options to the operations themselves. Each will declare the list of options it supports, without having to reference some common list.
This also removes an entire (although very uncommon) class of bugs: option-name referring to inexistent option.