### PR TITLE
config: add index_cache_fraction

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -359,6 +359,7 @@ scylla_tests = set([
     'test/boost/big_decimal_test',
     'test/boost/broken_sstable_test',
     'test/boost/bytes_ostream_test',
+    'test/boost/cache_algorithm_test',
     'test/boost/cache_flat_mutation_reader_test',
     'test/boost/cached_file_test',
     'test/boost/caching_options_test',

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -14,6 +14,7 @@
 #include "mutation/partition_version.hh"
 #include "mutation/mutation_cleaner.hh"
 #include "utils/cached_file_stats.hh"
+#include "sstables/partition_index_cache_stats.hh"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -80,6 +81,7 @@ public:
 private:
     stats _stats{};
     cached_file_stats _index_cached_file_stats{};
+    partition_index_cache_stats _partition_index_cache_stats{};
     seastar::metrics::metric_groups _metrics;
     logalloc::region _region;
     lru _lru;
@@ -136,6 +138,7 @@ public:
     void set_compaction_scheduling_group(seastar::scheduling_group);
     lru& get_lru() { return _lru; }
     cached_file_stats& get_index_cached_file_stats() { return _index_cached_file_stats; }
+    partition_index_cache_stats& get_partition_index_cache_stats() { return _partition_index_cache_stats; }
     seastar::memory::reclaiming_result evict_from_lru_shallow() noexcept;
 };
 

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -13,6 +13,7 @@
 #include "utils/updateable_value.hh"
 #include "mutation/partition_version.hh"
 #include "mutation/mutation_cleaner.hh"
+#include "utils/cached_file_stats.hh"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -78,6 +79,7 @@ public:
     };
 private:
     stats _stats{};
+    cached_file_stats _index_cached_file_stats{};
     seastar::metrics::metric_groups _metrics;
     logalloc::region _region;
     lru _lru;
@@ -133,6 +135,7 @@ public:
     stats& get_stats() noexcept { return _stats; }
     void set_compaction_scheduling_group(seastar::scheduling_group);
     lru& get_lru() { return _lru; }
+    cached_file_stats& get_index_cached_file_stats() { return _index_cached_file_stats; }
     seastar::memory::reclaiming_result evict_from_lru_shallow() noexcept;
 };
 

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -10,6 +10,7 @@
 
 #include "utils/lru.hh"
 #include "utils/logalloc.hh"
+#include "utils/updateable_value.hh"
 #include "mutation/partition_version.hh"
 #include "mutation/mutation_cleaner.hh"
 
@@ -83,12 +84,14 @@ private:
     mutation_cleaner _garbage;
     mutation_cleaner _memtable_cleaner;
     mutation_application_stats& _app_stats;
+    utils::updateable_value<double> _index_cache_fraction;
 private:
     void setup_metrics();
 public:
     using register_metrics = bool_class<class register_metrics_tag>;
-    cache_tracker(mutation_application_stats&, register_metrics);
-    cache_tracker(register_metrics = register_metrics::no);
+    cache_tracker(utils::updateable_value<double> index_cache_fraction, mutation_application_stats&, register_metrics);
+    cache_tracker(utils::updateable_value<double> index_cache_fraction, register_metrics);
+    cache_tracker();
     ~cache_tracker();
     void clear();
     void touch(rows_entry&);

--- a/db/config.cc
+++ b/db/config.cc
@@ -1002,9 +1002,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 10, "Time for which information about finished task stays in memory.")
     , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator")
     , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations")
-    , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, false,
+    , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,
         "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions. The amount of memory usable by index cache is limited with `index_cache_fraction`.")
