### PR TITLE
build: cmake: fixes for the release build

### DIFF
--- a/cmake/mode.RELEASE.cmake
+++ b/cmake/mode.RELEASE.cmake
@@ -21,7 +21,7 @@ add_compile_options(
 set(Seastar_DEFINITIONS_RELEASE
   SCYLLA_BUILD_MODE=release)
 
-set(CMAKE_STATIC_LINKER_FLAGS_RELEASE
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE
   "-Wl,--gc-sections")
 
 set(stack_usage_threshold_in_KB 13)

--- a/cmake/mode.RELEASE.cmake
+++ b/cmake/mode.RELEASE.cmake
@@ -12,13 +12,13 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
 else()
   set(clang_inline_threshold 2500)
 endif()
-string(APPEND CMAKE_CXX_FLAGS_RELEASE
-  " $<$<CXX_COMPILER_ID:GNU>:--param inline-unit-growth=300"
-  " $<$<CXX_COMPILER_ID:Clang>:-mllvm -inline-threshold=${clang_inline_threshold}>"
+add_compile_options(
+  "$<$<CXX_COMPILER_ID:GNU>:--param;inline-unit-growth=300>"
+  "$<$<CXX_COMPILER_ID:Clang>:-mllvm;-inline-threshold=${clang_inline_threshold}>"
   # clang generates 16-byte loads that break store-to-load forwarding
   # gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
-  " -fno-slp-vectorize")
-set(Seastar_DEFINITIONS_DEBUG
+  "-fno-slp-vectorize")
+set(Seastar_DEFINITIONS_RELEASE
   SCYLLA_BUILD_MODE=release)
 
 set(CMAKE_STATIC_LINKER_FLAGS_RELEASE


### PR DESCRIPTION
before this change, we use generator expression to initialize CMAKE_CXX_FLAGS_RELEASE, this has two problems:

1. the generator expression is not expanded when setting a regular variable.
2. the ending ">" is missing in one of the generator expression.
3. the parameters are not separated with ";"

so address them, let's just

* use `add_compile_options()` directly, as the corresponding `mode.${build_mode}.cmake` is only included when the "${build_mode}" is used.
* add comma in between the command line options.
* add the missing closing ">"