### PR TITLE
Add support for decommission with tablets

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -76,7 +76,7 @@ such as `check_and_repair_cdc_streams`.
 If there is no work for the state machine, tablet load balancer is invoked to
 check if we need to rebalance. If so, it computes an incremental tablet migration
 plan, persists it by moving tablets into transitional states, and moves the state machine
-into the tablet migration track. All this happens atomically form the perspective
+into the tablet migration track. All this happens atomically from the perspective
 of group0 state machine.
 
 The tablet migration track also invokes the load balancer and starts new migrations
@@ -84,9 +84,9 @@ to keep the cluster saturated with streaming. The load balancer is invoked
 on transition of tablet stages, and also continuously as long as it generates
 new migrations.
 
-If there is a pending topology change request, the load balancer
-will not be invoked to allow for current migrations to drain, after which the
-state machine will exit the tablet migration track and allow pending topology
+If there is a pending topology change request during tablet migration track,
+the load balancer will not be invoked to allow for current migrations to drain,
+after which the state machine will exit the tablet migration track and allow pending topology
 operation to start.
 
 The tablet migration track excludes with other topology changes, so node operations
@@ -102,6 +102,12 @@ When the topology state machine is not in the tablet_migration track, it is guar
 that there are no tablet transitions in the system.
 
 Tablets are migrated in parallel and independently.
+
+There is a variant of tablet migration track called tablet draining track, which is invoked
+as a step of certain topology operations (e.g. decommission). Its goal is to readjust tablet replicas
+so that a given topology change can proceed. For example, when decommissioning a node, we
+need to migrate tablet replicas away from the node being decommissioned.
+Tablet draining happens before making changes to vnode-based replication.
 
 # Tablet migration
 

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -52,4 +52,5 @@ struct raft_topology_pull_params {};
 verb raft_topology_cmd (raft::term_t term, uint64_t cmd_index, service::raft_topology_cmd) -> service::raft_topology_cmd_result;
 verb [[cancellable]] raft_pull_topology_snapshot (service::raft_topology_pull_params) -> service::raft_topology_snapshot;
 verb [[cancellable]] tablet_stream_data (locator::global_tablet_id);
+verb [[cancellable]] tablet_cleanup (locator::global_tablet_id);
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -494,6 +494,7 @@ effective_replication_map::effective_replication_map(replication_strategy_ptr rs
         : _rs(std::move(rs))
         , _tmptr(std::move(tmptr))
         , _replication_factor(replication_factor)
+        , _validity_abort_source(std::make_unique<abort_source>())
 { }
 
 vnode_effective_replication_map::factory_key vnode_effective_replication_map::make_factory_key(const replication_strategy_ptr& rs, const token_metadata_ptr& tmptr) {

--- a/locator/tablet_metadata_guard.hh
+++ b/locator/tablet_metadata_guard.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "replica/database.hh"
+#include "locator/tablets.hh"
+#include "locator/abstract_replication_strategy.hh"
+
+namespace locator {
+
+/// A holder for table's effective_replication_map which
+/// automatically switches to the latest one as long as it
+/// does not affect the tablet associated with this guard.
+///
+/// This is useful for tracking long-running operations in
+/// the context of a single tablet which we don't want to
+/// block topology barriers for other tablets, only barriers for
+/// this tablet.
+class tablet_metadata_guard {
+    lw_shared_ptr<replica::table> _table;
+    global_tablet_id _tablet;
+    effective_replication_map_ptr _erm;
+    std::optional<tablet_transition_stage> _stage;
+    seastar::abort_source _abort_source;
+    optimized_optional<seastar::abort_source::subscription> _callback;
+private:
+    void subscribe();
+    void check() noexcept;
+public:
+    tablet_metadata_guard(replica::table& table, global_tablet_id tablet);
+
+    /// Returns an abort_source which is signaled when effective_replication_map changes
+    /// in a way which is relevant for the tablet associated with this guard.
+    /// When this happens, the guard stops refreshing the effective_replication_map,
+    /// which will block topology coordinator barriers until the guard is destroyed.
+    ///
+    /// The abort_source is valid as long as this instance is alive.
+    seastar::abort_source& get_abort_source() {
+        return _abort_source;
+    }
+
+    locator::token_metadata_ptr get_token_metadata() {
+        return _erm->get_token_metadata_ptr();
+    }
+
+    /// Returns tablet_map for the table of the tablet associated with this guard.
+    /// The result is valid until the next deferring point.
+    const locator::tablet_map& get_tablet_map() {
+        return get_token_metadata()->tablets().get_tablet_map(_tablet.table);
+    }
+};
+
+} // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -45,6 +45,8 @@ write_replica_set_selector get_selector_for_writes(tablet_transition_stage stage
             return write_replica_set_selector::next;
         case tablet_transition_stage::cleanup:
             return write_replica_set_selector::next;
+        case tablet_transition_stage::end_migration:
+            return write_replica_set_selector::next;
     }
     on_internal_error(tablet_logger, format("Invalid tablet transition stage: {}", static_cast<int>(stage)));
 }
