### PR TITLE
RFC: Store and propagage GC timestamp markers from commitlog

### DIFF
--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -229,6 +229,13 @@ public:
     void discard_completed_segments(const cf_id_type&);
 
     /**
+     * Forces active segment switch.
+     * Called from API calls to help tests that need predictable
+     * compaction behaviour.
+    */
+    future<> force_new_active_segment() noexcept;
+
+    /**
      * A 'flush_handler' is invoked when the CL determines that size on disk has
      * exceeded allowable threshold. It is called once for every currently active
      * CF id with the highest replay_position which we would prefer to free "until".

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -18,6 +18,7 @@
 #include "replay_position.hh"
 #include "commitlog_entry.hh"
 #include "db/timeout_clock.hh"
+#include "gc_clock.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 
 namespace seastar { class file; }
@@ -356,6 +357,8 @@ public:
 
     future<std::vector<sstring>> list_existing_segments() const;
     future<std::vector<sstring>> list_existing_segments(const sstring& dir) const;
+
+    gc_clock::time_point min_gc_time(const cf_id_type&) const;
 
     typedef std::function<future<>(buffer_and_replay_position)> commit_load_reader_func;
 

--- a/main.cc
+++ b/main.cc
@@ -1447,6 +1447,24 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // making compaction manager api available, after system keyspace has already been established.
             api::set_server_compaction_manager(ctx).get();
 
+            cm.invoke_on_all([&](compaction_manager& cm) {
+                auto cl = db.local().commitlog();
+                auto scl = db.local().schema_commitlog();
+                if (cl && scl) {
+                    cm.get_tombstone_gc_state().set_gc_time_min_source([cl, scl](const table_id& id) {
+                        return std::min(cl->min_gc_time(id), scl->min_gc_time(id));
+                    });
+                } else if (cl) {
+                    cm.get_tombstone_gc_state().set_gc_time_min_source([cl](const table_id& id) {
+                        return cl->min_gc_time(id);
+                    });
+                } else if (scl) {
+                    cm.get_tombstone_gc_state().set_gc_time_min_source([scl](const table_id& id) {
+                        return scl->min_gc_time(id);
+                    });
+                }
+            }).get();
+
             supervisor::notify("loading tablet metadata");
             ss.local().load_tablet_metadata().get();
 


### PR DESCRIPTION
Yet another approach to Fixes #14870

(Originally suggested by @avikivity). Use commit log stored GC clock min positions to narrow compaction GC bounds.
(Still requires augmented manual flush:es with extensive CL clearing to pass various dtest, but this does not affect "real" execution). 

Adds a lowest timestamp of GC clock whenever a CF is added to a CL segment the first time. Because GC clock is wall 
clock time and only connected to TTL (not cell/row timestamps), this gives a fairly accurate view of GC low bounds
per segment. This is then (in a rather ugly way) propagated to tombstone_gc_state to narrow the allowed GC bounds for 
a CF, based on what is currently left in CL. 

Note: this is a rather unoptimized version - no caching or anything. But even so, should not be excessively expensive, 
esp. since various other code paths already cache the results.
