### PR TITLE
check cqlsh works as part of the restart procedure

### DIFF
--- a/docs/operating-scylla/procedures/config-change/rolling-restart.rst
+++ b/docs/operating-scylla/procedures/config-change/rolling-restart.rst
@@ -23,6 +23,9 @@ Procedure
 
 .. include:: /rst_include/scylla-commands-start-index.rst
 
-5. Verify the node is up and has returned to the Scylla cluster using :doc:`nodetool status </operating-scylla/nodetool-commands/status/>`.
+5. Verify the node is up and has returned to the Scylla cluster, and CQL port is available
+
+   * :doc:`nodetool status </operating-scylla/nodetool-commands/status/>`.
+   * ``cqlsh -e "SHOW VERSION" || exit 1``
 
 6. Repeat this procedure for all the relevant nodes in the cluster.


### PR DESCRIPTION
This PR adds CQLSh to the restart procedure as an additional test for the node status

Fix for https://github.com/scylladb/scylladb/issues/13156

Why I'm not sure about this proposal:
- Is it feasible to have a Scylla node in UP state (from nodetool status) but CQL available? Does this check add anything?
- What if the node uses as Alternator, and the CQL port is closed?
