### PR TITLE
test.py: test cases

### DIFF
--- a/test.py
+++ b/test.py
@@ -86,13 +86,38 @@ class TestTaskDef(NamedTuple):
        Representation is  suite::test[::case_name] where case_name is ommitted if not present.
        For a match for any suite (specified with ::test in command line), it will show as
        "all::test".
+       For a match for any test of a suite, it's represented as "suite::all"
     """
-    suite_name: str
-    test_file_name: str
+    suite_name: Optional[str]
+    test_file_name: Optional[str]
     case_name: Optional[str]
 
     def __str__(self):
-        return f"{self.suite_name}::{self.test_file_name}{'::' + self.case_name if self.case_name else ''}"
+        """Represent this TestTaskDef as suite::test_file_name::case_namae
+           If suite is not specified, 'all::test_file_name::case_namae' or 'all::test_file_name'.
+           If test file is not specified, 'suite::'.
+           If case name is not specified, 'suite::test'.
+        """
+        assert self.test_file_name or self.suite_name, "Either test file or suite name must be present"
+        suite = f"{self.suite_name}::" if self.suite_name else "all::"
+        assert self.test_file_name or (not self.test_file_name and not self.case_name), "No case if test is undefined"
+        test_name = self.test_file_name if self.test_file_name else ""
+        case_ = f"::{self.case_name}" if self.case_name else ""
+        return f"{suite}{test_name}{case_}"
+
+    def match(self, other: "TestTaskDef") -> bool:
+        """
+        Check if the 'other' TestTaskDef matches the pattern specified by this TestTaskDef instance.
+        An attribute in 'self' set to None is considered a wildcard, matching any value in 'other'.
+        """
+        if self.suite_name is not None and self.suite_name != other.suite_name:
+            return False
+        if self.test_file_name is not None and other.test_file_name is not None and \
+                not self.test_file_name in other.test_file_name:
+            return False
+        if self.case_name is not None and other.case_name is not None and not self.case_name in other.case_name:
+            return False
+        return True
 
     def startswith(self, test_file_name: str, case_name: Optional[str]):
         """Checks if self's test_file_name string starts with provided test_file_name string.
