### PR TITLE
[5.2 backport] doc: fix internal links

### DIFF
--- a/docs/architecture/ringarchitecture/index.rst
+++ b/docs/architecture/ringarchitecture/index.rst
@@ -70,9 +70,7 @@ You can use the ``nodetool`` command to describe different aspects of your nodes
 
 ``$ nodetool ring <keyspace>``
 
-Outputs all tokens of a node, and displays the token ring information_.  It produces output as follows for a single datacenter:
-
-.. _information: /operating-scylla/nodetool-commands/ring/
+Outputs all tokens of a node, and displays the :doc:`token ring information </operating-scylla/nodetool-commands/ring>`.  It produces output as follows for a single datacenter:
 
 .. code-block:: shell
 

--- a/docs/operating-scylla/admin-tools/sstable2json.rst
+++ b/docs/operating-scylla/admin-tools/sstable2json.rst
@@ -4,9 +4,7 @@ SSTable2json
 
 This tool allows you to converts SSTable into a JSON format file.
 SSTable2json supported when using Scylla 2.x or lower version.
-In newer versions, the tool is named SSTabledump_.
-
-.. _SSTabledump: /operating-scylla/admin-tools/sstabledump
+In newer versions, the tool is named :doc:`SSTabledump </operating-scylla/admin-tools/sstabledump>`.
 
 .. note:: 
 

--- a/docs/operating-scylla/admin-tools/sstabledump.rst
+++ b/docs/operating-scylla/admin-tools/sstabledump.rst
@@ -3,11 +3,9 @@ SSTabledump
 
 This tool allows you to converts SSTable into a JSON format file.
 SSTabledump supported when using Scylla 3.0, Scylla Enterprise 2019.1, and newer versions.
-In older versions, the tool is named SSTable2json_.
-If you need more flexibility or want to dump more than just the data-component, see scylla-sstable_.
+In older versions, the tool is named :doc:`SSTable2json </operating-scylla/admin-tools/sstable2json>`.
+If you need more flexibility or want to dump more than just the data-component, see :doc:`scylla-sstable </operating-scylla/admin-tools/scylla-sstable>`.
 
-.. _SSTable2json: /operating-scylla/admin-tools/sstable2json
-.. _scylla-sstable: /operating-scylla/admin-tools/scylla-sstable
 
 Use the full path to the data file when executing the command.
 

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -91,11 +91,16 @@ The :code:`scylla-server` file contains configuration related to starting up the
 
 .. include:: /operating-scylla/scylla-yaml.inc
 
+.. _admin-compression:
+
 Compression
 -----------
 
 In Scylla, you can configure compression at rest and compression in transit.
 For compression in transit, you can configure compression between nodes or between the client and the node.
+
+
+.. _admin-client-node-compression:
 
 Client - Node Compression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/operating-scylla/nodetool-commands/snapshot.rst
+++ b/docs/operating-scylla/nodetool-commands/snapshot.rst
@@ -108,10 +108,7 @@ Each of the snapshots is a **hardlink** to to the SSTable directory.
 Additional Resources
 ^^^^^^^^^^^^^^^^^^^^
 
-* `Backup your data`_ 
-* `Scylla Snapshots`_
-
-.. _`Backup your data`: /operating-scylla/procedures/backup-restore/backup
-.. _`Scylla Snapshots`: /kb/snapshots
+* :doc:`Backup your data </operating-scylla/procedures/backup-restore/backup>`
+* :doc:`Scylla Snapshots </kb/snapshots>`
 
 .. include:: /rst_include/apache-copyrights.rst

--- a/docs/operating-scylla/procedures/backup-restore/backup.rst
+++ b/docs/operating-scylla/procedures/backup-restore/backup.rst
@@ -17,12 +17,8 @@ The backup includes two procedures. These are:
 Full Backup - Snapshots
 =======================
 
