### PR TITLE
Remove some stale sugar from cql_test_env

### DIFF
--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -171,7 +171,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
             e.execute_cql(format("ALTER TABLE ks.tbl WITH cdc = {}", alter2_prop)).get();
             assert_cdc(alter2_expected);
             e.execute_cql("DROP TABLE ks.tbl").get();
-            e.require_table_does_not_exist("ks", cdc::log_name("tbl")).get();
+            BOOST_REQUIRE(!e.local_db().has_schema("ks", cdc::log_name("tbl")));
         };
 
         test("", "{'enabled':'true'}", "{'enabled':'false'}", {false}, {true}, {false});
@@ -187,7 +187,7 @@ SEASTAR_THREAD_TEST_CASE(test_detecting_conflict_of_cdc_log_table_with_existing_
         // Conflict on CREATE which enables cdc log
         e.execute_cql("CREATE TABLE ks.tbl_scylla_cdc_log (a int PRIMARY KEY)").get();
         BOOST_REQUIRE_THROW(e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY) WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
-        e.require_table_does_not_exist("ks", "tbl").get();
+        BOOST_REQUIRE(!e.local_db().has_schema("ks", "tbl"));
 
         // Conflict on ALTER which enables cdc log
         e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY)").get();
@@ -236,7 +236,7 @@ SEASTAR_THREAD_TEST_CASE(test_disallow_cdc_on_materialized_view) {
         BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
         BOOST_REQUIRE_THROW(e.execute_cql("CREATE MATERIALIZED VIEW ks.mv AS SELECT a FROM ks.tbl PRIMARY KEY (a) WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
-        e.require_table_does_not_exist("ks", "mv").get();
+        BOOST_REQUIRE(!e.local_db().has_schema("ks", "mv"));
     }).get();
 }
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -252,7 +252,9 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_description) {
         const std::string timestamps = "system_distributed.cdc_generation_timestamps";
 
         for (auto& t : {generations_v2, streams, timestamps}) {
-            e.require_table_exists(t).get();
+            auto dot_pos = t.find_first_of('.');
+            assert(dot_pos != std::string_view::npos && dot_pos != 0 && dot_pos != t.size() - 1);
+            BOOST_REQUIRE(e.local_db().has_schema(t.substr(0, dot_pos), t.substr(dot_pos + 1)));
 
             // Disallow DROP
             assert_unauthorized(format("DROP TABLE {}", t));

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -148,7 +148,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
             BOOST_REQUIRE_EQUAL(exp.enabled,
                     e.local_db().find_schema("ks", "tbl")->cdc_options().enabled());
             if (exp.enabled) {
-                e.require_table_exists("ks", cdc::log_name("tbl")).get();
+                BOOST_REQUIRE(e.local_db().has_schema("ks", cdc::log_name("tbl")));
             }
             BOOST_REQUIRE_EQUAL(exp.preimage,
                     e.local_db().find_schema("ks", "tbl")->cdc_options().preimage());
@@ -191,7 +191,7 @@ SEASTAR_THREAD_TEST_CASE(test_detecting_conflict_of_cdc_log_table_with_existing_
 
         // Conflict on ALTER which enables cdc log
         e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY)").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
         BOOST_REQUIRE_THROW(e.execute_cql("ALTER TABLE ks.tbl WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
     }).get();
 }
@@ -204,7 +204,7 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_log_table) {
         };
 
         e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY) WITH cdc = {'enabled': true}").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
         // Allow MODIFY, SELECT, ALTER
         auto log_table = "ks." + cdc::log_name("tbl");
