### PR TITLE
Gossiper: replace seastar threads with coroutines

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -200,8 +200,8 @@ future<> gossiper::handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg) {
         // Process the syn message immediately
         logger.debug("Process gossip syn msg from node {}, syn_msg={}", from, syn_msg);
         p.pending = true;
-        return do_with(std::move(syn_msg), [this, from, g = this->shared_from_this()] (gossip_digest_syn& syn_msg) mutable {
-            return repeat([this, from, g, &syn_msg] {
+        return do_with(std::move(syn_msg), [this, from] (gossip_digest_syn& syn_msg) mutable {
+            return repeat([this, from, &syn_msg] {
                 return do_send_ack_msg(from, std::move(syn_msg)).then([this, from, &syn_msg] () mutable {
                     if (!_syn_handlers.contains(from.addr)) {
                         return stop_iteration::yes;
@@ -300,7 +300,7 @@ future<> gossiper::handle_ack_msg(msg_addr id, gossip_digest_ack ack_msg) {
         f = this->apply_state_locally(std::move(ep_state_map));
     }
 
-    return f.then([this, from = id, ack_msg_digest = std::move(g_digest_list), mp = std::move(mp), g = this->shared_from_this()] () mutable {
+    return f.then([this, from = id, ack_msg_digest = std::move(g_digest_list), mp = std::move(mp)] () mutable {
         if (this->is_in_shadow_round()) {
             this->finish_shadow_round();
             // don't bother doing anything else, we have what we came for
@@ -318,8 +318,8 @@ future<> gossiper::handle_ack_msg(msg_addr id, gossip_digest_ack ack_msg) {
             // Process the ack message immediately
             logger.debug("Process gossip ack msg digests from node {}, ack_msg_digest={}", from, ack_msg_digest);
             p.pending = true;
-            return do_with(std::move(ack_msg_digest), [this, from, g] (utils::chunked_vector<gossip_digest>& ack_msg_digest) mutable {
-                return repeat([this, from, g, &ack_msg_digest] {
+            return do_with(std::move(ack_msg_digest), [this, from] (utils::chunked_vector<gossip_digest>& ack_msg_digest) mutable {
+                return repeat([this, from, &ack_msg_digest] {
                     return do_send_ack2_msg(from, std::move(ack_msg_digest)).then([this, from, &ack_msg_digest] () mutable {
                         if (!_ack_handlers.contains(from.addr)) {
                             return stop_iteration::yes;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -345,8 +345,8 @@ future<> gossiper::handle_ack_msg(msg_addr id, gossip_digest_ack ack_msg) {
                 ack_msg_pending& p = _ack_handlers[from.addr];
                 p.pending = false;
                 p.ack_msg_digest = {};
-                logger.warn("Failed to process gossip ack msg digests from node {}: {}", from, ep);
             }
+            logger.warn("Failed to process gossip ack msg digests from node {}: {}", from, ep);
             throw;
         }
     }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -389,7 +389,7 @@ future<> gossiper::do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_
 future<> gossiper::handle_ack2_msg(msg_addr from, gossip_digest_ack2 msg) {
     logger.trace("handle_ack2_msg():msg={}", msg);
     if (!is_enabled()) {
-        return make_ready_future<>();
+        co_return;
     }
 
 
@@ -406,7 +406,7 @@ future<> gossiper::handle_ack2_msg(msg_addr from, gossip_digest_ack2 msg) {
         }
     });
 
-    return apply_state_locally(std::move(remote_ep_state_map)).finally([mp = std::move(mp)] {});
+    co_await apply_state_locally(std::move(remote_ep_state_map));
 }
 
 future<> gossiper::handle_echo_msg(gms::inet_address from, std::optional<int64_t> generation_number_opt) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2236,43 +2236,41 @@ future<> gossiper::do_stop_gossiping() {
         logger.info("gossip is already stopped");
         co_return;
     }
-    // FIXME: indentation
-        auto my_ep_state = get_endpoint_state_ptr(get_broadcast_address());
-        if (my_ep_state) {
-            logger.info("My status = {}", get_gossip_status(*my_ep_state));
-        }
-        if (my_ep_state && !is_silent_shutdown_state(*my_ep_state)) {
-            auto local_generation = my_ep_state->get_heart_beat_state().get_generation();
-            logger.info("Announcing shutdown");
-            co_await add_local_application_state(application_state::STATUS, versioned_value::shutdown(true));
-            auto live_endpoints = _live_endpoints;
-            for (inet_address addr : live_endpoints) {
-                msg_addr id = get_msg_addr(addr);
-                logger.info("Sending a GossipShutdown to {} with generation {}", id.addr, local_generation);
-                try {
-                    co_await _messaging.send_gossip_shutdown(id, get_broadcast_address(), local_generation.value());
-                        logger.trace("Got GossipShutdown Reply");
-                    } catch (...) {
-                        logger.warn("Fail to send GossipShutdown to {}: {}", id, std::current_exception());
-                    }
+    auto my_ep_state = get_endpoint_state_ptr(get_broadcast_address());
+    if (my_ep_state) {
+        logger.info("My status = {}", get_gossip_status(*my_ep_state));
+    }
+    if (my_ep_state && !is_silent_shutdown_state(*my_ep_state)) {
+        auto local_generation = my_ep_state->get_heart_beat_state().get_generation();
+        logger.info("Announcing shutdown");
+        co_await add_local_application_state(application_state::STATUS, versioned_value::shutdown(true));
+        auto live_endpoints = _live_endpoints;
+        for (inet_address addr : live_endpoints) {
+            msg_addr id = get_msg_addr(addr);
+            logger.info("Sending a GossipShutdown to {} with generation {}", id.addr, local_generation);
+            try {
+                co_await _messaging.send_gossip_shutdown(id, get_broadcast_address(), local_generation.value());
+                logger.trace("Got GossipShutdown Reply");
+            } catch (...) {
+                logger.warn("Fail to send GossipShutdown to {}: {}", id, std::current_exception());
             }
-            co_await sleep(std::chrono::milliseconds(_gcfg.shutdown_announce_ms));
-        } else {
-            logger.warn("No local state or state is in silent shutdown, not announcing shutdown");
         }
-        logger.info("Disable and wait for gossip loop started");
-        // Set disable flag and cancel the timer makes sure gossip loop will not be scheduled
-        co_await container().invoke_on_all([] (gms::gossiper& g) {
-            g._enabled = false;
-        });
-        _scheduled_gossip_task.cancel();
-        // Take the semaphore makes sure existing gossip loop is finished
-        auto units = co_await get_units(_callback_running, 1);
-        co_await container().invoke_on_all([] (auto& g) {
-            return std::move(g._failure_detector_loop_done);
-        });
-        logger.info("Gossip is now stopped");
+        co_await sleep(std::chrono::milliseconds(_gcfg.shutdown_announce_ms));
+    } else {
+        logger.warn("No local state or state is in silent shutdown, not announcing shutdown");
+    }
+    logger.info("Disable and wait for gossip loop started");
+    // Set disable flag and cancel the timer makes sure gossip loop will not be scheduled
+    co_await container().invoke_on_all([] (gms::gossiper& g) {
+        g._enabled = false;
     });
+    _scheduled_gossip_task.cancel();
+    // Take the semaphore makes sure existing gossip loop is finished
+    auto units = co_await get_units(_callback_running, 1);
+    co_await container().invoke_on_all([] (auto& g) {
+        return std::move(g._failure_detector_loop_done);
+    });
+    logger.info("Gossip is now stopped");
 }
 
 future<> gossiper::start() {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2196,7 +2196,7 @@ future<> gossiper::add_local_application_state(std::list<std::pair<application_s
 
             auto es = gossiper.get_endpoint_state_ptr(ep_addr);
             if (!es) {
-                co_return;
+                on_internal_error(logger, format("endpoint_state_map does not contain endpoint = {}", ep_addr));
             }
 
             auto local_state = *es;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -168,24 +168,24 @@ future<> gossiper::handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg) {
     logger.trace("handle_syn_msg():from={},cluster_name:peer={},local={},group0_id:peer={},local={},partitioner_name:peer={},local={}",
         from, syn_msg.cluster_id(), get_cluster_name(), syn_msg.group0_id(), get_group0_id(), syn_msg.partioner(), get_partitioner_name());
     if (!this->is_enabled()) {
-        return make_ready_future<>();
+        co_return;
     }
 
     /* If the message is from a different cluster throw it away. */
     if (syn_msg.cluster_id() != get_cluster_name()) {
         logger.warn("ClusterName mismatch from {} {}!={}", from.addr, syn_msg.cluster_id(), get_cluster_name());
-        return make_ready_future<>();
+        co_return;
     }
 
     /* If the message is from a node with a different group0 id throw it away. */
     if (syn_msg.group0_id() && get_group0_id() && syn_msg.group0_id() != get_group0_id()) {
         logger.warn("Group0Id mismatch from {} {} != {}", from.addr, syn_msg.group0_id(), get_group0_id());
-        return make_ready_future<>();
+        co_return;
     }
 
     if (syn_msg.partioner() != "" && syn_msg.partioner() != get_partitioner_name()) {
         logger.warn("Partitioner mismatch from {} {}!={}", from.addr, syn_msg.partioner(), get_partitioner_name());
-        return make_ready_future<>();
+        co_return;
     }
 
     syn_msg_pending& p = _syn_handlers[from.addr];
@@ -195,16 +195,17 @@ future<> gossiper::handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg) {
         // one only.
         logger.debug("Queue gossip syn msg from node {}, syn_msg={}", from, syn_msg);
         p.syn_msg = std::move(syn_msg);
-        return make_ready_future<>();
-    } else {
+        co_return;
+    }
+    // FIXME: indentation
         // Process the syn message immediately
         logger.debug("Process gossip syn msg from node {}, syn_msg={}", from, syn_msg);
         p.pending = true;
-        return do_with(std::move(syn_msg), [this, from] (gossip_digest_syn& syn_msg) mutable {
-            return repeat([this, from, &syn_msg] {
-                return do_send_ack_msg(from, std::move(syn_msg)).then([this, from, &syn_msg] () mutable {
+    for (;;) {
+        try {
+            co_await do_send_ack_msg(from, std::move(syn_msg));
                     if (!_syn_handlers.contains(from.addr)) {
-                        return stop_iteration::yes;
+                        co_return;
                     }
                     syn_msg_pending& p = _syn_handlers[from.addr];
                     if (p.syn_msg) {
@@ -213,25 +214,24 @@ future<> gossiper::handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg) {
                                 from, p.syn_msg, p.pending);
                         syn_msg = std::move(p.syn_msg.value());
                         p.syn_msg = {};
-                        return stop_iteration::no;
+                        continue;
                     } else {
                         // No more pending syn msg to process
                         p.pending = false;
                         logger.debug("No more queued gossip syn msg from node {}, syn_msg={}, pending={}",
                                 from, p.syn_msg, p.pending);
-                        return stop_iteration::yes;
+                        co_return;
                     }
-                }).handle_exception([this, from] (std::exception_ptr ep) {
+        } catch (...) {
+            auto ep = std::current_exception();
                     if (_syn_handlers.contains(from.addr)) {
                         syn_msg_pending& p = _syn_handlers[from.addr];
                         p.pending = false;
                         p.syn_msg = {};
                     }
                     logger.warn("Failed to process gossip syn msg from node {}:  {}", from, ep);
-                    return make_exception_future<stop_iteration>(ep);
-                });
-            });
-        });
+            throw;
+        }
     }
 }
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -598,6 +598,8 @@ public:
 
 private:
     void build_seeds_list();
+    // Must be called on shard 0
+    future<> do_stop_gossiping();
 
 public:
     /**
@@ -622,7 +624,6 @@ public:
     future<> shutdown();
     // Needed by seastar::sharded
     future<> stop();
-    future<> do_stop_gossiping();
 
 public:
     bool is_enabled() const;


### PR DESCRIPTION
Many of the gossiper internal functions currently use seastar threads for historical reasons,
but since they are short living, the cost of spawning a seastar thread for them is excessive
and they can be simplified and made more efficient using coroutines.
