### PR TITLE
storage_service: Enforce tablet streaming runs on shard 0

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6108,7 +6108,9 @@ void storage_service::init_messaging_service(sharded<service::storage_proxy>& pr
         });
     });
     ser::storage_service_rpc_verbs::register_tablet_stream_data(&_messaging.local(), [this] (locator::global_tablet_id tablet) {
-        return stream_tablet(tablet);
+        return container().invoke_on(0, [tablet] (auto& ss) -> future<> {
+            return ss.stream_tablet(tablet);
+        });
     });
 }
 


### PR DESCRIPTION
SIGSEGV was caught during tablet streaming, and the reason was that storage_service::_group0 (via set_group0()) is only set on shard 0, therefore when streaming ran on any other shard, it tried to dereference garbage, which resulted in the crash.