### PR TITLE
docs: s/tar xvfz tar/tar xvfz/ in command line sample

### DIFF
--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -31,7 +31,7 @@ Download and Install
 
    .. code:: console
 
-    tar xvfz tar scylla-unified-5.2.4-0.20230623.cebbf6c5df2b.x86_64.tar.gz
+    tar xvfz scylla-unified-5.2.4-0.20230623.cebbf6c5df2b.x86_64.tar.gz
 
 #. Install OpenJDK 8 or 11.
 


### PR DESCRIPTION
should not "tar" to tar, otherwise we'd have following error:
```
tar (child): tar: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```
as "tar" is not the compressed tarball we want to untar.

Fixes #15328