### PR TITLE
Support for sending tablet info to the drivers

### DIFF
--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -42,7 +42,7 @@ namespace raw { class modification_statement; }
 class modification_statement : public cql_statement_opt_metadata {
 public:
     const statement_type type;
-
+    bool _may_use_token_aware_routing;
 private:
     const uint32_t _bound_terms;
     // If we have operation on list entries, such as adding or
@@ -236,7 +236,7 @@ public:
 
 private:
     future<exceptions::coordinator_result<>>
-    execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options) const;
+    execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
 
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_with_condition(query_processor& qp, service::query_state& qs, const query_options& options) const;
@@ -252,7 +252,7 @@ public:
      * @return vector of the mutations
      * @throws invalid_request_exception on invalid requests
      */
-    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs) const;
+    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
 
     virtual json_cache_opt maybe_prepare_json_cache(const query_options& options) const;
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -55,6 +55,7 @@ public:
     using parameters = raw::select_statement::parameters;
     using ordering_comparator_type = raw::select_statement::ordering_comparator_type;
     static constexpr int DEFAULT_COUNT_PAGE_SIZE = 10000;
+    bool _may_use_token_aware_routing;
 protected:
     static thread_local const lw_shared_ptr<const parameters> _default_parameters;
     schema_ptr _schema;

--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -180,3 +180,35 @@ The string map in the SUPPORTED response will contain the following parameters:
 
   - `ERROR_CODE`: a 32-bit signed decimal integer which Scylla
     will use as the error code for the rate limit exception.
+
+## Sending tablet info to the drivers
+
+This extension adds support for sending tablet info to the drivers if the 
+request was routed to the wrong node/shard.
+
+There is a need for sending tablet info to the drivers so they can be 
+tablet aware.
+For the best performance we want to get this info lazily only when it is 
+needed.
+
+The info is send when driver asks about the information that the specific 
+tablet contains and it is directed to the wrong node/shard so it could 
+use that information for every subsequent query.
+If we send the query to the wrong node/shard, we want to send the RESULT 
+message with additional information about the tablet in `custom_payload`:
+
+  - `tablet_replicas` - information about tablet replicas, for every
+    replica there is information about the host and shard.
+  - `token_range` - information about token range for that tablet in
+    format `(first_token, last_token]`.
+
+The driver has to be able to recive `custom_payload` and deserialise its fields
+from `bytes` to:
+
+  - for `tablet_replicas` - `ListType(TupleType(UUIDType, Int32Type))`.
+  - for `token_range` - two `Int32Type`.
+
+When the driver receives information about the tablet, it has to check if any of
+the previously received tablets has an overlapping token range.
+The group of tablets that meets this criterion has to be deleted, and the new
+tablet should replace them.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -120,6 +120,10 @@ inet_address_vector_replica_set vnode_effective_replication_map::get_endpoints_f
     return inet_address_vector_replica_set(endpoints->begin(), endpoints->end());
 }
 
