### PR TITLE
system_keyspace: remove flushes when writing to system tables

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -467,7 +467,7 @@ static future<json::json_return_type> describe_ring_as_json(sharded<service::sto
 
 void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<db::system_keyspace>& sys_ks) {
     ss::local_hostid.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto id = ctx.db.local().get_config().host_id;
+        auto id = ctx.db.local().get_token_metadata().get_my_id();
         return make_ready_future<json::json_return_type>(id.to_sstring());
     });
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -460,7 +460,6 @@ public:
 
     const db::extensions& extensions() const;
 
-    locator::host_id host_id;
     utils::updateable_value<std::unordered_map<sstring, s3::endpoint_config>> object_storage_config;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -88,15 +88,9 @@ static logging::logger diff_logger("schema_diff");
 /** system.schema_* tables used to store keyspace/table/type attributes prior to C* 3.0 */
 namespace db {
 namespace {
-    const auto set_null_sharder = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
-        if (ks_name == schema_tables::NAME) {
-            props.use_null_sharder = true;
-        }
-    });
     const auto set_use_schema_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
         if (ks_name == schema_tables::NAME) {
-            props.use_schema_commitlog = true;
-            props.load_phase = system_table_load_phase::phase2;
+            props.enable_schema_commitlog();
         }
     });
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -209,7 +209,7 @@ using namespace v3;
 
 using days = std::chrono::duration<int, std::ratio<24 * 3600>>;
 
