### PR TITLE
create-relocatable-package.py: add --node-exporter-dir and --build-dir options

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1848,11 +1848,11 @@ with open(buildfile, 'w') as f:
         rule strip
             command = scripts/strip.sh $in
         rule package
-            command = scripts/create-relocatable-package.py --mode $mode $out
+            command = scripts/create-relocatable-package.py --build-dir build/$mode $out
         rule stripped_package
-            command = scripts/create-relocatable-package.py --stripped --mode $mode $out
+            command = scripts/create-relocatable-package.py --stripped --build-dir build/$mode $out
         rule debuginfo_package
-            command = dist/debuginfo/scripts/create-relocatable-package.py --mode $mode $out
+            command = dist/debuginfo/scripts/create-relocatable-package.py --build-dir build/$mode $out
         rule rpmbuild
             command = reloc/build_rpm.sh --reloc-pkg $in --builddir $out
         rule debbuild

--- a/dist/debuginfo/scripts/create-relocatable-package.py
+++ b/dist/debuginfo/scripts/create-relocatable-package.py
@@ -34,6 +34,8 @@ ap.add_argument('dest',
                 help='Destination file (tar format)')
 ap.add_argument('--build-dir', default='build/release',
                 help='Build dir ("build/debug" or "build/release") to use')
+ap.add_argument('--node-exporter-dir', default='build/node_exporter',
+                help='the directory where node_exporter is located')
 
 args = ap.parse_args()
 
@@ -61,7 +63,7 @@ with tempfile.NamedTemporaryFile('w+t') as version_file:
 for exe in executables_scylla:
     basename = os.path.basename(exe)
     ar.reloc_add(f'{exe}.debug', arcname=f'libexec/.debug/{basename}.debug')
-ar.reloc_add('build/node_exporter/node_exporter.debug', arcname='node_exporter/.debug/node_exporter.debug')
+ar.reloc_add(f'{args.node_exporter_dir}/node_exporter.debug', arcname='node_exporter/.debug/node_exporter.debug')
 ar.reloc_add('dist/debuginfo/install.sh', arcname='install.sh')
 
 # Complete the tar output, and wait for the gzip process to complete

--- a/dist/debuginfo/scripts/create-relocatable-package.py
+++ b/dist/debuginfo/scripts/create-relocatable-package.py
@@ -32,14 +32,14 @@ def reloc_add(ar, name, arcname=None):
 ap = argparse.ArgumentParser(description='Create a relocatable scylla-debuginfo package.')
 ap.add_argument('dest',
                 help='Destination file (tar format)')
-ap.add_argument('--mode', dest='mode', default='release',
-                help='Build mode (debug/release) to use')
+ap.add_argument('--build-dir', default='build/release',
+                help='Build dir ("build/debug" or "build/release") to use')
 
 args = ap.parse_args()
 
 executables_scylla = [
-                'build/{}/scylla'.format(args.mode),
-                'build/{}/iotune'.format(args.mode)]
+                '{}/scylla'.format(args.build_dir),
+                '{}/iotune'.format(args.build_dir)]
 
 output = args.dest
 

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -67,8 +67,8 @@ def reloc_add(ar, name, arcname=None):
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('dest',
                 help='Destination file (tar format)')
-ap.add_argument('--mode', dest='mode', default='release',
-                help='Build mode (debug/release) to use')
+ap.add_argument('--build-dir', default='build/release',
+                help='Build dir ("build/debug" or "build/release") to use')
 ap.add_argument('--stripped', action='store_true',
                 help='use stripped binaries')
 ap.add_argument('--print-libexec', action='store_true',
@@ -77,8 +77,8 @@ ap.add_argument('--print-libexec', action='store_true',
 args = ap.parse_args()
 
 executables_scylla = [
-                'build/{}/scylla'.format(args.mode),
-                'build/{}/iotune'.format(args.mode)]
+                '{}/scylla'.format(args.build_dir),
+                '{}/iotune'.format(args.build_dir)]
 executables_distrocmd = [
                 '/usr/bin/patchelf',
                 '/usr/bin/lscpu',

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -69,6 +69,8 @@ ap.add_argument('dest',
                 help='Destination file (tar format)')
 ap.add_argument('--build-dir', default='build/release',
                 help='Build dir ("build/debug" or "build/release") to use')
+ap.add_argument('--node-exporter-dir', default='build/node_exporter',
+                help='the directory where node_exporter is located')
 ap.add_argument('--stripped', action='store_true',
                 help='use stripped binaries')
 ap.add_argument('--print-libexec', action='store_true',
@@ -165,13 +167,14 @@ ar.reloc_add('api')
 ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('build/debian/debian', arcname='debian')
+node_exporter_dir = args.node_exporter_dir
 if args.stripped:
-    ar.reloc_add('build/node_exporter', arcname='node_exporter')
-    ar.reloc_add('build/node_exporter/node_exporter.stripped', arcname='node_exporter/node_exporter')
+    ar.reloc_add(f'{node_exporter_dir}', arcname='node_exporter')
+    ar.reloc_add(f'{node_exporter_dir}/node_exporter.stripped', arcname='node_exporter/node_exporter')
 else:
-    ar.reloc_add('build/node_exporter/node_exporter', arcname='node_exporter/node_exporter')
-ar.reloc_add('build/node_exporter/LICENSE', arcname='node_exporter/LICENSE')
-ar.reloc_add('build/node_exporter/NOTICE', arcname='node_exporter/NOTICE')
+    ar.reloc_add(f'{node_exporter_dir}/node_exporter', arcname='node_exporter/node_exporter')
+ar.reloc_add(f'{node_exporter_dir}/LICENSE', arcname='node_exporter/LICENSE')
+ar.reloc_add(f'{node_exporter_dir}/NOTICE', arcname='node_exporter/NOTICE')
 ar.reloc_add('ubsan-suppressions.supp')
 ar.reloc_add('fix_system_distributed_tables.py')
 


### PR DESCRIPTION
this series adds `--node-exporter-dir` and `--build-dir` options to `create-relocatable-package.py`. this enables us to use create relocatable package from arbitrary build directories.

Refs #15241