### PR TITLE
tools/scylla-nodetool: mark format string as constexpr

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -246,7 +246,7 @@ int scylla_nodetool_main(int argc, char** argv) {
     auto replacement_argv = massage_argv(argc, argv);
     nlog.debug("replacement argv: {}", replacement_argv);
 
-    const auto description_template =
+    constexpr auto description_template =
 R"(scylla-nodetool - a command-line tool to administer local or remote ScyllaDB nodes
 
 # Operations


### PR DESCRIPTION
this change change `const` to `constexpr`. because the string literal defined here is not only immutable, but also initialized at compile-time, and can be used by constexpr expressions and functions.

this change is introduced to reduce the size of the change when moving to compile-time format string in future. so far, seastar::format() does not use the compile-time format string, but we have patches pending on review implementing this. and the author of this change has local branches implementing the changes on scylla side to support compile-time format string, which practically replaces most of the `format()` calls with `seastar::format()`.

without this change, if we use compile-time format check, compiler fails like:

```
/home/kefu/dev/scylladb/tools/scylla-nodetool.cc:276:44: error: call to consteval function 'fmt::basic_format_string<char, const char *const &, seastar::basic_sstring<char, unsigned int, 15>>::basic_format_string<const char *, 0>' is not a constant expression
            .description = seastar::format(description_template, app_name, boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
                                           ^
/usr/include/fmt/core.h:3148:67: note: read of non-constexpr variable 'description_template' is not allowed in a constant expression
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                                                                  ^
/home/kefu/dev/scylladb/tools/scylla-nodetool.cc:276:44: note: in call to 'basic_format_string(description_template)'
            .description = seastar::format(description_template, app_name, boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
                                           ^
/home/kefu/dev/scylladb/tools/scylla-nodetool.cc:258:16: note: declared here
    const auto description_template =
               ^
```