### PR TITLE
Export tablet load-balancer metrics

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1227,13 +1227,26 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,
                     gossiper.local(), feature_service.local(), sys_ks.local(), group0_client};
 
+            distributed<service::tablet_allocator> tablet_allocator;
+            if (cfg->check_experimental(db::experimental_features_t::feature::TABLETS)) {
+                if (!cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
+                    startlog.error("Bad configuration: The consistent-topology-changes feature has to be enabled if tablets feature is enabled");
+                    throw bad_configuration_error();
+                }
+                tablet_allocator.start(std::ref(mm_notifier), std::ref(db)).get();
+            }
+            auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {
+                tablet_allocator.stop().get();
+            });
+
             supervisor::notify("initializing storage service");
             debug::the_storage_service = &ss;
             ss.start(std::ref(stop_signal.as_sharded_abort_source()),
                 std::ref(db), std::ref(gossiper), std::ref(sys_ks),
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
-                std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch)).get();
+                std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
+                std::ref(tablet_allocator)).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();
@@ -1245,18 +1258,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             forward_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();
             auto stop_forward_service_handlers = defer_verbose_shutdown("forward service", [&forward_service] {
                 forward_service.stop().get();
-            });
-
-            distributed<service::tablet_allocator> tablet_allocator;
-            if (cfg->check_experimental(db::experimental_features_t::feature::TABLETS)) {
-                if (!cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
-                    startlog.error("Bad configuration: The consistent-topology-changes feature has to be enabled if tablets feature is enabled");
-                    throw bad_configuration_error();
-                }
-                tablet_allocator.start(std::ref(mm_notifier), std::ref(db)).get();
-            }
-            auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {
-                tablet_allocator.stop().get();
             });
 
             supervisor::notify("starting migration manager");

--- a/main.cc
+++ b/main.cc
@@ -1228,13 +1228,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     gossiper.local(), feature_service.local(), sys_ks.local(), group0_client};
 
             distributed<service::tablet_allocator> tablet_allocator;
-            if (cfg->check_experimental(db::experimental_features_t::feature::TABLETS)) {
-                if (!cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
+            if (cfg->check_experimental(db::experimental_features_t::feature::TABLETS) &&
+                !cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
                     startlog.error("Bad configuration: The consistent-topology-changes feature has to be enabled if tablets feature is enabled");
                     throw bad_configuration_error();
-                }
-                tablet_allocator.start(std::ref(mm_notifier), std::ref(db)).get();
             }
+            tablet_allocator.start(std::ref(mm_notifier), std::ref(db)).get();
             auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {
                 tablet_allocator.stop().get();
             });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -112,7 +112,8 @@ storage_service::storage_service(abort_source& abort_source,
     sharded<streaming::stream_manager>& stream_manager,
     endpoint_lifecycle_notifier& elc_notif,
     sharded<db::batchlog_manager>& bm,
-    sharded<locator::snitch_ptr>& snitch)
+    sharded<locator::snitch_ptr>& snitch,
+    sharded<service::tablet_allocator>& tablet_allocator)
         : _abort_source(abort_source)
         , _feature_service(feature_service)
         , _db(db)
@@ -133,6 +134,7 @@ storage_service::storage_service(abort_source& abort_source,
                 return ss.snitch_reconfigured();
             });
         })
+        , _tablet_allocator(tablet_allocator)
 {
     register_metrics();
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2007,6 +2007,11 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, cdc::gene
                     as->request_abort(); // we are no longer a leader, so abort the coordinator
                     co_await std::exchange(_topology_change_coordinator, make_ready_future<>());
                     as = std::nullopt;
+                    try {
+                        _tablet_allocator.local().on_leadership_lost();
+                    } catch (...) {
+                        slogger.error("tablet_allocator::on_leadership_lost() failed: {}", std::current_exception());
+                    }
                 }
             }
             // We are the leader now but that can change any time!

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -39,6 +39,7 @@
 #include "repair/id.hh"
 #include "raft/server.hh"
 #include "service/topology_state_machine.hh"
