### PR TITLE
storage_service: do not cast a string to string_view before formatting

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4589,7 +4589,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
                 "removenode: Rejected removenode operation for node {} ip {} "
                 "the node being removed is alive, maybe you should use decommission instead?",
                 id, *ip);
-            slogger.warn("raft topology {}", std::string_view(message));
+            slogger.warn("raft topology {}", message);
             throw std::runtime_error(message);
         }
 


### PR DESCRIPTION
seastar::format() just forward the parameters to be formatted to `fmt::format_to()`, which is able to format `std::string`, so there is no need to cast the `std::string` instance to `std::string_view` for formatting it.

in this change, the cast is dropped. simpler this way.