### PR TITLE
raft topology: add and deprecate support for --ignore-dead-nodes with IPs

### DIFF
--- a/docs/operating-scylla/nodetool-commands/removenode.rst
+++ b/docs/operating-scylla/nodetool-commands/removenode.rst
@@ -33,6 +33,10 @@ In such a case, to ensure that the operation succeeds, you must explicitly speci
 Use a comma-separated list to specify the Host IDs of all unavailable nodes in the cluster before specifying the node to remove.
 
 .. warning::
+    Instead of Host IDs, you can specify the IP addresses of all unavailable nodes. However, this feature is deprecated
+    with consistent topology updates enabled and will be removed in a future release. Using Host IDs is recommended.
+
+.. warning::
     Before you use the ``nodetool removenode --ignore-dead-nodes`` command, you must make sure that both the node you want
     to remove AND the nodes you want to ignore are permanently down and cannot be recovered. Ignoring a node that is running
     or a node that is temporarily down and could be later restored in the cluster may result in data loss.
@@ -41,7 +45,6 @@ Example:
 
 .. code-block:: console
 
-    nodetool removenode --ignore-dead-nodes 192.168.1.4,192.168.1.5 675ed9f4-6564-6dbd-can8-43fddce952gy
     nodetool removenode --ignore-dead-nodes 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e 675ed9f4-6564-6dbd-can8-43fddce952gy   
 
 .. include:: nodetool-index.rst

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2125,20 +2125,31 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, cdc::gene
     }
 }
 
