### PR TITLE
token_metadata: get_endpoint_to_host_id_map_for_reading: just inform that normal node has null host_id

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -568,7 +568,7 @@ std::unordered_map<inet_address, host_id> token_metadata_impl::get_endpoint_to_h
         if (const auto& host_id = node->host_id()) {
             map[endpoint] = host_id;
         } else {
-            on_internal_error_noexcept(tlogger, fmt::format("get_endpoint_to_host_id_map_for_reading: endpoint {} has null host_id", endpoint));
+            tlogger.info("get_endpoint_to_host_id_map_for_reading: endpoint {} has null host_id: state={}", endpoint, node->get_state());
         }
     }
     return map;


### PR DESCRIPTION
It is too early to require that all nodes in normal state have a non-null host_id.

The assertion was added in 44c14f3e2b779409d9c73e4cddd32d0c741bc14c but unfortunately there are several call sites where we add the node as normal, but without a host_id
and we patch it in later on.

In the future we should be able to require that
once we identify nodes by host_id over gossiper
and in token_metadata.

Fixes scylladb/scylladb#15181