@@ -233,7 +233,7 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_log_table) {
 SEASTAR_THREAD_TEST_CASE(test_disallow_cdc_on_materialized_view) {
     do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY)").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
         BOOST_REQUIRE_THROW(e.execute_cql("CREATE MATERIALIZED VIEW ks.mv AS SELECT a FROM ks.tbl PRIMARY KEY (a) WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
         e.require_table_does_not_exist("ks", "mv").get();

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -54,22 +54,18 @@
 using namespace std::literals::chrono_literals;
 
 SEASTAR_TEST_CASE(test_create_keyspace_statement) {
-    return do_with_cql_env([] (cql_test_env& e) {
-        return e.execute_cql("create keyspace ks2 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").discard_result().then([&e] {
-            return e.require_keyspace_exists("ks2");
-        });
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create keyspace ks2 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
+        e.require_keyspace_exists("ks2").get();
     });
 }
 
 SEASTAR_TEST_CASE(test_create_table_statement) {
-    return do_with_cql_env([] (cql_test_env& e) {
-        return e.execute_cql("create table users (user_name varchar PRIMARY KEY, birth_year bigint);").discard_result().then([&e] {
-            return e.require_table_exists("ks", "users");
-        }).then([&e] {
-            return e.execute_cql("create table cf (id int primary key, m map<int, int>, s set<text>, l list<uuid>);").discard_result();
-        }).then([&e] {
-            return e.require_table_exists("ks", "cf");
-        });
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table users (user_name varchar PRIMARY KEY, birth_year bigint);").get();
+        e.require_table_exists("ks", "users").get();
+        e.execute_cql("create table cf (id int primary key, m map<int, int>, s set<text>, l list<uuid>);").get();
+        e.require_table_exists("ks", "cf").get();
     });
 }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -56,7 +56,7 @@ using namespace std::literals::chrono_literals;
 SEASTAR_TEST_CASE(test_create_keyspace_statement) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create keyspace ks2 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
-        e.require_keyspace_exists("ks2").get();
+        BOOST_REQUIRE(e.local_db().has_keyspace("ks2"));
     });
 }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -63,9 +63,9 @@ SEASTAR_TEST_CASE(test_create_keyspace_statement) {
 SEASTAR_TEST_CASE(test_create_table_statement) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table users (user_name varchar PRIMARY KEY, birth_year bigint);").get();
-        e.require_table_exists("ks", "users").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "users"));
         e.execute_cql("create table cf (id int primary key, m map<int, int>, s set<text>, l list<uuid>);").get();
-        e.require_table_exists("ks", "cf").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "cf"));
     });
 }
 
@@ -100,7 +100,7 @@ SEASTAR_TEST_CASE(test_create_twcs_table_no_ttl) {
         e.execute_cql("CREATE TABLE tbl (a int, b int, PRIMARY KEY (a)) WITH "
                       "compaction = {'class': 'TimeWindowCompactionStrategy', "
                       "'compaction_window_size': '1', 'compaction_window_unit': 'MINUTES'};").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
         // Ensure ALTER TABLE works
         e.execute_cql("ALTER TABLE tbl WITH default_time_to_live=60;").get();
         // LiveUpdate and enforce TTL to be defined
@@ -112,7 +112,7 @@ SEASTAR_TEST_CASE(test_create_twcs_table_no_ttl) {
                       "compaction = {'class': 'TimeWindowCompactionStrategy', "
                       "'compaction_window_size': '1', 'compaction_window_unit': 'MINUTES'} AND "
                       "default_time_to_live=60").get();
-        e.require_table_exists("ks", "tbl2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl2"));
         assert_that_failed(e.execute_cql("ALTER TABLE tbl WITH default_time_to_live=0;"));
         // LiveUpdate and disable the check, then try table creation again
         e.execute_cql("UPDATE system.config SET value='false' WHERE name='restrict_twcs_without_default_ttl';").get();
@@ -123,7 +123,7 @@ SEASTAR_TEST_CASE(test_create_twcs_table_no_ttl) {
         e.execute_cql("UPDATE system.config SET value='true' WHERE name='restrict_twcs_without_default_ttl';").get();
         e.execute_cql("ALTER TABLE tbl3 WITH gc_grace_seconds=0;").get();
 
-        e.require_table_exists("ks", "tbl3").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl3"));
     });
 }
 
@@ -141,14 +141,14 @@ SEASTAR_TEST_CASE(test_twcs_max_window) {
                       "compaction = {'class': 'TimeWindowCompactionStrategy', "
                       "'compaction_window_size': '1', 'compaction_window_unit': 'HOURS'} "
                       "AND default_time_to_live=36000;").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
         // LiveUpdate - Disable check
         e.execute_cql("UPDATE system.config SET value='0' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("CREATE TABLE tbl2 (a int, b int, PRIMARY KEY (a)) WITH "
                       "compaction = {'class': 'TimeWindowCompactionStrategy', "
                       "'compaction_window_size': '1', 'compaction_window_unit': 'HOURS'} "
                       "AND default_time_to_live=864000000;").get();
-        e.require_table_exists("ks", "tbl2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl2"));
     });
 }
 
