### PR TITLE
raft topology: replace publish_cdc_generation with a bg fiber

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1576,6 +1576,17 @@ static std::unordered_set<raft::server_id> decode_nodes_ids(const set_type_impl:
     return ids_set;
 }
 
+static std::vector<cdc::generation_id_v2> decode_cdc_generations_ids(const set_type_impl::native_type& gen_ids) {
+    std::vector<cdc::generation_id_v2> gen_ids_list;
+    for (auto& gen_id: gen_ids) {
+        auto native = value_cast<tuple_type_impl::native_type>(gen_id);
+        auto ts = value_cast<db_clock::time_point>(native[0]);
+        auto id = value_cast<utils::UUID>(native[1]);
+        gen_ids_list.push_back(cdc::generation_id_v2{ts, id});
+    }
+    return gen_ids_list;
+}
+
 future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
 {
     if (ep == utils::fb_utilities::get_broadcast_address()) {
@@ -2647,6 +2658,10 @@ future<service::topology> system_keyspace::load_topology_state() {
                 on_internal_error(slogger,
                     "load_topology_state: normal nodes present but no current CDC generation ID");
             }
+        }
+
+        if (some_row.has("unpublished_cdc_generations")) {
+            ret.unpublished_cdc_generations = decode_cdc_generations_ids(deserialize_set_column(*topology(), some_row, "unpublished_cdc_generations"));
         }
 
         if (some_row.has("global_topology_request")) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -213,6 +213,8 @@ schema_ptr system_keyspace::batchlog() {
     return paxos;
 }
 
+thread_local data_type cdc_generation_id_v2_type = tuple_type_impl::get_instance({timestamp_type, uuid_type});
+
 schema_ptr system_keyspace::topology() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, TOPOLOGY);
@@ -237,6 +239,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("transition_state", utf8_type, column_kind::static_column)
             .with_column("current_cdc_generation_uuid", uuid_type, column_kind::static_column)
             .with_column("current_cdc_generation_timestamp", timestamp_type, column_kind::static_column)
