### PR TITLE
gossip: add group0_id attribute to gossip_digest_syn

### DIFF
--- a/gms/gossip_digest_syn.cc
+++ b/gms/gossip_digest_syn.cc
@@ -14,7 +14,7 @@
 namespace gms {
 
 std::ostream& operator<<(std::ostream& os, const gossip_digest_syn& syn) {
-    os << "cluster_id:" << syn._cluster_id << ",partioner:" << syn._partioner << ",";
+    os << "cluster_id:" << syn._cluster_id << ",partioner:" << syn._partioner << ",group0_id:" << syn._group0_id << ",";
     os << "digests:{";
     for (auto& d : syn._digests) {
         os << d << " ";

--- a/gms/gossip_digest_syn.hh
+++ b/gms/gossip_digest_syn.hh
@@ -14,6 +14,7 @@
 #include "utils/serialization.hh"
 #include "gms/gossip_digest.hh"
 #include "utils/chunked_vector.hh"
+#include "utils/UUID.hh"
 
 namespace gms {
 
@@ -26,18 +27,24 @@ private:
     sstring _cluster_id;
     sstring _partioner;
     utils::chunked_vector<gossip_digest> _digests;
+    utils::UUID _group0_id;
 public:
     gossip_digest_syn() {
     }
 
-    gossip_digest_syn(sstring id, sstring p, utils::chunked_vector<gossip_digest> digests)
+    gossip_digest_syn(sstring id, sstring p, utils::chunked_vector<gossip_digest> digests, utils::UUID group0_id)
         : _cluster_id(std::move(id))
         , _partioner(std::move(p))
-        , _digests(std::move(digests)) {
+        , _digests(std::move(digests))
+        , _group0_id(std::move(group0_id)) {
     }
 
     sstring cluster_id() const {
         return _cluster_id;
+    }
+
+    utils::UUID group0_id() const {
+        return _group0_id;
     }
 
     sstring partioner() const {
@@ -46,6 +53,10 @@ public:
 
     sstring get_cluster_id() const {
         return cluster_id();
+    }
+
+    utils::UUID get_group0_id() const {
+        return group0_id();
     }
 
     sstring get_partioner() const {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -71,6 +71,7 @@ struct ack_msg_pending {
 struct gossip_config {
     seastar::scheduling_group gossip_scheduling_group = seastar::scheduling_group();
     sstring cluster_name;
+    utils::UUID group0_id;
     std::set<inet_address> seeds;
     sstring partitioner;
     uint32_t ring_delay_ms = 30 * 1000;
@@ -135,6 +136,8 @@ public:
     // Only respond echo message listed in nodes with the generation number
     future<> advertise_to_nodes(generation_for_nodes advertise_to_nodes = {});
     const sstring& get_cluster_name() const noexcept;
+    void set_group0_id(utils::UUID group0_id);
+    const utils::UUID& get_group0_id() const noexcept;
 
     const sstring& get_partitioner_name() const noexcept {
         return _gcfg.partitioner;

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -56,6 +56,7 @@ class gossip_digest_syn {
     sstring get_cluster_id();
     sstring get_partioner();
     utils::chunked_vector<gms::gossip_digest> get_gossip_digests();
+    utils::UUID get_group0_id()[[version 5.4]];
 };
 
 class gossip_digest_ack {

--- a/main.cc
+++ b/main.cc
@@ -1210,6 +1210,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 gcfg.cluster_name = "Test Cluster";
                 startlog.warn("Using default cluster name is not recommended. Using a unique cluster name will reduce the chance of adding nodes to the wrong cluster by mistake");
             }
+            gcfg.group0_id = sys_ks.local().get_raft_group0_id().get();
 
             debug::the_gossiper = &gossiper;
             gossiper.start(std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(messaging), std::ref(*cfg), std::ref(gcfg)).get();

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -500,6 +500,12 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_
     // Allow peer_exchange() RPC to access group 0 only after group0_id is persisted.
 
     _group0 = group0_id;
+
+    co_await _gossiper.container().invoke_on_all([group0_id = group0_id.uuid()] (auto& gossiper) {
+        gossiper.set_group0_id(group0_id);
+        return make_ready_future<>();
+    });
+
     group0_log.info("server {} joined group 0 with group id {}", my_id, group0_id);
 }
 

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -8,6 +8,7 @@
  */
 
 #include <chrono>
+#include <optional>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
@@ -18,6 +19,7 @@
 #include "gms/gossip_digest_ack2.hh"
 #include "gms/gossip_digest.hh"
 #include "api/api.hh"
+#include "utils/UUID.hh"
 #include "utils/fb_utilities.hh"
 
 using namespace std::chrono_literals;
@@ -119,7 +121,7 @@ public:
         utils::chunked_vector<gms::gossip_digest> digests;
         digests.push_back(gms::gossip_digest(ep1, gen++, ver++));
         digests.push_back(gms::gossip_digest(ep2, gen++, ver++));
-        gms::gossip_digest_syn syn("my_cluster", "my_partition", digests);
+        gms::gossip_digest_syn syn("my_cluster", "my_partition", digests, utils::null_uuid());
         return ms.send_gossip_digest_syn(id, std::move(syn)).then([this] {
             return digest_test_done.get_future();
         });

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -9,7 +9,9 @@ skip_in_release:
   - test_shutdown_hang
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
+  - test_different_group0_ids
 skip_in_debug:
   - test_shutdown_hang
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
+  - test_different_group0_ids

--- a/test/topology_custom/test_different_group0_ids.py
+++ b/test/topology_custom/test_different_group0_ids.py
@@ -1,0 +1,68 @@
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_different_group0_ids(manager: ManagerClient):
+    """
+    The reproducer for #14448.
+
+    The test starts two nodes with different group0_ids. The second node
+    is restarted and tries to join the cluster consisting of the first node.
+    gossip_digest_syn message should be rejected by the first node, so
+    the second node will not be able to join the cluster.
+
+    This test uses repair-based node operations to make this test easier.
+    If the second node successfully joins the cluster, their tokens metadata
+    will be merged and the repair service will allow to decommission the second node.
+    If not - decommissioning the second node will fail with an exception
+    "zero replica after the removal" thrown by the repair service.
+    """
+
+    # Consistent cluster management is disabled to use repair based node operations.
+    scylla_a = await manager.server_add(config={
+        'experimental_features': ["udf"] # disable consistent cluster management
+    })
+    scylla_b = await manager.server_add(start=False, config={
+        'experimental_features': ["udf"], # disable consistent cluster management
+    })
+    await manager.server_update_config(scylla_b.server_id, key='seed_provider', value=[{
+            'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
+            'parameters': [{
+                    'seeds': f'{scylla_b.ip_addr}'
+                }]
+            }]
+        )
+    await manager.server_start(scylla_b.server_id)
+
+    await manager.server_stop(scylla_b.server_id)
+    await manager.server_update_config(scylla_b.server_id, key='seed_provider', value=[{
+            'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
+            'parameters': [{
+                    'seeds': f'{scylla_a.ip_addr},{scylla_b.ip_addr}'
+                }]
+            }]
+        )
+    await manager.server_start(scylla_b.server_id)
+
+    log_file_a = await manager.server_open_log(scylla_a.server_id)
+    log_file_b = await manager.server_open_log(scylla_b.server_id)
+
+    # Wait for a gossip round to finish
+    _, pending = await asyncio.wait([
+            asyncio.create_task(log_file_b.wait_for(f'InetAddress {scylla_a.ip_addr} is now UP')), # The second node joins the cluster
+            asyncio.create_task(log_file_a.wait_for(f'Group0Id mismatch')) # The first node discards gossip from the second node
+        ], return_when=asyncio.FIRST_COMPLETED)
+
+    for task in pending:
+        task.cancel()
+
+    # Check if decommissioning the second node fails.
+    # Repair service throws a runtime exception "zero replica after the removal"
+    # when it tries to remove the only one node from the cluster.
+    # If it is not thrown, it means that the second node succesfully send a gossip
+    # to the first node and they merged their tokens metadata.
+    with pytest.raises(Exception, match='zero replica after the removal'):
+        await manager.decommission_node(scylla_b.server_id)


### PR DESCRIPTION
# Motivation

The user can bootstrap 3 different clusters and then connect them (#14448). When these clusters start gossiping, their token rings will be merged, but there will be 3 different group 0s in there. It results in a corrupted cluster.

We need to prevent such situations from happening in clusters which don't use Raft-based topology

-------

Gossiper service sets its group0 id on startup if it is stored in `scylla_local` or sets it during joining group0.

Send group0_id (if it is set) when the node tries to initiate the gossip round. When a node gets gossip_digest_syn it checks if its group0 id equals the local one and if not, the message is discarded.

Fixes #14448.

# Testing
## Upgrade tests
Performed manual tests with the following scenario:
1. setup a cluster of two nodes (one compiled with and one without this patch)
2. setup a new node
3. create a basic keyspace and table
4. execute simple select and insert queries

Tested 4 scenarios: the seed node was with or without this patch, and the third node was with or without this patch.
These tests didn't detect any errors.