### PR TITLE
gossiper: get rid of uses_host_id

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1467,11 +1467,6 @@ stop_iteration gossiper::for_each_endpoint_state_until(std::function<stop_iterat
     return stop_iteration::no;
 }
 
-bool gossiper::uses_host_id(inet_address endpoint) const {
-    return _messaging.knows_version(endpoint) ||
-            get_application_state_ptr(endpoint, application_state::NET_VERSION);
-}
-
 bool gossiper::is_cql_ready(const inet_address& endpoint) const {
     // Note:
     // - New scylla node always send application_state::RPC_READY = false when
@@ -1492,9 +1487,6 @@ bool gossiper::is_cql_ready(const inet_address& endpoint) const {
 }
 
 locator::host_id gossiper::get_host_id(inet_address endpoint) const {
-    if (!uses_host_id(endpoint)) {
-        throw std::runtime_error(format("Host {} does not use new-style tokens!", endpoint));
-    }
     auto app_state = get_application_state_ptr(endpoint, application_state::HOST_ID);
     if (!app_state) {
         throw std::runtime_error(format("Host {} does not have HOST_ID application_state", endpoint));

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -444,8 +444,6 @@ public:
     // Called function must not yield
     stop_iteration for_each_endpoint_state_until(std::function<stop_iteration(const inet_address&, const endpoint_state&)>) const;
 
-    bool uses_host_id(inet_address endpoint) const;
-
     locator::host_id get_host_id(inet_address endpoint) const;
 
     std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3060,8 +3060,7 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint, gms::per
 
     tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::bootstrapping);
     tmptr->add_bootstrap_tokens(tokens, endpoint);
-    // FIXME: indentation
-        tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
+    tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
     co_await update_topology_change_info(tmptr, ::format("handle_state_bootstrap {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
@@ -3090,36 +3089,35 @@ future<> storage_service::handle_state_normal(inet_address endpoint, gms::permit
         endpoints_to_remove.insert(node);
     };
     // Order Matters, TM.updateHostID() should be called before TM.updateNormalToken(), (see CASSANDRA-4300).
-    // FIXME: indentation
-        auto host_id = _gossiper.get_host_id(endpoint);
-        auto existing = tmptr->get_endpoint_for_host_id(host_id);
-        if (existing && *existing != endpoint) {
-            if (*existing == get_broadcast_address()) {
-                slogger.warn("Not updating host ID {} for {} because it's mine", host_id, endpoint);
-                do_remove_node(endpoint);
-            } else if (_gossiper.compare_endpoint_startup(endpoint, *existing) > 0) {
-                slogger.warn("Host ID collision for {} between {} and {}; {} is the new owner", host_id, *existing, endpoint, endpoint);
-                do_remove_node(*existing);
-                slogger.info("Set host_id={} to be owned by node={}, existing={}", host_id, endpoint, *existing);
-                tmptr->update_host_id(host_id, endpoint);
-            } else {
-                slogger.warn("Host ID collision for {} between {} and {}; ignored {}", host_id, *existing, endpoint, endpoint);
-                do_remove_node(endpoint);
-            }
-        } else if (existing && *existing == endpoint) {
-            tmptr->del_replacing_endpoint(endpoint);
-        } else {
-            tmptr->del_replacing_endpoint(endpoint);
-            auto nodes = _gossiper.get_nodes_with_host_id(host_id);
-            bool left = std::any_of(nodes.begin(), nodes.end(), [this] (const gms::inet_address& node) { return _gossiper.is_left(node); });
-            if (left) {
-                slogger.info("Skip to set host_id={} to be owned by node={}, because the node is removed from the cluster, nodes {} used to own the host_id", host_id, endpoint, nodes);
-                _normal_state_handled_on_boot.insert(endpoint);
-                co_return;
-            }
-            slogger.info("Set host_id={} to be owned by node={}", host_id, endpoint);
+    auto host_id = _gossiper.get_host_id(endpoint);
+    auto existing = tmptr->get_endpoint_for_host_id(host_id);
+    if (existing && *existing != endpoint) {
+        if (*existing == get_broadcast_address()) {
+            slogger.warn("Not updating host ID {} for {} because it's mine", host_id, endpoint);
+            do_remove_node(endpoint);
+        } else if (_gossiper.compare_endpoint_startup(endpoint, *existing) > 0) {
+            slogger.warn("Host ID collision for {} between {} and {}; {} is the new owner", host_id, *existing, endpoint, endpoint);
+            do_remove_node(*existing);
+            slogger.info("Set host_id={} to be owned by node={}, existing={}", host_id, endpoint, *existing);
             tmptr->update_host_id(host_id, endpoint);
+        } else {
+            slogger.warn("Host ID collision for {} between {} and {}; ignored {}", host_id, *existing, endpoint, endpoint);
+            do_remove_node(endpoint);
         }
+    } else if (existing && *existing == endpoint) {
+        tmptr->del_replacing_endpoint(endpoint);
+    } else {
+        tmptr->del_replacing_endpoint(endpoint);
+        auto nodes = _gossiper.get_nodes_with_host_id(host_id);
+        bool left = std::any_of(nodes.begin(), nodes.end(), [this] (const gms::inet_address& node) { return _gossiper.is_left(node); });
+        if (left) {
+            slogger.info("Skip to set host_id={} to be owned by node={}, because the node is removed from the cluster, nodes {} used to own the host_id", host_id, endpoint, nodes);
+            _normal_state_handled_on_boot.insert(endpoint);
+            co_return;
+        }
+        slogger.info("Set host_id={} to be owned by node={}", host_id, endpoint);
+        tmptr->update_host_id(host_id, endpoint);
+    }
 
     // Tokens owned by the handled endpoint.
     // The endpoint broadcasts its set of chosen tokens. If a token was also chosen by another endpoint,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3060,9 +3060,8 @@ future<> storage_service::handle_state_bootstrap(inet_address endpoint, gms::per
 
     tmptr->update_topology(endpoint, get_dc_rack_for(endpoint), locator::node::state::bootstrapping);
     tmptr->add_bootstrap_tokens(tokens, endpoint);
-    if (_gossiper.uses_host_id(endpoint)) {
+    // FIXME: indentation
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
-    }
     co_await update_topology_change_info(tmptr, ::format("handle_state_bootstrap {}", endpoint));
     co_await replicate_to_all_cores(std::move(tmptr));
 }
@@ -3091,7 +3090,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint, gms::permit
         endpoints_to_remove.insert(node);
     };
     // Order Matters, TM.updateHostID() should be called before TM.updateNormalToken(), (see CASSANDRA-4300).
-    if (_gossiper.uses_host_id(endpoint)) {
+    // FIXME: indentation
         auto host_id = _gossiper.get_host_id(endpoint);
         auto existing = tmptr->get_endpoint_for_host_id(host_id);
         if (existing && *existing != endpoint) {
@@ -3121,7 +3120,6 @@ future<> storage_service::handle_state_normal(inet_address endpoint, gms::permit
             slogger.info("Set host_id={} to be owned by node={}", host_id, endpoint);
             tmptr->update_host_id(host_id, endpoint);
         }
-    }
 
     // Tokens owned by the handled endpoint.
     // The endpoint broadcasts its set of chosen tokens. If a token was also chosen by another endpoint,


### PR DESCRIPTION
This function practically returned true from inception.
    
In d38deef499f72d4f4bd629e134fb15b750db6d6c
it started using messaging_service().knows_version(endpoint)
that also returns `true` unconditionally, to this day

So there's no point calling it since we can assume
that `uses_host_id` is true for all versions.