### PR TITLE
migration_manager: announce: provide descriptions for all calls

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -578,7 +578,7 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
 
         std::move(m2.begin(), m2.end(), std::back_inserter(m));
 
-        co_await mm.announce(std::move(m), std::move(group0_guard));
+        co_await mm.announce(std::move(m), std::move(group0_guard), format("alternator-executor: delete {} table", table_name));
     });
 
     rjson::value response = rjson::empty_object();
@@ -1143,7 +1143,7 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
         db::schema_tables::add_table_or_view_to_schema_mutation(
             view_ptr(view_builder.build()), ts, true, schema_mutations);
     }
-    co_await mm.announce(std::move(schema_mutations), std::move(group0_guard));
+    co_await mm.announce(std::move(schema_mutations), std::move(group0_guard), format("alternator-executor: create {} table", table_name));
 
     co_await mm.wait_for_schema_agreement(sp.local_db(), db::timeout_clock::now() + 10s, nullptr);
     rjson::value status = rjson::empty_object();
@@ -1210,7 +1210,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
 
         auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema, false,  std::vector<view_ptr>(), group0_guard.write_timestamp());
 
-        co_await mm.announce(std::move(m), std::move(group0_guard));
+        co_await mm.announce(std::move(m), std::move(group0_guard), format("alternator-executor: update {} table", tab->cf_name()));
 
         co_await mm.wait_for_schema_agreement(p.local().local_db(), db::timeout_clock::now() + 10s, nullptr);
 

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -71,7 +71,8 @@ static future<> create_metadata_table_if_missing_impl(
         auto group0_guard = co_await mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
         try {
-            co_return co_await mm.announce(co_await ::service::prepare_new_column_family_announcement(qp.proxy(), table, ts), std::move(group0_guard));
+            co_return co_await mm.announce(co_await ::service::prepare_new_column_family_announcement(qp.proxy(), table, ts),
+                    std::move(group0_guard), format("auth: create {} metadata table", table->cf_name()));
         } catch (exceptions::already_exists_exception&) {}
     }
 }

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -178,7 +178,8 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
                     opts,
                     true);
 
-            co_return co_await mm.announce(::service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts), std::move(group0_guard));
+            co_return co_await mm.announce(::service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),
+                    std::move(group0_guard), format("auth_service: create {} keyspace", meta::AUTH_KS));
         }
     }
 }

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -924,9 +924,8 @@ query_processor::execute_schema_statement(const statements::schema_altering_stat
 
 future<std::string>
 query_processor::execute_thrift_schema_command(
-        std::function<future<std::vector<mutation>>(
-            data_dictionary::database, api::timestamp_type)
-        > prepare_schema_mutations) {
+        std::function<future<std::vector<mutation>>(data_dictionary::database, api::timestamp_type)> prepare_schema_mutations,
+        std::string_view description) {
     assert(this_shard_id() == 0);
 
     auto [remote_, holder] = remote();
@@ -934,7 +933,7 @@ query_processor::execute_thrift_schema_command(
     auto group0_guard = co_await mm.start_group0_operation();
     auto ts = group0_guard.write_timestamp();
 
-    co_await mm.announce(co_await prepare_schema_mutations(db(), ts), std::move(group0_guard));
+    co_await mm.announce(co_await prepare_schema_mutations(db(), ts), std::move(group0_guard), description);
 
     co_return std::string(db().get_version().to_sstring());
 }

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -394,9 +394,8 @@ public:
 
     future<std::string>
     execute_thrift_schema_command(
-            std::function<future<std::vector<mutation>>(
-                data_dictionary::database, api::timestamp_type)
-            > prepare_schema_mutations);
+            std::function<future<std::vector<mutation>>(data_dictionary::database, api::timestamp_type)> prepare_schema_mutations,
+            std::string_view description);
 
     std::unique_ptr<statements::prepared_statement> get_statement(
             const std::string_view& query,

--- a/db/tags/utils.cc
+++ b/db/tags/utils.cc
@@ -65,7 +65,7 @@ future<> modify_tags(service::migration_manager& mm, sstring ks, sstring cf,
         auto m = co_await service::prepare_column_family_update_announcement(mm.get_storage_proxy(),
                 builder.build(), false, std::vector<view_ptr>(), group0_guard.write_timestamp());
 
-        co_await mm.announce(std::move(m), std::move(group0_guard));
+        co_await mm.announce(std::move(m), std::move(group0_guard), format("Modify tags for {} table", cf));
     });
 }
 

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -203,7 +203,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
         }
 
         if (!ks_mutations.empty()) {
-            co_await mml.announce(std::move(ks_mutations), std::move(group0_guard));
+            co_await mml.announce(std::move(ks_mutations), std::move(group0_guard), "keyspace-utils: create keyspaces for redis");
         }
     }
 
@@ -228,7 +228,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
 
     // create default databases for redis.
     if (!table_mutations.empty()) {
-        co_await mml.announce(std::move(table_mutations), std::move(group0_guard));
+        co_await mml.announce(std::move(table_mutations), std::move(group0_guard), "keyspace-utils: create default databases for redis");
     }
 }
 

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -145,7 +145,7 @@ public:
 
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
-    future<> announce(std::vector<mutation> schema, group0_guard, std::string_view description = "");
+    future<> announce(std::vector<mutation> schema, group0_guard, std::string_view description);
 
     void passive_announce(table_schema_version version);
 

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -52,7 +52,8 @@ future<> table_helper::setup_table(cql3::query_processor& qp, service::migration
     // The important thing is that it will converge eventually (some traces may
     // be lost in a process but that's ok).
     try {
-        co_return co_await mm.announce(co_await service::prepare_new_column_family_announcement(qp.proxy(), b.build(), ts), std::move(group0_guard));
+        co_return co_await mm.announce(co_await service::prepare_new_column_family_announcement(qp.proxy(), b.build(), ts),
+                std::move(group0_guard), format("table_helper: create {} table", schema->cf_name()));
     } catch (...) {}
 }
 
