### PR TITLE
schema: flip the default of flush_schema_tables_after_modification to…

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -986,8 +986,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Related information: About replication strategy.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
             "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")
-    , flush_schema_tables_after_modification(this, "flush_schema_tables_after_modification", liveness::LiveUpdate, value_status::Used, true,
-        "Flush tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them")
+    , flush_schema_tables_after_modification(this, "flush_schema_tables_after_modification", liveness::LiveUpdate, value_status::Used, false,
+        "Flush tables in the system_schema keyspace after schema modification. This option used to be required for crash recovery and is now deprecated. Only enable if force_schema_commitlog is false.")
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Unused, db::tri_mode_restriction_t::mode::TRUE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
     , restrict_twcs_without_default_ttl(this, "restrict_twcs_without_default_ttl", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent creating TimeWindowCompactionStrategy tables without a default TTL. Can be true, false, or warn.")


### PR DESCRIPTION
… false

Since a separate schema commit log was introduced, schema recovery happens independently of the data recovery, first thing at boot, from the dedicated commit log.

force_schema_commit_log is now on by default, and there is on going back - once enabled, it can't be turned off.

However, we still keep doing a lot of extra work by flushing the memtables of every system table after modification - i.e. wasting all the benefits of a dedicated commit log.

Follow up on that with flipping the default.