### PR TITLE
gossiper: apply_new_states: tolerate listener errors during shutdown

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -801,11 +801,12 @@ future<gossiper::endpoint_permit> gossiper::lock_endpoint(inet_address ep, permi
     }
     pid = permit_id::create_random_id();
     logger.debug("{}: lock_endpoint {}: waiting: permit_id={}", caller, ep, pid);
-    eptr->units = co_await get_units(eptr->sem, 1);
+    eptr->units = co_await get_units(eptr->sem, 1, _abort_source);
     eptr->pid = pid;
     if (eptr->holders) {
         on_internal_error_noexcept(logger, fmt::format("{}: lock_endpoint {}: newly held endpoint_lock_entry has {} holders", caller, ep, eptr->holders));
     }
+    _abort_source.check();
     co_return endpoint_permit(std::move(eptr), std::move(ep), std::move(caller));
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -818,7 +818,7 @@ future<semaphore_units<>> gossiper::lock_endpoint_update_semaphore() {
     if (this_shard_id() != 0) {
         on_internal_error(logger, "must be called on shard 0");
     }
-    return get_units(_endpoint_update_semaphore, 1);
+    return get_units(_endpoint_update_semaphore, 1, _abort_source);
 }
 
 future<> gossiper::mutate_live_and_unreachable_endpoints(std::function<void(gossiper&)> func) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1784,7 +1784,12 @@ future<> gossiper::apply_new_states(inet_address addr, endpoint_state& local_sta
             co_await do_on_change_notifications(addr, key, remote_map.at(key), pid);
         }
     } catch (...) {
-        on_fatal_internal_error(logger, format("Gossip change listener failed: {}", std::current_exception()));
+        auto msg = format("Gossip change listener failed: {}", std::current_exception());
+        if (_abort_source.abort_requested()) {
+            logger.warn("{}. Ignored", msg);
+        } else {
+            on_fatal_internal_error(logger, msg);
+        }
     }
 
     maybe_rethrow_exception(std::move(ep));


### PR DESCRIPTION
Change 6449c59 brought back abort on listener failure, but this causes crashes when listeners hit expected errors like gate_closed.

Detect shutdown usig the gossiper _abort_source
and in this case just log a warning about the errors but do not abort.

Fixes scylladb/scylladb#15031