### PR TITLE
gossiper: add get_unreachable_members_synchronized and use over api

### DIFF
--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/core/coroutine.hh>
+
 #include "gossiper.hh"
 #include "api/api-doc/gossiper.json.hh"
 #include "gms/endpoint_state.hh"
@@ -16,9 +18,9 @@ using namespace seastar::httpd;
 using namespace json;
 
 void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
-    httpd::gossiper_json::get_down_endpoint.set(r, [&g] (const_req req) {
-        auto res = g.get_unreachable_members();
-        return container_to_vec(res);
+    httpd::gossiper_json::get_down_endpoint.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+        auto res = co_await g.get_unreachable_members_synchronized();
+        co_return json::json_return_type(container_to_vec(res));
     });
 
 
@@ -28,9 +30,11 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
         });
     });
 
-    httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (const_req req) {
-        gms::inet_address ep(req.param["addr"]);
-        return g.get_endpoint_downtime(ep);
+    httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+        gms::inet_address ep(req->param["addr"]);
+        // synchronize unreachable_members on all shards
+        co_await g.get_unreachable_members_synchronized();
+        co_return g.get_endpoint_downtime(ep);
     });
 
     httpd::gossiper_json::get_current_generation_number.set(r, [&g] (std::unique_ptr<http::request> req) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -479,6 +479,9 @@ public:
     // Get live members synchronized to all shards
     future<std::set<inet_address>> get_live_members_synchronized();
 
+    // Get live members synchronized to all shards
+    future<std::set<inet_address>> get_unreachable_members_synchronized();
+
     future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
 
 private:

--- a/test/rest_api/test_gossiper.py
+++ b/test/rest_api/test_gossiper.py
@@ -1,0 +1,42 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+import sys
+import requests
+import threading
+import time
+
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+
+def test_gossiper_live_endpoints(cql, rest_api):
+    resp = rest_api.send("GET", f"gossiper/endpoint/live")
+    resp.raise_for_status()
+    live_endpoints = set(resp.json())
+    all_hosts_endpoints = set([host.address for host in cql.cluster.metadata.all_hosts()])
+    assert live_endpoints == all_hosts_endpoints
+
+def test_gossiper_unreachable_endpoints(cql, rest_api):
+    resp = rest_api.send("GET", f"gossiper/endpoint/down")
+    resp.raise_for_status()
+    unreachable_endpoints = set(resp.json())
+    assert not unreachable_endpoints
+
+def test_gossiper_unreachable_endpoints(cql, rest_api):
+    resp = rest_api.send("GET", f"gossiper/endpoint/down")
+    resp.raise_for_status()
+    unreachable_endpoints = set(resp.json())
+    for ep in unreachable_endpoints:
+        resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
+        resp.raise_for_status()
+        assert int(resp.json()) > 0
+
+    resp = rest_api.send("GET", f"gossiper/endpoint/live")
+    resp.raise_for_status()
+    live_endpoints = set(resp.json())
+    for ep in live_endpoints:
+        resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
+        resp.raise_for_status()
+        assert int(resp.json()) == 0


### PR DESCRIPTION
Modeled after get_live_members_synchronized,
get_unreachable_members_synchronized calls
replicate_live_endpoints_on_change to synchronize
the state of unreachable_members on all shards.

Fixes #12261
Fixes #15088

Also, add rest_api unit test for those apis
