### PR TITLE
test/topology: skip features test for debug mode

### DIFF
--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -12,3 +12,5 @@ run_first:
     - test_tablets
 skip_in_release:
     - test_cluster_features
+skip_in_debug:
+    - test_cluster_features

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -13,3 +13,4 @@ skip_in_debug:
   - test_shutdown_hang
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
+  - test_deprecating_cluster_features

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -10,3 +10,5 @@ extra_scylla_config_options:
 skip_in_release:
   - test_blocked_bootstrap
   - test_raft_cluster_features
+skip_in_debug:
+  - test_raft_cluster_features


### PR DESCRIPTION
These tests are taking too long to run in debug mode and this mode is not useful anyway. Disable in debug for now.

Refs #13905