### PR TITLE
feature_service: don't load whole topology state to check features

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2531,9 +2531,8 @@ future<service::topology> system_keyspace::load_topology_state() {
             rebuild_option = row.get_as<sstring>("rebuild_option");
         }
 
-        std::set<sstring> supported_features;
-        if (row.has("supported_features")) {
-            supported_features = decode_features(deserialize_set_column(*topology(), row, "supported_features"));
+        if (row.has("supported_features") && nstate == service::node_state::normal) {
+            ret.features.normal_supported_features.emplace(host_id, decode_features(deserialize_set_column(*topology(), row, "supported_features")));
         }
 
         if (row.has("topology_request")) {
@@ -2602,7 +2601,7 @@ future<service::topology> system_keyspace::load_topology_state() {
         if (map) {
             map->emplace(host_id, service::replica_state{
                 nstate, std::move(datacenter), std::move(rack), std::move(release_version),
-                ring_slice, shard_count, ignore_msb, std::move(supported_features)});
+                ring_slice, shard_count, ignore_msb});
         }
     }
 
@@ -2677,7 +2676,7 @@ future<service::topology> system_keyspace::load_topology_state() {
         }
 
         if (some_row.has("enabled_features")) {
-            ret.enabled_features = decode_features(deserialize_set_column(*topology(), some_row, "enabled_features"));
+            ret.features.enabled_features = decode_features(deserialize_set_column(*topology(), some_row, "enabled_features"));
         }
     }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2531,10 +2531,6 @@ future<service::topology> system_keyspace::load_topology_state() {
             rebuild_option = row.get_as<sstring>("rebuild_option");
         }
 
-        if (row.has("supported_features") && nstate == service::node_state::normal) {
-            ret.features.normal_supported_features.emplace(host_id, decode_features(deserialize_set_column(*topology(), row, "supported_features")));
-        }
-
         if (row.has("topology_request")) {
             auto req = service::topology_request_from_string(row.get_as<sstring>("topology_request"));
             ret.requests.emplace(host_id, req);
@@ -2674,13 +2670,42 @@ future<service::topology> system_keyspace::load_topology_state() {
                     some_row.get_as<sstring>("global_topology_request"));
             ret.global_request.emplace(req);
         }
+    }
 
