### PR TITLE
treewide: reduce include of cql_statement.hh

### DIFF
--- a/api/authorization_cache.cc
+++ b/api/authorization_cache.cc
@@ -11,6 +11,7 @@
 #include "api/authorization_cache.hh"
 #include "api/api.hh"
 #include "auth/common.hh"
+#include "auth/service.hh"
 
 namespace api {
 using namespace json;

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -22,7 +22,6 @@
 #include "log.hh"
 #include "seastarx.hh"
 #include "utils/exponential_backoff_retry.hh"
-#include "service/query_state.hh"
 
 using namespace std::chrono_literals;
 
@@ -32,6 +31,7 @@ class database;
 
 namespace service {
 class migration_manager;
+class query_state;
 }
 
 namespace cql3 {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -20,6 +20,7 @@
 #include "cql3/prepared_statements_cache.hh"
 #include "cql3/authorized_prepared_statements_cache.hh"
 #include "cql3/statements/prepared_statement.hh"
+#include "cql3/cql_statement.hh"
 #include "exceptions/exceptions.hh"
 #include "service/migration_listener.hh"
 #include "transport/messages/result_message.hh"
@@ -28,6 +29,7 @@
 #include "service/broadcast_tables/experimental/query_result.hh"
 #include "utils/observable.hh"
 #include "lang/wasm.hh"
+#include "service/raft/raft_group0_client.hh"
 
 
 namespace service {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -13,6 +13,7 @@
 #include "schema/schema_builder.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
+#include "cql3/stats.hh"
 #include "replica/database.hh"
 #include "replica/tablets.hh"
 #include "replica/tablet_mutation_builder.hh"

--- a/service/query_state.hh
+++ b/service/query_state.hh
@@ -13,7 +13,6 @@
 #include "service/client_state.hh"
 #include "tracing/tracing.hh"
 #include "service_permit.hh"
-#include "cql3/cql_statement.hh"
 
 namespace qos {
 class service_level_controller;

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -13,7 +13,6 @@
 
 #include "cql3/result_set.hh"
 #include "cql3/statements/prepared_statement.hh"
-#include "cql3/cql_statement.hh"
 #include "cql3/query_options.hh"
 
 #include "transport/messages/result_message_base.hh"
@@ -34,14 +33,7 @@ private:
     cql3::prepared_metadata _metadata;
     ::shared_ptr<const cql3::metadata> _result_metadata;
 protected:
-    prepared(cql3::statements::prepared_statement::checked_weak_ptr prepared, bool support_lwt_opt)
-        : _prepared(std::move(prepared))
-        , _metadata(
-            _prepared->bound_names,
-            _prepared->partition_key_bind_indices,
-            support_lwt_opt ? _prepared->statement->is_conditional() : false)
-        , _result_metadata{extract_result_metadata(_prepared->statement)}
-    { }
+    prepared(cql3::statements::prepared_statement::checked_weak_ptr prepared, bool support_lwt_opt);
 public:
     cql3::statements::prepared_statement::checked_weak_ptr& get_prepared() {
         return _prepared;
@@ -58,9 +50,7 @@ public:
     class cql;
     class thrift;
 private:
-    static ::shared_ptr<const cql3::metadata> extract_result_metadata(::shared_ptr<cql3::cql_statement> statement) {
-        return statement->get_result_metadata();
-    }
+    static ::shared_ptr<const cql3::metadata> extract_result_metadata(::shared_ptr<cql3::cql_statement> statement);
 };
 
 class result_message::visitor {


### PR DESCRIPTION
ClangBuildAnalyzer reports cql3/cql_statement.hh as being one of the most expensive header files in the project - being included (mostly indirectly) in 129 source files, and costing a total of 844 CPU seconds of compilation.

This patch is an attempt, only *partially* successful, to reduce the number of times that cql_statement.hh is included. It succeeds in lowering the number 129 to 99, but not less :-( One of the biggest difficulties in reducing it further is that query_processor.hh includes a lot of templated code, which needs stuff from cql_statement.hh. The solution should be to un-template the functions in query_processor.hh and move them from the header to a source file, but this is beyond the scope of this patch and query_processor.hh appears problematic in other respects as well.

Unfortunately the compilation speedup by this patch is negligible (the `du -bc build/dev/**/*.o` metric shows less than 0.01% reduction). Beyond the fact that this patch only removes 30% of the inclusions of this header, it appears that most of the source files that no longer include cql_statement.hh after this patch, included anyway many of the other headers that cql_statement.hh included, so the saving is minimal.