### PR TITLE
Block tombstone GC if older data still exists in commitlog 

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -145,7 +145,7 @@ std::ostream& operator<<(std::ostream& os, compaction_type_options::scrub::quara
 
 static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_s, sstable_set::incremental_selector& selector,
         const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk, uint64_t& bloom_filter_checks) {
-    if (!table_s.tombstone_gc_enabled()) [[unlikely]] {
+    if (!table_s.tombstone_gc_enabled({compacting_set.begin(), compacting_set.end()})) [[unlikely]] {
         return api::min_timestamp;
     }
 

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -37,7 +37,7 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
         return candidate;
     }
 
-    if (!table_s.tombstone_gc_enabled()) {
+    if (!table_s.tombstone_gc_enabled(candidate.sstables)) {
         return compaction_descriptor();
     }
 

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -164,7 +164,7 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
         return sstables::compaction_descriptor(std::move(most_interesting));
     }
 
-    if (!table_s.tombstone_gc_enabled()) {
+    if (!table_s.tombstone_gc_enabled(candidates)) {
         return compaction_descriptor();
     }
 

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -50,7 +50,7 @@ public:
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
-    virtual bool tombstone_gc_enabled() const noexcept = 0;
+    virtual bool tombstone_gc_enabled(const std::vector<sstables::shared_sstable>& = {}) const noexcept = 0;
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept = 0;
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
     virtual const std::string& get_group_id() const noexcept = 0;

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -284,7 +284,7 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
         return most_interesting;
     }
 
-    if (!table_s.tombstone_gc_enabled()) {
+    if (!table_s.tombstone_gc_enabled(non_expiring_sstables)) {
         return {};
     }
 

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -229,6 +229,13 @@ public:
     void discard_completed_segments(const cf_id_type&);
 
     /**
+     * Forces active segment switch.
+     * Called from API calls to help tests that need predictable
+     * compaction behaviour.
+    */
+    future<> force_new_active_segment() noexcept;
+
+    /**
      * A 'flush_handler' is invoked when the CL determines that size on disk has
      * exceeded allowable threshold. It is called once for every currently active
      * CF id with the highest replay_position which we would prefer to free "until".

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -357,6 +357,10 @@ public:
     future<std::vector<sstring>> list_existing_segments() const;
     future<std::vector<sstring>> list_existing_segments(const sstring& dir) const;
 
+    std::optional<replay_position> lowest_active_table_rp(const cf_id_type&) const;
+    // debug only function
+    std::unordered_set<cf_id_type> active_cf_ids() const;
+
     typedef std::function<future<>(buffer_and_replay_position)> commit_load_reader_func;
 
     class segment_error : public std::exception {};

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2443,15 +2443,32 @@ future<> database::flush_table_on_all_shards(sharded<database>& sharded_db, std:
 }
 
 future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<sstring> table_names) {
-    return parallel_for_each(table_names, [&, ks_name] (const auto& table_name) {
-        return flush_table_on_all_shards(sharded_db, ks_name, table_name);
+    /**
+     * #14870 
+     * To ensure tests which use nodetool flush to force data
+     * to sstables and do things post this get what they expect,
+     * we do an extra call here and below, asking commitlog
+     * to discard the currently active segment, This ensures we get 
+     * as sstable-ish a universe as we can, as soon as we can.
+    */
+    return sharded_db.invoke_on_all([] (replica::database& db) {
+        return db._commitlog->force_new_active_segment();
+    }).then([&, ks_name, table_names = std::move(table_names)] {
+        return parallel_for_each(table_names, [&, ks_name] (const auto& table_name) {
+            return flush_table_on_all_shards(sharded_db, ks_name, table_name);
+        });
     });
 }
 
 future<> database::flush_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name) {
-    auto& ks = sharded_db.local().find_keyspace(ks_name);
-    return parallel_for_each(ks.metadata()->cf_meta_data(), [&] (auto& pair) {
-        return flush_table_on_all_shards(sharded_db, pair.second->id());
+    // see above
+    return sharded_db.invoke_on_all([] (replica::database& db) {
+        return db._commitlog->force_new_active_segment();
+    }).then([&, ks_name] {
+        auto& ks = sharded_db.local().find_keyspace(ks_name);
+        return parallel_for_each(ks.metadata()->cf_meta_data(), [&] (auto& pair) {
+            return flush_table_on_all_shards(sharded_db, pair.second->id());
+        });
     });
 }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -116,7 +116,7 @@ public:
     bool is_auto_compaction_disabled_by_user() const noexcept override {
         return table().is_auto_compaction_disabled_by_user();
     }
-    bool tombstone_gc_enabled() const noexcept override {
+    bool tombstone_gc_enabled(const std::vector<sstables::shared_sstable>&) const noexcept override {
         return table().tombstone_gc_enabled();
     }
     const tombstone_gc_state& get_tombstone_gc_state() const noexcept override {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -850,7 +850,7 @@ public:
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override { return make_ready_future<>(); }
     virtual bool is_auto_compaction_disabled_by_user() const noexcept override { return false; }
-    virtual bool tombstone_gc_enabled() const noexcept override { return false; }
+    virtual bool tombstone_gc_enabled(const std::vector<sstables::shared_sstable>&) const noexcept override { return false; }
     virtual const tombstone_gc_state& get_tombstone_gc_state() const noexcept override { return _tombstone_gc_state; }
     virtual compaction_backlog_tracker& get_backlog_tracker() override { return _backlog_tracker; }
     virtual const std::string& get_group_id() const noexcept override { return _group_id; }


### PR DESCRIPTION
Fixes #14870 (alternative solution)

Blocks GC for compactions of tables where the sstable set holds data
that is potentially newer than data still held in non-deleted commitlog
segments. This prevents resurrection of data in the case of crash+replay
in cases where a very early compation removes tombstones, but CL data
is kept alive by other CF:s

Test: https://github.com/scylladb/scylla-dtest/pull/3352

Note: this messes with other tests assumptions on nodetool flush + compaction
and the result thereof, which is why these paths now also try to replace active 
segment in commitlog (if clean) to ensure we can in fact, as often as possible,
do compaction with GC and get the results we hope for. 