### PR TITLE
util: replace <tab> with spaces

### DIFF
--- a/utils/abi/eh_ia64.hh
+++ b/utils/abi/eh_ia64.hh
@@ -28,7 +28,7 @@ struct cxa_exception {
     cxa_exception* nextException;
 
     int handlerCount;
-    int	handlerSwitchValue;
+    int handlerSwitchValue;
     const char* actionRecord;
     const char* languageSpecificData;
     void* catchTemp;

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -47,8 +47,8 @@ bool is_system_error_errno(int err_no)
 
 bool should_stop_on_system_error(const std::system_error& e) {
     if (e.code().category() == std::system_category()) {
-	// Whitelist of errors that don't require us to stop the server:
-	switch (e.code().value()) {
+        // Whitelist of errors that don't require us to stop the server:
+        switch (e.code().value()) {
         case EEXIST:
         case ENOENT:
             return false;


### PR DESCRIPTION
to be aligned with seastar's coding-style.md: scylladb uses seastar's coding-style.md. so let's adhere to it.