### PR TITLE
group0_state_machine: await transfer_snapshot

### DIFF
--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -51,6 +51,6 @@ struct raft_topology_snapshot {
 struct raft_topology_pull_params {};
 
 verb raft_topology_cmd (raft::term_t term, uint64_t cmd_index, service::raft_topology_cmd) -> service::raft_topology_cmd_result;
-verb raft_pull_topology_snapshot (service::raft_topology_pull_params) -> service::raft_topology_snapshot;
+verb [[cancellable]] raft_pull_topology_snapshot (service::raft_topology_pull_params) -> service::raft_topology_snapshot;
 verb [[cancellable]] tablet_stream_data (locator::global_tablet_id);
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1224,6 +1224,11 @@ future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canoni
     return send_message<future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>>>(this, messaging_verb::MIGRATION_REQUEST,
             std::move(id), options);
 }
+future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>> messaging_service::send_migration_request(msg_addr id,
+        abort_source& as, schema_pull_options options) {
+    return send_message_cancellable<future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>>>(this, messaging_verb::MIGRATION_REQUEST,
+            std::move(id), as, options);
+}
 
 void messaging_service::register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func) {
     register_handler(this, netw::messaging_verb::GET_SCHEMA_VERSION, std::move(func));

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -492,6 +492,8 @@ public:
     future<> unregister_migration_request();
     future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>> send_migration_request(msg_addr id,
             schema_pull_options options);
+    future<rpc::tuple<std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>>>> send_migration_request(msg_addr id,
+            abort_source& as, schema_pull_options options);
 
     // Wrapper for GET_SCHEMA_VERSION
     void register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func);

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -179,6 +179,8 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
     // log, so some raft entries may be double applied, but since the state
     // machine is idempotent it is not a problem.
 
+    auto holder = _gate.hold();
+
     slogger.trace("transfer snapshot from {} index {} snp id {}", from, snp.idx, snp.id);
     netw::messaging_service::msg_addr addr{from, 0};
     // (Ab)use MIGRATION_REQUEST to also transfer group0 history table mutation besides schema tables mutations.
@@ -207,7 +209,7 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
 }
 
 future<> group0_state_machine::abort() {
-    return make_ready_future<>();
+    return _gate.close();
 }
 
 } // end of namespace service

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -12,6 +12,7 @@
 #include "dht/token.hh"
 #include "message/messaging_service.hh"
 #include "mutation/canonical_mutation.hh"
+#include "seastar/core/abort_source.hh"
 #include "seastar/core/on_internal_error.hh"
 #include "service/broadcast_tables/experimental/query_result.hh"
 #include "schema_mutations.hh"
@@ -175,6 +176,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
 }
 
 future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::snapshot_descriptor snp) {
+  try {
     // Note that this may bring newer state than the group0 state machine raft's
     // log, so some raft entries may be double applied, but since the state
     // machine is idempotent it is not a problem.
@@ -183,21 +185,23 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
 
     slogger.trace("transfer snapshot from {} index {} snp id {}", from, snp.idx, snp.id);
     netw::messaging_service::msg_addr addr{from, 0};
+    auto& as = _abort_source;
+
     // (Ab)use MIGRATION_REQUEST to also transfer group0 history table mutation besides schema tables mutations.
-    auto [_, cm] = co_await _mm._messaging.send_migration_request(addr, netw::schema_pull_options { .group0_snapshot_transfer = true });
+    auto [_, cm] = co_await _mm._messaging.send_migration_request(addr, as, netw::schema_pull_options { .group0_snapshot_transfer = true });
     if (!cm) {
         // If we're running this code then remote supports Raft group 0, so it should also support canonical mutations
         // (which were introduced a long time ago).
         on_internal_error(slogger, "Expected MIGRATION_REQUEST to return canonical mutations");
     }
 
-    auto topology_snp = co_await ser::storage_service_rpc_verbs::send_raft_pull_topology_snapshot(&_mm._messaging, addr, service::raft_topology_pull_params{});
+    auto topology_snp = co_await ser::storage_service_rpc_verbs::send_raft_pull_topology_snapshot(&_mm._messaging, addr, as, service::raft_topology_pull_params{});
 
     auto history_mut = extract_history_mutation(*cm, _sp.data_dictionary());
 
     // TODO ensure atomicity of snapshot application in presence of crashes (see TODO in `apply`)
 
-    auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
+    auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex(as);
 
     co_await _mm.merge_schema_from(addr, std::move(*cm));
 
@@ -206,9 +210,13 @@ future<> group0_state_machine::transfer_snapshot(gms::inet_address from, raft::s
     }
 
     co_await _sp.mutate_locally({std::move(history_mut)}, nullptr);
+  } catch (const abort_requested_exception&) {
+    throw raft::request_aborted();
+  }
 }
 
 future<> group0_state_machine::abort() {
+    _abort_source.request_abort();
     return _gate.close();
 }
 

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -8,7 +8,9 @@
 #pragma once
 
 #include <seastar/core/gate.hh>
+#include <seastar/core/abort_source.hh>
 
+#include "seastar/core/abort_source.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "raft/raft.hh"
 #include "utils/UUID_gen.hh"
@@ -88,6 +90,7 @@ class group0_state_machine : public raft_state_machine {
     storage_service& _ss;
     cdc::generation_service& _cdc_gen_svc;
     seastar::gate _gate;
+    abort_source _abort_source;
 
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <seastar/core/gate.hh>
+
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "raft/raft.hh"
 #include "utils/UUID_gen.hh"
@@ -85,6 +87,7 @@ class group0_state_machine : public raft_state_machine {
     storage_proxy& _sp;
     storage_service& _ss;
     cdc::generation_service& _cdc_gen_svc;
+    seastar::gate _gate;
 
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -422,6 +422,10 @@ future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex() {
     return get_units(_read_apply_mutex, 1);
 }
 
+future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex(abort_source& as) {
+    return get_units(_read_apply_mutex, 1, as);
+}
+
 db::system_keyspace& raft_group0_client::sys_ks() {
     return _sys_ks;
 }

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -170,6 +170,7 @@ public:
     future<> wait_until_group0_upgraded(abort_source&);
 
     future<semaphore_units<>> hold_read_apply_mutex();
+    future<semaphore_units<>> hold_read_apply_mutex(abort_source&);
 
     db::system_keyspace& sys_ks();
 


### PR DESCRIPTION
Hold a (newly added) group0_state_machine gate
that is closed and waited on in group0_state_machine::abort()
To prevent use-after-free when destroying the group0_state_machine
while transfer_snapshot runs.

Fixes #14907

Also, use an abort_source in group0_state_machine
to abort an ongoing transfer_snapshot operation
on group0_state_machine::abort()