### PR TITLE
docs: correct the code sample for checking service status

### DIFF
--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -69,7 +69,7 @@ Configure and Run ScyllaDB
 
    .. code:: console
 
-    journalctl --user start scylla-server -xe
+    systemctl --user status scylla-server
 
 Now you can start using ScyllaDB. Here are some tools you may find useful.
 


### PR DESCRIPTION
```console
$ journalctl --user start scylla-server -xe
Failed to add match 'start': Invalid argument
```

`journalctl` expects a match filter as its positional arguments. but apparently, start is not a filter. we could use `--unit` to specify a unit though, like:

```console
$ journalctl --user --unit scylla-server.service -xe
```

but it would flood the stdout with the logging messages printed by scylla. this is not what a typical user expects. probably a better user experience can be achieved using

```console
$ systemctl --user status scylla-server
```
which also print the current status reported by the service, and the command line arguments. they would be more informative in typical use cases.