### PR TITLE
tasks: request abort in task_manager::module::stop()

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -295,6 +295,10 @@ void task_manager::module::unregister_task(task_id id) noexcept {
 
 future<> task_manager::module::stop() noexcept {
     tmlogger.info("Stopping module {}", _name);
+    auto& as = abort_source();
+    if (!as.abort_requested()) {
+        as.request_abort();
+    }
     co_await _gate.close();
     _tm.unregister_module(_name);
 }


### PR DESCRIPTION
In cql_test_env task manager modules may be stopped while abort isn't requested. Then, finished tasks aren't immediately unregistered from task manager, but need to wait for task_ttl time and a gate can't be closed before that.

Request abort in task_manager::module::stop() before closing a gate.