@@ -160,28 +160,28 @@ SEASTAR_TEST_CASE(test_twcs_restrictions_mixed) {
         // Cenario 1: STCS->TWCS with no TTL defined
         e.execute_cql("CREATE TABLE tbl (a int PRIMARY KEY, b int);").get();
         e.execute_cql("ALTER TABLE tbl WITH compaction = {'class': 'TimeWindowCompactionStrategy'};").get();
-        e.require_table_exists("ks", "tbl").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
         // Cenario 2: STCS->TWCS with small TTL. Note: TWCS default window size is 1 day (86400s)
         e.execute_cql("CREATE TABLE tbl2 (a int PRIMARY KEY, b int) WITH default_time_to_live = 60;").get();
         e.execute_cql("ALTER TABLE tbl2 WITH compaction = {'class': 'TimeWindowCompactionStrategy'};").get();
-        e.require_table_exists("ks", "tbl2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl2"));
 
         // Cenario 3: STCS->TWCS with large TTL value
         e.execute_cql("CREATE TABLE tbl3 (a int PRIMARY KEY, b int) WITH default_time_to_live = 8640000;").get();
-        e.require_table_exists("ks", "tbl3").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl3"));
         assert_that_failed(e.execute_cql("ALTER TABLE tbl3 WITH compaction = {'class': 'TimeWindowCompactionStrategy'};"));
 
         // Cenario 4: TWCS table with small to large TTL
         e.execute_cql("CREATE TABLE tbl4 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 60;").get();
-        e.require_table_exists("ks", "tbl4").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl4"));
         assert_that_failed(e.execute_cql("ALTER TABLE tbl4 WITH default_time_to_live = 86400000;"));
 
         // Cenario 5: No TTL TWCS to large TTL and then small TTL
         e.execute_cql("CREATE TABLE tbl5 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'}").get();
-        e.require_table_exists("ks", "tbl5").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl5"));
         assert_that_failed(e.execute_cql("ALTER TABLE tbl5 WITH default_time_to_live = 86400000;"));
         e.execute_cql("ALTER TABLE tbl5 WITH default_time_to_live = 60;").get();
 
