### PR TITLE
build: cmake: add "dist-server-debuginfo" target

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -10,7 +10,6 @@ add_custom_command(
     scylla
     ${CMAKE_BINARY_DIR}/iotune
     ${CMAKE_BINARY_DIR}/node_exporter/node_exporter
-    ${CMAKE_CURRENT_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_target(dist-server-deb
@@ -94,7 +93,6 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/scylla.stripped
     ${CMAKE_BINARY_DIR}/iotune.stripped
     ${CMAKE_BINARY_DIR}/node_exporter/node_exporter.stripped
-    ${CMAKE_CURRENT_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_custom_target(dist-server-tar
   DEPENDS ${stripped_dist_pkg})

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -29,13 +29,17 @@ function(add_stripped name)
   set(output ${name}.stripped)
   if(TARGET ${name})
     add_custom_command(
-      OUTPUT ${CMAKE_BINARY_DIR}/${name}.stripped
+      OUTPUT
+        ${CMAKE_BINARY_DIR}/${name}.debug
+        ${CMAKE_BINARY_DIR}/${name}.stripped
       COMMAND ${CMAKE_SOURCE_DIR}/scripts/strip.sh $<TARGET_FILE:${name}>
       DEPENDS ${name})
   else()
     # ${name} must be an absolute path
     add_custom_command(
-      OUTPUT ${name}.stripped
+      OUTPUT
+        ${name}.debug
+        ${name}.stripped
       COMMAND ${CMAKE_SOURCE_DIR}/scripts/strip.sh ${name}
       DEPENDS ${name})
   endif()
@@ -126,3 +130,5 @@ add_custom_command(
   VERBATIM)
 add_custom_target(dist-unified
   DEPENDS ${unified_dist_pkg})
+
+add_subdirectory(debuginfo)

--- a/dist/debuginfo/CMakeLists.txt
+++ b/dist/debuginfo/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(debuginfo_pkg
+  "${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-debuginfo-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+add_custom_command(
+  OUTPUT
+    ${debuginfo_pkg}
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/create-relocatable-package.py
+      --build-dir ${CMAKE_BINARY_DIR}
+      --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
+      ${debuginfo_pkg}
+  DEPENDS
+    ${CMAKE_BINARY_DIR}/scylla.debug
+    ${CMAKE_BINARY_DIR}/iotune.debug
+    ${CMAKE_BINARY_DIR}/node_exporter/node_exporter.debug
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-server-debuginfo
+  DEPENDS ${debuginfo_pkg})


### PR DESCRIPTION
this target mirrors the "dist-server-debuginfo-{mode}" target in the `build.ninja` created by `configure.py`.