-    , index_cache_fraction(this, "index_cache_fraction", liveness::LiveUpdate, value_status::Used, 1.0,
+    , index_cache_fraction(this, "index_cache_fraction", liveness::LiveUpdate, value_status::Used, 0.2,
         "The maximum fraction of cache memory permitted for use by index cache. Clamped to the [0.0; 1.0] range. Must be small enough to not deprive the row cache of memory, but should be big enough to fit a large fraction of the index. The default value 0.2 means that at least 80\% of cache memory is reserved for the row cache, while at most 20\% is usable by the index cache.")
      , consistent_cluster_management(this, "consistent_cluster_management", value_status::Used, true, "Use RAFT for cluster management and DDL")
     , wasm_cache_memory_fraction(this, "wasm_cache_memory_fraction", value_status::Used, 0.01, "Maximum total size of all WASM instances stored in the cache as fraction of total shard memory")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1003,7 +1003,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator")
     , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, false,
-        "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions.")
+        "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions. The amount of memory usable by index cache is limited with `index_cache_fraction`.")
+    , index_cache_fraction(this, "index_cache_fraction", liveness::LiveUpdate, value_status::Used, 1.0,
+        "The maximum fraction of cache memory permitted for use by index cache. Clamped to the [0.0; 1.0] range. Must be small enough to not deprive the row cache of memory, but should be big enough to fit a large fraction of the index. The default value 0.2 means that at least 80\% of cache memory is reserved for the row cache, while at most 20\% is usable by the index cache.")
      , consistent_cluster_management(this, "consistent_cluster_management", value_status::Used, true, "Use RAFT for cluster management and DDL")
     , wasm_cache_memory_fraction(this, "wasm_cache_memory_fraction", value_status::Used, 0.01, "Maximum total size of all WASM instances stored in the cache as fraction of total shard memory")
     , wasm_cache_timeout_in_ms(this, "wasm_cache_timeout_in_ms", value_status::Used, 5000, "Time after which an instance is evicted from the cache")

--- a/db/config.hh
+++ b/db/config.hh
@@ -424,6 +424,7 @@ public:
     named_value<uint32_t> nodeops_heartbeat_interval_seconds;
 
     named_value<bool> cache_index_pages;
