### PR TITLE
Gossiper: provide strong exception safety for endpoint state changes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4469,7 +4469,7 @@ future<executor::request_return_type> executor::describe_continuous_backups(clie
 // manually create the keyspace to override this predefined behavior.
 static future<std::vector<mutation>> create_keyspace(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts) {
     sstring keyspace_name_str(keyspace_name);
-    int endpoint_count = gossiper.get_endpoint_states().size();
+    int endpoint_count = gossiper.num_endpoints();
     int rf = 3;
     if (endpoint_count < rf) {
         rf = 1;

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -71,7 +71,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 
     fd::get_endpoint_state.set(r, [&g] (std::unique_ptr<request> req) {
-        auto* state = g.get_endpoint_state_for_endpoint_ptr(gms::inet_address(req->param["addr"]));
+        auto state = g.get_endpoint_state_ptr(gms::inet_address(req->param["addr"]));
         if (!state) {
             return make_ready_future<json::json_return_type>(format("unknown endpoint {}", req->param["addr"]));
         }

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -13,6 +13,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
 
+#include "gms/endpoint_state.hh"
 #include "keys.hh"
 #include "schema/schema_builder.hh"
 #include "replica/database.hh"
@@ -256,11 +257,9 @@ public:
 
 bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper& g) {
     auto my_host_id = g.get_host_id(me);
-    auto& eps = g.get_endpoint_states();
-    return std::none_of(eps.begin(), eps.end(),
-            [&] (const std::pair<gms::inet_address, gms::endpoint_state>& ep) {
-        return my_host_id < g.get_host_id(ep.first);
-    });
+    return g.for_each_endpoint_state_until([&] (const gms::inet_address& node, const gms::endpoint_state& eps) {
+        return stop_iteration(my_host_id < g.get_host_id(node));
+    }) == stop_iteration::no;
 }
 
 bool is_cdc_generation_optimal(const cdc::topology_description& gen, const locator::token_metadata& tm) {
@@ -830,11 +829,10 @@ future<> generation_service::check_and_repair_cdc_streams() {
     }
 
     std::optional<cdc::generation_id> latest = _gen_id;
-    const auto& endpoint_states = _gossiper.get_endpoint_states();
-    for (const auto& [addr, state] : endpoint_states) {
+    _gossiper.for_each_endpoint_state([&] (const gms::inet_address& addr, const gms::endpoint_state& state) {
         if (_gossiper.is_left(addr)) {
             cdc_log.info("check_and_repair_cdc_streams ignored node {} because it is in LEFT state", addr);
-            continue;
+            return;
         }
         if (!_gossiper.is_normal(addr)) {
             throw std::runtime_error(format("All nodes must be in NORMAL or LEFT state while performing check_and_repair_cdc_streams"
@@ -845,7 +843,7 @@ future<> generation_service::check_and_repair_cdc_streams() {
         if (!latest || (gen_id && get_ts(*gen_id) > get_ts(*latest))) {
             latest = gen_id;
         }
-    }
+    });
 
     auto tmptr = _token_metadata.get();
     auto sys_dist_ks = get_sys_dist_ks();
@@ -1031,12 +1029,12 @@ future<> generation_service::legacy_scan_cdc_generations() {
     assert_shard_zero(__PRETTY_FUNCTION__);
 
     std::optional<cdc::generation_id> latest;
-    for (const auto& ep: _gossiper.get_endpoint_states()) {
-        auto gen_id = get_generation_id_for(ep.first, _gossiper);
+    _gossiper.for_each_endpoint_state([&] (const gms::inet_address& node, const gms::endpoint_state& eps) {
+        auto gen_id = get_generation_id_for(node, _gossiper);
         if (!latest || (gen_id && get_ts(*gen_id) > get_ts(*latest))) {
             latest = gen_id;
         }
-    }
+    });
 
     if (latest) {
         cdc_log.info("Latest generation seen during startup: {}", *latest);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -802,10 +802,10 @@ future<> generation_service::leave_ring() {
     co_await _gossiper.unregister_(shared_from_this());
 }
 
-future<> generation_service::on_join(gms::inet_address ep, gms::endpoint_state ep_state, gms::permit_id pid) {
+future<> generation_service::on_join(gms::inet_address ep, gms::endpoint_state_ptr ep_state, gms::permit_id pid) {
     assert_shard_zero(__PRETTY_FUNCTION__);
 
-    auto val = ep_state.get_application_state_ptr(gms::application_state::CDC_GENERATION_ID);
+    auto val = ep_state->get_application_state_ptr(gms::application_state::CDC_GENERATION_ID);
     if (!val) {
         return make_ready_future();
     }

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -104,13 +104,13 @@ public:
         return _cdc_metadata;
     }
 
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
-    virtual future<> on_alive(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_remove(gms::inet_address, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    virtual future<> on_join(gms::inet_address, gms::endpoint_state, gms::permit_id) override;
+    virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override;
     virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
 
     future<> check_and_repair_cdc_streams();

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -67,9 +67,7 @@ public:
         return _ss.get_ownership().then([&, mutation_sink] (std::map<gms::inet_address, float> ownership) {
             const locator::token_metadata& tm = _ss.get_token_metadata();
 
-            for (auto&& e : _gossiper.get_endpoint_states()) {
-                auto endpoint = e.first;
-
+            _gossiper.for_each_endpoint_state([&] (const gms::inet_address& endpoint, const gms::endpoint_state&) {
                 mutation m(schema(), partition_key::from_single_value(*schema(), data_value(endpoint).serialize_nonnull()));
                 row& cr = m.partition().clustered_row(*schema(), clustering_key::make_empty()).cells();
 
@@ -94,7 +92,7 @@ public:
                 set_cell(cr, "tokens", int32_t(tm.get_tokens(endpoint).size()));
 
                 mutation_sink(std::move(m));
-            }
+            });
         });
     }
 };

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -151,6 +151,16 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const endpoint_state& x);
 };
 
+using endpoint_state_ptr = lw_shared_ptr<const endpoint_state>;
+
+inline endpoint_state_ptr make_endpoint_state_ptr(const endpoint_state& eps) {
+    return make_lw_shared<endpoint_state>(eps);
+}
+
+inline endpoint_state_ptr make_endpoint_state_ptr(endpoint_state&& eps) {
+    return make_lw_shared<endpoint_state>(std::move(eps));
+}
+
 // The endpoint state is protected with an endpoint lock
 // acquired in the gossiper using gossiper::lock_endpoint.
 //

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -223,7 +223,7 @@ public:
             , _sys_ks(s)
     {
     }
-    future<> on_join(inet_address ep, endpoint_state state, gms::permit_id) override {
+    future<> on_join(inet_address ep, endpoint_state_ptr state, gms::permit_id) override {
         return enable_features();
     }
     future<> on_change(inet_address ep, application_state state, const versioned_value&, gms::permit_id) override {
@@ -232,11 +232,11 @@ public:
         }
         return make_ready_future();
     }
-    future<> before_change(inet_address, endpoint_state, application_state, const versioned_value&) override { return make_ready_future(); }
-    future<> on_alive(inet_address, endpoint_state, gms::permit_id) override { return make_ready_future(); }
-    future<> on_dead(inet_address, endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    future<> before_change(inet_address, endpoint_state_ptr, application_state, const versioned_value&) override { return make_ready_future(); }
+    future<> on_alive(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_dead(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     future<> on_remove(inet_address, gms::permit_id) override { return make_ready_future(); }
-    future<> on_restart(inet_address, endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    future<> on_restart(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
     future<> enable_features();
 };

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1453,6 +1453,15 @@ std::vector<inet_address> gossiper::get_endpoints() const {
     return boost::copy_range<std::vector<inet_address>>(_endpoint_state_map | boost::adaptors::map_keys);
 }
 
+stop_iteration gossiper::for_each_endpoint_state_until(std::function<stop_iteration(const inet_address&, const endpoint_state&)> func) const {
+    for (const auto& [node, eps] : _endpoint_state_map) {
+        if (func(node, eps) == stop_iteration::yes) {
+            return stop_iteration::yes;
+        }
+    }
+    return stop_iteration::no;
+}
+
 bool gossiper::uses_host_id(inet_address endpoint) const {
     return _messaging.knows_version(endpoint) ||
             get_application_state_ptr(endpoint, application_state::NET_VERSION);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1193,7 +1193,7 @@ std::set<inet_address> gossiper::get_unreachable_members() const {
     return ret;
 }
 
-version_type gossiper::get_max_endpoint_state_version(endpoint_state state) const noexcept {
+version_type gossiper::get_max_endpoint_state_version(const endpoint_state& state) const noexcept {
     auto max_version = state.get_heart_beat_state().get_heart_beat_version();
     for (auto& entry : state.get_application_state_map()) {
         auto& value = entry.second;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -448,6 +448,12 @@ public:
      */
     sstring get_rpc_address(const inet_address& endpoint) const;
 private:
+    // Gets or creates endpoint_state for this node
+    endpoint_state& get_or_create_endpoint_state(inet_address ep);
+    endpoint_state& my_endpoint_state() {
+        return get_or_create_endpoint_state(get_broadcast_address());
+    }
+
     void update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map);
 
     void mark_alive(inet_address addr);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -527,7 +527,7 @@ private:
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
     // Must be called under lock_endpoint.
-    future<> do_before_change_notifications(inet_address addr, const endpoint_state& ep_state, const application_state& ap_state, const versioned_value& new_value);
+    future<> do_before_change_notifications(inet_address addr, endpoint_state_ptr ep_state, const application_state& ap_state, const versioned_value& new_value);
 
     // notify that an application state has changed
     // Must be called under lock_endpoint.

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -314,7 +314,7 @@ public:
      * @param ep_state
      * @return
      */
-    version_type get_max_endpoint_state_version(endpoint_state state) const noexcept;
+    version_type get_max_endpoint_state_version(const endpoint_state& state) const noexcept;
 
 
 private:

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -499,7 +499,7 @@ private:
      *
      * Must be called under lock_endpoint.
      */
-    future<> handle_major_state_change(inet_address ep, const endpoint_state& eps, permit_id);
+    future<> handle_major_state_change(inet_address ep, endpoint_state eps, permit_id);
 
 public:
     bool is_alive(inet_address ep) const;
@@ -519,11 +519,11 @@ public:
     future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
 
 private:
-    future<> do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
+    future<> do_apply_state_locally(gms::inet_address node, endpoint_state remote_state, bool listener_notification);
     future<> apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
     // Must be called under lock_endpoint.
-    future<> apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state, permit_id);
+    future<> apply_new_states(inet_address addr, endpoint_state local_state, const endpoint_state& remote_state, permit_id);
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
     // Must be called under lock_endpoint.

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -428,6 +428,10 @@ public:
 
     std::vector<inet_address> get_endpoints() const;
 
+    size_t num_endpoints() const noexcept {
+        return _endpoint_state_map.size();
+    }
+
     bool uses_host_id(inet_address endpoint) const;
 
     locator::host_id get_host_id(inet_address endpoint) const;

--- a/gms/i_endpoint_state_change_subscriber.hh
+++ b/gms/i_endpoint_state_change_subscriber.hh
@@ -42,15 +42,15 @@ public:
      * @param endpoint endpoint for which the state change occurred.
      * @param epState  state that actually changed for the above endpoint.
      */
-    virtual future<> on_join(inet_address endpoint, endpoint_state ep_state, permit_id) = 0;
+    virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, permit_id) = 0;
 
-    virtual future<> before_change(inet_address endpoint, endpoint_state current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
+    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
 
     virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, permit_id) = 0;
 
-    virtual future<> on_alive(inet_address endpoint, endpoint_state state, permit_id) = 0;
+    virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
 
-    virtual future<> on_dead(inet_address endpoint, endpoint_state state, permit_id) = 0;
+    virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
 
     virtual future<> on_remove(inet_address endpoint, permit_id) = 0;
 
@@ -60,7 +60,7 @@ public:
      * previously marked down. It will have only if {@code state.isAlive() == false}
      * as {@code state} is from before the restarted node is marked up.
      */
-    virtual future<> on_restart(inet_address endpoint, endpoint_state state, permit_id) = 0;
+    virtual future<> on_restart(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
 };
 
 } // namespace gms

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2985,13 +2985,13 @@ public:
     }
     virtual future<> on_join(
             gms::inet_address endpoint,
-            gms::endpoint_state ep_state,
+            gms::endpoint_state_ptr ep_state,
             gms::permit_id) override {
         return make_ready_future();
     }
     virtual future<> before_change(
             gms::inet_address endpoint,
-            gms::endpoint_state current_state,
+            gms::endpoint_state_ptr current_state,
             gms::application_state new_state_key,
             const gms::versioned_value& new_value) override {
         return make_ready_future();
@@ -3005,13 +3005,13 @@ public:
     }
     virtual future<> on_alive(
             gms::inet_address endpoint,
-            gms::endpoint_state state,
+            gms::endpoint_state_ptr state,
             gms::permit_id) override {
         return make_ready_future();
     }
     virtual future<> on_dead(
             gms::inet_address endpoint,
-            gms::endpoint_state state,
+            gms::endpoint_state_ptr state,
             gms::permit_id) override {
         return remove_row_level_repair(endpoint);
     }
@@ -3022,7 +3022,7 @@ public:
     }
     virtual future<> on_restart(
             gms::inet_address endpoint,
-            gms::endpoint_state ep_state,
+            gms::endpoint_state_ptr ep_state,
             gms::permit_id) override {
         return remove_row_level_repair(endpoint);
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2330,7 +2330,7 @@ table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, gms::in
     auto it = _cluster_cache_hit_rates.find(addr);
     if (it == _cluster_cache_hit_rates.end()) {
         // no data yet, get it from the gossiper
-        auto* eps = gossiper.get_endpoint_state_for_endpoint_ptr(addr);
+        auto eps = gossiper.get_endpoint_state_ptr(addr);
         if (eps) {
             auto* state = eps->get_application_state_ptr(gms::application_state::CACHE_HITRATES);
             float f = -1.0f; // missing state means old node

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4212,6 +4212,11 @@ class scylla_gms(gdb.Command):
             gossiper = sharded(gdb.parse_and_eval('gms::_the_gossiper')).local()
             state_map = gossiper['endpoint_state_map']
         for (endpoint, state) in unordered_map(state_map):
+            try:
+                state_ptr = seastar_lw_shared_ptr(state)
+                state = state_ptr.get().dereference()
+            except Exception:
+                pass
             ip = ip_to_str(int(get_ip(endpoint)), byteorder=sys.byteorder)
             gdb.write('%s: (gms::endpoint_state*) %s (%s)\n' % (ip, state.address, state['_heart_beat_state']))
             for app_state, vv in std_map(state['_application_state']):

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -42,21 +42,21 @@ public:
         return make_ready_future();
     }
 
-    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state, gms::permit_id pid) override {
-        auto* local_value = ep_state.get_application_state_ptr(gms::application_state::LOAD);
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id pid) override {
+        auto* local_value = ep_state->get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
             return on_change(endpoint, gms::application_state::LOAD, *local_value, pid);
         }
         return make_ready_future();
     }
     
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
 
-    future<> on_alive(gms::inet_address endpoint, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    future<> on_dead(gms::inet_address endpoint, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    future<> on_restart(gms::inet_address endpoint, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override {
         _load_info.erase(endpoint);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -233,7 +233,7 @@ bool migration_manager::have_schema_agreement() {
             return stop_iteration::no;
         }
         mlogger.debug("Checking schema state for {}.", endpoint);
-        auto* schema = eps.get_application_state_ptr(gms::application_state::SCHEMA);
+        auto schema = eps.get_application_state_ptr(gms::application_state::SCHEMA);
         if (!schema) {
             mlogger.debug("Schema state not yet available for {}.", endpoint);
             match = false;
@@ -289,7 +289,7 @@ future<> migration_manager::maybe_schedule_schema_pull(const table_schema_versio
         // pushed out simultaneously. See CASSANDRA-5025
         return sleep_abortable(migration_delay, _as).then([this, &db, endpoint] {
             // grab the latest version of the schema since it may have changed again since the initial scheduling
-            auto* ep_state = _gossiper.get_endpoint_state_for_endpoint_ptr(endpoint);
+            auto ep_state = _gossiper.get_endpoint_state_ptr(endpoint);
             if (!ep_state) {
                 mlogger.debug("epState vanished for {}, not submitting migration task", endpoint);
                 return make_ready_future<>();
@@ -1206,7 +1206,7 @@ future<> migration_manager::on_join(gms::inet_address endpoint, gms::endpoint_st
 
 future<> migration_manager::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) {
     if (state == gms::application_state::SCHEMA) {
-        auto* ep_state = _gossiper.get_endpoint_state_for_endpoint_ptr(endpoint);
+        auto ep_state = _gossiper.get_endpoint_state_ptr(endpoint);
         if (!ep_state || _gossiper.is_dead_state(*ep_state)) {
             mlogger.debug("Ignoring state change for dead or unknown endpoint: {}", endpoint);
             return make_ready_future();

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -222,11 +222,11 @@ void migration_manager::schedule_schema_pull(const gms::inet_address& endpoint, 
 }
 
 bool migration_manager::have_schema_agreement() {
-    const auto known_endpoints = _gossiper.get_endpoint_states();
-    if (known_endpoints.size() == 1) {
+    if (_gossiper.num_endpoints() == 1) {
         // Us.
         return true;
     }
+    const auto known_endpoints = _gossiper.get_endpoint_states();
     auto our_version = _storage_proxy.get_db().local().get_version();
     bool match = false;
     for (auto& x : known_endpoints) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1199,8 +1199,8 @@ future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id 
     return db::schema_tables::get_column_mapping(sys_ks, table_id, v);
 }
 
-future<> migration_manager::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state, gms::permit_id) {
-    schedule_schema_pull(endpoint, ep_state);
+future<> migration_manager::on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) {
+    schedule_schema_pull(endpoint, *ep_state);
     return make_ready_future();
 }
 
@@ -1218,8 +1218,8 @@ future<> migration_manager::on_change(gms::inet_address endpoint, gms::applicati
     return make_ready_future();
 }
 
-future<> migration_manager::on_alive(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) {
-    schedule_schema_pull(endpoint, state);
+future<> migration_manager::on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) {
+    schedule_schema_pull(endpoint, *state);
     return make_ready_future();
 }
 

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -191,13 +191,13 @@ public:
     future<schema_ptr> get_schema_for_write(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source* as = nullptr);
 
 private:
-    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state, gms::permit_id) override;
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
     virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override;
-    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override;
-    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
+    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
 
 public:
     // For tests only.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3245,14 +3245,14 @@ future<> storage_service::handle_state_removed(inet_address endpoint, std::vecto
     }
 }
 
-future<> storage_service::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state, gms::permit_id pid) {
+future<> storage_service::on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id pid) {
     slogger.debug("endpoint={} on_join: permit_id={}", endpoint, pid);
-    for (const auto& e : ep_state.get_application_state_map()) {
+    for (const auto& e : ep_state->get_application_state_map()) {
         co_await on_change(endpoint, e.first, e.second, pid);
     }
 }
 
-future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id pid) {
+future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id pid) {
     slogger.debug("endpoint={} on_alive: permit_id={}", endpoint, pid);
     bool is_normal_token_owner = get_token_metadata().is_normal_token_owner(endpoint);
     if (is_normal_token_owner) {
@@ -3265,7 +3265,7 @@ future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_sta
     }
 }
 
-future<> storage_service::before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) {
+future<> storage_service::before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) {
     slogger.debug("endpoint={} before_change: new app_state={}, new versioned_value={}", endpoint, new_state_key, new_value);
     return make_ready_future();
 }
@@ -3341,12 +3341,12 @@ future<> storage_service::on_remove(gms::inet_address endpoint, gms::permit_id p
     co_await replicate_to_all_cores(std::move(tmptr));
 }
 
-future<> storage_service::on_dead(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id pid) {
+future<> storage_service::on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id pid) {
     slogger.debug("endpoint={} on_dead: permit_id={}", endpoint, pid);
     return notify_down(endpoint);
 }
 
-future<> storage_service::on_restart(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id pid) {
+future<> storage_service::on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id pid) {
     slogger.debug("endpoint={} on_restart: permit_id={}", endpoint, pid);
     // If we have restarted before the node was even marked down, we need to reset the connection pool
     if (endpoint != get_broadcast_address() && _gossiper.is_alive(endpoint)) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -410,8 +410,8 @@ public:
             locator::vnode_effective_replication_map_ptr erm,
             const dht::token_range_vector& ranges) const;
 public:
-    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state, gms::permit_id) override;
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
     /*
      * Handle the reception of a new particular ApplicationState for a particular endpoint. Note that the value of the
      * ApplicationState has not necessarily "changed" since the last known value, if we already received the same update
@@ -445,10 +445,10 @@ public:
      * you should never bootstrap a new node during a removenode, decommission or move.
      */
     virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override;
-    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override;
-    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override;
+    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
+    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override;
-    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state state, gms::permit_id) override;
+    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
 
 public:
     // For migration_listener

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -43,11 +43,11 @@ public:
 
     virtual future<> on_remove(gms::inet_address, gms::permit_id) override;
 
-    virtual future<> on_join(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
-    virtual future<> on_alive(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address, gms::endpoint_state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 };
 
 }

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -341,7 +341,7 @@ future<> stream_manager::on_remove(inet_address endpoint, gms::permit_id) {
     return make_ready_future();
 }
 
-future<> stream_manager::on_restart(inet_address endpoint, endpoint_state ep_state, gms::permit_id) {
+future<> stream_manager::on_restart(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) {
     if (has_peer(endpoint)) {
         sslog.info("stream_manager: Close all stream_session with peer = {} in on_restart", endpoint);
         //FIXME: discarded future.
@@ -354,7 +354,7 @@ future<> stream_manager::on_restart(inet_address endpoint, endpoint_state ep_sta
     return make_ready_future();
 }
 
-future<> stream_manager::on_dead(inet_address endpoint, endpoint_state ep_state, gms::permit_id) {
+future<> stream_manager::on_dead(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) {
     if (has_peer(endpoint)) {
         sslog.info("stream_manager: Close all stream_session with peer = {} in on_dead", endpoint);
         //FIXME: discarded future.

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -69,6 +69,7 @@ struct stream_bytes {
 class stream_manager : public gms::i_endpoint_state_change_subscriber, public enable_shared_from_this<stream_manager>, public peering_sharded_service<stream_manager> {
     using inet_address = gms::inet_address;
     using endpoint_state = gms::endpoint_state;
+    using endpoint_state_ptr = gms::endpoint_state_ptr;
     using application_state = gms::application_state;
     using versioned_value = gms::versioned_value;
     /*
@@ -165,13 +166,13 @@ public:
     shared_ptr<stream_session> get_session(streaming::plan_id plan_id, gms::inet_address from, const char* verb, std::optional<table_id> cf_id = {});
 
 public:
-    virtual future<> on_join(inet_address endpoint, endpoint_state ep_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(inet_address endpoint, endpoint_state current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
+    virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
     virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_alive(inet_address endpoint, endpoint_state state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(inet_address endpoint, endpoint_state state, gms::permit_id) override;
+    virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_remove(inet_address endpoint, gms::permit_id) override;
-    virtual future<> on_restart(inet_address endpoint, endpoint_state ep_state, gms::permit_id) override;
+    virtual future<> on_restart(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override;
 
 private:
     void fail_all_sessions();


### PR DESCRIPTION
This series ensures that endpoint state changes (for each single endpoint) are applied to the gossiper endpoint_state_map as a whole and on all shards.
Any failure in the process will keep the existing endpoint state intact.

Note that verbs that modify the endpoint states of multiple endpoints may still succeed to modify some of them before hitting an error and those changes are committed to the endpoint_state_map, so we don't ensure atomicity when updating multiple endpoints' states.

Fixes scylladb/scylladb#14794
Fixes scylladb/scylladb#14799
