### PR TITLE
build: cmake: support Coverage and Sanitize build modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,15 @@ list(APPEND CMAKE_MODULE_PATH
 set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE
     STRING "Choose the type of build." FORCE)
 # Set the possible values of build type for cmake-gui
+set(scylla_build_types
+    "Debug" "Release" "Dev" "Sanitize" "Coverage")
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-  "Debug" "Release" "Dev" "Sanitize")
+  ${scylla_build_types})
+list(FIND scylla_build_types ${CMAKE_BUILD_TYPE} which_build_type)
+if(which_build_type EQUAL -1)
+    message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}. "
+        "Following types are supported: ${scylla_build_types}")
+endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" build_mode)
 include(mode.${build_mode})
 include(mode.common)

--- a/cmake/mode.COVERAGE.cmake
+++ b/cmake/mode.COVERAGE.cmake
@@ -1,0 +1,23 @@
+set(Seastar_OptimizationLevel_COVERAGE "g")
+set(CMAKE_CXX_FLAGS_COVERAGE
+  ""
+  CACHE
+  INTERNAL
+  "")
+string(APPEND CMAKE_CXX_FLAGS_COVERAGE
+  " -O${Seastar_OptimizationLevel_SANITIZE}")
+
+set(Seastar_DEFINITIONS_COVERAGE
+  SCYLLA_BUILD_MODE=debug
+  DEBUG
+  SANITIZE
+  DEBUG_LSA_SANITIZER
+  SCYLLA_ENABLE_ERROR_INJECTION)
+
+set(CMAKE_CXX_FLAGS_COVERAGE
+  " -O${Seastar_OptimizationLevel_COVERAGE} -fprofile-instr-generate -fcoverage-mapping -g -gz")
+
+set(CMAKE_STATIC_LINKER_FLAGS_COVERAGE
+  "-fprofile-instr-generate -fcoverage-mapping")
+
+set(stack_usage_threshold_in_KB 40)

--- a/cmake/mode.SANITIZE.cmake
+++ b/cmake/mode.SANITIZE.cmake
@@ -1,0 +1,17 @@
+set(Seastar_OptimizationLevel_SANITIZE "s")
+set(CMAKE_CXX_FLAGS_SANITIZE
+  ""
+  CACHE
+  INTERNAL
+  "")
+string(APPEND CMAKE_CXX_FLAGS_SANITIZE
+  " -O${Seastar_OptimizationLevel_SANITIZE}")
+
+set(Seastar_DEFINITIONS_SANITIZE
+  SCYLLA_BUILD_MODE=sanitize
+  DEBUG
+  SANITIZE
+  DEBUG_LSA_SANITIZER
+  SCYLLA_ENABLE_ERROR_INJECTION)
+
+set(stack_usage_threshold_in_KB 50)


### PR DESCRIPTION
to mirror the build modes supported by `configure.py`.