### PR TITLE
config: rename stream_plan_ranges_percentage to *_fraction

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -544,8 +544,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Throttles all streaming file transfer between the data centers. This setting allows throttles streaming throughput betweens data centers in addition to throttling all network stream traffic as configured with stream_throughput_outbound_megabits_per_sec.")
     , stream_io_throughput_mb_per_sec(this, "stream_io_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
         "Throttles streaming I/O to the specified total throughput (in MiBs/s) across the entire system. Streaming I/O includes the one performed by repair and both RBNO and legacy topology operations such as adding or removing a node. Setting the value to 0 disables stream throttling")
-    , stream_plan_ranges_percentage(this, "stream_plan_ranges_percentage", liveness::LiveUpdate, value_status::Used, 0.1,
-        "Specify the percentage of ranges to stream in a single stream plan. Value is between 0 and 1.")
+    , stream_plan_ranges_fraction(this, "stream_plan_ranges_fraction", liveness::LiveUpdate, value_status::Used, 0.1,
+        "Specify the fraction of ranges to stream in a single stream plan. Value is between 0 and 1.")
     , trickle_fsync(this, "trickle_fsync", value_status::Unused, false,
         "When doing sequential writing, enabling this option tells fsync to force the operating system to flush the dirty buffers at a set interval trickle_fsync_interval_in_kb. Enable this parameter to avoid sudden dirty buffer flushing from impacting read latencies. Recommended to use on SSDs, but not on HDDs.")
     , trickle_fsync_interval_in_kb(this, "trickle_fsync_interval_in_kb", value_status::Unused, 10240,

--- a/db/config.hh
+++ b/db/config.hh
@@ -227,7 +227,7 @@ public:
     named_value<uint32_t> stream_throughput_outbound_megabits_per_sec;
     named_value<uint32_t> inter_dc_stream_throughput_outbound_megabits_per_sec;
     named_value<uint32_t> stream_io_throughput_mb_per_sec;
-    named_value<double> stream_plan_ranges_percentage;
+    named_value<double> stream_plan_ranges_fraction;
     named_value<bool> trickle_fsync;
     named_value<uint32_t> trickle_fsync_interval_in_kb;
     named_value<bool> auto_bootstrap;

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -291,8 +291,8 @@ future<> range_streamer::stream_async() {
                     for (auto it = range_vec.begin(); it < range_vec.end();) {
                         ranges_to_stream.push_back(*it);
                         ++it;
-                        auto percentage = _db.local().get_config().stream_plan_ranges_percentage();
-                        size_t nr_ranges_per_stream_plan = nr_ranges_total * percentage;
+                        auto fraction = _db.local().get_config().stream_plan_ranges_fraction();
+                        size_t nr_ranges_per_stream_plan = nr_ranges_total * fraction;
                         if (ranges_to_stream.size() < nr_ranges_per_stream_plan) {
                             continue;
                         } else {


### PR DESCRIPTION
The value is specified as a fraction between 0 and 1, so don't mislead users into specifying a value between 0 and 100.