### PR TITLE
system_keyspace: De-bloat .setup() from messing with system.local

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -126,8 +126,6 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     static schema_ptr large_rows();
     static schema_ptr large_cells();
     static schema_ptr scylla_local();
-    future<> setup_version(sharded<netw::messaging_service>& ms);
-    future<> check_health();
     future<> force_blocking_flush(sstring cfname);
     future<> build_bootstrap_info();
     future<> cache_truncation_record();
@@ -405,16 +403,15 @@ public:
     bool was_decommissioned() const;
     future<> set_bootstrap_state(bootstrap_state state);
 
-    /**
-     * Read the host ID from the system keyspace, creating (and storing) one if
-     * none exists.
-     */
-    future<locator::host_id> load_local_host_id();
+    struct local_info {
+        locator::host_id host_id;
+        sstring cluster_name;
+        gms::inet_address listen_address;
+    };
+
+    future<local_info> load_local_info();
+    future<> save_local_info(local_info);
 private:
-    /**
-     * Sets the local host ID explicitly.  Used only internally when intializing the host_id
-     */
-    future<locator::host_id> set_local_random_host_id();
     future<truncation_record> get_truncation_record(table_id cf_id);
 
 public:

--- a/main.cc
+++ b/main.cc
@@ -1101,12 +1101,28 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
             replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
-            cfg->host_id = sys_ks.local().load_local_host_id().get0();
+
+            auto listen_address = utils::resolve(cfg->listen_address, family).get0();
+
+            auto linfo = sys_ks.local().load_local_info().get0();
+            if (linfo.cluster_name.empty()) {
+                linfo.cluster_name = cfg->cluster_name();
+            } else if (linfo.cluster_name != cfg->cluster_name()) {
+                throw exceptions::configuration_exception("Saved cluster name " + linfo.cluster_name + " != configured name " + cfg->cluster_name());
+            }
+            if (!linfo.host_id) {
+                linfo.host_id = locator::host_id::create_random_id();
+                startlog.info("Setting local host id to {}", linfo.host_id);
+            }
+
+            cfg->host_id = linfo.host_id;
+            linfo.listen_address = listen_address;
+            sys_ks.local().save_local_info(std::move(linfo)).get();
 
             netw::messaging_service::config mscfg;
 
             mscfg.id = cfg->host_id;
-            mscfg.ip = utils::resolve(cfg->listen_address, family).get0();
+            mscfg.ip = listen_address;
             mscfg.port = cfg->storage_port();
             mscfg.ssl_port = cfg->ssl_storage_port();
             mscfg.listen_on_broadcast_address = cfg->listen_on_broadcast_address();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -667,7 +667,12 @@ private:
             }
 
             if (!cfg->host_id) {
-                cfg->host_id = _sys_ks.local().load_local_host_id().get0();
+                auto linfo = _sys_ks.local().load_local_info().get0();
+                if (!linfo.host_id) {
+                    linfo.host_id = locator::host_id::create_random_id();
+                }
+                cfg->host_id = linfo.host_id;
+                _sys_ks.local().save_local_info(std::move(linfo)).get();
             }
 
             // don't start listening so tests can be run in parallel


### PR DESCRIPTION
On boot several manipulations with system.local are performed.

1. The host_id value is selected from it with key = local

   If not found, system_keyspace generates a new host_id, inserts the new value into the table and returns back

2. The cluster_name is selected from it with key = local

   Then it's system_keyspace that either checks that the name matches the one from db::config, or inserts the db::config value into the table

3. The row with key = local is updated with various info like versions, listen, rpc and bcast addresses, dc, rack, etc. Unconditionally

All three steps are scattered over main, p.1 is called directly, p.2 and p.3 are executed via system_keyspace::setup() that happens rather late. Also there's some touch of this table from the cql_test_env startup code.

The proposal is to collect this setup into one place and execute it early -- as soon as the system.local table is populated. This frees the system_keyspace code from the logic of selecting host id and cluster name leaving it to main and keeps it with only select/insert work.

refs: #2795