### PR TITLE
Restore storage_service -> cdc_generation_service dependency

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -102,9 +102,9 @@ future<> unset_rpc_controller(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_rpc_controller(ctx, r); });
 }
 
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<cdc::generation_service>& cdc_gs, sharded<db::system_keyspace>& sys_ks) {
-    return register_api(ctx, "storage_service", "The storage service API", [&ss, &g, &cdc_gs, &sys_ks] (http_context& ctx, routes& r) {
-            set_storage_service(ctx, r, ss, g.local(), cdc_gs, sys_ks);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<db::system_keyspace>& sys_ks) {
+    return register_api(ctx, "storage_service", "The storage service API", [&ss, &g, &sys_ks] (http_context& ctx, routes& r) {
+            set_storage_service(ctx, r, ss, g.local(), sys_ks);
         });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -51,7 +51,6 @@ class system_keyspace;
 }
 namespace netw { class messaging_service; }
 class repair_service;
-namespace cdc { class generation_service; }
 
 namespace gms {
 
@@ -86,7 +85,7 @@ future<> set_server_init(http_context& ctx);
 future<> set_server_config(http_context& ctx, const db::config& cfg);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<cdc::generation_service>& cdc_gs, sharded<db::system_keyspace>& sys_ks);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<db::system_keyspace>& sys_ks);
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader);
 future<> unset_server_sstables_loader(http_context& ctx);
 future<> set_server_view_builder(http_context& ctx, sharded<db::view::view_builder>& vb);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -25,7 +25,6 @@ class system_keyspace;
 }
 namespace netw { class messaging_service; }
 class repair_service;
-namespace cdc { class generation_service; }
 class sstables_loader;
 
 namespace gms {
@@ -58,7 +57,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, con
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
 std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
-void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<cdc::generation_service>& cdc_gs, sharded<db::system_keyspace>& sys_ls);
+void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<db::system_keyspace>& sys_ls);
 void set_sstables_loader(http_context& ctx, httpd::routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, httpd::routes& r);
 void set_view_builder(http_context& ctx, httpd::routes& r, sharded<db::view::view_builder>& vb);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -763,8 +763,8 @@ future<> generation_service::stop() {
         cdc_log.error("CDC stream rewrite failed: ", std::current_exception());
     }
 
