### PR TITLE
repair: delete unused fields

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -569,8 +569,6 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
     , rs(repair)
     , db(repair.get_db())
     , messaging(repair.get_messaging().container())
-    , sys_dist_ks(repair.get_sys_dist_ks())
-    , view_update_generator(repair.get_view_update_generator())
     , mm(repair.get_migration_manager())
     , gossiper(repair.get_gossiper())
     , sharder(get_sharder_for_tables(db, keyspace, table_ids_))
@@ -583,7 +581,6 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
     , hosts(hosts_)
     , ignore_nodes(ignore_nodes_)
     , total_rf(erm->get_replication_factor())
-    , nr_ranges_total(ranges.size())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed))
 { }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -346,7 +346,7 @@ static future<std::list<gms::inet_address>> get_hosts_participating_in_repair(
 }
 
 float node_ops_metrics::repair_finished_percentage() {
-    return _module->report_progress(streaming::stream_reason::repair);
+    return _module->report_progress();
 }
 
 repair::task_manager_module::task_manager_module(tasks::task_manager& tm, repair_service& rs, size_t max_repair_memory) noexcept
@@ -474,14 +474,14 @@ void repair::task_manager_module::abort_all_repairs() {
     rlogger.info0("Started to abort repair jobs={}, nr_jobs={}", _aborted_pending_repairs, _aborted_pending_repairs.size());
 }
 
-float repair::task_manager_module::report_progress(streaming::stream_reason reason) {
+float repair::task_manager_module::report_progress() {
     uint64_t nr_ranges_finished = 0;
     uint64_t nr_ranges_total = 0;
     for (auto& x : _repairs) {
         auto it = _tasks.find(x.second);
         if (it != _tasks.end()) {
             auto& impl = dynamic_cast<repair::shard_repair_task_impl&>(*it->second->_impl);
-            if (impl.reason() == reason) {
+            if (impl.reason() == streaming::stream_reason::repair) {
                 nr_ranges_total += impl.ranges_size();
                 nr_ranges_finished += impl.nr_ranges_finished;
             }

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -97,8 +97,6 @@ public:
     repair_service& rs;
     seastar::sharded<replica::database>& db;
     seastar::sharded<netw::messaging_service>& messaging;
-    sharded<db::system_distributed_keyspace>& sys_dist_ks;
-    sharded<db::view::view_update_generator>& view_update_generator;
     service::migration_manager& mm;
     gms::gossiper& gossiper;
     const dht::sharder& sharder;
@@ -113,7 +111,6 @@ public:
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
     size_t total_rf;
     uint64_t nr_ranges_finished = 0;
-    uint64_t nr_ranges_total;
     size_t nr_failed_ranges = 0;
     int ranges_index = 0;
     repair_stats _stats;

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -214,7 +214,7 @@ public:
     named_semaphore& range_parallelism_semaphore();
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
-    float report_progress(streaming::stream_reason reason);
+    float report_progress();
     bool is_aborted(const tasks::task_id& uuid);
 };
 


### PR DESCRIPTION
Delete unused shard_repair_task_impl members and incorrectly used method's argument.