-Snapshots are taken using `nodetool snapshot`_. First, the command flushes the MemTables from memory to SSTables on disk, and afterward, it creates a hard link for each SSTable in each keyspace.
-With time, SSTables are compacted, but the hard link keeps a copy of each file. This takes up an increasing amount of disk space. It is important to clear space by `clean unnecessary snapshots`_.
-
-.. _`nodetool snapshot`: /operating-scylla/nodetool-commands/snapshot
-
-.. _`clean unnecessary snapshots`: /operating-scylla/procedures/backup-restore/delete_snapshot
+Snapshots are taken using :doc:`nodetool snapshot </operating-scylla/nodetool-commands/snapshot>`. First, the command flushes the MemTables from memory to SSTables on disk, and afterward, it creates a hard link for each SSTable in each keyspace.
+With time, SSTables are compacted, but the hard link keeps a copy of each file. This takes up an increasing amount of disk space. It is important to clear space by :doc:`clean unnecessary snapshots </operating-scylla/procedures/backup-restore/delete-snapshot>`.
 
 **Procedure**
 
@@ -77,8 +73,6 @@ Incremental Backup
 Additional Resources
 ====================
 
-* `Scylla Snapshots`_
+* :doc:`Scylla Snapshots </kb/snapshots>`
 
-
-.. _`Scylla Snapshots`: /kb/snapshots
 

--- a/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
+++ b/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
@@ -133,9 +133,7 @@ Procedure
 
 See the full code example `here <https://github.com/scylladb/scylla-code-samples/tree/master/dual_writes>`_
 
-3. On each Apache Cassandra node, take a snapshot for every keyspace using the `nodetool snapshot`_ command. This will flush all SSTables to disk and generate a ``snapshots`` folder with an epoch timestamp for each underlying table in that keyspace. 
-
-.. _`nodetool snapshot`: /operating-scylla/nodetool-commands/snapshot
+3. On each Apache Cassandra node, take a snapshot for every keyspace using the :doc:`nodetool snapshot </operating-scylla/nodetool-commands/snapshot>` comand. This will flush all SSTables to disk and generate a ``snapshots`` folder with an epoch timestamp for each underlying table in that keyspace. 
 
    Folder path post snapshot: ``/var/lib/cassandra/data/keyspace/table-[uuid]/snapshots/[epoch_timestamp]/``
 

--- a/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
+++ b/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
@@ -306,9 +306,8 @@ First, download the file locally to the node:
 
   sudo docker exec -it some-scylla.2.0.1 curl -o file.csv https://<url>.com/<path>/<path>/<file>.csv
 
-Once you have the ``.csv`` downloaded, you can use the CQL ``COPY FROM`` command as explained here_ to load the data into ScyllaDB.
+Once you have the ``.csv`` downloaded, you can use the CQL ``COPY FROM`` command as explained :doc:`here </cql/cqlsh>` to load the data into ScyllaDB.
 
-.. _here: /getting-started/cqlsh/
 
 Such a copy command might look like this:
 

--- a/docs/troubleshooting/error-messages/create-mv.rst
+++ b/docs/troubleshooting/error-messages/create-mv.rst
@@ -4,9 +4,8 @@ A Removed Node was not Removed Properly from the Seed Node List
 Phenonoma
 ^^^^^^^^^
 
-Failed to create `materialized view`_ after node was removed from the cluster. 
+Failed to create :doc:`materialized view </cql/mv>` after node was removed from the cluster. 
 
-.. _`materialized view`: /getting-started/mv/
 
 Error message:
 
@@ -27,9 +26,7 @@ How to Verify
 
 Scylla logs show the error message above.
 
-To verify that the node wasn't remove properly use the `nodetool gossipinfo`_ command
-
-.. _`nodetool gossipinfo`: /operating-scylla/nodetool-commands/gossipinfo/
+To verify that the node wasn't remove properly use the :doc:`nodetool gossipinfo </operating-scylla/nodetool-commands/gossipinfo>` command
 
 For example:
 

--- a/docs/using-scylla/cassandra-compatibility.rst
+++ b/docs/using-scylla/cassandra-compatibility.rst
@@ -101,32 +101,32 @@ Consistency Level (read and write)
 | LOCAL_SERIAL                        | |v|:sup:`*`  |
 +-------------------------------------+--------------+
 
-:sup:`*` From ScyllaDB 4.0. See `Scylla LWT`_
+:sup:`*` From ScyllaDB 4.0. See :doc:`Scylla LWT </using-scylla/lwt>`.
 
 
 Snitches
 ^^^^^^^^