+            .with_column("unpublished_cdc_generations", set_type_impl::get_instance(cdc_generation_id_v2_type, true), column_kind::static_column)
             .with_column("global_topology_request", utf8_type, column_kind::static_column)
             .with_column("enabled_features", set_type_impl::get_instance(utf8_type, true), column_kind::static_column)
             .set_comment("Current state of topology change machine")

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -188,6 +188,7 @@ CREATE TABLE system.topology (
     transition_state text static,
     current_cdc_generation_timestamp timestamp static,
     current_cdc_generation_uuid uuid static,
+    unpublished_cdc_generations set<tuple<timestamp, id>> static,
     global_topology_request text static,
     new_cdc_generation_data_uuid uuid static,
     PRIMARY KEY (key, host_id)
@@ -214,5 +215,6 @@ There are also a few static columns for cluster-global properties:
 - `transition_state` - the transitioning state of the cluster (as described earlier), may be null
 - `current_cdc_generation_timestamp` - the timestamp of the last introduced CDC generation
 - `current_cdc_generation_uuid` - the UUID of the last introduced CDC generation (used to access its data)
+- `unpublished_cdc_generations` - the IDs of the committed yet unpublished CDC generations
 - `global_topology_request` - if set, contains one of the supported global topology requests
 - `new_cdc_generation_data_uuid` - used in `commit_cdc_generation` state, the UUID of the generation to be committed

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -33,29 +33,29 @@ Additionally to specific node states, there entire topology can also be in a tra
 - `commit_cdc_generation` - a new CDC generation data was written to internal tables earlier
     and now we need to commit the generation - create a timestamp for it and tell every node
     to start using it for CDC log table writes.
-- `publish_cdc_generation` - a new CDC generation was committed and now we need to publish it
-    to user-facing description tables.
 - `write_both_read_old` - one of the nodes is in a bootstrapping/decommissioning/removing/replacing state.
     Writes are going to both new and old replicas (new replicas means calculated according to modified
 token ring), reads are using old replicas.
 - `write_both_read_new` - as above, but reads are using new replicas.
 
 When a node bootstraps, we create new tokens for it and a new CDC generation
-and enter the `commit_cdc_generation` state. After committing the generation we
-move to `publish_cdc_generation`. Once the generation is published, we enter
-`write_both_read_old` state. After the entire cluster learns about it,
+and enter the `commit_cdc_generation` state. Once the generation is committed,
+we enter `write_both_read_old` state. After the entire cluster learns about it,
 streaming starts. When streaming finishes, we move to `write_both_read_new`
 state and again the whole cluster needs to learn about it and make sure that no
 reads that started before this point exist in the system. Finally we remove the
 transitioning state.
 
 Decommission, removenode and replace work similarly, except they don't go through
-`commit_cdc_generation` and `publish_cdc_generation`.
+`commit_cdc_generation`.
 
-The state machine may also go only through `commit_cdc_generation` and
-`publish_cdc_generation` states after getting a request from the user to create
-a new CDC generation if the current one is suboptimal (e.g. after a
-decommission).
+The state machine may also go only through the `commit_cdc_generation` state
+after getting a request from the user to create a new CDC generation if the
+current one is suboptimal (e.g. after a decommission).
+
+Committed CDC generations are continually published to user-facing description
+tables. This process is concurrent with the topology state transitioning and
+does not block its further progress.
 
 The state machine also maintains a map of topology requests per node.
 When a request is issued to a node the entry is added to the map. A

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -410,8 +410,6 @@ future<> storage_service::topology_state_load() {
                     [[fallthrough]];
                 case topology::transition_state::commit_cdc_generation:
                     [[fallthrough]];
-                case topology::transition_state::publish_cdc_generation:
-                    [[fallthrough]];
                 case topology::transition_state::write_both_read_old:
                     return read_new_t::no;
                 case topology::transition_state::write_both_read_new:
@@ -604,6 +602,7 @@ public:
     topology_mutation_builder& set_version(topology::version_t);
     topology_mutation_builder& set_current_cdc_generation_id(const cdc::generation_id_v2&);
     topology_mutation_builder& set_new_cdc_generation_data_uuid(const utils::UUID& value);
+    topology_mutation_builder& set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
     topology_mutation_builder& set_global_topology_request(global_topology_request);
     template<typename S>
     requires std::constructible_from<sstring, S>
@@ -770,6 +769,13 @@ topology_mutation_builder& topology_mutation_builder::set_current_cdc_generation
 topology_mutation_builder& topology_mutation_builder::set_new_cdc_generation_data_uuid(
         const utils::UUID& value) {
     return apply_atomic("new_cdc_generation_data_uuid", value);
+}
+
+topology_mutation_builder& topology_mutation_builder::set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values) {
+    auto dv = values | boost::adaptors::transformed([&] (const auto& v) {
+        return make_tuple_value(db::cdc_generation_id_v2_type, tuple_type_impl::native_type({v.ts, v.id}));
+    });
+    return apply_set("unpublished_cdc_generations", collection_apply_mode::overwrite, std::move(dv));
 }
 
 topology_mutation_builder& topology_mutation_builder::set_global_topology_request(global_topology_request value) {
@@ -1189,6 +1195,70 @@ class topology_coordinator {
         }
 
         co_return std::tuple{gen_uuid, std::move(guard), std::move(updates.back())};
+    }
+
+    // If there are some unpublished CDC generations, publishes the one with the oldest timestamp
+    // to user-facing description tables.
+    future<> publish_oldest_cdc_generation(group0_guard guard) {
+        const auto& unpublished_gens = _topo_sm._topology.unpublished_cdc_generations;
+        if (unpublished_gens.empty()) {
+            co_return;
+        }
+
+        // The generation under index 0 is the oldest because unpublished_cdc_generations are sorted by timestamp.
+        auto gen_id = unpublished_gens[0];
+
+        auto gen_data = co_await _sys_ks.read_cdc_generation(gen_id.id);
+
+        co_await _sys_dist_ks.local().create_cdc_desc(
+                gen_id.ts, gen_data, { get_token_metadata().count_normal_token_owners() });
+
+        std::vector<cdc::generation_id_v2> new_unpublished_gens(unpublished_gens.begin() + 1, unpublished_gens.end());
+        topology_mutation_builder builder(guard.write_timestamp());
+        builder.set_unpublished_cdc_generations(std::move(new_unpublished_gens));
+
+        auto str = ::format("published CDC generation, ID: {}", gen_id);
+        co_await update_topology_state(std::move(guard), {builder.build()}, std::move(str));
+    }
+
+    // The background fiber of the topology coordinator that continually publishes committed yet unpublished
+    // CDC generations. Every generation is published in a separate group 0 operation.
+    future<> cdc_generation_publisher_fiber() {
+        slogger.trace("raft topology: start CDC generation publisher fiber");
+
+        while (!_as.abort_requested()) {
+            bool sleep = false;
+            try {
+                auto guard = co_await start_operation();
+
+                co_await publish_oldest_cdc_generation(std::move(guard));
+
+                if (_topo_sm._topology.unpublished_cdc_generations.empty()) {
+                    // No CDC generations to publish. Wait until one appears or the topology coordinator aborts.
+                    slogger.trace("raft topology: CDC generation publisher fiber has nothing to do. Sleeping.");
+                    co_await _topo_sm.event.when([&] () {
+                        return !_topo_sm._topology.unpublished_cdc_generations.empty() || _as.abort_requested();
+                    });
+                    slogger.trace("raft topology: CDC generation publisher fiber wakes up");
+                }
+            } catch (raft::request_aborted&) {
+                slogger.debug("raft topology: CDC generation publisher fiber aborted");
+            } catch (group0_concurrent_modification&) {
+            } catch (term_changed_error&) {
+                slogger.debug("raft topology: CDC generation publisher fiber notices term change {} -> {}", _term, _raft.get_current_term());
+            } catch (...) {
+                slogger.error("raft topology: CDC generation publisher fiber got error {}", std::current_exception());
+                sleep = true;
+            }
+            if (sleep) {
+                try {
+                    co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
+                } catch (...) {
+                    slogger.debug("raft topology: CDC generation publisher: sleep failed: {}", std::current_exception());
+                }
+            }
+            co_await coroutine::maybe_yield();
+        }
     }
 
     // Precondition: there is no node request and no ongoing topology transition
@@ -1640,33 +1710,16 @@ class topology_coordinator {
                 // committed) - they won't coordinate CDC-enabled writes until they reconnect to the
                 // majority and commit.
                 topology_mutation_builder builder(guard.write_timestamp());
-                builder.set_transition_state(topology::transition_state::publish_cdc_generation)
-                       .set_current_cdc_generation_id(cdc_gen_id)
+                builder.set_current_cdc_generation_id(cdc_gen_id)
                        .add_unpublished_cdc_generation(cdc_gen_id)
                        .set_version(_topo_sm._topology.version + 1);
                 if (_topo_sm._topology.global_request == global_topology_request::new_cdc_generation) {
                     builder.del_global_topology_request();
-                }
-                auto str = ::format("committed new CDC generation, ID: {}", cdc_gen_id);
-                co_await update_topology_state(std::move(guard), {builder.build()}, std::move(str));
-            }
-                break;
-            case topology::transition_state::publish_cdc_generation: {
-                // We just committed a new CDC generation in the commit_cdc_generation step.
-                // Publish it to the user-facing distributed CDC description tables.
-                auto curr_gen_id = _topo_sm._topology.current_cdc_generation_id.value();
-                auto gen_data = co_await _sys_ks.read_cdc_generation(curr_gen_id.id);
-
-                co_await _sys_dist_ks.local().create_cdc_desc(
-                    curr_gen_id.ts, gen_data, { get_token_metadata().count_normal_token_owners() });
-
-                topology_mutation_builder builder(guard.write_timestamp());
-                if (_topo_sm._topology.transition_nodes.empty()) {
                     builder.del_transition_state();
                 } else {
                     builder.set_transition_state(topology::transition_state::write_both_read_old);
                 }
-                auto str = ::format("published CDC generation, ID: {}", curr_gen_id);
+                auto str = ::format("committed new CDC generation, ID: {}", cdc_gen_id);
                 co_await update_topology_state(std::move(guard), {builder.build()}, std::move(str));
             }
                 break;
@@ -2064,6 +2117,8 @@ future<> topology_coordinator::run() {
         _topo_sm.event.broadcast();
     });
 
