### PR TITLE
build: cmake: add packaging support

### DIFF
--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -29,3 +29,22 @@ function(build_submodule name dir)
   add_custom_target(dist-${name}
     DEPENDS dist-${name}-tar dist-${name}-rpm dist-${name}-deb)
 endfunction()
+
+macro(dist_submodule name dir pkgs)
+  # defined as a macro, so that we can append the path to the dist tarball to
+  # specfied "pkgs"
+  cmake_parse_arguments(parsed_args "NOARCH" "" "" ${ARGN})
+  if(parsed_args_NOARCH)
+    set(arch "noarch")
+  else()
+    set(arch "${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+  set(pkg_name "${Scylla_PRODUCT}-${name}-${Scylla_VERSION}-${Scylla_RELEASE}.${arch}.tar.gz")
+  set(reloc_pkg "${CMAKE_SOURCE_DIR}/tools/${dir}/build/${pkg_name}")
+  set(dist_pkg "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}")
+  add_custom_command(
+    OUTPUT ${dist_pkg}
+    COMMAND ${CMAKE_COMMAND} -E copy ${reloc_pkg} ${dist_pkg}
+    DEPENDS dist-${name}-tar)
+  list(APPEND ${pkgs} "${dist_pkg}")
+endmacro()

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -84,3 +84,30 @@ add_custom_target(dist-server-tar
 add_custom_target(package
   ${CMAKE_COMMAND} -E copy ${stripped_dist_pkg} ${Scylla_PRODUCT}-package.tar.gz
   DEPENDS ${stripped_dist_pkg})
+
+
+set(dist_pkgs
+  "${stripped_dist_pkg}")
+dist_submodule(cqlsh cqlsh dist_pkgs
+  NOARCH)
+dist_submodule(tools java dist_pkgs
+  NOARCH)
+dist_submodule(jmx jmx dist_pkgs
+  NOARCH)
+dist_submodule(python3 python3 dist_pkgs)
+set(unified_dist_pkg
+  "${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-unified-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+add_custom_command(
+  OUTPUT
+    "${unified_dist_pkg}"
+  COMMAND
+    ${CMAKE_SOURCE_DIR}/unified/build_unified.sh
+      --build-dir ${CMAKE_BINARY_DIR}
+      --pkgs "${dist_pkgs}"
+      --unified-pkg ${unified_dist_pkg}
+  DEPENDS
+    ${dist_pkgs}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  VERBATIM)
+add_custom_target(dist-unified
+  DEPENDS ${unified_dist_pkg})

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -63,7 +63,7 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 set(stripped_dist_pkg
-  "${CMAKE_BINARY_DIR}/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+  "${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
 add_custom_command(
   OUTPUT
     ${stripped_dist_pkg}


### PR DESCRIPTION
a new target "dist-unified" is added, so that CMake can build unified
package, which is a bundle of all subcomponents, like cqlsh, python3,
jmx and tools.

Fixes #15241 