### PR TITLE
sstable/writer: log sstable name and pk when capping ldt [5.1 backport]

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -663,6 +663,7 @@ private:
             int32_t ldt = adjusted_local_deletion_time(t.deletion_time, capped);
             if (capped) {
                 slogger.warn("Capping tombstone local_deletion_time {} to max {}", t.deletion_time.time_since_epoch().count(), ldt);
+                slogger.warn("Capping tombstone in sstable = {}, partition_key = {}", _sst.get_filename(), _partition_key->to_partition_key(_schema));
                 _sst.get_stats().on_capped_tombstone_deletion_time();
             }
             dt.local_deletion_time = ldt;


### PR DESCRIPTION
when the local_deletion_time is too large and beyond the epoch time of INT32_MAX, we cap it to INT32_MAX - 1. this is a signal of bad configuration or a bug in scylla. so let's add more information in the logging message to help track back to the source of the problem.

Fixes #15015
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>
(cherry picked from commit 9c24be05c3c06ad479b0c40ddea1e9339cf59ec9)