### PR TITLE
build: cmake: fix the build of rpm/deb from submodules

### DIFF
--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -14,9 +14,11 @@ function(build_submodule name dir)
     DEPENDS ${reloc_pkg})
   add_custom_target(dist-${name}-rpm
     COMMAND reloc/build_rpm.sh --reloc-pkg ${reloc_pkg}
+    DEPENDS ${reloc_pkg}
     WORKING_DIRECTORY "${working_dir}")
   add_custom_target(dist-${name}-deb
     COMMAND reloc/build_deb.sh --reloc-pkg ${reloc_pkg}
+    DEPENDS ${reloc_pkg}
     WORKING_DIRECTORY "${working_dir}")
   add_custom_target(dist-${name}
     DEPENDS dist-${name}-tar dist-${name}-rpm dist-${name}-deb)

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -1,9 +1,10 @@
 function(build_submodule name dir)
   string(REPLACE "-" "~" scylla_version_tilde ${Scylla_VERSION})
+  set(version "${scylla_version_tilde}-${Scylla_RELEASE}")
   set(scylla_version
     "${Scylla_PRODUCT}-${scylla_version_tilde}-${Scylla_RELEASE}")
-  set(reloc_pkg "${dir}/build/${name}-${scylla_version}.noarch.tar.gz")
   set(working_dir ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+  set(reloc_pkg "${working_dir}/build/${Scylla_PRODUCT}-${name}-${version}.noarch.tar.gz")
   add_custom_command(
     OUTPUT ${reloc_pkg}
     COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${ARGN}


### PR DESCRIPTION
in this series, the build of rpm and deb from submodules is fixed:

1. correct the path of reloc package
2. add the dependency of reloc package to deb/rpm build targets