+std::unordered_set<raft::server_id> storage_service::find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps) {
+    std::unordered_set<raft::server_id> ids;
+    for (const auto& hoep : hoeps) {
+        std::optional<raft::server_id> id;
+        if (hoep.has_host_id()) {
+            id = raft::server_id{hoep.id.uuid()};
+        } else {
+            id = _group0->address_map().find_by_addr(hoep.endpoint);
+            if (!id) {
+                throw std::runtime_error(::format("Cannot find a mapping to IP {}", hoep.endpoint));
+            }
+        }
+        if (!_topology_state_machine._topology.find(*id)) {
+            throw std::runtime_error(::format("Node {} is not found in the cluster", id));
+        }
+        ids.insert(*id);
+    }
+    return ids;
+}
 
 future<> storage_service::raft_replace(raft::server& raft_server, raft::server_id replaced_id, gms::inet_address replaced_ip) {
     auto ignore_nodes_strs = utils::split_comma_separated_list(_db.local().get_config().ignore_dead_nodes_for_replace());
-    std::unordered_set<raft::server_id> ignored_ids;
-    for (const sstring& n : ignore_nodes_strs) {
-        raft::server_id ignored_id;
-        // FIXME: IPs should be supported, but the current implementation of raft_address_map doesn't allow this.
-        // We can also deprecate the use of IPs with consistent topology.
-        try {
-            ignored_id = raft::server_id{utils::UUID(n)};
-        } catch (const std::exception&) {
-            throw std::invalid_argument(::format("invalid host ID of the ignored node {}", n));
-        }
-        ignored_ids.insert(ignored_id);
+    std::list<locator::host_id_or_endpoint> ignore_nodes_params;
+    for (const auto& n : ignore_nodes_strs) {
+        ignore_nodes_params.emplace_back(n);
     }
 
     // Read barrier to access the latest topology. Quorum of nodes has to be alive.
@@ -2151,7 +2162,6 @@ future<> storage_service::raft_replace(raft::server& raft_server, raft::server_i
 
     // add myself to topology with request to replace
     while (!_topology_state_machine._topology.contains(raft_server.id())) {
-        slogger.info("raft topology: adding myself to topology for replace: {} replacing {}, ignored nodes: {}", raft_server.id(), replaced_id, ignored_ids);
         auto guard = co_await _group0->client().start_operation(&_abort_source);
 
         auto it = _topology_state_machine._topology.normal_nodes.find(replaced_id);
@@ -2159,12 +2169,9 @@ future<> storage_service::raft_replace(raft::server& raft_server, raft::server_i
             throw std::runtime_error(::format("Cannot replace node {}/{} because it is not in the 'normal' state", replaced_ip, replaced_id));
         }
 
-        for (const auto& ignored_id : ignored_ids) {
-            if (!_topology_state_machine._topology.find(ignored_id)) {
-                throw std::runtime_error(::format("ignored node {} is not found in the cluster", ignored_id));
-            }
-        }
+        auto ignored_ids = find_raft_nodes_from_hoeps(ignore_nodes_params);
 
+        slogger.info("raft topology: adding myself to topology for replace: {} replacing {}, ignored nodes: {}", raft_server.id(), replaced_id, ignored_ids);
         auto& rs = it->second;
         topology_mutation_builder builder(guard.write_timestamp());
         builder.with_node(raft_server.id())
@@ -4553,15 +4560,6 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
 
 future<> storage_service::raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params) {
     auto id = raft::server_id{host_id.uuid()};
-    std::unordered_set<raft::server_id> ignored_ids;
-    for (const auto& hoep : ignore_nodes_params) {
-        // FIXME: IPs should be supported, but the current implementation of raft_address_map doesn't allow this.
-        // We can also deprecate the use of IPs with consistent topology.
-        if (hoep.has_endpoint()) {
-            throw std::invalid_argument("--ignore-dead-nodes does not support IPs, use host IDs instead");
-        }
-        ignored_ids.insert(raft::server_id{hoep.id.uuid()});
-    }
 
     while (true) {
         auto guard = co_await _group0->client().start_operation(&_abort_source);
@@ -4593,11 +4591,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
             throw std::runtime_error(message);
         }
 
-        for (const auto& ignored_id : ignored_ids) {
-            if (!_topology_state_machine._topology.find(ignored_id)) {
-                throw std::runtime_error(::format("ignored node {} is not found in the cluster", ignored_id));
-            }
-        }
+        auto ignored_ids = find_raft_nodes_from_hoeps(ignore_nodes_params);
 
         slogger.info("raft topology: request removenode for: {}, ignored nodes: {}", id, ignored_ids);
         topology_mutation_builder builder(guard.write_timestamp());

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -774,6 +774,8 @@ private:
         semaphore _operation_mutex{1};
     } _raft_topology_cmd_handler_state;
 
+    std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps);
+
     future<raft_topology_cmd_result> raft_topology_cmd_handler(sharded<db::system_distributed_keyspace>& sys_dist_ks, raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
 
     future<> raft_bootstrap(raft::server&);

--- a/test/topology_experimental_raft/test_raft_ignore_nodes.py
+++ b/test/topology_experimental_raft/test_raft_ignore_nodes.py
@@ -32,9 +32,7 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
     await manager.server_stop(servers[1].server_id)
     await manager.server_stop_gracefully(servers[2].server_id)
 
-    # TODO: Currently, raft_replace doesn't support IPs in the ignore_dead_nodes_for_replace parameter.
-    # After fixing it, we should change one of the host ids in ignore_dead to IP to check that it also works.
-    ignore_dead: list[IPAddress | HostID] = [s1_id, s2_id]
+    ignore_dead: list[IPAddress | HostID] = [s1_id, servers[2].ip_addr]
     logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}")
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True,
                                 ignore_dead_nodes = ignore_dead)
@@ -70,14 +68,12 @@ async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
     await manager.server_stop_gracefully(servers[1].server_id)
     await manager.server_stop_gracefully(servers[2].server_id)
 
-    # TODO: Currently, raft_removenode doesn't support IPs in the ignore_dead_nodes parameter. After fixing it,
-    # we should change one of the two ignore_dead assignments to the list of IPs to check that it also works.
     ignore_dead: list[IPAddress] | list[HostID] = [s1_id, s2_id]
     logger.info(f"Removing {servers[0]} initiated by {servers[3]}, ignore_dead_nodes = {ignore_dead}")
     await manager.remove_node(servers[3].server_id, servers[0].server_id, ignore_dead)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
-    ignore_dead = [s2_id]
+    ignore_dead = [servers[2].ip_addr]
     logger.info(f"Removing {servers[1]} initiated by {servers[4]}, ignore_dead_nodes = {ignore_dead}")
     await manager.remove_node(servers[4].server_id, servers[1].server_id, ignore_dead)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)


### PR DESCRIPTION
We want to stop supporting IPs for `--ignore-dead-nodes` in `raft_removenode` and `--ignore-dead-nodes-for-replace` for
`raft_replace`. However, we shouldn't remove these features without the deprecation period because the original `removenode` and `replace` operations still support them. So, we add them for now.

The `IP -> Raft ID` translation is done through the new `raft_address_map::find_by_addr` member function.

We update the documentation to inform about the deprecation of the IP support for `--ignore-dead-nodes`.

Fixes #15126