### PR TITLE
table: Introduce storage snapshot for upcoming tablet streaming

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -548,6 +548,8 @@ private:
     compaction_group* single_compaction_group_if_available() const noexcept;
     // Select a compaction group from a given token.
     compaction_group& compaction_group_for_token(dht::token token) const noexcept;
+    // Return ids of compaction groups, present in this shard, that own a particular token range.
+    std::vector<size_t> compaction_group_ids_for_token_range(dht::token_range tr) const;
     // Select a compaction group from a given key.
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const noexcept;
     // Select a compaction group from a given sstable based on its token range.
@@ -1170,6 +1172,11 @@ public:
 
     // Returns true if any of the sstables requries cleanup.
     bool requires_cleanup(const sstables::sstable_set& set) const;
+
+    // Takes snapshot of current storage state (includes memtable and sstables) from
+    // all compaction groups that overlap with a given token range. The output is
+    // a list of SSTables that represent the snapshot.
+    future<sstables::sstable_list> take_storage_snapshot(dht::token_range tr);
 
     friend class compaction_group;
 };


### PR DESCRIPTION
New file streaming for tablets will require integration with compaction groups. So this patch introduces a way for streaming to take a storage snapshot of a given tablet using its token range. Memtable is flushed first, so all data of a tablet can be streamed through its sstables. The interface is compaction group / tablet agnostic, but user can easily pick data from a single tablet by using the range in tablet metadata for a given tablet.

E.g.:

	auto erm = table.get_effective_replication_map();
	auto& tm = erm->get_token_metadata();
	auto tablet_map = tm.tablets().get_tablet_map(table.schema()->id());

	for (auto tid : tablet_map.tablet_ids()) {
		auto tr = tmap.get_token_range(tid);

		auto ssts = co_await table.take_storage_snapshot(tr);

		...
	}