### PR TITLE
sstables: delete_with_pending_deletion_log: batch sync_directory

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -527,8 +527,10 @@ future<> sstable_directory::delete_with_pending_deletion_log(std::vector<shared_
         }
 
         parallel_for_each(ssts, [] (shared_sstable sst) {
-            return sst->unlink();
+            return sst->unlink(sstables::storage::sync_dir::no);
         }).get();
+
+        sync_directory(first->_storage->prefix()).get();
 
         // Once all sstables are deleted, the log file can be removed.
         // Note: the log file will be removed also if unlink failed to remove

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -388,7 +388,9 @@ public:
 
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
-    future<> unlink() noexcept;
+    // Caller may pass sync_dir::no for batching multiple deletes in the same directory,
+    // and make sure the directory is sync'ed on or after the last call.
+    future<> unlink(storage::sync_dir sync = storage::sync_dir::yes) noexcept;
 
     db::large_data_handler& get_large_data_handler() {
         return _large_data_handler;
@@ -958,6 +960,8 @@ public:
 future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir);
 
 // similar to sstable::unlink, but works on a TOC file name
-future<> remove_by_toc_name(sstring sstable_toc_name);
+// Caller may pass sync_dir::no for batching multiple deletes in the same directory,
+// and make sure the directory is sync'ed on or after the last call.
+future<> remove_by_toc_name(sstring sstable_toc_name, storage::sync_dir sync = storage::sync_dir::yes);
 
 } // namespace sstables

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -48,13 +48,14 @@ public:
     virtual ~storage() {}
 
     using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
+    using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const = 0;
     virtual future<> change_state(const sstable& sst, sstring to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;
-    virtual future<> wipe(const sstable& sst) noexcept = 0;
+    virtual future<> wipe(const sstable& sst, sync_dir) noexcept = 0;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) = 0;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;


### PR DESCRIPTION
When deleting multiple sstables with the same prefix the deletion atomicity is ensured by the pending_delete_log file, so if scylla crashes in the middle, deletions will be replyed on restart.

Therefore, we don't have to ensure atomicity of each individual `unlink`.  We just need to sync the directory once, before removing the pending_delete_log file.