### PR TITLE
Relax cql_test_env services maintenance

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -551,7 +551,7 @@ public:
             sharded<service::forward_service> forward_service;
             sharded<direct_failure_detector::failure_detector> fd;
             sharded<service::raft_address_map> raft_address_map;
-            static sharded<service::direct_fd_pinger> fd_pinger;
+            sharded<service::direct_fd_pinger> fd_pinger;
             sharded<cdc::cdc_service> cdc;
 
             debug::the_database = &db;
@@ -790,7 +790,7 @@ public:
             });
 
             fd_pinger.start(std::ref(ms), std::ref(raft_address_map)).get();
-            auto stop_fd_pinger = defer([] { fd_pinger.stop().get(); });
+            auto stop_fd_pinger = defer([&fd_pinger] { fd_pinger.stop().get(); });
 
             service::direct_fd_clock fd_clock;
             fd.start(

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -554,6 +554,8 @@ public:
             sharded<service::direct_fd_pinger> fd_pinger;
             sharded<cdc::cdc_service> cdc;
 
+            single_node_cql_env env(db, feature_service, sstm, proxy, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, raft_gr, sys_ks, the_tablet_allocator);
+
             debug::the_database = &db;
             auto reset_db_ptr = defer([] {
                 debug::the_database = nullptr;
@@ -1010,7 +1012,6 @@ public:
 
             notify_set.notify_all(configurable::system_state::started).get();
 
-            single_node_cql_env env(db, feature_service, sstm, proxy, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, raft_gr, sys_ks, the_tablet_allocator);
             env._group0_client = &group0_client;
 
             env.start().get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -130,22 +130,22 @@ public:
     static constexpr std::string_view ks_name = "ks";
     static std::atomic<bool> active;
 private:
-    sharded<replica::database>& _db;
-    sharded<gms::feature_service>& _feature_service;
-    sharded<sstables::storage_manager>& _sstm;
-    sharded<service::storage_proxy>& _proxy;
-    sharded<cql3::query_processor>& _qp;
-    sharded<auth::service>& _auth_service;
-    sharded<db::view::view_builder>& _view_builder;
-    sharded<db::view::view_update_generator>& _view_update_generator;
-    sharded<service::migration_notifier>& _mnotifier;
-    sharded<qos::service_level_controller>& _sl_controller;
-    sharded<service::migration_manager>& _mm;
-    sharded<db::batchlog_manager>& _batchlog_manager;
-    sharded<gms::gossiper>& _gossiper;
-    sharded<service::raft_group_registry>& _group0_registry;
-    sharded<db::system_keyspace>& _sys_ks;
-    sharded<service::tablet_allocator>& _tablet_allocator;
+    sharded<replica::database> _db;
+    sharded<gms::feature_service> _feature_service;
+    sharded<sstables::storage_manager> _sstm;
+    sharded<service::storage_proxy> _proxy;
+    sharded<cql3::query_processor> _qp;
+    sharded<auth::service> _auth_service;
+    sharded<db::view::view_builder> _view_builder;
+    sharded<db::view::view_update_generator> _view_update_generator;
+    sharded<service::migration_notifier> _mnotifier;
+    sharded<qos::service_level_controller> _sl_controller;
+    sharded<service::migration_manager> _mm;
+    sharded<db::batchlog_manager> _batchlog_manager;
+    sharded<gms::gossiper> _gossiper;
+    sharded<service::raft_group_registry> _group0_registry;
+    sharded<db::system_keyspace> _sys_ks;
+    sharded<service::tablet_allocator> _tablet_allocator;
     service::raft_group0_client* _group0_client;
 
 private:
@@ -187,39 +187,7 @@ private:
         }
     }
 public:
-    single_node_cql_env(
-            sharded<replica::database>& db,
-            sharded<gms::feature_service>& feature_service,
-            sharded<sstables::storage_manager>& sstm,
-            sharded<service::storage_proxy>& proxy,
-            sharded<cql3::query_processor>& qp,
-            sharded<auth::service>& auth_service,
-            sharded<db::view::view_builder>& view_builder,
-            sharded<db::view::view_update_generator>& view_update_generator,
-            sharded<service::migration_notifier>& mnotifier,
-            sharded<service::migration_manager>& mm,
-            sharded<qos::service_level_controller> &sl_controller,
-            sharded<db::batchlog_manager>& batchlog_manager,
-            sharded<gms::gossiper>& gossiper,
-            sharded<service::raft_group_registry>& group0_registry,
-            sharded<db::system_keyspace>& sys_ks,
-            sharded<service::tablet_allocator>& tablet_allocator)
-            : _db(db)
-            , _feature_service(feature_service)
-            , _sstm(sstm)
-            , _proxy(proxy)
-            , _qp(qp)
-            , _auth_service(auth_service)
-            , _view_builder(view_builder)
-            , _view_update_generator(view_update_generator)
-            , _mnotifier(mnotifier)
-            , _sl_controller(sl_controller)
-            , _mm(mm)
-            , _batchlog_manager(batchlog_manager)
-            , _gossiper(gossiper)
-            , _group0_registry(group0_registry)
-            , _sys_ks(sys_ks)
-            , _tablet_allocator(tablet_allocator)
+    single_node_cql_env()
     {
         adjust_rlimit();
     }
@@ -516,23 +484,6 @@ public:
             // FIXME: handle signals (SIGINT, SIGTERM) - request aborts
             auto stop_abort_sources = defer([&] { abort_sources.stop().get(); });
 
-            sharded<replica::database> db;
-            sharded<gms::feature_service> feature_service;
-            sharded<sstables::storage_manager> sstm;
-            sharded<service::storage_proxy> proxy;
-            sharded<cql3::query_processor> qp;
-            sharded<auth::service> auth_service;
-            sharded<db::view::view_builder> view_builder;
-            sharded<db::view::view_update_generator> view_update_generator;
-            sharded<service::migration_notifier> mm_notif;
-            sharded<service::migration_manager> mm;
-            sharded<qos::service_level_controller> sl_controller;
-            sharded<db::batchlog_manager> bm;
-            sharded<gms::gossiper> gossiper;
-            sharded<service::raft_group_registry> raft_gr;
-            sharded<db::system_keyspace> sys_ks;
-            sharded<service::tablet_allocator> the_tablet_allocator;
-
             sharded<db::system_distributed_keyspace> sys_dist_ks;
             sharded<locator::snitch_ptr> snitch;
             sharded<compaction_manager> cm;
@@ -554,7 +505,24 @@ public:
             sharded<service::direct_fd_pinger> fd_pinger;
             sharded<cdc::cdc_service> cdc;
 
-            single_node_cql_env env(db, feature_service, sstm, proxy, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller), bm, gossiper, raft_gr, sys_ks, the_tablet_allocator);
+            single_node_cql_env env;
+
+            auto& db = env._db;
+            auto& feature_service = env._feature_service;
+            auto& sstm = env._sstm;
+            auto& proxy = env._proxy;
+            auto& qp = env._qp;
+            auto& auth_service = env._auth_service;
+            auto& view_builder = env._view_builder;
+            auto& view_update_generator = env._view_update_generator;
+            auto& mm_notif = env._mnotifier;
+            auto& mm = env._mm;
+            auto& sl_controller = env._sl_controller;
+            auto& bm = env._batchlog_manager;
+            auto& gossiper = env._gossiper;
+            auto& raft_gr = env._group0_registry;
+            auto& sys_ks = env._sys_ks;
+            auto& the_tablet_allocator = env._tablet_allocator;
 
             debug::the_database = &db;
             auto reset_db_ptr = defer([] {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -146,6 +146,27 @@ private:
     sharded<service::raft_group_registry> _group0_registry;
     sharded<db::system_keyspace> _sys_ks;
     sharded<service::tablet_allocator> _tablet_allocator;
+    sharded<db::system_distributed_keyspace> _sys_dist_ks;
+    sharded<locator::snitch_ptr> _snitch;
+    sharded<compaction_manager> _cm;
+    sharded<tasks::task_manager> _task_manager;
+    sharded<netw::messaging_service> _ms;
+    sharded<service::storage_service> _ss;
+    sharded<locator::shared_token_metadata> _token_metadata;
+    sharded<locator::effective_replication_map_factory> _erm_factory;
+    sharded<sstables::directory_semaphore> _sst_dir_semaphore;
+    sharded<wasm::manager> _wasm;
+    sharded<cql3::cql_config> _cql_config;
+    sharded<service::endpoint_lifecycle_notifier> _elc_notif;
+    sharded<cdc::generation_service> _cdc_generation_service;
+    sharded<repair_service> _repair;
+    sharded<streaming::stream_manager> _stream_manager;
+    sharded<service::forward_service> _forward_service;
+    sharded<direct_failure_detector::failure_detector> _fd;
+    sharded<service::raft_address_map> _raft_address_map;
+    sharded<service::direct_fd_pinger> _fd_pinger;
+    sharded<cdc::cdc_service> _cdc;
+
     service::raft_group0_client* _group0_client;
 
 private:
@@ -484,27 +505,6 @@ public:
             // FIXME: handle signals (SIGINT, SIGTERM) - request aborts
             auto stop_abort_sources = defer([&] { abort_sources.stop().get(); });
 
-            sharded<db::system_distributed_keyspace> sys_dist_ks;
-            sharded<locator::snitch_ptr> snitch;
-            sharded<compaction_manager> cm;
-            sharded<tasks::task_manager> task_manager;
-            sharded<netw::messaging_service> ms;
-            sharded<service::storage_service> ss;
-            sharded<locator::shared_token_metadata> token_metadata;
-            sharded<locator::effective_replication_map_factory> erm_factory;
-            sharded<sstables::directory_semaphore> sst_dir_semaphore;
-            sharded<wasm::manager> wasm;
-            sharded<cql3::cql_config> cql_config;
-            sharded<service::endpoint_lifecycle_notifier> elc_notif;
-            sharded<cdc::generation_service> cdc_generation_service;
-            sharded<repair_service> repair;
-            sharded<streaming::stream_manager> stream_manager;
-            sharded<service::forward_service> forward_service;
-            sharded<direct_failure_detector::failure_detector> fd;
-            sharded<service::raft_address_map> raft_address_map;
-            sharded<service::direct_fd_pinger> fd_pinger;
-            sharded<cdc::cdc_service> cdc;
-
             single_node_cql_env env;
 
             auto& db = env._db;
@@ -523,6 +523,26 @@ public:
             auto& raft_gr = env._group0_registry;
             auto& sys_ks = env._sys_ks;
             auto& the_tablet_allocator = env._tablet_allocator;
+            auto& sys_dist_ks = env._sys_dist_ks;
+            auto& snitch = env._snitch;
+            auto& cm = env._cm;
+            auto& task_manager = env._task_manager;
+            auto& ms = env._ms;
+            auto& ss = env._ss;
+            auto& token_metadata = env._token_metadata;
+            auto& erm_factory = env._erm_factory;
+            auto& sst_dir_semaphore = env._sst_dir_semaphore;
+            auto& wasm = env._wasm;
+            auto& cql_config = env._cql_config;
+            auto& elc_notif = env._elc_notif;
+            auto& cdc_generation_service = env._cdc_generation_service;
+            auto& repair = env._repair;
+            auto& stream_manager = env._stream_manager;
+            auto& forward_service = env._forward_service;
+            auto& fd = env._fd;
+            auto& raft_address_map = env._raft_address_map;
+            auto& fd_pinger = env._fd_pinger;
+            auto& cdc = env._cdc;
 
             debug::the_database = &db;
             auto reset_db_ptr = defer([] {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -144,8 +144,6 @@ public:
         const sstring& column_name,
         data_value expected) = 0;
 
-    virtual future<> stop() = 0;
-
     virtual service::client_state& local_client_state() = 0;
 
     virtual replica::database& local_db() = 0;


### PR DESCRIPTION
To add a sharded service to the cql_test_env one needs to patch it in 5 or 6 places

- add cql_test_env reference
- add cql_test_env constructor argument
- initialize the reference in initializer list
- add service variable to do_with method
- pass the variable to cql_test_env constructor
- (optionally) export it via cql_test_env public method

Steps 1 through 5 are annoying, things get much simpler if look like

- add cql_test_env variable
- (optionally) export it via cql_test_env public method

This is what this PR does

refs: #2795