### PR TITLE
tests: test_tablets: Reconnect the driver after server restart

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -8,6 +8,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.util import reconnect_driver
 
 import pytest
 import asyncio
@@ -78,6 +79,8 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     # Check that after rolling restart the tablet metadata is still there
     for s in servers:
         await manager.server_restart(s.server_id, wait_others=2)
+
+    cql = await reconnect_driver(manager)
 
     await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60)
 


### PR DESCRIPTION
This is a workaround for the flakiness of the test where INSERT statements following the rolling restart fail with "No host available" exception. The hypothesis is that those INSERTS race with driver reconnecting to the cluster and if INSERTs are attempted before reconnection is finished, the driver will refuse to execute the statements.

The real fix should be in the driver to join with reconnections but before that is ready we want to fix CI flakiness.

Refs #14746