### PR TITLE
test: Fix flakiness in sstable_compaction_test.autocompaction_control_test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3379,11 +3379,11 @@ SEASTAR_TEST_CASE(autocompaction_control_test) {
         // trigger background compaction
         cf->trigger_compaction();
         // wait until compaction finished
-        do_until([&cm] { return cm.get_stats().completed_tasks > 0; }, [] {
-            return sleep(std::chrono::milliseconds(100));
+        do_until([&ss] { return ss.completed_tasks > 0 && ss.pending_tasks == 0; }, [] {
+            return sleep(std::chrono::milliseconds(1));
         }).wait();
         // test no more running compactions
-        BOOST_REQUIRE(ss.pending_tasks == 0 && ss.active_tasks == 0);
+        BOOST_REQUIRE(ss.active_tasks == 0);
         // test compaction successfully finished
         BOOST_REQUIRE(ss.errors == 0);
         BOOST_REQUIRE(ss.completed_tasks == 1);


### PR DESCRIPTION
It's possible that compaction task is preempted after completion and before reevaluation, causing pending_tasks to be > 1.

Let's only exit the loop if there are no pending tasks, and also reduce 100ms sleep which is an eternity for this test.

Fixes #14809.