### PR TITLE
docs: autogenerate iam downloads docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ tags
 testlog
 test/*/*.reject
 .vscode
-docs/_build
-docs/poetry.lock
-docs/_data/*.yaml
 compile_commands.json
 .ccls-cache/
 .mypy_cache

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+_build
+poetry.lock
+_data

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -91,7 +91,7 @@ redirects: setup
 # Preview commands
 .PHONY: preview
 preview: setup
-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --host $(PREVIEW_HOST) --port 5500
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --host $(PREVIEW_HOST) --port 5500 --ignore '_data/*'
 
 .PHONY: multiversionpreview
 multiversionpreview: multiversion

--- a/docs/_ext/scylladb_aws_images.py
+++ b/docs/_ext/scylladb_aws_images.py
@@ -1,0 +1,217 @@
+import csv
+import os
+import re
+import requests
+
+from sphinx.application import Sphinx
+from docutils.parsers.rst import Directive, directives
+from sphinxcontrib.datatemplates.directive import DataTemplateCSV
+from sphinx.util import logging
+
+LOGGER = logging.getLogger(__name__)
+
+class AWSFileDownloader:
+    def __init__(self, base_url, session=None):
+        self.base_url = base_url
+        self.session = session or requests.Session()
+
+    def get_links(self, bucket_directory, extension):
+        url = f"{self.base_url}/?delimiter=/&prefix={bucket_directory}"
+        response = self.session.get(url)
+        response.raise_for_status()
+        return re.findall(rf"<Key>([^<]*\.{extension})</Key>", response.text)
+
+    def download_files(self, bucket_directory, download_directory, extension="csv"):
+        os.makedirs(download_directory, exist_ok=True)
+
+        links = self.get_links(bucket_directory, extension)
+        for link in links:
+            file_url = f"{self.base_url}/{link}"
+            print(f"Downloading {file_url}")
+            file_response = self.session.get(file_url)
+            file_response.raise_for_status()
+
+            with open(os.path.join(download_directory, link.split("/")[-1]), "wb") as file:
+                file.write(file_response.content)
+
+        print(f"Download complete. The {extension.upper()} files are in {download_directory}")
+
+
+class CloudFormationProcessor:
+    FILENAME_REGEX = r"^.+_(\d+\.\d+\.\d+)_(\w+)(\.yaml)?$"
+
+    def _extract_version_architecture(self, filename):
+        match = re.match(self.FILENAME_REGEX, filename)
+        if match:
+            return match.groups()[:-1]
+        return None, None
+
+    @staticmethod
+    def _append_to_csv(csv_path, link, architecture):
+        with open(csv_path, mode="r") as file:
+            data = list(csv.reader(file))
+
+        header = data[0]
+        col_name = f"Cluster_{architecture}"
+        if col_name not in header:
+            header.append(col_name)
+
+        for row in data[1:]:
+            row.append(link)
+
+        with open(csv_path, mode="w", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerows(data)
+
+    def process_files(self, download_directory, links):
+        for link in reversed(links):
+            version, architecture = self._extract_version_architecture(link)
+            if version and architecture:
+                matching_csv = next(
+                    (f for f in os.listdir(download_directory) if version in f), None
+                )
+
+                if matching_csv:
+                    csv_path = os.path.join(download_directory, matching_csv)
+                    self._append_to_csv(csv_path, link, architecture)
+        print("Appended cloudformation information to AWS images CSVs.")
+
+
+class AMIInformationDownloader:
+
+    def run(self, app, exception=None):  
+        config = app.config
+        base_url = config.scylladb_aws_images_base_url
+        ami_bucket_directory = config.scylladb_aws_images_ami_bucket_directory
+        ami_download_directory = os.path.join(app.builder.srcdir, config.scylladb_aws_images_ami_download_directory)
+        cloudformation_bucket_directory = config.scylladb_aws_images_cloudformation_bucket_directory
+
+        if os.path.exists(ami_download_directory) and os.listdir(ami_download_directory):
+            print(f"Files already exist in {ami_download_directory}. Skipping download.")
+            return
+
+        downloader = AWSFileDownloader(base_url)
+        downloader.download_files(ami_bucket_directory, ami_download_directory)
+
+        processor = CloudFormationProcessor()
+        links = downloader.get_links(cloudformation_bucket_directory, "yaml")
+        processor.process_files(ami_download_directory, links)
+
+
+class AMITemplateDirective(DataTemplateCSV):
+    option_spec = DataTemplateCSV.option_spec.copy()
+    option_spec["version"] = lambda x: x
+
+    def _make_context(self, data, config, env):
+        context = super()._make_context(data, config, env)
+        context["version"] = self.options.get("version")
+        return context
+
+    def run(self):
+        return super().run()
+
+
+class AMIVersionsTemplateDirective(Directive):
+    FILENAME_REGEX = re.compile(r"ami_ids_(\d+(?:\.\d+)?(?:\.\d+)?)(?:.*?)\.csv")
+
+    has_content = True
+    option_spec = {
+        "version": directives.unchanged,
+        "exclude": directives.unchanged,
+    }
+
+    def _extract_version_from_filename(self, filename):
+        match = self.FILENAME_REGEX.search(filename)
+        return match.group(1) if match else None
+
+    def _matches_version(self, filename, version):
+        if not version:
+            return True
+
+        file_version = self._extract_version_from_filename(filename)
+        if not file_version:
+            return False
+
+        if "." in version:
+            return file_version.startswith(version)
+
+        return file_version.split(".")[0] == version
+
+    def _excluded(self, filename, patterns):
+        return any(pattern in filename for pattern in patterns if pattern)
+
+    def _version_key(self, filename):
+        version = self._extract_version_from_filename(filename)
+        return tuple(map(int, version.split("."))) if version else (0,)
+
+
+    def run(self):
+        app = self.state.document.settings.env.app
+        version_pattern = self.options.get("version", "")
+        exclude_patterns = self.options.get("exclude", "").split(",")
+
+        download_directory = os.path.join(
+            app.builder.srcdir, app.config.scylladb_aws_images_ami_download_directory
+        )
+        docname = self.state.document.settings.env.docname
+        current_rst_path = os.path.join(app.builder.srcdir, docname + ".rst")
+        current_rst_dir = os.path.dirname(current_rst_path)
+        relative_path_from_current_rst = os.path.relpath(
+            download_directory, current_rst_dir
+        )
+
+        files = sorted([
+            file for file in os.listdir(download_directory) if file.endswith('.csv') and 
+            self._matches_version(file, version_pattern) and not self._excluded(file, exclude_patterns)
+        ], key=self._version_key, reverse=True)
+
+        if len(files) == 0:
+            LOGGER.warning(
+                f"No files match in directory '{download_directory}' with version pattern '{version_pattern}'."
+            )
+
+        output = []
+        for file in files:
+            data_directive = AMITemplateDirective(
+                name=self.name,
+                arguments=[os.path.join(relative_path_from_current_rst, file)],
+                options=self.options,
+                content=self.content,
+                lineno=self.lineno,
+                content_offset=self.content_offset,
+                block_text=self.block_text,
+                state=self.state,
+                state_machine=self.state_machine,
+            )
+            data_directive.options["template"] = "aws_image.tmpl"
+            data_directive.options["version"] = self._extract_version_from_filename(
+                file
+            )
+            output.extend(data_directive.run())
+        return output
+
+
+def setup(app: Sphinx):
+    app.add_config_value(
+        "scylladb_aws_images_base_url",
+        default="https://s3.amazonaws.com/downloads.scylladb.com",
+        rebuild="html",
+    )
+    app.add_config_value(
+        "scylladb_aws_images_ami_bucket_directory",
+        default="downloads/scylla/aws/ami/",
+        rebuild="html",
+    )
+    app.add_config_value(
+        "scylladb_aws_images_ami_download_directory",
+        default="_data/opensource/aws/ami",
+        rebuild="html",
+    )
+    app.add_config_value(
+        "scylladb_aws_images_cloudformation_bucket_directory",
+        default="downloads/scylla/aws/cloudformation/",
+        rebuild="html",
+    )
+    app.connect("builder-inited",  AMIInformationDownloader().run)
+
+    app.add_directive("scylladb_aws_images_template", AMIVersionsTemplateDirective)

--- a/docs/_templates/aws_image.tmpl
+++ b/docs/_templates/aws_image.tmpl
@@ -1,0 +1,20 @@
+.. -*- mode: rst -*-
+
+{{version}}
+{{ '-' * version|length }}
+
+.. list-table::
+   :header-rows: 1
+
+   * - Region
+     - x86 AMI ID
+     - Launch x86
+     - ARM AMI ID
+     - Launch ARM
+{% for row in data[1:] %}
+   * - {{ row[0] }}
+     - {{ row[2] }}
+     - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[2] }}>`__ {% if row|length > 4 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[4] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[2] }}>`__{% endif %}
+     - {{ row[3] }}
+     - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[3] }}>`__ {% if row|length > 5 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[5] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[3] }}>`__{% endif %}
+{% endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "recommonmark",  # optional
     "sphinxcontrib.datatemplates",
     "scylladb_cc_properties",
+    "scylladb_aws_images"
 ]
 
 # The suffix(es) of source filenames.
@@ -54,7 +55,7 @@ author = u"ScyllaDB Project Contributors"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'lib', 'lib64','**/_common/*', 'README.md', 'index.md', '.git', '.github', '_utils', 'rst_include', 'venv', 'dev']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'lib', 'lib64','**/_common/*', 'README.md', 'index.md', '.git', '.github', '_utils', 'rst_include', 'venv', 'dev', '_data/**']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
@@ -141,6 +142,13 @@ html_baseurl = BASE_URL
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {"html_baseurl": html_baseurl}
+
+# -- Options for scylladb_aws_images -----------------------------
+
+scylladb_aws_images_base_url = "https://s3.amazonaws.com/downloads.scylladb.com"
+scylladb_aws_images_ami_bucket_directory = "downloads/scylla/aws/ami/"
+scylladb_aws_images_ami_download_directory = "_data/opensource/aws/ami"
+scylladb_aws_images_cloudformation_bucket_directory = "downloads/scylla/aws/cloudformation/"
 
 # -- Initialize Sphinx ----------------------------------------------
 def setup(sphinx):

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["ScyllaDB Contributors"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyyaml = "6.0"
+pyyaml = "6.0.1"
 pygments = "2.15.1"
 recommonmark = "0.7.1"
 sphinx-scylladb-theme = "~1.5.1"

--- a/docs/reference/aws-images.rst
+++ b/docs/reference/aws-images.rst
@@ -1,0 +1,7 @@
+==========
+AWS images
+==========
+
+.. scylladb_aws_images_template::
+   :version: 5.2
+   :exclude: rc,dev


### PR DESCRIPTION
## Motivation

We are moving the image information from the [website](https://www.scylladb.com/download/?platform=aws#open-source) to the documentation. The goal is to improve user experience and facilitate maintenance.

## Requirements

* Retrieve the information from https://downloads.scylladb.com/downloads/scylla/aws/ami/.
* The docs with the new image documentation will be published by sending a PR that contains the updated files. In this way, we'll keep track of the updates.
* The image info will be documented per release.

## How it works

The command `make awsimagesdownload` downloads the image information directly from the S3 bucket in CSV format. It stores this information under the directory `docs/_data/opensource/aws/ami`.

The custom directive `scylladb_aws_images_template` renders the information from the CSVs in a table format.

For example:

```
.. scylladb_aws_images_template:
   :version: 5
```

Renders a table with  5.x.x images information.

Additionally, this directive also allows you to define more specific releases. For example:

```
.. scylladb_aws_images_template:
   :version: 5.2
   :exclude: rc,dev
```

Renders a table with all 5.2.x images and excludes the ones tagged as RC or dev.