-+-------------------------------------+--------+
-|   Options                           | Support|
-+=====================================+========+
-| SimpleSnitch_                       |   |v|  |
-+-------------------------------------+--------+
-| RackInferringSnitch_                |   |v|  |
-+-------------------------------------+--------+
-| PropertyFileSnitch                  |   |x|  |
-+-------------------------------------+--------+
-| GossipingPropertyFileSnitch_        |   |v|  |
-+-------------------------------------+--------+
-| Dynamic snitching                   |   |x|  |
-+-------------------------------------+--------+
-| EC2Snitch_                          |   |v|  |
-+-------------------------------------+--------+
-| EC2MultiRegionSnitch_               |   |v|  |
-+-------------------------------------+--------+
-| GoogleCloudSnitch_                  |   |v|  |
-+-------------------------------------+--------+
-| CloudstackSnitch                    |   |x|  |
-+-------------------------------------+--------+
++-----------------------------------------------------------------------------+--------+
+|   Options                                                                   | Support|
++=============================================================================+========+
+|:ref:`SimpleSnitch <snitch-simple-snitch>`                                   |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| :ref:`RackInferringSnitch <snitch-rack-inferring-snitch>`                   |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| PropertyFileSnitch                                                          |   |x|  |
++-----------------------------------------------------------------------------+--------+
+| :ref:`GossipingPropertyFileSnitch <snitch-gossiping-property-file-snitch>`  |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| Dynamic snitching                                                           |   |x|  |
++-----------------------------------------------------------------------------+--------+
+| :ref:`EC2Snitch <snitch-ec2-snitch>`                                        |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| :ref:`EC2MultiRegionSnitch <snitch-ec2-multi-region-snitch>`                |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| :ref:`GoogleCloudSnitch <GoogleCloudSnitch>`                                |   |v|  |
++-----------------------------------------------------------------------------+--------+
+| CloudstackSnitch                                                            |   |x|  |
++-----------------------------------------------------------------------------+--------+
 
 Partitioners
 ^^^^^^^^^^^^
@@ -148,61 +148,61 @@ Partitioners
 
 Protocol Options
 ^^^^^^^^^^^^^^^^
-+-------------------------------------+--------------+
-|   Options                           | Support      |
-+=====================================+==============+
-| Encryption_                         |   |v|        |
-+-------------------------------------+--------------+
-| Authentication_                     |   |v|        |
-+-------------------------------------+--------------+
-| Compression_  (see below)           |   |v|        |
-+-------------------------------------+--------------+
++--------------------------------------------------------------------------+--------------+
+|   Options                                                                | Support      |
++==========================================================================+==============+
+| :doc:`Encryption </operating-scylla/security/client-node-encryption>`    |   |v|        |
++--------------------------------------------------------------------------+--------------+
+| :doc:`Authentication </operating-scylla/security/authentication>`        |   |v|        |
++--------------------------------------------------------------------------+--------------+
+| :ref:`Compression <admin-compression>`  (see below)                      |   |v|        |
++--------------------------------------------------------------------------+--------------+
 
 
 Compression
 ^^^^^^^^^^^
-+-------------------------------------+--------------+
-|   Options                           | Support      |
-+=====================================+==============+
-|CQL Compression                      |   |v|        |
-+-------------------------------------+--------------+
-| LZ4                                 |   |v|        |
-+-------------------------------------+--------------+
-| Snappy                              |   |v|        |
-+-------------------------------------+--------------+
-| `Node to Node Compression`_         |   |v|        |
-+-------------------------------------+--------------+
-| `Client to Node Compression`_       |   |v|        |
-+-------------------------------------+--------------+
++-------------------------------------------------------------------+--------------+
+|   Options                                                         | Support      |
++===================================================================+==============+
+|CQL Compression                                                    |   |v|        |
++-------------------------------------------------------------------+--------------+
+| LZ4                                                               |   |v|        |
++-------------------------------------------------------------------+--------------+
+| Snappy                                                            |   |v|        |
++-------------------------------------------------------------------+--------------+
+| :ref:`Node to Node Compression <internode-compression>`           |   |v|        |
++-------------------------------------------------------------------+--------------+
+| :ref:`Client to Node Compression <admin-client-node-compression>` |   |v|        |
++-------------------------------------------------------------------+--------------+
 
 Backup and Restore
 ^^^^^^^^^^^^^^^^^^