@@ -189,7 +189,7 @@ SEASTAR_TEST_CASE(test_twcs_restrictions_mixed) {
         e.execute_cql("UPDATE system.config SET value='0' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("CREATE TABLE tbl6 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 86400000;").get();
-        e.require_table_exists("ks", "tbl6").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl6"));
         e.execute_cql("UPDATE system.config SET value='50' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("ALTER TABLE tbl6 WITH default_time_to_live = 60;").get();
 
@@ -197,27 +197,27 @@ SEASTAR_TEST_CASE(test_twcs_restrictions_mixed) {
         e.execute_cql("UPDATE system.config SET value='0' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("CREATE TABLE tbl7 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 86400000;").get();
-        e.require_table_exists("ks", "tbl7").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl7"));
         e.execute_cql("UPDATE system.config SET value='50' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("ALTER TABLE tbl7 WITH compaction = {'class': 'SizeTieredCompactionStrategy'}").get();
 
         // Cenario 8: No TTL TWCS table to STCS
         e.execute_cql("CREATE TABLE tbl8 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'};").get();
-        e.require_table_exists("ks", "tbl8").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks" ,"tbl8"));
         e.execute_cql("ALTER TABLE tbl8 WITH compaction = {'class': 'SizeTieredCompactionStrategy'};").get();
 
         // Cenario 9: Large TTL TWCS table, modify attribute other than compaction and default_time_to_live
         e.execute_cql("UPDATE system.config SET value='0' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("CREATE TABLE tbl9 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 86400000;").get();
-        e.require_table_exists("ks", "tbl9").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl9"));
         e.execute_cql("UPDATE system.config SET value='50' WHERE name='twcs_max_window_count';").get();
         e.execute_cql("ALTER TABLE tbl9 WITH gc_grace_seconds = 0;").get();
 
         // Cenario 10: Large TTL STCS table, fail to switch to TWCS with no TTL
         e.execute_cql("CREATE TABLE tbl10 (a int PRIMARY KEY, b int) WITH default_time_to_live = 8640000;").get();
-        e.require_table_exists("ks", "tbl10").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl10"));
         assert_that_failed(e.execute_cql("ALTER TABLE tbl10 WITH compaction = {'class': 'TimeWindowCompactionStrategy'};"));
         e.execute_cql("ALTER TABLE tbl10 WITH compaction = {'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 0;").get();
 
@@ -225,7 +225,7 @@ SEASTAR_TEST_CASE(test_twcs_restrictions_mixed) {
         e.execute_cql("CREATE TABLE tbl11 (a int PRIMARY KEY, b int) WITH compaction = "
                       "{'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '1', "
                       "'compaction_window_unit': 'MINUTES'} AND default_time_to_live=3000;").get();
-       e.require_table_exists("ks", "tbl11").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl11"));
        assert_that_failed(e.execute_cql("ALTER TABLE tbl11 WITH default_time_to_live=3600;"));
        e.execute_cql("ALTER TABLE tbl11 WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
                      "'compaction_window_size': '2', 'compaction_window_unit': 'MINUTES'};").get();
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(test_twcs_restrictions_mixed) {
                           "{'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': -65535};"));
        e.execute_cql("CREATE TABLE tbl12 (a int PRIMARY KEY, b int) WITH compaction = "
                      "{'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': 1};").get();
-       e.require_table_exists("ks", "tbl12").get();
+       BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl12"));
        assert_that_failed(e.execute_cql("ALTER TABLE tbl12 WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
                           "'compaction_window_size': 0};"));
     });
@@ -1845,11 +1845,11 @@ SEASTAR_TEST_CASE(test_validate_table) {
 SEASTAR_TEST_CASE(test_table_compression) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tb1 (foo text PRIMARY KEY, bar text) with compression = { };").get();
-        e.require_table_exists("ks", "tb1").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb1"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb1")->get_compressor_params().get_compressor() == nullptr);
 
         e.execute_cql("create table tb5 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : '' };").get();
-        e.require_table_exists("ks", "tb5").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb5"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb5")->get_compressor_params().get_compressor() == nullptr);
 
         BOOST_REQUIRE_THROW(e.execute_cql(
@@ -1863,20 +1863,20 @@ SEASTAR_TEST_CASE(test_table_compression) {
                 std::exception);
 
         e.execute_cql("create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'LZ4Compressor', 'chunk_length_kb' : 2 };").get();
-        e.require_table_exists("ks", "tb2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb2"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb2")->get_compressor_params().get_compressor() == compressor::lz4);
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb2")->get_compressor_params().chunk_length() == 2 * 1024);
 
         e.execute_cql("create table tb3 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'DeflateCompressor' };").get();
-        e.require_table_exists("ks", "tb3").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb3"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb3")->get_compressor_params().get_compressor() == compressor::deflate);
 
         e.execute_cql("create table tb4 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.DeflateCompressor' };").get();
-        e.require_table_exists("ks", "tb4").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb4"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb4")->get_compressor_params().get_compressor() == compressor::deflate);
 
         e.execute_cql("create table tb6 (foo text PRIMARY KEY, bar text);").get();
-        e.require_table_exists("ks", "tb6").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tb6"));
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb6")->get_compressor_params().get_compressor() == compressor::lz4);
     });
 }
@@ -2024,7 +2024,7 @@ SEASTAR_TEST_CASE(test_types) {
                 "    s time,"
                 "    u duration,"
                 ");").get();
