### PR TITLE
open-coredump: use the dbuild script in current repo

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -343,4 +343,8 @@ Good luck!
 EOF
 fi
 
-exec ${SCYLLA_REPO_PATH}/tools/toolchain/dbuild -it -v $(pwd):/workdir -v ${SCYLLA_REPO_PATH}:/src/scylla -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb:Z -w /workdir -- bash -l
+TOP_SRCDIR=$(dirname $(dirname $0))
+IMAGE="${SCYLLA_REPO_PATH}/tools/toolchain/image"
+exec ${TOP_SRCDIR}/tools/toolchain/dbuild \
+    --image "$(<"$IMAGE")" \
+    -it -v $(pwd):/workdir -v ${SCYLLA_REPO_PATH}:/src/scylla -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb -w /workdir -- bash -l

--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -345,6 +345,10 @@ fi
 
 TOP_SRCDIR=$(dirname $(dirname $0))
 IMAGE="${SCYLLA_REPO_PATH}/tools/toolchain/image"
-exec ${TOP_SRCDIR}/tools/toolchain/dbuild \
-    --image "$(<"$IMAGE")" \
-    -it -v $(pwd):/workdir -v ${SCYLLA_REPO_PATH}:/src/scylla -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb -w /workdir -- bash -l
+exec ${TOP_SRCDIR}/tools/toolchain/dbuild               \
+    --image "$(<"$IMAGE")"                              \
+    -it                                                 \
+    -v $(pwd):/workdir                                  \
+    -v ${SCYLLA_REPO_PATH}:/src/scylla                  \
+    -v ${ARTIFACT_DIR}/scylla.package:/opt/scylladb     \
+    -w /workdir -- bash -l


### PR DESCRIPTION
the dbuild script provided by the branch being debugged might not include the recent fixes included by current branch from which `open-coredump.sh` is launched.

so, instead of using the dbuild script in the repo being debugged, let's use the dbuild provided by current branch.