### PR TITLE
RFC: Table: (Mis-)use truncation table to watershed mutations to replay for compacted tables

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -271,6 +271,10 @@ public:
         return _cfg.throughput_mb_per_sec.get();
     }
 
+    seastar::shared_ptr<db::system_keyspace> system_keyspace() const {
+        return _sys_ks;
+    }
+
     void register_metrics();
 
     // enable the compaction manager.


### PR DESCRIPTION
Fixes #14870 (at least partially)

When doing a compaction with potential GC of tombstones Put an entry into truncation table, corresponding to the last RP flushed to sstable (note - does not even have to be related to what we compacted here, only a value such that we _know_ that data younger that this is already on disk, or potentially handled by this compation). This will prevent any replay of mutations younger than this, and ensure nothing we GC:d tombstones for gets resurrected. TODO: maybe move this to separate table, or rename it to avoid confusion. NOTE: the timestamp here does not matter, nor does the fact that we don't sync it across shards, since this is run inside a compaction, i.e. real truncation is locked out, so said "real" records, where timestamp might matter, will be done either before or after this. We use the "actual" timestamp as cached in table object (this will somewhat break if ignore_truncation_record is true, but so will truncation)

NOTE: this is potentially a misuse of un-renamed tables. Don't merge.