### PR TITLE
utils/lister: Limit the API of scan_dir() to fs::path

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -660,7 +660,7 @@ public:
     ///
     /// \param hints_directory A hints directory to rebalance
     /// \return A future that resolves when the operation is complete.
-    static future<> rebalance(sstring hints_directory);
+    static future<> rebalance(fs::path hints_directory);
 
 private:
     future<> compute_hints_dir_device_id();
@@ -674,7 +674,7 @@ private:
     ///
     /// \param hints_directory directory to scan
     /// \return a map: ep -> map: shard -> segments (full paths)
-    static hints_segments_map get_current_hints_segments(const sstring& hints_directory);
+    static hints_segments_map get_current_hints_segments(const fs::path& hints_directory);
 
     /// \brief Rebalance hints segments for a given (destination) end point
     ///
@@ -698,7 +698,7 @@ private:
     static void rebalance_segments_for(
             const sstring& ep,
             size_t segments_per_shard,
-            const sstring& hints_directory,
+            const fs::path& hints_directory,
             hints_ep_segments_map& ep_segments,
             std::list<fs::path>& segments_to_move);
 
@@ -713,7 +713,7 @@ private:
     ///
     /// \param hints_directory a root hints directory
     /// \param segments_map a map that was built by get_current_hints_segments()
-    static void rebalance_segments(const sstring& hints_directory, hints_segments_map& segments_map);
+    static void rebalance_segments(const fs::path& hints_directory, hints_segments_map& segments_map);
 
     /// \brief Remove sub-directories of shards that are not relevant any more (re-sharding to a lower number of shards case).
     ///
@@ -721,7 +721,7 @@ private:
     ///                           E is a number of end points for which hints where ever created.
     ///
     /// \param hints_directory a root hints directory
-    static void remove_irrelevant_shards_directories(const sstring& hints_directory);
+    static void remove_irrelevant_shards_directories(const fs::path& hints_directory);
 
     node_to_hint_store_factory_type& store_factory() noexcept {
         return _store_factory;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2687,7 +2687,7 @@ future<std::vector<database::snapshot_details_result>> database::get_snapshot_de
     std::vector<database::snapshot_details_result> details;
 
     for (auto& datadir : data_dirs) {
-        co_await lister::scan_dir(datadir, lister::dir_entry_types::of<directory_entry_type::directory>(), [&details] (fs::path parent_dir, directory_entry de) -> future<> {
+        co_await lister::scan_dir(fs::path{datadir}, lister::dir_entry_types::of<directory_entry_type::directory>(), [&details] (fs::path parent_dir, directory_entry de) -> future<> {
             // KS directory
             sstring ks_name = de.name;
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -551,7 +551,8 @@ future<> distributed_loader::init_non_system_keyspaces(distributed<replica::data
 
         parallel_for_each(cfg.data_file_directories(), [&dirs] (sstring directory) {
             // we want to collect the directories first, so we can get a full set of potential dirs
-            return lister::scan_dir(directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [&dirs] (fs::path datadir, directory_entry de) {
+            return lister::scan_dir(fs::path{directory}, lister::dir_entry_types::of<directory_entry_type::directory>(),
+                    [&dirs] (fs::path datadir, directory_entry de) {
                 if (!is_system_keyspace(de.name)) {
                     dirs.emplace(de.name, datadir.native());
                 }

--- a/utils/lister.hh
+++ b/utils/lister.hh
@@ -91,20 +91,6 @@ public:
         return scan_dir(std::move(dir), std::move(type), do_show_hidden, std::move(walker), [] (const fs::path& parent_dir, const directory_entry& entry) { return true; });
     }
 
-    /** Overloads accepting sstring as the first parameter */
-    static future<> scan_dir(sstring dir, dir_entry_types type, show_hidden do_show_hidden, walker_type walker, filter_type filter) {
-        return scan_dir(fs::path(std::move(dir)), std::move(type), do_show_hidden, std::move(walker), std::move(filter));
-    }
-    static future<> scan_dir(sstring dir, dir_entry_types type, walker_type walker, filter_type filter) {
-        return scan_dir(fs::path(std::move(dir)), std::move(type), show_hidden::no, std::move(walker), std::move(filter));
-    }
-    static future<> scan_dir(sstring dir, dir_entry_types type, walker_type walker) {
-        return scan_dir(fs::path(std::move(dir)), std::move(type), show_hidden::no, std::move(walker), [] (const fs::path& parent_dir, const directory_entry& entry) { return true; });
-    }
-    static future<> scan_dir(sstring dir, dir_entry_types type, show_hidden do_show_hidden, walker_type walker) {
-        return scan_dir(fs::path(std::move(dir)), std::move(type), do_show_hidden, std::move(walker), [] (const fs::path& parent_dir, const directory_entry& entry) { return true; });
-    }
-
     /**
      * Removes the given directory with all its contents (like 'rm -rf <dir>' shell command).
      *


### PR DESCRIPTION
Callers of lister::scan_dir() should perform the conversion to std::filesystem::path explicitly.

Continuation of #15165 