### PR TITLE
Collect dangling object-store sstables

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -75,6 +75,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _state(state)
     , _sstable_dir(make_path(_table_dir, _state))
     , _error_handler_gen(error_handler_gen)
+    , _storage(make_storage(_manager, *_storage_opts, _table_dir, _state))
     , _lister(make_components_lister())
     , _sharder(sharder)
     , _unshared_remote_sstables(smp::count)

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -344,7 +344,7 @@ future<> sstable_directory::system_keyspace_components_lister::commit() {
     return make_ready_future<>();
 }
 
-future<> sstable_directory::system_keyspace_components_lister::garbage_collect() {
+future<> sstable_directory::system_keyspace_components_lister::garbage_collect(storage& st) {
     // FIXME -- implement
     co_return;
 }
@@ -590,10 +590,10 @@ future<> sstable_directory::filesystem_components_lister::replay_pending_delete_
 }
 
 future<> sstable_directory::garbage_collect() {
-    return _lister->garbage_collect();
+    return _lister->garbage_collect(*_storage);
 }
 
-future<> sstable_directory::filesystem_components_lister::garbage_collect() {
+future<> sstable_directory::filesystem_components_lister::garbage_collect(storage& st) {
     // First pass, cleanup temporary sstable directories and sstables pending delete.
     co_await cleanup_column_family_temp_sst_dirs();
     co_await handle_sstables_pending_delete();

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -33,6 +33,7 @@ namespace db { class system_keyspace; }
 namespace sstables {
 
 enum class sstable_state;
+class storage;
 class sstables_manager;
 bool manifest_json_filter(const std::filesystem::path&, const directory_entry& entry);
 
@@ -138,6 +139,7 @@ private:
     sstable_state _state;
     std::filesystem::path _sstable_dir; // FIXME -- remove eventually
     io_error_handler_gen _error_handler_gen;
+    std::unique_ptr<storage> _storage;
     std::unique_ptr<components_lister> _lister;
     const dht::sharder& _sharder;
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -75,7 +75,7 @@ public:
     public:
         virtual future<> process(sstable_directory& directory, process_flags flags) = 0;
         virtual future<> commit() = 0;
-        virtual future<> garbage_collect() = 0;
+        virtual future<> garbage_collect(storage&) = 0;
         virtual ~components_lister() {}
     };
 
@@ -111,7 +111,7 @@ public:
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
-        virtual future<> garbage_collect() override;
+        virtual future<> garbage_collect(storage&) override;
     };
 
     class system_keyspace_components_lister final : public components_lister {
@@ -123,7 +123,7 @@ public:
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
-        virtual future<> garbage_collect() override;
+        virtual future<> garbage_collect(storage&) override;
     };
 
 private:

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -30,6 +30,7 @@ enum class sstable_state;
 class delayed_commit_changes;
 class sstable;
 class sstables_manager;
+class entry_descriptor;
 
 class storage {
     friend class test;
@@ -62,6 +63,7 @@ public:
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
+    virtual future<> remove_by_registry_entry(utils::UUID uuid, entry_descriptor desc) = 0;
 
     virtual sstring prefix() const  = 0;
 };

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -741,6 +741,9 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
     auto& db_cfg = *db_cfg_ptr;
     db_cfg.enable_user_defined_functions({true}, db::config::config_source::CommandLine);
     db_cfg.experimental_features({experimental_features_t::feature::UDF, experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS}, db::config::config_source::CommandLine);
+    std::unordered_map<sstring, s3::endpoint_config> so_config;
+    so_config["localhost"] = s3::endpoint_config{};
+    db_cfg.object_storage_config = std::move(so_config);
     if (regenerate) {
         db_cfg.data_file_directories({data_dir}, db::config::config_source::CommandLine);
     } else {


### PR DESCRIPTION
Sstables in transitional states are marked with the respective 'status' in the registry. Currently there are two of such -- 'creating' and 'removing'. And the 'sealed' status for sstables in use.

On boot the distributed loader tries to garbage collect the dangling sstables. For filesystem storage it's done with the help of temorary sstables' dirs and pending deletion logs. For s3-backed sstables, the garbage collection means fetching all non-sealed entries and removing the corresponding objects from the storage.

Test included (last patch)

fixes #13024