### PR TITLE
conf: update commented out experimental_features

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -278,8 +278,9 @@ batch_size_fail_threshold_in_kb: 1024
 # experimental_features:
 #     - udf
 #     - alternator-streams
-#     - alternator-ttl
-#     - raft
+#     - consistent-topology-changes
+#     - broadcast-tables
+#     - keyspace-storage-options
 #     - tablets
 
 # The directory where hints files are stored if hinted handoff is enabled.


### PR DESCRIPTION
update commented out experimental_features to reflect the latest experimental features:

- in 4f23eec4, "raft" was renamed to "consistent-topology-changes".
- in 2dedb5ea, "alternator-ttl" was moved out of experimental features.
- in 5b1421cc, "broadcast-tables" was added to experimental features.