### PR TITLE
Restrict sstables atomic delete parallelism

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -249,7 +249,7 @@ public:
     // until all shards agree it can be deleted.
     //
     // This function only solves the second problem for now.
-    static future<> delete_with_pending_deletion_log(std::vector<shared_sstable> ssts);
+    static future<> delete_with_pending_deletion_log(sstables_manager&, std::vector<shared_sstable> ssts);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
     future<> garbage_collect();

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -35,20 +35,6 @@ namespace sstables {
 class sstables_manager;
 bool manifest_json_filter(const std::filesystem::path&, const directory_entry& entry);
 
-class directory_semaphore {
-    unsigned _concurrency;
-    semaphore _sem;
-public:
-    directory_semaphore(unsigned concurrency)
-            : _concurrency(concurrency)
-            , _sem(concurrency)
-    {
-    }
-
-    friend class sstable_directory;
-    friend class ::replica::table; // FIXME table snapshots should switch to sstable_directory
-};
-
 // Handles a directory containing SSTables. It could be an auxiliary directory (like upload),
 // or the main directory.
 class sstable_directory {
@@ -167,9 +153,6 @@ private:
     future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg = {}) const;
     future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, process_flags flags) const;
 
-    template <std::ranges::range Container, typename Func>
-    requires std::is_invocable_r_v<future<>, Func, typename std::ranges::range_value_t<Container>&>
-    future<> parallel_for_each_restricted(Container& C, Func func);
     future<> load_foreign_sstables(sstable_entry_descriptor_vector info_vec);
 
     // Sort the sstable according to owner

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -170,7 +170,7 @@ future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
     // front element. The deleter implementation is welcome to check
     // that sstables from the vector really live in it.
     auto deleter = ssts.front()->get_storage().atomic_deleter();
-    co_await deleter(std::move(ssts));
+    co_await deleter(*this, std::move(ssts));
 }
 
 future<> sstables_manager::close() {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -67,7 +67,7 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
+    virtual noncopyable_function<future<>(sstables_manager&, std::vector<shared_sstable>)> atomic_deleter() const override {
         return sstable_directory::delete_with_pending_deletion_log;
     }
 
@@ -431,7 +431,7 @@ class s3_storage : public sstables::storage {
 
     future<> ensure_remote_prefix(const sstable& sst);
 
-    static future<> delete_with_system_keyspace(std::vector<shared_sstable>);
+    static future<> delete_with_system_keyspace(sstables_manager&, std::vector<shared_sstable>);
 
 public:
     s3_storage(shared_ptr<s3::client> client, sstring bucket, sstring dir)
@@ -453,7 +453,7 @@ public:
     virtual future<> destroy(const sstable& sst) override {
         return make_ready_future<>();
     }
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
+    virtual noncopyable_function<future<>(sstables_manager&, std::vector<shared_sstable>)> atomic_deleter() const override {
         return delete_with_system_keyspace;
     }
 
@@ -530,7 +530,8 @@ future<> s3_storage::wipe(const sstable& sst) noexcept {
     co_await sys_ks.sstables_registry_delete_entry(_location, sst.generation());
 }
 
-future<> s3_storage::delete_with_system_keyspace(std::vector<shared_sstable> ssts) {
+future<> s3_storage::delete_with_system_keyspace(sstables_manager&, std::vector<shared_sstable> ssts) {
+    // FIXME: use the stables manager for throttling / atomic deletion
     co_await coroutine::parallel_for_each(ssts, [] (shared_sstable sst) -> future<> {
         const s3_storage* storage = dynamic_cast<const s3_storage*>(&sst->get_storage());
         if (!storage) {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -59,7 +59,7 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
+    virtual noncopyable_function<future<>(sstables_manager&, std::vector<shared_sstable>)> atomic_deleter() const = 0;
 
     virtual sstring prefix() const  = 0;
 };


### PR DESCRIPTION
Pass a reference to the sstables manager in filesystem_storage::atomic_deleter to sstable_directory::delete_with_pending_deletion_log and use the manager semaphore there to limit unlink parallelism.

The reasons to do so are two-fold:
1. SSTable components are created in the same temporary sub-directory so they'd be co-located in the same XFS block allocation group (see [Merge "Create sstable in a sub-directory" from Benny](https://github.com/scylladb/scylladb/compare/4dc402b53f39d6435f49b62851787f8a8f25bab8)), by limiting parallelism we encourage locality of access to thos allocation groups.
2. With the -o discard mount option deleting many files in parallel creates a discard storm that may hamper the disk sub-system.  Although the discards are asynchronous throttling delete parallelism may help flatten this spike.

Refs #14940