-future<> save_system_schema(cql3::query_processor& qp, const sstring & ksname) {
+static future<> save_system_schema_to_keyspace(cql3::query_processor& qp, const sstring & ksname) {
     auto ks = qp.db().find_keyspace(ksname);
     auto ksm = ks.metadata();
 
@@ -225,9 +225,10 @@ future<> save_system_schema(cql3::query_processor& qp, const sstring & ksname) {
     }
 }
 
-/** add entries to system_schema.* for the hardcoded system definitions */
-future<> save_system_keyspace_schema(cql3::query_processor& qp) {
-    return save_system_schema(qp, NAME);
+future<> save_system_schema(cql3::query_processor& qp) {
+    co_await save_system_schema_to_keyspace(qp, schema_tables::NAME);
+    // #2514 - make sure "system" is written to system_schema.keyspaces.
+    co_await save_system_schema_to_keyspace(qp, system_keyspace::NAME);
 }
 
 namespace v3 {

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -176,11 +176,9 @@ std::vector<schema_ptr> all_tables(schema_features);
 // Like all_tables(), but returns schema::cf_name() of each table.
 std::vector<sstring> all_table_names(schema_features);
 
-// saves/creates "ks" + all tables etc, while first deleting all old schema entries (will be rewritten)
-future<> save_system_schema(cql3::query_processor& qp, const sstring & ks);
-
-// saves/creates "system_schema" keyspace
-future<> save_system_keyspace_schema(cql3::query_processor& qp);
+// saves/creates all the system objects in the appropriate keyspaces;
+// deletes them first, so they will be effectively overwritten.
+future<> save_system_schema(cql3::query_processor& qp);
 
 future<table_schema_version> calculate_schema_digest(distributed<service::storage_proxy>& proxy, schema_features, noncopyable_function<bool(std::string_view)> accept_keyspace);
 // Calculates schema digest for all non-system keyspaces

--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -53,8 +53,11 @@ future<> sstables_format_selector::maybe_select_format(sstables::sstable_version
 future<> sstables_format_selector::start() {
     assert(this_shard_id() == 0);
     co_await read_sstables_format();
-    _features.local().me_sstable.when_enabled(_me_feature_listener);
-    _features.local().md_sstable.when_enabled(_md_feature_listener);
+    // The listener may fire immediately, create a thread for that case.
+    co_await seastar::async([this] {
+        _features.local().me_sstable.when_enabled(_me_feature_listener);
+        _features.local().md_sstable.when_enabled(_md_feature_listener);
+    });
 }
 
 future<> sstables_format_selector::stop() {

--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -50,7 +50,7 @@ future<> sstables_format_selector::update_format(sstables::sstable_version_types
     if (!_sys_ks) {
         on_internal_error(logger, format("system keyspace is not loaded"));
     }
-    co_await _sys_ks->set_scylla_local_param(SSTABLE_FORMAT_PARAM_NAME, fmt::to_string(new_format));
+    co_await _sys_ks->set_scylla_local_param(SSTABLE_FORMAT_PARAM_NAME, fmt::to_string(new_format), true);
     co_await select_format(new_format);
 }
 

--- a/db/sstables-format-selector.hh
+++ b/db/sstables-format-selector.hh
@@ -30,37 +30,48 @@ class feature_service;
 namespace db {
 
 class system_keyspace;
-class sstables_format_selector;
+class sstables_format_listener;
 
 class feature_enabled_listener : public gms::feature::listener {
-    sstables_format_selector& _selector;
+    sstables_format_listener& _listener;
     sstables::sstable_version_types _format;
 
 public:
-    feature_enabled_listener(sstables_format_selector& s, sstables::sstable_version_types format)
-        : _selector(s)
+    feature_enabled_listener(sstables_format_listener& l, sstables::sstable_version_types format)
+        : _listener(l)
         , _format(format)
     { }
     void on_enabled() override;
 };
 
 class sstables_format_selector {
+    sharded<replica::database>& _db;
+    db::system_keyspace* _sys_ks = nullptr;
+    sstables::sstable_version_types _selected_format = sstables::sstable_version_types::mc;
+    future<> select_format(sstables::sstable_version_types new_format);
+    future<> read_sstables_format();
+public:
+    explicit sstables_format_selector(sharded<replica::database>& db);
+
+    future<> on_system_tables_loaded(db::system_keyspace& sys_ks);
+
+    inline sstables::sstable_version_types selected_format() const noexcept {
+        return _selected_format;
+    }
+    future<> update_format(sstables::sstable_version_types new_format);
+};
+
+class sstables_format_listener {
     gms::gossiper& _gossiper;
     sharded<gms::feature_service>& _features;
-    sharded<replica::database>& _db;
-    db::system_keyspace& _sys_ks;
+    sstables_format_selector& _selector;
     seastar::named_semaphore _sem = {1, named_semaphore_exception_factory{"feature listeners"}};
     seastar::gate _sel;
 
     feature_enabled_listener _md_feature_listener;
     feature_enabled_listener _me_feature_listener;
-
-    sstables::sstable_version_types _selected_format = sstables::sstable_version_types::mc;
-    future<> select_format(sstables::sstable_version_types new_format);
-    future<> read_sstables_format();
-
 public:
-    sstables_format_selector(gms::gossiper& g, sharded<gms::feature_service>& f, sharded<replica::database>& db, db::system_keyspace& sys_ks);
+    sstables_format_listener(gms::gossiper& g, sharded<gms::feature_service>& f, sstables_format_selector& selector);
 
     future<> start();
     future<> stop();

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -375,7 +375,7 @@ future<std::unordered_map<locator::host_id, sstring>> system_distributed_keyspac
 }
 
 future<> system_distributed_keyspace::start_view_build(sstring ks_name, sstring view_name) const {
-    auto host_id = _sp.local_db().get_config().host_id;
+    auto host_id = _sp.local_db().get_token_metadata().get_my_id();
     return _qp.execute_internal(
             format("INSERT INTO {}.{} (keyspace_name, view_name, host_id, status) VALUES (?, ?, ?, ?)", NAME, VIEW_BUILD_STATUS),
             db::consistency_level::ONE,
@@ -385,7 +385,7 @@ future<> system_distributed_keyspace::start_view_build(sstring ks_name, sstring 
 }
 
 future<> system_distributed_keyspace::finish_view_build(sstring ks_name, sstring view_name) const {
-    auto host_id = _sp.local_db().get_config().host_id;
+    auto host_id = _sp.local_db().get_token_metadata().get_my_id();
     return _qp.execute_internal(
             format("UPDATE {}.{} SET status = ? WHERE keyspace_name = ? AND view_name = ? AND host_id = ?", NAME, VIEW_BUILD_STATUS),
             db::consistency_level::ONE,

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -72,14 +72,9 @@ namespace {
         static const std::unordered_set<sstring> extra_durable_tables = {
             system_keyspace::PAXOS,
             system_keyspace::SCYLLA_LOCAL,
-            system_keyspace::RAFT,
-            system_keyspace::RAFT_SNAPSHOTS,
-            system_keyspace::RAFT_SNAPSHOT_CONFIG,
-            system_keyspace::DISCOVERY,
             system_keyspace::BROADCAST_KV_STORE,
             system_keyspace::TOPOLOGY,
             system_keyspace::CDC_GENERATIONS_V3,
-            system_keyspace::TABLETS,
         };
         if (ks_name == system_keyspace::NAME && extra_durable_tables.contains(cf_name)) {
             props.wait_for_sync_to_commitlog = true;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -52,7 +52,7 @@ namespace db {
 namespace {
     const auto set_null_sharder = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
         // tables in the "system" keyspace which need to use null sharder
-        static const std::unordered_set<sstring> system_ks_null_shard_tables = {
+        static const std::unordered_set<sstring> tables = {
             schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY,
             system_keyspace::RAFT,
             system_keyspace::RAFT_SNAPSHOTS,
@@ -64,24 +64,24 @@ namespace {
             system_keyspace::CDC_GENERATIONS_V3,
             system_keyspace::TABLETS,
         };
-        if (ks_name == system_keyspace::NAME && system_ks_null_shard_tables.contains(cf_name)) {
+        if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.use_null_sharder = true;
         }
     });
     const auto set_wait_for_sync_to_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
-        static const std::unordered_set<sstring> extra_durable_tables = {
+        static const std::unordered_set<sstring> tables = {
             system_keyspace::PAXOS,
             system_keyspace::SCYLLA_LOCAL,
             system_keyspace::BROADCAST_KV_STORE,
             system_keyspace::TOPOLOGY,
             system_keyspace::CDC_GENERATIONS_V3,
         };
-        if (ks_name == system_keyspace::NAME && extra_durable_tables.contains(cf_name)) {
+        if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.wait_for_sync_to_commitlog = true;
         }
     });
     const auto set_use_schema_commitlog = schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
-        static const std::unordered_set<sstring> raft_tables = {
+        static const std::unordered_set<sstring> tables = {
             system_keyspace::RAFT,
             system_keyspace::RAFT_SNAPSHOTS,
             system_keyspace::RAFT_SNAPSHOT_CONFIG,
@@ -89,7 +89,7 @@ namespace {
             system_keyspace::DISCOVERY,
             system_keyspace::TABLETS,
         };
-        if (ks_name == system_keyspace::NAME && raft_tables.contains(cf_name)) {
+        if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.use_schema_commitlog = true;
             props.load_phase = system_table_load_phase::phase2;
         }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1928,7 +1928,7 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
 
 future<> system_keyspace::make(
         locator::effective_replication_map_factory& erm_factory,
-        replica::database& db, db::config& cfg, system_table_load_phase phase) {
+        replica::database& db, system_table_load_phase phase) {
     for (auto&& table : system_keyspace::all_tables(db.get_config())) {
         if (table->static_props().load_phase != phase) {
             continue;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -44,7 +44,6 @@
 #include "cdc/generation.hh"
 #include "replica/tablets.hh"
 #include "replica/query.hh"
-#include "db/virtual_tables.hh"
 
 using days = std::chrono::duration<int, std::ratio<24 * 3600>>;
 
@@ -1936,20 +1935,6 @@ future<> system_keyspace::make(
 
         co_await db.create_local_system_table(table, maybe_write_in_user_memory(table), erm_factory);
     }
-}
-
-future<> system_keyspace::initialize_virtual_tables(
-        distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
-        sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr,
-        db::config& cfg) {
-    register_virtual_tables(dist_db, dist_ss, dist_gossiper, dist_raft_gr, cfg);
-
-    auto& db = dist_db.local();
-    for (auto&& table: all_virtual_tables()) {
-        co_await db.create_local_system_table(table, false, dist_ss.local().get_erm_factory());
-    }
-
-    install_virtual_readers(*this, db);
 }
 
 future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -82,6 +82,7 @@ namespace {
             system_keyspace::DISCOVERY,
             system_keyspace::TABLETS,
             system_keyspace::LOCAL,
+            system_keyspace::PEERS,
         };
         if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.enable_schema_commitlog();
@@ -1575,7 +1576,6 @@ future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unorder
     slogger.debug("INSERT INTO system.{} (peer, tokens) VALUES ({}, {})", PEERS, ep, tokens);
     auto set_type = set_type_impl::get_instance(utf8_type, true);
     co_await execute_cql(req, ep.addr(), make_set_value(set_type, prepare_tokens(tokens))).discard_result();
-    co_await force_blocking_flush(PEERS);
 }
 
 
@@ -1722,7 +1722,6 @@ future<> system_keyspace::remove_endpoint(gms::inet_address ep) {
     sstring req = format("DELETE FROM system.{} WHERE peer = ?", PEERS);
     slogger.debug("DELETE FROM system.{} WHERE peer = {}", PEERS, ep);
     co_await execute_cql(req, ep.addr()).discard_result();
-    co_await force_blocking_flush(PEERS);
 }
 
 future<> system_keyspace::update_tokens(const std::unordered_set<dht::token>& tokens) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -54,15 +54,9 @@ namespace {
         // tables in the "system" keyspace which need to use null sharder
         static const std::unordered_set<sstring> tables = {
             schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY,
-            system_keyspace::RAFT,
-            system_keyspace::RAFT_SNAPSHOTS,
-            system_keyspace::RAFT_SNAPSHOT_CONFIG,
-            system_keyspace::GROUP0_HISTORY,
-            system_keyspace::DISCOVERY,
             system_keyspace::BROADCAST_KV_STORE,
             system_keyspace::TOPOLOGY,
             system_keyspace::CDC_GENERATIONS_V3,
-            system_keyspace::TABLETS,
         };
         if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.use_null_sharder = true;
@@ -90,8 +84,7 @@ namespace {
             system_keyspace::TABLETS,
         };
         if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
-            props.use_schema_commitlog = true;
-            props.load_phase = system_table_load_phase::phase2;
+            props.enable_schema_commitlog();
         }
     });
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -82,7 +82,8 @@ namespace {
             system_keyspace::TABLETS,
             system_keyspace::LOCAL,
             system_keyspace::PEERS,
-            system_keyspace::SCYLLA_LOCAL
+            system_keyspace::SCYLLA_LOCAL,
+            system_keyspace::v3::CDC_LOCAL
         };
         if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.enable_schema_commitlog();
@@ -1775,8 +1776,6 @@ future<> system_keyspace::update_cdc_generation_id(cdc::generation_id gen_id) {
                 sstring(v3::CDC_LOCAL), id.ts, id.id);
     }
     ), gen_id);
-
-    co_await force_blocking_flush(v3::CDC_LOCAL);
 }
 
 future<std::optional<cdc::generation_id>> system_keyspace::get_cdc_generation_id() {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1442,9 +1442,7 @@ future<> system_keyspace::setup(sharded<netw::messaging_service>& ms) {
     assert(this_shard_id() == 0);
 
     co_await build_bootstrap_info();
-    co_await db::schema_tables::save_system_keyspace_schema(_qp);
-    // #2514 - make sure "system" is written to system_schema.keyspaces.
-    co_await db::schema_tables::save_system_schema(_qp, NAME);
+    co_await db::schema_tables::save_system_schema(_qp);
     co_await cache_truncation_record();
 }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -282,8 +282,9 @@ public:
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
     future<> make(
             locator::effective_replication_map_factory&,
-            replica::database&,
-            system_table_load_phase phase);
+            replica::database&);
+
+    void mark_writable();
 
 
     /// overloads

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -126,8 +126,6 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     static schema_ptr large_cells();
     static schema_ptr scylla_local();
     future<> force_blocking_flush(sstring cfname);
-    future<> build_bootstrap_info();
-    future<> cache_truncation_record();
     template <typename Value>
     future<> update_cached_values(gms::inet_address ep, sstring column_name, Value value);
 public:
@@ -249,7 +247,8 @@ public:
 
     static table_schema_version generate_schema_version(table_id table_id, uint16_t offset = 0);
 
-    future<> setup(sharded<netw::messaging_service>& ms);
+    future<> build_bootstrap_info();
+    future<> cache_truncation_record();
     future<> update_schema_version(table_schema_version version);
 
     /*

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -284,7 +284,6 @@ public:
     future<> make(
             locator::effective_replication_map_factory&,
             replica::database&,
-            db::config&,
             system_table_load_phase phase);
 
     future<> initialize_virtual_tables(

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -286,13 +286,6 @@ public:
             replica::database&,
             system_table_load_phase phase);
 
-    future<> initialize_virtual_tables(
-                         distributed<replica::database>&,
-                         distributed<service::storage_service>&,
-                         sharded<gms::gossiper>&,
-                         sharded<service::raft_group_registry>&,
-                         db::config&);
-
 
     /// overloads
 

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -1028,6 +1028,7 @@ future<> initialize_virtual_tables(
     auto& db = dist_db.local();
     for (auto&& [id, vt] : virtual_tables) {
         co_await db.create_local_system_table(vt->schema(), false, dist_ss.local().get_erm_factory());
+        db.find_column_family(vt->schema()).mark_ready_for_writes(nullptr);
     }
 
     install_virtual_readers_and_writers(sys_ks.local(), db);

--- a/db/virtual_tables.hh
+++ b/db/virtual_tables.hh
@@ -30,9 +30,12 @@ namespace db {
 class config;
 class system_keyspace;
 
-void register_virtual_tables(distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
-        sharded<gms::gossiper>& dist_gossiper, sharded<service::raft_group_registry>& dist_raft_gr, db::config& cfg);
-void install_virtual_readers(db::system_keyspace& sys_ks, replica::database& db);
-std::vector<schema_ptr> all_virtual_tables();
+future<> initialize_virtual_tables(
+    distributed<replica::database>&,
+    distributed<service::storage_service>&,
+    sharded<gms::gossiper>&,
+    sharded<service::raft_group_registry>&,
+    sharded<db::system_keyspace>& sys_ks,
+    db::config&);
 
 } // namespace db

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -247,12 +247,16 @@ future<> feature_service::enable_features_on_join(gossiper& g, db::system_keyspa
     return enabler->enable_features();
 }
 
-future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks, bool use_raft_cluster_features) {
+future<> feature_service::on_system_tables_loaded(db::system_keyspace& sys_ks) {
+    return enable_features_on_startup(sys_ks);
+}
+
+future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks) {
     std::set<sstring> features_to_enable;
     std::set<sstring> persisted_features;
     std::set<sstring> persisted_unsafe_to_disable_features;
 
-    if (!use_raft_cluster_features) {
+    if (!_config.use_raft_cluster_features) {
         persisted_features = co_await sys_ks.load_local_enabled_features();
     } else {
         auto topo_features = co_await sys_ks.load_topology_features_state();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -339,7 +339,7 @@ future<> persistent_feature_enabler::enable_features() {
             feats_set.emplace(f.name());
         }
     }
-    co_await _sys_ks.save_local_enabled_features(std::move(feats_set));
+    co_await _sys_ks.save_local_enabled_features(std::move(feats_set), true);
 
     co_await _feat.container().invoke_on_all([&features] (feature_service& fs) -> future<> {
         std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -33,6 +33,7 @@ class gossiper;
 class feature_service;
 
 struct feature_config {
+    bool use_raft_cluster_features = false;
 private:
     std::set<sstring> _disabled_features;
     feature_config();
@@ -66,6 +67,8 @@ class feature_service final : public peering_sharded_service<feature_service> {
     std::unordered_map<sstring, std::reference_wrapper<feature>> _registered_features;
 
     feature_config _config;
+
+    future<> enable_features_on_startup(db::system_keyspace&);
 public:
     explicit feature_service(feature_config cfg);
     ~feature_service() = default;
@@ -138,8 +141,8 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
-    future<> enable_features_on_startup(db::system_keyspace&, bool use_raft_cluster_features);
     future<> enable_features_on_join(gossiper&, db::system_keyspace&);
+    future<> on_system_tables_loaded(db::system_keyspace& sys_ks);
 
     // Performs the feature check.
     // Throws an unsupported_feature_exception if there is a feature either

--- a/main.cc
+++ b/main.cc
@@ -1121,7 +1121,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // done only by shard 0, so we'll no longer face race conditions as
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase1).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, system_table_load_phase::phase1).get();
 
             const auto listen_address = utils::resolve(cfg->listen_address, family).get0();
             const auto host_id = initialize_local_info_thread(sys_ks, snitch, listen_address, *cfg);
@@ -1345,7 +1345,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // because table construction consults enabled features.
             // Needs to be before system_keyspace::setup(), which writes to schema tables.
             supervisor::notify("loading system_schema sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, *cfg, system_table_load_phase::phase2).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db, system_table_load_phase::phase2).get();
 
             if (raft_gr.local().is_enabled()) {
                 if (!db.local().uses_schema_commitlog()) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1576,7 +1576,7 @@ public:
             schema_ptr table, bool write_in_user_memory, locator::effective_replication_map_factory&);
 
     void maybe_init_schema_commitlog();
-    future<> add_column_family_and_make_directory(schema_ptr schema);
+    future<> add_column_family_and_make_directory(schema_ptr schema, bool readonly);
 
     /* throws no_such_column_family if missing */
     table_id find_uuid(std::string_view ks, std::string_view cf) const;
@@ -1744,7 +1744,7 @@ public:
 public:
     bool update_column_family(schema_ptr s);
 private:
-    future<> add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg);
+    future<> add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, bool readonly);
     future<> detach_column_family(table& cf);
 
     struct table_truncate_state;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1414,7 +1414,7 @@ private:
     bool _enable_incremental_backups = false;
     bool _shutdown = false;
     bool _enable_autocompaction_toggle = false;
-    bool _uses_schema_commitlog = false;
+    std::optional<bool> _uses_schema_commitlog;
     query::querier_cache _querier_cache;
 
     std::unique_ptr<db::large_data_handler> _large_data_handler;
@@ -1801,9 +1801,7 @@ public:
         return _sst_dir_semaphore;
     }
 
-    bool uses_schema_commitlog() const {
-        return _uses_schema_commitlog;
-    }
+    bool uses_schema_commitlog() const;
 
     bool is_user_semaphore(const reader_concurrency_semaphore& semaphore) const;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -394,7 +394,6 @@ public:
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
     };
-    struct no_commitlog {};
 
     struct snapshot_details {
         int64_t total;
@@ -445,6 +444,12 @@ private:
 
     // Provided by the database that owns this commitlog
     db::commitlog* _commitlog;
+    // The table is constructed in readonly mode - this flag is true after the constructor finishes.
+    // This allows to read the table on the early stages of the node boot process,
+    // when the commitlog is not yet initialized.
+    // The flag is set to false in mark_ready_for_writes function, which
+    // is called when the commitlog is created and the table is ready to accept writes.
+    bool _readonly;
     bool _durable_writes;
     sstables::sstables_manager& _sstables_manager;
     secondary_index::secondary_index_manager _index_manager;
@@ -655,13 +660,7 @@ public:
     // to a db in memory only, and if anybody is about to write to a CF, that was most
     // likely already called. We need to call this explicitly when we are sure we're ready
     // to issue disk operations safely.
-    void mark_ready_for_writes() {
-        update_sstables_known_generation(sstables::generation_from_value(0));
-    }
-
-    bool is_ready_for_writes() const {
-        return _sstable_generation_generator.has_value();
-    }
+    void mark_ready_for_writes(db::commitlog* cl);
 
     // Creates a mutation reader which covers all data sources for this column family.
     // Caller needs to ensure that column_family remains live (FIXME: relax this).
@@ -777,18 +776,14 @@ public:
     future<std::vector<locked_cell>> lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout);
 
     logalloc::occupancy_stats occupancy() const;
-private:
-    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options>, db::commitlog* cl, compaction_manager&, sstables::sstables_manager&, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm);
 public:
-    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options> sopts, db::commitlog& cl, compaction_manager& cm, sstables::sstables_manager& sm, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm)
-        : table(schema, std::move(cfg), std::move(sopts), &cl, cm, sm, cl_stats, row_cache_tracker, std::move(erm)) {}
-    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options> sopts, no_commitlog, compaction_manager& cm, sstables::sstables_manager& sm, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm)
-        : table(schema, std::move(cfg), std::move(sopts), nullptr, cm, sm, cl_stats, row_cache_tracker, std::move(erm)) {}
+    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options> sopts, compaction_manager& cm, sstables::sstables_manager& sm, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm);
+
     table(column_family&&) = delete; // 'this' is being captured during construction
     ~table();
     const schema_ptr& schema() const { return _schema; }
     void set_schema(schema_ptr);
-    db::commitlog* commitlog() { return _commitlog; }
+    db::commitlog* commitlog() const;
     const locator::effective_replication_map_ptr& get_effective_replication_map() const { return _erm; }
     void update_effective_replication_map(locator::effective_replication_map_ptr);
     [[gnu::always_inline]] bool uses_tablets() const;
@@ -1450,6 +1445,7 @@ private:
 
 public:
     data_dictionary::database as_data_dictionary() const;
+    db::commitlog* commitlog_for(const schema_ptr& schema);
     std::shared_ptr<data_dictionary::user_types_storage> as_user_types_storage() const noexcept;
     const data_dictionary::user_types_storage& user_types() const noexcept;
     future<> init_commitlog();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -334,9 +334,13 @@ public:
         co_await populate_subdir(sstables::sstable_state::quarantine, allow_offstrategy_compaction::no, must_exist::no);
         co_await populate_subdir(sstables::sstable_state::normal, allow_offstrategy_compaction::yes);
 
-        co_await smp::invoke_on_all([this] {
-            _global_table->mark_ready_for_writes();
-        });
+        // system tables are made writable through sys_ks::mark_writable
+        if (!is_system_keyspace(_ks)) {
+            co_await smp::invoke_on_all([this] {
+                auto s = _global_table->schema();
+                _db.local().find_column_family(s).mark_ready_for_writes(_db.local().commitlog_for(s));
+            });
+        }
     }
 
     future<> stop() {
@@ -475,15 +479,6 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         auto uuid = s->id();
         lw_shared_ptr<replica::column_family> cf = tables_metadata.get_table(uuid).shared_from_this();
 
-        // System tables (from system and system_schema keyspaces) are loaded in two phases.
-        // The populate_keyspace function can be called in the second phase for tables that
-        // were already populated in the first phase.
-        // This check protects from double-populating them, since every populated cf
-        // is marked as ready_for_writes.
-        if (cf->is_ready_for_writes()) {
-            co_return;
-        }
-
         sstring cfname = cf->schema()->cf_name();
         dblog.info("Keyspace {}: Reading CF {} id={} version={} storage={}", ks_name, cfname, uuid, s->version(), cf->get_storage_options().type_string());
 
@@ -518,20 +513,18 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     });
 }
 
