### PR TITLE
doc: do not suggest "-node xxx" when running c-s

### DIFF
--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -90,7 +90,7 @@ Run cassandra-stress:
 
 .. code:: console
 
-    ~/scylladb/share/cassandra/bin/cassandra-stress write -node xxx
+    ~/scylladb/share/cassandra/bin/cassandra-stress write
 
 .. note::
 


### PR DESCRIPTION
cassandra-stress connects to "localhost" by default. that's exactly the use case when we install scylla using the unified installer. so do not suggest "-node xxx" option. the "xxx" part is but confusing.