-        if (some_row.has("enabled_features")) {
-            ret.features.enabled_features = decode_features(deserialize_set_column(*topology(), some_row, "enabled_features"));
+    ret.features = decode_topology_features_state(std::move(rs));
+
+    co_return ret;
+}
+
+future<service::topology_features> system_keyspace::load_topology_features_state() {
+    auto rs = co_await execute_cql(
+        format("SELECT host_id, node_state, supported_features, enabled_features FROM system.{} WHERE key = '{}'", TOPOLOGY, TOPOLOGY));
+    assert(rs);
+
+    co_return decode_topology_features_state(std::move(rs));
+}
+
+service::topology_features system_keyspace::decode_topology_features_state(::shared_ptr<cql3::untyped_result_set> rs) {
+    service::topology_features ret;
+
+    if (rs->empty()) {
+        return ret;
+    }
+
+    for (auto& row : *rs) {
+        raft::server_id host_id{row.get_as<utils::UUID>("host_id")};
+        service::node_state nstate = service::node_state_from_string(row.get_as<sstring>("node_state"));
+        if (row.has("supported_features") && nstate == service::node_state::normal) {
+            ret.normal_supported_features.emplace(host_id, decode_features(deserialize_set_column(*topology(), row, "supported_features")));
         }
     }
 
-    co_return ret;
+    auto& some_row = *rs->begin();
+    if (some_row.has("enabled_features")) {
+        ret.enabled_features = decode_features(deserialize_set_column(*topology(), some_row, "enabled_features"));
+    }
+
+    return ret;
 }
 
 future<int64_t> system_keyspace::get_topology_fence_version() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -35,6 +35,7 @@ namespace service {
 class storage_service;
 class raft_group_registry;
 struct topology;
+struct topology_features;
 
 namespace paxos {
     class paxos_state;
@@ -475,6 +476,7 @@ public:
     future<bool> group0_history_contains(utils::UUID state_id);
 
     future<service::topology> load_topology_state();
+    future<service::topology_features> load_topology_features_state();
     future<int64_t> get_topology_fence_version();
     future<> update_topology_fence_version(int64_t value);
 
@@ -508,6 +510,11 @@ public:
 
     future<bool> get_must_synchronize_topology();
     future<> set_must_synchronize_topology(bool);
+
+private:
+    static service::topology_features decode_topology_features_state(::shared_ptr<cql3::untyped_result_set> rs);
+
+public:
 
     system_keyspace(cql3::query_processor& qp, replica::database& db, const locator::snitch_ptr&) noexcept;
     ~system_keyspace();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -257,8 +257,8 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
         persisted_features = co_await sys_ks.load_local_enabled_features();
     } else {
         auto topo = co_await sys_ks.load_topology_state();
-        persisted_unsafe_to_disable_features = topo.calculate_not_yet_enabled_features();
-        persisted_features = std::move(topo.enabled_features);
+        persisted_unsafe_to_disable_features = topo.features.calculate_not_yet_enabled_features();
+        persisted_features = std::move(topo.features.enabled_features);
     }
 
     if (persisted_features.empty() && persisted_unsafe_to_disable_features.empty()) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -256,9 +256,9 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     if (!use_raft_cluster_features) {
         persisted_features = co_await sys_ks.load_local_enabled_features();
     } else {
-        auto topo = co_await sys_ks.load_topology_state();
-        persisted_unsafe_to_disable_features = topo.features.calculate_not_yet_enabled_features();
-        persisted_features = std::move(topo.features.enabled_features);
+        auto topo_features = co_await sys_ks.load_topology_features_state();
+        persisted_unsafe_to_disable_features = topo_features.calculate_not_yet_enabled_features();
+        persisted_features = std::move(topo_features.enabled_features);
     }
 
     if (persisted_features.empty() && persisted_unsafe_to_disable_features.empty()) {

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -36,11 +36,11 @@ bool topology::contains(raft::server_id id) {
            left_nodes.contains(id);
 }
 
-std::set<sstring> topology::calculate_not_yet_enabled_features() const {
+std::set<sstring> topology_features::calculate_not_yet_enabled_features() const {
     std::set<sstring> to_enable;
     bool first = true;
 
-    for (const auto& [_, rs] : normal_nodes) {
+    for (const auto& [id, supported_features] : normal_supported_features) {
         if (!first && to_enable.empty()) {
             break;
         }
@@ -49,11 +49,13 @@ std::set<sstring> topology::calculate_not_yet_enabled_features() const {
             // This is the first node that we process.
             // Calculate the set of features that this node understands
             // but are not enabled yet.
-            std::ranges::set_difference(rs.supported_features, enabled_features, std::inserter(to_enable, to_enable.begin()));
+            std::ranges::set_difference(supported_features, enabled_features, std::inserter(to_enable, to_enable.begin()));
             first = false;
         } else {
             // Erase the elements that this node doesn't support
-            std::erase_if(to_enable, [&rs = rs] (const sstring& f) { return !rs.supported_features.contains(f); });
+            std::erase_if(to_enable, [&supported_features = supported_features] (const sstring& f) {
+                return !supported_features.contains(f);
+            });
         }
     }
 


### PR DESCRIPTION
Currently, feature service uses `system_keyspace::load_topology_state`
to load information about features from the `system.topology` table.
This function implicitly assumes that it is called after schema
commitlog replay and will correspond to the state of the topology state
machine after some command is applied.

However, feature check happens before the commitlog replay. If some
group 0 command consists of multiple mutations that are not applied
atomically, the `load_topology_state` function may fail to construct a
`service::topology` object based on the table state. Moreover, this
function not only checks `system.topology` but also
`system.cdc_generations_v3` - in the case of the issue, the entry that
was loaded from the this table didn't contain the `num_ranges`
parameter.

In order to fix this, the feature check code now uses
`load_topology_features_state` which only loads enabled and supported
features from `system.topology`. Only this information is really
necessary for the feature check, and it doesn't have any invariants to
check.

Fixes: #14944