### PR TITLE
gossiper: properly acquire lock_endpoint_update_semaphore in reset_en…

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1440,7 +1440,7 @@ endpoint_state& gossiper::get_or_create_endpoint_state(inet_address ep) {
 
 future<> gossiper::reset_endpoint_state_map() {
     logger.debug("Resetting endpoint state map");
-    auto lock = lock_endpoint_update_semaphore();
+    auto lock = co_await lock_endpoint_update_semaphore();
     auto version = _live_endpoints_version + 1;
     co_await container().invoke_on_all([version] (gossiper& g) {
         g._unreachable_endpoints.clear();


### PR DESCRIPTION
…dpoint_state_map

The `gossiper::reset_endpoint_state_map` function is supposed to acquire a lock in order to serialize with `replicate_live_endpoints_on_change`. The `lock_endpoint_update_semaphore` is called, but its result is a future - and it is not co_awaited. Therefore, the lock has no effect.

This commit fixes the issue by adding missing co_await.

Fixes: #15361