### PR TITLE
tablets: change persistent type of replica set from set to list

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -199,8 +199,8 @@ CREATE TABLE system.tablets (
     keyspace_name text,
     table_id uuid,
     last_token bigint,
-    new_replicas frozen<set<frozen<tuple<uuid, int>>>>,
-    replicas frozen<set<frozen<tuple<uuid, int>>>>,
+    new_replicas frozen<list<frozen<tuple<uuid, int>>>>,
+    replicas frozen<list<frozen<tuple<uuid, int>>>>,
     stage text,
     table_name text static,
     tablet_count int static,
@@ -223,7 +223,7 @@ Only tables which use tablet-based replication strategy have an entry here.
 ```
 
 Each tablet is represented by a single row. `replicas` holds the set of shard-replicas of the tablet.
-It's a set of tuples where the first element is `host_id` of the replica and the second element is the `shard_id` of the replica.
+It's a list of tuples where the first element is `host_id` of the replica and the second element is the `shard_id` of the replica.
 
 During tablet migration, the columns `new_replicas` and `stage` are set to represent the transition. The
 `new_replicas` column holds what will be put in `replicas` after transition is done.


### PR DESCRIPTION
The system.tablets table stores replica sets as a CQL set type, which is sorted. This means that if, in a tablet replica set [n1, n2, n3] n2 is replaced with n4, then on reload we'll see [n1, n3, n4], changing the relative position of n3 from the third replica to the second.

The relative position of replicas in a replica set is important for materialized views, as they use it to pair base replicas with view replicas. To prepare for materialized views using tablets, change the persistent data type to list, which preserves order.

The code that generates new replica sets already preserves order: see locator::replace_replica().

While this changes the system schema, tablets are an experimental feature so we don't need to worry about upgrades.