### PR TITLE
migration_manager: log when performing read barrier in `get_schema_for_write`

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1157,6 +1157,7 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
     if (use_raft) {
         // Schema is synchronized through Raft, so perform a group 0 read barrier.
         // Batch the barriers so we don't invoke them redundantly.
+        mlogger.trace("Performing raft read barrier because schema is not synced, version: {}", v);
         co_await (as ? _group0_barrier.trigger(*as) : _group0_barrier.trigger());
     }
 
@@ -1164,6 +1165,7 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
 
     if (use_raft) {
         // If Raft is used the schema is synced already (through barrier above), mark it as such.
+        mlogger.trace("Mark schema {} as synced", v);
         co_await s->registry_entry()->maybe_sync([] { return make_ready_future<>(); });
     } else {
         co_await maybe_sync(s, dst);


### PR DESCRIPTION
Will be useful for debugging problems with timing out queries if they are caused by slow schema sync read barriers.

Ref: #15357