### PR TITLE
dbuild: use --userns option when using podman

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -154,10 +154,8 @@ if [ -z "$is_podman" ]; then
        --pids-limit -1
        )
 else
-    TMP_PASSWD=$(mktemp --tmpdir passwd.XXXXXX)
-    FULLNAME=$(getent passwd $USER | cut -d ':' -f 5)
-    echo "$USER:x:0:0:$FULLNAME:$HOME:/bin/bash" > "$TMP_PASSWD"
-    docker_common_args+=(-v "$TMP_PASSWD:/etc/passwd:ro")
+    docker_common_args+=(
+        --userns keep-id)
     # --pids-limit is not supported on podman with cgroupsv1
     # detection code from
     #   https://unix.stackexchange.com/questions/617764/how-do-i-check-if-system-is-using-cgroupv1


### PR DESCRIPTION
instead of fabricating a `/etc/password` manually, we can just leave it to podman to add an entry in `/etc/password` in container. as podman allows us to map user's account to the same UID in the container. see
https://docs.podman.io/en/stable/markdown/options/userns.container.html.

this is not only a cosmetic change, it also avoid the permission denied failure when accessing `/etc/passwd` in the container when selinux is enabled. without this change, we would otherwise need to either add the selinux lable to the bind volume with ':Z' option address the failure like:

```
type=AVC msg=audit(1693449115.261:2599): avc:  denied  { open } for  pid=2298247 comm="bash" path="/etc/passwd" dev="tmpfs" ino=5931 scontext=system_u:system_r:container_t:s0:c252,c259 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file permissive=0
type=AVC msg=audit(1693449115.263:2600): avc:  denied  { open } for  pid=2298249 comm="id" path="/etc/passwd" dev="tmpfs" ino=5931 scontext=system_u:system_r:container_t:s0:c252,c259 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file permissive=0
```

found in `/var/log/audit/audit.log`.