-    if (this_shard_id() == 0) {
-        co_await _gossiper.unregister_(shared_from_this());
+    if (_joined && (this_shard_id() == 0)) {
+        co_await leave_ring();
     }
 
     _stopped = true;
@@ -792,6 +792,12 @@ future<> generation_service::after_join(std::optional<cdc::generation_id>&& star
     // Since this depends on the entire cluster (and therefore we cannot guarantee
     // timely completion), run it in the background and wait for it in stop().
     _cdc_streams_rewrite_complete = maybe_rewrite_streams_descriptions();
+}
+
+future<> generation_service::leave_ring() {
+    assert_shard_zero(__PRETTY_FUNCTION__);
+    _joined = false;
+    co_await _gossiper.unregister_(shared_from_this());
 }
 
 future<> generation_service::on_join(gms::inet_address ep, gms::endpoint_state ep_state, gms::permit_id pid) {
@@ -957,16 +963,12 @@ future<> generation_service::legacy_handle_cdc_generation(std::optional<cdc::gen
         co_return;
     }
 
-    if (!_sys_ks.local().bootstrap_complete() || !_sys_dist_ks.local_is_initialized()
-            || !_sys_dist_ks.local().started()) {
-        // The service should not be listening for generation changes until after the node
-        // is bootstrapped. Therefore we would previously assume that this condition
-        // can never become true and call on_internal_error here, but it turns out that
-        // it may become true on decommission: the node enters NEEDS_BOOTSTRAP
-        // state before leaving the token ring, so bootstrap_complete() becomes false.
-        // In that case we can simply return.
-        co_return;
+    if (!_sys_dist_ks.local_is_initialized() || !_sys_dist_ks.local().started()) {
+        on_internal_error(cdc_log, "Legacy handle CDC generation with sys.dist.ks. down");
     }
+
+    // The service should not be listening for generation changes until after the node
+    // is bootstrapped and since the node leaves the ring on decommission
 
     if (co_await container().map_reduce(and_reducer(), [ts = get_ts(*gen_id)] (generation_service& svc) {
         return !svc._cdc_metadata.prepare(ts);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -776,7 +776,6 @@ generation_service::~generation_service() {
 
 future<> generation_service::after_join(std::optional<cdc::generation_id>&& startup_gen_id) {
     assert_shard_zero(__PRETTY_FUNCTION__);
-    assert(_sys_ks.local().bootstrap_complete());
 
     _gen_id = std::move(startup_gen_id);
     _gossiper.register_(shared_from_this());

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -98,6 +98,7 @@ public:
      * Must be called on shard 0 - that's where the generation management happens.
      */
     future<> after_join(std::optional<cdc::generation_id>&& startup_gen_id);
+    future<> leave_ring();
 
     cdc::metadata& get_cdc_metadata() {
         return _cdc_metadata;

--- a/main.cc
+++ b/main.cc
@@ -1659,7 +1659,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.local().join_cluster(cdc_generation_service.local(), sys_dist_ks, proxy, qp.local());
+                return ss.local().join_cluster(sys_dist_ks, proxy, qp.local());
             }).get();
 
             sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {

--- a/main.cc
+++ b/main.cc
@@ -1643,7 +1643,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Need to do it before allowing incomming messaging service connections since
             // storage proxy's and migration manager's verbs may access group0.
             // This will also disable migration manager schema pulls if needed.
-            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local(), cdc_generation_service.local()).get();
+            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
 
             // It's essential to load fencing_version prior to starting the messaging service,
             // since incoming messages may require fencing.

--- a/main.cc
+++ b/main.cc
@@ -1275,7 +1275,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
-                std::ref(tablet_allocator)).get();
+                std::ref(tablet_allocator), std::ref(cdc_generation_service)).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();

--- a/main.cc
+++ b/main.cc
@@ -1577,7 +1577,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
             });
-            api::set_server_storage_service(ctx, ss, gossiper, cdc_generation_service, sys_ks).get();
+            api::set_server_storage_service(ctx, ss, gossiper, sys_ks).get();
             api::set_server_repair(ctx, repair).get();
             auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
                 api::unset_server_repair(ctx).get();

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -101,7 +101,7 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     },
     [&] (topology_change& chng) -> future<> {
         co_await write_mutations_to_database(_sp, cmd.creator_addr, std::move(chng.mutations));
-        co_await _ss.topology_transition(_cdc_gen_svc);
+        co_await _ss.topology_transition();
     },
     [&] (write_mutations& muts) -> future<> {
         return write_mutations_to_database(_sp, cmd.creator_addr, std::move(muts.mutations));
@@ -171,7 +171,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     // topology_state_load applies persisted state machine state into
     // memory and thus needs to be protected with apply mutex
     auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
-    co_await _ss.topology_state_load(_cdc_gen_svc);
+    co_await _ss.topology_state_load();
     _ss._topology_state_machine.event.broadcast();
 }
 

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -17,10 +17,6 @@
 #include "mutation/canonical_mutation.hh"
 #include "service/raft/raft_state_machine.hh"
 
-namespace cdc {
-class generation_service;
-}
-
 namespace service {
 class raft_group0_client;
 class migration_manager;
@@ -88,13 +84,12 @@ class group0_state_machine : public raft_state_machine {
     migration_manager& _mm;
     storage_proxy& _sp;
     storage_service& _ss;
-    cdc::generation_service& _cdc_gen_svc;
     seastar::gate _gate;
     abort_source _abort_source;
 
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, cdc::generation_service& cdc_gen_svc) : _client(client), _mm(mm), _sp(sp), _ss(ss), _cdc_gen_svc(cdc_gen_svc) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss) : _client(client), _mm(mm), _sp(sp), _ss(ss) {}
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -196,8 +196,8 @@ const raft::server_id& raft_group0::load_my_id() {
 }
 
 raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
-                                                            service::migration_manager& mm, cdc::generation_service& cdc_gen_svc) {
-    auto state_machine = std::make_unique<group0_state_machine>(_client, mm, qp.proxy(), ss, cdc_gen_svc);
+                                                            service::migration_manager& mm) {
+    auto state_machine = std::make_unique<group0_state_machine>(_client, mm, qp.proxy(), ss);
     auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms.local(), _raft_gr.address_map(), gid, my_id);
     // Keep a reference to a specific RPC class.
     auto& rpc_ref = *rpc;
@@ -377,8 +377,7 @@ future<> raft_group0::abort() {
     co_await stop_group0();
 }
 
-future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
-                                              cdc::generation_service& cdc_gen_service) {
+future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     assert(group0_id != raft::group_id{});
     // The address map may miss our own id in case we connect
     // to an existing Raft Group 0 leader.
@@ -390,7 +389,7 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
     // we ensure we haven't missed any IP update in the map.
     load_initial_raft_address_map();
     group0_log.info("Server {} is starting group 0 with id {}", my_id, group0_id);
-    co_await _raft_gr.start_server_for_group(create_server_for_group0(group0_id, my_id, ss, qp, mm, cdc_gen_service));
+    co_await _raft_gr.start_server_for_group(create_server_for_group0(group0_id, my_id, ss, qp, mm));
     _group0.emplace<raft::group_id>(group0_id);
 }
 
