### PR TITLE
config: mark "experimental" option unused and cleanups

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1154,8 +1154,6 @@ bool db::config::check_experimental(experimental_features_t::feature f) const {
                                });
 }
 
-namespace bpo = boost::program_options;
-
 logging::settings db::config::logging_settings(const log_cli::options& opts) const {
     auto value = [&](auto& v, const auto& opt) {
         if (opt.defaulted() && v.is_set()) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -1147,8 +1147,11 @@ db::fs::path db::config::get_conf_sub(db::fs::path sub) {
 }
 
 bool db::config::check_experimental(experimental_features_t::feature f) const {
-    const auto& optval = experimental_features();
-    return find(begin(optval), end(optval), enum_option<experimental_features_t>{f}) != end(optval);
+    enum_option<experimental_features_t> to_check{f};
+    return std::ranges::any_of(experimental_features(),
+                               [to_check](auto& enabled) {
+                                   return to_check == enabled;
+                               });
 }
 
 namespace bpo = boost::program_options;

--- a/db/config.cc
+++ b/db/config.cc
@@ -861,7 +861,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , developer_mode(this, "developer_mode", value_status::Used, DEVELOPER_MODE_DEFAULT, "Relax environment checks. Setting to true can reduce performance and reliability significantly.")
     , skip_wait_for_gossip_to_settle(this, "skip_wait_for_gossip_to_settle", value_status::Used, -1, "An integer to configure the wait for gossip to settle. -1: wait normally, 0: do not wait at all, n: wait for at most n polls. Same as -Dcassandra.skip_wait_for_gossip_to_settle in cassandra.")
     , force_gossip_generation(this, "force_gossip_generation", liveness::LiveUpdate, value_status::Used, -1 , "Force gossip to use the generation number provided by user")
-    , experimental(this, "experimental", value_status::Used, false, "[Deprecated] Set to true to unlock all experimental features (except 'consistent-topology-changes' feature, which should be enabled explicitly via 'experimental-features' option). Please use 'experimental-features', instead.")
+    , experimental(this, "experimental", value_status::Unused, false, "[Deprecated] Set to true to unlock all experimental features (except 'consistent-topology-changes' feature, which should be enabled explicitly via 'experimental-features' option). Please use 'experimental-features', instead.")
     , experimental_features(this, "experimental_features", value_status::Used, {}, experimental_features_help_string())
     , lsa_reclamation_step(this, "lsa_reclamation_step", value_status::Used, 1, "Minimum number of segments to reclaim in a single step")
     , prometheus_port(this, "prometheus_port", value_status::Used, 9180, "Prometheus port, set to zero to disable")
@@ -1147,13 +1147,6 @@ db::fs::path db::config::get_conf_sub(db::fs::path sub) {
 }
 
 bool db::config::check_experimental(experimental_features_t::feature f) const {
-    if (experimental()
-        && f != experimental_features_t::feature::UNUSED
-        && f != experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES
-        && f != experimental_features_t::feature::BROADCAST_TABLES
-        && f != experimental_features_t::feature::TABLETS) {
-            return true;
-    }
     const auto& optval = experimental_features();
     return find(begin(optval), end(optval), enum_option<experimental_features_t>{f}) != end(optval);
 }

--- a/db/config.hh
+++ b/db/config.hh
@@ -97,8 +97,6 @@ namespace db {
 
 /// Enumeration of all valid values for the `experimental` config entry.
 struct experimental_features_t {
-    // NOTE: CONSISTENT_TOPOLOGY_CHANGES and BROADCAST_TABLES features are not enabled via `experimental` umbrella flag.
-    // These options should be enabled explicitly.
     enum class feature {
         UNUSED,
         UDF,

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -1035,18 +1035,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
     return make_ready_future();
 }
 
-SEASTAR_TEST_CASE(test_parse_experimental_true) {
-    auto cfg_ptr = std::make_unique<config>();
-    config& cfg = *cfg_ptr;
-    cfg.read_from_yaml("experimental: true", throw_on_error);
-    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
-    BOOST_CHECK(cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
-    return make_ready_future();
-}
-
 SEASTAR_TEST_CASE(test_parse_experimental_false) {
     auto cfg_ptr = std::make_unique<config>();
     config& cfg = *cfg_ptr;

--- a/test/broadcast_tables/suite.yaml
+++ b/test/broadcast_tables/suite.yaml
@@ -1,2 +1,5 @@
 type: Python
-extra_scylla_cmdline_options: ["--consistent-cluster-management=true", "--experimental-features=broadcast-tables"]
+extra_scylla_cmdline_options:
+  - "--consistent-cluster-management=true"
+  - "--experimental-features=broadcast-tables"
+  - "--enable-user-defined-functions=false"

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -71,8 +71,12 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         'enable_user_defined_functions': True,
-        'experimental': True,
-        'experimental_features': ['udf', 'consistent-topology-changes'],
+        'experimental_features': ['udf',
+                                  'alternator-streams',
+                                  'consistent-topology-changes',
+                                  'broadcast-tables',
+                                  'keyspace-storage-options',
+                                  'tablets'],
 
         'consistent_cluster_management': True,
 

--- a/test/topology_custom/test_boot_after_ip_change.py
+++ b/test/topology_custom/test_boot_after_ip_change.py
@@ -21,7 +21,8 @@ async def test_boot_after_ip_change(manager: ManagerClient) -> None:
     """Bootstrap a new node after existing one changed its IP.
        Regression test for #14468. Does not apply to Raft-topology mode.
     """
-    cfg = {'experimental_features': list[str]()}
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': list[str]()}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)

--- a/test/topology_custom/test_replace_ignore_nodes.py
+++ b/test/topology_custom/test_replace_ignore_nodes.py
@@ -25,7 +25,8 @@ async def test_replace_ignore_nodes(manager: ManagerClient) -> None:
        we don't want to run it in debug mode.
        Preferably run it only in one mode e.g. dev.
     """
-    cfg = {'experimental_features': list[str]()}
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': list[str]()}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(7)]
     s2_id = await manager.get_host_id(servers[2].server_id)

--- a/test/topology_custom/test_topology_remove_garbage_group0.py
+++ b/test/topology_custom/test_topology_remove_garbage_group0.py
@@ -24,7 +24,8 @@ async def test_remove_garbage_group0_members(manager: ManagerClient):
     even though the node is no longer a token ring member. Does not apply to Raft-topology mode.
     """
     # 4 servers, one dead
-    cfg = {'experimental_features': list[str]()}
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': list[str]()}
     servers = [await manager.server_add(config=cfg) for _ in range(4)]
     removed_host_id = await manager.get_host_id(servers[0].server_id)
     await manager.server_stop_gracefully(servers[0].server_id)

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -5,6 +5,7 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
+    enable_user_defined_functions: False
     experimental_features: ['consistent-topology-changes', 'tablets']
 skip_in_release:
   - test_blocked_bootstrap

--- a/test/topology_raft_disabled/suite.yaml
+++ b/test/topology_raft_disabled/suite.yaml
@@ -5,6 +5,7 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
+    enable_user_defined_functions: False
     experimental_features: []
     consistent_cluster_management: False
 run_first:

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -564,7 +564,6 @@ future<schema_ptr> load_one_schema_from_file(std::filesystem::path path) {
 
 schema_ptr load_system_schema(std::string_view keyspace, std::string_view table) {
     db::config cfg;
-    cfg.experimental.set(true);
     cfg.experimental_features.set(db::experimental_features_t::all());
     const std::unordered_map<std::string_view, std::vector<schema_ptr>> schemas{
         {db::schema_tables::NAME, db::schema_tables::all_tables(db::schema_features::full())},


### PR DESCRIPTION
in this series, the "experimental" option is marked `Unused` as it has been marked deprecated for almost 2 years since scylla 4.6. and use `experimental_features` to specify the used experimental features explicitly.