### PR TITLE
sstable_set: maintain bytes on disk

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -47,8 +47,6 @@ class compaction_group {
     // have not been deleted yet, so must not GC any tombstones in other sstables
     // that may delete data in these sstables:
     std::vector<sstables::shared_sstable> _sstables_compacted_but_not_deleted;
-    uint64_t _main_set_disk_space_used = 0;
-    uint64_t _maintenance_set_disk_space_used = 0;
     seastar::condition_variable _staging_done_condition;
 private:
     // Adds new sstable to the set of sstables

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -483,9 +483,7 @@ compaction_group::do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, 
 }
 
 void compaction_group::add_sstable(sstables::shared_sstable sstable) {
-    auto sstable_size = sstable->bytes_on_disk();
     _main_sstables = do_add_sstable(_main_sstables, std::move(sstable), enable_backlog_tracker::yes);
-    _main_set_disk_space_used += sstable_size;
 }
 
 const lw_shared_ptr<sstables::sstable_set>& compaction_group::main_sstables() const noexcept {
@@ -494,13 +492,10 @@ const lw_shared_ptr<sstables::sstable_set>& compaction_group::main_sstables() co
 
 void compaction_group::set_main_sstables(lw_shared_ptr<sstables::sstable_set> new_main_sstables) {
     _main_sstables = std::move(new_main_sstables);
-    _main_set_disk_space_used = calculate_disk_space_used_for(*_main_sstables);
 }
 
 void compaction_group::add_maintenance_sstable(sstables::shared_sstable sst) {
-    auto sstable_size = sst->bytes_on_disk();
     _maintenance_sstables = do_add_sstable(_maintenance_sstables, std::move(sst), enable_backlog_tracker::no);
-    _maintenance_set_disk_space_used += sstable_size;
 }
 
 const lw_shared_ptr<sstables::sstable_set>& compaction_group::maintenance_sstables() const noexcept {
@@ -509,7 +504,6 @@ const lw_shared_ptr<sstables::sstable_set>& compaction_group::maintenance_sstabl
 
 void compaction_group::set_maintenance_sstables(lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables) {
     _maintenance_sstables = std::move(new_maintenance_sstables);
-    _maintenance_set_disk_space_used = calculate_disk_space_used_for(*_maintenance_sstables);
 }
 
 void table::add_sstable(compaction_group& cg, sstables::shared_sstable sstable) {
@@ -1070,7 +1064,7 @@ size_t compaction_group::live_sstable_count() const noexcept {
 }
 
 uint64_t compaction_group::live_disk_space_used() const noexcept {
-    return _main_set_disk_space_used + _maintenance_set_disk_space_used;
+    return _main_sstables->bytes_on_disk() + _maintenance_sstables->bytes_on_disk();
 }
 
 uint64_t compaction_group::total_disk_space_used() const noexcept {

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -60,7 +60,14 @@ using sstable_predicate = noncopyable_function<bool(const sstable&)>;
 const sstable_predicate& default_sstable_predicate();
 
 class sstable_set_impl {
+protected:
+    uint64_t _bytes_on_disk = 0;
+
+    // for cloning
+    explicit sstable_set_impl(uint64_t bytes_on_disk) noexcept : _bytes_on_disk(bytes_on_disk) {}
 public:
+    sstable_set_impl() = default;
+    sstable_set_impl(const sstable_set_impl&) = default;
     virtual ~sstable_set_impl() {}
     virtual std::unique_ptr<sstable_set_impl> clone() const = 0;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range) const = 0;
@@ -73,6 +80,15 @@ public:
     // Return true iff sst was erased
     virtual bool erase(shared_sstable sst) = 0;
     virtual size_t size() const noexcept = 0;
+    virtual uint64_t bytes_on_disk() const noexcept {
+        return _bytes_on_disk;
+    }
+    uint64_t add_bytes_on_disk(uint64_t delta) noexcept {
+        return _bytes_on_disk += delta;
+    }
+    uint64_t sub_bytes_on_disk(uint64_t delta) noexcept {
+        return _bytes_on_disk -= delta;
+    }
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
 
     virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
@@ -130,6 +146,7 @@ public:
     // Return true iff sst was erase
     bool erase(shared_sstable sst);
     size_t size() const noexcept;
+    uint64_t bytes_on_disk() const noexcept;
 
     // Used to incrementally select sstables from sstable set using ring-position.
     // sstable set must be alive during the lifetime of the selector.

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -68,8 +68,10 @@ public:
     virtual lw_shared_ptr<const sstable_list> all() const = 0;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const = 0;
     virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const = 0;
-    virtual void insert(shared_sstable sst) = 0;
-    virtual void erase(shared_sstable sst) = 0;
+    // Return true iff sst was inserted
+    virtual bool insert(shared_sstable sst) = 0;
+    // Return true iff sst was erased
+    virtual bool erase(shared_sstable sst) = 0;
     virtual size_t size() const noexcept = 0;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
 
@@ -123,8 +125,10 @@ public:
             return futurator::invoke(func, sst);
         });
     }
-    void insert(shared_sstable sst);
-    void erase(shared_sstable sst);
+    // Return true iff sst was inserted
+    bool insert(shared_sstable sst);
+    // Return true iff sst was erase
+    bool erase(shared_sstable sst);
     size_t size() const noexcept;
 
     // Used to incrementally select sstables from sstable set using ring-position.

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -57,7 +57,8 @@ public:
         const interval_map_type& leveled_sstables,
         const lw_shared_ptr<sstable_list>& all,
         const std::unordered_map<run_id, sstable_run>& all_runs,
-        bool use_level_metadata);
+        bool use_level_metadata,
+        uint64_t bytes_on_disk);
 
     virtual std::unique_ptr<sstable_set_impl> clone() const override;
     virtual std::vector<shared_sstable> select(const dht::partition_range& range) const override;