-+-------------------------------------+--------------+
-|   Options                           | Support      |
-+=====================================+==============+
-| Snapshot_                           |   |v|        |
-+-------------------------------------+--------------+
-| `Incremental backup`_               |   |v|        |
-+-------------------------------------+--------------+
-| Restore_                            |   |v|        |
-+-------------------------------------+--------------+
++-----------------------------------------------------------------------+--------------+
+|   Options                                                             | Support      |
++=======================================================================+==============+
+| :ref:`Snapshot <backup-full-backup-snapshots>`                        |   |v|        |
++-----------------------------------------------------------------------+--------------+
+| :ref:`Incremental backup <backup-incremental-backup>`                 |   |v|        |
++-----------------------------------------------------------------------+--------------+
+| :doc:`Restore </operating-scylla/procedures/backup-restore/restore>`  |   |v|        |
++-----------------------------------------------------------------------+--------------+
 
 Repair and Consistency
 ^^^^^^^^^^^^^^^^^^^^^^
-+-------------------------------------+--------------+
-|   Options                           | Support      |
-+=====================================+==============+
-| `Nodetool Repair`_                  |   |v|        |
-+-------------------------------------+--------------+
-| Incremental Repair                  | |x|          |
-+-------------------------------------+--------------+
-|`Hinted Handoff`_                    | |v|          |
-+-------------------------------------+--------------+
-|`Lightweight transactions`_          |  |v|:sup:`*` |
-+-------------------------------------+--------------+
++----------------------------------------------------------------------+--------------+
+|   Options                                                            | Support      |
++======================================================================+==============+
+| :doc:`Nodetool Repair </operating-scylla/nodetool-commands/repair>`  |   |v|        |
++----------------------------------------------------------------------+--------------+
+| Incremental Repair                                                   | |x|          |
++----------------------------------------------------------------------+--------------+
+|:doc:`Hinted Handoff </architecture/anti-entropy/hinted-handoff>`     | |v|          |
++----------------------------------------------------------------------+--------------+
+|:doc:`Lightweight Transactions </using-scylla/lwt>`                   |  |v|:sup:`*` |
++----------------------------------------------------------------------+--------------+
 
 
-:sup:`*` From ScyllaDB 4.0. See `Scylla LWT`_
+:sup:`*` From ScyllaDB 4.0. See :doc:`Scylla LWT </using-scylla/lwt>`.
 
 Replica Replacement Strategy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,15 +230,15 @@ Security
 Indexing and Caching
 ^^^^^^^^^^^^^^^^^^^^^
 
-+-------------------------------------+-----------------------------------------+
-|   Options                           | Support                                 |
-+=====================================+=========================================+
-|row / key cache                      | |x| (More on `Scylla memory and cache`_)|
-+-------------------------------------+-----------------------------------------+
-|`Secondary Index`_                   | |v| :sup:`*`                            |
-+-------------------------------------+-----------------------------------------+
-|`Materialized Views`_                |  |v|:sup:`*`                            |
-+-------------------------------------+-----------------------------------------+
++--------------------------------------------------------------+--------------------------------------------------------------------------------------+
+|   Options                                                    | Support                                                                              |
++==============================================================+======================================================================================+
+|row / key cache                                               | |x| (More on `Scylla memory and cache <http://www.scylladb.com/technology/memory/>`_)|
++--------------------------------------------------------------+--------------------------------------------------------------------------------------+
+|:doc:`Secondary Index </using-scylla/secondary-indexes>`      | |v| :sup:`*`                                                                         |
++--------------------------------------------------------------+--------------------------------------------------------------------------------------+
+|:doc:`Materialized Views </using-scylla/materialized-views>`  |  |v|:sup:`*`                                                                         |
++--------------------------------------------------------------+--------------------------------------------------------------------------------------+
 
 :sup:`*` In ScyllaDB Open Source and ScyllaDB Enterprise from 2019.1
 
@@ -269,32 +269,6 @@ Additional Features
 
 :sup:`*`  Experimental 
 
