### PR TITLE
storage_proxy: silence abort_requested_exception on reads and writes

### DIFF
--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -15,10 +15,14 @@ struct no_exception {};
 class rate_limit_exception {
 };
 
+class abort_requested_exception {
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
-            replica::rate_limit_exception
+            replica::rate_limit_exception,
+            replica::abort_requested_exception
     > reason;
 };
 

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -22,6 +22,8 @@ exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
         std::rethrow_exception(std::move(eptr));
     } catch (rate_limit_exception&) {
         return rate_limit_exception();
+    } catch (abort_requested_exception&) {
+        return abort_requested_exception();
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -13,6 +13,7 @@
 #include <optional>
 #include <variant>
 
+#include "seastar/core/abort_source.hh"
 #include "seastar/core/sstring.hh"
 #include "seastar/core/timed_out_error.hh"
 
@@ -43,10 +44,13 @@ public:
     virtual const char* what() const noexcept override { return "rate limit exceeded"; }
 };
 
+using abort_requested_exception = seastar::abort_requested_exception;
+
 struct exception_variant {
     std::variant<unknown_exception,
             no_exception,
-            rate_limit_exception
+            rate_limit_exception,
+            abort_requested_exception
     > reason;
 
     exception_variant()


### PR DESCRIPTION
This is a backport of #14681 which fixes #10447 to `5.1`.

This PR is even simpler than #14681 because refactoring `encode_replica_exception_for_rpc` has been unneeded. Additionally, there is no need to individually handle the `abort_requested_exception` throw from `get_schema_for_read` in `handle_read_{data, mutation_data, digest}` -- `then_wrapped` already takes care of it. Another small difference is introducing `std::optional<sstring> msg` in `handle_mutation_failed` which was present on `master` before #14681.