### PR TITLE
tasks: db: change default task_ttl value

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -570,6 +570,9 @@ murmur3_partitioner_ignore_msb_bits: 12
 # may be lost if the node was not cleanly stopped.
 force_schema_commit_log: true
 
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
 # Use Raft to consistently manage schema information in the cluster.
 # Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
 # The 'Handling Failures' section is especially important.

--- a/db/config.cc
+++ b/db/config.cc
@@ -999,7 +999,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Ignore truncation record stored in system tables as if tables were never truncated.")
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,
         "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
-    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 10, "Time for which information about finished task stays in memory.")
+    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Time for which information about finished task stays in memory.")
     , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator")
     , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, false,


### PR DESCRIPTION
If someone (or a test) isn't going to use task manager or isn't interested in statuses of finished tasks, then keeping them in the memory for some time (currently 10s by default) after they are finished is a memory waste.

Set default task_ttl value to zero. It can be changed by setting --task-ttl-in-seconds or through rest api (/task_manager/ttl).