### PR TITLE
Use sstable_state in sstables populator

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -411,8 +411,7 @@ sstables::shared_sstable make_sstable(replica::table& table, sstables::sstable_s
 }
 
 future<> table_populator::populate_subdir(sstables::sstable_state state, allow_offstrategy_compaction do_allow_offstrategy_compaction) {
-    auto sstdir = get_path(state);
-    dblog.debug("Populating {}/{}/{} allow_offstrategy_compaction={}", _ks, _cf, sstdir, do_allow_offstrategy_compaction);
+    dblog.debug("Populating {}/{}/{} state={} allow_offstrategy_compaction={}", _ks, _cf, _base_path, state, do_allow_offstrategy_compaction);
 
     if (!_sstable_directories.contains(state)) {
         co_return;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -154,6 +154,10 @@ inline sstring state_to_dir(sstable_state state) {
     }
 }
 
+inline std::ostream& operator<<(std::ostream& o, sstable_state s) {
+    return o << state_to_dir(s);
+}
+
 // FIXME -- temporary, move to fs storage after patching the rest
 inline fs::path make_path(std::string_view table_dir, sstable_state state) {
     fs::path ret(table_dir);


### PR DESCRIPTION
Some time ago populating of tables from sstables was reworked to use sstable states instead of full paths (#12707). Since then few places in the populator was left that still operate on the state-based subdirectory name. This PR collects most of those dangling ends

refs: #13020