-        e.require_table_exists("ks", "all_types").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "all_types"));
 
         e.execute_cql(
             "INSERT INTO all_types (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u) VALUES ("
@@ -2140,7 +2140,7 @@ SEASTAR_TEST_CASE(test_types) {
 SEASTAR_TEST_CASE(test_order_by) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table torder (p1 int, c1 int, c2 int, r1 int, r2 int, PRIMARY KEY(p1, c1, c2));").discard_result().get();
-        e.require_table_exists("ks", "torder").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "torder"));
 
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (0, 1, 2, 3);").get();
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (0, 2, 1, 0);").get();
@@ -2312,7 +2312,7 @@ SEASTAR_TEST_CASE(test_order_by_validate) {
 SEASTAR_TEST_CASE(test_multi_column_restrictions) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tmcr (p1 int, c1 int, c2 int, c3 int, r1 int, PRIMARY KEY (p1, c1, c2, c3));").get();
-        e.require_table_exists("ks", "tmcr").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tmcr"));
         e.execute_cql("insert into tmcr (p1, c1, c2, c3, r1) values (0, 0, 0, 0, 0);").get();
         e.execute_cql("insert into tmcr (p1, c1, c2, c3, r1) values (0, 0, 0, 1, 1);").get();
         e.execute_cql("insert into tmcr (p1, c1, c2, c3, r1) values (0, 0, 1, 0, 2);").get();
@@ -2386,7 +2386,7 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
 SEASTAR_TEST_CASE(test_select_distinct) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tsd (p1 int, c1 int, r1 int, PRIMARY KEY (p1, c1));").get();
-        e.require_table_exists("ks", "tsd").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tsd"));
         e.execute_cql("insert into tsd (p1, c1, r1) values (0, 0, 0);").get();
         e.execute_cql("insert into tsd (p1, c1, r1) values (1, 1, 1);").get();
         e.execute_cql("insert into tsd (p1, c1, r1) values (1, 1, 2);").get();
@@ -2408,7 +2408,7 @@ SEASTAR_TEST_CASE(test_select_distinct) {
         }
 
         e.execute_cql("create table tsd2 (p1 int, p2 int, c1 int, r1 int, PRIMARY KEY ((p1, p2), c1));").get();
-        e.require_table_exists("ks", "tsd2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tsd2"));
         e.execute_cql("insert into tsd2 (p1, p2, c1, r1) values (0, 0, 0, 0);").get();
         e.execute_cql("insert into tsd2 (p1, p2, c1, r1) values (0, 0, 1, 1);").get();
         e.execute_cql("insert into tsd2 (p1, p2, c1, r1) values (1, 1, 0, 0);").get();
@@ -2525,7 +2525,7 @@ APPLY BATCH;)"
 SEASTAR_TEST_CASE(test_in_restriction) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tir (p1 int, c1 int, r1 int, PRIMARY KEY (p1, c1));").get();
-        e.require_table_exists("ks", "tir").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tir"));
         e.execute_cql("insert into tir (p1, c1, r1) values (0, 0, 0);").get();
         e.execute_cql("insert into tir (p1, c1, r1) values (1, 0, 1);").get();
         e.execute_cql("insert into tir (p1, c1, r1) values (1, 1, 2);").get();
@@ -2583,7 +2583,7 @@ SEASTAR_TEST_CASE(test_in_restriction) {
         }
 
         e.execute_cql("create table tir2 (p1 int, c1 int, r1 int, PRIMARY KEY (p1, c1,r1));").get();
-        e.require_table_exists("ks", "tir2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tir2"));
         e.execute_cql("insert into tir2 (p1, c1, r1) values (0, 0, 0);").get();
         e.execute_cql("insert into tir2 (p1, c1, r1) values (1, 0, 1);").get();
         e.execute_cql("insert into tir2 (p1, c1, r1) values (1, 1, 2);").get();
@@ -2627,7 +2627,7 @@ SEASTAR_TEST_CASE(test_in_restriction) {
 SEASTAR_TEST_CASE(test_compact_storage) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tcs (p1 int, c1 int, r1 int, PRIMARY KEY (p1, c1)) with compact storage;").get();
-        e.require_table_exists("ks", "tcs").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tcs"));
         e.execute_cql("insert into tcs (p1, c1, r1) values (1, 2, 3);").get();
         e.require_column_has_value("tcs", {1}, {2}, "r1", 3).get();
         e.execute_cql("update tcs set r1 = 4 where p1 = 1 and c1 = 2;").get();
@@ -2637,7 +2637,7 @@ SEASTAR_TEST_CASE(test_compact_storage) {
             { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(4) },
         });
         e.execute_cql("create table tcs2 (p1 int, c1 int, PRIMARY KEY (p1, c1)) with compact storage;").get();
