### PR TITLE
Sanitize batchlog manager start/stop

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -115,10 +115,12 @@ future<> db::batchlog_manager::start() {
 }
 
 future<> db::batchlog_manager::drain() {
-    blogger.info("Asked to drain");
-    if (!_stop.abort_requested()) {
-        _stop.request_abort();
+    if (_stop.abort_requested()) {
+        co_return;
     }
+
+    blogger.info("Asked to drain");
+    _stop.request_abort();
     if (this_shard_id() == 0) {
         // Abort do_batch_log_replay if waiting on the semaphore.
         _sem.broken();

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -111,10 +111,6 @@ future<> db::batchlog_manager::batchlog_replay_loop() {
     }
 }
 
-future<> db::batchlog_manager::start() {
-    return make_ready_future<>();
-}
-
 future<> db::batchlog_manager::drain() {
     if (_stop.abort_requested()) {
         co_return;

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -61,12 +61,12 @@ private:
     db::system_keyspace& _sys_ks;
     db_clock::duration _write_request_timeout;
     uint64_t _replay_rate;
-    shared_future<> _started;
     std::chrono::milliseconds _delay;
     semaphore _sem{1};
     seastar::gate _gate;
     unsigned _cpu = 0;
     seastar::abort_source _stop;
+    future<> _loop_done;
 
     future<> replay_all_failed_batches();
 public:

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -75,7 +75,6 @@ public:
     // shard qp (which is what you feed here).
     batchlog_manager(cql3::query_processor&, db::system_keyspace& sys_ks, batchlog_manager_config config);
 
-    future<> start();
     // abort the replay loop and return its future.
     future<> drain();
     future<> stop();

--- a/main.cc
+++ b/main.cc
@@ -1718,7 +1718,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_batchlog_manager = defer_verbose_shutdown("batchlog manager", [&bm] {
                 bm.stop().get();
             });
-            bm.invoke_on_all(&db::batchlog_manager::start).get();
 
             supervisor::notify("starting load meter");
             load_meter.init(db, gossiper.local()).get();


### PR DESCRIPTION
This code is now spread over main and differs in cql_test_env. The PR unifies both places and makes the manager start-stop look standard

refs: #2795