### PR TITLE
tools/scylla-sstable: path::parent_path() when appropriate

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -253,7 +253,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
             }
         }
 
-        const auto dir_path = std::filesystem::path(sst_path).remove_filename();
+        const auto dir_path = sst_path.parent_path();
         const auto sst_filename = sst_path.filename();
 
         auto ed = sstables::entry_descriptor::make_descriptor(dir_path.c_str(), sst_filename.c_str(), schema->ks_name(), schema->cf_name());


### PR DESCRIPTION
in load_sstables(), `sst_path` is already an instace of `std::filesystem::path`, so there is no need to cast it to `std::filesystem::path`. also, `path.remove_filename()` returns something like
"system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/", when the trailing slash. when we get a component's path in `sstable::filename`, we always add a "/" in between the `dir` and the filename, so this'd end up with two slashes in the path like:

"/var/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f//mc-2-big-Data.db"

so, in order to remove the duplicated slash, let's just use `path.parent_path()` here.