### PR TITLE
test: remove unnecessary check in compaction_manager_basic_test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -181,7 +181,6 @@ SEASTAR_TEST_CASE(compaction_manager_basic_test) {
         return sleep(std::chrono::milliseconds(100));
     }).wait();
     // test no more running compactions
-    BOOST_CHECK_EQUAL(cm.get_stats().pending_tasks, 0);
     BOOST_CHECK_EQUAL(cm.get_stats().active_tasks, 0);
     // test compaction successfully finished
     BOOST_CHECK_EQUAL(cm.get_stats().completed_tasks, 1);


### PR DESCRIPTION
we wait for the same condition couple lines before, so no need to check it again using `BOOST_CHECK_EQUAL()`.