### PR TITLE
compaction: add formatter for compaction_task_executor

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -454,7 +454,6 @@ public:
         failed,     // task failed (may transition only to state::none)
                     // counted in compaction_manager::stats::errors
     };
-    static std::string_view to_string(state);
 protected:
     compaction_manager& _cm;
     ::compaction::table_state* _compacting_table = nullptr;
@@ -563,15 +562,23 @@ public:
 
     sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
 
-    std::string describe() const;
-
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task);
+    friend fmt::formatter<compaction_task_executor>;
 };
 
-std::ostream& operator<<(std::ostream& os, compaction::compaction_task_executor::state s);
-std::ostream& operator<<(std::ostream& os, const compaction::compaction_task_executor& task);
-
 }
+
+template <>
+struct fmt::formatter<compaction::compaction_task_executor::state> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(compaction::compaction_task_executor::state c, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<compaction::compaction_task_executor> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const compaction::compaction_task_executor& ex, fmt::format_context& ctx) const  -> decltype(ctx.out());
+};
 
 bool needs_cleanup(const sstables::shared_sstable& sst, const dht::token_range_vector& owned_ranges);
 


### PR DESCRIPTION
add fmt formatter for `compaction_task_executor::state` and `compaction_task_executor` and its derived classes.

this is a part of a series to migrating from `operator<<(ostream&, ..)` based formatting to fmtlib based formatting. the goal here is to enable fmtlib to print `compaction_task_executor`, its derived classes and `compaction_task_executor::state` without the help of `operator<<`.

since all of the callers of 'operator<<' of these types now use formatters, the operator<< are removed in this change. the helpers like `to_string()` and `describe()` are removed as well, as it'd be more consistent if we always use fmtlib for formatting instead of inventing APIs with different names.

Refs #13245