### PR TITLE
docs: improve configuration parameters reference

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -2,8 +2,11 @@ import os
 import re
 import yaml
 from sphinx.application import Sphinx
+from sphinxcontrib.datatemplates.directive import DataTemplateYAML
+from docutils.parsers.rst import directives
 
 CONFIG_FILE_PATH = '../db/config.cc'
+CONFIG_HEADER_FILE_PATH = '../db/config.hh'
 DESTINATION_PATH = '_data/db_config.yaml'
 
 def create_yaml_file(destination, data):
@@ -20,15 +23,18 @@ def create_yaml_file(destination, data):
         with open(destination, 'w') as file:
             yaml.dump(data, file)
 
-def parse_db_properties(config_file):
+def parse_db_properties(config_file, config_header_file):
+
+    properties_dict = {}
+
+    # Parse config file
     with open(config_file, 'r') as file:
-        content = file.read()
+        config_content = file.read()
 
-    pattern = r',\s*(\w+)\(this,\s*"(\w+)",\s*(?:liveness::(\w+),\s*)?value_status::(\w+),\s*([^,]+),\s*"([^"]+)"\)'
-    matches = re.findall(pattern, content)
+    config_pattern = r',\s*(\w+)\(this,\s*"(\w+)",\s*(?:liveness::(\w+),\s*)?value_status::(\w+),\s*([^,]+),\s*"([^"]+)"\)'
+    config_matches = re.findall(config_pattern, config_content)
 
-    properties = []
-    for match in matches:
+    for match in config_matches:
         property_data = {
             "name": match[1].strip(),
             "value_status": match[3].strip(), 
@@ -36,15 +42,38 @@ def parse_db_properties(config_file):
             "liveness": 'True' if match[2] else 'False',
             "description": match[5].strip().replace('\n', '<br />')
         }
-        properties.append(property_data)
+        properties_dict[match[1].strip()] = property_data
 
-    return properties
+    # Parse header file
+    with open(config_header_file, 'r') as file:
+        config_header_content = file.read()
+
+    config_header_pattern = r'\s*named_value<(\w+)> (\w+);'
+    config_header_matches = re.findall(config_header_pattern, config_header_content)
+
+    for match in config_header_matches:
+        if match[1] in properties_dict: 
+            properties_dict[match[1]]['type'] = match[0].strip()
+
+    return list(properties_dict.values())
+
 
 def generate_cc_docs(app: Sphinx):
     dest_path = os.path.join(app.builder.srcdir, DESTINATION_PATH)
-    parsed_properties = parse_db_properties(CONFIG_FILE_PATH)
+    parsed_properties = parse_db_properties(CONFIG_FILE_PATH, CONFIG_HEADER_FILE_PATH)
     create_yaml_file(dest_path, parsed_properties)
 
 
+class DBConfigTemplateDirective(DataTemplateYAML):
+    
+    option_spec = DataTemplateYAML.option_spec.copy()
+    option_spec["value_status"] = directives.unchanged_required
+
+    def _make_context(self, data, config, env):
+        context = super()._make_context(data, config, env)
+        context['value_status'] = self.options.get('value_status')
+        return context
+
 def setup(app: Sphinx):
     app.connect("builder-inited", generate_cc_docs)
+    app.add_directive('scylladb_config_template', DBConfigTemplateDirective)

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -7,17 +7,20 @@
    * - Name
      - Description
 {% for item in data %}
+{% if item.value_status == value_status %}
 
    * - .. _config_{{ item.name }}:
 
           ``{{ item.name }}``
-     - **Default value:** ``{{ item.default }}``
-       
-       **Value status:** {{ item.value_status }}
-       
-       **Liveness:** {{ item.liveness }}
+     - {% if item.type %}**Type:** ``{{ item.type }}``{% endif %}
+
+       {% if item.default %}**Default value:** ``{{ item.default }}``{% endif %}
+
+       {% if item.liveness %}**Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
 
        .. raw:: html
 
           <p>{{item.description}}</p>
+
+{% endif %}
 {% endfor %}

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["ScyllaDB Contributors"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyyaml = "6.0"
+pyyaml = "6.0.1"
 pygments = "2.15.1"
 recommonmark = "0.7.1"
 sphinx-scylladb-theme = "~1.5.1"

--- a/docs/reference/configuration-parameters.rst
+++ b/docs/reference/configuration-parameters.rst
@@ -1,0 +1,10 @@
+========================
+Configuration parameters
+========================
+
+This section contains a list of properties that can be configured in ``scylla.yaml`` - the main configuration file for ScyllaDB.
+In addition, properties that support live updates (liveness) can be updated via the ``system.config`` virtual table or the REST API.
+
+.. scylladb_config_template:: ../_data/db_config.yaml
+  :template: db_config.tmpl
+  :value_status: Used

--- a/docs/reference/db-config.rst
+++ b/docs/reference/db-config.rst
@@ -1,8 +1,0 @@
-:orphan:
-
-=======================
-db/config.cc properties
-=======================
-
-.. datatemplate:yaml:: ../_data/db_config.yaml
-  :template: db_config.tmpl

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -64,6 +64,10 @@ Glossary
     Leveled compaction strategy (LCS)
       :abbr:`LCS (Leveled compaction strategy)` uses small, fixed-size (by default 160 MB) SSTables divided into different levels. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
+    Liveness
+      The ability to update a configuration property without restarting the node. Properties that support live updates can be updated via the ``system.config`` virtual table or the REST API.
+      The change will take effect without a node restart, changing the value in the config file, then sending ``SIGHUP`` to the scylla-process, triggering it to re-read its configuration.
+    
     Log-structured-merge (LSM)
       A technique of keeping sorted files and merging them. LSM is a data structure that maintains key-value pairs. See :doc:`Compaction </kb/compaction>`
 


### PR DESCRIPTION
Closes #15161 

This PR:

- Adds type for each option.
- Filters out unused / invalid values, moves them to a separate section.
- Adds the term "liveness" to the glossary.
- Removes unused and invalid properties from the docs.
- Updates to the latest version of pyaml.
