### PR TITLE
Add maintenance mode

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1001,7 +1001,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
     ss::is_initialized.set(r, [&ss](std::unique_ptr<http::request> req) {
         return ss.local().get_operation_mode().then([&ss] (auto mode) {
-            bool is_initialized = mode >= service::storage_service::mode::STARTING;
+            bool is_initialized = mode >= service::storage_service::mode::STARTING && mode != service::storage_service::mode::MAINTENANCE;
             if (mode == service::storage_service::mode::NORMAL) {
                 is_initialized = ss.local().gossiper().is_enabled();
             }
@@ -1015,7 +1015,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
     ss::is_joined.set(r, [&ss] (std::unique_ptr<http::request> req) {
         return ss.local().get_operation_mode().then([] (auto mode) {
-            return make_ready_future<json::json_return_type>(mode >= service::storage_service::mode::JOINING);
+            return make_ready_future<json::json_return_type>(mode >= service::storage_service::mode::JOINING && mode != service::storage_service::mode::MAINTENANCE);
         });
     });
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -128,7 +128,7 @@ service::service(
         std::unique_ptr<authorizer> z,
         std::unique_ptr<authenticator> a,
         std::unique_ptr<role_manager> r,
-        db::maintenance_socket_enabled used_by_maintenance_socket)
+        maintenance_socket_enabled used_by_maintenance_socket)
             : _loading_cache_config(std::move(c))
             , _permissions_cache(nullptr)
             , _qp(qp)
@@ -150,7 +150,7 @@ service::service(
         ::service::migration_notifier& mn,
         ::service::migration_manager& mm,
         const service_config& sc,
-        db::maintenance_socket_enabled used_by_maintenance_socket)
+        maintenance_socket_enabled used_by_maintenance_socket)
             : service(
                       std::move(c),
                       qp,

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -26,6 +26,7 @@
 #include "utils/observable.hh"
 #include "utils/serialized_action.hh"
 #include "db/config.hh"
+#include "service/maintenance_mode.hh"
 
 namespace cql3 {
 class query_processor;
@@ -94,7 +95,7 @@ class service final : public seastar::peering_sharded_service<service> {
     utils::observer<uint32_t> _permissions_cache_update_interval_in_ms_observer;
     utils::observer<uint32_t> _permissions_cache_validity_in_ms_observer;
 
-    db::maintenance_socket_enabled _used_by_maintenance_socket;
+    maintenance_socket_enabled _used_by_maintenance_socket;
 
 public:
     service(
@@ -104,7 +105,7 @@ public:
             std::unique_ptr<authorizer>,
             std::unique_ptr<authenticator>,
             std::unique_ptr<role_manager>,
-            db::maintenance_socket_enabled);
+            maintenance_socket_enabled);
 
     ///
     /// This constructor is intended to be used when the class is sharded via \ref seastar::sharded. In that case, the
@@ -117,7 +118,7 @@ public:
             ::service::migration_notifier&,
             ::service::migration_manager&,
             const service_config&,
-            db::maintenance_socket_enabled);
+            maintenance_socket_enabled);
 
     future<> start(::service::migration_manager&);
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -763,6 +763,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\tworkdir        the node will open the maintenance socket on the path <scylla's workdir>/cql.m,\n"
         "\t               where <scylla's workdir> is a path defined by the workdir configuration option\n"
         "\t<socket path>  the node will open the maintenance socket on the path <socket path>")
+    , maintenance_mode(this, "maintenance_mode", value_status::Used, false, "If set to true, the node will not connect to other nodes. It will only serve requests to its local data.")
     , native_transport_port_ssl(this, "native_transport_port_ssl", value_status::Used, 9142,
         "Port on which the CQL TLS native transport listens for clients."
         "Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption"

--- a/db/config.hh
+++ b/db/config.hh
@@ -278,6 +278,7 @@ public:
     named_value<bool> start_native_transport;
     named_value<uint16_t> native_transport_port;
     named_value<sstring> maintenance_socket;
+    named_value<bool> maintenance_mode;
     named_value<uint16_t> native_transport_port_ssl;
     named_value<uint16_t> native_shard_aware_transport_port;
     named_value<uint16_t> native_shard_aware_transport_port_ssl;

--- a/db/config.hh
+++ b/db/config.hh
@@ -126,8 +126,6 @@ struct replication_strategy_restriction_t {
 
 constexpr unsigned default_murmur3_partitioner_ignore_msb_bits = 12;
 
-using maintenance_socket_enabled = bool_class<class maintenance_socket_enabled_tag>;
-
 class config final : public utils::config_file {
 public:
     config();

--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -16,6 +16,7 @@
 * :doc:`perftune</operating-scylla/admin-tools/perftune>` - performance configuration.
 * :doc:`SELECT * FROM MUTATION_FRAGMENTS() Statement </operating-scylla/admin-tools/select-from-mutation-fragments/>` - dump the underlying mutation data from tables.
 * :doc:`Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>` - a Unix domain socket for full-permission CQL connection.
+* :doc:`Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>` - a mode for performing maintenance tasks on an offline Scylla node.
 
 
 Run each tool with ``-h``, ``--help`` for full options description.

--- a/docs/operating-scylla/admin-tools/index.rst
+++ b/docs/operating-scylla/admin-tools/index.rst
@@ -21,6 +21,7 @@ Admin Tools
    Virtual Tables </operating-scylla/admin-tools/virtual-tables/>
    SELECT * FROM MUTATION_FRAGMENTS() Statement </operating-scylla/admin-tools/select-from-mutation-fragments/>
    Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>
+   Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>
 
 .. panel-box::
   :title: Admin Tools

--- a/docs/operating-scylla/admin-tools/maintenance-mode.rst
+++ b/docs/operating-scylla/admin-tools/maintenance-mode.rst
@@ -1,0 +1,23 @@
+Maintenance mode
+================
+
+In this mode, the node is not reachable from the outside, i.e.
+
+ * it refuses all incoming RPC connections,
+ * it does not join the cluster, thus
+
+   * all operations that need synchronizing with other nodes are disabled (e.g. schema changes),
+   * all cluster-wide operations are disabled for this node (e.g. repair),
+   * other nodes see this node as dead,
+   * cannot read or write data from/to other nodes,
+ * it does not open Alternator and Redis transport ports and the TCP CQL port.
+
+The only way to make CQL queries is to use :doc:`the maintenance socket </operating-scylla/admin-tools/maintenance-socket/>`. The node serves only local data.
+
+To start the node in maintenance mode, use the `--maintenance-mode true` flag or set `maintenance_mode: true` in the configuration file.
+
+REST API works as usual, but some routes are disabled:
+
+  * authorization_cache
+  * failure_detector
+  * hinted_hand_off_manager

--- a/docs/operating-scylla/admin-tools/maintenance-socket.rst
+++ b/docs/operating-scylla/admin-tools/maintenance-socket.rst
@@ -26,10 +26,10 @@ With python driver
 
     from cassandra.cluster import Cluster
     from cassandra.connection import UnixSocketEndPoint
-    from cassandra.policies import HostFilterPolicy, RoundRobinPolicy
+    from cassandra.policies import WhiteListRoundRobinPolicy
     
-    socket = "<node's workdir>/cql.m"
-    cluster = Cluster([UnixSocketEndPoint(socket)],
+    socket = UnixSocketEndPoint("<node's workdir>/cql.m")
+    cluster = Cluster([socket],
                       # Driver tries to connect to other nodes in the cluster, so we need to filter them out.
-                      load_balancing_policy=HostFilterPolicy(RoundRobinPolicy(), lambda h: h.address == socket))
+                      load_balancing_policy=WhiteListRoundRobinPolicy([socket]))
     session = cluster.connect()

--- a/docs/operating-scylla/admin-tools/maintenance-socket.rst
+++ b/docs/operating-scylla/admin-tools/maintenance-socket.rst
@@ -33,3 +33,10 @@ With python driver
                       # Driver tries to connect to other nodes in the cluster, so we need to filter them out.
                       load_balancing_policy=WhiteListRoundRobinPolicy([socket]))
     session = cluster.connect()
+
+With :doc:`CQLSh</cql/cqlsh/>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    cqlsh <node's workdir>/cql.m

--- a/main.cc
+++ b/main.cc
@@ -1246,6 +1246,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             if (snitch.local()->prefer_local()) {
                 mscfg.preferred_ips = sys_ks.local().get_preferred_ips().get0();
             }
+            mscfg.maintenance_mode = maintenance_mode_enabled{cfg->maintenance_mode()};
 
             const auto& seo = cfg->server_encryption_options();
             auto encrypt = utils::get_or_default(seo, "internode_encryption", "none");

--- a/main.cc
+++ b/main.cc
@@ -1359,7 +1359,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // group0 client exists only on shard 0.
             // The client has to be created before `stop_raft` since during
             // destruction it has to exist until raft_gr.stop() completes.
-            service::raft_group0_client group0_client{raft_gr.local(), sys_ks.local()};
+            service::raft_group0_client group0_client{raft_gr.local(), sys_ks.local(), maintenance_mode_enabled{cfg->maintenance_mode()}};
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,

--- a/main.cc
+++ b/main.cc
@@ -1685,11 +1685,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             maintenance_auth_config.authenticator_java_name = sstring{auth::allow_all_authenticator_name};
             maintenance_auth_config.role_manager_java_name = sstring{auth::maintenance_socket_role_manager_name};
 
-            maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, db::maintenance_socket_enabled::yes).get();
+            maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, maintenance_socket_enabled::yes).get();
 
             scheduling_group_key_config maintenance_cql_sg_stats_cfg =
-            make_scheduling_group_key_config<cql_transport::cql_sg_stats>(db::maintenance_socket_enabled::yes);
-            cql_transport::controller cql_maintenance_server_ctl(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, scheduling_group_key_create(maintenance_cql_sg_stats_cfg).get0(), db::maintenance_socket_enabled::yes);
+            make_scheduling_group_key_config<cql_transport::cql_sg_stats>(maintenance_socket_enabled::yes);
+            cql_transport::controller cql_maintenance_server_ctl(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, scheduling_group_key_create(maintenance_cql_sg_stats_cfg).get0(), maintenance_socket_enabled::yes);
 
             std::any stop_maintenance_auth_service;
             std::any stop_maintenance_cql;
@@ -1778,7 +1778,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auth_config.authenticator_java_name = qualified_authenticator_name;
             auth_config.role_manager_java_name = qualified_role_manager_name;
 
-            auth_service.start(std::move(perm_cache_config), std::ref(qp), std::ref(mm_notifier), std::ref(mm), auth_config, db::maintenance_socket_enabled::no).get();
+            auth_service.start(std::move(perm_cache_config), std::ref(qp), std::ref(mm_notifier), std::ref(mm), auth_config, maintenance_socket_enabled::no).get();
 
             std::any stop_auth_service;
             start_auth_service(auth_service, stop_auth_service, "auth service");
@@ -1877,8 +1877,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             notify_set.notify_all(configurable::system_state::started).get();
 
-            scheduling_group_key_config cql_sg_stats_cfg = make_scheduling_group_key_config<cql_transport::cql_sg_stats>(db::maintenance_socket_enabled::no);
-            cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, scheduling_group_key_create(cql_sg_stats_cfg).get0(), db::maintenance_socket_enabled::no);
+            scheduling_group_key_config cql_sg_stats_cfg = make_scheduling_group_key_config<cql_transport::cql_sg_stats>(maintenance_socket_enabled::no);
+            cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, scheduling_group_key_create(cql_sg_stats_cfg).get0(), maintenance_socket_enabled::no);
 
             ss.local().register_protocol_server(cql_server_ctl);
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -802,6 +802,9 @@ gms::inet_address messaging_service::get_public_endpoint_for(const gms::inet_add
 
 shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::get_rpc_client(messaging_verb verb, msg_addr id) {
     assert(!_shutting_down);
+    if (_cfg.maintenance_mode) {
+        on_internal_error(mlogger, "This node is in maintenance mode, it shouldn't contact other nodes");
+    }
     auto idx = get_rpc_client_idx(verb);
     auto it = _clients[idx].find(id);
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "db/config.hh"
 #include "messaging_service_fwd.hh"
 #include "msg_addr.hh"
 #include <seastar/core/seastar.hh>
@@ -22,6 +23,7 @@
 #include "streaming/stream_fwd.hh"
 #include "locator/host_id.hh"
 #include "service/session.hh"
+#include "service/maintenance_mode.hh"
 
 #include <list>
 #include <vector>
@@ -281,6 +283,7 @@ public:
         bool listen_on_broadcast_address = false;
         size_t rpc_memory_limit = 1'000'000;
         std::unordered_map<gms::inet_address, gms::inet_address> preferred_ips;
+        maintenance_mode_enabled maintenance_mode = maintenance_mode_enabled::no;
     };
 
     struct scheduling_config {

--- a/service/maintenance_mode.hh
+++ b/service/maintenance_mode.hh
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <seastar/util/bool_class.hh>
+
+using namespace seastar;
+
+using maintenance_socket_enabled = bool_class<class maintenance_socket_enabled_tag>;

--- a/service/maintenance_mode.hh
+++ b/service/maintenance_mode.hh
@@ -13,3 +13,4 @@
 using namespace seastar;
 
 using maintenance_socket_enabled = bool_class<class maintenance_socket_enabled_tag>;
+using maintenance_mode_enabled = bool_class<class maintenance_mode_enabled_tag>;

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -24,6 +24,7 @@
 #include "gc_clock.hh"
 #include "service/raft/group0_state_machine.hh"
 #include "db/system_keyspace.hh"
+#include "service/maintenance_mode.hh"
 
 namespace service {
 // Obtaining this object means that all previously finished operations on group 0 are visible on this node.
@@ -83,6 +84,8 @@ class raft_group0_client {
 
     std::unordered_map<utils::UUID, std::optional<service::broadcast_tables::query_result>> _results;
 
+    maintenance_mode_enabled _maintenance_mode;
+
     // Guard manages the result of a single query. If it is created for a particular query,
     // then `group0_state_machine` will save the result of that query and it can be returned by the guard.
     // Guard manages the lifetime of the _results entry. It creates and destroys the entry, which state machine puts the result in.
@@ -99,7 +102,7 @@ class raft_group0_client {
     };
 
 public:
-    raft_group0_client(service::raft_group_registry&, db::system_keyspace&);
+    raft_group0_client(service::raft_group_registry&, db::system_keyspace&, maintenance_mode_enabled);
 
     // Call after `system_keyspace` is initialized.
     future<> init();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5874,6 +5874,14 @@ bool storage_service::is_repair_based_node_ops_enabled(streaming::stream_reason 
     return global_enabled && enabled_set.contains(reason);
 }
 
+future<> storage_service::start_maintenance_mode() {
+    set_mode(mode::MAINTENANCE);
+
+    return mutate_token_metadata([this] (mutable_token_metadata_ptr token_metadata) -> future<> {
+        return token_metadata->update_normal_tokens({ dht::token{} }, get_token_metadata_ptr()->get_topology().my_host_id());
+    }, acquire_merge_lock::yes);
+}
+
 node_ops_meta_data::node_ops_meta_data(
         node_ops_id ops_uuid,
         gms::inet_address coordinator,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -785,6 +785,14 @@ public:
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst);
     future<> set_tablet_balancing_enabled(bool);
 
+    // In the maintenance mode, other nodes won't be available thus we disabled joining
+    // the token ring and the token metadata won't be populated with the local node's endpoint.
+    // When a CQL query is executed it checks the `token_metadata` structure and fails if it is empty.
+    //
+    // This method initialises `token_metadata` with the local node as the only node in the token ring.
+    // It is incompatible with the `join_cluster` method.
+    future<> start_maintenance_mode();
+
 private:
     // Synchronizes the local node state (token_metadata, system.peers/system.local tables,
     // gossiper) to align it with the other raft topology nodes.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -283,7 +283,7 @@ private:
 
 public:
     std::chrono::milliseconds get_ring_delay();
-    enum class mode { NONE, STARTING, JOINING, BOOTSTRAP, NORMAL, LEAVING, DECOMMISSIONED, MOVING, DRAINING, DRAINED };
+    enum class mode { NONE, STARTING, JOINING, BOOTSTRAP, NORMAL, LEAVING, DECOMMISSIONED, MOVING, DRAINING, DRAINED, MAINTENANCE };
 private:
     mode _operation_mode = mode::NONE;
     /* Used for tracking drain progress */
@@ -837,6 +837,7 @@ struct fmt::formatter<service::storage_service::mode> : fmt::formatter<std::stri
         case MOVING:         name = "MOVING"; break;
         case DRAINING:       name = "DRAINING"; break;
         case DRAINED:        name = "DRAINED"; break;
+        case MAINTENANCE:    name = "MAINTENANCE"; break;
         }
         return fmt::format_to(ctx.out(), "{}", name);
     }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -925,7 +925,7 @@ private:
             auth_config.authenticator_java_name = qualified_authenticator_name;
             auth_config.role_manager_java_name = qualified_role_manager_name;
 
-            _auth_service.start(perm_cache_config, std::ref(_qp), std::ref(_mnotifier), std::ref(_mm), auth_config, db::maintenance_socket_enabled::no).get();
+            _auth_service.start(perm_cache_config, std::ref(_qp), std::ref(_mnotifier), std::ref(_mm), auth_config, maintenance_socket_enabled::no).get();
             _auth_service.invoke_on_all([this] (auth::service& auth) {
                 return auth.start(_mm.local());
             }).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -741,7 +741,7 @@ private:
             auto stop_forward_service =  defer([this] { _forward_service.stop().get(); });
 
             // gropu0 client exists only on shard 0
-            service::raft_group0_client group0_client(_group0_registry.local(), _sys_ks.local());
+            service::raft_group0_client group0_client(_group0_registry.local(), _sys_ks.local(), maintenance_mode_enabled::no);
 
             _mm.start(std::ref(_mnotifier), std::ref(_feature_service), std::ref(_ms), std::ref(_proxy), std::ref(_gossiper), std::ref(group0_client), std::ref(_sys_ks)).get();
             auto stop_mm = defer([this] { _mm.stop().get(); });

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -24,6 +24,7 @@ from cassandra.policies import TokenAwarePolicy                          # type:
 from cassandra.policies import WhiteListRoundRobinPolicy                 # type: ignore
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
+from cassandra.connection import EndPoint          # type: ignore # pylint: disable=no-name-in-module
 
 
 Session.run_async = run_async     # patch Session for convenience
@@ -84,12 +85,12 @@ class CustomConnection(Cluster.connection_class):
 
 
 # cluster_con helper: set up client object for communicating with the CQL API.
-def cluster_con(hosts: List[IPAddress], port: int, use_ssl: bool, auth_provider=None):
+def cluster_con(hosts: List[IPAddress | EndPoint], port: int, use_ssl: bool, auth_provider=None, load_balancing_policy=RoundRobinPolicy()):
     """Create a CQL Cluster connection object according to configuration.
        It does not .connect() yet."""
     assert len(hosts) > 0, "python driver connection needs at least one host to connect to"
     profile = ExecutionProfile(
-        load_balancing_policy=RoundRobinPolicy(),
+        load_balancing_policy=load_balancing_policy,
         consistency_level=ConsistencyLevel.LOCAL_QUORUM,
         serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
         # The default timeouts should have been more than enough, but in some

--- a/test/topology_custom/test_maintenance_mode.py
+++ b/test/topology_custom/test_maintenance_mode.py
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from cassandra.protocol import ConfigurationException
+from cassandra.connection import UnixSocketEndPoint
+from cassandra.policies import WhiteListRoundRobinPolicy
+from test.pylib.manager_client import ManagerClient
+from test.topology.conftest import cluster_con
+
+import pytest
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_maintenance_mode(manager: ManagerClient):
+    """
+    The test checks that in maintenance mode server A is not available for other nodes and for clients.
+    It is possible to connect by the maintenance socket to server A and perform local CQL operations.
+    """
+
+    server_a, server_b = await manager.server_add(), await manager.server_add()
+    workdir = await manager.server_get_workdir(server_a.server_id)
+    socket_endpoint = UnixSocketEndPoint(workdir + "/cql.m")
+
+    cluster = cluster_con([server_b.ip_addr], 9042, False)
+    cql = cluster.connect()
+
+    await cql.run_async("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE ks.t (k int PRIMARY KEY, v int)")
+
+    # Token ranges of the server A
+    # [(start_token, end_token)]
+    ranges = [(int(row[0]), int(row[1])) for row in await cql.run_async(f"""SELECT start_token, end_token, endpoint
+                                                                            FROM system.token_ring WHERE keyspace_name = 'ks'
+                                                                            AND endpoint = '{server_a.ip_addr}' ALLOW FILTERING""")]
+
+    # Insert data to the cluster and find a key that is stored on server A.
+    for i in range(256):
+        await cql.run_async(f"INSERT INTO ks.t (k, v) VALUES ({i}, {i})")
+
+    # [(key, token of this key)]
+    keys_with_tokens = [(int(row[0]), int(row[1])) for row in await cql.run_async("SELECT k, token(k) FROM ks.t")]
+    key_on_server_a = None
+
+    for key, token in keys_with_tokens:
+        for start, end in ranges:
+            if (start < end and start < token <= end) or (start >= end and (token <= end or start < token)):
+                key_on_server_a = key
+
+    if key_on_server_a is None:
+        # There is only a chance ~(1/2)^256 that all keys are stored on the server B
+        # In this case we skip the test
+        pytest.skip("All keys are stored on the server B")
+
+    # Start server A in maintenance mode
+    await manager.server_stop_gracefully(server_a.server_id)
+    await manager.server_update_config(server_a.server_id, "maintenance_mode", "true")
+    await manager.server_start(server_a.server_id)
+
+    # Check that the regular CQL port is not available
+    assert socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((server_a.ip_addr, 9042)) != 0
+
+    maintenance_cluster = cluster_con([socket_endpoint], 9042, False,
+                                      load_balancing_policy=WhiteListRoundRobinPolicy([socket_endpoint]))
+    maintenance_cql = maintenance_cluster.connect()
+
+    # Check that local data is available in maintenance mode
+    res = await maintenance_cql.run_async(f"SELECT v FROM ks.t WHERE k = {key_on_server_a}")
+    assert res[0][0] == key_on_server_a
+
+    # Check that group0 operations are disabled
+    with pytest.raises(ConfigurationException):
+        await maintenance_cql.run_async(f"CREATE TABLE ks.t2 (k int PRIMARY KEY, v int)")
+
+    await maintenance_cql.run_async(f"UPDATE ks.t SET v = {key_on_server_a + 1} WHERE k = {key_on_server_a}")
+
+    # Ensure that server B recognizes server A as being shutdown, not as being alive.
+    res = await cql.run_async(f"SELECT status FROM system.cluster_status WHERE peer = '{server_a.ip_addr}'")
+    assert res[0][0] == "shutdown"
+
+    await manager.server_stop_gracefully(server_a.server_id)
+
+    # Restart in normal mode to see if the changes made in maintenance mode are persisted
+    await manager.server_update_config(server_a.server_id, "maintenance_mode", "false")
+    await manager.server_start(server_a.server_id, wait_others=1)
+
+    res = await cql.run_async(f"SELECT v FROM ks.t WHERE k = {key_on_server_a}")
+    assert res[0][0] == key_on_server_a + 1
+
+

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -26,7 +26,7 @@ static logging::logger logger("cql_server_controller");
 controller::controller(sharded<auth::service>& auth, sharded<service::migration_notifier>& mn,
         sharded<gms::gossiper>& gossiper, sharded<cql3::query_processor>& qp, sharded<service::memory_limiter>& ml,
         sharded<qos::service_level_controller>& sl_controller, sharded<service::endpoint_lifecycle_notifier>& elc_notif,
-        const db::config& cfg, scheduling_group_key cql_opcode_stats_key, db::maintenance_socket_enabled used_by_maintenance_socket)
+        const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket)
     : _ops_sem(1)
     , _auth_service(auth)
     , _mnotifier(mn)

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -15,6 +15,7 @@
 
 #include "db/config.hh"
 #include "protocol_server.hh"
+#include "service/maintenance_mode.hh"
 
 using namespace seastar;
 
@@ -58,13 +59,13 @@ class controller : public protocol_server {
     future<> subscribe_server(sharded<cql_server>& server);
     future<> unsubscribe_server(sharded<cql_server>& server);
 
-    db::maintenance_socket_enabled _used_by_maintenance_socket;
+    maintenance_socket_enabled _used_by_maintenance_socket;
 
 public:
     controller(sharded<auth::service>&, sharded<service::migration_notifier>&, sharded<gms::gossiper>&,
             sharded<cql3::query_processor>&, sharded<service::memory_limiter>&,
             sharded<qos::service_level_controller>&, sharded<service::endpoint_lifecycle_notifier>&,
-            const db::config& cfg, scheduling_group_key cql_opcode_stats_key, db::maintenance_socket_enabled used_by_maintenance_socket);
+            const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket);
     virtual sstring name() const override;
     virtual sstring protocol() const override;
     virtual sstring protocol_version() const override;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -188,7 +188,7 @@ event::event_type parse_event_type(const sstring& value)
     }
 }
 
-cql_sg_stats::cql_sg_stats(db::maintenance_socket_enabled used_by_maintenance_socket)
+cql_sg_stats::cql_sg_stats(maintenance_socket_enabled used_by_maintenance_socket)
     : _cql_requests_stats(static_cast<uint8_t>(cql_binary_opcode::OPCODES_COUNT))
 {
     if (used_by_maintenance_socket) {
@@ -236,7 +236,7 @@ void cql_sg_stats::register_metrics()
 cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& auth_service,
         service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
-        db::maintenance_socket_enabled used_by_maintenance_socket)
+        maintenance_socket_enabled used_by_maintenance_socket)
     : server("CQLServer", clogger)
     , _query_processor(qp)
     , _config(std::move(config))

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -33,6 +33,7 @@
 #include "exceptions/coordinator_result.hh"
 #include "db/operation_type.hh"
 #include "db/config.hh"
+#include "service/maintenance_mode.hh"
 
 namespace cql3 {
 
@@ -123,7 +124,7 @@ struct cql_sg_stats {
         uint64_t response_size = 0;
     };
 
-    cql_sg_stats(db::maintenance_socket_enabled);
+    cql_sg_stats(maintenance_socket_enabled);
     request_kind_stats& get_cql_opcode_stats(cql_binary_opcode op) { return _cql_requests_stats[static_cast<uint8_t>(op)]; }
     void register_metrics();
 private:
@@ -170,7 +171,7 @@ public:
             qos::service_level_controller& sl_controller,
             gms::gossiper& g,
             scheduling_group_key stats_key,
-            db::maintenance_socket_enabled used_by_maintenance_socket);
+            maintenance_socket_enabled used_by_maintenance_socket);
 public:
     using response = cql_transport::response;
     using result_with_foreign_response_ptr = exceptions::coordinator_result<foreign_ptr<std::unique_ptr<cql_server::response>>>;


### PR DESCRIPTION
In this mode, the node is not reachable from the outside, i.e.
* it refuses all incoming RPC connections,
* it does not join the cluster, thus
  * all group0 operations are disabled (e.g. schema changes),
  * all cluster-wide operations are disabled for this node (e.g. repair),
  * other nodes see this node as dead,
  * cannot read or write data from/to other nodes,
* it does not open Alternator and Redis transport ports and the TCP CQL port.

The only way to make CQL queries is to use the maintenance socket. The node serves only local data.

To start the node in maintenance mode, use the `--maintenance-mode true` flag or set `maintenance_mode: true` in the configuration file.

REST API works as usual, but some routes are disabled:
* authorization_cache
* failure_detector
* hinted_hand_off_manager

This PR also updates the maintenance socket documentation:
* add cqlsh usage to the documentation
* update the documentation to use `WhiteListRoundRobinPolicy`

Fixes #5489.