### PR TITLE
unified: add --build-dir option and respect --pkgs

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1858,7 +1858,7 @@ with open(buildfile, 'w') as f:
         rule debbuild
             command = reloc/build_deb.sh --reloc-pkg $in --builddir $out
         rule unified
-            command = unified/build_unified.sh --mode $mode --unified-pkg $out
+            command = unified/build_unified.sh --build-dir build/$mode --unified-pkg $out
         rule rust_header
             command = cxxbridge --include rust/cxx.h --header $in > $out
             description = RUST_HEADER $out

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -28,7 +28,7 @@ RELEASE_ESC=${RELEASE//./\.}
 
 PKGS=
 BUILD_DIR="build/release"
-UNIFIED_PKG="build/release/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
+UNIFIED_PKG=""
 while [ $# -gt 0 ]; do
     case "$1" in
         "--build-dir")
@@ -49,6 +49,9 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ -z "$UNIFIED_PKG" ]; then
+    UNIFIED_PKG="$BUILD_DIR/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
+fi
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
 PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.noarch.tar.gz"
 BASEDIR="$BUILD_DIR/unified/$PRODUCT-$VERSION"

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -8,8 +8,8 @@
 #
 
 print_usage() {
-    echo "build_unified.sh --mode <mode>"
-    echo "  --mode specify mode (default: release)"
+    echo "build_unified.sh --build-dir <build_dir>"
+    echo "  --build-dir specify build directory (default: build/release)"
     echo "  --pkgs specify source packages"
     echo "  --unified-pkg specify package path (default: build/release/scylla-unified-package.tar.gz)"
     exit 1
@@ -27,12 +27,12 @@ RELEASE=`cat build/SCYLLA-RELEASE-FILE`
 RELEASE_ESC=${RELEASE//./\.}
 
 PKGS=
-MODE="release"
+BUILD_DIR="build/release"
 UNIFIED_PKG="build/release/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
 while [ $# -gt 0 ]; do
     case "$1" in
-        "--mode")
-            MODE="$2"
+        "--build-dir")
+            BUILD_DIR="$2"
             shift 2
             ;;
         "--pkgs")
@@ -50,10 +50,10 @@ while [ $# -gt 0 ]; do
 done
 
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
-PKGS="build/$MODE/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz build/$MODE/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz build/$MODE/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz build/$MODE/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz build/$MODE/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.noarch.tar.gz"
-BASEDIR="build/$MODE/unified/$PRODUCT-$VERSION"
+PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.noarch.tar.gz"
+BASEDIR="$BUILD_DIR/unified/$PRODUCT-$VERSION"
 
-rm -rf build/"$MODE"/unified/
+rm -rf $BUILD_DIR/unified/
 mkdir -p "$BASEDIR"
 for pkg in $PKGS; do
     if [ ! -e "$pkg" ]; then
@@ -74,5 +74,5 @@ ln -f unified/install.sh "$BASEDIR"
 ln -f unified/uninstall.sh "$BASEDIR"
 # relocatable package format version = 3.0
 echo "3.0" > "$BASEDIR"/.relocatable_package_version
-cd build/"$MODE"/unified
+cd $BUILD_DIR/unified
 tar cpf "$UNIFIED_PKG" --use-compress-program=pigz "$PRODUCT-$VERSION"

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -62,7 +62,9 @@ if [ -z "$UNIFIED_PKG" ]; then
     UNIFIED_PKG="$BUILD_DIR/$PRODUCT-unified-$VERSION-$RELEASE.$(arch).tar.gz"
 fi
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
-PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.noarch.tar.gz"
+if [ -z "$PKGS" ]; then
+    PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.noarch.tar.gz"
+fi
 BASEDIR="$BUILD_DIR/unified/$PRODUCT-$VERSION"
 
 rm -rf $BUILD_DIR/unified/

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -25,7 +25,7 @@ while [ $# -gt 0 ]; do
             shift 2
             ;;
         "--pkgs")
-            PKGS="$2"
+            PKGS="${2//;/ }"
             shift 2
             ;;
         "--unified-pkg")


### PR DESCRIPTION
in this series, `unified/build_unified.sh` is improved in couple perspectives:

1. add `--build-dir` option, so we don't hardwire the build directory to the naming convention of `build/$mode`.
2. `--pkgs` is respected. this allows the caller to specify the paths to the dist tarballs instead of hardwiring to the paths defined in this script

these changes give us more flexibility when building unified package, and enable us to switch over to CMake based building system,

Refs #15241