### PR TITLE
build: cmake: package cqlsh and fix the noarch postfix of python3 package

### DIFF
--- a/cmake/add_version_library.cmake
+++ b/cmake/add_version_library.cmake
@@ -12,7 +12,10 @@ function(generate_scylla_version)
   file(STRINGS ${version_file} scylla_version)
   file(STRINGS ${release_file} scylla_release)
   file(STRINGS ${product_file} scylla_product)
-  set(Scylla_VERSION "${scylla_version}" CACHE INTERNAL "")
+
+  string(REPLACE "-" "~" scylla_version_tilde ${scylla_version})
+
+  set(Scylla_VERSION "${scylla_version_tilde}" CACHE INTERNAL "")
   set(Scylla_RELEASE "${scylla_release}" CACHE INTERNAL "")
   set(Scylla_PRODUCT "${scylla_product}" CACHE INTERNAL "")
 endfunction(generate_scylla_version)

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -1,13 +1,20 @@
 function(build_submodule name dir)
+  cmake_parse_arguments(parsed_args "NOARCH" "" "" ${ARGN})
   string(REPLACE "-" "~" scylla_version_tilde ${Scylla_VERSION})
   set(version "${scylla_version_tilde}-${Scylla_RELEASE}")
   set(scylla_version
     "${Scylla_PRODUCT}-${scylla_version_tilde}-${Scylla_RELEASE}")
   set(working_dir ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
-  set(reloc_pkg "${working_dir}/build/${Scylla_PRODUCT}-${name}-${version}.noarch.tar.gz")
+  if(parsed_args_NOARCH)
+    set(arch "noarch")
+  else()
+    set(arch "${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+  set(reloc_args ${parsed_args_UNPARSED_ARGUMENTS})
+  set(reloc_pkg "${working_dir}/build/${Scylla_PRODUCT}-${name}-${version}.${arch}.tar.gz")
   add_custom_command(
     OUTPUT ${reloc_pkg}
-    COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${ARGN}
+    COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${reloc_args}
     WORKING_DIRECTORY "${working_dir}"
     JOB_POOL submodule_pool)
   add_custom_target(dist-${name}-tar

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -9,7 +9,6 @@ function(build_submodule name dir)
     OUTPUT ${reloc_pkg}
     COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${ARGN}
     WORKING_DIRECTORY "${working_dir}"
-    COMMENT "Generating submodule ${name} in ${dir}"
     JOB_POOL submodule_pool)
   add_custom_target(dist-${name}-tar
     DEPENDS ${reloc_pkg})

--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -1,9 +1,8 @@
 function(build_submodule name dir)
   cmake_parse_arguments(parsed_args "NOARCH" "" "" ${ARGN})
-  string(REPLACE "-" "~" scylla_version_tilde ${Scylla_VERSION})
-  set(version "${scylla_version_tilde}-${Scylla_RELEASE}")
-  set(scylla_version
-    "${Scylla_PRODUCT}-${scylla_version_tilde}-${Scylla_RELEASE}")
+  set(version_release "${Scylla_VERSION}-${Scylla_RELEASE}")
+  set(product_version_release
+    "${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}")
   set(working_dir ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
   if(parsed_args_NOARCH)
     set(arch "noarch")
@@ -11,10 +10,10 @@ function(build_submodule name dir)
     set(arch "${CMAKE_SYSTEM_PROCESSOR}")
   endif()
   set(reloc_args ${parsed_args_UNPARSED_ARGUMENTS})
-  set(reloc_pkg "${working_dir}/build/${Scylla_PRODUCT}-${name}-${version}.${arch}.tar.gz")
+  set(reloc_pkg "${working_dir}/build/${Scylla_PRODUCT}-${name}-${version_release}.${arch}.tar.gz")
   add_custom_command(
     OUTPUT ${reloc_pkg}
-    COMMAND reloc/build_reloc.sh --version ${scylla_version} --nodeps ${reloc_args}
+    COMMAND reloc/build_reloc.sh --version ${product_version_release} --nodeps ${reloc_args}
     WORKING_DIRECTORY "${working_dir}"
     JOB_POOL submodule_pool)
   add_custom_target(dist-${name}-tar

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(tools
     db)
 
 include(build_submodule)
+build_submodule(cqlsh cqlsh
+  NOARCH)
 build_submodule(tools java
   NOARCH)
 build_submodule(jmx jmx

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,8 +20,10 @@ target_link_libraries(tools
     db)
 
 include(build_submodule)
-build_submodule(tools java)
-build_submodule(jmx jmx)
+build_submodule(tools java
+  NOARCH)
+build_submodule(jmx jmx
+  NOARCH)
 build_submodule(python3 python3
   --packages
   "python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro python3-click python3-six"


### PR DESCRIPTION
in this series, the packaging of tools modules are improved:

- package cqlsh also. as cqlsh should be redistributed as a part of the unified package
- use ${arch} in the postfix of the python3 package. the python3 package is not architecture independent.
- set the version with tide for `Scylla_VERSION`, so it can be reused elsewhere.

Refs #15241