### PR TITLE
Topology: use this host_id in is_configured_this_node

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -145,7 +145,7 @@ bool topology::is_configured_this_node(const node& n) const {
         return _cfg.this_host_id == n.host_id();
     }
     if (_cfg.this_endpoint != inet_address()) { // Selection by endpoint
-        return _cfg.this_endpoint == n.endpoint();;
+        return _cfg.this_endpoint == n.endpoint();
     }
     return false; // No selection;
 }

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -141,6 +141,9 @@ const node* topology::add_node(host_id id, const inet_address& ep, const endpoin
 }
 
 bool topology::is_configured_this_node(const node& n) const {
+    if (_cfg.this_host_id && n.host_id()) { // Selection by host_id
+        return _cfg.this_host_id == n.host_id();
+    }
     if (_cfg.this_endpoint != inet_address()) { // Selection by endpoint
         return _cfg.this_endpoint == n.endpoint();;
     }


### PR DESCRIPTION
Since 5d1f60439a845c1ea91fce17de35b879c8d642e0 we have
this node's host_id in topology config, so it can be used
to determine this node when adding it.

Prepare for extending the token_metadata interface
to provide host_id in update_topology.

We would like to compare the host_id first to be able to distinguish
this node from a node we're replacing that may have the same ip address
(but different host_id).
