### PR TITLE
test: topology: add tests for gossiper/endpoint/live and gossiper/endpoint/down

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -244,20 +244,20 @@ class ManagerClient():
                                          response_type="json")
         return IPAddress(ret["ip_addr"])
 
-    async def wait_for_host_known(self, dst_server_id: str, expect_host_id: str,
+    async def wait_for_host_known(self, dst_server_ip: IPAddress, expect_host_id: HostID,
                                   deadline: Optional[float] = None) -> None:
         """Waits until dst_server_id knows about expect_host_id, with timeout"""
         async def host_is_known():
-            host_id_map = await self.api.get_host_id_map(dst_server_id)
+            host_id_map = await self.api.get_host_id_map(dst_server_ip)
             return True if any(entry for entry in host_id_map if entry['value'] == expect_host_id) else None
 
         return await wait_for(host_is_known, deadline or (time() + 30))
 
-    async def wait_for_host_down(self, dst_server_id: str, server_id: str, deadline: Optional[float] = None) -> None:
+    async def wait_for_host_down(self, dst_server_ip: IPAddress, server_ip: IPAddress, deadline: Optional[float] = None) -> None:
         """Waits for dst_server_id to consider server_id as down, with timeout"""
         async def host_is_down():
-            down_endpoints = await self.api.get_down_endpoints(dst_server_id)
-            return True if server_id in down_endpoints else None
+            down_endpoints = await self.api.get_down_endpoints(dst_server_ip)
+            return True if server_ip in down_endpoints else None
 
         return await wait_for(host_is_down, deadline or (time() + 30))
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -146,19 +146,17 @@ class ScyllaRESTAPIClient():
         host_uuid = host_uuid.lstrip('"').rstrip('"')
         return HostID(host_uuid)
 
-    async def get_host_id_map(self, dst_server_id: str) -> list:
+    async def get_host_id_map(self, dst_server_ip: IPAddress) -> list[HostID]:
         """Retrieve the mapping of endpoint to host ID"""
-        response = await self.client.get("/storage_service/host_id", dst_server_id)
-        result = await response.json()
-        assert(type(result) == list)
-        return result
+        data = await self.client.get_json("/storage_service/host_id/", dst_server_ip)
+        assert(type(data) == list)
+        return data
 
-    async def get_down_endpoints(self, dst_server_id: str) -> list:
+    async def get_down_endpoints(self, node_ip: IPAddress) -> list[IPAddress]:
         """Retrieve down endpoints from gossiper's point of view """
-        response = await self.client.get("/gossiper/endpoint/down/", dst_server_id)
-        result = await response.json()
-        assert(type(result) == list)
-        return result
+        data = await self.client.get_json("/gossiper/endpoint/down/", node_ip)
+        assert(type(data) == list)
+        return data
 
     async def remove_node(self, initiator_ip: IPAddress, host_id: HostID,
                           ignore_dead: list[IPAddress], timeout: float) -> None:

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -12,3 +12,5 @@ run_first:
     - test_tablets
 skip_in_release:
     - test_cluster_features
+run_in_release:
+    - test_gossiper

--- a/test/topology/test_gossiper.py
+++ b/test/topology/test_gossiper.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.manager_client import ManagerClient
+import pytest
+
+@pytest.mark.asyncio
+async def test_gossiper_endpoints(manager: ManagerClient) -> None:
+    servers = await manager.running_servers()
+    servers_ips = [await manager.get_host_ip(server.server_id) for server in servers]
+
+    alive_endpoints_lists = [await manager.api.get_alive_endpoints(ip) for ip in servers_ips]
+    alive_endpoints_num = len(alive_endpoints_lists[0])
+    assert all(len(alive_endpoints) == alive_endpoints_num for alive_endpoints in alive_endpoints_lists), "Servers see different number of alive endpoints"
+
+    down_endpoints_lists = [await manager.api.get_down_endpoints(ip) for ip in servers_ips]
+    assert not any(down_endpoints_lists), "Some servers see a down endpoint"
+
+    down_server_index = 1
+    down_server_ip = servers_ips[down_server_index]
+    await manager.server_stop(servers[down_server_index].server_id)
+    for ip in servers_ips:
+        if ip != down_server_ip:
+            await manager.server_not_sees_other_server(ip, down_server_ip)
+
+            alive_endpoints = await manager.api.get_alive_endpoints(ip)
+            assert len(alive_endpoints) == alive_endpoints_num - 1, "Incorrect number of alive endpoints"
+            assert down_server_ip not in alive_endpoints, "Stopped server is marked as alive"
+
+            down_endpoints = await manager.api.get_down_endpoints(ip)
+            assert len(down_endpoints) == 1, "Incorrect number of down endpoints"
+            assert down_server_ip in down_endpoints, "Stopped server isn't marked as dead"


### PR DESCRIPTION
Add tests for gossiper/endpoint/live and gossiper/endpoint/down
which run only in release mode.

Enable test_remove_node_with_concurrent_ddl and fix types and
variables names used by it, so that they can be reused in gossiper 
test.

Fixes: #15223.