### PR TITLE
api: ignore future in task_manager_json::wait_task

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -192,7 +192,9 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
             task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) {
                 return task->done().then_wrapped([task] (auto f) {
                     task->unregister_task();
-                    f.get();
+                    // done() is called only because we want the task to be complete before getting its status.
+                    // The future should be ignored here as the result does not matter.
+                    f.ignore_ready_future();
                     return make_foreign(task);
                 });
             }));


### PR DESCRIPTION
Before returning task status, wait_task waits for it to finish with done() method and calls get() on a resulting future.

If requested task fails, an exception will be thrown and user will get internal server error instead of failed task status.

Result of done() method is ignored.

Fixes: #14914.