### PR TITLE
compaction: extract compact_on_writer() out of compaction::consume()

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -731,10 +731,10 @@ private:
         _ms_metadata.max_timestamp = timestamp_tracker.max();
     }
 
-    // This consumer will perform mutation compaction on producer side using
+    // performs mutation compaction on producer (reader) side using
     // compacting_reader. It's useful for allowing data from different buckets
     // to be compacted together.
-    future<> consume_without_gc_writer(gc_clock::time_point compaction_time) {
+    future<> compact_on_reader() {
         auto consumer = make_interposer_consumer([this] (flat_mutation_reader_v2 reader) mutable {
             return seastar::async([this, reader = std::move(reader)] () mutable {
                 auto close_reader = deferred_close(reader);
@@ -742,44 +742,57 @@ private:
                 reader.consume_in_thread(std::move(cfc));
             });
         });
+        auto now = gc_clock::now();
         const auto& gc_state = _table_s.get_tombstone_gc_state();
-        return consumer(make_compacting_reader(setup_sstable_reader(), compaction_time, max_purgeable_func(), gc_state));
+        return consumer(make_compacting_reader(setup_sstable_reader(), now, max_purgeable_func(), gc_state));
     }
 
-    future<> consume() {
-        auto now = gc_clock::now();
-        // consume_without_gc_writer(), which uses compacting_reader, is ~3% slower.
-        // let's only use it when GC writer is disabled and interposer consumer is enabled, as we
-        // wouldn't like others to pay the penalty for something they don't need.
-        if (!enable_garbage_collected_sstable_writer() && use_interposer_consumer()) {
-            return consume_without_gc_writer(now);
+    template<bool WithGC> auto get_gc_consumer() {
+        if constexpr (WithGC) {
+            return get_gc_compacted_fragments_writer();
+        } else {
+            return noop_compacted_fragments_consumer{};
         }
-        auto consumer = make_interposer_consumer([this, now] (flat_mutation_reader_v2 reader) mutable
-        {
-            return seastar::async([this, reader = std::move(reader), now] () mutable {
+    }
+    // performs mutation compaction on consumer (writer) side using
+    // compact_mutation_v2. in addition to the regular compaction writer, it
+    // also optionally arms the consumer with a gc consumer for generating a
+    // temporary sstable run for collecting the garbage collected data if
+    // `WithGC` is true.
+    template<bool WithGC>
+    future<> compact_on_writer() {
+        auto now = gc_clock::now();
+        auto consumer = make_interposer_consumer([this, now] (flat_mutation_reader_v2 reader) mutable {
+            return seastar::async([this, now, reader = std::move(reader)] () mutable {
                 auto close_reader = deferred_close(reader);
-
-                if (enable_garbage_collected_sstable_writer()) {
-                    using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
-                    auto cfc = compact_mutations(*schema(), now,
-                        max_purgeable_func(),
-                        _table_s.get_tombstone_gc_state(),
-                        get_compacted_fragments_writer(),
-                        get_gc_compacted_fragments_writer());
-
-                    reader.consume_in_thread(std::move(cfc));
-                    return;
-                }
-                using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
+                auto gc_consumer = get_gc_consumer<WithGC>();
+                using compact_mutations = compact_for_compaction_v2<::sstables::compacted_fragments_writer,
+                                                                    decltype(gc_consumer)>;
                 auto cfc = compact_mutations(*schema(), now,
                     max_purgeable_func(),
                     _table_s.get_tombstone_gc_state(),
                     get_compacted_fragments_writer(),
-                    noop_compacted_fragments_consumer());
+                    std::move(gc_consumer));
+
                 reader.consume_in_thread(std::move(cfc));
             });
         });
         return consumer(setup_sstable_reader());
+    }
+
+    future<> consume() {
+        // compact_on_reader(), which uses compacting_reader, is ~3% slower.
+        // let's only use it when GC writer is disabled and interposer consumer is enabled, as we
+        // wouldn't like others to pay the penalty for something they don't need.
+        if (!enable_garbage_collected_sstable_writer() &&
+            use_interposer_consumer()) {
+            return compact_on_reader();
+        }
+        if (enable_garbage_collected_sstable_writer()) {
+            return compact_on_writer<true>();
+        } else {
+            return compact_on_writer<false>();
+        }
     }
 
     virtual reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) {

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -600,7 +600,7 @@ uint64_t compaction_strategy::adjust_partition_estimate(const mutation_source_me
     return _compaction_strategy_impl->adjust_partition_estimate(ms_meta, partition_estimate);
 }
 
-reader_consumer_v2 compaction_strategy::make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const {
+reader_consumer_v2 compaction_strategy::make_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const {
     return _compaction_strategy_impl->make_interposer_consumer(ms_meta, std::move(end_consumer));
 }
 

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -106,7 +106,7 @@ public:
 
     uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate) const;
 
-    reader_consumer_v2 make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const;
+    reader_consumer_v2 make_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const;
 
     // Returns whether or not interposer consumer is used by a given strategy.
     bool use_interposer_consumer() const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -900,7 +900,7 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
             co_await _compaction_manager.maybe_wait_for_sstable_count_reduction(cg.as_table_state());
         }
 
-        auto consumer = _compaction_strategy.make_interposer_consumer(metadata, [this, old, permit, &newtabs, estimated_partitions, &cg] (flat_mutation_reader_v2 reader) mutable -> future<> {
+        auto consumer = _compaction_strategy.make_consumer(metadata, [this, old, permit, &newtabs, estimated_partitions, &cg] (flat_mutation_reader_v2 reader) mutable -> future<> {
           std::exception_ptr ex;
           try {
             sstables::sstable_writer_config cfg = get_sstables_manager().configure_writer("memtable");

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -39,7 +39,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                 if (offstrategy) {
                     return end_consumer;
                 }
-                return cs.make_interposer_consumer(ms_meta, std::move(end_consumer));
+                return cs.make_consumer(ms_meta, std::move(end_consumer));
             };
 
             auto consumer = make_interposer_consumer(metadata,

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -34,15 +34,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
             auto metadata = mutation_source_metadata{};
             auto& cs = cf->get_compaction_strategy();
             const auto adjusted_estimated_partitions = cs.adjust_partition_estimate(metadata, estimated_partitions);
-            auto make_interposer_consumer = [&cs, offstrategy] (const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) mutable {
-                // postpone data segregation to off-strategy compaction if enabled
-                if (offstrategy) {
-                    return end_consumer;
-                }
-                return cs.make_consumer(ms_meta, std::move(end_consumer));
-            };
-
-            auto consumer = make_interposer_consumer(metadata,
+            reader_consumer_v2 consumer =
                     [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path, &vug, origin = std::move(origin), offstrategy] (flat_mutation_reader_v2 reader) {
                 sstables::shared_sstable sst;
                 try {
@@ -72,7 +64,11 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                     }
                     return vug.local().register_staging_sstable(sst, std::move(cf));
                 });
-            });
+            };
+            // postpone data segregation to off-strategy compaction if enabled
+            if (!offstrategy) {
+                consumer = cs.make_consumer(metadata, std::move(consumer));
+            }
             co_return co_await consumer(std::move(reader));
         } catch (...) {
             ex = std::current_exception();


### PR DESCRIPTION
this series restructures `compaction::consume()` so that 

1. the way how we dispatch consume() calls to different implementations is more obvious by flattening the logic.
2. `make_interpose_consumer()` is renamed to `make_consumer()`. as we don't always interpose consumer in the returned value.