### PR TITLE
s3/client: check for available port before starting minio server

### DIFF
--- a/test.py
+++ b/test.py
@@ -1269,7 +1269,7 @@ async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) ->
                 continue    # skip signaled task result
             console.print_progress(result)
 
-    ms = MinioServer(options.tmpdir, TestSuite.hosts, LogPrefixAdapter(logging.getLogger('minio'), {'prefix': 'minio'}))
+    ms = MinioServer(options.tmpdir, '127.0.0.1', LogPrefixAdapter(logging.getLogger('minio'), {'prefix': 'minio'}))
     await ms.start()
     TestSuite.artifacts.add_exit_artifact(None, ms.stop)
 

--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -12,10 +12,7 @@ from contextlib import contextmanager
 # use minio_server
 sys.path.insert(1, sys.path[0] + '/../..')
 from test.pylib.minio_server import MinioServer
-from test.pylib.host_registry import HostRegistry
 from test.pylib.cql_repl import conftest
-
-hosts = HostRegistry()
 
 
 def pytest_addoption(parser):
@@ -92,7 +89,7 @@ async def s3_server(pytestconfig, tmpdir):
     else:
         tempdir = tmpdir.strpath
         server = MinioServer(tempdir,
-                             hosts,
+                             '127.0.0.1',
                              logging.getLogger('minio'))
     await server.start()
     try:

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -25,10 +25,9 @@ from io import BufferedWriter
 class MinioServer:
     log_file: BufferedWriter
 
-    def __init__(self, tempdir_base, hosts, logger):
-        self.hosts = hosts
+    def __init__(self, tempdir_base, address, logger):
         self.srv_exe = shutil.which('minio')
-        self.address = None
+        self.address = address
         self.port = 9000
         tempdir = tempfile.mkdtemp(dir=tempdir_base, prefix="minio-")
         self.tempdir = pathlib.Path(tempdir)
@@ -151,7 +150,6 @@ class MinioServer:
             return
 
         self.port = await self._find_available_port(self.port, self.port + 1000)
-        self.address = await self.hosts.lease_host()
         self.log_file = self.log_filename.open("wb")
         os.environ['S3_SERVER_ADDRESS_FOR_TEST'] = f'{self.address}'
         os.environ['S3_SERVER_PORT_FOR_TEST'] = f'{self.port}'
@@ -212,31 +210,15 @@ class MinioServer:
             shutil.rmtree(self.tempdir)
 
 
-class HostRegistry:
-    def __init__(self, host: str) -> None:
-        self._host = host
-
-    async def lease_host(self) -> str:
-        assert self._host is not None
-        host = self._host
-        self._host = None
-        return host
-
-    async def release_host(self, host: str) -> None:
-        assert self._host is None
-        self._host = host
-
-
 async def main():
     parser = argparse.ArgumentParser(description="Start a MinIO server")
     parser.add_argument('--tempdir')
     parser.add_argument('--host', default='127.0.0.1')
     args = parser.parse_args()
-    host_registry = HostRegistry(args.host)
     with tempfile.TemporaryDirectory(suffix='-minio', dir=args.tempdir) as tempdir:
         if args.tempdir is None:
             print(f'{tempdir=}')
-        server = MinioServer(tempdir, host_registry, logging.getLogger('minio'))
+        server = MinioServer(tempdir, args.host, logging.getLogger('minio'))
         await server.start()
         print(f'export S3_SERVER_ADDRESS_FOR_TEST={server.address}')
         print(f'export S3_SERVER_PORT_FOR_TEST={server.port}')


### PR DESCRIPTION
there is chance that the default port of 9000 has been used on the host running the test, in that case, we should try to use another available port.

so, in this change, we try ports in the ranges of [9000, 9000+1000), and use the first one which is not connectable.

Fixes #14985
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>