### PR TITLE
scripts: pull_gitgub_pr.sh: absolutize project reference

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -69,7 +69,7 @@ git fetch "$REMOTE" pull/$PR_NUM/head
 
 nr_commits=$(git log --pretty=oneline HEAD..FETCH_HEAD | wc -l)
 
-closes="${NL}${NL}Closes #${PR_NUM}${NL}"
+closes="${NL}${NL}Closes ${PROJECT}#${PR_NUM}${NL}"
 
 if [[ $nr_commits == 1 ]]; then
 	commit=$(git log --pretty=oneline HEAD..FETCH_HEAD | awk '{print $1}')


### PR DESCRIPTION
pull_gitgub_pr.sh adds a "Closes #xyz" tag so github can close the pull request after next promotion. Convert it to an absolute refefence (scylladb/scylladb#xyz) so the commit can be cherry-picked into another repository without the reference dangling.