### PR TITLE
tasks: api: show tasks' scopes

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -224,6 +224,10 @@
                 "type":"string",
                 "description":"The description of the task"
              },
+             "scope":{
+                "type":"string",
+                "description":"The scope of the task"
+             },
              "keyspace":{
                 "type":"string",
                 "description":"The keyspace the task is working on (if applicable)"
@@ -253,6 +257,10 @@
              "type":{
                 "type":"string",
                 "description":"The description of the task"
+             },
+             "scope":{
+                "type":"string",
+                "description":"The scope of the task"
              },
              "state":{
                "type":"string",

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -44,6 +44,7 @@ struct task_stats {
         : task_id(task->id().to_sstring())
         , state(task->get_status().state)
         , type(task->type())
+        , scope(task->get_status().scope)
         , keyspace(task->get_status().keyspace)
         , table(task->get_status().table)
         , entity(task->get_status().entity)
@@ -53,6 +54,7 @@ struct task_stats {
     sstring task_id;
     tasks::task_manager::task_state state;
     std::string type;
+    std::string scope;
     std::string keyspace;
     std::string table;
     std::string entity;
@@ -69,6 +71,7 @@ tm::task_status make_status(full_task_status status) {
     tm::task_status res{};
     res.id = status.task_status.id.to_sstring();
     res.type = status.type;
+    res.scope = status.task_status.scope;
     res.state = status.task_status.state;
     res.is_abortable = bool(status.abortable);
     res.start_time = st;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -465,7 +465,7 @@ protected:
 public:
     explicit sstables_task_executor(compaction_manager& mgr, table_state* t, sstables::compaction_type compaction_type, sstring desc, std::vector<sstables::shared_sstable> sstables, tasks::task_id parent_id, sstring entity = "")
         : compaction_task_executor(mgr, t, compaction_type, std::move(desc))
-        , sstables_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, t->schema()->ks_name(), t->schema()->cf_name(), std::move(entity), parent_id)
+        , sstables_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), std::move(entity), parent_id)
     {
         set_sstables(std::move(sstables));
     }
@@ -489,7 +489,7 @@ public:
             table_state* t,
             tasks::task_id parent_id)
         : compaction_task_executor(mgr, t, sstables::compaction_type::Compaction, "Major compaction")
-        , major_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
+        , major_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
     {}
 
     virtual tasks::is_internal is_internal() const noexcept override {
@@ -580,7 +580,7 @@ class custom_compaction_task_executor : public compaction_task_executor, public 
 public:
     custom_compaction_task_executor(compaction_manager& mgr, table_state* t, tasks::task_id parent_id, sstables::compaction_type type, sstring desc, noncopyable_function<future<>(sstables::compaction_data&)> job)
         : compaction_task_executor(mgr, t, type, std::move(desc))
-        , compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
+        , compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
         , _job(std::move(job))
     {}
 
@@ -1260,7 +1260,7 @@ class offstrategy_compaction_task_executor : public compaction_task_executor, pu
 public:
     offstrategy_compaction_task_executor(compaction_manager& mgr, table_state* t, tasks::task_id parent_id, bool& performed)
         : compaction_task_executor(mgr, t, sstables::compaction_type::Reshape, "Offstrategy compaction")
-        , offstrategy_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), parent_id ? 0 : mgr._task_manager_module->new_sequence_number(), t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
+        , offstrategy_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), parent_id ? 0 : mgr._task_manager_module->new_sequence_number(), "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
         , _performed(performed)
     {
         _performed = false;
@@ -1621,7 +1621,7 @@ public:
     cleanup_sstables_compaction_task_executor(compaction_manager& mgr, table_state* t, tasks::task_id parent_id, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr,
                                      std::vector<sstables::shared_sstable> candidates, compacting_sstable_registration compacting)
             : compaction_task_executor(mgr, t, options.type(), sstring(sstables::to_string(options.type())))
-            , cleanup_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
+            , cleanup_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
             , _cleanup_options(std::move(options))
             , _owned_ranges_ptr(std::move(owned_ranges_ptr))
             , _compacting(std::move(compacting))

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -28,11 +28,12 @@ public:
     compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : tasks::task_manager::task::impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : tasks::task_manager::task::impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -47,11 +48,12 @@ public:
     major_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -72,7 +74,7 @@ public:
             std::string keyspace,
             sharded<replica::database>& db,
             std::vector<table_info> table_infos) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
     {}
@@ -90,7 +92,7 @@ public:
             tasks::task_id parent_id,
             replica::database& db,
             std::vector<table_info> local_tables) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _local_tables(std::move(local_tables))
     {}
@@ -115,7 +117,7 @@ public:
             table_info ti,
             seastar::condition_variable& cv,
             tasks::task_manager::task_ptr& current_task) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
         , _db(db)
         , _ti(std::move(ti))
         , _cv(cv)