+    named_value<double> index_cache_fraction;
 
     named_value<bool> consistent_cluster_management;
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -352,7 +352,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             std::numeric_limits<size_t>::max(),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(std::numeric_limits<uint32_t>::max()))
-    , _row_cache_tracker(cache_tracker::register_metrics::yes)
+    , _row_cache_tracker(_cfg.index_cache_fraction.operator utils::updateable_value<double>(), cache_tracker::register_metrics::yes)
     , _apply_stage("db_apply", &database::do_apply)
     , _version(empty_version)
     , _compaction_manager(cm)

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -778,7 +778,8 @@ public:
         , _trace_state(std::move(trace_state))
         , _local_index_cache(caching ? nullptr
             : std::make_unique<partition_index_cache>(_sstable->manager().get_cache_tracker().get_lru(),
-                                                      _sstable->manager().get_cache_tracker().region()))
+                                                      _sstable->manager().get_cache_tracker().region(),
+                                                      _sstable->manager().get_cache_tracker().get_partition_index_cache_stats()))
         , _index_cache(caching ? *_sstable->_index_cache : *_local_index_cache)
         , _region(_sstable->manager().get_cache_tracker().region())
         , _use_caching(caching)

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -22,7 +22,6 @@
 namespace sstables {
 
 extern seastar::logger sstlog;
-extern thread_local cached_file::metrics index_page_cache_metrics;
 extern thread_local mc::cached_promoted_index::metrics promoted_index_cache_metrics;
 
 // Promoted index information produced by the parser.
@@ -337,7 +336,7 @@ std::unique_ptr<clustered_index_cursor> promoted_index::make_cursor(shared_sstab
         seastar::shared_ptr<cached_file> cached_file_ptr = caching
                 ? sst->_cached_index_file
                 : seastar::make_shared<cached_file>(make_tracked_index_file(*sst, permit, trace_state, caching),
-                                                    index_page_cache_metrics,
+                                                    sst->manager().get_cache_tracker().get_index_cached_file_stats(),
                                                     sst->manager().get_cache_tracker().get_lru(),
                                                     sst->manager().get_cache_tracker().region(),
                                                     sst->_index_file_size);

--- a/sstables/partition_index_cache.hh
+++ b/sstables/partition_index_cache.hh
@@ -32,7 +32,7 @@ public:
     using key_type = uint64_t;
 private:
     // Allocated inside LSA
-    class entry : public evictable, public lsa::weakly_referencable<entry> {
+    class entry final : public index_evictable, public lsa::weakly_referencable<entry> {
     public:
         partition_index_cache* _parent;
         key_type _key;

--- a/sstables/partition_index_cache_stats.hh
+++ b/sstables/partition_index_cache_stats.hh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct partition_index_cache_stats {
+    uint64_t hits = 0; // Number of times entry was found ready
+    uint64_t misses = 0; // Number of times entry was not found
+    uint64_t blocks = 0; // Number of times entry was not ready (>= misses)
+    uint64_t evictions = 0; // Number of times entry was evicted
+    uint64_t populations = 0; // Number of times entry was inserted
+    uint64_t used_bytes = 0; // Number of bytes entries occupy in memory
+};

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1336,7 +1336,7 @@ future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
     _index_file_size = size;
     assert(!_cached_index_file);
     _cached_index_file = seastar::make_shared<cached_file>(_index_file,
-                                                            index_page_cache_metrics,
+                                                            _manager.get_cache_tracker().get_index_cached_file_stats(),
                                                             _manager.get_cache_tracker().get_lru(),
                                                             _manager.get_cache_tracker().region(),
                                                             _index_file_size);
@@ -2804,12 +2804,29 @@ sstable::unlink(storage::sync_dir sync) noexcept {
 
 thread_local sstables_stats::stats sstables_stats::_shard_stats;
 thread_local partition_index_cache::stats partition_index_cache::_shard_stats;
-thread_local cached_file::metrics index_page_cache_metrics;
 thread_local mc::cached_promoted_index::metrics promoted_index_cache_metrics;
 static thread_local seastar::metrics::metric_groups metrics;
 
 size_t space_used_by_index_cache() {
-    return partition_index_cache::shard_stats().used_bytes + index_page_cache_metrics.cached_bytes;
+    return partition_index_cache::shard_stats().used_bytes;
+}
+
+void register_index_page_cache_metrics(seastar::metrics::metric_groups& metrics, cached_file_stats& m) {
+    namespace sm = seastar::metrics;
+    metrics.add_group("sstables", {
+        sm::make_counter("index_page_cache_hits", [&m] { return m.page_hits; },
+            sm::description("Index page cache requests which were served from cache")),
+        sm::make_counter("index_page_cache_misses", [&m] { return m.page_misses; },
+            sm::description("Index page cache requests which had to perform I/O")),
+        sm::make_counter("index_page_cache_evictions", [&m] { return m.page_evictions; },
+            sm::description("Total number of index page cache pages which have been evicted")),
+        sm::make_counter("index_page_cache_populations", [&m] { return m.page_populations; },
+            sm::description("Total number of index page cache pages which were inserted into the cache")),
+        sm::make_gauge("index_page_cache_bytes", [&m] { return m.cached_bytes; },
+            sm::description("Total number of bytes cached in the index page cache")),
+        sm::make_gauge("index_page_cache_bytes_in_std", [&m] { return m.bytes_in_std; },
+            sm::description("Total number of bytes in temporary buffers which live in the std allocator")),
+    });
 }
 
 future<> init_metrics() {
@@ -2828,19 +2845,6 @@ future<> init_metrics() {
             sm::description("Index pages which got populated into memory")),
         sm::make_gauge("index_page_used_bytes", [] { return partition_index_cache::shard_stats().used_bytes; },
             sm::description("Amount of bytes used by index pages in memory")),
-
-        sm::make_counter("index_page_cache_hits", [] { return index_page_cache_metrics.page_hits; },
-            sm::description("Index page cache requests which were served from cache")),
-        sm::make_counter("index_page_cache_misses", [] { return index_page_cache_metrics.page_misses; },
-            sm::description("Index page cache requests which had to perform I/O")),
-        sm::make_counter("index_page_cache_evictions", [] { return index_page_cache_metrics.page_evictions; },
-            sm::description("Total number of index page cache pages which have been evicted")),
-        sm::make_counter("index_page_cache_populations", [] { return index_page_cache_metrics.page_populations; },
-            sm::description("Total number of index page cache pages which were inserted into the cache")),
-        sm::make_gauge("index_page_cache_bytes", [] { return index_page_cache_metrics.cached_bytes; },
-            sm::description("Total number of bytes cached in the index page cache")),
-        sm::make_gauge("index_page_cache_bytes_in_std", [] { return index_page_cache_metrics.bytes_in_std; },
-            sm::description("Total number of bytes in temporary buffers which live in the std allocator")),
 
         sm::make_counter("pi_cache_hits_l0", [] { return promoted_index_cache_metrics.hits_l0; },
             sm::description("Number of requests for promoted index block in state l0 which didn't have to go to the page cache")),

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -100,7 +100,7 @@ namespace sstables {
 // This flag is intended to be a temporary hack. The goal is to eventually
 // solve index caching problems via a smart cache replacement policy.
 //
-thread_local utils::updateable_value<bool> global_cache_index_pages(false);
+thread_local utils::updateable_value<bool> global_cache_index_pages(true);
 
 logging::logger sstlog("sstable");
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2808,6 +2808,10 @@ thread_local cached_file::metrics index_page_cache_metrics;
 thread_local mc::cached_promoted_index::metrics promoted_index_cache_metrics;
 static thread_local seastar::metrics::metric_groups metrics;
 
+size_t space_used_by_index_cache() {
+    return partition_index_cache::shard_stats().used_bytes + index_page_cache_metrics.cached_bytes;
+}
+
 future<> init_metrics() {
   return seastar::smp::invoke_on_all([] {
     namespace sm = seastar::metrics;

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -28,6 +28,8 @@ add_scylla_test(btree_test
   KIND SEASTAR)
 add_scylla_test(bytes_ostream_test
   KIND SEASTAR)
+add_scylla_test(cache_algorithm_test
+  KIND SEASTAR)
 add_scylla_test(cache_flat_mutation_reader_test
   KIND SEASTAR)
 add_scylla_test(cached_file_test

--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/testing/test_case.hh>
+#include "test/lib/cql_test_env.hh"
+
+// These tests are slow, and tuned to a particular amount of memory
+// (and --memory is ignored in debug mode).
+// Hence they are not run in debug.
+#ifndef SEASTAR_DEBUG
+
+// The problem with naive index caching is that every uncached read drags a full
+// index page into the cache. But the index page can be orders of magnitude bigger
+// than the ingested row. Depending on the workload, this can effectively bloat the
+// memory usage of every cached row by orders of magnitude, and ruin cache
+// effectiveness.
+//
+// This test checks for the above problem.
+//
+// The table created by the test has the following properties:
+// - There is only one column in the schema -- the partition key --
+//   because this results in the biggest `index page size`:`row size` ratio,
+//   due to details of the SSTable format.
+//   This makes the effects drastic, and so easy to test.
+// - The total size of all keys is at least 2 times greater than the size of RAM.
+//   This ensures that most of the index is uncached. This is necessary for
+//   the issue to become a visible.
+// - The size of user data (1000 per partition) is significantly bigger
+//   than several hundred bytes, to make various constant overheads
+//   (per-cell, per-row, per-partition) smaller than the size of user data.
+//   This simplifies reasoning about the test.
+//   In particular, it should ensure that each index page contains about 2000 keys,
+//   so it has size about 2 MiB.
+//
+// After populating this table, the test reads (sequentially) a subset of 1000 rows
+// multiple times. Since the total size of this hot subset (including overheads) is
+// only about 1 MiB, the test expects it to be perfectly cached.
+// This should be true unless index cache is flooding the cache.
+SEASTAR_TEST_CASE(test_index_doesnt_flood_cache_in_small_partition_workload) {
+    cql_test_config cfg;
+    // Prevents an unnecessary sleep at the end of the test.
+    cfg.db_config->task_ttl_seconds.set(0);
+    // Scylla refreshes query permissions periodically.
+    // This causes background queries to system_auth.roles, which in turn can cause
+    // spurious cache misses to appear in cache_tracker stats, which breaks
+    // the assumptions of the test.
+    // The lines below effectively disable the permission refresh to get rid of that problem.
+    cfg.db_config->permissions_validity_in_ms.set(uint32_t(-1));
+    cfg.db_config->permissions_update_interval_in_ms.set(uint32_t(-1));
+    // As of this writing, uncommenting the below should make the test fail.
+    // cfg.db_config->index_cache_fraction.set(1.0);
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // We disable compactions because they cause confusing cache mispopulations.
+        e.execute_cql("CREATE TABLE ks.t(pk blob PRIMARY KEY) WITH compaction = { 'class' : 'NullCompactionStrategy' };").get();
+        auto insert_query = e.prepare("INSERT INTO ks.t(pk) VALUES (?)").get0();
+        auto select_query = e.prepare("SELECT * FROM t WHERE pk = ?").get0();
+
+        constexpr uint64_t pk_number = 600000;
+        constexpr uint64_t pk_size = 1000;
+        // Sanity check. The test assumes that the total index size is significantly bigger than RAM.
+        BOOST_REQUIRE_GT(pk_size * pk_number, 2 * seastar::memory::stats().total_memory());
+
+        // A bijection between uint64_t and blobs of size pk_size.
+        auto make_key = [pk_size] (uint64_t x) {
+            bytes b(bytes::initialized_later(), std::max(pk_size, sizeof(x)));
+            auto i = b.begin();
+            write<uint64_t>(i, x);
+            return b;
+        };
+
+        // Populate the table.
+        for (size_t i = 0; i < pk_number; ++i) {
+            e.execute_prepared(insert_query, {{cql3::raw_value::make_value(make_key(i))}}).get0();
+        }
+        // Flushing makes reasoning easier.
+        e.db().invoke_on_all(&replica::database::flush_all_memtables).get();
+
+
+        constexpr uint64_t hot_subset_size = 1000;
+        // Sanity check. The test assumes that the total *hot* index size is significantly bigger than RAM.
+        //
+        // data_summary_ratio is the target `data file size : summary file size` ratio.
+        // In a table containing only primary keys, the approximate size of an index page is `pk_size * data_summary_ratio`.
+        //
+        // The sanity check here is that the maximum total size of the touched index pages is much greater than RAM.
+        // (Maximum is reached when each hot row lands on a different index page.)
+        const uint64_t data_summary_ratio = static_cast<uint64_t>(1 / e.local_db().get_config().sstable_summary_ratio());
+        BOOST_REQUIRE_GT(hot_subset_size * pk_size * data_summary_ratio, 2 * seastar::memory::stats().total_memory());
+
+        auto get_misses = [&e] { return e.local_db().row_cache_tracker().get_stats().partition_misses; };
+        uint64_t misses_before = get_misses();
+        for (size_t i = 0; i < hot_subset_size; ++i) {
+            e.execute_prepared(select_query, {{cql3::raw_value::make_value(make_key(i))}}).get0();
+            // Sanity check. If a single query is causing multiple partition misses,
+            // something unexpected is happening.
+            BOOST_REQUIRE_LE(get_misses() - misses_before, i + 1);
+        }
+
+        misses_before = get_misses();
+        // The rows we just read have a small total size. They should be perfectly cached.
+        for (size_t repeat = 0; repeat < 3; ++repeat) {
+            for (size_t i = 0; i < hot_subset_size; ++i) {
+                e.execute_prepared(select_query, {{cql3::raw_value::make_value(make_key(i))}}).get0();
+                // If the rows were perfectly cached, there were no new misses.
+                BOOST_REQUIRE_EQUAL(get_misses(), misses_before);
+            }
+        }
+    }, std::move(cfg));
+}
+
+// The previous test checks that index_cache_fraction doesn't allow index cache to
+// flood the memory.
+//
+// This test checks that it doesn't completely kill caching.
+SEASTAR_TEST_CASE(test_index_is_cached_in_big_partition_workload) {
+    cql_test_config cfg;
+    // Prevents an unnecessary sleep at the end of the test.
+    cfg.db_config->task_ttl_seconds.set(0);
+    // Scylla refreshes query permissions periodically.
+    // This causes background queries to system_auth.roles, which in turn can cause
+    // spurious cache misses to appear in cache_tracker stats, which breaks
+    // the assumptions of the test.
+    // The lines below effectively disable the permission refresh to get rid of that problem.
+    cfg.db_config->permissions_validity_in_ms.set(uint32_t(-1));
+    cfg.db_config->permissions_update_interval_in_ms.set(uint32_t(-1));
+    // As of this writing, uncommenting the below should make the test fail.
+    // cfg.db_config->index_cache_fraction.set(0.0);
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // We disable compactions because they cause confusing cache mispopulations.
+        e.execute_cql("CREATE TABLE ks.t(pk bigint, ck bigint, v blob, primary key (pk, ck)) WITH compaction = { 'class' : 'NullCompactionStrategy' };").get();
+        auto insert_query = e.prepare("INSERT INTO ks.t(pk, ck, v) VALUES (?, ?, ?)").get0();
+        auto select_query = e.prepare("SELECT * FROM t WHERE pk = ? AND ck = ?").get0();
+
+        constexpr uint64_t pk_number = 10;
+        constexpr uint64_t ck_number = 600;
+        constexpr uint64_t v_size = 100000;
+        // Sanity check. The test assumes that the total table size is significantly bigger than RAM.
+        BOOST_REQUIRE_GT(pk_number * ck_number * v_size, 2 * seastar::memory::stats().total_memory());
+
+        // A bijection between uint64_t and blobs of size x.
+        auto make_key = [] (uint64_t x) {
+            bytes b(bytes::initialized_later(), sizeof(x));
+            auto i = b.begin();
+            write<uint64_t>(i, x);
+            return b;
+        };
+
+        // Populate the table.
+        for (size_t pk = 0; pk < pk_number; ++pk) {
+            for (size_t ck = 0; ck < ck_number; ++ck) {
+                e.execute_prepared(insert_query, {{cql3::raw_value::make_value(make_key(pk))}, {cql3::raw_value::make_value(make_key(ck))}, {cql3::raw_value::make_value(bytes(v_size, 0))}}).get0();
+            }
+        }
+        // Flushing makes reasoning easier.
+        e.db().invoke_on_all(&replica::database::flush_all_memtables).get();
+
+        // Populate the index cache.
+        for (size_t ck = 0; ck < ck_number; ++ck) {
+            for (size_t pk = 0; pk < pk_number; ++pk) {
+                e.execute_prepared(select_query, {{cql3::raw_value::make_value(make_key(pk))}, {cql3::raw_value::make_value(make_key(ck))}}).get0();
+            }
+        }
+
+        // The index is small and used once every few reads, so it should be perfectly cached.
+        auto get_misses = [&e] { return e.local_db().row_cache_tracker().get_partition_index_cache_stats().misses; };
+        uint64_t misses_before = get_misses();
+        for (size_t ck = 0; ck < ck_number; ++ck) {
+            for (size_t pk = 0; pk < pk_number; ++pk) {
+                e.execute_prepared(select_query, {{cql3::raw_value::make_value(make_key(pk))}, {cql3::raw_value::make_value(make_key(ck))}}).get0();
+            }
+        }
+        BOOST_REQUIRE_EQUAL(get_misses(), misses_before);
+    }, std::move(cfg));
+}
+
+#endif

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -99,7 +99,7 @@ test_file make_test_file(size_t size) {
 
 SEASTAR_THREAD_TEST_CASE(test_file_wrapper) {
     auto page_size = cached_file::page_size;
-    cached_file::metrics metrics;
+    cached_file_stats metrics;
     test_file tf = make_test_file(page_size * 3);
     logalloc::region region;
     cached_file cf(tf.f, metrics, cf_lru, region, page_size * 3);
@@ -123,7 +123,7 @@ SEASTAR_THREAD_TEST_CASE(test_file_wrapper) {
 /* Reproducer for issue https://github.com/scylladb/scylladb/issues/14814 */
 SEASTAR_THREAD_TEST_CASE(test_no_crash_on_dtor_after_oom) {
     auto page_size = cached_file::page_size;
-    cached_file::metrics metrics;
+    cached_file_stats metrics;
     test_file tf = make_test_file(page_size * 32); // 128k.
     logalloc::region region;
     cached_file cf(tf.f, metrics, cf_lru, region, page_size * 32);
@@ -141,7 +141,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_crash_on_dtor_after_oom) {
 
 SEASTAR_THREAD_TEST_CASE(test_concurrent_population) {
     auto page_size = cached_file::page_size;
-    cached_file::metrics metrics;
+    cached_file_stats metrics;
     test_file tf = make_test_file(page_size * 3);
     logalloc::region region;
     cached_file cf(tf.f, metrics, cf_lru, region, page_size * 3);
@@ -167,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(test_reading_from_small_file) {
     test_file tf = make_test_file(1024);
 
     {
-        cached_file::metrics metrics;
+        cached_file_stats metrics;
         logalloc::region region;
         cached_file cf(tf.f, metrics, cf_lru, region, tf.contents.size());
 
@@ -210,7 +210,7 @@ SEASTAR_THREAD_TEST_CASE(test_eviction_via_lru) {
     test_file tf = make_test_file(file_size);
 
     {
-        cached_file::metrics metrics;
+        cached_file_stats metrics;
         logalloc::region region;
         cached_file cf(tf.f, metrics, cf_lru, region, tf.contents.size());
 
@@ -322,7 +322,7 @@ SEASTAR_THREAD_TEST_CASE(test_stress_eviction) {
     auto file_size = page_size * n_pages;
     auto cached_size = 4'000'000;
 
-    cached_file::metrics metrics;
+    cached_file_stats metrics;
     logalloc::region region;
 
     auto f = file(make_shared<garbage_file_impl>());
@@ -367,7 +367,7 @@ SEASTAR_THREAD_TEST_CASE(test_invalidation) {
     auto page_size = cached_file::page_size;
     test_file tf = make_test_file(page_size * 2);
 
-    cached_file::metrics metrics;
+    cached_file_stats metrics;
     logalloc::region region;
     cached_file cf(tf.f, metrics, cf_lru, region, page_size * 2);
 

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1240,8 +1240,8 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
 
             auto ms = make_sstable_mutation_source(env, s, {m1, m2}, version);
 
-            auto index_accesses = [] {
-                auto&& stats = sstables::partition_index_cache::shard_stats();
+            auto index_accesses = [&env] {
+                auto&& stats = env.manager().get_cache_tracker().get_partition_index_cache_stats();
                 return stats.hits + stats.misses + stats.blocks;
             };
 

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -40,5 +40,7 @@ custom_args:
         - '-c1 -m256M'
     multishard_mutation_query_test:
         - '-c2 -m3G'
+    cache_algorithm_test:
+        - '-c1 -m256M'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -70,7 +70,7 @@ struct metrics_snapshot {
     reactor::io_stats io;
     reactor::sched_stats sched;
     memory::statistics mem;
-    sstables::partition_index_cache::stats index;
+    partition_index_cache_stats index;
     cache_tracker::stats cache;
     uint64_t instructions;
 
@@ -82,7 +82,7 @@ struct metrics_snapshot {
         busy_time = r.total_busy_time();
         idle_time = r.total_idle_time();
         hr_clock = std::chrono::high_resolution_clock::now();
-        index = sstables::partition_index_cache::shard_stats();
+        index = cql_env->local_db().row_cache_tracker().get_partition_index_cache_stats();
         cache = cql_env->local_db().row_cache_tracker().get_stats();
         instructions = the_instructions_counter.read();
     }

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -56,7 +56,7 @@ public:
         uint64_t bytes_in_std = 0; // memory used by active temporary_buffer:s
     };
 private:
-    class cached_page : public evictable {
+    class cached_page final : public index_evictable {
     public:
         cached_file* parent;
         page_idx_type idx;

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -14,6 +14,7 @@
 #include "utils/lru.hh"
 #include "utils/error_injection.hh"
 #include "tracing/trace_state.hh"
+#include "utils/cached_file_stats.hh"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/coroutine.hh>
@@ -47,14 +48,6 @@ public:
 
     using offset_type = uint64_t;
 
-    struct metrics {
-        uint64_t page_hits = 0;
-        uint64_t page_misses = 0;
-        uint64_t page_evictions = 0;
-        uint64_t page_populations = 0;
-        uint64_t cached_bytes = 0;
-        uint64_t bytes_in_std = 0; // memory used by active temporary_buffer:s
-    };
 private:
     class cached_page final : public index_evictable {
     public:
@@ -144,7 +137,7 @@ private:
 
     file _file;
     sstring _file_name; // for logging / tracing
-    metrics& _metrics;
+    cached_file_stats& _metrics;
     lru& _lru;
     logalloc::region& _region;
     logalloc::allocating_section _as;
@@ -353,7 +346,7 @@ public:
     /// \param m Metrics object which should be updated from operations on this object.
     ///          The metrics object can be shared by many cached_file instances, in which case it
     ///          will reflect the sum of operations on all cached_file instances.
-    cached_file(file f, cached_file::metrics& m, lru& l, logalloc::region& reg, offset_type size, sstring file_name = {})
+    cached_file(file f, cached_file_stats& m, lru& l, logalloc::region& reg, offset_type size, sstring file_name = {})
         : _file(std::move(f))
         , _file_name(std::move(file_name))
         , _metrics(m)

--- a/utils/cached_file_stats.hh
+++ b/utils/cached_file_stats.hh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct cached_file_stats {
+    uint64_t page_hits = 0;
+    uint64_t page_misses = 0;
+    uint64_t page_evictions = 0;
+    uint64_t page_populations = 0;
+    uint64_t cached_bytes = 0;
+    uint64_t bytes_in_std = 0; // memory used by active temporary_buffer:s
+};


### PR DESCRIPTION
Index caching was disabled by default because it caused performance regressions
for some small-partition workloads. See https://github.com/scylladb/scylladb/issues/11202.

However, it also means that there are workloads which could benefit from the
index cache, but (by default) don't.

As a compromise, we can set a default limit on the memory usage of index cache,
which should be small enough to avoid catastrophic regressions in
small-partition workloads, but big enough to accommodate workloads where
index cache is obviously beneficial.

This series adds such a configurable limit, sets it to to 0.2 of total cache memory by default,
and re-enables index caching by default.

Fixes #15118