### PR TITLE
tools: toolchain: prepare: don't overwrite existing images

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -22,6 +22,16 @@ if (( ! ok )); then
     exit 1
 fi
 
+if ! reg version > /dev/null; then
+    echo install the reg command for registry inspection
+    exit 1
+fi
+
+if reg digest $(<tools/toolchain/image) > /dev/null; then
+    echo "Toolchain image $(<tools/toolchain/image) exists; select a new name"
+    exit 1
+fi
+
 archs=(amd64 arm64)
 
 # docker arch has a diffrent spelling than uname arch


### PR DESCRIPTION
The docker/podman tooling is destructive: it will happily overwrite images locally and on the server. If a maintainer forgets to update tools/toolchain/image, this can result in losing an older toolchain container image.

To prevent that, check that the image name is new.