### PR TITLE
tools/scylla-nodetools: do not create unowned bpo::value 

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -164,7 +164,9 @@ const std::map<std::string_view, std::string_view> option_substitutions{
     {"-et", "--end-token"},
 };
 
-const std::map<operation, operation_func> operations_with_func{
+auto get_operations_with_func() {
+
+const static std::map<operation, operation_func> operations_with_func {
     {{"compact",
             "Force a (major) compaction on one or more tables",
 R"(
@@ -191,6 +193,9 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
             }},
             compact_operation},
 };
+
+    return operations_with_func;
+}
 
 // boost::program_options doesn't allow multi-char option short-form,
 // e.g. -pw, that C*'s nodetool uses. We silently map these to the
@@ -261,7 +266,7 @@ Supported Nodetool operations:
 For more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool.html
 )";
 
-    const auto operations = boost::copy_range<std::vector<operation>>(operations_with_func | boost::adaptors::map_keys);
+    const auto operations = boost::copy_range<std::vector<operation>>(get_operations_with_func() | boost::adaptors::map_keys);
     tool_app_template::config app_cfg{
             .name = app_name,
             .description = format(description_template, app_name, boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
@@ -277,7 +282,7 @@ For more information, see: https://opensource.docs.scylladb.com/stable/operating
         scylla_rest_client client(app_config["host"].as<sstring>(), app_config["port"].as<uint16_t>());
 
         try {
-            operations_with_func.at(operation)(client, app_config);
+            get_operations_with_func().at(operation)(client, app_config);
         } catch (std::invalid_argument& e) {
             fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
             return 1;

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -166,9 +166,11 @@ const std::map<std::string_view, std::string_view> option_substitutions{
 
 auto get_operations_with_func() {
 
-const static std::map<operation, operation_func> operations_with_func {
-    {{"compact",
-            "Force a (major) compaction on one or more tables",
+    const static std::map<operation, operation_func> operations_with_func {
+        {
+            {
+                "compact",
+                "Force a (major) compaction on one or more tables",
 R"(
 Forces a (major) compaction on one or more tables. Compaction is an optimization
 that reduces the cost of IO and CPU over time by merging rows in the background.
@@ -181,18 +183,20 @@ command-line arguments, the compaction will run on these tables.
 
 Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/compact.html
 )",
-            {
+                {
                     typed_option<>("split-output,s", "Don't create a single big file (unused)"),
                     typed_option<>("user-defined", "Submit listed SStable files for user-defined compaction (unused)"),
                     typed_option<int64_t>("start-token", "Specify a token at which the compaction range starts (unused)"),
                     typed_option<int64_t>("end-token", "Specify a token at which the compaction range end (unused)"),
                     typed_option<sstring>("partition", "String representation of the partition key to compact (unused)"),
-            },
-            {
+                },
+                {
                     {"compaction_arg", bpo::value<std::vector<sstring>>(), "[<keyspace> <tables>...] or [<SStable files>...] ", -1},
-            }},
-            compact_operation},
-};
+                }
+            },
+            compact_operation
+        },
+    };
 
     return operations_with_func;
 }


### PR DESCRIPTION
in other words, do not create bpo::value unless transfer it to an
option_description.

`boost::program_options::value()` create a new typed_value<T> object,
without holding it with a shared_ptr. boost::program_options expects
developer to construct a `bpo::option_description` right away from it.
and `boost::program_options::option_description` takes the ownership
of the `type_value<T>*` raw pointer, and manages its life cycle with
a shared_ptr. but before passing it to a `bpo::option_description`,
the pointer created by `boost::program_options::value()` is a still
a raw pointer.

before this change, we initialize `operations_with_func` as global
variables using `boost::program_options::value()`. but unfortunately,
we don't always initialize a `bpo::option_description` from it --
we only do this on demand when the corresponding subcommand is
called.

so, if the corresponding subcommand is not called, the created
`typed_value<T>` objects are leaked. hence LeakSanitizer warns us.

after this change, we create the option map as a static
local variable in a function so it is created on demand as well.
as an alternative, we could initialize the options map as local
variable where it used. but to be more consistent with how
`global_option` is specified. and to colocate them in a single
place, let's keep the existing code layout.

this change is quite similar to https://github.com/scylladb/scylladb/commit/374bed8c3d58c75af037fb9e1fc98e7473869308

Fixes https://github.com/scylladb/scylladb/issues/15429