### PR TITLE
Alternator: Support new ReturnValuesOnConditionCheckFailure feature

### DIFF
--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -69,7 +69,11 @@ protected:
     enum class returnvalues {
         NONE, ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATED_NEW
     } _returnvalues;
+    enum class returnvalues_on_condition_check_failure {
+        NONE, ALL_OLD
+    } _returnvalues_on_condition_check_failure;
     static returnvalues parse_returnvalues(const rjson::value& request);
+    static returnvalues_on_condition_check_failure parse_returnvalues_on_condition_check_failure(const rjson::value& request);
     // When _returnvalues != NONE, apply() should store here, in JSON form,
     // the values which are to be returned in the "Attributes" field.
     // The default null JSON means do not return an Attributes field at all.
@@ -77,6 +81,8 @@ protected:
     // it (see explanation below), but note that because apply() may be
     // called more than once, if apply() will sometimes set this field it
     // must set it (even if just to the default empty value) every time.
+    // Additionaly when _returnvalues_on_condition_check_failure is ALL_OLD
+    // then condition check failure will also result in storing values here.
     mutable rjson::value _return_attributes;
 public:
     // The constructor of a rmw_operation subclass should parse the request

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -156,6 +156,9 @@ public:
 protected:
     void generate_error_reply(reply& rep, const api_error& err) {
         rjson::value results = rjson::empty_object();
+        if (!err._extra_fields.IsNull() && err._extra_fields.IsObject()) {
+            results = rjson::copy(err._extra_fields);
+        }
         rjson::add(results, "__type", rjson::from_string("com.amazonaws.dynamodb.v20120810#" + err._type));
         rjson::add(results, "message", err._msg);
         rep._content = rjson::print(std::move(results));

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -314,8 +314,3 @@ they should be easy to detect. Here is a list of these unimplemented features:
   that can be used to forbid table deletion. This table option was added to
   DynamoDB in March 2023.
   <https://github.com/scylladb/scylla/issues/14482>
-
-* Alternator does not support the ReturnValuesOnConditionCheckFailure
-  option on writes added to DynamoDB in June 2023. The older ReturnValues
-  is supported.
-  <https://github.com/scylladb/scylla/issues/14481>

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -166,6 +166,29 @@ inline std::string_view to_string_view(const rjson::value& v) {
 // Copies given JSON value - involves allocation
 rjson::value copy(const rjson::value& value);
 
+// copyable_value can be used when seamless copying of value is needed
+class copyable_value : public value {
+public:
+    copyable_value() noexcept : value() {
+    }
+    copyable_value(const copyable_value& v) : value(copy(v)) {
+    }
+    copyable_value(copyable_value&& v) noexcept : value(std::move(v)) {
+    }
+    copyable_value(value&& v) noexcept : value(std::move(v)) {
+    }
+    copyable_value& operator=(const copyable_value& v) {
+        if (this != &v) {
+            *this = copy(v);
+        }
+        return *this;
+    }
+    copyable_value& operator=(copyable_value&& v) noexcept {
+        value::operator=(value(std::move(v)));
+        return *this;
+    }
+};
+
 // Parses a JSON value from given string or raw character array.
 // The string/char array liveness does not need to be persisted,
 // as parse() will allocate member names and values.


### PR DESCRIPTION
alternator: add support for ReturnValuesOnConditionCheckFailure feature

As announced in https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-dynamodb-cost-failed-conditional-writes/, DynamoDB added a new option for write operations (PutItem, UpdateItem, or DeleteItem), ReturnValuesOnConditionCheckFailure, which if set to ALL_OLD returns the current value of the item - but only if a condition check failed.

Fixes https://github.com/scylladb/scylladb/issues/14481
