### PR TITLE
migration_notifier: get schema_ptr by value

### DIFF
--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -123,19 +123,19 @@ public:
     /// Unregister a migration listener on current shard.
     future<> unregister_listener(migration_listener* listener);
 
-    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm);
-    future<> create_column_family(const schema_ptr& cfm);
-    future<> create_user_type(const user_type& type);
-    future<> create_view(const view_ptr& view);
-    future<> update_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm);
-    future<> update_column_family(const schema_ptr& cfm, bool columns_changed);
-    future<> update_user_type(const user_type& type);
-    future<> update_view(const view_ptr& view, bool columns_changed);
+    future<> create_keyspace(lw_shared_ptr<keyspace_metadata> ksm);
+    future<> create_column_family(schema_ptr cfm);
+    future<> create_user_type(user_type type);
+    future<> create_view(view_ptr view);
+    future<> update_keyspace(lw_shared_ptr<keyspace_metadata> ksm);
+    future<> update_column_family(schema_ptr cfm, bool columns_changed);
+    future<> update_user_type(user_type type);
+    future<> update_view(view_ptr view, bool columns_changed);
     future<> update_tablet_metadata();
-    future<> drop_keyspace(const sstring& ks_name);
-    future<> drop_column_family(const schema_ptr& cfm);
-    future<> drop_user_type(const user_type& type);
-    future<> drop_view(const view_ptr& view);
+    future<> drop_keyspace(sstring ks_name);
+    future<> drop_column_family(schema_ptr cfm);
+    future<> drop_user_type(user_type type);
+    future<> drop_view(view_ptr view);
     future<> drop_function(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
     future<> drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -441,7 +441,7 @@ future<> migration_notifier::on_schema_change(std::function<void(migration_liste
     });
 }
 
-future<> migration_notifier::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
+future<> migration_notifier::create_keyspace(lw_shared_ptr<keyspace_metadata> ksm) {
     const auto& name = ksm->name();
     co_await on_schema_change([&] (migration_listener* listener) {
         listener->on_create_keyspace(name);
@@ -450,7 +450,7 @@ future<> migration_notifier::create_keyspace(const lw_shared_ptr<keyspace_metada
     });
 }
 
-future<> migration_notifier::create_column_family(const schema_ptr& cfm) {
+future<> migration_notifier::create_column_family(schema_ptr cfm) {
     const auto& ks_name = cfm->ks_name();
     const auto& cf_name = cfm->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -460,7 +460,7 @@ future<> migration_notifier::create_column_family(const schema_ptr& cfm) {
     });
 }
 
-future<> migration_notifier::create_user_type(const user_type& type) {
+future<> migration_notifier::create_user_type(user_type type) {
     const auto& ks_name = type->_keyspace;
     const auto& type_name = type->get_name_as_string();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -470,7 +470,7 @@ future<> migration_notifier::create_user_type(const user_type& type) {
     });
 }
 
-future<> migration_notifier::create_view(const view_ptr& view) {
+future<> migration_notifier::create_view(view_ptr view) {
     const auto& ks_name = view->ks_name();
     const auto& view_name = view->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -494,7 +494,7 @@ public void notifyCreateAggregate(UDAggregate udf)
 }
 #endif
 
-future<> migration_notifier::update_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
+future<> migration_notifier::update_keyspace(lw_shared_ptr<keyspace_metadata> ksm) {
     const auto& name = ksm->name();
     co_await on_schema_change([&] (migration_listener* listener) {
         listener->on_update_keyspace(name);
@@ -503,7 +503,7 @@ future<> migration_notifier::update_keyspace(const lw_shared_ptr<keyspace_metada
     });
 }
 
-future<> migration_notifier::update_column_family(const schema_ptr& cfm, bool columns_changed) {
+future<> migration_notifier::update_column_family(schema_ptr cfm, bool columns_changed) {
     const auto& ks_name = cfm->ks_name();
     const auto& cf_name = cfm->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -513,7 +513,7 @@ future<> migration_notifier::update_column_family(const schema_ptr& cfm, bool co
     });
 }
 
-future<> migration_notifier::update_user_type(const user_type& type) {
+future<> migration_notifier::update_user_type(user_type type) {
     const auto& ks_name = type->_keyspace;
     const auto& type_name = type->get_name_as_string();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -523,7 +523,7 @@ future<> migration_notifier::update_user_type(const user_type& type) {
     });
 }
 
-future<> migration_notifier::update_view(const view_ptr& view, bool columns_changed) {
+future<> migration_notifier::update_view(view_ptr view, bool columns_changed) {
     const auto& ks_name = view->ks_name();
     const auto& view_name = view->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -555,7 +555,7 @@ public void notifyUpdateAggregate(UDAggregate udf)
 }
 #endif
 
-future<> migration_notifier::drop_keyspace(const sstring& ks_name) {
+future<> migration_notifier::drop_keyspace(sstring ks_name) {
     co_await on_schema_change([&] (migration_listener* listener) {
         listener->on_drop_keyspace(ks_name);
     }, [&] (std::exception_ptr ex) {
@@ -563,7 +563,7 @@ future<> migration_notifier::drop_keyspace(const sstring& ks_name) {
     });
 }
 
-future<> migration_notifier::drop_column_family(const schema_ptr& cfm) {
+future<> migration_notifier::drop_column_family(schema_ptr cfm) {
     const auto& ks_name = cfm->ks_name();
     const auto& cf_name = cfm->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -573,7 +573,7 @@ future<> migration_notifier::drop_column_family(const schema_ptr& cfm) {
     });
 }
 
-future<> migration_notifier::drop_user_type(const user_type& type) {
+future<> migration_notifier::drop_user_type(user_type type) {
     const auto& ks_name = type->_keyspace;
     const auto& type_name = type->get_name_as_string();
     co_await on_schema_change([&] (migration_listener* listener) {
@@ -583,7 +583,7 @@ future<> migration_notifier::drop_user_type(const user_type& type) {
     });
 }
 
-future<> migration_notifier::drop_view(const view_ptr& view) {
+future<> migration_notifier::drop_view(view_ptr view) {
     const auto& ks_name = view->ks_name();
     const auto& view_name = view->cf_name();
     co_await on_schema_change([&] (migration_listener* listener) {


### PR DESCRIPTION
To prevent use-after-free as seen in
https://github.com/scylladb/scylladb/issues/15097
where a temp schema_ptr retrieved from a global_schema_ptr get destroyed when the notification function yielded.

Capturing the schema_ptr on the coroutine frame
is inexpensive since its a shared ptr and it makes sure that the schema remains valid throughput the coroutine life time.

Fixes scylladb/scylladb#15097