### PR TITLE
storage_service: Remove query processor arg from join_cluster()

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1660,7 +1660,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.local().join_cluster(sys_dist_ks, proxy, qp.local());
+                return ss.local().join_cluster(sys_dist_ks, proxy);
             }).get();
 
             sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2329,8 +2329,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         std::unordered_set<gms::inet_address> initial_contact_nodes,
         std::unordered_set<gms::inet_address> loaded_endpoints,
         std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
-        std::chrono::milliseconds delay,
-        cql3::query_processor& qp) {
+        std::chrono::milliseconds delay) {
     std::unordered_set<token> bootstrap_tokens;
     std::map<gms::application_state, gms::versioned_value> app_states;
     /* The timestamp of the CDC streams generation that this node has proposed when joining.
@@ -2554,7 +2553,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
 
     assert(_group0);
     // if the node is bootstrapped the functin will do nothing since we already created group0 in main.cc
-    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, raft_replace_info, *this, qp, _migration_manager.local());
+    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, raft_replace_info, *this, *_qp, _migration_manager.local());
 
     raft::server* raft_server = co_await [this] () -> future<raft::server*> {
         if (!_raft_topology_change_enabled) {
@@ -2620,7 +2619,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
             throw std::runtime_error(err);
         }
 
-        co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local());
+        co_await _group0->finish_setup_after_join(*this, *_qp, _migration_manager.local());
         co_return;
     }
 
@@ -2778,7 +2777,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
     }
 
     assert(_group0);
-    co_await _group0->finish_setup_after_join(*this, qp, _migration_manager.local());
+    co_await _group0->finish_setup_after_join(*this, *_qp, _migration_manager.local());
     co_await _cdc_gens.local().after_join(std::move(cdc_gen_id));
 }
 
@@ -3493,8 +3492,9 @@ void storage_service::set_group0(raft_group0& group0, bool raft_topology_change_
     _raft_topology_change_enabled = raft_topology_change_enabled;
 }
 
-future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy, cql3::query_processor& qp) {
+future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy) {
     assert(this_shard_id() == 0);
+    assert(_qp != nullptr);
 
     set_mode(mode::STARTING);
 
@@ -3558,7 +3558,7 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
     for (auto& x : loaded_peer_features) {
         slogger.info("peer={}, supported_features={}", x.first, x.second);
     }
-    co_return co_await join_token_ring(sys_dist_ks, proxy, std::move(initial_contact_nodes), std::move(loaded_endpoints), std::move(loaded_peer_features), get_ring_delay(), qp);
+    co_return co_await join_token_ring(sys_dist_ks, proxy, std::move(initial_contact_nodes), std::move(loaded_endpoints), std::move(loaded_peer_features), get_ring_delay());
 }
 
 future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -335,7 +335,7 @@ public:
      *
      * \see init_messaging_service_part
      */
-    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy, cql3::query_processor& qp);
+    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
 
     void set_group0(service::raft_group0&, bool raft_topology_change_enabled);
 
@@ -352,7 +352,7 @@ private:
             std::unordered_set<gms::inet_address> initial_contact_nodes,
             std::unordered_set<gms::inet_address> loaded_endpoints,
             std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
-            std::chrono::milliseconds, cql3::query_processor& qp);
+            std::chrono::milliseconds);
     future<> start_sys_dist_ks();
 public:
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -841,7 +841,7 @@ private:
             _ss.local().set_group0(group0_service, raft_topology_change_enabled);
 
             try {
-                _ss.local().join_cluster(_sys_dist_ks, _proxy, _qp.local()).get();
+                _ss.local().join_cluster(_sys_dist_ks, _proxy).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error


### PR DESCRIPTION
The s.service since d42685d0cb6 is having on-board query processor ref^w pointer and can use it to join cluster