-        e.require_table_exists("ks", "tcs2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tcs2"));
         e.execute_cql("insert into tcs2 (p1, c1) values (1, 2);").get();
         msg = e.execute_cql("select * from tcs2 where p1 = 1;").get0();
         assert_that(msg).is_rows().with_rows({
@@ -3122,7 +3122,7 @@ SEASTAR_TEST_CASE(test_pg_style_string_literal) {
 SEASTAR_TEST_CASE(test_long_text_value) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto prepared = e.execute_cql("CREATE TABLE t (id int PRIMARY KEY, v text, v2 varchar)").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
         sstring big_one(17324, 'x');
         sstring bigger_one(29123, 'y');
         e.execute_cql(format("INSERT INTO t (id, v, v2) values (1, '{}', '{}')", big_one, big_one)).get();
@@ -3138,7 +3138,7 @@ SEASTAR_TEST_CASE(test_time_conversions) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto prepared = e.execute_cql(
             "CREATE TABLE time_data (id timeuuid PRIMARY KEY, d date, ts timestamp);").get();
-        e.require_table_exists("ks", "time_data").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "time_data"));
 
         e.execute_cql("INSERT INTO time_data (id, d, ts) VALUES (f4e30f80-6958-11e8-96d6-000000000000, '2017-06-11', '2018-06-05 00:00:00+0000');").get();
 
@@ -3191,7 +3191,7 @@ SEASTAR_TEST_CASE(test_empty_partition_range_scan) {
 SEASTAR_TEST_CASE(test_allow_filtering_contains) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (p frozen<map<text, text>>, c1 frozen<list<int>>, c2 frozen<set<int>>, v map<text, text>, PRIMARY KEY(p, c1, c2));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (p, c1, c2, v) VALUES ({'a':'a'}, [1,2,3], {1, 5}, {'x':'xyz', 'y1':'abc'});").get();
         e.execute_cql("INSERT INTO t (p, c1, c2, v) VALUES ({'b':'b'}, [2,3,4], {3, 4}, {'d':'def', 'y1':'abc'});").get();
@@ -3239,7 +3239,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_contains) {
 SEASTAR_TEST_CASE(test_in_restriction_on_not_last_partition_key) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int,b int,c int,d int,PRIMARY KEY ((a, b), c));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (a,b,c,d) VALUES (1,1,1,100); ").get();
         e.execute_cql("INSERT INTO t (a,b,c,d) VALUES (1,1,2,200); ").get();
@@ -3584,7 +3584,7 @@ SEASTAR_TEST_CASE(test_select_with_mixed_order_table) {
         std::string select_query_template = "SELECT f FROM foo WHERE a=0 AND {};";
         std::vector<std::string> column_names = { "b", "c", "d", "e" };
         e.execute_cql("CREATE TABLE foo (a int, b int, c int,d int,e int,f int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d DESC,e ASC);").get();
-        e.require_table_exists("ks", "foo").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "foo"));
 
         // We convert the range 0-> max mapped integers to the mapped tuple,
         // this will create a table satisfying the slice_testcase assumption.

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -33,7 +33,7 @@ using namespace std::literals::chrono_literals;
 SEASTAR_TEST_CASE(test_allow_filtering_check) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (p int, c int, v int, PRIMARY KEY(p, c));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j <3; ++j) {
@@ -53,7 +53,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_check) {
         }
 
         e.execute_cql("CREATE TABLE t2 (p int PRIMARY KEY, a int, b int);").get();
-        e.require_table_exists("ks", "t2").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t2"));
         e.execute_cql("CREATE INDEX ON t2(a)").get();
         for (int i = 0; i < 5; ++i) {
             e.execute_cql(format("INSERT INTO t2 (p, a, b) VALUES ({}, {}, {})", i, i * 10, i * 100)).get();
@@ -83,7 +83,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_check) {
 SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (11, 12, 13, 14, 15)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (11, 15, 16, 17, 18)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (21, 22, 23, 24, 25)").get();
@@ -179,7 +179,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
 SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 1, 1, 1, 15)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 1, 1, 2, 18)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 2, 1, 2, 25)").get();
@@ -287,7 +287,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
 SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (k int, c int, v int, PRIMARY KEY (k, c));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 2, 1)").get();
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 3, 2)").get();
@@ -401,7 +401,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_two_clustering_columns) {
 SEASTAR_TEST_CASE(test_allow_filtering_static_column) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, s int static, PRIMARY KEY(a, b));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
         e.execute_cql("CREATE INDEX ON t(c)").get();
 
         e.execute_cql("INSERT INTO t (a, b, c, s) VALUES (1, 1, 1, 1)").get();
@@ -442,7 +442,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_static_column) {
 SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, d int, e int, f list<int>, g set<int>, h map<int, text>, PRIMARY KEY(a, b));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (a, b, c, d, e, f, g) VALUES (1, 1, 1, 1, 1, [1], {})").get();
         e.execute_cql("INSERT INTO t (a, b, c, d, e, f, g) VALUES (1, 2, 3, 4, 5, [1, 2], {1, 2, 3})").get();
