### PR TITLE
test: increase `wait_for_token_ring_and_group0_consistency` timeouts

### DIFF
--- a/test/topology/test_replace.py
+++ b/test/topology/test_replace.py
@@ -20,7 +20,7 @@ async def test_replace_different_ip(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
 @pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:
@@ -29,7 +29,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
 @pytest.mark.asyncio
 async def test_replace_reuse_ip(manager: ManagerClient) -> None:
@@ -38,7 +38,7 @@ async def test_replace_reuse_ip(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
 @pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
@@ -47,4 +47,4 @@ async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = True)
     await manager.server_add(replace_cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)

--- a/test/topology/test_topology_remove_decom.py
+++ b/test/topology/test_topology_remove_decom.py
@@ -62,7 +62,7 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
     await manager.api.enable_injection(
         bootstrapped_server.ip_addr, 'storage_service_decommission_prepare_handler_sleep', one_shot=True)
     await manager.decommission_node(decommission_target.server_id)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
     await table.add_column()
     await random_tables.verify_schema()
 

--- a/test/topology/test_topology_schema.py
+++ b/test/topology/test_topology_schema.py
@@ -24,7 +24,7 @@ async def test_topology_schema_changes(manager, random_tables):
 
     # Test add column after adding a server
     await manager.server_add()
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
     await table.add_column()
     await random_tables.verify_schema()
 

--- a/test/topology_custom/test_boot_after_ip_change.py
+++ b/test/topology_custom/test_boot_after_ip_change.py
@@ -25,7 +25,7 @@ async def test_boot_after_ip_change(manager: ManagerClient) -> None:
            'experimental_features': list[str]()}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     logger.info(f"Stopping server {servers[1]}")
     await manager.server_stop_gracefully(servers[1].server_id)

--- a/test/topology_custom/test_replace_ignore_nodes.py
+++ b/test/topology_custom/test_replace_ignore_nodes.py
@@ -42,16 +42,16 @@ async def test_replace_ignore_nodes(manager: ManagerClient) -> None:
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False,
                                 ignore_dead_nodes = ignore_dead)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     ignore_dead = [servers[2].ip_addr] 
     logger.info(f"Replacing {servers[1]}, ignore_dead_nodes = {ignore_dead}")
     replace_cfg = ReplaceConfig(replaced_id = servers[1].server_id, reuse_ip_addr = False, use_host_id = False,
                                 ignore_dead_nodes = ignore_dead)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     logger.info(f"Replacing {servers[2]}")
     replace_cfg = ReplaceConfig(replaced_id = servers[2].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg=replace_cfg, config=cfg)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)

--- a/test/topology_custom/test_select_from_mutation_fragments.py
+++ b/test/topology_custom/test_select_from_mutation_fragments.py
@@ -15,7 +15,7 @@ async def test_sticky_coordinator_enforced(manager: ManagerClient) -> None:
     s1 = await manager.server_add(cmdline=['--logger-log-level', 'paging=trace'])
     s2 = await manager.server_add(cmdline=['--logger-log-level', 'paging=trace'])
 
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     cql = manager.get_cql()
 

--- a/test/topology_custom/test_shutdown_hang.py
+++ b/test/topology_custom/test_shutdown_hang.py
@@ -21,7 +21,7 @@ async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
         'error_injections_at_startup': ['decrease_hints_flush_period']
     })
     s2 = await manager.server_add()
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     cql = manager.get_cql()
 

--- a/test/topology_custom/test_topology_smp.py
+++ b/test/topology_custom/test_topology_smp.py
@@ -44,7 +44,7 @@ async def test_nodes_with_different_smp(request: FixtureRequest, manager: Manage
     logger.info(f'Adding --smp=5 server')
     await manager.server_add(cmdline=['--smp', '5'])
 
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
 
     logger.info(f'Creating new tables')
     tables = RandomTables(request.node.name, manager, unique_name(), 3)


### PR DESCRIPTION
30 seconds is sometimes too low for tests, because the driver is sometimes, for some reason, taking ~30 seconds just to connect to a node which we need to fetch group 0 members before even doing the consistency check.

Increase to 60 seconds.

Fixes scylladb/scylladb#15104