### PR TITLE
Add CQL event for tablet change

### DIFF
--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -180,3 +180,7 @@ The string map in the SUPPORTED response will contain the following parameters:
 
   - `ERROR_CODE`: a 32-bit signed decimal integer which Scylla
     will use as the error code for the rate limit exception.
+
+## Tablet change event
+
+When the tablet table changes, there is an event notification sent (`cql_transport::event::event_type::TABLET_CHANGE`). Currently it only informs that something changed without specifying details. The body of the message is empty (except the event type).

--- a/transport/event.cc
+++ b/transport/event.cc
@@ -71,4 +71,8 @@ event::schema_change::schema_change(change_type change, target_type target, sstr
         break;
     }
 }
+
+event::tablet_change::tablet_change()
+    : event{event_type::TABLET_CHANGE}
+{ }
 }

--- a/transport/event.hh
+++ b/transport/event.hh
@@ -22,7 +22,7 @@ namespace cql_transport {
 
 class event {
 public:
-    enum class event_type { TOPOLOGY_CHANGE, STATUS_CHANGE, SCHEMA_CHANGE };
+    enum class event_type { TOPOLOGY_CHANGE, STATUS_CHANGE, SCHEMA_CHANGE, TABLET_CHANGE };
 
     const event_type type;
 private:
@@ -31,6 +31,7 @@ public:
     class topology_change;
     class status_change;
     class schema_change;
+    class tablet_change;
 };
 
 class event::topology_change : public event {
@@ -80,6 +81,11 @@ public:
     template <typename... Ts>
     schema_change(change_type change, target_type target, sstring keyspace, Ts... arguments)
         : schema_change(change, target, keyspace, std::vector<sstring>{std::move(arguments)...}) {}
+};
+
+class event::tablet_change : public event {
+public:
+    tablet_change();
 };
 
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -183,6 +183,8 @@ event::event_type parse_event_type(const sstring& value)
         return event::event_type::STATUS_CHANGE;
     } else if (value == "SCHEMA_CHANGE") {
         return event::event_type::SCHEMA_CHANGE;
+    } else if (value == "TABLET_CHANGE") {
+        return event::event_type::TABLET_CHANGE;
     } else {
         throw exceptions::protocol_exception(format("Invalid value '{}' for Event.Type", value));
     }
@@ -1570,6 +1572,14 @@ cql_server::connection::make_schema_change_event(const event::schema_change& eve
     auto response = std::make_unique<cql_server::response>(-1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
     response->write_string("SCHEMA_CHANGE");
     response->serialize(event, _version);
+    return response;
+}
+
+std::unique_ptr<cql_server::response>
+cql_server::connection::make_tablet_change_event(const event::tablet_change& event) const
+{
+    auto response = std::make_unique<cql_server::response>(-1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
+    response->write_string("TABLET_CHANGE");
     return response;
 }
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -254,6 +254,7 @@ private:
         std::unique_ptr<cql_server::response> make_topology_change_event(const cql_transport::event::topology_change& event) const;
         std::unique_ptr<cql_server::response> make_status_change_event(const cql_transport::event::status_change& event) const;
         std::unique_ptr<cql_server::response> make_schema_change_event(const cql_transport::event::schema_change& event) const;
+        std::unique_ptr<cql_server::response> make_tablet_change_event(const cql_transport::event::tablet_change& event) const;
         std::unique_ptr<cql_server::response> make_autheticate(int16_t, std::string_view, const tracing::trace_state_ptr& tr_state) const;
         std::unique_ptr<cql_server::response> make_auth_success(int16_t, bytes, const tracing::trace_state_ptr& tr_state) const;
         std::unique_ptr<cql_server::response> make_auth_challenge(int16_t, bytes, const tracing::trace_state_ptr& tr_state) const;
@@ -290,6 +291,7 @@ class cql_server::event_notifier : public service::migration_listener,
     std::set<cql_server::connection*> _topology_change_listeners;
     std::set<cql_server::connection*> _status_change_listeners;
     std::set<cql_server::connection*> _schema_change_listeners;
+    std::set<cql_server::connection*> _tablet_change_listeners;
     std::unordered_map<gms::inet_address, event::status_change::status_type> _last_status_change;
 
     // We want to delay sending NEW_NODE CQL event to clients until the new node


### PR DESCRIPTION
The protocol extended with a new kind of event, cql_transport::event::event_type::TABLET_CHANGE.

It is sent whenever tablet metadata changes. It does not have information about the type of change
that happened just the information that something have changed.

I added the information about new event to the docs.