### PR TITLE
build: cmake: add targets for building deb and rpm packages

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -1,13 +1,18 @@
 set(unstripped_dist_pkg
-  ${Scylla_PRODUCT}-unstripped-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz)
+  ${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-unstripped-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz)
 add_custom_command(
   OUTPUT ${unstripped_dist_pkg}
-  COMMAND script/create-relocatable-package.py --mode ${CMAKE_BUILD_TYPE} ${unstripped_dist_pkg}
+  COMMAND scripts/create-relocatable-package.py
+    --build-dir ${CMAKE_BINARY_DIR}
+    --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
+    ${unstripped_dist_pkg}
   DEPENDS
     scylla
-    iotune
-    ${CMAKE_BINARY_DIR}/debian/debian
-    ${CMAKE_BINARY_DIR}/node_exporter/node_exporter)
+    ${CMAKE_BINARY_DIR}/iotune
+    ${CMAKE_BINARY_DIR}/node_exporter/node_exporter
+    ${CMAKE_CURRENT_BINARY_DIR}/debian
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 
 function(add_stripped name)
   set(output ${name}.stripped)

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -13,6 +13,18 @@ add_custom_command(
     ${CMAKE_CURRENT_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+add_custom_target(dist-server-deb
+  COMMAND reloc/build_deb.sh
+    --reloc-pkg ${unstripped_dist_pkg}
+    --builddir ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${unstripped_dist_pkg}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-server-rpm
+  COMMAND reloc/build_rpm.sh
+    --reloc-pkg ${unstripped_dist_pkg}
+    --builddir ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${unstripped_dist_pkg}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 function(add_stripped name)
   set(output ${name}.stripped)


### PR DESCRIPTION
in this series,

- the build of unstripped package is fixed, and 
- the targets for building deb and rpm packages are added. these targets builds deb and rpm packages from the unstripped package.