### PR TITLE
open-coredump: pass the content of "image" file not its path to dbuild

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -344,8 +344,9 @@ EOF
 fi
 
 TOP_SRCDIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
+IMAGE="${SCYLLA_REPO_PATH}/tools/toolchain/image"
 exec ${TOP_SRCDIR}/tools/toolchain/dbuild               \
-    --image ${SCYLLA_REPO_PATH}/tools/toolchain/image   \
+    --image "$(<"$IMAGE")"                              \
     -it                                                 \
     -v $(pwd):/workdir                                  \
     -v ${SCYLLA_REPO_PATH}:/src/scylla                  \


### PR DESCRIPTION
in a4eb3c6e0f15252253d98280abedc17ce5662d69, we passed the path of "image" to `dbuild`, but that was wrong. we should pass its content to this script. so in this change, it is fixed.