### PR TITLE
raft: remove a replaced node from group 0 earlier

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1681,6 +1681,9 @@ class topology_coordinator {
                 }
                     break;
                 case node_state::replacing: {
+                    auto replaced_node_id = parse_replaced_node(node);
+                    co_await remove_from_group0(replaced_node_id);
+
                     topology_mutation_builder builder1(node.guard.write_timestamp());
                     // Move new node to 'normal'
                     builder1.del_transition_state()
@@ -1690,7 +1693,7 @@ class topology_coordinator {
 
                     // Move old node to 'left'
                     topology_mutation_builder builder2(node.guard.write_timestamp());
-                    builder2.with_node(parse_replaced_node(node))
+                    builder2.with_node(replaced_node_id)
                             .del("tokens")
                             .set("node_state", node_state::left);
                     co_await update_topology_state(take_guard(std::move(node)), {builder1.build(), builder2.build()},


### PR DESCRIPTION
The topology coordinator only marks a replaced node as LEFT during the replace operation and actually removes it from the group 0 config in `cleanup_group0_config_if_needed`. If this function is called before raft has committed a replacing node as a voter, it does not remove the replaced node from the group 0 config. Then, the coordinator can decide that it has no work to do and starts sleeping, leaving us with an outdated config.

This behavior reduces group 0 availability and causes problems in tests (see  #14885). Also, it makes the coordinator's logic confusing - it claims that it has no work to do when it has some work to do. Therefore, we modify the coordinator so that it removes the replaced node earlier in `handle_topology_transition`.

Fixes #14885
Fixes #14975