### PR TITLE
view, storage_proxy: carry effective_replication_map along with endpoints

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -27,6 +27,7 @@
 #include "db/hints/resource_manager.hh"
 #include "db/hints/host_filter.hh"
 #include "db/hints/sync_point.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 class fragmented_temporary_buffer;
 
@@ -276,9 +277,10 @@ public:
             /// to it, otherwise execute the mutation "from scratch" with CL=ALL.
             ///
             /// \param m mutation to send
+            /// \param ermp points to the effective_replication_map used to obtain \c natural_endpoints
             /// \param natural_endpoints current replicas for the given mutation
             /// \return future that resolves when the operation is complete
-            future<> do_send_one_mutation(frozen_mutation_and_schema m, const inet_address_vector_replica_set& natural_endpoints) noexcept;
+            future<> do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const inet_address_vector_replica_set& natural_endpoints) noexcept;
 
             /// \brief Send one mutation out.
             ///

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3759,6 +3759,7 @@ bool storage_proxy::cannot_hint(const Range& targets, db::write_type type) const
 
 future<> storage_proxy::send_to_endpoint(
         std::unique_ptr<mutation_holder> m,
+        locator::effective_replication_map_ptr ermp,
         gms::inet_address target,
         inet_address_vector_topology_change pending_endpoints,
         db::write_type type,
@@ -3777,7 +3778,7 @@ future<> storage_proxy::send_to_endpoint(
         timeout = clock_type::now() + 5min;
     }
     return mutate_prepare(std::array{std::move(m)}, cl, type, /* does view building should hold a real permit */ empty_service_permit(),
-            [this, tr_state, target = std::array{target}, pending_endpoints = std::move(pending_endpoints), &stats, cancellable] (
+            [this, tr_state, erm = std::move(ermp), target = std::array{target}, pending_endpoints = std::move(pending_endpoints), &stats, cancellable] (
                 std::unique_ptr<mutation_holder>& m,
                 db::consistency_level cl,
                 db::write_type type, service_permit permit) mutable {
@@ -3789,8 +3790,6 @@ future<> storage_proxy::send_to_endpoint(
                 std::inserter(targets, targets.begin()),
                 std::back_inserter(dead_endpoints),
                 std::bind_front(&storage_proxy::is_alive, this));
-        auto& table = _db.local().find_column_family(m->schema()->id());
-        auto erm = table.get_effective_replication_map();
         slogger.trace("Creating write handler with live: {}; dead: {}", targets, dead_endpoints);
         db::assure_sufficient_live_nodes(cl, *erm, targets, pending_endpoints);
         return create_write_response_handler(
@@ -3815,6 +3814,7 @@ future<> storage_proxy::send_to_endpoint(
 
 future<> storage_proxy::send_to_endpoint(
         frozen_mutation_and_schema fm_a_s,
+        locator::effective_replication_map_ptr ermp,
         gms::inet_address target,
         inet_address_vector_topology_change pending_endpoints,
         db::write_type type,
@@ -3823,6 +3823,7 @@ future<> storage_proxy::send_to_endpoint(
         is_cancellable cancellable) {
     return send_to_endpoint(
             std::make_unique<shared_mutation>(std::move(fm_a_s)),
+            std::move(ermp),
             std::move(target),
             std::move(pending_endpoints),
             type,
@@ -3834,6 +3835,7 @@ future<> storage_proxy::send_to_endpoint(
 
 future<> storage_proxy::send_to_endpoint(
         frozen_mutation_and_schema fm_a_s,
+        locator::effective_replication_map_ptr ermp,
         gms::inet_address target,
         inet_address_vector_topology_change pending_endpoints,
         db::write_type type,
@@ -3843,6 +3845,7 @@ future<> storage_proxy::send_to_endpoint(
         is_cancellable cancellable) {
     return send_to_endpoint(
             std::make_unique<shared_mutation>(std::move(fm_a_s)),
+            std::move(ermp),
             std::move(target),
             std::move(pending_endpoints),
             type,
@@ -3852,10 +3855,11 @@ future<> storage_proxy::send_to_endpoint(
             cancellable);
 }
 
-future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target) {
+future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, gms::inet_address target) {
     if (!_features.hinted_handoff_separate_connection) {
         return send_to_endpoint(
                 std::make_unique<shared_mutation>(std::move(fm_a_s)),
+                std::move(ermp),
                 std::move(target),
                 { },
                 db::write_type::SIMPLE,
@@ -3867,6 +3871,7 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
 
     return send_to_endpoint(
             std::make_unique<hint_mutation>(std::move(fm_a_s)),
+            std::move(ermp),
             std::move(target),
             { },
             db::write_type::SIMPLE,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -421,6 +421,7 @@ private:
 
     future<> send_to_endpoint(
             std::unique_ptr<mutation_holder> m,
+            locator::effective_replication_map_ptr ermp,
             gms::inet_address target,
             inet_address_vector_topology_change pending_endpoints,
             db::write_type type,
@@ -586,15 +587,15 @@ public:
     // Inspired by Cassandra's StorageProxy.sendToHintedEndpoints but without
     // hinted handoff support, and just one target. See also
     // send_to_live_endpoints() - another take on the same original function.
-    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
+    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
             tracing::trace_state_ptr tr_state, write_stats& stats, allow_hints, is_cancellable);
-    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
+    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
             tracing::trace_state_ptr tr_state, allow_hints, is_cancellable);
 
     // Send a mutation to a specific remote target as a hint.
     // Unlike regular mutations during write operations, hints are sent on the streaming connection
     // and use different RPC verb.
-    future<> send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target);
+    future<> send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, gms::inet_address target);
 
     /**
      * Performs the truncate operatoin, which effectively deletes all data from


### PR DESCRIPTION
When sending mutation to remote endpoint,
the selected endpoints must be in sync with
the current effective_replication_map.

Currently, the endpoints are sent down the storage_proxy stack, and later on an effective_replication_map is retrieved again, and it might not match the target or pending endpoints, similar to the case seen in https://github.com/scylladb/scylladb/issues/15138

The correct way is to carry the same effective replication map used to select said endpoints and pass it down the stack. See also https://github.com/scylladb/scylladb/pull/15141

Fixes https://github.com/scylladb/scylladb/issues/14730