### PR TITLE
test: topology: wait_for_token_ring_and_group0_consistency: per-server timeout

### DIFF
--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -42,10 +42,10 @@ async def wait_for(
         pred: Callable[[], Awaitable[Optional[T]]],
         deadline: float, period: float = 1) -> T:
     while True:
-        assert(time.time() < deadline), "Deadline exceeded, failing test."
         res = await pred()
         if res is not None:
             return res
+        assert(time.time() < deadline), "Deadline exceeded, failing test."
         await asyncio.sleep(period)
 
 

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -20,7 +20,7 @@ async def test_new_table(manager, random_tables):
     # Before performing data queries, make sure that the token ring
     # has converged (we're using ring_delay = 0).
     # Otherwise the queries may pick wrong replicas.
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
+    await wait_for_token_ring_and_group0_consistency(manager, 60)
     await cql.run_async(f"INSERT INTO {table} ({','.join(c.name for c in table.columns)})" \
                         f"VALUES ({', '.join(['%s'] * len(table.columns))})",
                         parameters=[c.val(1) for c in table.columns])

--- a/test/topology/test_replace.py
+++ b/test/topology/test_replace.py
@@ -20,7 +20,7 @@ async def test_replace_different_ip(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
 @pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:
@@ -29,7 +29,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
 @pytest.mark.asyncio
 async def test_replace_reuse_ip(manager: ManagerClient) -> None:
@@ -38,7 +38,7 @@ async def test_replace_reuse_ip(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
 @pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
@@ -47,4 +47,4 @@ async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = True)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)

--- a/test/topology/test_topology_remove_decom.py
+++ b/test/topology/test_topology_remove_decom.py
@@ -62,7 +62,7 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
     await manager.api.enable_injection(
         bootstrapped_server.ip_addr, 'storage_service_decommission_prepare_handler_sleep', one_shot=True)
     await manager.decommission_node(decommission_target.server_id)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
     await table.add_column()
     await random_tables.verify_schema()
 

--- a/test/topology/test_topology_schema.py
+++ b/test/topology/test_topology_schema.py
@@ -24,7 +24,7 @@ async def test_topology_schema_changes(manager, random_tables):
 
     # Test add column after adding a server
     await manager.server_add()
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
     await table.add_column()
     await random_tables.verify_schema()
 

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -74,13 +74,14 @@ async def check_token_ring_and_group0_consistency(manager: ManagerClient) -> Non
         assert token_ring_ids == group0_ids
 
 
-async def wait_for_token_ring_and_group0_consistency(manager: ManagerClient, deadline: float) -> None:
+async def wait_for_token_ring_and_group0_consistency(manager: ManagerClient, timeout: int = 30) -> None:
     """Weaker version of the above check; the token ring is not immediately updated after
     bootstrap/replace/decommission - the normal tokens of the new node propagate through gossip.
     Take this into account and wait for the equality condition to hold, with a timeout.
     """
     servers = await manager.running_servers()
     for srv in servers:
+        deadline = time.time() + timeout
         group0_members = await get_current_group0_config(manager, srv)
         group0_ids = {m[0] for m in group0_members}
         async def token_ring_matches():

--- a/test/topology_custom/test_boot_after_ip_change.py
+++ b/test/topology_custom/test_boot_after_ip_change.py
@@ -24,7 +24,7 @@ async def test_boot_after_ip_change(manager: ManagerClient) -> None:
     cfg = {'experimental_features': list[str]()}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     logger.info(f"Stopping server {servers[1]}")
     await manager.server_stop_gracefully(servers[1].server_id)

--- a/test/topology_custom/test_replace_ignore_nodes.py
+++ b/test/topology_custom/test_replace_ignore_nodes.py
@@ -41,16 +41,16 @@ async def test_replace_ignore_nodes(manager: ManagerClient) -> None:
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False,
                                 ignore_dead_nodes = ignore_dead)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     ignore_dead = [servers[2].ip_addr] 
     logger.info(f"Replacing {servers[1]}, ignore_dead_nodes = {ignore_dead}")
     replace_cfg = ReplaceConfig(replaced_id = servers[1].server_id, reuse_ip_addr = False, use_host_id = False,
                                 ignore_dead_nodes = ignore_dead)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     logger.info(f"Replacing {servers[2]}")
     replace_cfg = ReplaceConfig(replaced_id = servers[2].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)