@@ -101,8 +126,9 @@ class TestTaskDef(NamedTuple):
            If case_name is provided but not definded in self, returns False.
            If case_name is provided and definded in self, and self starts with provided, returns True.
         """
+        assert self.test_file_name, "Need to have test_file_name to compare"
         return self.test_file_name.startswith(test_file_name) and \
-                (not case_name or (self.case_name and self.case_name.startswith(case_name)))
+                (not case_name or (self.case_name is not None and self.case_name.startswith(case_name)))
 
 
 class TestSuite(ABC):
@@ -266,23 +292,27 @@ class TestSuite(ABC):
             test_defs.sort(key=lambda tc: not any(tc.startswith(test_file_name, case_name)
                                                   for test_file_name, case_name in run_first_tc))
 
-        # From command line, so includes suite path
-        def is_enabled(test_file_path: str):
-            return not options.names or any (n in test_file_path for n in options.names)
+        # Specified in command line so need suite; checks pattern starting with
+        # can be abbreviated like a prefix* for test and case
+        def is_enabled(test_def: TestTaskDef):
+            if not options.names:
+                return True             # no test specified in command line, run all tests
+            return any(n.match(test_def) for n in options.names)
+
+        # From config, test file name without suite path; pattern in suite::test::case
+        def is_disabled(test_str: str):
+            return self.disabled_tests and any(disabled in test_str for disabled in self.disabled_tests)
 
         # From command line, so includes suite path
-        def should_skip(test_file_path: str):
-            return options.skip_pattern and options.skip_pattern in test_file_path
-
-        # From config, test file name without suite path
-        def is_disabled(test_file: str):
-            return test_file in self.disabled_tests
+        def should_skip(test_str: str):
+            return options.skip_pattern and options.skip_pattern in test_str
 
         add_test_tasks = []
         for test_def in test_defs:
-            name = str(test_def)
+            assert test_def.test_file_name is not None
+            test_str = str(test_def)
             for _ in range(options.repeat):
-                if not is_disabled(test_def.test_file_name) and not should_skip(name) and is_enabled(name):
+                if not is_disabled(test_str) and not should_skip(test_str) and is_enabled(test_def):
                     add_test_tasks.append(asyncio.create_task(self.add_test(test_def)))
 
         if add_test_tasks:
@@ -308,6 +338,7 @@ class UnitTestSuite(TestSuite):
         self.all_can_run_compaction_groups_except = cfg.get("all_can_run_compaction_groups_except")
 
     async def create_test(self, test_def: TestTaskDef, suite: TestSuite, args) -> None:
+        assert test_def.test_file_name is not None
         exe = os.path.join("build", suite.mode, "test", suite.name, test_def.test_file_name)
         if not os.access(exe, os.X_OK):
             print(palette.warn(f"Unit test executable {exe} not found."))
@@ -320,6 +351,7 @@ class UnitTestSuite(TestSuite):
         """Create a UnitTest class with possibly custom command line
         arguments and add it to the list of tests"""
         # Skip tests which are not configured, and hence are not built
+        assert test_def.test_file_name is not None
         if os.path.join("test", self.name, test_def.test_file_name) not in self.options.tests:
             return
 
@@ -602,7 +634,10 @@ class Test:
         self.suite = suite
         # Unique file name, which is also readable by human, as filename prefix
         # TODO: change inner '.' to '-' for a more conventional file naming
-        self.uname = f"{self.full_name.replace('::', '.')}.{self.id}"
+        if test_def.case_name:
+            self.uname = f"{test_def.suite_name}.{test_def.test_file_name}.{test_def.case_name}.{self.id}"
+        else:
+            self.uname = f"{test_def.suite_name}.{test_def.test_file_name}.{self.id}"
         self.log_filename = pathlib.Path(suite.options.tmpdir) / self.mode / (self.uname + ".log")
         self.log_filename.parent.mkdir(parents=True, exist_ok=True)
         if test_def.case_name is None:
@@ -666,6 +701,7 @@ class UnitTest(Test):
 
     def __init__(self, test_no: int, test_def: TestTaskDef, suite, args: str) -> None:
         super().__init__(test_no, test_def, suite)
+        assert test_def.test_file_name is not None
         self.path = os.path.join("build", self.mode, "test", suite.name, test_def.test_file_name)
         self.args = shlex.split(args) + UnitTest.standard_args
         if self.mode == "coverage":
@@ -721,8 +757,8 @@ class BoostTest(UnitTest):
     @staticmethod
     def test_path_of_element(test: ET.Element) -> TestTaskDef:
         path = test.attrib['path']
-        suite_name, test_name, case_name = path.rsplit('::')
-        return TestTaskDef(suite_name, test_name, case_name)
+        elems = path.rsplit('::')
+        return TestTaskDef(elems[0], elems[1], elems[2] if len(elems) == 3 else None)
 
     def __parse_logger(self) -> None:
         def attach_path_and_mode(test):
@@ -768,10 +804,11 @@ class CQLApprovalTest(Test):
         super().__init__(test_no, test_def, suite)
         # Path to cql_repl driver, in the given build mode
         self.path = "pytest"
-        self.cql = suite.suite_path / (self.test_def.test_file_name + ".cql")
-        self.result = suite.suite_path / (self.test_def.test_file_name + ".result")
+        assert test_def.test_file_name is not None
+        self.cql = suite.suite_path / (test_def.test_file_name + ".cql")
+        self.result = suite.suite_path / (test_def.test_file_name + ".result")
         self.tmpfile = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".reject")
-        self.reject = suite.suite_path / (self.test_def.test_file_name + ".reject")
+        self.reject = suite.suite_path / (test_def.test_file_name + ".reject")
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None
         CQLApprovalTest._reset(self)
@@ -950,6 +987,7 @@ class PythonTest(Test):
             # https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
             no_tests_selected_exit_code = 5
             self.valid_exit_codes = [0, no_tests_selected_exit_code]
+        assert self.test_def.test_file_name is not None
         self.args.append(str(self.suite.suite_path / (self.test_def.test_file_name + ".py")))
 
     def _reset(self) -> None:
@@ -1065,6 +1103,7 @@ class ToolTest(Test):
             # https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
             no_tests_selected_exit_code = 5
             self.valid_exit_codes = [0, no_tests_selected_exit_code]
+        assert self.test_def.test_file_name is not None
         self.args.append(str(self.suite.suite_path / (self.test_def.test_file_name + ".py")))
 
     def _reset(self) -> None:
@@ -1243,6 +1282,17 @@ def setup_signal_handlers(loop, signaled) -> None:
         loop.add_signal_handler(signo, lambda: asyncio.create_task(shutdown(loop, signo, signaled)))
 
 
+def pattern_to_case(value: str) -> TestTaskDef:
+    """From a command line test pattern create a TestTaskDef."""
+    pattern = re.compile(r'^(?P<suite>[a-zA-Z0-9_-]*)(::(?P<test>[a-zA-Z0-9_/-]+))?(::(?P<case>[a-zA-Z0-9_-]+))?$')
+    match = pattern.match(value)
+    if not match:
+        raise ValueError("Invalid pattern. Must be 'suite', 'suite::test', or 'suite::test::case'.")
+
+    suite = None if match.group('suite') == '' else match.group('suite')
+    return TestTaskDef(suite, match.group('test'), match.group('case'))
+
+
 def parse_cmd_line() -> argparse.Namespace:
     """ Print usage and process command line options. """
 
@@ -1251,12 +1301,19 @@ def parse_cmd_line() -> argparse.Namespace:
         "names",
         nargs="*",
         action="store",
-        help="""Can be empty. List of test names, to look for in
-                suites. Each name is used as a substring to look for in the
-                path to test file, e.g. "mem" will run all tests that have
-                "mem" in their name in all suites, "boost/mem" will only enable
-                tests starting with "mem" in "boost" suite. Default: run all
-                tests in all suites.""",
+        type=pattern_to_case,
+        help="""Can be empty. Space separated list of tests look for.
+                The syntax is either test_suite, test_suite::test_file_name, or
+                test_suite::test_file_name::test_case. For example:
+                    boost::database_test::clear_snapshot       runs one test case
+                    topology::test_change_ip                   runs all tests in a file
+                    cql-pytest                                 suite only, runs all its tests
+                    ::test_tablets                             tests matching any suite
+
+                Test and case can be partial match. (e.g. "::tablets" instead of "::test_tablets").
+                Note: if suite is not specified the "::" prefix MUST be placed before test name.
+
+                If no name is specified, all tests in all suites will be run.""",
     )
     parser.add_argument(
         "--tmpdir",
@@ -1596,7 +1653,7 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
     test_cases = sorted(test_cases, key=BoostTest.test_path_of_element)
 
     xml = ET.Element("TestLog")
-    for full_path, tests in itertools.groupby(
+    for test_task_def, tests in itertools.groupby(
             test_cases,
             key=BoostTest.test_path_of_element):
         # dedup the tests with the same name, so only the representive one is
@@ -1605,13 +1662,14 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
         test_case.attrib.pop('path')
         test_case.attrib.pop('mode')
 
-        suite_name, test_name, _ = full_path
-        suite = xml.find(f"./TestSuite[@name='{suite_name}']")
+        suite = xml.find(f"./TestSuite[@name='{test_task_def.suite_name}']")
         if suite is None:
-            suite = ET.SubElement(xml, 'TestSuite', name=suite_name)
-        test = suite.find(f"./TestSuite[@name='{test_name}']")
+            assert test_task_def.suite_name is not None
+            suite = ET.SubElement(xml, 'TestSuite', name=test_task_def.suite_name)
+        test = suite.find(f"./TestSuite[@name='{test_task_def.test_file_name}']")
         if test is None:
-            test = ET.SubElement(suite, 'TestSuite', name=test_name)
+            assert test_task_def.test_file_name is not None
+            test = ET.SubElement(suite, 'TestSuite', name=test_task_def.test_file_name)
         test.append(test_case)
     et = ET.ElementTree(xml)
     et.write(f'{tmpdir}/{mode}/xml/boost.xunit.xml', encoding='unicode')

--- a/test.py
+++ b/test.py
@@ -155,7 +155,7 @@ class TestSuite(ABC):
         self.n_failed = 0
 
         self.run_first_tests = set(cfg.get("run_first", []))
-        self.no_parallel_cases = set(cfg.get("no_parallel_cases", []))
+        self.parallel_cases = set(cfg.get("parallel_cases", []))
         # Skip tests disabled in suite.yaml
         self.disabled_tests = set(self.cfg.get("disable", []))
         # Skip tests disabled in specific mode.
@@ -409,9 +409,7 @@ class BoostTestSuite(UnitTestSuite):
         ret: List[TestTaskDef] = []
 
         for test_file_name in test_list:
-            if test_file_name in self.no_parallel_cases:
-                case_list: List[Optional[str]] = [None]
-            else:
+            if test_file_name in self.parallel_cases:
                 exe = os.path.join("build", self.mode, "test", self.name, test_file_name)
                 if not os.access(exe, os.X_OK):
                     print(palette.warn(f"Boost test executable {exe} not found."))
@@ -421,6 +419,8 @@ class BoostTestSuite(UnitTestSuite):
                 if fqname not in self._case_cache:
                     self._case_cache[fqname] = await self._exe_list_cases(exe)  # store in cache
                 case_list = self._case_cache[fqname]
+            else:
+                case_list = [None]            # no parallel cases
 
             ret.extend([TestTaskDef(self.name, test_file_name, case_name) for case_name in case_list])
 
@@ -548,14 +548,14 @@ class PythonTestSuite(TestSuite):
         return matches
 
     async def _create_test_cases(self, test_file_name: str) -> List[TestTaskDef]:
-        if test_file_name[:-3] in self.no_parallel_cases:
-            case_list: List[Optional[str]] = [None]
-        else:
+        if test_file_name[:-3] in self.parallel_cases:
             if test_file_name not in self._case_cache:
                 case_list = await self._pytest_list_cases(test_file_name)
                 self._case_cache[test_file_name] = case_list  # Assuming cache is thread-safe
             else:
                 case_list = self._case_cache[test_file_name]
+        else:
+            case_list = [None]      # no parallel cases
 
         return [TestTaskDef(self.name, test_file_name, case_name) for case_name in case_list]
 

--- a/test.py
+++ b/test.py
@@ -230,7 +230,7 @@ class TestSuite(ABC):
                 continue
 
             t = os.path.join(self.name, shortname)
-            patterns = options.name if options.name else [t]
+            patterns = options.names if options.names else [t]
             if options.skip_pattern and options.skip_pattern in t:
                 continue
 
@@ -1182,7 +1182,7 @@ def parse_cmd_line() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description="Scylla test runner")
     parser.add_argument(
-        "name",
+        "names",
         nargs="*",
         action="store",
         help="""Can be empty. List of test names, to look for in
