### PR TITLE
task_manager: module: make_task: enter gate when the task is created

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -164,6 +164,9 @@ private:
     // Requires task->_compaction_state.gate to be held and task to be registered in _tasks.
     future<compaction_stats_opt> perform_task(shared_ptr<compaction::compaction_task_executor> task, throw_if_stopping do_throw_if_stopping);
 
+    // Return nullopt if compaction cannot be started
+    std::optional<gate::holder> start_compaction(table_state& t);
+
     // parent_info set to std::nullopt means that task manager should not register this task executor.
     // To create a task manager task with no parent, parent_info argument should contain empty task_info.
     template<typename TaskExecutor, typename... Args>

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
 
 #include "task_manager.hh"
 #include "test_module.hh"
@@ -145,7 +146,7 @@ void task_manager::task::impl::finish_failed(std::exception_ptr ex) {
     finish_failed(ex, fmt::format("{}", ex));
 }
 
-task_manager::task::task(task_impl_ptr&& impl) noexcept : _impl(std::move(impl)) {
+task_manager::task::task(task_impl_ptr&& impl, gate::holder gh) noexcept : _impl(std::move(impl)), _gate_holder(std::move(gh)) {
     register_task();
 }
 
@@ -186,14 +187,13 @@ void task_manager::task::start() {
     try {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
-        (void)with_gate(_impl->_module->async_gate(), [f = done(), module = _impl->_module, id = id()] () mutable {
-            return std::move(f).finally([module] {
+        auto module = _impl->_module;
+            (void)done().finally([module] {
                 return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
-            }).then_wrapped([module, id] (auto f) {
+            }).then_wrapped([module, id = id()] (auto f) {
                 f.ignore_ready_future();
                 module->unregister_task(id);
             });
-        });
         _impl->_as.check();
         _impl->_status.state = task_manager::task_state::running;
         _impl->run_to_completion();
@@ -307,7 +307,7 @@ future<> task_manager::module::stop() noexcept {
 }
 
 future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_ptr task_impl_ptr, task_info parent_d) {
-    auto task = make_lw_shared<task_manager::task>(std::move(task_impl_ptr));
+    auto task = make_lw_shared<task_manager::task>(std::move(task_impl_ptr), async_gate().hold());
     bool abort = false;
     if (parent_d) {
         task->get_status().sequence_number = co_await _tm.container().invoke_on(parent_d.shard, [id = parent_d.id, task = make_foreign(task), &abort] (task_manager& tm) mutable {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -188,12 +188,12 @@ void task_manager::task::start() {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
         auto module = _impl->_module;
-            (void)done().finally([module] {
-                return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
-            }).then_wrapped([module, id = id()] (auto f) {
-                f.ignore_ready_future();
-                module->unregister_task(id);
-            });
+        (void)done().finally([module] {
+            return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
+        }).then_wrapped([module, id = id()] (auto f) {
+            f.ignore_ready_future();
+            module->unregister_task(id);
+        });
         _impl->_as.check();
         _impl->_status.state = task_manager::task_state::running;
         _impl->run_to_completion();

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -31,7 +31,7 @@ task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_
 {
     // Child tasks do not need to subscribe to abort source because they will be aborted recursively by their parents.
     if (!parent_id) {
-        _shutdown_subscription = module->get_task_manager()._as.subscribe([this] () noexcept {
+        _shutdown_subscription = module->abort_source().subscribe([this] () noexcept {
             (void)abort();
         });
     }

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -174,13 +174,16 @@ public:
         task_map _tasks;
         gate _gate;
         uint64_t _sequence_number = 0;
+    private:
+        abort_source _as;
+        optimized_optional<abort_source::subscription> _abort_subscription;
     public:
         module(task_manager& tm, std::string name) noexcept;
         virtual ~module() = default;
 
         uint64_t new_sequence_number() noexcept;
         task_manager& get_task_manager() noexcept;
-        virtual seastar::abort_source& abort_source() noexcept;
+        seastar::abort_source& abort_source() noexcept;
         gate& async_gate() noexcept;
         const std::string& get_name() const noexcept;
         task_manager::task_map& get_tasks() noexcept;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -139,8 +139,10 @@ public:
         using task_impl_ptr = shared_ptr<impl>;
     protected:
         task_impl_ptr _impl;
+    private:
+        gate::holder _gate_holder;
     public:
-        task(task_impl_ptr&& impl) noexcept;
+        task(task_impl_ptr&& impl, gate::holder) noexcept;
 
         task_id id();
         std::string type() const;

--- a/tasks/test_module.hh
+++ b/tasks/test_module.hh
@@ -15,19 +15,8 @@
 namespace tasks {
 
 class test_module : public task_manager::module {
-private:
-    seastar::abort_source _as;
 public:
     test_module(task_manager& tm) noexcept : module(tm, "test") {}
-
-    seastar::abort_source& abort_source() noexcept override {
-        return _as;
-    }
-
-    future<> stop() noexcept override {
-        _as.request_abort();
-        co_await task_manager::module::stop();
-    }
 };
 
 class test_task_impl : public task_manager::task::impl {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4802,22 +4802,24 @@ SEASTAR_TEST_CASE(check_table_sstable_set_includes_maintenance_sstables) {
 }
 
 // Without commit aba475fe1d24d5c, scylla will fail miserably (either with abort or segfault; depends on the version).
-SEASTAR_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
+SEASTAR_THREAD_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
     abort_source as;
 
     auto cfg = compaction_manager::config{ .available_memory = 1 };
     auto task_manager = tasks::task_manager({}, as);
+    auto stop_task_manager = deferred_stop(task_manager);
     auto cm = compaction_manager(cfg, as, task_manager);
+    auto stop_cm = deferred_stop(cm);
     cm.enable();
 
     testlog.info("requesting abort");
     as.request_abort();
 
     testlog.info("draining compaction manager");
-    co_await cm.drain();
+    cm.drain().get();
 
     testlog.info("stopping compaction manager");
-    co_await cm.stop();
+    stop_cm.stop_now();
 }
 
 SEASTAR_TEST_CASE(test_print_shared_sstables_vector) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4454,12 +4454,14 @@ SEASTAR_TEST_CASE(simple_backlog_controller_test) {
         auto as = abort_source();
 
         auto task_manager = tasks::task_manager({}, as);
+        auto stop_task_manager = deferred_stop(task_manager);
         compaction_manager::config cfg = {
             .compaction_sched_group = { default_scheduling_group() },
             .maintenance_sched_group = { default_scheduling_group() },
             .available_memory = available_memory,
         };
         auto manager = compaction_manager(std::move(cfg), as, task_manager);
+        auto stop_manager = deferred_stop(manager);
 
         auto add_sstable = [&env] (table_for_tests& t, uint64_t data_size, int level) {
             auto sst = env.make_sstable(t.schema());


### PR DESCRIPTION
Passing the gate_closed_exception to the task promise
ends up with abandoned exception since no-one is waiting
for it.

Instead, enter the gate when the task is made
so it will fail make_task if the gate is already closed.

Fixes scylladb/scylladb#15211

In addition, this series adds a private abort_source for each task_manager module
(chained to the main task_manager::abort_source) and abort is requested on task_manager::module::stop().

gate holding in compaction_manager is hardened
and makes sure to stop compaction_manager and task_manager in sstable_compaction_test cases.