+#include "service/tablet_allocator.hh"
 
 class node_ops_cmd_request;
 class node_ops_cmd_response;
@@ -161,7 +162,8 @@ public:
         sharded<streaming::stream_manager>& stream_manager,
         endpoint_lifecycle_notifier& elc_notif,
         sharded<db::batchlog_manager>& bm,
-        sharded<locator::snitch_ptr>& snitch);
+        sharded<locator::snitch_ptr>& snitch,
+        sharded<service::tablet_allocator>& tablet_allocator);
 
     // Needed by distributed<>
     future<> stop();
@@ -485,6 +487,7 @@ private:
     future<> replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept;
     sharded<db::system_keyspace>& _sys_ks;
     locator::snitch_signal_slot_t _snitch_reconfigure;
+    sharded<service::tablet_allocator>& _tablet_allocator;
 private:
     /**
      * Handle node bootstrap

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -14,6 +14,7 @@
 #include "service/tablet_allocator.hh"
 #include "utils/error_injection.hh"
 #include "utils/stall_free.hh"
+#include "db/config.hh"
 #include "locator/load_sketch.hh"
 #include "utils/div_ceil.hh"
 
@@ -555,7 +556,9 @@ public:
     tablet_allocator_impl(service::migration_notifier& mn, replica::database& db)
             : _migration_notifier(mn)
             , _db(db) {
-        _migration_notifier.register_listener(this);
+        if (db.get_config().check_experimental(db::experimental_features_t::feature::TABLETS)) {
+            _migration_notifier.register_listener(this);
+        }
     }
 
     tablet_allocator_impl(tablet_allocator_impl&&) = delete; // "this" captured.

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -701,6 +701,10 @@ public:
         }
     }
 
+    void on_leadership_lost() {
+        _load_balancer_stats.unregister();
+    }
+
     // FIXME: Handle materialized views.
 };
 
@@ -718,6 +722,10 @@ future<migration_plan> tablet_allocator::balance_tablets(locator::token_metadata
 
 tablet_allocator_impl& tablet_allocator::impl() {
     return static_cast<tablet_allocator_impl&>(*_impl);
+}
+
+void tablet_allocator::on_leadership_lost() {
+    impl().on_leadership_lost();
 }
 
 }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -65,6 +65,9 @@ public:
     /// The algorithm takes care of limiting the streaming load on the system, also by taking active migrations into account.
     ///
     future<migration_plan> balance_tablets(locator::token_metadata_ptr);
+
+    /// Should be called when the node is no longer a leader.
+    void on_leadership_lost();
 };
 
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -847,7 +847,8 @@ public:
                 std::ref(stream_manager),
                 std::ref(elc_notif),
                 std::ref(bm),
-                std::ref(snitch)).get();
+                std::ref(snitch),
+                std::ref(the_tablet_allocator)).get();
             auto stop_storage_service = defer([&ss] { ss.stop().get(); });
 
             ss.invoke_on_all([&] (service::storage_service& ss) {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -24,6 +24,7 @@
 #include "cql3/query_processor.hh"
 #include "bytes.hh"
 #include "schema/schema.hh"
+#include "service/tablet_allocator.hh"
 #include "test/lib/eventually.hh"
 
 namespace replica {
@@ -176,6 +177,8 @@ public:
     virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
     virtual sharded<db::system_keyspace>& get_system_keyspace() = 0;
+
+    virtual sharded<service::tablet_allocator>& get_tablet_allocator() = 0;
 
     virtual sharded<service::storage_proxy>& get_storage_proxy() = 0;
 


### PR DESCRIPTION
The metrics are registered on-demand when load-balancer is invoked, so that only leader exports the metrics. When leader changes, the old leader will stop exporting.

The metrics are divided into two levels: per-dc and per-node. In prometheus, they will have appropriate labels for dc and host_id values.

