### PR TITLE
Rewrap keyspace population loop

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -522,13 +522,13 @@ future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& 
             return sys_ks.make(erm_factory.local(), db.local());
         }).get();
 
-            for (auto ksname : system_keyspaces) {
-                auto& ks = db.local().get_keyspaces();
-                auto i = ks.find(ksname);
-                if (i != ks.end()) {
-                    distributed_loader::populate_keyspace(db, i->second, sstring(ksname)).get();
-                }
+        for (auto ksname : system_keyspaces) {
+            auto& ks = db.local().get_keyspaces();
+            auto i = ks.find(ksname);
+            if (i != ks.end()) {
+                distributed_loader::populate_keyspace(db, i->second, sstring(ksname)).get();
             }
+        }
     });
 }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -538,30 +538,16 @@ future<> distributed_loader::init_non_system_keyspaces(distributed<replica::data
         }).get();
 
         const auto& cfg = db.local().get_config();
-        using ks_dirs = std::unordered_multimap<sstring, sstring>;
-
-        ks_dirs dirs;
-
-        parallel_for_each(cfg.data_file_directories(), [&dirs] (sstring directory) {
-            // we want to collect the directories first, so we can get a full set of potential dirs
-            return lister::scan_dir(fs::path{directory}, lister::dir_entry_types::of<directory_entry_type::directory>(),
-                    [&dirs] (fs::path datadir, directory_entry de) {
-                if (!is_system_keyspace(de.name)) {
-                    dirs.emplace(de.name, datadir.native());
-                }
-                return make_ready_future<>();
-            });
-        }).get();
-
 
         for (bool prio_only : { true, false}) {
             std::vector<future<>> futures;
 
-            // treat "dirs" as immutable to avoid modifying it while still in
-            // a range-iteration. Also to simplify the "finally"
-            for (auto i = dirs.begin(); i != dirs.end();) {
-                auto& ks_name = i->first;
-                auto j = i++;
+            for (auto& ks : db.local().get_keyspaces()) {
+                auto& ks_name = ks.first;
+
+                if (is_system_keyspace(ks_name)) {
+                    continue;
+                }
 
                 /**
                  * Must process in two phases: Prio and non-prio.
@@ -573,12 +559,10 @@ future<> distributed_loader::init_non_system_keyspaces(distributed<replica::data
                     continue;
                 }
 
-                auto e = dirs.equal_range(ks_name).second;
                 // might have more than one dir for a keyspace iff data_file_directories is > 1 and
                 // somehow someone placed sstables in more than one of them for a given ks. (import?)
-                futures.emplace_back(parallel_for_each(j, e, [&](const std::pair<sstring, sstring>& p) {
-                    auto& datadir = p.second;
-                    return distributed_loader::populate_keyspace(db, datadir, ks_name);
+                futures.emplace_back(parallel_for_each(cfg.data_file_directories(), [&] (const sstring& data_dir) {
+                    return distributed_loader::populate_keyspace(db, data_dir, ks_name);
                 }));
             }
 

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -73,7 +73,7 @@ class distributed_loader {
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,
             bool needs_view_update, sstring ks, sstring cf);
-    static future<> populate_keyspace(distributed<replica::database>& db, sstring datadir, sstring ks_name);
+    static future<> populate_keyspace(distributed<replica::database>& db, keyspace& ks, sstring datadir, sstring ks_name);
 
 public:
     static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -73,6 +73,7 @@ class distributed_loader {
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,
             bool needs_view_update, sstring ks, sstring cf);
+    static future<> populate_keyspace(distributed<replica::database>& db, keyspace& ks, sstring ks_name);
     static future<> populate_keyspace(distributed<replica::database>& db, keyspace& ks, sstring datadir, sstring ks_name);
 
 public:


### PR DESCRIPTION
Populating of non-system keyspaces is now done by listing datadirs and assuming that each subdir found is a keyspace. For S3-backed keyspaces this is also true, but it's a bug (#13020). The loop needs to walk the list of known keyspaces instead, and try to find the keyspace storage later, based on the storage option.