### PR TITLE
gossiper: wait_for_live_nodes_to_show_up: allow grace for pending alive endpoints

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2328,17 +2328,17 @@ future<> gossiper::wait_for_live_nodes_to_show_up(size_t n) {
     while (get_live_members().size() < n) {
         auto now = gossiper::clk::now();
         if (timeout <= now) {
-          // Extend the initial timeout up to `max_timeout`
-          // as long as activity is detected in _pending_mark_alive_endpoints
-          if (_pending_mark_alive_endpoints != pending_mark_alive_endpoints && max_timeout > now) {
-            logger.info("pending_mark_alive_endpoints changed while waiting for live nodes: {}", _pending_mark_alive_endpoints);
-            pending_mark_alive_endpoints = _pending_mark_alive_endpoints;
-            timeout += timeout_delay;
-          } else {
-            auto err = ::format("Timed out waiting for {} live nodes to show up in gossip", n);
-            logger.error("{}", err);
-            throw std::runtime_error{std::move(err)};
-          }
+            // Extend the initial timeout up to `max_timeout`
+            // as long as activity is detected in _pending_mark_alive_endpoints
+            if (_pending_mark_alive_endpoints != pending_mark_alive_endpoints && max_timeout > now) {
+                logger.info("pending_mark_alive_endpoints changed while waiting for live nodes: {}", _pending_mark_alive_endpoints);
+                pending_mark_alive_endpoints = _pending_mark_alive_endpoints;
+                timeout += timeout_delay;
+            } else {
+                auto err = ::format("Timed out waiting for {} live nodes to show up in gossip", n);
+                logger.error("{}", err);
+                throw std::runtime_error{std::move(err)};
+            }
         }
 
         logger.log(log_level::info, rate_limit,

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -457,6 +457,7 @@ public:
     future<> wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout);
 
     // Wait for `n` live nodes to show up in gossip (including ourself).
+    // Must be called on shard 0.
     future<> wait_for_live_nodes_to_show_up(size_t n);
 
     // Get live members synchronized to all shards


### PR DESCRIPTION
There are spurious dtest failure where
wait_for_live_nodes_to_show_up times up after 30 seconds waiting for 2 nodes to show up in gossip.

I'm seeing this locally when running multiple topology-related dtest with -n 6 parallelism and I managed to reproduce this by adding a sleep of 10 seconds before real_mark_alive in the send_gossip_echo continuation.

This commit extends the loop timeout if a change is seen in _pending_mark_alive_endpoints.  This means that there's a `mark_alive` in progress and possibly
`real_mark_alive` may be blocking in lock_endpoint.

Still, limit the loop to max_timeout of 6 minutes
(twice the debug-mode timeout).