### PR TITLE
scylla_fstrim_setup: stop disabling fstrim.timer

### DIFF
--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -18,5 +18,3 @@ if __name__ == '__main__':
         sys.exit(1)
     systemd_unit('scylla-fstrim.timer').enable()
     systemd_unit('scylla-fstrim.timer').start()
-    if is_redhat_variant() or is_arch() or is_suse_variant():
-        systemd_unit('fstrim.timer').disable()


### PR DESCRIPTION
Disabling fstrim.timer was for avoid running fstrim on /var/lib/scylla from both scylla-fstrim.timer and fstrim.timer, but fstrim.timer actually never do that, since it is only looking on fstab entries, not our systemd unit.

To run fstrim correctly on rootfs and other filesystems not related scylla, we should stop disabling fstrim.timer.

Fixes #15176