### PR TITLE
tools: do not create bpo::value unless transfer it to an option_descr…

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2483,9 +2483,12 @@ const std::vector<operation_option> global_options {
     typed_option<sstring>("scylla-data-dir", "path to the scylla data dir (usually /var/lib/scylla/data), to read the schema tables from"),
 };
 
-const std::vector<app_template::positional_option> global_positional_options{
-    {"sstables", bpo::value<std::vector<sstring>>(), "sstable(s) to process for operations that have sstable inputs, can also be provided as positional arguments", -1},
-};
+static auto get_global_positional_options() {
+    static const std::vector<app_template::positional_option> options = {
+        {"sstables", bpo::value<std::vector<sstring>>(), "sstable(s) to process for operations that have sstable inputs, can also be provided as positional arguments", -1},
+    };
+    return &options;
+}
 
 const std::map<operation, operation_func> operations_with_func{
 /* dump-data */
@@ -2842,7 +2845,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             .lsa_segment_pool_backend_size_mb = 100,
             .operations = std::move(operations),
             .global_options = &global_options,
-            .global_positional_options = &global_positional_options};
+            .global_positional_options = get_global_positional_options()};
     tool_app_template app(std::move(app_cfg));
 
     return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -245,9 +245,12 @@ const std::vector<operation_option> global_options{
     typed_option<unsigned>("ignore-msb-bits", 12u, "number of shards (only relevant for shardof action)"),
 };
 
-const std::vector<app_template::positional_option> global_positional_options{
-    {"value", bpo::value<std::vector<sstring>>(), "value(s) to process, can also be provided as positional arguments", -1}
-};
+static auto get_global_positional_options() {
+    static const std::vector<app_template::positional_option> options{
+        {"value", bpo::value<std::vector<sstring>>(), "value(s) to process, can also be provided as positional arguments", -1}
+    };
+    return &options;
+}
 
 const std::map<operation, operation_func_variant> operations_with_func = {
     {{"serialize", "serialize the value and print it in hex encoded form",
@@ -377,7 +380,7 @@ $ scylla types {{action}} --help
                 [] (const operation& op) { return format("* {} - {}", op.name(), op.summary()); } ), "\n")),
         .operations = std::move(operations),
         .global_options = &global_options,
-        .global_positional_options = &global_positional_options,
+        .global_positional_options = get_global_positional_options(),
     };
     tool_app_template app(std::move(app_cfg));
 


### PR DESCRIPTION
…iption

`boost::program_options::value()` create a new typed_value<T> object, without holding it with a shared_ptr. boost::program_options expects developer to construct a `bpo::option_description` right away from it. and `boost::program_options::option_description` takes the ownership of the `type_value<T>*` raw pointer, and manages its life cycle with a shared_ptr. but before passing it to a `bpo::option_description`, the pointer created by `boost::program_options::value()` is a still a raw pointer.

before this change, we initialize positional options as global variables using `boost::program_options::value()`. but unfortunately, we don't always initialize a `bpo::option_description` from it -- we only do this on demand when the corresponding subcommand is called.

so, if the corresponding subcommand is not called, the created `typed_value<T>` objects are leaked. hence LeakSanitizer warns us.

after this change, we create the option vector as a static local variable in a function so it is created on demand as well. as an alternative, we could initialize the options vector as local variable where it used. but to be more consistent with how `global_option` is specified. and to colocate them in a single place, let's keep the existing code layout.

Fixes #14929
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>