### PR TITLE
[Backport 5.2] distributed_loader: process_sstable_dir: do not verify snapshots

### DIFF
--- a/utils/directories.hh
+++ b/utils/directories.hh
@@ -39,12 +39,16 @@ public:
         std::set<fs::path> _paths;
     };
 
+    using recursive = bool_class<struct recursive_tag>;
+
     directories(bool developer_mode);
     future<> create_and_verify(set dir_set);
-    static future<> verify_owner_and_mode(std::filesystem::path path);
+    static future<> verify_owner_and_mode(std::filesystem::path path, recursive r = recursive::yes);
 private:
     bool _developer_mode;
     std::vector<file_lock> _locks;
+
+    static future<> do_verify_owner_and_mode(std::filesystem::path path, recursive, int level);
 };
 
 } // namespace utils


### PR DESCRIPTION
This mini-series backports the fix for #12010 along with low-risk patches it depends on.

Fixes: #12010 