### PR TITLE
s3/test: remove tempdir if log does not exists

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -47,7 +47,7 @@ def _remove_all_but(tempdir, to_preserve):
     # orig_fn does not exist
     if not os.path.exists(orig_fn):
         # it's fine if tempdir does not exist
-        shutil.rmtree(tempdir=True)
+        shutil.rmtree(tempdir, ignore_errors=True)
         return
 
     with tempfile.TemporaryDirectory() as backup_tempdir:


### PR DESCRIPTION
should have been use `ignore_errors=True` to ignore the error. this issue has not poped up, because
we haven't run into the case where the log file
does not exist.

this was a regression introduced by
d4ee84ee1e3034d9b0ffce5f8abcd3a4a4342c40