### PR TITLE
docs: improve command line samples in unified-installer.rst

### DIFF
--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -39,7 +39,7 @@ Download and Install
 
    .. code:: console
     
-    sudo yum install -y java-11-openjdk
+    sudo yum install -y java-11-openjdk-headless
 
    For root offline installation on Debian-like systems, two additional packages, ``xfsprogs`` 
    and ``mdadm``, should be installed to be used in RAID setup.

--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -48,7 +48,7 @@ Download and Install
 
    .. code:: console
 
-    sh -x ./install.sh --nonroot --python3 ~/scylladb/python3/bin/python3
+    ./install.sh --nonroot --python3 ~/scylladb/python3/bin/python3
 
 Configure and Run ScyllaDB
 ----------------------------


### PR DESCRIPTION
in this series, we try to improve `unified-installer.rst`

- encourage user to install smaller package
- run `./install.sh` directly instead relying on that `sh` points to `bash`