@@ -137,6 +138,7 @@ public:
     virtual bool insert(shared_sstable sst) override;
     virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
+    virtual uint64_t bytes_on_disk() const noexcept override;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
 
     virtual flat_mutation_reader_v2 create_single_key_sstable_reader(

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -65,8 +65,8 @@ public:
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
     virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
-    virtual void insert(shared_sstable sst) override;
-    virtual void erase(shared_sstable sst) override;
+    virtual bool insert(shared_sstable sst) override;
+    virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
     class incremental_selector;
@@ -93,8 +93,8 @@ public:
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
     virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
-    virtual void insert(shared_sstable sst) override;
-    virtual void erase(shared_sstable sst) override;
+    virtual bool insert(shared_sstable sst) override;
+    virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
 
@@ -134,8 +134,8 @@ public:
     virtual lw_shared_ptr<const sstable_list> all() const override;
     virtual stop_iteration for_each_sstable_until(std::function<stop_iteration(const shared_sstable&)> func) const override;
     virtual future<stop_iteration> for_each_sstable_gently_until(std::function<future<stop_iteration>(const shared_sstable&)> func) const override;
-    virtual void insert(shared_sstable sst) override;
-    virtual void erase(shared_sstable sst) override;
+    virtual bool insert(shared_sstable sst) override;
+    virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -493,7 +493,7 @@ static shared_sstable add_sstable_for_overlapping_test(test_env& env, lw_shared_
 static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_ptr& schema,
         const partition_key& first_key, const partition_key& last_key, uint32_t level = 0) {
     auto sst = env.make_sstable(schema);
-    sstables::test(sst).set_values_for_leveled_strategy(0, level, 0, first_key, last_key);
+    sstables::test(sst).set_values_for_leveled_strategy(1 /* size */, level, 0 /* max_timestamp */, first_key, last_key);
     return sst;
 }
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -467,7 +467,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
 static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_ptr& schema,
         const partition_key& first_key, const partition_key& last_key, uint32_t level = 0) {
     auto sst = env.make_sstable(schema);
-    sstables::test(sst).set_values_for_leveled_strategy(0, level, 0, first_key, last_key);
+    sstables::test(sst).set_values_for_leveled_strategy(1 /* data_size */, level, 0 /* max_timestamp */, first_key, last_key);
     return sst;
 }
 


### PR DESCRIPTION
and use that in compaction_group, rather than
respective accumulators of its own.

This is part of of larger series to make cache updates exception safe.

Refs #14043