### PR TITLE
Generate run_id for sstables created by row-level repair

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -832,15 +832,15 @@ public:
             , _repair_hasher(_seed, _schema)
             , _compaction_time(compaction_time)
             {
-            if (master) {
-                add_to_repair_meta_for_masters(*this);
-            } else {
-                add_to_repair_meta_for_followers(*this);
-            }
-            _all_node_states.push_back(repair_node_state(utils::fb_utilities::get_broadcast_address()));
-            for (auto& node : all_live_peer_nodes) {
-                _all_node_states.push_back(repair_node_state(node));
-            }
+        if (master) {
+            add_to_repair_meta_for_masters(*this);
+        } else {
+            add_to_repair_meta_for_followers(*this);
+        }
+        _all_node_states.push_back(repair_node_state(utils::fb_utilities::get_broadcast_address()));
+        for (auto& node : all_live_peer_nodes) {
+            _all_node_states.push_back(repair_node_state(node));
+        }
     }
 
     // follower constructor

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -500,7 +500,7 @@ void repair_writer_impl::create_writer(lw_shared_ptr<repair_writer> w) {
     replica::table& t = _db.local().find_column_family(_schema->id());
     rlogger.debug("repair_writer: keyspace={}, table={}, estimated_partitions={}", w->schema()->ks_name(), w->schema()->cf_name(), w->get_estimated_partitions());
     _writer_done = mutation_writer::distribute_reader_and_consume_on_shards(_schema, _schema->get_sharder(), std::move(_queue_reader),
-            streaming::make_streaming_consumer(sstables::repair_origin, _db, _sys_dist_ks, _view_update_generator, w->get_estimated_partitions(), _reason, is_offstrategy_supported(_reason)),
+            streaming::make_streaming_consumer(sstables::repair_origin, _db, _sys_dist_ks, _view_update_generator, w->get_estimated_partitions(), _reason, is_offstrategy_supported(_reason), _run_id),
     t.stream_in_progress()).then([w] (uint64_t partitions) {
         rlogger.debug("repair_writer: keyspace={}, table={}, managed to write partitions={} to sstable",
             w->schema()->ks_name(), w->schema()->cf_name(), partitions);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -8,6 +8,7 @@
 
 #include <exception>
 #include <seastar/util/defer.hh>
+#include "dht/token.hh"
 #include "repair/repair.hh"
 #include "message/messaging_service.hh"
 #include "repair/task_manager_module.hh"
@@ -17,6 +18,7 @@
 #include "mutation_writer/multishard_writer.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"
+#include "sstables/types_fwd.hh"
 #include "utils/to_string.hh"
 #include "utils/xx_hasher.hh"
 #include "utils/UUID.hh"
@@ -696,6 +698,7 @@ private:
     repair_master _repair_master;
     gms::inet_address _myip;
     uint32_t _repair_meta_id;
+    sstables::run_id _run_id;
     streaming::stream_reason _reason;
     // Repair master's sharding configuration
     shard_config _master_node_shard_config;
@@ -762,6 +765,9 @@ public:
     uint32_t repair_meta_id() const {
         return _repair_meta_id;
     }
+    const sstables::run_id& run_id() const noexcept {
+        return _run_id;
+    }
     const std::optional<repair_sync_boundary>& current_sync_boundary() const {
         return _current_sync_boundary;
     }
@@ -788,6 +794,7 @@ public:
             uint64_t seed,
             repair_master master,
             uint32_t repair_meta_id,
+            sstables::run_id run_id,
             streaming::stream_reason reason,
             shard_config master_node_shard_config,
             inet_address_vector_replica_set all_live_peer_nodes,
@@ -810,6 +817,7 @@ public:
             , _repair_master(master)
             , _myip(utils::fb_utilities::get_broadcast_address())
             , _repair_meta_id(repair_meta_id)
+            , _run_id(run_id)
             , _reason(reason)
             , _master_node_shard_config(std::move(master_node_shard_config))
             , _remote_sharder(make_remote_sharder())
@@ -841,6 +849,7 @@ public:
         for (auto& node : all_live_peer_nodes) {
             _all_node_states.push_back(repair_node_state(node));
         }
+        rlogger.debug("Created repair_meta: repair_meta_id={} range={} run_id={}", _repair_meta_id, _range, _run_id);
     }
 
     // follower constructor
@@ -855,11 +864,12 @@ public:
             uint64_t seed,
             repair_master master,
             uint32_t repair_meta_id,
+            sstables::run_id run_id,
             streaming::stream_reason reason,
             shard_config master_node_shard_config,
             inet_address_vector_replica_set all_live_peer_nodes,
             gc_clock::time_point compaction_time)
-        : repair_meta(rs, cf, std::move(s), std::move(permit), std::move(range), algo, max_row_buf_size, seed, master, repair_meta_id, reason,
+        : repair_meta(rs, cf, std::move(s), std::move(permit), std::move(range), algo, max_row_buf_size, seed, master, repair_meta_id, run_id, reason,
                 std::move(master_node_shard_config), std::move(all_live_peer_nodes), 1, nullptr, compaction_time)
     {
     }
@@ -2845,6 +2855,7 @@ public:
                     _seed,
                     repair_master::yes,
                     repair_meta_id,
+                    sstables::run_id{},
                     _shard_task.reason(),
                     std::move(master_node_shard_config),
                     _all_live_peer_nodes,
@@ -3127,6 +3138,22 @@ repair_meta_ptr repair_service::get_repair_meta(gms::inet_address from, uint32_t
     }
 }
 
+void repair_service::range_tracker::insert_range(const dht::token_range& range) {
+    auto interval = interval_type(
+        range.start() ? range.start()->value() : dht::minimum_token(),
+        range.end() ? range.end()->value() : dht::maximum_token()
+    );
+    if (ranges.empty()) {
+        run_id = sstables::run_id::create_random_id();
+        rlogger.debug("range_tracker: generated new run_id={} for range={}", run_id, range);
+    } else if (auto it = ranges.find(interval); it != ranges.end()) {
+        run_id = sstables::run_id::create_random_id();
+        rlogger.debug("range_tracker: detected overlap between new range={} and repaired range={}: generated new run_id={}", interval, *it, run_id);
+        ranges.clear();
+    }
+    ranges.insert(interval);
+}
+
 future<>
 repair_service::insert_repair_meta(
         const gms::inet_address& from,
@@ -3166,6 +3193,10 @@ repair_service::insert_repair_meta(
                 reason,
                 compaction_time] (reader_permit permit) mutable {
         node_repair_meta_id id{from, repair_meta_id};
+        sstables::run_id run_id;
+        auto [it, _] = repair_ranges_map().try_emplace(from, range_tracker{});
+        it->second.insert_range(range);
+        run_id = it->second.run_id;
         auto rm = seastar::make_shared<repair_meta>(*this,
                 cf,
                 s,
@@ -3176,6 +3207,7 @@ repair_service::insert_repair_meta(
                 seed,
                 repair_master::no,
                 repair_meta_id,
+                run_id,
                 reason,
                 std::move(master_node_shard_config),
                 inet_address_vector_replica_set{from},
@@ -3183,11 +3215,11 @@ repair_service::insert_repair_meta(
         rm->set_repair_state_for_local_node(repair_state::row_level_start_started);
         bool insertion = repair_meta_map().emplace(id, rm).second;
         if (!insertion) {
-            rlogger.warn("insert_repair_meta: repair_meta_id {} for node {} already exists, replace existing one", id.repair_meta_id, id.ip);
+            rlogger.warn("insert_repair_meta: repair_meta_id {} for node {} already exists, replace existing one run_id={}", id.repair_meta_id, id.ip, run_id);
             repair_meta_map()[id] = rm;
             rm->set_repair_state_for_local_node(repair_state::row_level_start_finished);
         } else {
-            rlogger.debug("insert_repair_meta: Inserted repair_meta_id {} for node {}", id.repair_meta_id, id.ip);
+            rlogger.debug("insert_repair_meta: Inserted repair_meta_id {} for node {}, run_id={}", id.repair_meta_id, id.ip, run_id);
         }
         });
     });

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -9,11 +9,15 @@
 #pragma once
 
 #include <vector>
+
+#include <boost/icl/interval_base_set.hpp>
+
 #include "gms/inet_address.hh"
 #include "repair/repair.hh"
 #include "repair/task_manager_module.hh"
 #include "tasks/task_manager.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "sstables/types_fwd.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/util/bool_class.hh>
 
@@ -96,6 +100,17 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     node_ops_metrics _node_ops_metrics;
     std::unordered_map<node_repair_meta_id, repair_meta_ptr> _repair_metas;
     uint32_t _next_repair_meta_id = 0;  // used only on shard 0
+
+    struct range_tracker {
+        using interval_set_type = boost::icl::interval_set<dht::token>;
+        using interval_type = interval_set_type::interval_type;
+        interval_set_type ranges;
+        sstables::run_id run_id;
+
+        range_tracker() = default;
+        void insert_range(const dht::token_range&);
+    };
+    std::unordered_map<gms::inet_address, range_tracker> _repair_ranges;
 
     std::unordered_map<tasks::task_id, repair_history> _finished_ranges_history;
 
@@ -198,6 +213,10 @@ public:
 
     std::unordered_map<node_repair_meta_id, repair_meta_ptr>& repair_meta_map() noexcept {
         return _repair_metas;
+    }
+
+    std::unordered_map<gms::inet_address, range_tracker>& repair_ranges_map() noexcept {
+        return _repair_ranges;
     }
 
     repair_meta_ptr get_repair_meta(gms::inet_address from, uint32_t repair_meta_id);

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -9,6 +9,7 @@
 #include "repair/decorated_key_with_hash.hh"
 #include "readers/queue.hh"
 #include "sstables/sstable_set.hh"
+#include "sstables/types_fwd.hh"
 #include "readers/upgrading_consumer.hh"
 #include <seastar/core/coroutine.hh>
 
@@ -154,5 +155,6 @@ lw_shared_ptr<repair_writer> make_repair_writer(
             streaming::stream_reason reason,
             sharded<replica::database>& db,
             sharded<db::system_distributed_keyspace>& sys_dist_ks,
-            sharded<db::view::view_update_generator>& view_update_generator);
+            sharded<db::view::view_update_generator>& view_update_generator,
+            sstables::run_id run_id);
 

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -7,6 +7,7 @@
  */
 
 #include "sstables/sstable_set.hh"
+#include "sstables/types_fwd.hh"
 #include "streaming/stream_reason.hh"
 
 namespace replica {
@@ -28,6 +29,7 @@ std::function<future<>(flat_mutation_reader_v2)> make_streaming_consumer(sstring
     sharded<db::view::view_update_generator>& vug,
     uint64_t estimated_partitions,
     stream_reason reason,
-    sstables::offstrategy offstrategy);
+    sstables::offstrategy offstrategy,
+    sstables::run_id run_id = sstables::run_id::create_null_id());
 
 }


### PR DESCRIPTION
Track the repaired ranges per shard, per repair-master node and generate a random sstables::run_id for new repair ranges.  Reuse that run_id for writing sstables util a overlapping repair range is encountered, in which case, a new, random run_id is dispatched.

Note that this implementation assumes that repair is done one table at a time and moving on to the next table will produce a token range that will overlap with a previously repaired range (for the previous table).
We can track the repair ranges per keyspace/table to enable repairing of multiple tables in parallel, but we don't have a good way to clear this state after each table is repaired.

Fixes #8478