### PR TITLE
Gossiper: do_on_dead_notifications

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -695,10 +695,7 @@ future<> gossiper::remove_endpoint(inet_address endpoint, permit_id pid) {
         try {
             auto state = get_endpoint_state(endpoint);
             logger.info("InetAddress {} is now DOWN, status = {}", endpoint, get_gossip_status(state));
-            co_await _subscribers.for_each([endpoint, state, pid] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) -> future<> {
-                co_await subscriber->on_dead(endpoint, state, pid);
-                logger.trace("Notified {}", fmt::ptr(subscriber.get()));
-            });
+            co_await do_on_dead_notifications(endpoint, std::move(state), pid);
         } catch (...) {
             logger.warn("Fail to call on_dead callback: {}", std::current_exception());
         }
@@ -1642,10 +1639,7 @@ future<> gossiper::mark_dead(inet_address addr, endpoint_state& local_state, per
         g._unreachable_endpoints[addr] = now();
     });
     logger.info("InetAddress {} is now DOWN, status = {}", addr, get_gossip_status(state));
-    co_await _subscribers.for_each([addr, state, pid] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) -> future<> {
-        co_await subscriber->on_dead(addr, state, pid);
-        logger.trace("Notified {}", fmt::ptr(subscriber.get()));
-    });
+    co_await do_on_dead_notifications(addr, std::move(state), pid);
 }
 
 future<> gossiper::handle_major_state_change(inet_address ep, const endpoint_state& eps, permit_id pid) {
@@ -1812,6 +1806,12 @@ future<> gossiper::do_before_change_notifications(inet_address addr, const endpo
 future<> gossiper::do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value, permit_id pid) {
     co_await _subscribers.for_each([addr, state, value, pid] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) {
         return subscriber->on_change(addr, state, value, pid);
+    });
+}
+
+future<> gossiper::do_on_dead_notifications(inet_address addr, endpoint_state state, permit_id pid) {
+    co_await _subscribers.for_each([addr, state = std::move(state), pid] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) {
+        return subscriber->on_dead(addr, state, pid);
     });
 }
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -495,6 +495,11 @@ private:
     // notify that an application state has changed
     // Must be called under lock_endpoint.
     future<> do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value, permit_id);
+
+    // notify that a node is DOWN (dead)
+    // Must be called under lock_endpoint.
+    future<> do_on_dead_notifications(inet_address addr, endpoint_state state, permit_id);
+
     /* Request all the state for the endpoint in the g_digest */
 
     void request_all(gossip_digest& g_digest, utils::chunked_vector<gossip_digest>& delta_gossip_digest_list, generation_type remote_generation);


### PR DESCRIPTION
Use common code to notify subscribers on_dead
from remove_endpoint() and from mark_dead().

Modeled after do_on_change_notifications.

Refs https://github.com/scylladb/scylladb/pull/15179#discussion_r1306969125