### PR TITLE
dist/debian: add command line option for builddir 

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
+import argparse
 import string
 import os
 import shutil
@@ -79,8 +80,18 @@ def rename_to(outputdir, from_product, to_product):
 
 
 def main():
-    builddir = 'build'
-    outputdir = os.path.join(builddir, 'debian', 'debian')
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--build-dir', action='store', default='build',
+                            help='build directory')
+    arg_parser.add_argument('--output-dir', action='store', default='debian/debian',
+                            help='output directory')
+    args = arg_parser.parse_args()
+    builddir = args.build_dir
+    if os.path.isabs(args.output_dir):
+        outputdir = args.output_dir
+    else:
+        outputdir = os.path.join(builddir, args.output_dir)
+
     if os.path.exists(outputdir):
         shutil.rmtree(outputdir)
     shutil.copytree('dist/debian/debian', outputdir)

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -48,13 +48,22 @@ def generate_changelog(scriptdir, outputdir, product, version, release):
     with open(os.path.join(scriptdir, 'changelog.template')) as f:
         changelog_template = f.read()
     s = DebianFilesTemplate(changelog_template)
-    changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')
+    changelog_applied = s.substitute(product=product,
+                                     version=version,
+                                     release=release,
+                                     revision='1',
+                                     codename='stable')
     with open(os.path.join(outputdir, 'changelog'), 'w') as f:
         f.write(changelog_applied)
 
 
 def generate_include_binaries(outputdir):
-    include_binaries = subprocess.run("./scripts/create-relocatable-package.py --print-libexec -", shell=True, check=True, capture_output=True, encoding='utf-8').stdout
+    include_binaries = subprocess.run(
+        "./scripts/create-relocatable-package.py --print-libexec -",
+        shell=True,
+        check=True,
+        capture_output=True,
+        encoding='utf-8').stdout
     with open(os.path.join(outputdir, 'source', 'include-binaries'), 'w') as f:
         f.write(include_binaries)
 

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -18,29 +18,48 @@ from pathlib import Path
 class DebianFilesTemplate(string.Template):
     delimiter = '%'
 
-scriptdir = os.path.dirname(__file__)
 
-with open(os.path.join(scriptdir, 'changelog.template')) as f:
-    changelog_template = f.read()
+def get_version(builddir):
+    with open(os.path.join(builddir, 'SCYLLA-VERSION-FILE')) as f:
+        return f.read().strip().replace('-', '~')
 
-with open(os.path.join(scriptdir, 'control.template')) as f:
-    control_template = f.read()
 
-with open('build/SCYLLA-PRODUCT-FILE') as f:
-    product = f.read().strip()
+def get_release(builddir):
+    with open(os.path.join(builddir, 'SCYLLA-RELEASE-FILE')) as f:
+        return f.read().strip()
 