@@ -63,6 +65,8 @@ read_replica_set_selector get_selector_for_reads(tablet_transition_stage stage) 
         case tablet_transition_stage::use_new:
             return read_replica_set_selector::next;
         case tablet_transition_stage::cleanup:
+            return read_replica_set_selector::next;
+        case tablet_transition_stage::end_migration:
             return read_replica_set_selector::next;
     }
     on_internal_error(tablet_logger, format("Invalid tablet transition stage: {}", static_cast<int>(stage)));
@@ -232,6 +236,7 @@ static const std::unordered_map<tablet_transition_stage, sstring> tablet_transit
     {tablet_transition_stage::streaming, "streaming"},
     {tablet_transition_stage::use_new, "use_new"},
     {tablet_transition_stage::cleanup, "cleanup"},
+    {tablet_transition_stage::end_migration, "end_migration"},
 };
 
 static const std::unordered_map<sstring, tablet_transition_stage> tablet_transition_stage_from_name = std::invoke([] {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -141,6 +141,7 @@ enum class tablet_transition_stage {
     write_both_read_new,
     use_new,
     cleanup,
+    end_migration,
 };
 
 sstring tablet_transition_stage_to_string(tablet_transition_stage);

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -597,6 +597,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::NODE_OPS_CMD:
     case messaging_verb::HINT_MUTATION:
     case messaging_verb::TABLET_STREAM_DATA:
+    case messaging_verb::TABLET_CLEANUP:
         return 1;
     case messaging_verb::CLIENT_ID:
     case messaging_verb::MUTATION:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -183,7 +183,8 @@ enum class messaging_verb : int32_t {
     RAFT_TOPOLOGY_CMD = 64,
     RAFT_PULL_TOPOLOGY_SNAPSHOT = 65,
     TABLET_STREAM_DATA = 66,
-    LAST = 67,
+    TABLET_CLEANUP = 67,
+    LAST = 68,
 };
 
 } // namespace netw

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -62,6 +62,7 @@
 #include "sstables/generation_type.hh"
 #include "db/rate_limiter.hh"
 #include "db/operation_type.hh"
+#include "locator/tablets.hh"
 #include "utils/serialized_action.hh"
 #include "compaction/compaction_fwd.hh"
 
@@ -792,6 +793,7 @@ public:
     const locator::effective_replication_map_ptr& get_effective_replication_map() const { return _erm; }
     void update_effective_replication_map(locator::effective_replication_map_ptr);
     [[gnu::always_inline]] bool uses_tablets() const;
+    future<> cleanup_tablet(locator::tablet_id);
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_row_ptr> find_row(schema_ptr, reader_permit permit, const dht::decorated_key& partition_key, clustering_key clustering_key) const;
     shard_id shard_of(const mutation& m) const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1674,6 +1674,9 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
 }
 
 void table::update_effective_replication_map(locator::effective_replication_map_ptr erm) {
+    if (_erm) {
+        _erm->invalidate();
+    }
     _erm = std::move(erm);
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2964,4 +2964,9 @@ bool table::requires_cleanup(const sstables::sstable_set& set) const {
     }));
 }
 
