### PR TITLE
migration_manager: Register RPC verbs on start

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1482,8 +1482,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
             static seastar::sharded<memory_threshold_guard> mtg;
             mtg.start(cfg->large_memory_allocation_warning_threshold()).get();
-            supervisor::notify("initializing migration manager RPC verbs");
-            mm.invoke_on_all(&service::migration_manager::init_messaging_service).get();
             supervisor::notify("initializing storage proxy RPC verbs");
             proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(messaging), std::ref(gossiper), std::ref(mm), std::ref(sys_ks)).get();
             auto stop_proxy_handlers = defer_verbose_shutdown("storage proxy RPC verbs", [&proxy] {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -63,6 +63,7 @@ migration_manager::migration_manager(migration_notifier& notifier, gms::feature_
         , _schema_push([this] { return passive_announce(); })
         , _concurrent_ddl_retries{10}
 {
+    init_messaging_service();
 }
 
 future<> migration_manager::stop() {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -158,12 +158,11 @@ public:
     bool have_schema_agreement();
     future<> wait_for_schema_agreement(const replica::database& db, db::timeout_clock::time_point deadline, seastar::abort_source* as);
 
-    void init_messaging_service();
-
     // Maximum number of retries one should attempt when trying to perform
     // a DDL statement and getting `group0_concurrent_modification` exception.
     size_t get_concurrent_ddl_retries() const { return _concurrent_ddl_retries; }
 private:
+    void init_messaging_service();
     future<> uninit_messaging_service();
 
     future<> push_schema_mutation(const gms::inet_address& endpoint, const std::vector<mutation>& schema);


### PR DESCRIPTION
There's a dedicated call to register migration manager's verbs somewhere in the middle of main. However, until messaging service listening starts it makes no difference when to register verbs.

This patch moves the verbs registration into mig. manager constructor thus making it called it with sharded<migration_manager>::start().

Unregistration happens in migration_manager::drain() and it's not touched here.