### PR TITLE
compaction: use promise to check if compaction is done

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -470,7 +470,8 @@ protected:
     state _state = state::none;
 
 private:
-    shared_future<compaction_manager::compaction_stats_opt> _compaction_done = make_ready_future<compaction_manager::compaction_stats_opt>();
+    promise<compaction_manager::compaction_stats_opt> _compaction_done_promise;
+    shared_future<compaction_manager::compaction_stats_opt> _compaction_done = _compaction_done_promise.get_future();
     exponential_backoff_retry _compaction_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(300));
     sstables::compaction_type _type;
     sstables::run_id _output_run_identifier;
@@ -524,6 +525,8 @@ protected:
         return ct == sstables::compaction_type::Compaction;
     }
 public:
+    void fail_exceptionally(std::exception_ptr ex) noexcept;
+
     future<compaction_manager::compaction_stats_opt> run_compaction() noexcept;
 
     const ::compaction::table_state* compacting_table() const noexcept {


### PR DESCRIPTION
Currently, shared_future is used to allow checking whether compaction
is finished from different layers.

Since compaction tasks executors were turned into tasks::task_manager::task::impl,
do_run() does not have to be assigned to the shared_future (_compaction_done)
immediately after an executor is created. If some other layer calls
compaction_task_executor::compaction_done() between the two, it would get
a resolved future (which _compaction_done is assigned to by default),
even though the compaction hasn't even started.

Use promise so that future returned from compaction_done() is resolved iff
value or exception was explicitly set.

Fixes: #14912.