### PR TITLE
test/pylib: protect double call to cluster stop

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -650,24 +650,24 @@ class ScyllaCluster:
     async def stop(self) -> None:
         """Stop all running servers ASAP"""
         if self.is_running:
+            self.is_running = False
             self.logger.info("Cluster %s stopping", self)
             self.is_dirty = True
             # If self.running is empty, no-op
             await asyncio.gather(*(server.stop() for server in self.running.values()))
             self.stopped.update(self.running)
             self.running.clear()
-            self.is_running = False
 
     async def stop_gracefully(self) -> None:
         """Stop all running servers in a clean way"""
         if self.is_running:
+            self.is_running = False
             self.logger.info("Cluster %s stopping gracefully", self)
             self.is_dirty = True
             # If self.running is empty, no-op
             await asyncio.gather(*(server.stop_gracefully() for server in self.running.values()))
             self.stopped.update(self.running)
             self.running.clear()
-            self.is_running = False
 
     def _seeds(self) -> List[str]:
         return [server.ip_addr for server in self.running.values()]


### PR DESCRIPTION
`test.py` schedules calls to cluster `.uninstall()` and `.stop()` making double calls to it running at the same time. Mark the cluster as not running early on.