### PR TITLE
sstable, test: log sstable name and pk when capping local_deletion_time 

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -669,6 +669,7 @@ private:
             int32_t ldt = adjusted_local_deletion_time(t.deletion_time, capped);
             if (capped) {
                 slogger.warn("Capping tombstone local_deletion_time {} to max {}", t.deletion_time.time_since_epoch().count(), ldt);
+                slogger.warn("Capping tombstone in sstable = {}, partition_key = {}", _sst.get_filename(), _partition_key->to_partition_key(_schema));
                 _sst.get_stats().on_capped_tombstone_deletion_time();
             }
             dt.local_deletion_time = ldt;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -27,11 +27,12 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
+using validate = bool_class<struct validate_tag>;
 // Must be called in a seastar thread.
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt);
 sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt);
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts);
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts);
+sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts, validate do_validate = validate::yes);
+sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts, validate do_validate = validate::yes);
 
 inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstables::shared_sstable sst) {
     return write_memtable_to_sstable(mt, sst, sst->manager().configure_writer("memtable"));


### PR DESCRIPTION
in this series, we also print the sstable name and pk when writing a tombstone whose local_deletion_time (ldt for short) is greater than INT32_MAX which cannot be represented by an uint32_t.

Fixes #15015
