### PR TITLE
test: randomized_nemesis_test: mark direct_fd_{pinger,clock} final

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1035,7 +1035,7 @@ public:
 };
 
 template <typename State>
-class direct_fd_pinger : public direct_failure_detector::pinger {
+class direct_fd_pinger final : public direct_failure_detector::pinger {
     ::rpc<State>& _rpc;
 
 public:
@@ -1057,7 +1057,7 @@ public:
     }
 };
 
-class direct_fd_clock : public direct_failure_detector::clock {
+class direct_fd_clock final : public direct_failure_detector::clock {
     // We use `logical_timer` for an implementation of `sleep_until`
     // (for simplicity of implementation we route the sleep to shard 0),
     // but we also need a separate atomic _ticks counter because we need a `now` function callable from every shard.


### PR DESCRIPTION
`raft_server` in test/raft/randomized_nemesis_test.cc manages instances of direct_fd_pinger and direct_fd_clock with unique_ptr<>. this unique_ptr<> deletes these managed instances using delete. but since these two classes have virtual methods, the compiler feels nervous when deleting them. because these two classes have virtual functions, but they do not have virtual destructor. in other words, in theory, these pointers could be pointing derived classes of them, and deleting them could lead to leak.

so to silence the warning and to prevent potential issues, let's just mark these two classes final.

this should address the warning like:

```
In file included from /home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:9:
In file included from /home/kefu/dev/scylladb/seastar/include/seastar/core/reactor.hh:24:
In file included from /home/kefu/dev/scylladb/seastar/include/seastar/core/aligned_buffer.hh:24:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/memory:78:
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:99:2: error: delete called on non-final 'direct_fd_pinger<int>' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:404:4: note: in instantiation of member function 'std::default_delete<direct_fd_pinger<int>>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:1400:5: note: in instantiation of member function 'std::unique_ptr<direct_fd_pinger<int>>::~unique_ptr' requested here
    ~raft_server() {
    ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:99:2: note: in instantiation of member function 'raft_server<ExReg>::~raft_server' requested here
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:404:4: note: in instantiation of member function 'std::default_delete<raft_server<ExReg>>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:1704:24: note: in instantiation of member function 'std::unique_ptr<raft_server<ExReg>>::~unique_ptr' requested here
            ._server = nullptr,
                       ^
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:1742:19: note: in instantiation of member function 'environment<ExReg>::new_node' requested here
        auto id = new_node(first, std::move(cfg));
                  ^
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:2113:39: note: in instantiation of member function 'environment<ExReg>::new_server' requested here
        auto leader_id = co_await env.new_server(true);
                                      ^
```