### PR TITLE
replica:database: log if endpoint not found

### DIFF
--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -75,7 +75,12 @@ void storage_manager::update_config(const db::config& cfg) {
 }
 
 shared_ptr<s3::client> storage_manager::get_endpoint_client(sstring endpoint) {
-    auto& ep = _s3_endpoints.at(endpoint);
+    auto found = _s3_endpoints.find(endpoint);
+    if (found == _s3_endpoints.end()) {
+        smlogger.error("unable to find {} in configured object-storage endpoints", endpoint);
+        throw std::invalid_argument(format("endpoint {} not found", endpoint));
+    }
+    auto& ep = found->second;
     if (ep.client == nullptr) {
         ep.client = s3::client::make(endpoint, ep.cfg, [ &ct = container() ] (std::string ep) {
             return ct.local().get_endpoint_client(ep);


### PR DESCRIPTION
if the endpoint specified when creating a KEYSPACE is not found, when flushing a memtable, we would throw an `std::out_of_range` exception when looking up the client in `storage_manager::_s3_endpoints` by the name of endpoint. and scylla would crash because of it. so far, we don't have a good way to error out early. since the storage option for keyspace is still experimental, we can live with this, but would be better if we can spot this error in logging messages when testing this feature.

also, in this change, `std::invalid_argument` is thrown instead of `std::out_of_range`. it's more appropriate in this circumstance.

Refs #15074
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>