### PR TITLE
test: use more frequent reconnection policy

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -17,6 +17,7 @@ import pytest
 from cassandra.cluster import Session                                    # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster, ConsistencyLevel                  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore # pylint: disable=no-name-in-module
+from cassandra.policies import ExponentialReconnectionPolicy             # type: ignore
 from cassandra.policies import RoundRobinPolicy                          # type: ignore
 from cassandra.policies import TokenAwarePolicy                          # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy                 # type: ignore
@@ -112,6 +113,12 @@ def cluster_con(hosts: List[IPAddress], port: int, use_ssl: bool):
                    # else the driver can't handle a server being down
                    max_schema_agreement_wait=20,
                    idle_heartbeat_timeout=200,
+                   # The default reconnection policy has a large maximum interval
+                   # between retries (600 seconds). In tests that restart/replace nodes,
+                   # where a node can be unavailable for an extended period of time,
+                   # this can cause the reconnection retry interval to get very large,
+                   # longer than a test timeout.
+                   reconnection_policy = ExponentialReconnectionPolicy(1.0, 4.0)
                    )
 
 


### PR DESCRIPTION
The default reconnection policy in Python Driver is an exponential backoff (with jitter) policy, which starts at 1 second reconnection interval and ramps up to 600 seconds.

This is a problem in tests (refs #15104), especially in tests that restart or replace nodes. In such a scenario, a node can be unavailable for an  extended period of time and the driver will try to reconnect to it  multiple times, eventually reaching very long reconnection interval  values, exceeding the timeout of a test.

Fix the issue by using an exponential reconnection policy with a maximum interval of 4 seconds. A smaller value was not chosen, as each retry clutters the logs with reconnection exception stack trace.

Fixes #15104