### PR TITLE
tasks: change task_manager::task::impl::is_internal()

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -473,10 +473,6 @@ public:
     virtual ~sstables_task_executor() = default;
 
     virtual void release_resources() noexcept override;
-
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal::yes;
-    }
 protected:
     virtual future<> run() override {
         return compaction_done().discard_result();
@@ -491,10 +487,6 @@ public:
         : compaction_task_executor(mgr, t, sstables::compaction_type::Compaction, "Major compaction")
         , major_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), 0, "compaction group", t->schema()->ks_name(), t->schema()->cf_name(), "", parent_id)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal::yes;
-    }
 protected:
     virtual future<> run() override {
         return compaction_done().discard_result();
@@ -599,10 +591,6 @@ public:
 
     virtual std::string type() const override {
         return fmt::format("{} compaction", compaction_type());
-    }
-
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal::yes;
     }
 protected:
     virtual future<> run() override {
@@ -1293,10 +1281,6 @@ public:
     bool performed() const noexcept {
         return _performed;
     }
-
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal(bool(_parent_id));
-    }
 protected:
     virtual future<> run() override {
         return compaction_done().discard_result();
@@ -1668,10 +1652,6 @@ public:
         _compacting.release_all();
         _owned_ranges_ptr = nullptr;
         compaction_task_executor::release_resources();
-    }
-
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal::yes;
     }
 protected:
     virtual future<> run() override {

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -263,10 +263,6 @@ future<> major_keyspace_compaction_task_impl::run() {
     });
 }
 
-tasks::is_internal shard_major_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
-}
-
 future<> shard_major_keyspace_compaction_task_impl::run() {
     seastar::condition_variable cv;
     tasks::task_manager::task_ptr current_task;
@@ -277,10 +273,6 @@ future<> shard_major_keyspace_compaction_task_impl::run() {
     }
 
     co_await run_table_tasks(_db, std::move(table_tasks), cv, current_task, true);
-}
-
-tasks::is_internal table_major_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> table_major_keyspace_compaction_task_impl::run() {
@@ -299,10 +291,6 @@ future<> cleanup_keyspace_compaction_task_impl::run() {
     });
 }
 
-tasks::is_internal shard_cleanup_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
-}
-
 future<> shard_cleanup_keyspace_compaction_task_impl::run() {
     seastar::condition_variable cv;
     tasks::task_manager::task_ptr current_task;
@@ -313,10 +301,6 @@ future<> shard_cleanup_keyspace_compaction_task_impl::run() {
     }
 
     co_await run_table_tasks(_db, std::move(table_tasks), cv, current_task, true);
-}
-
-tasks::is_internal table_cleanup_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> table_cleanup_keyspace_compaction_task_impl::run() {
@@ -338,10 +322,6 @@ future<> offstrategy_keyspace_compaction_task_impl::run() {
     }, false, std::plus<bool>());
 }
 
-tasks::is_internal shard_offstrategy_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
-}
-
 future<> shard_offstrategy_keyspace_compaction_task_impl::run() {
     seastar::condition_variable cv;
     tasks::task_manager::task_ptr current_task;
@@ -352,10 +332,6 @@ future<> shard_offstrategy_keyspace_compaction_task_impl::run() {
     }
 
     co_await run_table_tasks(_db, std::move(table_tasks), cv, current_task, false);
-}
-
-tasks::is_internal table_offstrategy_keyspace_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> table_offstrategy_keyspace_compaction_task_impl::run() {
@@ -375,10 +351,6 @@ future<> upgrade_sstables_compaction_task_impl::run() {
     });
 }
 
-tasks::is_internal shard_upgrade_sstables_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
-}
-
 future<> shard_upgrade_sstables_compaction_task_impl::run() {
     seastar::condition_variable cv;
     tasks::task_manager::task_ptr current_task;
@@ -389,10 +361,6 @@ future<> shard_upgrade_sstables_compaction_task_impl::run() {
     }
 
     co_await run_table_tasks(_db, std::move(table_tasks), cv, current_task, false);
-}
-
-tasks::is_internal table_upgrade_sstables_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> table_upgrade_sstables_compaction_task_impl::run() {
@@ -417,10 +385,6 @@ future<> scrub_sstables_compaction_task_impl::run() {
     }, sstables::compaction_stats{}, std::plus<sstables::compaction_stats>());
 }
 
