### PR TITLE
docs: parse db/config.cc edge cases

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -5,75 +5,125 @@ from sphinx.application import Sphinx
 from sphinxcontrib.datatemplates.directive import DataTemplateYAML
 from docutils.parsers.rst import directives
 
-CONFIG_FILE_PATH = '../db/config.cc'
-CONFIG_HEADER_FILE_PATH = '../db/config.hh'
-DESTINATION_PATH = '_data/db_config.yaml'
-
-def create_yaml_file(destination, data):
-    current_data = None
-    
-    try:
-        with open(destination, 'r') as file:
-            current_data = yaml.safe_load(file)
-    except FileNotFoundError:
-        pass
-
-    if current_data != data:
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'w') as file:
-            yaml.dump(data, file)
-
-def parse_db_properties(config_file, config_header_file):
-
-    properties_dict = {}
-
-    # Parse config file
-    with open(config_file, 'r') as file:
-        config_content = file.read()
-
-    config_pattern = r',\s*(\w+)\(this,\s*"(\w+)",\s*(?:liveness::(\w+),\s*)?value_status::(\w+),\s*([^,]+),\s*"([^"]+)"\)'
-    config_matches = re.findall(config_pattern, config_content)
-
-    for match in config_matches:
-        property_data = {
-            "name": match[1].strip(),
-            "value_status": match[3].strip(), 
-            "default": match[4].strip(),
-            "liveness": 'True' if match[2] else 'False',
-            "description": match[5].strip().replace('\n', '<br />')
-        }
-        properties_dict[match[1].strip()] = property_data
-
-    # Parse header file
-    with open(config_header_file, 'r') as file:
-        config_header_content = file.read()
-
-    config_header_pattern = r'\s*named_value<(\w+)> (\w+);'
-    config_header_matches = re.findall(config_header_pattern, config_header_content)
-
-    for match in config_header_matches:
-        if match[1] in properties_dict: 
-            properties_dict[match[1]]['type'] = match[0].strip()
-
-    return list(properties_dict.values())
+CONFIG_FILE_PATH = "../db/config.cc"
+CONFIG_HEADER_FILE_PATH = "../db/config.hh"
+DESTINATION_PATH = "_data/db_config.yaml"
 
 
-def generate_cc_docs(app: Sphinx):
-    dest_path = os.path.join(app.builder.srcdir, DESTINATION_PATH)
-    parsed_properties = parse_db_properties(CONFIG_FILE_PATH, CONFIG_HEADER_FILE_PATH)
-    create_yaml_file(dest_path, parsed_properties)
+class DBConfigParser:
+
+    """
+    Regex pattern for parsing the configuration properties.
+    """
+
+    CONFIG_CC_REGEX_PATTERN = (
+        r',\s*(\w+)\(this,'  # 0. Property name
+        r'\s*"([^"]*)",\s*'  # 1. Property key
+        r'(?:\s*"([^"]+)",)?'  # 2. Property alias (optional)
+        r'\s*(?:liveness::(\w+),\s*)?'  # 3. Liveness (optional)
+        r'(?:value_status::)?(\w+),\s*'  # 4. Value status
+        r'(\{[^{}]*\}|"[^"]*"|[^,]+)?,'  # 5. Default value
+        r'\s*"(.*?)"'  # 6. Description text, divided in multiple lines.
+        r'(?:,\s*(.+?))?'  # 7. Available values (optional)
+        r'\s*\)'
+    )
+
+    """
+    Regex pattern for parsing named values in the configuration header file:
+    """
+    CONFIG_H_REGEX_PATTERN = r"\s*named_value<([\w:<>,\s]+)> (\w+);"
+
+    """
+    Regex pattern for parsing comments.
+    """
+    COMMENT_PATTERN = r"/\*.*?\*/|//.*?$"
+
+    def __init__(self, config_file_path, config_header_file_path, destination_path):
+        self.config_file_path = config_file_path
+        self.config_header_file_path = config_header_file_path
+        self.destination_path = destination_path
+
+    def _create_yaml_file(self, destination, data):
+        current_data = None
+
+        try:
+            with open(destination, "r") as file:
+                current_data = yaml.safe_load(file)
+        except FileNotFoundError:
+            pass
+
+        if current_data != data:
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            with open(destination, "w") as file:
+                yaml.dump(data, file)
+
+    @staticmethod
+    def _clean_description(description):
+        return (
+            description.replace("\\n", "")
+            .replace('<', '&lt;')
+            .replace('>', '&gt;')
+            .replace("\n", "<br>")
+            .replace("\\t", "- ")
+            .replace('"', "")
+        )
+
+    def _parse_db_properties(self):
+        properties_dict = {}
+
+        with open(self.config_file_path, "r") as file:
+            config_content = file.read()
+
+        config_content = re.sub(
+            self.COMMENT_PATTERN, "", config_content, flags=re.DOTALL | re.MULTILINE
+        )
+        config_matches = re.findall(
+            self.CONFIG_CC_REGEX_PATTERN, config_content, re.DOTALL
+        )
+
+        for match in config_matches:
+            property_data = {
+                "name": match[1].strip(),
+                "value_status": match[4].strip(),
+                "default": match[5].strip(),
+                "liveness": "True" if match[3] else "False",
+                "description": self._clean_description(match[6].strip()),
+            }
+            properties_dict[match[1].strip()] = property_data
+
+        with open(self.config_header_file_path, "r") as file:
+            config_header_content = file.read()
+
+        config_header_matches = re.findall(
+            self.CONFIG_H_REGEX_PATTERN, config_header_content
+        )
+
+        for match in config_header_matches:
+            property_key = match[1].strip()
+            if property_key in properties_dict:
+                properties_dict[property_key]["type"] = match[0].strip()
+        return list(properties_dict.values())
+
+    def run(self, app: Sphinx):
+        dest_path = os.path.join(app.builder.srcdir, self.destination_path)
+        parsed_properties = self._parse_db_properties()
+        self._create_yaml_file(dest_path, parsed_properties)
 
 
 class DBConfigTemplateDirective(DataTemplateYAML):
-    
+
     option_spec = DataTemplateYAML.option_spec.copy()
     option_spec["value_status"] = directives.unchanged_required
 
     def _make_context(self, data, config, env):
         context = super()._make_context(data, config, env)
-        context['value_status'] = self.options.get('value_status')
+        context["value_status"] = self.options.get("value_status")
         return context
 
+
 def setup(app: Sphinx):
-    app.connect("builder-inited", generate_cc_docs)
-    app.add_directive('scylladb_config_template', DBConfigTemplateDirective)
+    db_parser = DBConfigParser(
+        CONFIG_FILE_PATH, CONFIG_HEADER_FILE_PATH, DESTINATION_PATH
+    )
+    app.connect("builder-inited", db_parser.run)
+    app.add_directive("scylladb_config_template", DBConfigTemplateDirective)


### PR DESCRIPTION
Closes #15337

> The [DB config documentation](https://opensource.docs.scylladb.com/master/reference/db-config.html) only handles basic properties. We've identified in https://github.com/scylladb/scylla-enterprise/pull/3398 some advanced cases where the parser may fail. 

This pull request:

- Captures properties with descriptions that span multiple lines.
- Captures properties with a property alias set.
- Captures properties with available values defined.
- Captures properties with inlined comments.
- Improves the readability of the regex.

## How to test

Preview: https://pr-15338.d33vp1qmzwl1gq.amplifyapp.com/reference/configuration-parameters/

- `seed_provider` property with description in multiple lines is rendered.
- `data_file_directories` property with an alias set is rendered.
- `endpoint_snitch` property with inlined comments in the description is rendered.