@@ -133,11 +135,12 @@ public:
     cleanup_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -158,7 +161,7 @@ public:
             std::string keyspace,
             sharded<replica::database>& db,
             std::vector<table_info> table_infos) noexcept
-        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
     {}
@@ -176,7 +179,7 @@ public:
             tasks::task_id parent_id,
             replica::database& db,
             std::vector<table_info> local_tables) noexcept
-        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
+        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _local_tables(std::move(local_tables))
     {}
@@ -201,7 +204,7 @@ public:
             table_info ti,
             seastar::condition_variable& cv,
             tasks::task_manager::task_ptr& current_task) noexcept
-        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
         , _db(db)
         , _ti(std::move(ti))
         , _cv(cv)
@@ -218,11 +221,12 @@ public:
     offstrategy_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -245,7 +249,7 @@ public:
             sharded<replica::database>& db,
             std::vector<table_info> table_infos,
             bool& needed) noexcept
-        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
         , _needed(needed)
@@ -266,7 +270,7 @@ public:
             replica::database& db,
             std::vector<table_info> table_infos,
             bool& needed) noexcept
-        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
+        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _table_infos(std::move(table_infos))
         , _needed(needed)
@@ -294,7 +298,7 @@ public:
             seastar::condition_variable& cv,
             tasks::task_manager::task_ptr& current_task,
             bool& needed) noexcept
-        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : offstrategy_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
         , _db(db)
         , _ti(std::move(ti))
         , _cv(cv)
@@ -312,11 +316,12 @@ public:
     sstables_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -339,7 +344,7 @@ public:
             sharded<replica::database>& db,
             std::vector<table_info> table_infos,
             bool exclude_current_version) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
         , _exclude_current_version(exclude_current_version)
@@ -364,7 +369,7 @@ public:
             replica::database& db,
             std::vector<table_info> table_infos,
             bool exclude_current_version) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _table_infos(std::move(table_infos))
         , _exclude_current_version(exclude_current_version)
@@ -396,7 +401,7 @@ public:
             seastar::condition_variable& cv,
             tasks::task_manager::task_ptr& current_task,
             bool exclude_current_version) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
         , _db(db)
         , _ti(std::move(ti))
         , _cv(cv)
@@ -426,7 +431,7 @@ public:
             std::vector<sstring> column_families,
             sstables::compaction_type_options::scrub opts,
             sstables::compaction_stats& stats) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), "", "", tasks::task_id::create_null_id())
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _column_families(std::move(column_families))
         , _opts(opts)
@@ -454,7 +459,7 @@ public:
             std::vector<sstring> column_families,
             sstables::compaction_type_options::scrub opts,
             sstables::compaction_stats& stats) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), "", "", parent_id)
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
         , _db(db)
         , _column_families(std::move(column_families))
         , _opts(opts)
@@ -483,7 +488,7 @@ public:
             replica::database& db,
             sstables::compaction_type_options::scrub opts,
             sstables::compaction_stats& stats) noexcept
-        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : sstables_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
         , _db(db)
         , _opts(opts)
         , _stats(stats)
@@ -503,11 +508,12 @@ public:
     reshaping_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -535,7 +541,7 @@ public:
             sstables::reshape_mode mode,
             sstables::compaction_sstable_creator_fn creator,
             std::function<bool (const sstables::shared_sstable&)> filter) noexcept
-        : reshaping_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
+        : reshaping_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "table", std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
         , _dir(dir)
         , _db(db)
         , _mode(mode)
@@ -565,7 +571,7 @@ public:
             sstables::compaction_sstable_creator_fn creator,
             std::function<bool (const sstables::shared_sstable&)> filter,
             uint64_t& total_shard_size) noexcept
-        : reshaping_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : reshaping_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), std::move(table), "", parent_id)
         , _dir(dir)
         , _db(db)
         , _mode(mode)
@@ -585,11 +591,12 @@ public:
     resharding_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
+            std::string scope,
             std::string keyspace,
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }
@@ -615,7 +622,7 @@ public:
             sharded<replica::database>& db,
             sstables::compaction_sstable_creator_fn creator,
             compaction::owned_ranges_ptr owned_ranges_ptr) noexcept
-        : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
+        : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "table", std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
         , _dir(dir)
         , _db(db)
         , _creator(std::move(creator))
@@ -642,7 +649,7 @@ public:
             sstables::compaction_sstable_creator_fn creator,
             compaction::owned_ranges_ptr local_owned_ranges_ptr,
             std::vector<replica::reshard_shard_descriptor>& destinations) noexcept
-        : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, std::move(keyspace), std::move(table), "", parent_id)
+        : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), std::move(table), "", parent_id)
         , _dir(dir)
         , _db(db)
         , _creator(std::move(creator))
