### PR TITLE
Make replica::database and cql3::query_processor share wasm manager

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -481,8 +481,6 @@ future<> query_processor::stop_remote() {
 future<> query_processor::stop() {
     return _mnotifier.unregister_listener(_migration_subscriber.get()).then([this] {
         return _authorized_prepared_cache.stop().finally([this] { return _prepared_cache.stop(); });
-    }).then([this] {
-        return _wasm._instance_cache ? _wasm._instance_cache->stop() : make_ready_future<>();
     });
 }
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -174,9 +174,7 @@ public:
         return *_wasm._instance_cache;
     }
 
-    wasm::alien_thread_runner& alien_runner() {
-        return *_wasm._alien_runner;
-    }
+    wasm::manager& wasm() { return _wasm; }
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const std::optional<auth::authenticated_user>& user, const prepared_cache_key_type& key) {
         if (user) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -166,14 +166,6 @@ public:
         return _cql_stats;
     }
 
-    wasmtime::Engine& wasm_engine() {
-        return **_wasm._engine;
-    }
-
-    wasm::instance_cache& wasm_instance_cache() {
-        return *_wasm._instance_cache;
-    }
-
     wasm::manager& wasm() { return _wasm; }
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const std::optional<auth::authenticated_user>& user, const prepared_cache_key_type& key) {

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -51,7 +51,7 @@ seastar::future<shared_ptr<functions::function>> create_function_statement::crea
        // FIXME: need better way to test wasm compilation without real_database()
        wasm::context ctx{qp.wasm_engine(), _name.name, qp.wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
        try {
-            co_await wasm::precompile(qp.alien_runner(), ctx, arg_names, _body);
+            co_await qp.wasm().precompile(ctx, arg_names, _body);
             co_return ::make_shared<functions::user_function>(_name, _arg_types, std::move(arg_names), _body, _language,
                 std::move(return_type), _called_on_null_input, std::move(ctx));
        } catch (const wasm::exception& we) {

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -49,7 +49,7 @@ seastar::future<shared_ptr<functions::function>> create_function_statement::crea
             std::move(return_type), _called_on_null_input, std::move(ctx));
     } else if (_language == "wasm") {
        // FIXME: need better way to test wasm compilation without real_database()
-       wasm::context ctx{qp.wasm_engine(), _name.name, qp.wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+       wasm::context ctx(qp.wasm(), _name.name, db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel());
        try {
             co_await qp.wasm().precompile(ctx, arg_names, _body);
             co_return ::make_shared<functions::user_function>(_name, _arg_types, std::move(arg_names), _body, _language,

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1912,7 +1912,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
     } else if (language == "wasm") {
-        wasm::context ctx{qctx->qp().wasm_engine(), name.name, qctx->qp().wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
+        wasm::context ctx(qctx->qp().wasm(), name.name, db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel());
         co_await qctx->qp().wasm().precompile(ctx, arg_names, body);
         co_return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1913,7 +1913,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
     } else if (language == "wasm") {
         wasm::context ctx{qctx->qp().wasm_engine(), name.name, qctx->qp().wasm_instance_cache(), db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel()};
-        co_await wasm::precompile(qctx->qp().alien_runner(), ctx, arg_names, body);
+        co_await qctx->qp().wasm().precompile(ctx, arg_names, body);
         co_return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1981,7 +1981,7 @@ static void drop_cached_func(replica::database& db, const query::result_set_row&
         cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("function_name")};
         auto arg_types = read_arg_types(db, row, name.keyspace);
-        qctx->qp().wasm_instance_cache().remove(name, arg_types);
+        qctx->qp().wasm().remove(name, arg_types);
     }
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1912,8 +1912,8 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
     } else if (language == "wasm") {
-        wasm::context ctx(qctx->qp().wasm(), name.name, db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel());
-        co_await qctx->qp().wasm().precompile(ctx, arg_names, body);
+        wasm::context ctx(db.wasm(), name.name, db.get_config().wasm_udf_yield_fuel(), db.get_config().wasm_udf_total_fuel());
+        co_await db.wasm().precompile(ctx, arg_names, body);
         co_return ::make_shared<cql3::functions::user_function>(std::move(name), std::move(arg_types), std::move(arg_names),
                 std::move(body), language, std::move(return_type),
                 row.get_nonnull<bool>("called_on_null_input"), std::move(ctx));
@@ -1981,7 +1981,7 @@ static void drop_cached_func(replica::database& db, const query::result_set_row&
         cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("function_name")};
         auto arg_types = read_arg_types(db, row, name.keyspace);
-        qctx->qp().wasm().remove(name, arg_types);
+        db.wasm().remove(name, arg_types);
     }
 }
 

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -55,6 +55,10 @@ context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache&
     , total_fuel(total_fuel) {
 }
 
+context::context(manager& manager, std::string name, uint64_t yield_fuel, uint64_t total_fuel)
+    : context(**manager._engine, std::move(name), *manager._instance_cache, yield_fuel, total_fuel)
+{ }
+
 static constexpr size_t WASM_PAGE_SIZE = 64 * 1024;
 
 static void init_abstract_arg(const abstract_type& t, const bytes_opt& param, wasmtime::ValVec& argv, wasmtime::Store& store, wasmtime::Instance& instance) {

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -41,6 +41,12 @@ manager::manager(const std::optional<wasm::startup_context>& ctx)
         , _alien_runner(ctx ? ctx->alien_runner : nullptr)
 {}
 
+future<> manager::stop() {
+    if (_instance_cache) {
+        co_await _instance_cache->stop();
+    }
+}
+
 context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel)
     : engine_ptr(engine_ptr)
     , function_name(name)

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -35,6 +35,12 @@ startup_context::startup_context(db::config& cfg, replica::database_config& dbcf
     , timer_period(std::chrono::milliseconds(cfg.wasm_cache_timeout_in_ms())) {
 }
 
+manager::manager(const std::optional<wasm::startup_context>& ctx)
+        : _engine(ctx ? ctx->engine : nullptr)
+        , _instance_cache(ctx ? std::make_optional<wasm::instance_cache>(ctx->cache_size, ctx->instance_size, ctx->timer_period) : std::nullopt)
+        , _alien_runner(ctx ? ctx->alien_runner : nullptr)
+{}
+
 context::context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel)
     : engine_ptr(engine_ptr)
     , function_name(name)

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -239,6 +239,10 @@ struct from_val_visitor {
     }
 };
 
+seastar::future<> manager::precompile(context& ctx, const std::vector<sstring>& arg_names, std::string script) {
+    return ::wasm::precompile(*_alien_runner, ctx, arg_names, std::move(script));
+}
+
 seastar::future<> precompile(alien_thread_runner& alien_runner, context& ctx, const std::vector<sstring>& arg_names, std::string script) {
     seastar::promise<rust::Box<wasmtime::Module>> done;
     alien_runner.submit(done, [&engine_ptr = ctx.engine_ptr, script = std::move(script)] {

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -57,6 +57,7 @@ class manager {
 public:
     manager(const std::optional<wasm::startup_context>&);
     friend class cql3::query_processor;
+    future<> stop();
 };
 
 struct context {

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -18,10 +18,6 @@
 #include "db/config.hh"
 #include "replica/database.hh"
 
-namespace cql3 {
-class query_processor;
-}
-
 namespace wasm {
 
 class instance_cache;
@@ -56,7 +52,7 @@ class manager {
 
 public:
     manager(const std::optional<wasm::startup_context>&);
-    friend class cql3::query_processor;
+    friend context;
     future<> stop();
     seastar::future<> precompile(context& ctx, const std::vector<sstring>& arg_names, std::string script);
     void remove(const db::functions::function_name& name, const std::vector<data_type>& arg_types) noexcept {
@@ -73,6 +69,7 @@ struct context {
     uint64_t total_fuel;
 
     context(wasmtime::Engine& engine_ptr, std::string name, instance_cache& cache, uint64_t yield_fuel, uint64_t total_fuel);
+    context(manager&, std::string name, uint64_t yield_fuel, uint64_t total_fuel);
 };
 
 seastar::future<> precompile(alien_thread_runner& alien_runner, context& ctx, const std::vector<sstring>& arg_names, std::string script);

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -58,6 +58,7 @@ public:
     manager(const std::optional<wasm::startup_context>&);
     friend class cql3::query_processor;
     future<> stop();
+    seastar::future<> precompile(context& ctx, const std::vector<sstring>& arg_names, std::string script);
 };
 
 struct context {

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -13,9 +13,14 @@
 #include <seastar/core/future.hh>
 #include "db/functions/function_name.hh"
 #include "rust/wasmtime_bindings.hh"
+#include "lang/wasm_instance_cache.hh"
 #include "lang/wasm_alien_thread_runner.hh"
 #include "db/config.hh"
 #include "replica/database.hh"
+
+namespace cql3 {
+class query_processor;
+}
 
 namespace wasm {
 
@@ -42,6 +47,16 @@ struct startup_context {
     seastar::lowres_clock::duration timer_period;
 
     startup_context(db::config& cfg, replica::database_config& dbcfg);
+};
+
+class manager {
+    std::shared_ptr<rust::Box<wasmtime::Engine>> _engine;
+    std::optional<wasm::instance_cache> _instance_cache;
+    std::shared_ptr<wasm::alien_thread_runner> _alien_runner;
+
+public:
+    manager(const std::optional<wasm::startup_context>&);
+    friend class cql3::query_processor;
 };
 
 struct context {

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -59,6 +59,9 @@ public:
     friend class cql3::query_processor;
     future<> stop();
     seastar::future<> precompile(context& ctx, const std::vector<sstring>& arg_names, std::string script);
+    void remove(const db::functions::function_name& name, const std::vector<data_type>& arg_types) noexcept {
+        _instance_cache->remove(name, arg_types);
+    }
 };
 
 struct context {

--- a/lang/wasm_instance_cache.hh
+++ b/lang/wasm_instance_cache.hh
@@ -16,11 +16,14 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timer.hh>
 #include <unordered_map>
-#include "lang/wasm.hh"
 #include "rust/cxx.h"
 #include "rust/wasmtime_bindings.hh"
+#include "types/types.hh"
 
 namespace wasm {
+
+class instance_cache;
+struct context;
 
 class module_handle {
     wasmtime::Module& _module;

--- a/main.cc
+++ b/main.cc
@@ -1036,7 +1036,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             static sharded<wasm::manager> wasm;
             wasm.start(std::ref(wasm_ctx)).get();
-            // don't stop until query_processor stops
+            // don't stop for real until query_processor stops
+            auto stop_wasm = defer_verbose_shutdown("wasm", [] { wasm.invoke_on_all(&wasm::manager::stop).get(); });
 
             qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notifier), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::ref(wasm)).get();
 

--- a/main.cc
+++ b/main.cc
@@ -1034,7 +1034,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 wasm_ctx.emplace(*cfg, dbcfg);
             }
 
-            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notifier), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::move(wasm_ctx)).get();
+            static sharded<wasm::manager> wasm;
+            wasm.start(std::ref(wasm_ctx)).get();
+            // don't stop until query_processor stops
+
+            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notifier), qp_mcfg, std::ref(cql_config), std::move(auth_prep_cache_config), std::ref(wasm)).get();
 
             supervisor::notify("starting lifecycle notifier");
             lifecycle_notifier.start().get();

--- a/main.cc
+++ b/main.cc
@@ -974,7 +974,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("starting database");
             debug::the_database = &db;
             db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
-                    std::ref(cm), std::ref(sstm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+                    std::ref(cm), std::ref(sstm), std::ref(wasm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
             auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
                 // #293 - do not stop anything - not even db (for real)
                 //return db.stop();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -310,7 +310,7 @@ public:
 };
 
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-        compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
+        compaction_manager& cm, sstables::storage_manager& sstm, wasm::manager& wasm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
     , _cl_stats(std::make_unique<cell_locker_stats>())
@@ -374,6 +374,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _mnotifier(mn)
     , _feat(feat)
     , _shared_token_metadata(stm)
+    , _wasm(wasm)
     , _sst_dir_semaphore(sst_dir_sem)
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -77,6 +77,8 @@ class reconcilable_result;
 namespace tracing { class trace_state_ptr; }
 namespace s3 { struct endpoint_config; }
 
+namespace wasm { class manager; }
+
 namespace service {
 class storage_proxy;
 class storage_service;
@@ -1428,6 +1430,7 @@ private:
     gms::feature_service& _feat;
     std::vector<std::any> _listeners;
     const locator::shared_token_metadata& _shared_token_metadata;
+    wasm::manager& _wasm;
 
     sharded<sstables::directory_semaphore>& _sst_dir_semaphore;
 
@@ -1516,7 +1519,7 @@ public:
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
 
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            compaction_manager& cm, sstables::storage_manager& sstm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            compaction_manager& cm, sstables::storage_manager& sstm, wasm::manager& wasm, sharded<sstables::directory_semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 
@@ -1550,6 +1553,9 @@ public:
 
     const locator::shared_token_metadata& get_shared_token_metadata() const { return _shared_token_metadata; }
     const locator::token_metadata& get_token_metadata() const { return *_shared_token_metadata.get(); }
+
+    wasm::manager& wasm() noexcept { return _wasm; }
+    const wasm::manager& wasm() const noexcept { return _wasm; }
 
     service::migration_notifier& get_notifier() { return _mnotifier; }
     const service::migration_notifier& get_notifier() const { return _mnotifier; }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -694,7 +694,11 @@ public:
                 wasm_ctx.emplace(*cfg, dbcfg);
             }
 
-            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notif), qp_mcfg, std::ref(cql_config), auth_prep_cache_config, wasm_ctx).get();
+            sharded<wasm::manager> wasm;
+            wasm.start(std::ref(wasm_ctx)).get();
+            auto stop_wasm = defer([&wasm] { wasm.stop().get(); });
+
+            qp.start(std::ref(proxy), std::move(local_data_dict), std::ref(mm_notif), qp_mcfg, std::ref(cql_config), auth_prep_cache_config, std::ref(wasm)).get();
             auto stop_qp = defer([&qp] { qp.stop().get(); });
 
             sharded<service::endpoint_lifecycle_notifier> elc_notif;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -660,7 +660,7 @@ public:
             auto stop_wasm = defer([&wasm] { wasm.stop().get(); });
 
 
-            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notif), std::ref(feature_service), std::ref(token_metadata), std::ref(cm), std::ref(sstm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notif), std::ref(feature_service), std::ref(token_metadata), std::ref(cm), std::ref(sstm), std::ref(wasm), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
             auto stop_db = defer([&db] {
                 db.stop().get();
             });


### PR DESCRIPTION
This makes it possible to remove remaining users of the global qctx.

The thing is that db::schema_tables code needs to get wasm's engine, alien runner and instance cache to build wasm context for the merged function or to drop it from cache in the opposite case. To get the wasm stuff, this code uses global qctx -> query_processor -> wasm chain. However, the functions (un)merging code already has the database reference at hand, and its natural to get wasm stuff from it, not from the q.p. which is not available

So this PR packs the wasm engine, runner and cache on sharded<wasm::manager> instance, makes the manager be referenced by both q.p. and database and removes the qctx from schema tables code