### PR TITLE
schema::describe: print 'synchronous_updates' only if it was specified

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -786,15 +786,6 @@ static bool is_index(replica::database& db, const table_id& id, const schema& s)
     return  db.find_column_family(id).get_index_manager().is_index(s);
 }
 
-static bool is_update_synchronously_view(const schema& s) {
-    auto tag_opt = db::find_tag(s, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);
-    if (!tag_opt.has_value()) {
-        return false;
-    }
-
-    return *tag_opt == "true";
-}
-
 sstring schema::element_type(replica::database& db) const {
     if (is_view()) {
         if (is_index(db, view_info()->base_id(), *this)) {
@@ -949,7 +940,10 @@ std::ostream& schema::describe(replica::database& db, std::ostream& os, bool wit
         os << "\n    AND cdc = " << cdc_options().to_sstring();
     }
     if (is_view() && !is_index(db, view_info()->base_id(), *this)) {
-        os << "\n    AND synchronous_updates = " << std::boolalpha << is_update_synchronously_view(*this);
+        auto is_sync_update = db::find_tag(*this, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);
+        if (is_sync_update.has_value()) {
+            os << "\n    AND synchronous_updates = " << *is_sync_update;
+        }
     }
     os << ";\n";
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4335,8 +4335,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
               "    AND read_repair_chance = 0\n"
               "    AND speculative_retry = '99.0PERCENTILE'\n"
               "    AND paxos_grace_seconds = 43200\n"
-              "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'}\n"
-              "    AND synchronous_updates = false;\n"},
+              "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"},
           {"cf_index_index", "CREATE INDEX cf_index ON \"KS\".\"cF\"(col2);"},
           {"cf_index1_index", "CREATE INDEX cf_index1 ON \"KS\".\"cF\"(pk);"},
           {"cf_index2_index", "CREATE INDEX cf_index2 ON \"KS\".\"cF\"(pk1);"},


### PR DESCRIPTION
While describing materialized view, print synchronous_updates option only if the tag is present in schema's extensions map. Previously if the key wasn't present, the default (false) value was printed.

Fixes: https://github.com/scylladb/scylladb/issues/14924
Refers: https://github.com/scylladb/scylla-dtest/issues/3324