@@ -669,7 +676,7 @@ public:
             std::string table,
             std::string entity,
             tasks::task_id parent_id) noexcept
-        : compaction_task_impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : compaction_task_impl(module, id, sequence_number, "compaction group", std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {
         // FIXME: add progress units
     }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -566,7 +566,7 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
         streaming::stream_reason reason_,
         bool hints_batchlog_flushed,
         std::optional<int> ranges_parallelism)
-    : repair_task_impl(module, id, 0, keyspace, "", "", parent_id_.uuid(), reason_)
+    : repair_task_impl(module, id, 0, "shard", keyspace, "", "", parent_id_.uuid(), reason_)
     , rs(repair)
     , db(repair.get_db())
     , messaging(repair.get_messaging().container())

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -17,8 +17,8 @@ class repair_task_impl : public tasks::task_manager::task::impl {
 protected:
     streaming::stream_reason _reason;
 public:
-    repair_task_impl(tasks::task_manager::module_ptr module, tasks::task_id id, unsigned sequence_number, std::string keyspace, std::string table, std::string entity, tasks::task_id parent_id, streaming::stream_reason reason) noexcept
-        : tasks::task_manager::task::impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+    repair_task_impl(tasks::task_manager::module_ptr module, tasks::task_id id, unsigned sequence_number, std::string scope, std::string keyspace, std::string table, std::string entity, tasks::task_id parent_id, streaming::stream_reason reason) noexcept
+        : tasks::task_manager::task::impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
         , _reason(reason) {
         _status.progress_units = "ranges";
     }
@@ -48,7 +48,7 @@ private:
     std::optional<int> _ranges_parallelism;
 public:
     user_requested_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, lw_shared_ptr<locator::global_vnode_effective_replication_map> germs, std::vector<sstring> cfs, dht::token_range_vector ranges, std::vector<sstring> hosts, std::vector<sstring> data_centers, std::unordered_set<gms::inet_address> ignore_nodes, std::optional<int> ranges_parallelism) noexcept
-        : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), streaming::stream_reason::repair)
+        : repair_task_impl(module, id.uuid(), id.id, "keyspace", std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), streaming::stream_reason::repair)
         , _germs(germs)
         , _cfs(std::move(cfs))
         , _ranges(std::move(ranges))
@@ -74,7 +74,7 @@ private:
     optimized_optional<abort_source::subscription> _abort_subscription;
 public:
     data_sync_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, dht::token_range_vector ranges, std::unordered_map<dht::token_range, repair_neighbors> neighbors, streaming::stream_reason reason, shared_ptr<node_ops_info> ops_info)
-        : repair_task_impl(module, id.uuid(), id.id, std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), reason)
+        : repair_task_impl(module, id.uuid(), id.id, "keyspace", std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), reason)
         , _ranges(std::move(ranges))
         , _neighbors(std::move(neighbors))
     {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -15,12 +15,13 @@ namespace tasks {
 
 logging::logger tmlogger("task_manager");
 
-task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept
+task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_number, std::string scope, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept
     : _status({
         .id = id,
         .state = task_state::created,
         .sequence_number = sequence_number,
         .shard = this_shard_id(),
+        .scope = std::move(scope),
         .keyspace = std::move(keyspace),
         .table = std::move(table),
         .entity = std::move(entity)

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -98,6 +98,7 @@ public:
             std::string error;
             uint64_t sequence_number = 0;   // A running sequence number of the task.
             unsigned shard = 0;
+            std::string scope;
             std::string keyspace;
             std::string table;
             std::string entity;             // Additional entity specific for the given type of task.
@@ -114,7 +115,7 @@ public:
             seastar::abort_source _as;
             optimized_optional<seastar::abort_source::subscription> _shutdown_subscription;
         public:
-            impl(module_ptr module, task_id id, uint64_t sequence_number, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept;
+            impl(module_ptr module, task_id id, uint64_t sequence_number, std::string scope, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept;
             virtual ~impl() = default;
 
             virtual std::string type() const = 0;

--- a/tasks/test_module.hh
+++ b/tasks/test_module.hh
@@ -36,7 +36,7 @@ private:
     bool _finished = false;
 public:
     test_task_impl(task_manager::module_ptr module, task_id id, uint64_t sequence_number = 0, std::string keyspace = "", std::string table = "", std::string entity = "", task_id parent_id = task_id::create_null_id()) noexcept
-        : task_manager::task::impl(module, id, sequence_number, std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        : task_manager::task::impl(module, id, sequence_number, "test", std::move(keyspace), std::move(table), std::move(entity), parent_id)
     {}
 
     virtual std::string type() const override {


### PR DESCRIPTION
To make manual analysis of task manager tasks easier, task_status and task_stats contain operation scope (e.g. shard, table).