+    auto cdc_generation_publisher = cdc_generation_publisher_fiber();
+
     while (!_as.abort_requested()) {
         bool sleep = false;
         try {
@@ -2098,7 +2153,9 @@ future<> topology_coordinator::run() {
         }
         co_await coroutine::maybe_yield();
     }
+
     co_await _async_gate.close();
+    co_await std::move(cdc_generation_publisher);
 }
 
 future<> storage_service::raft_state_monitor_fiber(raft::server& raft, sharded<db::system_distributed_keyspace>& sys_dist_ks) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1227,6 +1227,12 @@ class topology_coordinator {
         slogger.trace("raft topology: start CDC generation publisher fiber");
 
         while (!_as.abort_requested()) {
+            co_await utils::get_local_injector().inject_with_handler("cdc_generation_publisher_fiber", [] (auto& handler) -> future<> {
+                slogger.info("raft toplogy: CDC generation publisher fiber sleeps after injection");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+                slogger.info("raft toplogy: CDC generation publisher fiber finishes sleeping after injection");
+            });
+
             bool sleep = false;
             try {
                 auto guard = co_await start_operation();

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -76,7 +76,6 @@ std::ostream& operator<<(std::ostream& os, const fencing_token& fencing_token) {
 
 static std::unordered_map<topology::transition_state, sstring> transition_state_to_name_map = {
     {topology::transition_state::commit_cdc_generation, "commit cdc generation"},
-    {topology::transition_state::publish_cdc_generation, "publish cdc generation"},
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
     {topology::transition_state::tablet_migration, "tablet migration"},

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -137,6 +137,9 @@ struct topology {
     // It's used as partition key in CDC_GENERATIONS_V3 table.
     std::optional<utils::UUID> new_cdc_generation_data_uuid;
 
+    // The IDs of the commited yet unpublished CDC generations sorted by timestamps.
+    std::vector<cdc::generation_id_v2> unpublished_cdc_generations;
+
     // Describes the state of the features of normal nodes
     topology_features features;
 

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -97,7 +97,6 @@ struct topology_features {
 struct topology {
     enum class transition_state: uint16_t {
         commit_cdc_generation,
-        publish_cdc_generation,
         write_both_read_old,
         write_both_read_new,
         tablet_migration,

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -9,7 +9,9 @@ extra_scylla_config_options:
     experimental_features: ['consistent-topology-changes', 'tablets']
 skip_in_release:
   - test_blocked_bootstrap
+  - test_cdc_generation_publishing
   - test_raft_cluster_features
   - test_raft_ignore_nodes
 skip_in_debug:
+  - test_cdc_generation_publishing
   - test_raft_ignore_nodes

--- a/test/topology_experimental_raft/test_cdc_generation_publishing.py
+++ b/test/topology_experimental_raft/test_cdc_generation_publishing.py
@@ -1,0 +1,106 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+
+from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement # type: ignore # pylint: disable=no-name-in-module
+
+import pytest
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_cdc_generations_are_published(request, manager: ManagerClient):
+    """Test that the CDC generation publisher eventually publishes committed CDC generations in the correct order."""
+    query_gen_timestamps = SimpleStatement(
+        "select time from system_distributed.cdc_generation_timestamps where key = 'timestamps'",
+        consistency_level = ConsistencyLevel.ONE)
+
+    servers = list[ServerInfo]()
+    gen_timestamps = set[datetime]()
+
+    async def new_gen_appeared() -> Optional[set[datetime]]:
+        cql = manager.get_cql()
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        new_gen_timestamps = {r.time for r in await cql.run_async(query_gen_timestamps)}
+        assert len(gen_timestamps) + 1 >= len(new_gen_timestamps)
+        if gen_timestamps < new_gen_timestamps:
+            gen_timestamps_diff = new_gen_timestamps.difference(gen_timestamps)
+            # Check that we didn't lose any CDC generation.
+            assert len(gen_timestamps_diff) == 1
+            # Check that the new timestamp is not lower than the previous ones.
+            new_timestamp = next(iter(gen_timestamps_diff))
+            assert new_timestamp == max(new_gen_timestamps)
+            return new_gen_timestamps
+        return None
+
+    logger.info("Bootstrapping first node")
+    servers = [await manager.server_add()]
+    gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60)
+    logger.info(f"Timestamps after boostrapping first node: {gen_timestamps}")
+
+    logger.info("Bootstrapping second node")
+    servers += [await manager.server_add()]
+    gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60)
+    logger.info(f"Timestamps after boostrapping second node: {gen_timestamps}")
+
+    logger.info("Bootstrapping third node")
+    servers += [await manager.server_add()]
+    gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60)
+    logger.info(f"Timestamps after boostrapping third node: {gen_timestamps}")
+
+
+@pytest.mark.asyncio
+async def test_multiple_unpublished_cdc_generations(request, manager: ManagerClient):
+    """Test that the CDC generation publisher works correctly when there is more than one unpublished CDC generation."""
+    query_gen_timestamps = SimpleStatement(
+        "select time from system_distributed.cdc_generation_timestamps where key = 'timestamps'",
+        consistency_level = ConsistencyLevel.ONE)
+
+    logger.info("Bootstrapping first node")
+    servers = [await manager.server_add()]
+
+    async with inject_error(manager.api, servers[0].ip_addr, "cdc_generation_publisher_fiber") as handler:
+        # This injection delays publishing CDC generations committed after bootstrapping the following nodes.
+        # After all 3 nodes bootstrap, there should be 3 or 4 unpublished CDC generations (4 if publishing the first
+        # CDC generation hasn't started before injecting an error).
+        logger.info("Bootstrapping other nodes")
+        servers += [await manager.server_add() for _ in range(3)]
+
+        cql = manager.get_cql()
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        gen_timestamps = set[datetime]()
+
+        async def new_gen_appeared() -> Optional[set[datetime]]:
+            new_gen_timestamps = {r.time for r in await cql.run_async(query_gen_timestamps)}
+            assert gen_timestamps <= new_gen_timestamps
+            if gen_timestamps < new_gen_timestamps:
+                # Check that we didn't lose any CDC generations.
+                assert not gen_timestamps.difference(new_gen_timestamps)
+                # Check that all new timestamps are not lower than the previous ones.
+                gen_timestamps_diff = new_gen_timestamps.difference(gen_timestamps)
+                for new_timestamp in gen_timestamps_diff:
+                    assert not gen_timestamps or new_timestamp >= max(gen_timestamps)
+                return new_gen_timestamps
+            return None
+
+        # Check that all 4 CDC generations are eventually published in the correct order.
+        await handler.message()
+        while len(gen_timestamps) < 4:
+            # We prefer to detect CDC generation publications one-by-one, because it increases our chances of catching
+            # potential bugs like incorrect order of publications. Therefore, we use very short period - 0.01 s.
+            gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60, 0.01)
+
+        assert len(gen_timestamps) == 4


### PR DESCRIPTION
Currently, the topology coordinator has the `topology::transition_state::publish_cdc_generation` state responsible for publishing the already created CDC generations to the user-facing description tables. This process cannot fail as it would cause some CDC updates to be missed. On the other hand, we would like to abort the `publish_cdc_generation` state when bootstrap aborts. Of course, we could also wait until handling this state finishes, even in the case of the bootstrap abort, but that would be inefficient. We don't want to unnecessarily block topology operations by publishing CDC generations.

The solution proposed by this PR is to remove the `publish_cdc_generation` state completely and introduce a new background fiber of the topology coordinator -- `cdc_generation_publisher` -- that continually publishes committed CDC generations.

Apart from introducing the CDC generation publisher, we add `test_cdc_generation_publishing.py` that verifies its correctness and we adapt other CDC tests to the new changes.

Fixes #15194