@@ -1310,8 +1310,8 @@ async def find_tests(options: argparse.Namespace) -> None:
                 await suite.add_test_list()
 
     if not TestSuite.test_count():
-        if len(options.name):
-            print("Test {} not found".format(palette.path(options.name[0])))
+        if len(options.names):
+            print("Test {} not found".format(palette.path(options.names[0])))
             sys.exit(1)
         else:
             print(palette.warn("No tests found. Please enable tests in ./configure.py first."))

--- a/test.py
+++ b/test.py
@@ -265,9 +265,17 @@ class TestSuite(ABC):
         """Tests which participate in a consolidated junit report"""
         return self.tests
 
+    def _filter_test_list(self, tests: List[str]) -> List[str]:
+        patterns = [tc.test_file for tc in self.options.names if tc.suite_name in [self.name, None]]
+        # If any of the patterns is wildcard (None), include all tests, else only specified tests
+        patterns = [""] if not patterns or None in patterns else patterns
+        tests = [test for test in tests if any(patt in test for patt in patterns)]
+        return tests
+
     def build_test_list(self) -> List[str]:
-        return [os.path.splitext(t.relative_to(self.suite_path))[0] for t in
+        tests = [os.path.splitext(t.relative_to(self.suite_path))[0] for t in
                 self.suite_path.glob(self.pattern)]
+        return self._filter_test_list(tests)
 
     async def _test_defs(self, test_list: List[str]) -> List[TestTaskDef]:
         """From a list of test names (files) of this suite, build a list of TestTaskDef definitions
@@ -515,7 +523,8 @@ class PythonTestSuite(TestSuite):
         """For pytest, search for directories recursively"""
         path = self.suite_path
         pytests = itertools.chain(path.rglob("*_test.py"), path.rglob("test_*.py"))
-        return [os.path.splitext(t.relative_to(self.suite_path))[0] for t in pytests]
+        tests = [os.path.splitext(t.relative_to(self.suite_path))[0] for t in pytests]
+        return self._filter_test_list(tests)
 
     @property
     def pattern(self) -> str:

--- a/test.py
+++ b/test.py
@@ -1391,7 +1391,7 @@ def read_log(log_filename: pathlib.Path) -> str:
         return "===Error reading log {}===".format(e)
 
 
-def print_summary(failed_tests, options: argparse.Namespace) -> None:
+def print_summary(failed_tests: List[Test], options: argparse.Namespace) -> None:
     rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
     cpu_used = rusage.ru_stime + rusage.ru_utime
     cpu_available = (time.monotonic() - launch_time) * multiprocessing.cpu_count()

--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -9,10 +9,9 @@
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
 
-// These tests are slow, and tuned to a particular amount of memory
-// (and --memory is ignored in debug mode).
-// Hence they are not run in debug.
-#ifndef SEASTAR_DEBUG
+// NOTE: These tests are slow, and tuned to a particular amount of memory
+//       (and --memory is ignored in debug mode).
+//       Hence they should be disabled in debug.
 
 // The problem with naive index caching is that every uncached read drags a full
 // index page into the cache. But the index page can be orders of magnitude bigger
@@ -177,5 +176,3 @@ SEASTAR_TEST_CASE(test_index_is_cached_in_big_partition_workload) {
         BOOST_REQUIRE_EQUAL(get_misses(), misses_before);
     }, std::move(cfg));
 }
-
-#endif

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -20,11 +20,38 @@ run_first:
     - memtable_test::test_memtable_with_many_versions_conforms_to_mutation_source
     - memtable_test::flushing_rate_is_reduced_if_compaction_doesnt_keep_up
     - memtable_test::test_memtable_conforms_to_mutation_source
-# These test cannot work in case-by-case mode because
+# Tests with slow cases to run each case separately
+parallel_cases:
+    - cdc_test
+    - cql_functions_test
+    - cql_query_like_test
+    - cql_query_test
+    - database_test
+    - database_test.unpaged_mutation_read_global_limit
+    - index_with_paging_test
+    - memtable_test
+    - multishard_combining_reader_as_mutation_source_test
+    - mutation_fragment_test
+    - mutation_reader_test
+    - network_topology_strategy_test
+    - reader_concurrency_semaphore_test
+    - restrictions_test
+    - row_cache_test
+    - schema_change_test
+    - secondary_index_test
+    - sstable_3_x_test
+    - sstable_compaction_test
+    - sstable_conforms_to_mutation_source_test
+    - tablets_test
+    - user_function_test
+    - user_types_test
+    - view_complex_test
+    - view_schema_test
+    - virtual_reader_test
+# NOTE: These test cannot work in case-by-case mode because
 # some test-cases depend on each other
-no_parallel_cases:
-    - logalloc_test
-    - logalloc_standard_allocator_segment_pool_backend_test
+# logalloc_test, logalloc_standard_allocator_segment_pool_backend_test
+
 # Enable compaction groups on tests except on a few, listed below
 all_can_run_compaction_groups_except:
     - exceptions_optimized_test

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -81,3 +81,5 @@ custom_args:
         - '-c1 -m256M'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
+skip_in_debug:
+    - cache_algorithm_test

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -1,15 +1,25 @@
 type: boost
 # A list of long tests, which should be started early
 run_first:
-    - index_with_paging_test
+    - index_with_paging_test::test_index_with_paging
     - schema_changes_test
-    - sstable_conforms_to_mutation_source_test
-    - secondary_index_test
-    - mutation_reader_test
+    - sstable_conforms_to_mutation_source_test::test_sstable_conforms_to_mutation_source
+    - secondary_index_test::test_indexing_paging_and_aggregation
+    - secondary_index_test::test_deleting_ghost_rows
+    - mutation_reader_test::test_combined_mutation_source_is_a_mutation_source
+    - mutation_reader_test::test_foreign_reader_as_mutation_source
+    - mutation_reader_test::clustering_combined_reader_mutation_source_test
+    - mutation_reader_test::test_compacting_reader_as_mutation_source
+    - mutation_reader_test::test_multishard_streaming_reader
+    - mutation_reader_test::test_manual_paused_evictable_reader_is_mutation_source
+    - mutation_reader_test::test_auto_paused_evictable_reader_is_mutation_source
     - multishard_combining_reader_as_mutation_source_test
-    - database_test
-    - cql_function_test
-    - memtable_test
+    - database_test::test_database_with_data_in_sstables_is_a_mutation_source
+    - database_test::unpaged_mutation_read_global_limit
+    - cql_functions_test::test_aggregate_functions
+    - memtable_test::test_memtable_with_many_versions_conforms_to_mutation_source
+    - memtable_test::flushing_rate_is_reduced_if_compaction_doesnt_keep_up
+    - memtable_test::test_memtable_conforms_to_mutation_source
 # These test cannot work in case-by-case mode because
 # some test-cases depend on each other
 no_parallel_cases:

--- a/test/cql-pytest/suite.yaml
+++ b/test/cql-pytest/suite.yaml
@@ -2,3 +2,26 @@ type: Python
 pool_size: 4
 dirties_cluster:
   - test_native_transport
+# Tests with slow cases to run each case separately
+parallel_cases:
+    - cassandra_tests/validation/entities/collections_test
+    - cassandra_tests/validation/entities/frozen_collections_test
+    - cassandra_tests/validation/entities/secondary_index_test
+    - cassandra_tests/validation/entities/uf_types_test
+    - cassandra_tests/validation/entities/user_types_test
+    - cassandra_tests/validation/operations/alter_test
+    - cassandra_tests/validation/operations/compact_storage_test
+    - cassandra_tests/validation/operations/delete_test
+    - cassandra_tests/validation/operations/insert_update_if_condition_collections_test
+    - cassandra_tests/validation/operations/select_limit_test
+    - cassandra_tests/validation/operations/select_multi_column_relation_test
+    - cassandra_tests/validation/operations/select_order_by_test
+    - cassandra_tests/validation/operations/select_single_column_relation_test
+    - test_describe
+    - test_keyspace
+    - test_permissions
+    - test_secondary_index
+    - test_sstable_validation
+    - test_tombstone_limit
+    - test_tools
+    - test_uda

--- a/test/raft/many_test.cc
+++ b/test/raft/many_test.cc
@@ -30,7 +30,6 @@ SEASTAR_THREAD_TEST_CASE(test_many_100) {
     rpc_config{ .network_delay = 20ms, .local_delay = 1ms });
 }
 
-#ifndef SEASTAR_DEBUG
 SEASTAR_THREAD_TEST_CASE(test_many_400) {
     replication_test<steady_clock_type>(
         {.nodes = 400, .total_values = 10,
@@ -55,4 +54,3 @@ SEASTAR_THREAD_TEST_CASE(test_many_1000) {
     , true, tick_delay,
     rpc_config{ .network_delay = 20ms, .local_delay = 1ms });
 }
-#endif

--- a/test/raft/suite.yaml
+++ b/test/raft/suite.yaml
@@ -1,1 +1,9 @@
 type: boost
+# Tests with slow cases to run each case separately
+parallel_cases:
+    - many_test
+    - raft_sys_table_storage_test
+    - replication_test
+skip_in_debug:
+    - many_test::test_many_400
+    - many_test::test_many_1000

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -14,3 +14,11 @@ skip_in_release:
     - test_cluster_features
 run_in_release:
     - test_gossiper
+# Tests with slow cases to run each case separately
+parallel_cases:
+    - test_cluster_features
+    - test_mutation_schema_change
+    - test_random_tables
+    - test_replace
+    - test_topology_remove_decom
+    - test_topology_schema

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -7,6 +7,7 @@ extra_scylla_config_options:
     authorizer: AllowAllAuthorizer
     enable_user_defined_functions: False
     experimental_features: ['consistent-topology-changes', 'tablets']
+no_parallel_cases_modes: [dev, release]
 skip_in_release:
   - test_blocked_bootstrap
   - test_cdc_generation_clearing


### PR DESCRIPTION
Handle cases per test from command line and add internal logic. Allow splitting pytest test by case.

Major speedup by only loading suites and tests specified in command line (if specified). Before this PR, all suites would be loaded, including `boost` suite running all its 168 binaries to collect the cases.

Syntax changed to `suite::test::case` with possible patterns  `suite`, `suite::test`, `suite::test::case`, `::test`, `::test::case`.

Previous PR discussion for pytest case: https://github.com/scylladb/scylladb/pull/13950 (closed).