@@ -416,14 +415,14 @@ future<> raft_group0::leadership_monitor_fiber() {
 }
 
 future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
-                                  cdc::generation_service& cdc_gen_service, db::system_keyspace& sys_ks) {
+                                  db::system_keyspace& sys_ks) {
     assert(this_shard_id() == 0);
     assert(!joined_group0());
 
     auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID present means we've already joined group 0 before.
-        co_return co_await start_server_for_group0(group0_id, ss, qp, mm, cdc_gen_service);
+        co_return co_await start_server_for_group0(group0_id, ss, qp, mm);
     }
 
     raft::server* server = nullptr;
@@ -465,7 +464,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, bool as_
             // Bootstrap the initial configuration
             co_await raft_sys_table_storage(qp, group0_id, my_id)
                     .bootstrap(std::move(initial_configuration), nontrivial_snapshot);
-            co_await start_server_for_group0(group0_id, ss, qp, mm, cdc_gen_service);
+            co_await start_server_for_group0(group0_id, ss, qp, mm);
             server = &_raft_gr.group0();
             // FIXME if we crash now or after getting added to the config but before storing group 0 ID,
             // we'll end with a bootstrapped server that possibly added some entries, but we won't remember that we have such a server
@@ -571,7 +570,7 @@ future<bool> raft_group0::use_raft() {
     co_return true;
 }
 