@@ -581,7 +581,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
 SEASTAR_TEST_CASE(test_allow_filtering_desc) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, d int, e int, PRIMARY KEY((a, b), c, d)) WITH CLUSTERING ORDER BY (c DESC);").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 1, 1, 1)").get();
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 3, 4, 5)").get();
@@ -632,7 +632,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
 SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (a int, b int, c int, d int, e int, PRIMARY KEY(a, b));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
         e.execute_cql("CREATE INDEX ON t(c)").get();
 
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 1, 1, 1, 1)").get();
@@ -1012,7 +1012,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
 SEASTAR_TEST_CASE(test_allow_filtering_with_in_on_regular_column) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE t (k int, c int, v int, PRIMARY KEY (k, c));").get();
-        e.require_table_exists("ks", "t").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "t"));
 
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 2, 1)").get();
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 3, 2)").get();

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -57,7 +57,7 @@ SEASTAR_TEST_CASE(test_select_json_types) {
                 "    w int,"
                 ");").get();
 
-        e.require_table_exists("ks", "all_types").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "all_types"));
         e.execute_cql(
             "INSERT INTO all_types (a, b, c, d, e, f, \"G\", \"H\", \"I\", j, k, l, m, n, o, p, q, r, s, u) VALUES ("
                 "    'ascii',"
@@ -156,7 +156,7 @@ SEASTAR_TEST_CASE(test_select_json_collections) {
                 "    d list<frozen<list<tinyint>>>"
                 ");").get();
 
-        e.require_table_exists("ks", "collections").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "collections"));
 
         e.execute_cql(
             "INSERT INTO collections (a, b, c, d) VALUES ("
@@ -225,7 +225,7 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
                 "    u duration,"
                 ");").get();
 
-        e.require_table_exists("ks", "all_types").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "all_types"));
         e.execute_cql(
             "INSERT INTO all_types JSON '"
                 "{\"a\": \"ascii\", "
@@ -336,7 +336,7 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
         )").get(), marshal_exception);
 
         e.execute_cql("CREATE TABLE multi_column_pk_table (p1 int, p2 int, p3 int, c1 int, c2 int, v int, PRIMARY KEY((p1, p2, p3), c1, c2));").get();
-        e.require_table_exists("ks", "multi_column_pk_table").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "multi_column_pk_table"));
 
         e.execute_cql("INSERT INTO multi_column_pk_table JSON '"
                 "{\"p1\": 1, "
@@ -371,7 +371,7 @@ SEASTAR_TEST_CASE(test_insert_json_collections) {
                 "    d list<frozen<list<tinyint>>>"
                 ");").get();
 
-        e.require_table_exists("ks", "collections").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "collections"));
 
         e.execute_cql(
             "INSERT INTO collections JSON '"
@@ -421,7 +421,7 @@ SEASTAR_TEST_CASE(test_insert_json_null_frozen_collections) {
                 "    u frozen<ut>"
                 ");").get();
 
-        e.require_table_exists("ks", "collections").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "collections"));
 
         e.execute_cql("INSERT INTO collections JSON '{\"k\": 0}'").get();
         e.execute_cql("INSERT INTO collections JSON '{\"k\": 1, \"m\": null, \"s\": null, \"l\": null, \"u\": null}'").get();
@@ -571,7 +571,7 @@ SEASTAR_TEST_CASE(test_prepared_json) {
                 "    d list<float>"
                 ");").get();
 