+future<> table::cleanup_tablet(locator::tablet_id) {
+    co_await flush();
+    // FIXME: Remove sstables
+}
+
 } // namespace replica

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1467,7 +1467,7 @@ class topology_coordinator {
     }
 
     future<> generate_migration_updates(std::vector<canonical_mutation>& out, const group0_guard& guard, const migration_plan& plan) {
-        for (const tablet_migration_info& mig : plan) {
+        for (const tablet_migration_info& mig : plan.migrations()) {
             co_await coroutine::maybe_yield();
             generate_migration_update(out, guard, mig);
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -438,7 +438,10 @@ future<> storage_service::topology_state_load() {
             auto ip = co_await id2ip(id);
 
             slogger.trace("raft topology: loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={}",
-                          id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate, rs.ring->tokens);
+                          id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate,
+                          seastar::value_of([&] () -> sstring {
+                              return rs.ring ? ::format("{}", rs.ring->tokens) : sstring("null");
+                          }));
 
             switch (rs.state) {
             case node_state::bootstrapping:

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1903,6 +1903,7 @@ class topology_coordinator {
                 break;
             case topology::transition_state::tablet_migration:
                 co_await handle_tablet_migration(std::move(guard));
+                break;
         }
         co_return true;
     };

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -16,6 +16,7 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablets.hh"
+#include "locator/tablet_metadata_guard.hh"
 #include "inet_address_vectors.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/condition-variable.hh>
@@ -156,7 +157,7 @@ private:
     future<> node_ops_abort_thread();
     future<> do_tablet_operation(locator::global_tablet_id tablet,
                                  sstring op_name,
-                                 std::function<future<>()> op);
+                                 std::function<future<>(locator::tablet_metadata_guard&)> op);
     future<> stream_tablet(locator::global_tablet_id);
     inet_address host2ip(locator::host_id);
 public:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -114,6 +114,13 @@ private:
     using inet_address = gms::inet_address;
     using versioned_value = gms::versioned_value;
 
+    struct tablet_operation {
+        sstring name;
+        shared_future<> done;
+    };
+
+    using tablet_op_registry = std::unordered_map<locator::global_tablet_id, tablet_operation>;
+
     abort_source& _abort_source;
     gms::feature_service& _feature_service;
     distributed<replica::database>& _db;
@@ -147,6 +154,9 @@ private:
     future<> node_ops_abort(node_ops_id ops_uuid);
     void node_ops_signal_abort(std::optional<node_ops_id> ops_uuid);
     future<> node_ops_abort_thread();
+    future<> do_tablet_operation(locator::global_tablet_id tablet,
+                                 sstring op_name,
+                                 std::function<future<>()> op);
     future<> stream_tablet(locator::global_tablet_id);
     inet_address host2ip(locator::host_id);
 public:
@@ -766,7 +776,7 @@ private:
     std::optional<shared_future<>> _decomission_result;
     std::optional<shared_future<>> _rebuild_result;
     std::unordered_map<raft::server_id, std::optional<shared_future<>>> _remove_result;
-    std::unordered_map<locator::global_tablet_id, std::optional<shared_future<>>> _tablet_streaming;
+    tablet_op_registry _tablet_ops;
     // During decommission, the node waits for the coordinator to tell it to shut down.
     std::optional<promise<>> _shutdown_request_promise;
     struct {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -159,6 +159,7 @@ private:
                                  sstring op_name,
                                  std::function<future<>(locator::tablet_metadata_guard&)> op);
     future<> stream_tablet(locator::global_tablet_id);
+    future<> cleanup_tablet(locator::global_tablet_id);
     inet_address host2ip(locator::host_id);
 public:
     storage_service(abort_source& as, distributed<replica::database>& db,

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -179,7 +179,7 @@ class load_balancer {
     };
 
     struct node_load {
-        host_id node;
+        host_id id;
         uint64_t shard_count = 0;
         uint64_t tablet_count = 0;
 
@@ -310,6 +310,7 @@ public:
         topo.for_each_node([&] (const locator::node* node_ptr) {
             if (node_ptr->get_state() == locator::node::state::normal && node_ptr->dc_rack().dc == dc) {
                 node_load& load = nodes[node_ptr->host_id()];
+                load.id = node_ptr->host_id();
                 load.shard_count = node_ptr->get_shard_count();
                 load.shards.resize(load.shard_count);
                 if (!load.shard_count) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -285,7 +285,7 @@ public:
         for (auto&& dc : topo.get_datacenters()) {
             auto dc_plan = co_await make_plan(dc);
             lblogger.info("Prepared {} migrations in DC {}", dc_plan.size(), dc);
-            std::move(dc_plan.begin(), dc_plan.end(), std::back_inserter(plan));
+            plan.merge(std::move(dc_plan));
         }
 
         lblogger.info("Prepared {} migrations", plan.size());
@@ -578,7 +578,7 @@ public:
                 src_node_info.shards[src_shard].streaming_read_load += 1;
                 lblogger.debug("Adding migration: {}", mig);
                 _stats.for_dc(dc).migrations_produced++;
-                plan.push_back(std::move(mig));
+                plan.add(std::move(mig));
             } else {
                 // Shards are overloaded with streaming. Do not include the migration in the plan, but
                 // continue as if it was in the hope that we will find a migration which can be executed without

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -265,6 +265,8 @@ private:
                 return false;
             case tablet_transition_stage::cleanup:
                 return false;
+            case tablet_transition_stage::end_migration:
+                return false;
         }
         on_internal_error(lblogger, format("Invalid transition stage: {}", static_cast<int>(trinfo->stage)));
     }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -22,7 +22,24 @@ struct tablet_migration_info {
     locator::tablet_replica dst;
 };
 
-using migration_plan = utils::chunked_vector<tablet_migration_info>;
+class migration_plan {
+public:
+    using migrations_vector = utils::chunked_vector<tablet_migration_info>;
+private:
+    migrations_vector _migrations;
+public:
+    const migrations_vector& migrations() const { return _migrations; }
+    bool empty() const { return _migrations.empty(); }
+    size_t size() const { return _migrations.size(); }
+
+    void add(tablet_migration_info info) {
+        _migrations.emplace_back(std::move(info));
+    }
+
+    void merge(migration_plan&& other) {
+        std::move(other._migrations.begin(), other._migrations.end(), std::back_inserter(_migrations));
+    }
+};
 
 class tablet_allocator_impl;
 

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -27,7 +27,11 @@ public:
     using migrations_vector = utils::chunked_vector<tablet_migration_info>;
 private:
     migrations_vector _migrations;
+    bool _has_nodes_to_drain = false;
 public:
+    /// Returns true iff there are decommissioning nodes which own some tablet replicas.
+    bool has_nodes_to_drain() const { return _has_nodes_to_drain; }
+
     const migrations_vector& migrations() const { return _migrations; }
     bool empty() const { return _migrations.empty(); }
     size_t size() const { return _migrations.size(); }
@@ -38,6 +42,11 @@ public:
 
     void merge(migration_plan&& other) {
         std::move(other._migrations.begin(), other._migrations.end(), std::back_inserter(_migrations));
+        _has_nodes_to_drain |= other._has_nodes_to_drain;
+    }
+
+    void set_has_nodes_to_drain(bool b) {
+        _has_nodes_to_drain = b;
     }
 };
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -79,6 +79,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
     {topology::transition_state::tablet_migration, "tablet migration"},
+    {topology::transition_state::tablet_draining, "tablet draining"},
 };
 
 std::ostream& operator<<(std::ostream& os, topology::transition_state s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -97,6 +97,7 @@ struct topology_features {
 struct topology {
     enum class transition_state: uint16_t {
         commit_cdc_generation,
+        tablet_draining,
         write_both_read_old,
         write_both_read_new,
         tablet_migration,

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -592,7 +592,7 @@ SEASTAR_THREAD_TEST_CASE(test_token_ownership_splitting) {
 // Reflects the plan in a given token metadata as if the migrations were fully executed.
 static
 void apply_plan(token_metadata& tm, const migration_plan& plan) {
-    for (auto&& mig : plan) {
+    for (auto&& mig : plan.migrations()) {
         tablet_map& tmap = tm.tablets().get_tablet_map(mig.tablet.table);
         auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
         tinfo.replicas = replace_replica(tinfo.replicas, mig.src, mig.dst);
@@ -612,7 +612,7 @@ tablet_transition_info migration_to_transition_info(const tablet_migration_info&
 // Reflects the plan in a given token metadata as if the migrations were started but not yet executed.
 static
 void apply_plan_as_in_progress(token_metadata& tm, const migration_plan& plan) {
-    for (auto&& mig : plan) {
+    for (auto&& mig : plan.migrations()) {
         tablet_map& tmap = tm.tablets().get_tablet_map(mig.tablet.table);
         auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
         tmap.set_tablet_transition_info(mig.tablet.tablet, migration_to_transition_info(mig, tinfo));

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -143,7 +143,7 @@ async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
-async def test_bootstrap(manager: ManagerClient):
+async def test_topology_changes(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
 
@@ -176,6 +176,10 @@ async def test_bootstrap(manager: ManagerClient):
 
     await check()
     time.sleep(5) # Give load balancer some time to do work
+    await check()
+
+    await manager.decommission_node(servers[0].server_id)
+
     await check()
 
     await cql.run_async("DROP KEYSPACE test;")


### PR DESCRIPTION
Load balancer will recognize decommissioning nodes and will
move tablet replicas away from such nodes with highest priority.

Topology changes have now an extra step called "tablet draining" which
calls the load balancer. The step will execute tablet migration track
as long as there are nodes which require draining. It will not do regular
load balancing.

If load balancer is unable to find new tablet replicas, because RF
cannot be met or availability is at risk due to insufficient node
distribution in racks, it will throw an exception. Currently, topology
change will retry in a loop. We should make this error cause topology
change to be aborted. There is no infrastructure for
aborts yet, so this is not implemented.
