### PR TITLE
test/alternator: avoid warnings about unverified HTTPS

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -16,14 +16,6 @@ import re
 from util import create_test_table, is_aws, scylla_log
 from urllib.parse import urlparse
 
-# When tests are run with HTTPS, the server often won't have its SSL
-# certificate signed by a known authority. So we will disable certificate
-# verification with the "verify=False" request option. However, once we do
-# that, we start getting scary-looking warning messages, saying that this
-# makes HTTPS insecure. The following silences those warnings:
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 # Test that the Boto libraries are new enough. These tests want to test a
 # large variety of DynamoDB API features, and to do this we need a new-enough
 # version of the the Boto libraries (boto3 and botocore) so that they can

--- a/test/alternator/pytest.ini
+++ b/test/alternator/pytest.ini
@@ -1,4 +1,12 @@
 # Pytest configuration file. If we don't have one in this directory,
 # pytest will look for one in our ancestor directories, and may find
-# something irrelevant. So we should have one here, even if empty.
+# something irrelevant - so we should keep this file even if in the future
+# we decide that we don't need to configure anything.
+
 [pytest]
+
+# Ignore warnings about HTTPS requests without certificate verification
+# (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,
+# so we need to do this here.
+filterwarnings =
+    ignore::urllib3.exceptions.InsecureRequestWarning


### PR DESCRIPTION
The Alternator tests can run against HTTPS - namely when using test/alternator/run with the "--https" option (local Alternator configured with HTTPS) or "--aws" option (DynamoDB, using HTTPS).

In some cases we make these HTTPS requests with verify=False, to avoid checking the SSL certificates. E.g., this is necessary for Alternator with a self-signed certificate. Unfortunately, the urllib3 library adds an ugly warning message when SSL certificate verification is disabled.

In the past we tried to disable these warnings, using the documented urllib3.disable_warnings() function, but it didn't help. It turns out that pytest has its own warning handling, so to disable warnings in pytest we must say so in a special configuration parameter in pytest.ini.

So in this patch, we drop the disable_warnings call from conftest.py (where it didn't help), and instead put a similar declaration in pytest.ini. The disable_warnings call in the test/alternator/run script needs to remain - it is run outside pytest, so pytest.ini doesn't affect it.

After this patch, running test/alternator/run with --https or --aws finishes without warnings, as desired.

Fixes #15287