### PR TITLE
storage_service: get_all_ranges: reserve enough space in ranges

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6078,7 +6078,7 @@ storage_service::get_all_ranges(const std::vector<token>& sorted_tokens) const {
         co_return dht::token_range_vector();
     int size = sorted_tokens.size();
     dht::token_range_vector ranges;
-    ranges.reserve(size);
+    ranges.reserve(size + 1);
     ranges.push_back(dht::token_range::make_ending_with(range_bound<token>(sorted_tokens[0], true)));
     co_await coroutine::maybe_yield();
     for (int i = 1; i < size; ++i) {


### PR DESCRIPTION
Commit bc5f6cf45dfd006fe1747f748339a6ed227d28d7
added a reserve call to the `ranges` vector before inserting all the returned token ranges into it.
However, that reservation is too small as we insert `size` tokens to it plus two more as first and last.

Fixes #14849