-future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service) {
+future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     if (!co_await use_raft()) {
         co_return;
     }
@@ -590,7 +589,7 @@ future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service
     if (group0_id) {
         // Group 0 ID is present => we've already joined group 0 earlier.
         group0_log.info("setup_group0: group 0 ID present. Starting existing Raft server.");
-        co_await start_server_for_group0(group0_id, ss, qp, mm, cdc_gen_service);
+        co_await start_server_for_group0(group0_id, ss, qp, mm);
 
         // If we're not restarting in the middle of the Raft upgrade procedure, we must disable
         // migration_manager schema pulls.
@@ -616,7 +615,7 @@ future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service
 
 future<> raft_group0::setup_group0(
         db::system_keyspace& sys_ks, const std::unordered_set<gms::inet_address>& initial_contact_nodes,
-        std::optional<replace_info> replace_info, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service) {
+        std::optional<replace_info> replace_info, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     if (!co_await use_raft()) {
         co_return;
     }
@@ -634,7 +633,7 @@ future<> raft_group0::setup_group0(
     }
 
     group0_log.info("setup_group0: joining group 0...");
-    co_await join_group0(std::move(seeds), false /* non-voter */, ss, qp, mm, cdc_gen_service, sys_ks);
+    co_await join_group0(std::move(seeds), false /* non-voter */, ss, qp, mm, sys_ks);
     group0_log.info("setup_group0: successfully joined group 0.");
 
     // Start group 0 leadership monitor fiber.
@@ -717,7 +716,7 @@ void raft_group0::load_initial_raft_address_map() {
     }
 }
 
-future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service) {
+future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     if (joined_group0()) {
         group0_log.info("finish_setup_after_join: group 0 ID present, loading server info.");
         auto my_id = load_my_id();
@@ -752,10 +751,10 @@ future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3
     }
 
     // The listener may fire immediately, create a thread for that case.
-    co_await seastar::async([this, &ss, &qp, &mm, &cdc_gen_service] {
-        _raft_support_listener = _feat.supports_raft_cluster_mgmt.when_enabled([this, &ss, &qp, &mm, &cdc_gen_service] {
+    co_await seastar::async([this, &ss, &qp, &mm] {
+        _raft_support_listener = _feat.supports_raft_cluster_mgmt.when_enabled([this, &ss, &qp, &mm] {
             group0_log.info("finish_setup_after_join: SUPPORTS_RAFT feature enabled. Starting internal upgrade-to-raft procedure.");
-            upgrade_to_group0(ss, qp, mm, cdc_gen_service).get();
+            upgrade_to_group0(ss, qp, mm).get();
         });
     });
 }
@@ -1526,7 +1525,7 @@ static auto warn_if_upgrade_takes_too_long() {
     });
 }
 
-future<> raft_group0::upgrade_to_group0(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service) {
+future<> raft_group0::upgrade_to_group0(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     assert(this_shard_id() == 0);
 
     // The SUPPORTS_RAFT cluster feature is enabled, so the local RAFT feature must also be enabled
@@ -1552,10 +1551,10 @@ future<> raft_group0::upgrade_to_group0(service::storage_service& ss, cql3::quer
     }
 
     (void)[] (raft_group0& self, abort_source& as, group0_upgrade_state start_state, gate::holder pause_shutdown, service::storage_service& ss, cql3::query_processor& qp,
-                service::migration_manager& mm, cdc::generation_service& cdc_gen_service) -> future<> {
+                service::migration_manager& mm) -> future<> {
         auto warner = warn_if_upgrade_takes_too_long();
         try {
-            co_await self.do_upgrade_to_group0(start_state, ss, qp, mm, cdc_gen_service);
+            co_await self.do_upgrade_to_group0(start_state, ss, qp, mm);
             co_await self._client.set_group0_upgrade_state(group0_upgrade_state::use_post_raft_procedures);
             upgrade_log.info("Raft upgrade finished. Disabling migration_manager schema pulls.");
             co_await mm.disable_schema_pulls();
@@ -1565,12 +1564,11 @@ future<> raft_group0::upgrade_to_group0(service::storage_service& ss, cql3::quer
                 " If the procedure gets stuck, manual recovery may be required."
                 " Consult the relevant documentation: {}", std::current_exception(), raft_upgrade_doc);
         }
-    }(std::ref(*this), std::ref(_abort_source), start_state, _shutdown_gate.hold(), ss, qp, mm, cdc_gen_service);
+    }(std::ref(*this), std::ref(_abort_source), start_state, _shutdown_gate.hold(), ss, qp, mm);
 }
 
 // `start_state` is either `use_pre_raft_procedures` or `synchronize`.
-future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
-                                           cdc::generation_service& cdc_gen_service) {
+future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
     assert(this_shard_id() == 0);
 
     // Check if every peer knows about the upgrade procedure.
@@ -1597,7 +1595,7 @@ future<> raft_group0::do_upgrade_to_group0(group0_upgrade_state start_state, ser
 
     if (!joined_group0()) {
         upgrade_log.info("Joining group 0...");
-        co_await join_group0(co_await _sys_ks.load_peers(), true, ss, qp, mm, cdc_gen_service, _sys_ks);
+        co_await join_group0(co_await _sys_ks.load_peers(), true, ss, qp, mm, _sys_ks);
     } else {
         upgrade_log.info(
             "We're already a member of group 0."

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -16,8 +16,6 @@ namespace cql3 { class query_processor; }
 
 namespace db { class system_keyspace; }
 
-namespace cdc { class generation_service; }
-
 namespace gms { class gossiper; class feature_service; }
 
 namespace service {
@@ -142,7 +140,7 @@ public:
     //
     // Also make sure to call `finish_setup_after_join` after the node has joined the cluster and entered NORMAL state.
     future<> setup_group0(db::system_keyspace&, const std::unordered_set<gms::inet_address>& initial_contact_nodes,
-                          std::optional<replace_info>, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+                          std::optional<replace_info>, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Call during the startup procedure before networking is enabled.
     //
@@ -153,7 +151,7 @@ public:
     //
     // Cannot be called twice.
     //
-    future<> setup_group0_if_exist(db::system_keyspace&, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+    future<> setup_group0_if_exist(db::system_keyspace&, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Call at the end of the startup procedure, after the node entered NORMAL state.
     // `setup_group0()` must have finished earlier.
@@ -162,7 +160,7 @@ public:
     //
     // If the node has just upgraded, enables a feature listener for the RAFT feature
     // which will start a procedure to create group 0 and switch administrative operations to use it.
-    future<> finish_setup_after_join(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+    future<> finish_setup_after_join(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // If Raft is disabled or in RECOVERY mode, returns `false`.
     // Otherwise:
@@ -253,7 +251,7 @@ private:
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
 
     raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
-        service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+        service::migration_manager& mm);
 
     // Run the discovery algorithm.
     //
@@ -273,10 +271,10 @@ private:
     // from places which must not block.
     //
     // Precondition: the SUPPORTS_RAFT cluster feature is enabled.
-    future<> upgrade_to_group0(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+    future<> upgrade_to_group0(service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Blocking part of `upgrade_to_group0`, runs in background.
-    future<> do_upgrade_to_group0(group0_upgrade_state start_state, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service);
+    future<> do_upgrade_to_group0(group0_upgrade_state start_state, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Start a Raft server for the cluster-wide group 0 and join it to the group.
     // Called during bootstrap or upgrade.
@@ -301,7 +299,7 @@ private:
     // Preconditions: Raft local feature enabled
     // and we haven't initialized group 0 yet after last Scylla start (`joined_group0()` is false).
     // Postcondition: `joined_group0()` is true.
-    future<> join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, cdc::generation_service& cdc_gen_service, db::system_keyspace& sys_ks);
+    future<> join_group0(std::vector<gms::inet_address> seeds, bool as_voter, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, db::system_keyspace& sys_ks);
 
     // Start an existing Raft server for the cluster-wide group 0.
     // Assumes the server was already added to the group earlier so we don't attempt to join it again.
@@ -314,8 +312,7 @@ private:
     // XXX: perhaps it would be good to make this function callable multiple times,
     // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
     // (we could then try restarting the server internally).
-    future<> start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
-                                     cdc::generation_service& cdc_gen_service);
+    future<> start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Make the given server a non-voter in Raft group 0 configuration.
     // Retries on raft::commit_status_unknown.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2548,7 +2548,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
 
     assert(_group0);
     // if the node is bootstrapped the functin will do nothing since we already created group0 in main.cc
-    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, raft_replace_info, *this, qp, _migration_manager.local(), cdc_gen_service);
+    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, raft_replace_info, *this, qp, _migration_manager.local());
 
     raft::server* raft_server = co_await [this] () -> future<raft::server*> {
         if (!_raft_topology_change_enabled) {
@@ -2614,7 +2614,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
             throw std::runtime_error(err);
         }
 
-        co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local(), cdc_gen_service);
+        co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local());
         co_return;
     }
 
@@ -2772,7 +2772,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     }
 
     assert(_group0);
-    co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local(), cdc_gen_service);
+    co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local());
     co_await cdc_gen_service.after_join(std::move(cdc_gen_id));
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5423,6 +5423,7 @@ future<> storage_service::excise(std::unordered_set<token> tokens, inet_address 
 }
 
 future<> storage_service::leave_ring() {
+    co_await _cdc_gens.local().leave_ring();
     co_await _sys_ks.local().set_bootstrap_state(db::system_keyspace::bootstrap_state::NEEDS_BOOTSTRAP);
     co_await mutate_token_metadata([this] (mutable_token_metadata_ptr tmptr) {
         auto endpoint = get_broadcast_address();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4758,14 +4758,18 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
     });
 }
 
-future<> storage_service::check_and_repair_cdc_streams(cdc::generation_service& cdc_gen_svc) {
+future<> storage_service::check_and_repair_cdc_streams() {
     assert(this_shard_id() == 0);
+
+    if (!_cdc_gens.local_is_initialized()) {
+        return make_exception_future<>(std::runtime_error("CDC generation service not initialized yet"));
+    }
 
     if (_raft_topology_change_enabled) {
         return raft_check_and_repair_cdc_streams();
     }
 
-    return cdc_gen_svc.check_and_repair_cdc_streams();
+    return _cdc_gens.local().check_and_repair_cdc_streams();
 }
 
 class node_ops_meta_data {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -298,7 +298,7 @@ future<> storage_service::wait_for_ring_to_settle() {
     slogger.info("Checking bootstrapping/leaving nodes: ok");
 }
 
-future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_svc) {
+future<> storage_service::topology_state_load() {
 #ifdef SEASTAR_DEBUG
     static bool running = false;
     assert(!running); // The function is not re-entrant
@@ -493,13 +493,13 @@ future<> storage_service::topology_state_load(cdc::generation_service& cdc_gen_s
 
     if (auto gen_id = _topology_state_machine._topology.current_cdc_generation_id) {
         slogger.debug("topology_state_load: current CDC generation ID: {}", *gen_id);
-        co_await cdc_gen_svc.handle_cdc_generation(*gen_id);
+        co_await _cdc_gens.local().handle_cdc_generation(*gen_id);
     }
 }
 
-future<> storage_service::topology_transition(cdc::generation_service& cdc_gen_svc) {
+future<> storage_service::topology_transition() {
     assert(this_shard_id() == 0);
-    co_await topology_state_load(cdc_gen_svc); // reload new state
+    co_await topology_state_load(); // reload new state
 
     _topology_state_machine.event.broadcast();
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2087,7 +2087,7 @@ future<> topology_coordinator::run() {
     co_await _async_gate.close();
 }
 
-future<> storage_service::raft_state_monitor_fiber(raft::server& raft, cdc::generation_service& cdc_gen_svc, sharded<db::system_distributed_keyspace>& sys_dist_ks) {
+future<> storage_service::raft_state_monitor_fiber(raft::server& raft, sharded<db::system_distributed_keyspace>& sys_dist_ks) {
     std::optional<abort_source> as;
     try {
         while (!_abort_source.abort_requested()) {
@@ -2577,7 +2577,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
         slogger.info("topology changes are using raft");
 
         // start topology coordinator fiber
-        _raft_state_monitor = raft_state_monitor_fiber(*raft_server, cdc_gen_service, sys_dist_ks);
+        _raft_state_monitor = raft_state_monitor_fiber(*raft_server, sys_dist_ks);
 
         // Need to start system_distributed_keyspace before bootstrap because bootstraping
         // process may access those tables.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -112,7 +112,8 @@ storage_service::storage_service(abort_source& abort_source,
     endpoint_lifecycle_notifier& elc_notif,
     sharded<db::batchlog_manager>& bm,
     sharded<locator::snitch_ptr>& snitch,
-    sharded<service::tablet_allocator>& tablet_allocator)
+    sharded<service::tablet_allocator>& tablet_allocator,
+    sharded<cdc::generation_service>& cdc_gens)
         : _abort_source(abort_source)
         , _feature_service(feature_service)
         , _db(db)
@@ -134,6 +135,7 @@ storage_service::storage_service(abort_source& abort_source,
             });
         })
         , _tablet_allocator(tablet_allocator)
+        , _cdc_gens(cdc_gens)
 {
     register_metrics();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -793,10 +793,10 @@ private:
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held
     // Precondition: the topology mutations were already written to disk; the function only transitions the in-memory state machine.
-    future<> topology_transition(cdc::generation_service&);
+    future<> topology_transition();
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
-    future<> topology_state_load(cdc::generation_service&);
+    future<> topology_state_load();
     // Applies received raft snapshot to local state machine persistent storage
     // raft_group0_client::_read_apply_mutex must be held
     future<> merge_topology_snapshot(raft_topology_snapshot snp);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -335,8 +335,7 @@ public:
      *
      * \see init_messaging_service_part
      */
-    future<> join_cluster(cdc::generation_service& cdc_gen_service,
-            sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy, cql3::query_processor& qp);
+    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy, cql3::query_processor& qp);
 
     void set_group0(service::raft_group0&, bool raft_topology_change_enabled);
 
@@ -348,8 +347,7 @@ private:
     bool should_bootstrap();
     bool is_replacing();
     bool is_first_node();
-    future<> join_token_ring(cdc::generation_service& cdc_gen_service,
-            sharded<db::system_distributed_keyspace>& sys_dist_ks,
+    future<> join_token_ring(sharded<db::system_distributed_keyspace>& sys_dist_ks,
             sharded<service::storage_proxy>& proxy,
             std::unordered_set<gms::inet_address> initial_contact_nodes,
             std::unordered_set<gms::inet_address> loaded_endpoints,
@@ -368,7 +366,7 @@ private:
     // Stream data for which we become a new replica.
     // Before that, if we're not replacing another node, inform other nodes about our chosen tokens
     // and wait for RING_DELAY ms so that we receive new writes from coordinators during streaming.
-    future<> bootstrap(cdc::generation_service& cdc_gen_service, std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id, const std::optional<replacement_info>& replacement_info);
+    future<> bootstrap(std::unordered_set<token>& bootstrap_tokens, std::optional<cdc::generation_id>& cdc_gen_id, const std::optional<replacement_info>& replacement_info);
 
 public:
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -163,7 +163,8 @@ public:
         endpoint_lifecycle_notifier& elc_notif,
         sharded<db::batchlog_manager>& bm,
         sharded<locator::snitch_ptr>& snitch,
-        sharded<service::tablet_allocator>& tablet_allocator);
+        sharded<service::tablet_allocator>& tablet_allocator,
+        sharded<cdc::generation_service>& cdc_gs);
 
     // Needed by distributed<>
     future<> stop();
@@ -488,6 +489,7 @@ private:
     sharded<db::system_keyspace>& _sys_ks;
     locator::snitch_signal_slot_t _snitch_reconfigure;
     sharded<service::tablet_allocator>& _tablet_allocator;
+    sharded<cdc::generation_service>& _cdc_gens;
 private:
     /**
      * Handle node bootstrap

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -691,7 +691,7 @@ public:
     future<std::map<gms::inet_address, float>> effective_ownership(sstring keyspace_name);
 
     // Must run on shard 0.
-    future<> check_and_repair_cdc_streams(cdc::generation_service&);
+    future<> check_and_repair_cdc_streams();
 
 private:
     promise<> _drain_finished;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -754,7 +754,7 @@ private:
     future<> _raft_state_monitor = make_ready_future<>();
     // This fibers monitors raft state and start/stops the topology change
     // coordinator fiber
-    future<> raft_state_monitor_fiber(raft::server&, cdc::generation_service&, sharded<db::system_distributed_keyspace>& sys_dist_ks);
+    future<> raft_state_monitor_fiber(raft::server&, sharded<db::system_distributed_keyspace>& sys_dist_ks);
 
      // State machine that is responsible for topology change
     topology_state_machine _topology_state_machine;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -791,7 +791,8 @@ private:
                 std::ref(_elc_notif),
                 std::ref(_batchlog_manager),
                 std::ref(_snitch),
-                std::ref(_tablet_allocator)).get();
+                std::ref(_tablet_allocator),
+                std::ref(_cdc_generation_service)).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });
 
             _ss.invoke_on_all([this] (service::storage_service& ss) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -888,7 +888,7 @@ private:
             _ss.local().set_group0(group0_service, raft_topology_change_enabled);
 
             try {
-                _ss.local().join_cluster(_cdc_generation_service.local(), _sys_dist_ks, _proxy, _qp.local()).get();
+                _ss.local().join_cluster(_sys_dist_ks, _proxy, _qp.local()).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error


### PR DESCRIPTION
The main goal of this PR is to stop cdc_generation_service from calling system_keyspace::bootstrap_complete(). The reason why it's there is that gen. service doesn't want to handle generation before node joined the ring or after it was decommissioned. The cleanup is done with the help of storage_service->cdc_generation_service explicit dependency brought back and this, in turn, suddenly freed the raft and API code from the need to carry cdc gen. service reference around.