### PR TITLE
raft topology: make every type in request_param a named struct

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -10,6 +10,8 @@
 #include <unordered_map>
 #include <sstream>
 
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
 #include <boost/any.hpp>
 #include <boost/program_options.hpp>
 #include <yaml-cpp/yaml.h>
@@ -1335,6 +1337,20 @@ future<> update_relabel_config_from_file(const std::string& name) {
         throw std::runtime_error("conflicts found during relabeling");
     }
     co_return;
+}
+
+std::vector<sstring> split_comma_separated_list(sstring comma_separated_list) {
+    std::vector<sstring> strs, trimmed_strs;
+    boost::split(strs, std::move(comma_separated_list), boost::is_any_of(","));
+    for (sstring n : strs) {
+        std::replace(n.begin(), n.end(), '\"', ' ');
+        std::replace(n.begin(), n.end(), '\'', ' ');
+        boost::trim_all(n);
+        if (!n.empty()) {
+            trimmed_strs.push_back(n);
+        }
+    }
+    return trimmed_strs;
 }
 
 }

--- a/db/config.hh
+++ b/db/config.hh
@@ -513,4 +513,7 @@ future<gms::inet_address> resolve(const config_file::named_value<sstring>&, gms:
  * Will throw an exception if there is a conflict with the metrics names
  */
 future<> update_relabel_config_from_file(const std::string& name);
+
+std::vector<sstring> split_comma_separated_list(sstring comma_separated_list);
+
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2554,10 +2554,10 @@ future<service::topology> system_keyspace::load_topology_state() {
                 if (!rebuild_option) {
                     on_internal_error(slogger, fmt::format("rebuild_option is missing for a node {}", host_id));
                 }
-                ret.req_param.emplace(host_id, *rebuild_option);
+                ret.req_param.emplace(host_id, service::rebuild_param{*rebuild_option});
                 break;
             case service::topology_request::join:
-                ret.req_param.emplace(host_id, num_tokens);
+                ret.req_param.emplace(host_id, service::join_param{num_tokens});
                 break;
             default:
                 // no parameters for other requests
@@ -2581,7 +2581,7 @@ future<service::topology> system_keyspace::load_topology_state() {
                 if (!rebuild_option) {
                     on_internal_error(slogger, fmt::format("rebuild_option is missing for a node {}", host_id));
                 }
-                ret.req_param.emplace(host_id, *rebuild_option);
+                ret.req_param.emplace(host_id, service::rebuild_param{*rebuild_option});
                 break;
             default:
                 // no parameters for other operations

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -226,6 +226,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("release_version", utf8_type)
             .with_column("topology_request", utf8_type)
             .with_column("replaced_id", uuid_type)
+            .with_column("ignore_nodes", set_type_impl::get_instance(uuid_type, true))
             .with_column("rebuild_option", utf8_type)
             .with_column("num_tokens", int32_type)
             .with_column("shard_count", int32_type)

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -181,6 +181,7 @@ CREATE TABLE system.topology (
     rebuild_option text,
     release_version text,
     replaced_id uuid,
+    ignore_nodes set<uuid>,
     shard_count int,
     tokens set<text>,
     topology_request text,
@@ -205,6 +206,7 @@ Each node has a clustering row in the table where its `host_id` is the clusterin
 - `topology_request`   -  if set contains one of the supported node-specific topology requests
 - `tokens`             -  if set contains a list of tokens that belongs to the node
 - `replaced_id`        -  if the node replacing or replaced another node here will be the id of that node
+- `ignore_nodes`       -  if set contains a list of ids of nodes ignored during the remove or replace operation
 - `rebuild_option`     -  if the node is being rebuild contains datacenter name that is used as a rebuild source
 - `num_tokens`         -  the requested number of tokens when the node bootstraps
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1013,7 +1013,7 @@ class topology_coordinator {
 
     future<group0_guard> exec_global_command(
             group0_guard guard, const raft_topology_cmd& cmd,
-            const utils::small_vector<raft::server_id, 2>& exclude_nodes,
+            const std::unordered_set<raft::server_id>& exclude_nodes,
             drop_guard_and_retake drop_and_retake = drop_guard_and_retake::yes) {
         auto nodes = _topo_sm._topology.normal_nodes | boost::adaptors::filtered(
                 [&exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
@@ -1033,9 +1033,9 @@ class topology_coordinator {
     future<node_to_work_on> exec_global_command(
             node_to_work_on&& node, const raft_topology_cmd& cmd, bool include_local,
             drop_guard_and_retake do_retake = drop_guard_and_retake::yes) {
-        utils::small_vector<raft::server_id, 2> exclude_nodes{parse_replaced_node(node)};
+        std::unordered_set<raft::server_id> exclude_nodes{parse_replaced_node(node)};
         if (!include_local) {
-            exclude_nodes.push_back(_raft.id());
+            exclude_nodes.insert(_raft.id());
         }
         auto guard = co_await exec_global_command(std::move(node.guard), cmd, exclude_nodes, do_retake);
         co_return retake_node(std::move(guard), node.id);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1794,7 +1794,7 @@ class topology_coordinator {
                 switch (node.request.value()) {
                     case topology_request::join: {
                         assert(!node.rs->ring);
-                        auto num_tokens = std::get<uint32_t>(node.req_param.value());
+                        auto num_tokens = std::get<join_param>(node.req_param.value()).num_tokens;
                         // A node just joined and does not have tokens assigned yet
                         // Need to assign random tokens to the node
                         auto tmptr = get_token_metadata_ptr();
@@ -5828,7 +5828,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(shar
                 }
                 break;
                 case node_state::rebuilding: {
-                    auto source_dc = std::get<sstring>(_topology_state_machine._topology.req_param[raft_server.id()]);
+                    auto source_dc = std::get<rebuild_param>(_topology_state_machine._topology.req_param[raft_server.id()]).source_dc;
                     slogger.info("raft topology: rebuild from dc: {}", source_dc == "" ? "(any dc)" : source_dc);
                     co_await retrier(_rebuild_result, [&] () -> future<> {
                         auto tmptr = get_token_metadata_ptr();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -778,7 +778,7 @@ private:
 
     future<> raft_bootstrap(raft::server&);
     future<> raft_decomission();
-    future<> raft_removenode(locator::host_id host_id);
+    future<> raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params);
     future<> raft_replace(raft::server&, raft::server_id, gms::inet_address);
     future<> raft_rebuild(sstring source_dc);
     future<> raft_check_and_repair_cdc_streams();

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -46,7 +46,16 @@ enum class topology_request: uint16_t {
     rebuild
 };
 
-using request_param = std::variant<raft::server_id, sstring, uint32_t>;
+struct removenode_param {
+    std::unordered_set<raft::server_id> ignored_ids;
+};
+
+struct replace_param {
+    raft::server_id replaced_id;
+    std::unordered_set<raft::server_id> ignored_ids;
+};
+
+using request_param = std::variant<sstring, uint32_t, removenode_param, replace_param>;
 
 enum class global_topology_request: uint16_t {
     new_cdc_generation,

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -46,6 +46,14 @@ enum class topology_request: uint16_t {
     rebuild
 };
 
+struct join_param {
+    uint32_t num_tokens;
+};
+
+struct rebuild_param {
+    sstring source_dc;
+};
+
 struct removenode_param {
     std::unordered_set<raft::server_id> ignored_ids;
 };
@@ -55,7 +63,7 @@ struct replace_param {
     std::unordered_set<raft::server_id> ignored_ids;
 };
 
-using request_param = std::variant<sstring, uint32_t, removenode_param, replace_param>;
+using request_param = std::variant<join_param, rebuild_param, removenode_param, replace_param>;
 
 enum class global_topology_request: uint16_t {
     new_cdc_generation,

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -203,7 +203,7 @@ class ManagerClient():
         return s_info
 
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
-                          ignore_dead: List[IPAddress] = []) -> None:
+                          ignore_dead: List[IPAddress] | List[HostID] = []) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
         logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
         data = {"server_id": server_id, "ignore_dead": ignore_dead}

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -10,3 +10,6 @@ extra_scylla_config_options:
 skip_in_release:
   - test_blocked_bootstrap
   - test_raft_cluster_features
+  - test_raft_ignore_nodes
+skip_in_debug:
+  - test_raft_ignore_nodes

--- a/test/topology_experimental_raft/test_raft_ignore_nodes.py
+++ b/test/topology_experimental_raft/test_raft_ignore_nodes.py
@@ -1,0 +1,87 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import time
+import pytest
+import logging
+
+from test.pylib.internal_types import IPAddress, HostID
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.manager_client import ManagerClient
+from test.topology.util import wait_for_token_ring_and_group0_consistency
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
+    """Replace 3 dead nodes.
+
+       This is a slow test with a 7 node cluster and 3 replace operations,
+       we want to run it only in dev mode.
+    """
+    logger.info(f"Booting initial cluster")
+    servers = [await manager.server_add() for _ in range(7)]
+    s1_id = await manager.get_host_id(servers[1].server_id)
+    s2_id = await manager.get_host_id(servers[2].server_id)
+    logger.info(f"Stopping servers {servers[:3]}")
+    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[1].server_id)
+    await manager.server_stop_gracefully(servers[2].server_id)
+
+    # TODO: Currently, raft_replace doesn't support IPs in the ignore_dead_nodes_for_replace parameter.
+    # After fixing it, we should change one of the host ids in ignore_dead to IP to check that it also works.
+    ignore_dead: list[IPAddress | HostID] = [s1_id, s2_id]
+    logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}")
+    replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True,
+                                ignore_dead_nodes = ignore_dead)
+    await manager.server_add(replace_cfg=replace_cfg)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    ignore_dead = [s2_id]
+    logger.info(f"Replacing {servers[1]}, ignore_dead_nodes = {ignore_dead}")
+    replace_cfg = ReplaceConfig(replaced_id = servers[1].server_id, reuse_ip_addr = False, use_host_id = True,
+                                ignore_dead_nodes = ignore_dead)
+    await manager.server_add(replace_cfg=replace_cfg)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    logger.info(f"Replacing {servers[2]}")
+    replace_cfg = ReplaceConfig(replaced_id = servers[2].server_id, reuse_ip_addr = False, use_host_id = True)
+    await manager.server_add(replace_cfg=replace_cfg)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+
+@pytest.mark.asyncio
+async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
+    """Remove 3 dead nodes.
+
+       This is a slow test with a 7 node cluster and 3 removenode operations,
+       we want to run it only in dev mode.
+    """
+    logger.info(f"Booting initial cluster")
+    servers = [await manager.server_add() for _ in range(7)]
+    s1_id = await manager.get_host_id(servers[1].server_id)
+    s2_id = await manager.get_host_id(servers[2].server_id)
+    logger.info(f"Stopping servers {servers[:3]}")
+    await manager.server_stop_gracefully(servers[0].server_id)
+    await manager.server_stop_gracefully(servers[1].server_id)
+    await manager.server_stop_gracefully(servers[2].server_id)
+
+    # TODO: Currently, raft_removenode doesn't support IPs in the ignore_dead_nodes parameter. After fixing it,
+    # we should change one of the two ignore_dead assignments to the list of IPs to check that it also works.
+    ignore_dead: list[IPAddress] | list[HostID] = [s1_id, s2_id]
+    logger.info(f"Removing {servers[0]} initiated by {servers[3]}, ignore_dead_nodes = {ignore_dead}")
+    await manager.remove_node(servers[3].server_id, servers[0].server_id, ignore_dead)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    ignore_dead = [s2_id]
+    logger.info(f"Removing {servers[1]} initiated by {servers[4]}, ignore_dead_nodes = {ignore_dead}")
+    await manager.remove_node(servers[4].server_id, servers[1].server_id, ignore_dead)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    logger.info(f"Removing {servers[2]} initiated by {servers[5]}")
+    await manager.remove_node(servers[5].server_id, servers[2].server_id, ignore_dead)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)


### PR DESCRIPTION
The follow-up to #15113, it introduces only the last commit

We make every alternative type in the `request_param` variant a named struct to make the code more readable. Additionally, this change will make extending request parameters easier if we decide to do so in the future.