### PR TITLE
compaction: change behaviour of compaction task executors

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -745,7 +745,8 @@ void sstables_task_executor::release_resources() noexcept {
 
 future<compaction_manager::compaction_stats_opt> compaction_task_executor::run_compaction() noexcept {
     try {
-        _compaction_done = do_run();
+        _compaction_done = stopping() ? make_exception_future<compaction_manager::compaction_stats_opt>(make_compaction_stopped_exception())
+            : do_run();
         return compaction_done();
     } catch (...) {
         return current_exception_as_future<compaction_manager::compaction_stats_opt>();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -172,8 +172,8 @@ private:
     template<typename TaskExecutor, typename... Args>
     requires std::is_base_of_v<compaction_task_executor, TaskExecutor> &&
             std::is_base_of_v<compaction_task_impl, TaskExecutor> &&
-    requires (compaction_manager& cm, Args&&... args) {
-        {TaskExecutor(cm, std::forward<Args>(args)...)} -> std::same_as<TaskExecutor>;
+    requires (compaction_manager& cm, throw_if_stopping do_throw_if_stopping, Args&&... args) {
+        {TaskExecutor(cm, do_throw_if_stopping, std::forward<Args>(args)...)} -> std::same_as<TaskExecutor>;
     }
     future<compaction_manager::compaction_stats_opt> perform_compaction(throw_if_stopping do_throw_if_stopping, std::optional<tasks::task_info> parent_info, Args&&... args);
 
@@ -471,6 +471,7 @@ protected:
     compaction::compaction_state& _compaction_state;
     sstables::compaction_data _compaction_data;
     state _state = state::none;
+    throw_if_stopping _do_throw_if_stopping;
 
 private:
     shared_future<compaction_manager::compaction_stats_opt> _compaction_done = make_ready_future<compaction_manager::compaction_stats_opt>();
@@ -480,7 +481,7 @@ private:
     sstring _description;
 
 public:
-    explicit compaction_task_executor(compaction_manager& mgr, ::compaction::table_state* t, sstables::compaction_type type, sstring desc);
+    explicit compaction_task_executor(compaction_manager& mgr, throw_if_stopping do_throw_if_stopping, ::compaction::table_state* t, sstables::compaction_type type, sstring desc);
 
     compaction_task_executor(compaction_task_executor&&) = delete;
     compaction_task_executor(const compaction_task_executor&) = delete;
@@ -575,8 +576,8 @@ public:
     template<typename TaskExecutor, typename... Args>
     requires std::is_base_of_v<compaction_task_executor, TaskExecutor> &&
             std::is_base_of_v<compaction_task_impl, TaskExecutor> &&
-    requires (compaction_manager& cm, Args&&... args) {
-        {TaskExecutor(cm, std::forward<Args>(args)...)} -> std::same_as<TaskExecutor>;
+    requires (compaction_manager& cm, throw_if_stopping do_throw_if_stopping, Args&&... args) {
+        {TaskExecutor(cm, do_throw_if_stopping, std::forward<Args>(args)...)} -> std::same_as<TaskExecutor>;
     }
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, std::optional<tasks::task_info> parent_info, Args&&... args);
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task, throw_if_stopping do_throw_if_stopping);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -567,11 +567,12 @@ public:
     const sstring& description() const noexcept {
         return _description;
     }
-
+private:
+    // Before _compaction_done is set in compaction_task_executor::run_compaction(), compaction_done() returns ready future.
     future<compaction_manager::compaction_stats_opt> compaction_done() noexcept {
         return _compaction_done.get_future();
     }
-
+public:
     bool stopping() const noexcept {
         return _compaction_data.abort.abort_requested();
     }
@@ -589,6 +590,7 @@ public:
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, std::optional<tasks::task_info> parent_info, Args&&... args);
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task, throw_if_stopping do_throw_if_stopping);
     friend fmt::formatter<compaction_task_executor>;
+    friend future<> compaction_manager::stop_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks, sstring reason);
 };
 
 }

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -165,7 +165,7 @@ class compaction_manager_test_task : public compaction::compaction_task_executor
 
 public:
     compaction_manager_test_task(compaction_manager& cm, table_state& table_s, sstables::run_id run_id, noncopyable_function<future<> (sstables::compaction_data&)> job)
-        : compaction::compaction_task_executor(cm, &table_s, sstables::compaction_type::Compaction, "Test compaction")
+        : compaction::compaction_task_executor(cm, throw_if_stopping::no, &table_s, sstables::compaction_type::Compaction, "Test compaction")
         , _run_id(run_id)
         , _job(std::move(job))
     { }


### PR DESCRIPTION
Compaction tasks executors serve two different purposes - as compaction
manager related entity they execute compaction operation and as task
manager related entity they track compaction status. 

When one role depends on the other, as it currently is for 
compaction_task_impl::done() and compaction_task_executor::compaction_done(),
requirements of both roles need to be satisfied at the same time in each 
corner case. Such complexity leads to bugs.

To prevent it, compaction_task_impl::done() of executors no longer depends 
on compaction_task_executor::compaction_done().

Fixes: #14912.