-.. _`Secondary Index`: /using-scylla/secondary-indexes/
-.. _`Lightweight Transactions`: /using-scylla/lwt/
-.. _`Materialized Views`: /using-scylla/materialized-views/
-.. _`Node to Node Compression`: /operating-scylla/admin/#internode-compression
-.. _`Client to Node Compression`: /operating-scylla/admin/#client-node-compression
-.. _`Compression`: /operating-scylla/admin/#compression
-.. _`Scylla LWT`: /using-scylla/lwt/
-.. _401: https://github.com/scylladb/scylla/issues/401
-.. _1141: https://github.com/scylladb/scylla/issues/1141
-.. _1619: https://github.com/scylladb/scylla/issues/1619
-.. _577: https://github.com/scylladb/scylla/issues/577
-.. _`Scylla memory and cache`: http://www.scylladb.com/technology/memory/
-.. _Encryption: /operating-scylla/security/client_node_encryption/
-.. _Authentication: /operating-scylla/security/authentication/
-.. _Authorization: /operating-scylla/security/authorization/
-.. _`Nodetool Repair`: /operating-scylla/nodetool-commands/repair/
-.. _Snapshot: /operating-scylla/procedures/backup-restore/backup/#full-backup-snapshots
-.. _`Incremental backup`: /operating-scylla/procedures/backup-restore/backup/#incremental-backup
-.. _Restore: /operating-scylla/procedures/backup-restore/restore/
-.. _SimpleSnitch: /operating-scylla/system-configuration/snitch/#simplesnitch
-.. _RackInferringSnitch: /operating-scylla/system-configuration/snitch/#rackinferringsnitch
-.. _GossipingPropertyFileSnitch: /operating-scylla/system-configuration/snitch/#gossipingpropertyfilesnitch/
-.. _EC2Snitch: /operating-scylla/system-configuration/snitch/#ec2snitch/
-.. _EC2MultiRegionSnitch: /operating-scylla/system-configuration/snitch/#ec2multiregionsnitch
-.. _GoogleCloudSnitch: /operating-scylla/system-configuration/snitch/#googlecloudsnitch
-.. _`Hinted Handoff`: /architecture/anti-entropy/hinted-handoff/
 
 CQL Command Compatibility
 -------------------------
@@ -384,17 +358,17 @@ Create Table Att
 Create Table Compaction
 .......................
 
-+----------------------------------------+-------------------------------------+
-| Feature                                | Support                             |
-+========================================+=====================================+
-| SizeTieredCompactionStrategy_ (STCS)   | |v|                                 |
-+----------------------------------------+-------------------------------------+
-|LeveledCompactionStrategy_ (LCS)        | |v|                                 |
-+----------------------------------------+-------------------------------------+
-|DateTieredCompactionStrategy (DTCS)     | |v|  :sup:`*`                       |
-+----------------------------------------+-------------------------------------+
-|TimeWindowCompactionStrategy_ (TWCS)    | |v|                                 |
-+----------------------------------------+-------------------------------------+
++----------------------------------------------------+-------------------------------------+
+| Feature                                            | Support                             |
++====================================================+=====================================+
+| :ref:`SizeTieredCompactionStrategy <STCS>` (STCS)  | |v|                                 |
++----------------------------------------------------+-------------------------------------+
+|:ref:`LeveledCompactionStrategy <LCS>` (LCS)        | |v|                                 |
++----------------------------------------------------+-------------------------------------+
+|DateTieredCompactionStrategy (DTCS)                 | |v|  :sup:`*`                       |
++----------------------------------------------------+-------------------------------------+
+|:ref:`TimeWindowCompactionStrategy <TWCS>` (TWCS)   | |v|                                 |
++----------------------------------------------------+-------------------------------------+
 
 :sup:`*`  Deprecated in ScyllaDB 4.0, use TWCS instead
 
@@ -533,15 +507,6 @@ Index commands
 +----------------------------------------+-------------------------------------+
 |DROP INDEX                              | |v|                                 |
 +----------------------------------------+-------------------------------------+
-
-
-.. _SizeTieredCompactionStrategy: /getting-started/compaction/#size-tiered-compaction-strategy
-
-.. _LeveledCompactionStrategy: /getting-started/compaction/#leveled-compaction-strategy
-
-.. _TimeWindowCompactionStrategy: /getting-started/compaction/#time-window-compactionstrategy
-
-.. _1432: https://github.com/scylladb/scylla/issues/1432
 
 .. include:: /rst_include/apache-copyrights-index.rst
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/14490

This commit fixes mulitple links that were broken
after the documentation is published (but not in
the preview) due to incorrect syntax.
I've fixed the syntax to use the :docs: and :ref:
directive for pages and sections, respectively.

Closes #14664
Fixes #15019

(cherry picked from commit a93fd2b162a80db905519d14e10f7b621bdd8dc1)