### PR TITLE
storage_service: initialize group0 in ctor

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -127,6 +127,7 @@ storage_service::storage_service(abort_source& abort_source,
         , _repair(repair)
         , _stream_manager(stream_manager)
         , _snitch(snitch)
+        , _group0(nullptr)
         , _node_ops_abort_thread(node_ops_abort_thread())
         , _shared_token_metadata(stm)
         , _erm_factory(erm_factory)


### PR DESCRIPTION
there are a couple of places that check group is not nullptr, so let's set it to nullptr on ctor, so shards that don't have it initialized will bump on assert, instead of failing with a cryptic segfault error.