### PR TITLE
cql3: select_statement: reject DISTINCT with GROUP BY on clustering keys

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
@@ -1247,7 +1247,7 @@ def testCompactStorage(cql, test_keyspace):
         assert_rows2(execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS"), [row(True)], [row(True,None,None,None)])
 
 # SelectGroupByTest
-@pytest.mark.xfail(reason="issue #4244, #5361, #5362, #5363, #12479")
+@pytest.mark.xfail(reason="issue #4244, #5361, #5362, #5363")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_group_by_test.py
@@ -7,7 +7,7 @@
 
 from cassandra_tests.porting import *
 
-@pytest.mark.xfail(reason="Issue #2060, #5361, #5362, #5363, #12479, #13109")
+@pytest.mark.xfail(reason="Issue #2060, #5361, #5362, #5363, #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
 

--- a/test/cql-pytest/test_distinct.py
+++ b/test/cql-pytest/test_distinct.py
@@ -43,7 +43,6 @@ def test_distinct_in_partition_group_by(cql, table1):
 
 # "select distinct p" with "group by p,c" doesn't makes sense (we always
 # have one value for p, we can't split it per c), and should not be allowed.
-@pytest.mark.xfail(reason="issue #12479")
 def test_distinct_in_partition_group_by_c(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"insert into {table1} (p, c, v) values (?, ?, ?)")


### PR DESCRIPTION
While in SQL DISTINCT applies to the result set, in CQL it applies to the table being selected, and doesn't allow GROUP BY with clustering keys. So reject the combination like Cassandra does.

While this is not an important issue to fix, it blocks un-xfailing other issues, so I'm clearing it ahead of fixing those issues.

An issue is unmarked as xfail, and other xfails lose this issue as a blocker.

Fixes https://github.com/scylladb/scylladb/issues/12479