-        e.require_table_exists("ks", "json_data").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "json_data"));
 
         cql3::prepared_cache_key_type prepared_id = e.prepare(
             "begin batch \n"
@@ -627,7 +627,7 @@ SEASTAR_TEST_CASE(test_json_default_unset) {
                 "    d int,"
                 "PRIMARY KEY (a, b));").get();
 
-        e.require_table_exists("ks", "json_data").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "json_data"));
 
         e.execute_cql("INSERT INTO json_data JSON '{\"a\": \"abc\", \"b\": 2, \"c\": 1}'").get();
 

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -632,7 +632,7 @@ SEASTAR_THREAD_TEST_CASE(test_resources_based_cache_eviction) {
         env.execute_cql("CREATE KEYSPACE querier_cache WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
         env.execute_cql("CREATE TABLE querier_cache.test (pk int, ck int, value int, primary key (pk, ck));").get();
 
-        env.require_table_exists("querier_cache", "test").get();
+        BOOST_REQUIRE(env.local_db().has_schema("querier_cache", "test"));
 
         auto insert_id = env.prepare("INSERT INTO querier_cache.test (pk, ck, value) VALUES (?, ?, ?);").get0();
         auto pk = cql3::raw_value::make_value(serialized(0));
@@ -641,7 +641,7 @@ SEASTAR_THREAD_TEST_CASE(test_resources_based_cache_eviction) {
             env.execute_prepared(insert_id, {{pk, ck, ck}}).get();
         }
 
-        env.require_table_exists("querier_cache", "test").get();
+        BOOST_REQUIRE(env.local_db().has_schema("querier_cache", "test"));
 
         auto& cf = db.find_column_family("querier_cache", "test");
         auto s = cf.schema();

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1311,7 +1311,7 @@ memory_limit_table create_memory_limit_table(cql_test_env& env, uint64_t target_
 
     env.execute_cql("CREATE TABLE ks.tbl (pk int, ck int, value text, primary key (pk, ck)) WITH compaction = {'class': 'NullCompactionStrategy'};").get();
 
-    env.require_table_exists("ks", "tbl").get();
+    BOOST_REQUIRE(env.local_db().has_schema("ks", "tbl"));
 
     auto& tbl = db.find_column_family("ks", "tbl");
     auto s = tbl.schema();

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4397,7 +4397,7 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
         env.execute_cql(format(
             "CREATE TABLE {}.{} (pk int, ck int, PRIMARY KEY(pk, ck));", ks_name, table_name)).get();
 
-        env.require_table_exists(ks_name, table_name).get();
+        BOOST_REQUIRE(env.local_db().has_schema(ks_name, table_name));
 
         replica::table& t = env.local_db().find_column_family(ks_name, table_name);
         schema_ptr s = t.schema();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -315,31 +315,6 @@ public:
         co_return co_await _mm.local().announce(co_await service::prepare_new_column_family_announcement(_proxy.local(), s, ts), std::move(group0_guard), "");
     }
 
-    virtual future<> require_keyspace_exists(const sstring& ks_name) override {
-        auto& db = _db.local();
-        assert(db.has_keyspace(ks_name));
-        return make_ready_future<>();
-    }
-
-    virtual future<> require_table_exists(const sstring& ks_name, const sstring& table_name) override {
-        auto& db = _db.local();
-        assert(db.has_schema(ks_name, table_name));
-        return make_ready_future<>();
-    }
-
-    virtual future<> require_table_exists(std::string_view qualified_name) override {
-        auto dot_pos = qualified_name.find_first_of('.');
-        assert(dot_pos != std::string_view::npos && dot_pos != 0 && dot_pos != qualified_name.size() - 1);
-        assert(_db.local().has_schema(qualified_name.substr(0, dot_pos), qualified_name.substr(dot_pos + 1)));
-        return make_ready_future<>();
-    }
-
-    virtual future<> require_table_does_not_exist(const sstring& ks_name, const sstring& table_name) override {
-        auto& db = _db.local();
-        assert(!db.has_schema(ks_name, table_name));
-        return make_ready_future<>();
-    }
-
     virtual future<> require_column_has_value(const sstring& table_name,
                                       std::vector<data_value> pk,
                                       std::vector<data_value> ck,

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -131,12 +131,6 @@ public:
 
     virtual future<> create_table(std::function<schema(std::string_view)> schema_maker) = 0;
 
-    virtual future<> require_keyspace_exists(const sstring& ks_name) = 0;
-
-    virtual future<> require_table_exists(const sstring& ks_name, const sstring& cf_name) = 0;
-    virtual future<> require_table_exists(std::string_view qualified_name) = 0;
-    virtual future<> require_table_does_not_exist(const sstring& ks_name, const sstring& cf_name) = 0;
-
     virtual future<> require_column_has_value(
         const sstring& table_name,
         std::vector<data_value> pk,

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -1100,8 +1100,6 @@ future<> random_schema::create_with_cql(cql_test_env& env) {
         _schema->describe(db, ss, false);
 
         env.execute_cql(ss.str()).get();
-
-        env.require_table_exists(ks_name, tbl_name).get();
         auto& tbl = db.find_column_family(ks_name, tbl_name);
 
         _schema = tbl.schema();


### PR DESCRIPTION
There are some asserting checks for keyspace and table existence on cql_test_env that perform some one-linee work in a complex manner, tests can do better on their own. Removing it makes cql_test_env simpler

refs: #2795