### PR TITLE
tablets: Fix crash on table drop

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -155,7 +155,8 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     std::map<table_id, schema_mutations>&& tables_after,
     std::map<table_id, schema_mutations>&& views_before,
     std::map<table_id, schema_mutations>&& views_after,
-    bool reload);
+    bool reload,
+    bool has_tablet_mutations);
 
 struct [[nodiscard]] user_types_to_drop final {
     seastar::noncopyable_function<future<> ()> drop;
@@ -1307,18 +1308,11 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
     auto new_aggregates = co_await read_schema_for_keyspaces(proxy, AGGREGATES, keyspaces);
     auto new_scylla_aggregates = co_await read_schema_for_keyspaces(proxy, SCYLLA_AGGREGATES, keyspaces);
 
-    if (has_tablet_mutations) {
-        slogger.info("Tablet metadata changed");
-        co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-            co_await db.get_notifier().update_tablet_metadata();
-        });
-    }
-
     std::set<sstring> keyspaces_to_drop = co_await merge_keyspaces(proxy, std::move(old_keyspaces), std::move(new_keyspaces));
     auto types_to_drop = co_await merge_types(proxy, std::move(old_types), std::move(new_types));
     co_await merge_tables_and_views(proxy, sys_ks,
         std::move(old_column_families), std::move(new_column_families),
-        std::move(old_views), std::move(new_views), reload);
+        std::move(old_views), std::move(new_views), reload, has_tablet_mutations);
     co_await merge_functions(proxy, std::move(old_functions), std::move(new_functions));
     co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates), std::move(old_scylla_aggregates), std::move(new_scylla_aggregates));
     co_await types_to_drop.drop();
@@ -1464,7 +1458,8 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     std::map<table_id, schema_mutations>&& tables_after,
     std::map<table_id, schema_mutations>&& views_before,
     std::map<table_id, schema_mutations>&& views_after,
-    bool reload)
+    bool reload,
+    bool has_tablet_mutations)
 {
     auto tables_diff = diff_table_or_view(proxy, std::move(tables_before), std::move(tables_after), reload, [&] (schema_mutations sm, schema_diff_side) {
         return create_table_from_mutations(proxy, std::move(sm));
@@ -1522,6 +1517,16 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, sys_ks, s.ks_name(), s.cf_name());
     });
+
+    if (has_tablet_mutations) {
+        slogger.info("Tablet metadata changed");
+        // We must do it after tables are dropped so that table snapshot doesn't experience missing tablet map,
+        // and so that compaction groups are not destroyed altogether.
+        // We must also do it before tables are created so that new tables see the tablet map.
+        co_await db.invoke_on_all([&] (replica::database& db) -> future<> {
+            co_await db.get_notifier().update_tablet_metadata();
+        });
+    }
 
     co_await db.invoke_on_all([&] (replica::database& db) -> future<> {
         // In order to avoid possible races we first create the tables and only then the views.


### PR DESCRIPTION
Before the patch, tablet metadata update was processed on local schema merge before table changes.

When table is dropped, this means that for a while table will exist without a corresponding tablet map. This can cause memtable flush for this table to fail, resulting in intentional abort(). That's because sstable writing attempts to access tablet map to generate sharding metadata.

If auto_snapshot is enabled, this is much more likely to happen, because we flush memtables on table drop.

To fix the problem, process tablet metadata after dropping tables, but before creating tables.

Fixes #14943