--- a/test/topology_custom/test_select_from_mutation_fragments.py
+++ b/test/topology_custom/test_select_from_mutation_fragments.py
@@ -15,7 +15,7 @@ async def test_sticky_coordinator_enforced(manager: ManagerClient) -> None:
     s1 = await manager.server_add(cmdline=['--logger-log-level', 'paging=trace'])
     s2 = await manager.server_add(cmdline=['--logger-log-level', 'paging=trace'])
 
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     cql = manager.get_cql()
 

--- a/test/topology_custom/test_shutdown_hang.py
+++ b/test/topology_custom/test_shutdown_hang.py
@@ -21,7 +21,7 @@ async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
         'error_injections_at_startup': ['decrease_hints_flush_period']
     })
     s2 = await manager.server_add()
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     cql = manager.get_cql()
 

--- a/test/topology_custom/test_topology_smp.py
+++ b/test/topology_custom/test_topology_smp.py
@@ -44,7 +44,7 @@ async def test_nodes_with_different_smp(request: FixtureRequest, manager: Manage
     logger.info(f'Adding --smp=5 server')
     await manager.server_add(cmdline=['--smp', '5'])
 
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager)
 
     logger.info(f'Creating new tables')
     tables = RandomTables(request.node.name, manager, unique_name(), 3)


### PR DESCRIPTION
The function is currently flaky, especially in debug mode since it is given a single deadline for matching the group0 config vs. token_ring_host_ids on all servers in the cluster.

Instead, define a timeout of 30 seconds by default, but applied for each server.

Also, make sure to call token_ring_matches() at least once for each server, even if the deadline exceeded as it may succeed gracefully.

See for example https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/2928/artifact/testlog/x86_64/debug/topology.test_replace.3.log
```
09:20:50.423 INFO> Group 0 members by Server(352, 127.248.218.41): {('831964b5-ea26-4e41-b380-6b4ae52d08fa', True), ('a842b1fe-a263-4ea2-85af-7e61bc1d712b', True), ('d9535651-692a-476b-96ba-7ba0da59de0c', True), ('cdaf1f9f-b26b-432e-87e6-b57db9860506', True)}
09:20:50.423 DEBUG> RESTClient fetching GET http://127.248.218.41:10000/storage_service/tokens_endpoint
09:20:50.426 INFO> Normal endpoints' IPs by Server(352, 127.248.218.41): {'127.248.218.12', '127.248.218.22', '127.248.218.41'}
09:20:50.426 DEBUG> RESTClient fetching GET http://127.248.218.41:10000/storage_service/host_id
09:20:50.427 INFO> All host IDs by Server(352, 127.248.218.41): {'831964b5-ea26-4e41-b380-6b4ae52d08fa', 'a842b1fe-a263-4ea2-85af-7e61bc1d712b', 'd9535651-692a-476b-96ba-7ba0da59de0c'}
09:20:50.427 INFO> Normal endpoints' host IDs by Server(352, 127.248.218.41): {'831964b5-ea26-4e41-b380-6b4ae52d08fa', 'a842b1fe-a263-4ea2-85af-7e61bc1d712b', 'd9535651-692a-476b-96ba-7ba0da59de0c'}
09:20:50.427 WARNING> Group 0 members and token ring members don't yet match according to Server(352, 127.248.218.41), symmetric difference: {'cdaf1f9f-b26b-432e-87e6-b57db9860506'}
...
09:21:19.927 WARNING> Group 0 members and token ring members don't yet match according to Server(352, 127.248.218.41), symmetric difference: {'cdaf1f9f-b26b-432e-87e6-b57db9860506'}
---------------------------- Captured log teardown -----------------------------
09:21:20.449 DEBUG> after_test for test_replace_different_ip_using_host_id (success: False)
09:21:20.449 DEBUG> RESTClient fetching GET http+unix://api/cluster/after-test/False
09:21:20.475 INFO> Cluster after test test_replace_different_ip_using_host_id: ScyllaCluster(name: a13d62e0-35b3-11ee-b749-a8a159ead561, running: ScyllaServer(352, 127.248.218.41, 831964b5-ea26-4e41-b380-6b4ae52d08fa), ScyllaServer(355, 127.248.218.12, d9535651-692a-476b-96ba-7ba0da59de0c), ScyllaServer(368, 127.248.218.22, a842b1fe-a263-4ea2-85af-7e61bc1d712b), stopped: ScyllaServer(348, 127.248.218.30, cdaf1f9f-b26b-432e-87e6-b57db9860506))
- generated xml file: /jenkins/workspace/scylla-master/scylla-ci/scylla/testlog/x86_64/debug/xml/topology.test_replace.3.xunit.xml -
=========================== short test summary info ============================
FAILED test/topology/test_replace.py::test_replace_different_ip_using_host_id
```