### PR TITLE
open-coredump: use the dbuild script in current branch

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -341,4 +341,11 @@ Good luck!
 EOF
 fi
 
-exec ${SCYLLA_REPO_PATH}/tools/toolchain/dbuild -it -v $(pwd):/workdir -v ${SCYLLA_REPO_PATH}:/src/scylla -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb -w /workdir -- bash -l
+TOP_SRCDIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
+exec ${TOP_SRCDIR}/tools/toolchain/dbuild               \
+    --image ${SCYLLA_REPO_PATH}/tools/toolchain/image   \
+    -it                                                 \
+    -v $(pwd):/workdir                                  \
+    -v ${SCYLLA_REPO_PATH}:/src/scylla                  \
+    -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb     \
+    -w /workdir -- bash -l


### PR DESCRIPTION
open-coredump: use the dbuild script in current repo

the dbuild script provided by the branch being debugged might not
include the recent fixes included by current branch from which
`open-coredump.sh` is launched.

so, instead of using the dbuild script in the repo being debugged,
let's use the dbuild provided by current branch. also, wrap the
dbuild command line. for better readability.
