### PR TITLE
Cluster features on raft: topology coordinator + check on boot followups

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -287,11 +287,11 @@ void feature_service::check_features(const std::set<sstring>& enabled_features,
         const bool is_registered_feat = _registered_features.contains(sstring(f));
         if (!known_features.contains(f)) {
             if (is_registered_feat) {
-                throw std::runtime_error(format(
+                throw unsupported_feature_exception(format(
                     "Feature '{}' was previously enabled in the cluster but its support is disabled by this node. "
                     "Set the corresponding configuration option to enable the support for the feature.", f));
             } else {
-                throw std::runtime_error(format("Unknown feature '{}' was previously enabled in the cluster. "
+                throw unsupported_feature_exception(format("Unknown feature '{}' was previously enabled in the cluster. "
                     " That means this node is performing a prohibited downgrade procedure"
                     " and should not be allowed to boot.", f));
             }
@@ -308,12 +308,12 @@ void feature_service::check_features(const std::set<sstring>& enabled_features,
         const bool is_registered_feat = _registered_features.contains(sstring(f));
         if (!known_features.contains(f)) {
             if (is_registered_feat) {
-                throw std::runtime_error(format(
+                throw unsupported_feature_exception(format(
                     "Feature '{}' was previously supported by all nodes in the cluster. It is unknown whether "
                     "the feature became enabled or not, therefore it is not safe for this node to boot. "
                     "Set the corresponding configuration option to enable the support for the feature.", f));
             } else {
-                throw std::runtime_error(format(
+                throw unsupported_feature_exception(format(
                     "Unknown feature '{}' was previously supported by all nodes in the cluster. "
                     "That means this node is performing a prohibited downgrade procedure "
                     "and should not be allowed to boot.", f));

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -260,13 +260,30 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
         persisted_features = std::move(topo_features.enabled_features);
     }
 
-    if (persisted_features.empty() && persisted_unsafe_to_disable_features.empty()) {
-        co_return;
+    check_features(persisted_features, persisted_unsafe_to_disable_features);
+
+    for (auto&& f : persisted_features) {
+        logger.debug("Enabling persisted feature '{}'", f);
+        if (_registered_features.contains(sstring(f))) {
+            features_to_enable.insert(std::move(f));
+        }
+    }
+
+    co_await container().invoke_on_all([&features_to_enable] (auto& srv) -> future<> {
+        std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
+        co_await srv.enable(std::move(feat));
+    });
+}
+
+void feature_service::check_features(const std::set<sstring>& enabled_features,
+            const std::set<sstring>& unsafe_to_disable_features) {
+
+    if (enabled_features.empty() && unsafe_to_disable_features.empty()) {
+        return;
     }
 
     const auto known_features = supported_feature_set();
-    for (auto&& f : persisted_features) {
-        logger.debug("Enabling persisted feature '{}'", f);
+    for (auto&& f : enabled_features) {
         const bool is_registered_feat = _registered_features.contains(sstring(f));
         if (!known_features.contains(f)) {
             if (is_registered_feat) {
@@ -279,9 +296,6 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
                     " and should not be allowed to boot.", f));
             }
         }
-        if (is_registered_feat) {
-            features_to_enable.insert(std::move(f));
-        }
         // If a feature is not in `registered_features` but still in `known_features` list
         // that means the feature name is used for backward compatibility and should be implicitly
         // enabled in the code by default, so just skip it.
@@ -290,7 +304,7 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     // With raft cluster features, it is also unsafe to disable support for features
     // that are supported by everybody but not enabled yet. There is a possibility
     // that the feature became enabled and this node didn't notice it.
-    for (auto&& f : persisted_unsafe_to_disable_features) {
+    for (auto&& f : unsafe_to_disable_features) {
         const bool is_registered_feat = _registered_features.contains(sstring(f));
         if (!known_features.contains(f)) {
             if (is_registered_feat) {
@@ -306,11 +320,6 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
             }
         }
     }
-
-    co_await container().invoke_on_all([&features_to_enable] (auto& srv) -> future<> {
-        std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
-        co_await srv.enable(std::move(feat));
-    });
 }
 
 future<> persistent_feature_enabler::enable_features() {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/sharded.hh>
 #include <unordered_map>
 #include <functional>
+#include <exception>
 #include <set>
 #include <any>
 #include "seastarx.hh"
@@ -41,6 +42,13 @@ private:
 };
 
 feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
+
+class unsupported_feature_exception : public std::runtime_error {
+public:
+    unsupported_feature_exception(std::string what)
+            : runtime_error(std::move(what))
+    {}
+};
 
 using namespace std::literals;
 
@@ -134,9 +142,9 @@ public:
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
 
     // Performs the feature check.
-    // Throws an exception if there is a feature either in `enabled_features`
-    // or `unsafe_to_disable_features` that is not being currently supported
-    // by this node.
+    // Throws an unsupported_feature_exception if there is a feature either
+    // in `enabled_features` or `unsafe_to_disable_features` that is not being
+    // currently supported by this node.
     void check_features(const std::set<sstring>& enabled_features, const std::set<sstring>& unsafe_to_disable_features);
 };
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -132,6 +132,12 @@ public:
     static std::set<sstring> to_feature_set(sstring features_string);
     future<> enable_features_on_startup(db::system_keyspace&, bool use_raft_cluster_features);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
+
+    // Performs the feature check.
+    // Throws an exception if there is a feature either in `enabled_features`
+    // or `unsafe_to_disable_features` that is not being currently supported
+    // by this node.
+    void check_features(const std::set<sstring>& enabled_features, const std::set<sstring>& unsafe_to_disable_features);
 };
 
 } // namespace gms

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -27,7 +27,6 @@ struct fencing_token {
 struct raft_topology_cmd {
     enum class command: uint8_t {
         barrier,
-        barrier_after_feature_update,
         barrier_and_drain,
         stream_ranges,
         fence

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1507,6 +1507,10 @@ class topology_coordinator {
             return std::make_pair(true, std::move(guard));
         }
 
+        if (!_topo_sm._topology.features.calculate_not_yet_enabled_features().empty()) {
+            return std::make_pair(true, std::move(guard));
+        }
+
         return std::make_pair(false, std::move(guard));
     }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2207,11 +2207,6 @@ future<> storage_service::raft_bootstrap(raft::server& raft_server) {
 }
 
 future<> storage_service::update_topology_with_local_metadata(raft::server& raft_server) {
-    co_await do_update_topology_with_local_metadata(raft_server);
-    _topology_updated_with_local_metadata = true;
-}
-
-future<> storage_service::do_update_topology_with_local_metadata(raft::server& raft_server) {
     // TODO: include more metadata here
     auto local_shard_count = smp::count;
     auto local_ignore_msb = _db.local().get_config().murmur3_partitioner_ignore_msb_bits();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -783,10 +783,6 @@ private:
     future<> raft_rebuild(sstring source_dc);
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
-    future<> do_update_topology_with_local_metadata(raft::server&);
-
-    // Set to true after successful `update_topology_with_local_metadata` call
-    bool _topology_updated_with_local_metadata = false;
 
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -177,9 +177,6 @@ std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd
         case raft_topology_cmd::command::barrier:
             os << "barrier";
             break;
-        case raft_topology_cmd::command::barrier_after_feature_update:
-            os << "barrier_after_feature_update";
-            break;
         case raft_topology_cmd::command::barrier_and_drain:
             os << "barrier_and_drain";
             break;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -155,8 +155,6 @@ struct topology_state_machine {
 struct raft_topology_cmd {
       enum class command: uint16_t {
           barrier,              // request to wait for the latest topology
-          barrier_after_feature_update, // same as `barrier` but only succeeds after
-                                        // supported features were updated by the node
           barrier_and_drain,    // same + drain requests which use previous versions
           stream_ranges,        // reqeust to stream data, return when streaming is
                                 // done

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -54,7 +54,7 @@ async def change_support_for_test_feature_and_restart(manager: ManagerClient, sr
             injections.remove(TEST_FEATURE_ENABLE_ERROR_INJECTION)
         await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, list(injections))
 
-    await asyncio.gather(*(manager.server_stop_gracefully(srv.server_id) for srv in srvs))
+    await asyncio.gather(*(manager.server_stop(srv.server_id) for srv in srvs))
     await asyncio.gather(*(adjust_feature_in_config(manager, srv, enable) for srv in srvs))
     await asyncio.gather(*(manager.server_start(srv.server_id, expected_error) for srv in srvs))
 
@@ -198,7 +198,7 @@ async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerC
         assert TEST_FEATURE_NAME not in await get_enabled_features(cql, host)
 
     # Remove the last node
-    await manager.server_stop_gracefully(servers[-1].server_id)
+    await manager.server_stop(servers[-1].server_id)
     await manager.server_not_sees_other_server(servers[0].ip_addr, servers[-1].ip_addr)
     await manager.remove_node(servers[0].server_id, servers[-1].server_id)
 

--- a/test/topology_experimental_raft/test_raft_cluster_features.py
+++ b/test/topology_experimental_raft/test_raft_cluster_features.py
@@ -73,7 +73,7 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
 
     # Try to downgrade one node
     await manager.server_update_config(servers[0].server_id, 'error_injections_at_startup', [])
-    await manager.server_stop_gracefully(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id)
     await manager.server_start(servers[0].server_id,
                                expected_error="Feature 'TEST_ONLY_FEATURE' was previously supported by all nodes in the cluster")
     


### PR DESCRIPTION
This PR collects followups described in #14972:

- The `system.topology` table is now flushed every time feature-related columns are modified. This is done because of the feature check that happens before the schema commitlog is replayed.
- The implementation now guarantees that, if all nodes support some feature as described by the `supported_features` column, then support for that feature will not be revoked by any node.
  Previously, in an edge case where a node is the last one to add support for some feature `X` in `supported_features` column, crashes before applying/persisting it and then restarts without supporting `X`, it would be allowed to boot anyway and would revoke support for the `X` in `system.topology`.
  The existing behavior, although counterintuitive, was safe - the topology coordinator is responsible for explicitly marking features as enabled, and in order to enable a feature it needs to perform a special kind of a global barrier (`barrier_after_feature_update`) which only succeeds after the node has updated its features column - so there is no risk of enabling an unsupported feature.
  In order to make the behavior less confusing, the node now will perform a second check when it tries to update its `supported_features` column in `system.topology`.
- The `barrier_after_feature_update` is removed and the regular global `barrier` topology command is used instead. The `barrier` handler now performs a feature check if the node did not have a chance to verify and update its cluster features for the second time.

JOIN_NODE rpc will be sent separately as it is a big item on its own.

Fixes: #14972