### PR TITLE
compaction: release resources of compaction executors

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -480,6 +480,7 @@ public:
     compaction_task_executor(compaction_task_executor&&) = delete;
     compaction_task_executor(const compaction_task_executor&) = delete;
 
+    virtual void release_resources() noexcept {}
     virtual ~compaction_task_executor() = default;
 
     // called when a compaction replaces the exhausted sstables with the new set


### PR DESCRIPTION
Before compaction task executors started inheriting from
compaction_task_impl, they were destructed immediately after
compaction finished. Destructors of executors and their
fields performed actions that affected global structures and
statistics and had impact on compaction process.

Currently, task executors are kept in memory much longer, as their
are tracked by task manager. Thus, destructors are not called just
after the compaction, which results in compaction stats not being
updated, which causes e.g. infinite cleanup loop.

Add release_resources() method which is called at the end
of compaction process and does what destructors used to.

Fixes: https://github.com/scylladb/scylladb/issues/14966.
Fixes: https://github.com/scylladb/scylladb/issues/15030.