### PR TITLE
docs: format configuration parameters reference as list

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,5 +1,6 @@
 /* Override theme styles */
 
+/* Home */
 .topic-box--product p {
     margin-bottom: 0;
 }
@@ -8,4 +9,18 @@
     .hero__title {
         max-width: 550px;
     }
+}
+
+/* Description lists */ 
+.content blockquote {
+    padding-left: 20px;
+}
+
+.content blockquote li p {
+    margin-bottom: 10px;
+}
+
+h2 .pre {
+    font-size: 16px;
+    font-weight: bold;
 }

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -1,26 +1,18 @@
 .. -*- mode: rst -*-
 
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Name
-     - Description
 {% for item in data %}
 {% if item.value_status == value_status %}
 
-   * - .. _config_{{ item.name }}:
+``{{ item.name }}``
+{{ '-' * (item.name|length + 4) }}
 
-          ``{{ item.name }}``
-     - {% if item.type %}**Type:** ``{{ item.type }}``{% endif %}
+   .. raw:: html
 
-       {% if item.default %}**Default value:** ``{{ item.default }}``{% endif %}
+      <p>{{item.description}}</p>
 
-       {% if item.liveness %}**Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
-
-       .. raw:: html
-
-          <p>{{item.description}}</p>
+   {% if item.type %}* **Type:** ``{{ item.type }}``{% endif %}
+   {% if item.default %}* **Default value:** ``{{ item.default }}``{% endif %}
+   {% if item.liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
 
 {% endif %}
 {% endfor %}

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -3,7 +3,7 @@ Reference
 ===============
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    /reference/*


### PR DESCRIPTION
Related issue https://github.com/scylladb/scylladb/issues/15161

This pull request proposes a reformatting of the database configuration properties table into a list. Given the recent discussions, I've separated this change to allow us to evaluate both formats in isolation.

Please review it after [PR #15164](https://github.com/scylladb/scylladb/pull/15164) is merged. Depending on feedback, I'm prepared to rebase onto "master" for a clean merge if this format is preferred.