### PR TITLE
storage_service: Capture structured binding explicitly

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -444,7 +444,7 @@ future<> storage_service::topology_state_load() {
 
             slogger.trace("raft topology: loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={}",
                           id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate,
-                          seastar::value_of([&] () -> sstring {
+                          seastar::value_of([&rs = rs] () -> sstring {
                               return rs.ring ? ::format("{}", rs.ring->tokens) : sstring("null");
                           }));
 


### PR DESCRIPTION
Implicit capturing of structured binding had been illegal up until c++20, but then the standard was relaxed. However, clang-15 still doesn't know it failing the compilation