### PR TITLE
config: respect --log-with-color 1

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1174,6 +1174,7 @@ logging::settings db::config::logging_settings(const log_cli::options& opts) con
         .default_level = value(default_log_level, opts.default_log_level),
         .stdout_enabled = value(log_to_stdout, opts.log_to_stdout),
         .syslog_enabled = value(log_to_syslog, opts.log_to_syslog),
+        .with_color = opts.log_with_color.get_value(),
         .stdout_timestamp_style =  opts.logger_stdout_timestamps.get_value(),
         .logger_ostream = opts.logger_ostream_type.get_value(),
     };


### PR DESCRIPTION
scylladb overrides some of seastar logging related options with its own options by applying them with `logging::apply_settings()`. but we fail to inherit `with_color` from Seastar as we are using the designated initializer, so the unspecified members are zero initialized. that's why we always have logging message in black and white even if scylla is running in a tty and `--log-with-color 1` is specified.

so, make the debugging life more colorful, let's inherit the option from Seastar, and apply it when setting logging related options.

see also 29e09a3292b976b8ea28fdceb6d2e6c399f00232