-with open('build/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip().replace('-', '~')
 
-with open('build/SCYLLA-RELEASE-FILE') as f:
-    release = f.read().strip()
+def get_product(builddir):
+    with open(os.path.join(builddir, 'SCYLLA-PRODUCT-FILE')) as f:
+        return f.read().strip()
 
-if os.path.exists('build/debian/debian'):
-    shutil.rmtree('build/debian/debian')
-shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
-if product != 'scylla':
-    for p in Path('build/debian/debian').glob('scylla-*'):
+def generate_control(scriptdir, outputdir, product):
+    with open(os.path.join(scriptdir, 'control.template')) as f:
+        control_template = f.read()
+    s = DebianFilesTemplate(control_template)
+    control_applied = s.substitute(product=product)
+    with open(os.path.join(outputdir, 'control'), 'w') as f:
+        f.write(control_applied)
+
+
+def generate_changelog(scriptdir, outputdir, product, version, release):
+    with open(os.path.join(scriptdir, 'changelog.template')) as f:
+        changelog_template = f.read()
+    s = DebianFilesTemplate(changelog_template)
+    changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')
+    with open(os.path.join(outputdir, 'changelog'), 'w') as f:
+        f.write(changelog_applied)
+
+
+def generate_include_binaries(outputdir):
+    include_binaries = subprocess.run("./scripts/create-relocatable-package.py --print-libexec -", shell=True, check=True, capture_output=True, encoding='utf-8').stdout
+    with open(os.path.join(outputdir, 'source', 'include-binaries'), 'w') as f:
+        f.write(include_binaries)
+
+
+def rename_to(outputdir, from_product, to_product):
+    for p in Path(outputdir).glob('scylla-*'):
         # pat1: scylla-server.service
         #    -> scylla-enterprise-server.scylla-server.service
         #       or
@@ -52,24 +71,28 @@ if product != 'scylla':
         #    -> scylla-enterprise-conf.install
 
         if m := re.match(r'^scylla(-[^.]+)\.(service|default)$', p.name):
-            p.rename(p.parent / f'{product}{m.group(1)}.{p.name}')
+            p.rename(p.parent / f'{to_product}{m.group(1)}.{p.name}')
         elif m := re.match(r'^scylla(-[^.]+\.scylla-[^.]+\.[^.]+)$', p.name):
-            p.rename(p.parent / f'{product}{m.group(1)}')
+            p.rename(p.parent / f'{to_product}{m.group(1)}')
         else:
-            p.rename(p.parent / p.name.replace('scylla', product, 1))
+            p.rename(p.parent / p.name.replace(from_product, to_product, 1))
 
-s = DebianFilesTemplate(changelog_template)
-changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')
 
-s = DebianFilesTemplate(control_template)
-control_applied = s.substitute(product=product)
+def main():
+    builddir = 'build'
+    outputdir = os.path.join(builddir, 'debian', 'debian')
+    if os.path.exists(outputdir):
+        shutil.rmtree(outputdir)
+    shutil.copytree('dist/debian/debian', outputdir)
 
-with open('build/debian/debian/changelog', 'w') as f:
-    f.write(changelog_applied)
+    product = get_product(builddir)
+    if product != 'scylla':
+        rename_to(outputdir, 'scylla', product)
+    scriptdir = os.path.dirname(__file__)
+    generate_changelog(scriptdir, outputdir, product, get_version(builddir), get_release(builddir))
+    generate_control(scriptdir, outputdir, product)
+    generate_include_binaries(outputdir)
 
-with open('build/debian/debian/control', 'w') as f:
-    f.write(control_applied)
 
-include_binaries = subprocess.run("./scripts/create-relocatable-package.py --print-libexec -", shell=True, check=True, capture_output=True, encoding='utf-8').stdout
-with open('build/debian/debian/source/include-binaries', 'w') as f:
-    f.write(include_binaries)
+if __name__ == '__main__':
+    main()

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -40,7 +40,7 @@ def generate_control(scriptdir, outputdir, product):
         control_template = f.read()
     s = DebianFilesTemplate(control_template)
     control_applied = s.substitute(product=product)
-    with open(os.path.join(outputdir, 'control'), 'w') as f:
+    with open(os.path.join(outputdir, 'control'), 'w', encoding='utf-8') as f:
         f.write(control_applied)
 
 
@@ -53,7 +53,7 @@ def generate_changelog(scriptdir, outputdir, product, version, release):
                                      release=release,
                                      revision='1',
                                      codename='stable')
-    with open(os.path.join(outputdir, 'changelog'), 'w') as f:
+    with open(os.path.join(outputdir, 'changelog'), 'w', encoding='utf-8') as f:
         f.write(changelog_applied)
 
 
@@ -64,7 +64,7 @@ def generate_include_binaries(outputdir):
         check=True,
         capture_output=True,
         encoding='utf-8').stdout
-    with open(os.path.join(outputdir, 'source', 'include-binaries'), 'w') as f:
+    with open(os.path.join(outputdir, 'source', 'include-binaries'), 'w', encoding='utf-8') as f:
         f.write(include_binaries)
 
 


### PR DESCRIPTION
so we can point `debian_files_gen.py` to builddir other than
'build', and can optionally use other output directory. this would
help to reduce the number of "magic numbers" in our building system.

Refs https://github.com/scylladb/scylladb/issues/15241