-future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<locator::effective_replication_map_factory>& erm_factory, distributed<replica::database>& db, system_table_load_phase phase) {
+future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<locator::effective_replication_map_factory>& erm_factory, distributed<replica::database>& db) {
     population_started = true;
 
-    return seastar::async([&sys_ks, &erm_factory, &db, phase] {
-        sys_ks.invoke_on_all([&erm_factory, &db, phase] (auto& sys_ks) {
-            return sys_ks.make(erm_factory.local(), db.local(), phase);
+    return seastar::async([&sys_ks, &erm_factory, &db] {
+        sys_ks.invoke_on_all([&erm_factory, &db] (auto& sys_ks) {
+            return sys_ks.make(erm_factory.local(), db.local());
         }).get();
 
         const auto& cfg = db.local().get_config();
         for (auto& data_dir : cfg.data_file_directories()) {
             for (auto ksname : system_keyspaces) {
-                if (db.local().has_keyspace(ksname)) {
-                    distributed_loader::populate_keyspace(db, data_dir, sstring(ksname)).get();
-                }
+                distributed_loader::populate_keyspace(db, data_dir, sstring(ksname)).get();
             }
         }
     });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -518,12 +518,12 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     });
 }
 
-future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<locator::effective_replication_map_factory>& erm_factory, distributed<replica::database>& db, db::config& cfg, system_table_load_phase phase) {
+future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<locator::effective_replication_map_factory>& erm_factory, distributed<replica::database>& db, system_table_load_phase phase) {
     population_started = true;
 
-    return seastar::async([&sys_ks, &erm_factory, &db, &cfg, phase] {
-        sys_ks.invoke_on_all([&erm_factory, &db, &cfg, phase] (auto& sys_ks) {
-            return sys_ks.make(erm_factory.local(), db.local(), cfg, phase);
+    return seastar::async([&sys_ks, &erm_factory, &db, phase] {
+        sys_ks.invoke_on_all([&erm_factory, &db, phase] (auto& sys_ks) {
+            return sys_ks.make(erm_factory.local(), db.local(), phase);
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -76,7 +76,7 @@ class distributed_loader {
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&, db::config& cfg, system_table_load_phase phase);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&, system_table_load_phase phase);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -76,7 +76,7 @@ class distributed_loader {
     static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&, system_table_load_phase phase);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1312,6 +1312,23 @@ schema_ptr schema_builder::build() {
     for (const auto& c: static_configurators()) {
         c(new_raw._ks_name, new_raw._cf_name, static_props);
     }
+    if (static_props.use_schema_commitlog) {
+        if (!static_props.use_null_sharder) {
+            on_internal_error(dblog,
+                format("{}.{} uses schema commitlog, but not null sharder, "
+                       "schema commitlog works only on shard 0", ks_name(), cf_name()));
+        }
+        if (static_props.load_phase == system_table_load_phase::phase1) {
+            on_internal_error(dblog,
+                format("{}.{} uses schema commitlog, but it is loaded on phase1, "
+                       "tables using schema commitlog must be loaded on phase2", ks_name(), cf_name()));
+        }
+        if (static_props.wait_for_sync_to_commitlog) {
+            on_internal_error(dblog,
+                format("{}.{} uses schema commitlog, wait_for_sync_to_commitlog is redundant",
+                        ks_name(), cf_name()));
+        }
+    }
 
     if (_version) {
         new_raw._version = *_version;

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1318,11 +1318,6 @@ schema_ptr schema_builder::build() {
                 format("{}.{} uses schema commitlog, but not null sharder, "
                        "schema commitlog works only on shard 0", ks_name(), cf_name()));
         }
-        if (static_props.load_phase == system_table_load_phase::phase1) {
-            on_internal_error(dblog,
-                format("{}.{} uses schema commitlog, but it is loaded on phase1, "
-                       "tables using schema commitlog must be loaded on phase2", ks_name(), cf_name()));
-        }
         if (static_props.wait_for_sync_to_commitlog) {
             on_internal_error(dblog,
                 format("{}.{} uses schema commitlog, wait_for_sync_to_commitlog is redundant",

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -573,6 +573,11 @@ struct schema_static_props {
     bool wait_for_sync_to_commitlog = false; // true if all writes using this schema have to be synced immediately by commitlog
     bool use_schema_commitlog = false;
     system_table_load_phase load_phase = system_table_load_phase::phase1;
+    void enable_schema_commitlog() {
+        use_schema_commitlog = true;
+        use_null_sharder = true; // schema commitlog lives only on the null shard
+        load_phase = system_table_load_phase::phase2;
+    }
 };
 
 /*

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -553,30 +553,13 @@ public:
     }
 };
 
-// To break some cyclic data dependencies in the early stages of a node boot process,
-// the system tables are loaded in two phases. This allows to use the tables
-// from the first phase to load the tables from the second phase.
-// For example, we need system.scylla_local table to load raft tables, since it
-// stores the enabled features, and SCHEMA_COMMITLOG feature is used to choose
-// what commitlog (regular or schema) will be used for raft tables.
-enum class system_table_load_phase {
-    phase1,
-    phase2
-};
-constexpr system_table_load_phase all_system_table_load_phases[] = {
-    system_table_load_phase::phase1,
-    system_table_load_phase::phase2
-};
-
 struct schema_static_props {
     bool use_null_sharder = false; // use a sharder that puts everything on shard 0
     bool wait_for_sync_to_commitlog = false; // true if all writes using this schema have to be synced immediately by commitlog
     bool use_schema_commitlog = false;
-    system_table_load_phase load_phase = system_table_load_phase::phase1;
     void enable_schema_commitlog() {
         use_schema_commitlog = true;
         use_null_sharder = true; // schema commitlog lives only on the null shard
-        load_phase = system_table_load_phase::phase2;
     }
 };
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6382,7 +6382,7 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(const std::v
     db::hints::sync_point spoint;
     spoint.regular_per_shard_rps.resize(smp::count);
     spoint.mv_per_shard_rps.resize(smp::count);
-    spoint.host_id = _db.local().get_config().host_id;
+    spoint.host_id = get_token_metadata_ptr()->get_my_id();
     co_await coroutine::parallel_for_each(boost::irange<unsigned>(0, smp::count), [this, &target_hosts, &spoint] (unsigned shard) -> future<> {
         const auto& sharded_sp = container();
         // sharded::invoke_on does not have a const-method version, so we cannot use it here
@@ -6399,7 +6399,7 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(const std::v
 }
 
 future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spoint, clock_type::time_point deadline) {
-    const auto my_host_id = _db.local().get_config().host_id;
+    const auto my_host_id = get_token_metadata_ptr()->get_my_id();
     if (spoint.host_id != my_host_id) {
         throw std::runtime_error(format("The hint sync point was created on another node, with host ID {}. This node's host ID is {}",
                 spoint.host_id, my_host_id));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -328,7 +328,7 @@ future<> storage_service::topology_state_load() {
     // Update the legacy `enabled_features` key in `system.scylla_local`.
     // It's OK to update it after enabling features because `system.topology` now
     // is the source of truth about enabled features.
-    co_await _sys_ks.local().save_local_enabled_features(_topology_state_machine._topology.features.enabled_features);
+    co_await _sys_ks.local().save_local_enabled_features(_topology_state_machine._topology.features.enabled_features, false);
 
     const auto& am = _group0->address_map();
     auto id2ip = [this, &am] (raft::server_id id) -> future<gms::inet_address> {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -99,9 +99,13 @@ private:
     reader_concurrency_semaphore _sstable_metadata_concurrency_sem;
     directory_semaphore& _dir_semaphore;
     seastar::shared_ptr<db::system_keyspace> _sys_ks;
+    // This function is bound to token_metadata.get_my_id() in the database constructor,
+    // it can return unset value (bool(host_id) == false) until host_id is loaded
+    // after system_keyspace initialization.
+    noncopyable_function<locator::host_id()> _resolve_host_id;
 
 public:
-    explicit sstables_manager(db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem, storage_manager* shared = nullptr);
+    explicit sstables_manager(db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem, noncopyable_function<locator::host_id()>&& resolve_host_id, storage_manager* shared = nullptr);
     virtual ~sstables_manager();
 
     shared_sstable make_sstable(schema_ptr schema, sstring table_dir,
@@ -127,7 +131,7 @@ public:
     void set_format(sstable_version_types format) noexcept { _format = format; }
     sstables::sstable::version_types get_highest_supported_format() const noexcept { return _format; }
 
-    const locator::host_id& get_local_host_id() const;
+    locator::host_id get_local_host_id() const;
 
     reader_concurrency_semaphore& sstable_metadata_concurrency_sem() noexcept { return _sstable_metadata_concurrency_sem; }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -103,8 +103,8 @@ with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::s
         auto cm = make_lw_shared<compaction_manager>(tm, compaction_manager::for_testing_tag{});
         auto cl_stats = make_lw_shared<cell_locker_stats>();
         auto s_opts = make_lw_shared<replica::storage_options>();
-        auto cf = make_lw_shared<replica::column_family>(s, cfg, s_opts, replica::column_family::no_commitlog(), *cm, sm, *cl_stats, *tracker, nullptr);
-        cf->mark_ready_for_writes();
+        auto cf = make_lw_shared<replica::column_family>(s, cfg, s_opts, *cm, sm, *cl_stats, *tracker, nullptr);
+        cf->mark_ready_for_writes(nullptr);
         co_await func(*cf);
         co_await cf->stop();
     }

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -148,8 +148,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
     return do_with_cql_env([] (cql_test_env& e) -> future<> {
         random_mutation_generator gen{random_mutation_generator::generate_counters::no, local_shard_only::no};
         co_await e.db().invoke_on_all([gs = global_schema_ptr(gen.schema())](replica::database& db) -> future<> {
-            co_await db.add_column_family_and_make_directory(gs.get());
-            db.find_column_family(gs.get()).mark_ready_for_writes();
+            co_await db.add_column_family_and_make_directory(gs.get(), false);
         });
         auto& cf = e.local_db().find_column_family(gen.schema());
         const auto& local_sharder = cf.schema()->get_sharder();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5168,7 +5168,6 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     large_row_handler handler(threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        env.db_config().host_id = locator::host_id::create_random_id();
         auto sst = env.make_sstable(s, version);
 
         // The test provides thresholds values for the large row handler. Whether the handler gets
@@ -5223,7 +5222,6 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        env.db_config().host_id = locator::host_id::create_random_id();
         auto sst = env.make_sstable(s, version);
 
         // The test provides thresholds values for the large row handler. Whether the handler gets
@@ -5282,7 +5280,6 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        env.db_config().host_id = locator::host_id::create_random_id();
         auto sst = env.make_sstable(sc, version);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
@@ -5334,7 +5331,6 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
     large_row_handler handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), threshold, f);
 
     sstables::test_env::do_with_async([&] (auto& env) {
-        env.db_config().host_id = locator::host_id::create_random_id();
         auto sst = env.make_sstable(sc, version);
         sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3017,8 +3017,8 @@ static flat_mutation_reader_v2 compacted_sstable_reader(test_env& env, schema_pt
     auto cm = make_lw_shared<compaction_manager_for_testing>(false);
     auto cl_stats = make_lw_shared<cell_locker_stats>();
     auto tracker = make_lw_shared<cache_tracker>();
-    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), make_lw_shared<replica::storage_options>(), replica::column_family::no_commitlog(), **cm, env.manager(), *cl_stats, *tracker, nullptr);
-    cf->mark_ready_for_writes();
+    auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), make_lw_shared<replica::storage_options>(), **cm, env.manager(), *cl_stats, *tracker, nullptr);
+    cf->mark_ready_for_writes(nullptr);
     lw_shared_ptr<replica::memtable> mt = make_lw_shared<replica::memtable>(s);
 
     auto sstables = open_sstables(env, s, format("test/resource/sstables/3.x/uncompressed/{}", table_name), generations);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2791,7 +2791,6 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
         auto tracker = make_lw_shared<cache_tracker>();
         auto cf = env.make_table_for_tests(s);
         auto close_cf = deferred_stop(cf);
-        cf->mark_ready_for_writes();
         cf->start();
         cf->set_compaction_strategy(sstables::compaction_strategy_type::size_tiered);
         auto compact = [&, s] (std::vector<shared_sstable> all, auto replacer) -> std::vector<shared_sstable> {
@@ -3781,7 +3780,6 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
                 return cf.make_sstable(version);
             };
 
-            cf->mark_ready_for_writes();
             cf->start();
 
             for (auto i = 0; i < cf->schema()->max_compaction_threshold(); i++) {
@@ -4137,9 +4135,9 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             cfg.enable_commitlog = false;
             cfg.enable_incremental_backups = false;
 
-            auto cf = make_lw_shared<replica::column_family>(s, cfg, make_lw_shared<replica::storage_options>(), replica::column_family::no_commitlog(), *cm, env.manager(), *cl_stats, *tracker, nullptr);
+            auto cf = make_lw_shared<replica::column_family>(s, cfg, make_lw_shared<replica::storage_options>(), *cm, env.manager(), *cl_stats, *tracker, nullptr);
             cf->start();
-            cf->mark_ready_for_writes();
+            cf->mark_ready_for_writes(nullptr);
             tables.push_back(cf);
         }
 
@@ -5198,7 +5196,6 @@ SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness) {
         sorted_muts.insert(make_mut(pks[1]));
 
         auto t = env.make_table_for_tests(s, env.tempdir().path().string());
-        t->mark_ready_for_writes();
         auto close_t = deferred_stop(t);
 
         auto sst_gen = env.make_sst_factory(s);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -616,9 +616,9 @@ private:
 
             _sys_ks.start(std::ref(_qp), std::ref(_db)).get();
             auto stop_sys_kd = defer([this] { _sys_ks.stop().get(); });
-            for (const auto p: all_system_table_load_phases) {
-                replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db, p).get();
-            }
+
+            replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db).get();
+            _sys_ks.invoke_on_all(&db::system_keyspace::mark_writable).get();
 
             auto host_id = cfg_in.host_id;
             if (!host_id) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -63,6 +63,7 @@
 #include "streaming/stream_manager.hh"
 #include "debug.hh"
 #include "db/schema_tables.hh"
+#include "db/virtual_tables.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service/raft/raft_group0.hh"
 #include "sstables/sstables_manager.hh"
@@ -744,8 +745,8 @@ private:
             _ss.invoke_on_all([this] (service::storage_service& ss) {
                 ss.set_query_processor(_qp.local());
             }).get();
-            _sys_ks.invoke_on_all([this, &cfg] (db::system_keyspace& sys_ks) {
-                return sys_ks.initialize_virtual_tables(_db, _ss, _gossiper, _group0_registry, *cfg);
+            smp::invoke_on_all([&] {
+                return db::initialize_virtual_tables(_db, _ss, _gossiper, _group0_registry, _sys_ks, *cfg);
             }).get();
 
             replica::distributed_loader::init_non_system_keyspaces(_db, _proxy, _sys_ks).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -616,7 +616,7 @@ private:
             _sys_ks.start(std::ref(_qp), std::ref(_db)).get();
             auto stop_sys_kd = defer([this] { _sys_ks.stop().get(); });
             for (const auto p: all_system_table_load_phases) {
-                replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db, *cfg, p).get();
+                replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db, p).get();
             }
 
             auto host_id = cfg_in.host_id;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -619,21 +619,22 @@ private:
                 replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db, *cfg, p).get();
             }
 
-            if (!cfg->host_id) {
+            auto host_id = cfg_in.host_id;
+            if (!host_id) {
                 auto linfo = _sys_ks.local().load_local_info().get0();
                 if (!linfo.host_id) {
                     linfo.host_id = locator::host_id::create_random_id();
                 }
-                cfg->host_id = linfo.host_id;
+                host_id = linfo.host_id;
                 _sys_ks.local().save_local_info(std::move(linfo), _snitch.local()->get_location()).get();
             }
-            locator::shared_token_metadata::mutate_on_all_shards(_token_metadata, [hostid = cfg->host_id] (locator::token_metadata& tm) {
+            locator::shared_token_metadata::mutate_on_all_shards(_token_metadata, [hostid = host_id] (locator::token_metadata& tm) {
                 tm.get_topology().set_host_id_cfg(hostid);
                 return make_ready_future<>();
             }).get();
 
             // don't start listening so tests can be run in parallel
-            _ms.start(cfg->host_id, listen, std::move(7000)).get();
+            _ms.start(host_id, listen, std::move(7000)).get();
             auto stop_ms = defer([this] { _ms.stop().get(); });
 
             // Normally the auth server is already stopped in here,
@@ -689,7 +690,7 @@ private:
             });
 
             _group0_registry.start(cfg->consistent_cluster_management(),
-                raft::server_id{cfg->host_id.id},
+                raft::server_id{host_id.id},
                 std::ref(_raft_address_map),
                 std::ref(_ms), std::ref(_gossiper), std::ref(_fd)).get();
             auto stop_raft_gr = deferred_stop(_group0_registry);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -618,6 +618,7 @@ private:
             auto stop_sys_kd = defer([this] { _sys_ks.stop().get(); });
 
             replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db).get();
+            _db.local().maybe_init_schema_commitlog();
             _sys_ks.invoke_on_all(&db::system_keyspace::mark_writable).get();
 
             auto host_id = cfg_in.host_id;

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -92,6 +92,7 @@ public:
     std::set<sstring> disabled_features;
     std::optional<cql3::query_processor::memory_config> qp_mcfg;
     bool need_remote_proxy = false;
+    locator::host_id host_id;
 
     cql_test_config();
     cql_test_config(const cql_test_config&);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -143,8 +143,8 @@ table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, s
     _data->cfg.cf_stats = &_data->cf_stats;
     _data->cfg.enable_commitlog = false;
     _data->cm.enable();
-    _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, make_lw_shared<replica::storage_options>(), replica::column_family::no_commitlog(), _data->cm, sstables_manager, _data->cl_stats, _data->tracker, nullptr);
-    _data->cf->mark_ready_for_writes();
+    _data->cf = make_lw_shared<replica::column_family>(_data->s, _data->cfg, make_lw_shared<replica::storage_options>(), _data->cm, sstables_manager, _data->cl_stats, _data->tracker, nullptr);
+    _data->cf->mark_ready_for_writes(nullptr);
     _data->table_s = std::make_unique<table_state>(*_data, sstables_manager);
     _data->cm.add(*_data->table_s);
     _data->storage = std::move(storage);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -189,7 +189,6 @@ std::unordered_map<sstring, s3::endpoint_config> make_storage_options_config(con
 std::unique_ptr<db::config> make_db_config(sstring temp_dir, const data_dictionary::storage_options so) {
     auto cfg = std::make_unique<db::config>();
     cfg->data_file_directories.set({ temp_dir });
-    cfg->host_id = locator::host_id::create_random_id();
     cfg->object_storage_config = make_storage_options_config(so);
     return cfg;
 }
@@ -199,7 +198,9 @@ test_env::impl::impl(test_env_config cfg, sstables::storage_manager* sstm)
     , db_config(make_db_config(dir.path().native(), cfg.storage))
     , dir_sem(1)
     , feature_service(gms::feature_config_from_db_config(*db_config))
-    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem, sstm)
+    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config,
+        feature_service, cache_tracker, memory::stats().total_memory(), dir_sem,
+        [host_id = locator::host_id::create_random_id()]{ return host_id; }, sstm)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
     , storage(std::move(cfg.storage))
 { }

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -228,7 +228,7 @@ public:
                 cell_locker_stats cl_stats;
                 tasks::task_manager tm;
                 auto cm = make_lw_shared<compaction_manager>(tm, compaction_manager::for_testing_tag{});
-                auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), make_lw_shared<replica::storage_options>(), replica::column_family::no_commitlog(), *cm, env.manager(), cl_stats, tracker, nullptr);
+                auto cf = make_lw_shared<replica::column_family>(s, env.make_table_config(), make_lw_shared<replica::storage_options>(), *cm, env.manager(), cl_stats, tracker, nullptr);
 
                 auto start = perf_sstable_test_env::now();
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -339,7 +339,7 @@ struct sstable_manager_service {
     explicit sstable_manager_service()
         : feature_service(gms::feature_config_from_db_config(dbcfg))
         , dir_sem(1)
-        , sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem) {
+        , sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem, []{ return locator::host_id{}; }) {
     }
 
     future<> stop() {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2876,9 +2876,10 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         auto& dbcfg = *pdbcfg;
         gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
         cache_tracker tracker;
-        dbcfg.host_id = locator::host_id::create_random_id();
         sstables::directory_semaphore dir_sem(1);
-        sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem);
+        sstables::sstables_manager sst_man(large_data_handler, dbcfg, feature_service, tracker,
+            memory::stats().total_memory(), dir_sem,
+            [host_id = locator::host_id::create_random_id()] { return host_id; });
         auto close_sst_man = deferred_close(sst_man);
 
         std::vector<sstables::shared_sstable> sstables;


### PR DESCRIPTION
There are several system tables with strict durability requirements. This means that if we have written to such a table, we want to be sure that the write won't be lost in case of node failure. We currently accomplish this by accompanying each write to these tables with `db.flush()` on all shards. This is 
expensive, since it causes all the memtables to be written to sstables, which causes a lot of disk writes. This overheads can become painful during node startup, when we write the current boot state to `system.local`/`system.scylla_local` or during topology change, when `update_peer_info`/`update_tokens` write to `system.peers`.

In this series we remove flushes on writes to the `system.local`, `system.peers`, `system.scylla_local` and `system.cdc_local` tables and start using schema commitlog for durability.

Fixes: #15133