### PR TITLE
replica: reduce the size limit of the schema commitlog

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -956,7 +956,7 @@ void database::maybe_init_schema_commitlog() {
     c.commit_log_location = _cfg.schema_commitlog_directory();
     c.fname_prefix = db::schema_tables::COMMITLOG_FILENAME_PREFIX;
     c.metrics_category_name = "schema-commitlog";
-    c.commitlog_total_space_in_mb = 10 << 20;
+    c.commitlog_total_space_in_mb = 2 * _cfg.schema_commitlog_segment_size_in_mb();
     c.commitlog_segment_size_in_mb = _cfg.schema_commitlog_segment_size_in_mb();
     c.mode = db::commitlog::sync_mode::BATCH;
     c.extensions = &_cfg.extensions();


### PR DESCRIPTION
The size of the schema commitlog is incorrectly set to 10 TB. To avoid wasting space, we reduce it to 2 * schema commitlog segment size.

Fixes #14802