### PR TITLE
sstables: throw at seeing invalid chunk_len

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -740,6 +740,9 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
     uint32_t chunk_len = 0;
 
     co_await parse(s, v, in, c.name, c.options, chunk_len, data_len);
+    if (chunk_len == 0) {
+        throw malformed_sstable_exception("CompressionInfo is malformed: zero chunk_len");
+    }
     c.set_uncompressed_chunk_length(chunk_len);
     c.set_uncompressed_file_length(data_len);
 


### PR DESCRIPTION
before this change, when running into a zero chunk_len, scylla crashes with `assert(chunk_size != 0)`. but we can do better than printing a backtrace like:
```
scylla: sstables/compress.cc:158: void
sstables::compression::segmented_offsets::init(uint32_t): Assertion `chunk_size != 0' failed.
```
so, in this change, a `malformed_sstable_exception` is throw in place of an `assert()`, which is supposed to verify the programming invariants, not for identifying corrupted data file.

Fixes #15265