@@ -136,7 +137,8 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
             std::map<sstring, sstring> opts;
             opts["replication_factor"] = replication_factor;
             auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), true);
-            co_await mm.announce(service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts), std::move(group0_guard));
+            co_await mm.announce(service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),
+                    std::move(group0_guard), format("table_helper: create {} keyspace", keyspace_name));
         }
     }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4046,7 +4046,7 @@ SEASTAR_TEST_CASE(test_view_with_two_regular_base_columns_in_key) {
         auto& mm = e.migration_manager().local();
         auto group0_guard = mm.start_group0_operation().get();
         auto ts = group0_guard.write_timestamp();
-        mm.announce(service::prepare_new_view_announcement(mm.get_storage_proxy(), view_ptr(view_schema), ts).get(), std::move(group0_guard)).get();
+        mm.announce(service::prepare_new_view_announcement(mm.get_storage_proxy(), view_ptr(view_schema), ts).get(), std::move(group0_guard), "").get();
 
         // Verify that deleting and restoring columns behaves as expected - i.e. the row is deleted and regenerated
         cquery_nofail(e, "INSERT INTO t (p, c, v1, v2) VALUES (1, 2, 3, 4)");

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -266,13 +266,13 @@ static void test_database(void (*run_tests)(populate_fn_ex, bool), unsigned cgs)
                 auto group0_guard = mm.start_group0_operation().get();
                 auto ts = group0_guard.write_timestamp();
                 e.local_db().find_column_family(s->ks_name(), s->cf_name());
-                mm.announce(service::prepare_column_family_drop_announcement(mm.get_storage_proxy(), s->ks_name(), s->cf_name(), ts).get(), std::move(group0_guard)).get();
+                mm.announce(service::prepare_column_family_drop_announcement(mm.get_storage_proxy(), s->ks_name(), s->cf_name(), ts).get(), std::move(group0_guard), "").get();
             } catch (const replica::no_such_column_family&) {
                 // expected
             }
             auto group0_guard = mm.start_group0_operation().get();
             auto ts = group0_guard.write_timestamp();
-            mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard)).get();
+            mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard), "").get();
             replica::column_family& cf = e.local_db().find_column_family(s);
             auto uuid = cf.schema()->id();
             for (auto&& m : partitions) {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1001,7 +1001,7 @@ SEASTAR_TEST_CASE(sstable_compaction_does_not_resurrect_data) {
             .build();
         auto group0_guard = mm.start_group0_operation().get();
         auto ts = group0_guard.write_timestamp();
-        mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard)).get();
+        mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard), "").get();
 
         replica::table& t = db.find_column_family(ks_name, table_name);
 
@@ -1066,7 +1066,7 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         schema_ptr s = ss.schema();
         auto group0_guard = mm.start_group0_operation().get();
         auto ts = group0_guard.write_timestamp();
-        mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard)).get();
+        mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard), "").get();
 
         replica::table& t = db.find_column_family("ks", "cf");
         auto memtables = t.active_memtables();
@@ -1135,7 +1135,7 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
                     auto group0_guard = co_await mm.start_group0_operation();
                     auto ts = group0_guard.write_timestamp();
                     auto announcement = co_await service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts);
-                    co_await mm.announce(std::move(announcement), std::move(group0_guard));
+                    co_await mm.announce(std::move(announcement), std::move(group0_guard), "");
                 });
             }
 
@@ -1144,7 +1144,7 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
                     auto group0_guard = co_await mm.start_group0_operation();
                     auto ts = group0_guard.write_timestamp();
                     auto announcement = co_await service::prepare_column_family_drop_announcement(mm.get_storage_proxy(), ks_name(), cf_name(shard), ts);
-                    co_await mm.announce(std::move(announcement), std::move(group0_guard));
+                    co_await mm.announce(std::move(announcement), std::move(group0_guard), "");
                 });
             }
 

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4169,7 +4169,8 @@ SEASTAR_TEST_CASE(row_cache_is_populated_using_compacting_sstable_reader) {
             .build();
         mm.announce(
             service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, api::new_timestamp()).get(),
-            mm.start_group0_operation().get()
+            mm.start_group0_operation().get(),
+            ""
         ).get();
 
         replica::table& t = db.find_column_family(ks_name, table_name);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -313,7 +313,7 @@ public:
         auto s = builder.build(schema_builder::compact_storage::no);
         auto group0_guard = co_await _mm.local().start_group0_operation();
         auto ts = group0_guard.write_timestamp();
-        co_return co_await _mm.local().announce(co_await service::prepare_new_column_family_announcement(_proxy.local(), s, ts), std::move(group0_guard));
+        co_return co_await _mm.local().announce(co_await service::prepare_new_column_family_announcement(_proxy.local(), s, ts), std::move(group0_guard), "");
     }
 
     virtual future<> require_keyspace_exists(const sstring& ks_name) override {


### PR DESCRIPTION
The `system.group0_history` table provides useful descriptions for each command committed to Raft group 0. One way of applying a command to group 0 is by calling `migration_manager::announce`. This function has the `description` parameter set to empty string by default. Some calls to `announce` use this default value which causes `null` values in `system.group0_history`. We want `system.group0_history` to have an actual description for every command, so we change all default descriptions to reasonable ones.

Going further, We remove the default value for the `description` parameter of `migration_manager::announce` to avoid using it in the future. Thanks to this, all commands in `system.group0_history` will have a non-null description.

Fixes #13370

