### PR TITLE
s3/client: generate config file for tests and cleanups

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -85,9 +85,9 @@ async def s3_server(pytestconfig, tmpdir):
     s3_server_port = pytestconfig.getoption('--s3-server-port')
     s3_server_bucket = pytestconfig.getoption('--s3-server-bucket')
 
-    default_address = os.environ.get('S3_SERVER_ADDRESS_FOR_TEST')
-    default_port = os.environ.get('S3_SERVER_PORT_FOR_TEST')
-    default_bucket = os.environ.get('S3_PUBLIC_BUCKET_FOR_TEST')
+    default_address = os.environ.get(MinioServer.ENV_ADDRESS)
+    default_port = os.environ.get(MinioServer.ENV_PORT)
+    default_bucket = os.environ.get(MinioServer.ENV_BUCKET)
 
     tempdir = tmpdir.strpath
     if s3_server_address:

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -26,6 +26,9 @@ from io import BufferedWriter
 
 class MinioServer:
     ENV_CONFFILE = 'S3_CONFFILE_FOR_TEST'
+    ENV_ADDRESS = 'S3_SERVER_ADDRESS_FOR_TEST'
+    ENV_PORT = 'S3_SERVER_PORT_FOR_TEST'
+    ENV_BUCKET = 'S3_PUBLIC_BUCKET_FOR_TEST'
 
     log_file: BufferedWriter
 
@@ -192,9 +195,9 @@ class MinioServer:
 
         self.create_conf_file(self.address, self.port, self.config_file)
         os.environ[self.ENV_CONFFILE] = f'{self.config_file}'
-        os.environ['S3_SERVER_ADDRESS_FOR_TEST'] = f'{self.address}'
-        os.environ['S3_SERVER_PORT_FOR_TEST'] = f'{self.port}'
-        os.environ['S3_PUBLIC_BUCKET_FOR_TEST'] = f'{self.bucket_name}'
+        os.environ[self.ENV_ADDRESS] = f'{self.address}'
+        os.environ[self.ENV_PORT] = f'{self.port}'
+        os.environ[self.ENV_BUCKET] = f'{self.bucket_name}'
 
         try:
             alias = 'local'


### PR DESCRIPTION
before this change, object_store/test_basic.py create a config file
for specifying the object storage settings, and pass the path of this
file as the argument of `--object-storage-config-file` option when
running scylla. we have the same requirement when testing scylla
with minio server, where we launch a minio server and manually
create a the config file and feed it to scylla.

to ease the preparation work, let's consolidate by creating the
config file in `minio_server.py`, so it always creates the config
file and put it in its tempdir. since object_store/test_basic.py
can also run against an S3 bucket, the fixture implemented
object_store/conftest.py is updated accordingly to reuse the
helper exposed by MinioServer to create the config file when it
is not available.