### PR TITLE
storage_service, tablets: Fix corruption of tablet metadata on migration concurrent with table drop

### DIFF
--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -53,6 +53,8 @@ public:
     // Until the upgrade procedure finishes, we will perform operations such as schema changes using the old way,
     // but still pass the guard around to synchronize operations with the upgrade procedure.
     bool with_raft() const;
+
+    explicit operator bool() const { return bool(_impl); }
 };
 
 void release_guard(group0_guard guard);

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -127,6 +127,9 @@ async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
 
     cql = manager.get_cql()
 
+    # Increases the chance of tablet migration concurrent with schema change
+    await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+
     for i in range(3):
         await cql.run_async("DROP KEYSPACE IF EXISTS test;")
         await cql.run_async("CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8 };")


### PR DESCRIPTION
Tablet migration may execute a global token metadata barrier before executing updates of system.tablets. If table is dropped while the barrier is happening, the updates will bring back rows for migrated tablets in a table which is no longer there. This will cause tablet metadata loading to fail with error:

 missing_column (missing column: tablet_count)

Like in this log line:

storage_service - raft topology: topology change coordinator fiber got error raft::stopped_error (Raft instance is stopped, reason: "background error, std::_Nested_exception<raft::state_machine_error> (State machine error at raft/server.cc:1206): std::_Nested_exception<std::runtime_error> (Failed to read tablet metadata): missing_column (missing column: tablet_count)œ")

The fix is to read and execute the updates in a single group0 guard scope, and move execution of the barrier later. We cannot now generate updates in the same handle_tablet_migration() step if barrier needs to be executed, so we resuse the mechanism for two-step stage transition which we already have for handling of streaming. The next pass will notice that the barrier is not needed for a given tablet and will generate the stage update.

Fixes #15061