### PR TITLE
Enable incremental compaction on off-strategy

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -609,7 +609,7 @@ protected:
     }
 
     bool enable_garbage_collected_sstable_writer() const noexcept {
-        return _contains_multi_fragment_runs && _max_sstable_size != std::numeric_limits<uint64_t>::max();
+        return _contains_multi_fragment_runs && _max_sstable_size != std::numeric_limits<uint64_t>::max() && bool(_replacer);
     }
 public:
     compaction& operator=(const compaction&) = delete;

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -608,7 +608,7 @@ protected:
         return _used_garbage_collected_sstables;
     }
 
-    bool enable_garbage_collected_sstable_writer() const noexcept {
+    virtual bool enable_garbage_collected_sstable_writer() const noexcept {
         return _contains_multi_fragment_runs && _max_sstable_size != std::numeric_limits<uint64_t>::max() && bool(_replacer);
     }
 public:
@@ -1175,14 +1175,23 @@ private:
     }
 };
 
-class reshape_compaction : public compaction {
+class reshape_compaction : public regular_compaction {
+private:
+    bool has_sstable_replacer() const noexcept {
+        return bool(_replacer);
+    }
 public:
     reshape_compaction(table_state& table_s, compaction_descriptor descriptor, compaction_data& cdata)
-            : compaction(table_s, std::move(descriptor), cdata) {
+            : regular_compaction(table_s, std::move(descriptor), cdata) {
     }
 
     virtual sstables::sstable_set make_sstable_set_for_input() const override {
         return sstables::make_partitioned_sstable_set(_schema, false);
+    }
+
+    // Unconditionally enable incremental compaction if the strategy specifies a max output size, e.g. LCS.
+    virtual bool enable_garbage_collected_sstable_writer() const noexcept override {
+        return _max_sstable_size != std::numeric_limits<uint64_t>::max() && bool(_replacer);
     }
 
     flat_mutation_reader_v2 make_sstable_reader(schema_ptr s,
@@ -1220,7 +1229,17 @@ public:
 
     virtual void stop_sstable_writer(compaction_writer* writer) override {
         if (writer) {
-            finish_new_sstable(writer);
+            if (has_sstable_replacer()) {
+                regular_compaction::stop_sstable_writer(writer);
+            } else {
+                finish_new_sstable(writer);
+            }
+        }
+    }
+
+    virtual void on_end_of_compaction() override {
+        if (has_sstable_replacer()) {
+            regular_compaction::on_end_of_compaction();
         }
     }
 };

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -521,7 +521,8 @@ protected:
     future<sstables::compaction_result> compact_sstables_and_update_history(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, on_replacement&,
                                 compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes);
     future<sstables::compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, on_replacement&,
-                                compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes);
+                                compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes,
+                                sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> update_history(::compaction::table_state& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata);
     bool should_update_history(sstables::compaction_type ct) {
         return ct == sstables::compaction_type::Compaction;


### PR DESCRIPTION
Off-strategy suffers with a 100% space overhead, as it adopted
a sort of all or nothing approach. Meaning all input sstables,
living in maintenance set, are kept alive until they're all
reshaped according to the strategy criteria.

Input sstables in off-strategy are very likely to be mostly disjoint,
so it can greatly benefit from incremental compaction.

The incremental compaction approach is not only good for
decreasing disk usage, but also memory usage (as metadata of
input and output live in memory), and file desc count, which
takes memory away from OS.

Turns out that this approach also greatly simplifies the
off-strategy impl in compaction manager, as it no longer have
to maintain new unused sstables and mark them for
deletion on failure, and also unlink intermediary sstables
used between reshape rounds.

Fixes https://github.com/scylladb/scylladb/issues/14992.