### PR TITLE
raft: make a replaced node a non-voter early

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1649,6 +1649,13 @@ class topology_coordinator {
                         }
                     }
                 }
+                if (node.rs->state == node_state::replacing) {
+                    // We make a replaced node a non-voter early, just like a removed node.
+                    auto replaced_node_id = parse_replaced_node(node);
+                    if (_group0.is_member(replaced_node_id, true)) {
+                        co_await _group0.make_nonvoter(replaced_node_id);
+                    }
+                }
 
                 raft_topology_cmd cmd{raft_topology_cmd::command::stream_ranges};
                 if (node.rs->state == node_state::removing) {


### PR DESCRIPTION
We make a replaced node a non-voter early, just as a removed node in 377f87c91acbb5253237047d111b84b3c0712a8a.