-tasks::is_internal shard_scrub_sstables_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
-}
-
 future<> shard_scrub_sstables_compaction_task_impl::run() {
     _stats = co_await map_reduce(_column_families, [&] (sstring cfname) -> future<sstables::compaction_stats> {
         sstables::compaction_stats stats{};
@@ -430,10 +394,6 @@ future<> shard_scrub_sstables_compaction_task_impl::run() {
         co_await task->done();
         co_return stats;
     }, sstables::compaction_stats{}, std::plus<sstables::compaction_stats>());
-}
-
-tasks::is_internal table_scrub_sstables_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> table_scrub_sstables_compaction_task_impl::run() {
@@ -461,10 +421,6 @@ future<> table_reshaping_compaction_task_impl::run() {
         auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
         dblog.info("Reshaped {} in {:.2f} seconds, {}", utils::pretty_printed_data_size(total_size), duration.count(), utils::pretty_printed_throughput(total_size, duration));
     }
-}
-
-tasks::is_internal shard_reshaping_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> shard_reshaping_compaction_task_impl::run() {
@@ -549,10 +505,6 @@ future<> table_resharding_compaction_task_impl::run() {
 
     auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
     dblog.info("Resharded {} for {}.{} in {:.2f} seconds, {}", utils::pretty_printed_data_size(total_size), _status.keyspace, _status.table, duration.count(), utils::pretty_printed_throughput(total_size, duration));
-}
-
-tasks::is_internal shard_resharding_compaction_task_impl::is_internal() const noexcept {
-    return tasks::is_internal::yes;
 }
 
 future<> shard_resharding_compaction_task_impl::run() {

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -96,8 +96,6 @@ public:
         , _db(db)
         , _local_tables(std::move(local_tables))
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -123,8 +121,6 @@ public:
         , _cv(cv)
         , _current_task(current_task)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -183,8 +179,6 @@ public:
         , _db(db)
         , _local_tables(std::move(local_tables))
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -210,8 +204,6 @@ public:
         , _cv(cv)
         , _current_task(current_task)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -275,8 +267,6 @@ public:
         , _table_infos(std::move(table_infos))
         , _needed(needed)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -305,8 +295,6 @@ public:
         , _current_task(current_task)
         , _needed(needed)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -378,8 +366,6 @@ public:
     virtual std::string type() const override {
         return "upgrade " + sstables_compaction_task_impl::type();
     }
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -412,8 +398,6 @@ public:
     virtual std::string type() const override {
         return "upgrade " + sstables_compaction_task_impl::type();
     }
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -469,8 +453,6 @@ public:
     virtual std::string type() const override {
         return "scrub " + sstables_compaction_task_impl::type();
     }
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -497,8 +479,6 @@ public:
     virtual std::string type() const override {
         return "scrub " + sstables_compaction_task_impl::type();
     }
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -579,8 +559,6 @@ public:
         , _filter(std::move(filter))
         , _total_shard_size(total_shard_size)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -656,8 +634,6 @@ public:
         , _local_owned_ranges_ptr(std::move(local_owned_ranges_ptr))
         , _destinations(destinations)
     {}
-
-    virtual tasks::is_internal is_internal() const noexcept override;
 protected:
     virtual future<> run() override;
 };

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -142,9 +142,6 @@ public:
             streaming::stream_reason reason_,
             bool hints_batchlog_flushed,
             std::optional<int> ranges_parallelism);
-    virtual tasks::is_internal is_internal() const noexcept override {
-        return tasks::is_internal::yes;
-    }
     void check_failed_ranges();
     void check_in_abort_or_shutdown();
     repair_neighbors get_repair_neighbors(const dht::token_range& range);

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -87,7 +87,7 @@ is_abortable task_manager::task::impl::is_abortable() const noexcept {
 }
 
 is_internal task_manager::task::impl::is_internal() const noexcept {
-    return is_internal::no;
+    return tasks::is_internal(bool(_parent_id));
 }
 
 future<> task_manager::task::impl::abort() noexcept {


### PR DESCRIPTION
Most of the time only the roots of tasks tree should be non internal.

Change default implementation of is_internal and delete overrides consistent with it.