### PR TITLE
scylla-gdb: Remove _cost_capacity from fair-group debug

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3679,7 +3679,6 @@ class scylla_io_queues(gdb.Command):
 
             for fg, fq in zip(f_groups, f_queues):
                 try:
-                    gdb.write("\tCost capacity:       {}\n".format(self.ticket(fg['_cost_capacity'])))
                     try:
                         gdb.write("\tCapacity tail:       {}\n".format(std_atomic(fg['_token_bucket']['_rovers']['tail']).get()))
                         gdb.write("\tCapacity head:       {}\n".format(std_atomic(fg['_token_bucket']['_rovers']['head']).get()))


### PR DESCRIPTION
This field is about to be removed in newer seastar, so it shouldn't be checked in scylla-gdb

refs: ae6fdf159974032839dc8bdb8dec8a6cf3cf31ab
refs: #15154