### PR TITLE
docs/operating-scylla/admin-tools: add note on deprecating sstabledump

### DIFF
--- a/docs/operating-scylla/admin-tools/sstabledump.rst
+++ b/docs/operating-scylla/admin-tools/sstabledump.rst
@@ -1,6 +1,9 @@
 SSTabledump
 ============
 
+.. warning:: SSTabledump is deprecated since Scylla 5.4, and will be removed in a future release.
+             Please consider switching to :doc:`Scylla SSTable </operating-scylla/admin-tools/scylla-sstable>`.
+
 This tool allows you to converts SSTable into a JSON format file.
 SSTabledump supported when using Scylla 3.0, Scylla Enterprise 2019.1, and newer versions.
 In older versions, the tool is named :doc:`SSTable2json </operating-scylla/admin-tools/sstable2json>`.


### PR DESCRIPTION
sstabledump is deprecated in place of `scylla sstable` commands. so let's reflect this in the document.

Fixes #15020
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>