### PR TITLE
repair: Shutdown repair on nodetool drain too

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1877,10 +1877,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("serving");
             // Register at_exit last, so that storage_service::drain_on_shutdown will be called first
 
-            auto stop_repair = defer_verbose_shutdown("repair", [&repair] {
-                repair.invoke_on_all(&repair_service::shutdown).get();
-            });
-
             auto drain_sl_controller = defer_verbose_shutdown("service level controller update loop", [&lifecycle_notifier] {
                 sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {
                     return lifecycle_notifier.local().unregister_subscriber(&controller);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5064,6 +5064,7 @@ future<> storage_service::do_drain() {
 
     co_await _db.invoke_on_all(&replica::database::drain);
     co_await _sys_ks.invoke_on_all(&db::system_keyspace::shutdown);
+    co_await _repair.invoke_on_all(&repair_service::shutdown);
 }
 
 future<> storage_service::raft_rebuild(sstring source_dc) {


### PR DESCRIPTION
Currently repair shutdown only happens on stop, but it looks like nodetool drain can call shutdown too to abort no longer relevant repair tasks if any. This also makes the main()'s deferred shutdown/stop paths cleaner a little bit