### PR TITLE
gossiper: real_mark_alive: do not erase from unreachable_endpoints without holding lock

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1649,10 +1649,6 @@ future<> gossiper::real_mark_alive(inet_address addr) {
     update_timestamp(es);
 
     logger.debug("removing expire time for endpoint : {}", addr);
-    _unreachable_endpoints.erase(addr);
-    _expire_time_endpoint_map.erase(addr);
-
-    logger.debug("removing expire time for endpoint : {}", addr);
     bool was_live = false;
     co_await mutate_live_and_unreachable_endpoints([addr, &was_live] (gossiper& g) {
         g._unreachable_endpoints.erase(addr);


### PR DESCRIPTION
This code was supposed to be moved into
`mutate_live_and_unreachable_endpoints`
in 2c27297dbdc926f891e7d1a4d4ee964967afad3b
but it looks like the original statements were left in place outside the mutate function.

This patch just removes the stale code since the required logic is already done inside `mutate_live_and_unreachable_endpoints`.

Fixes scylladb/scylladb#15296