### PR TITLE
test: randomized_nemesis_test: do not brace around scalars

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2184,13 +2184,13 @@ SEASTAR_TEST_CASE(test_frequent_snapshotting) {
             return ping_shards();
         }, 10'000);
         const auto server_config = raft::server::configuration {
-            .snapshot_threshold{1},
-            .snapshot_threshold_log_size{150},
-            .snapshot_trailing{5},
-            .snapshot_trailing_size{75},
-            .max_log_size{300},
-            .enable_forwarding{true},
-            .max_command_size{30}
+            .snapshot_threshold = 1,
+            .snapshot_threshold_log_size = 150,
+            .snapshot_trailing = 5,
+            .snapshot_trailing_size= 75,
+            .max_log_size = 300,
+            .enable_forwarding = true,
+            .max_command_size = 30
         };
 
         auto leader_id = co_await env.new_server(true, server_config);
@@ -3232,16 +3232,16 @@ SEASTAR_TEST_CASE(basic_generator_test) {
         const auto max_command_size = 2 * sizeof(raft::log_entry);
         auto srv_cfg = frequent_snapshotting
             ? raft::server::configuration {
-                .snapshot_threshold{10},
-                .snapshot_threshold_log_size{3 * (max_command_size + sizeof(raft::log_entry))},
-                .snapshot_trailing{5},
-                .snapshot_trailing_size{max_command_size + sizeof(raft::log_entry)},
-                .max_log_size{5 * (max_command_size + sizeof(raft::log_entry))},
-                .enable_forwarding{forwarding},
-                .max_command_size{max_command_size}
+                .snapshot_threshold = 10,
+                .snapshot_threshold_log_size = 3 * (max_command_size + sizeof(raft::log_entry)),
+                .snapshot_trailing = 5,
+                .snapshot_trailing_size = max_command_size + sizeof(raft::log_entry),
+                .max_log_size = 5 * (max_command_size + sizeof(raft::log_entry)),
+                .enable_forwarding = forwarding,
+                .max_command_size = max_command_size
             }
             : raft::server::configuration {
-                .enable_forwarding{forwarding},
+                .enable_forwarding = forwarding,
             };
 
         tlogger.info("basic_generator_test: forwarding: {}, frequent snapshotting: {}", forwarding, frequent_snapshotting);


### PR DESCRIPTION
Clang and GCC's warning option of `-Wbraced-scalar-init` warns at seeing superfluous use of braces, like:
```
/home/kefu/dev/scylladb/test/raft/randomized_nemesis_test.cc:2187:32: error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]
            .snapshot_threshold{1},
                               ^~~

```
usually, this does not hurt. but by taking the braces out, we have a more readable piece of code, and less warnings.