+std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token& token) const {
+    return {};
+}
+
 bool vnode_effective_replication_map::has_pending_ranges(inet_address endpoint) const {
     for (const auto& item : _pending_endpoints) {
         const auto& nodes = item.second;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -24,6 +24,7 @@
 #include "utils/maybe_yield.hh"
 #include "utils/sequenced_set.hh"
 #include "utils/simple_hashers.hh"
+#include "tablets.hh"
 
 // forward declaration since replica/database.hh includes this file
 namespace replica {
@@ -215,6 +216,9 @@ public:
     /// Returns a list of nodes to which a read request should be directed.
     virtual inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const = 0;
 
+    virtual std::optional<tablet_routing_info> check_locality(const token& token) const = 0;
+
+
     /// Returns true if there are any pending ranges for this endpoint.
     /// This operation is expensive, for vnode_erm it iterates
     /// over all pending ranges which is O(number of tokens).
@@ -290,6 +294,7 @@ public: // effective_replication_map
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
     inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
     inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override;
+    std::optional<tablet_routing_info> check_locality(const token& token) const override;
     bool has_pending_ranges(inet_address endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -114,6 +114,16 @@ tablet_replica_set replace_replica(const tablet_replica_set& rs, tablet_replica 
     return result;
 }
 
+inline
+bool contains(const tablet_replica_set& rs, host_id host) {
+    for (auto replica : rs) {
+        if (replica.host == host) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /// Stores information about a single tablet.
 struct tablet_info {
     tablet_replica_set replicas;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -349,6 +349,11 @@ public:
     friend std::ostream& operator<<(std::ostream&, const tablet_metadata&);
 };
 
+struct tablet_routing_info {
+    tablet_replica_set tablet_replicas;
+    std::pair<dht::token, dht::token> token_range;
+};
+
 }
 
 template <>

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -25,6 +25,10 @@ using namespace locator;
 static thread_local auto replica_type = tuple_type_impl::get_instance({uuid_type, int32_type});
 static thread_local auto replica_set_type = list_type_impl::get_instance(replica_type, false);
 
+data_type get_replica_set_type() {
+    return replica_set_type;
+}
+
 schema_ptr make_tablets_schema() {
     // FIXME: Allow UDTs in system keyspace:
     // CREATE TYPE tablet_replica (replica_id uuid, shard int);
@@ -43,7 +47,6 @@ schema_ptr make_tablets_schema() {
             .build();
 }
 
-static
 std::vector<data_value> replicas_to_data_value(const tablet_replica_set& replicas) {
     std::vector<data_value> result;
     result.reserve(replicas.size());

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include "types/types.hh"
+#include "types/tuple.hh"
+#include "types/list.hh"
 #include "timestamp.hh"
 #include "locator/tablets.hh"
 #include "schema/schema_fwd.hh"
@@ -28,7 +31,11 @@ class query_processor;
 
 namespace replica {
 
+data_type get_replica_set_type();
+
 schema_ptr make_tablets_schema();
+
+std::vector<data_value> replicas_to_data_value(const locator::tablet_replica_set& replicas);
 
 /// Converts information in tablet_map to mutations of system.tablets.
 ///

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -290,8 +290,10 @@ public:
         }
         auto& qo = cql3::query_options::DEFAULT;
         auto timeout = db::timeout_clock::now() + qs->get_client_state().get_timeout_config().write_timeout;
+        cql3::statements::modification_statement::json_cache_opt json_cache = modif_stmt->maybe_prepare_json_cache(qo);
+        std::vector<dht::partition_range> keys = modif_stmt->build_partition_keys(qo, json_cache);
 
-        return modif_stmt->get_mutations(local_qp(), qo, timeout, false, qo.get_timestamp(*qs), *qs)
+        return modif_stmt->get_mutations(local_qp(), qo, timeout, false, qo.get_timestamp(*qs), *qs, json_cache, keys)
             .finally([qs, modif_stmt = std::move(modif_stmt)] {});
     }
 

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <map>
 #include <vector>
 #include <seastar/core/sstring.hh>
 
@@ -19,6 +20,7 @@ namespace messages {
 
 class result_message {
     std::vector<sstring> _warnings;
+    std::optional<std::unordered_map<sstring, bytes>> _custom_payload;
 public:
     class visitor;
     class visitor_base;
@@ -33,6 +35,17 @@ public:
 
     const std::vector<sstring>& warnings() const {
         return _warnings;
+    }
+
+    void add_custom_payload(sstring key, bytes value) {
+        if (!_custom_payload) {
+            _custom_payload = std::optional<std::unordered_map<sstring, bytes>>{std::unordered_map<sstring, bytes>()};
+        }
+        _custom_payload.value()[key] = value;
+    }
+
+    const std::optional<std::unordered_map<sstring, bytes>>& custom_payload() const {
+        return _custom_payload;
     }
 
     virtual std::optional<unsigned> move_to_shard() const {

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -73,6 +73,7 @@ public:
     void write_consistency(db::consistency_level c);
     void write_string_map(std::map<sstring, sstring> string_map);
     void write_string_multimap(std::multimap<sstring, sstring> string_map);
+    void write_string_bytes_map(const std::unordered_map<sstring, bytes>& map);
     void write_value(bytes_opt value);
     void write_value(std::optional<managed_bytes_view> value);
     void write(const cql3::metadata& m, bool skip = false);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -75,6 +75,7 @@ enum class cql_compression {
 enum cql_frame_flags {
     compression = 0x01,
     tracing     = 0x02,
+    custom_payload = 0x04,
     warning     = 0x08,
 };
 


### PR DESCRIPTION
There is a need for sending tablet info to the drivers so they can be tablet aware. For the best performance we want to get this info lazily only when it is needed.

The info is send when driver asks about the information that the specific tablet contains and it is directed to the wrong node/shard so it could use that information for every subsequent query. If we send the query to the wrong node/shard, we want to send the RESULT message with additional information about the tablet (replicas and token range) in custom_payload.

Mechanism for sending custom_payload added.

Sending custom_payload tested using three node cluster and cqlsh queries. I used RF=1 so choosing wrong node was testable.

I also manually tested it with the python-driver and confirmed that the tablet info can be deserialized properly. 

Automatic tests added.