### PR TITLE
Gossiper: add endpoint_id to interface

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -798,7 +798,7 @@ future<> generation_service::leave_ring() {
     co_await _gossiper.unregister_(shared_from_this());
 }
 
-future<> generation_service::on_join(gms::inet_address ep, gms::endpoint_state_ptr ep_state, gms::permit_id pid) {
+future<> generation_service::on_join(gms::endpoint_id node, gms::endpoint_state_ptr ep_state, gms::permit_id pid) {
     assert_shard_zero(__PRETTY_FUNCTION__);
 
     auto val = ep_state->get_application_state_ptr(gms::application_state::CDC_GENERATION_ID);
@@ -806,10 +806,10 @@ future<> generation_service::on_join(gms::inet_address ep, gms::endpoint_state_p
         return make_ready_future();
     }
 
-    return on_change(ep, gms::application_state::CDC_GENERATION_ID, *val, pid);
+    return on_change(node, gms::application_state::CDC_GENERATION_ID, *val, pid);
 }
 
-future<> generation_service::on_change(gms::inet_address ep, gms::application_state app_state, const gms::versioned_value& v, gms::permit_id) {
+future<> generation_service::on_change(gms::endpoint_id node, gms::application_state app_state, const gms::versioned_value& v, gms::permit_id) {
     assert_shard_zero(__PRETTY_FUNCTION__);
 
     if (app_state != gms::application_state::CDC_GENERATION_ID) {
@@ -817,7 +817,7 @@ future<> generation_service::on_change(gms::inet_address ep, gms::application_st
     }
 
     auto gen_id = gms::versioned_value::cdc_generation_id_from_string(v.value());
-    cdc_log.debug("Endpoint: {}, CDC generation ID change: {}", ep, gen_id);
+    cdc_log.debug("Endpoint: {}, CDC generation ID change: {}", node, gen_id);
 
     return legacy_handle_cdc_generation(gen_id);
 }

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -104,14 +104,14 @@ public:
         return _cdc_metadata;
     }
 
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
-    virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_remove(gms::inet_address, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::endpoint_id, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_remove(gms::endpoint_id, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override;
-    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
+    virtual future<> on_join(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override;
+    virtual future<> on_change(gms::endpoint_id, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
 
     future<> check_and_repair_cdc_streams();
 

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -334,7 +334,7 @@ filter_for_query(consistency_level cl,
 
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
             // local node is always first if present (see storage_proxy::get_endpoints_for_reading)
-            unsigned local_idx = epi[0].first == utils::fb_utilities::get_broadcast_address() ? 0 : epi.size() + 1;
+            unsigned local_idx = utils::fb_utilities::is_me(epi[0].first) ? 0 : epi.size() + 1;
             live_endpoints = boost::copy_range<inet_address_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
         }
     }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1562,7 +1562,7 @@ static std::vector<cdc::generation_id_v2> decode_cdc_generations_ids(const set_t
 
 future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
 {
-    if (ep == utils::fb_utilities::get_broadcast_address()) {
+    if (utils::fb_utilities::is_me(ep)) {
         co_return co_await remove_endpoint(ep);
     }
 
@@ -1659,7 +1659,7 @@ future<> system_keyspace::update_cached_values(gms::inet_address ep, sstring col
 
 template <typename Value>
 future<> system_keyspace::update_peer_info(gms::inet_address ep, sstring column_name, Value value) {
-    if (ep == utils::fb_utilities::get_broadcast_address()) {
+    if (utils::fb_utilities::is_me(ep)) {
         co_return;
     }
 

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -67,13 +67,13 @@ public:
         return _ss.get_ownership().then([&, mutation_sink] (std::map<gms::inet_address, float> ownership) {
             const locator::token_metadata& tm = _ss.get_token_metadata();
 
-            _gossiper.for_each_endpoint_state([&] (const gms::inet_address& endpoint, const gms::endpoint_state&) {
+            _gossiper.for_each_endpoint_state([&] (const gms::inet_address& endpoint, const gms::endpoint_state& ep_state) {
                 mutation m(schema(), partition_key::from_single_value(*schema(), data_value(endpoint).serialize_nonnull()));
                 row& cr = m.partition().clustered_row(*schema(), clustering_key::make_empty()).cells();
 
                 set_cell(cr, "up", _gossiper.is_alive(endpoint));
-                set_cell(cr, "status", _gossiper.get_gossip_status(endpoint));
-                set_cell(cr, "load", _gossiper.get_application_state_value(endpoint, gms::application_state::LOAD));
+                set_cell(cr, "status", _gossiper.get_gossip_status(ep_state));
+                set_cell(cr, "load", ep_state.get_application_state_value(gms::application_state::LOAD));
 
                 auto hostid = tm.get_host_id_if_known(endpoint);
                 if (hostid) {

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -37,7 +37,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
         const std::vector<inet_address>& addresses = x.second;
         bool found_source = false;
         for (const auto& address : addresses) {
-            if (address == utils::fb_utilities::get_broadcast_address()) {
+            if (utils::fb_utilities::is_me(address)) {
                 // If localhost is a source, we have found one, but we don't add it to the map to avoid streaming locally
                 found_source = true;
                 continue;

--- a/gms/endpoint_id.hh
+++ b/gms/endpoint_id.hh
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include <iostream>
+
+#include <fmt/format.h>
+
+#include "locator/host_id.hh"
+#include "gms/inet_address.hh"
+#include "message/msg_addr.hh"
+
+namespace gms {
+
+struct endpoint_id {
+    locator::host_id host_id;
+    gms::inet_address addr;
+
+    endpoint_id() noexcept = default;
+    endpoint_id(const locator::host_id& host_id, const gms::inet_address& addr) noexcept : host_id(host_id), addr(addr) {}
+
+    bool operator==(const endpoint_id&) const = default;
+    auto operator<=>(const endpoint_id& x) const = default;
+
+    explicit operator netw::msg_addr() const noexcept {
+        return netw::msg_addr(addr);
+    }
+};
+
+} // namespace gms
+
+namespace fmt {
+template <>
+struct formatter<gms::endpoint_id> : formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const gms::endpoint_id& epid, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}/{}", epid.host_id, epid.addr);
+    }
+};
+
+} // namespace fmt
+
+namespace std {
+
+template<>
+struct hash<gms::endpoint_id> {
+    size_t operator()(const gms::endpoint_id& id) const {
+        return std::hash<locator::host_id>()(id.host_id) ^ std::hash<gms::inet_address>()(id.addr);
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const gms::endpoint_id& epid) {
+    fmt::print(os, "{}", epid);
+    return os;
+}
+
+} // namespace std

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -32,6 +32,15 @@ const versioned_value* endpoint_state::get_application_state_ptr(application_sta
     }
 }
 
+sstring endpoint_state::get_application_state_value(application_state key) const noexcept {
+    auto* app_state = get_application_state_ptr(key);
+    if (app_state) {
+        return app_state->value();
+    } else {
+        return {};
+    }
+}
+
 std::ostream& operator<<(std::ostream& os, const endpoint_state& x) {
     os << "HeartBeatState = " << x._heart_beat_state << ", AppStateMap =";
     for (auto&entry : x._application_state) {

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -80,6 +80,8 @@ public:
 
     const versioned_value* get_application_state_ptr(application_state key) const noexcept;
 
+    sstring get_application_state_value(application_state key) const noexcept;
+
     /**
      * TODO replace this with operations that don't expose private state
      */

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -134,6 +134,15 @@ public:
         return std::string_view(value.c_str(), pos);
     }
 
+    locator::host_id get_host_id() const noexcept {
+        locator::host_id host_id;
+        auto* app_state = get_application_state_ptr(application_state::HOST_ID);
+        if (app_state) {
+            host_id = locator::host_id(utils::UUID(app_state->value()));
+        }
+        return host_id;
+    }
+
     bool is_shutdown() const noexcept {
         return get_status() == versioned_value::SHUTDOWN;
     }

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -223,20 +223,20 @@ public:
             , _sys_ks(s)
     {
     }
-    future<> on_join(inet_address ep, endpoint_state_ptr state, gms::permit_id) override {
+    future<> on_join(endpoint_id, endpoint_state_ptr state, gms::permit_id) override {
         return enable_features();
     }
-    future<> on_change(inet_address ep, application_state state, const versioned_value&, gms::permit_id) override {
+    future<> on_change(endpoint_id, application_state state, const versioned_value&, gms::permit_id) override {
         if (state == application_state::SUPPORTED_FEATURES) {
             return enable_features();
         }
         return make_ready_future();
     }
-    future<> before_change(inet_address, endpoint_state_ptr, application_state, const versioned_value&) override { return make_ready_future(); }
-    future<> on_alive(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    future<> on_dead(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    future<> on_remove(inet_address, gms::permit_id) override { return make_ready_future(); }
-    future<> on_restart(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> before_change(endpoint_id, endpoint_state_ptr, application_state, const versioned_value&) override { return make_ready_future(); }
+    future<> on_alive(endpoint_id, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_dead(endpoint_id, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_remove(endpoint_id, gms::permit_id) override { return make_ready_future(); }
+    future<> on_restart(endpoint_id, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
     future<> enable_features();
 };

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1604,32 +1604,31 @@ std::set<gms::inet_address> gossiper::get_nodes_with_host_id(locator::host_id ho
 
 std::optional<endpoint_state> gossiper::get_state_for_version_bigger_than(inet_address for_endpoint, const endpoint_state& eps, version_type version) const {
     std::optional<endpoint_state> reqd_endpoint_state;
-    // FIXME: indentation
-        /*
-             * Here we try to include the Heart Beat state only if it is
-             * greater than the version passed in. It might happen that
-             * the heart beat version maybe lesser than the version passed
-             * in and some application state has a version that is greater
-             * than the version passed in. In this case we also send the old
-             * heart beat and throw it away on the receiver if it is redundant.
-            */
-        auto local_hb_version = eps.get_heart_beat_state().get_heart_beat_version();
-        if (local_hb_version > version) {
-            reqd_endpoint_state.emplace(eps.get_heart_beat_state());
-            logger.trace("local heartbeat version {} greater than {} for {}", local_hb_version, version, for_endpoint);
-        }
-        /* Accumulate all application states whose versions are greater than "version" variable */
-        for (auto& entry : eps.get_application_state_map()) {
-            auto& value = entry.second;
-            if (value.version() > version) {
-                if (!reqd_endpoint_state) {
-                    reqd_endpoint_state.emplace(eps.get_heart_beat_state());
-                }
-                auto& key = entry.first;
-                logger.trace("Adding state of {}, {}: {}" , for_endpoint, key, value.value());
-                reqd_endpoint_state->add_application_state(key, value);
+    /*
+     * Here we try to include the Heart Beat state only if it is
+     * greater than the version passed in. It might happen that
+     * the heart beat version maybe lesser than the version passed
+     * in and some application state has a version that is greater
+     * than the version passed in. In this case we also send the old
+     * heart beat and throw it away on the receiver if it is redundant.
+     */
+    auto local_hb_version = eps.get_heart_beat_state().get_heart_beat_version();
+    if (local_hb_version > version) {
+        reqd_endpoint_state.emplace(eps.get_heart_beat_state());
+        logger.trace("local heartbeat version {} greater than {} for {}", local_hb_version, version, for_endpoint);
+    }
+    /* Accumulate all application states whose versions are greater than "version" variable */
+    for (auto& entry : eps.get_application_state_map()) {
+        auto& value = entry.second;
+        if (value.version() > version) {
+            if (!reqd_endpoint_state) {
+                reqd_endpoint_state.emplace(eps.get_heart_beat_state());
             }
+            auto& key = entry.first;
+            logger.trace("Adding state of {}, {}: {}" , for_endpoint, key, value.value());
+            reqd_endpoint_state->add_application_state(key, value);
         }
+    }
     return reqd_endpoint_state;
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1569,8 +1569,7 @@ locator::host_id gossiper::get_host_id(inet_address endpoint, throw_on_error thr
 std::set<gms::inet_address> gossiper::get_nodes_with_host_id(locator::host_id host_id) const {
     std::set<gms::inet_address> nodes;
     for (const auto& [node, eps] : get_endpoint_states()) {
-        auto app_state = eps->get_application_state_ptr(application_state::HOST_ID);
-        if (app_state && host_id == locator::host_id(utils::UUID(app_state->value()))) {
+        if (host_id == eps->get_host_id()) {
             nodes.insert(node);
         }
     }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -603,6 +603,7 @@ future<> gossiper::do_apply_state_locally(gms::inet_address node, endpoint_state
             if (remote_host_id) {
                 if (local_host_id != remote_host_id) {
                     logger.info("Node {}/{} is replaced by {}/{} with same IP address", local_host_id, addr, remote_host_id, addr);
+                    co_return co_await this->handle_major_state_change(node, std::move(remote_state), permit.id());
                 }
             }
         }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2599,11 +2599,12 @@ future<> gossiper::wait_for_range_setup() const {
     return wait_for_gossip(ring_delay, force_after);
 }
 
-bool gossiper::is_safe_for_bootstrap(inet_address endpoint) const {
+bool gossiper::is_safe_for_bootstrap() const {
     // We allow to bootstrap a new node in only two cases:
     // 1) The node is a completely new node and no state in gossip at all
     // 2) The node has state in gossip and it is already removed from the
     // cluster either by nodetool decommission or nodetool removenode
+    auto endpoint = get_broadcast_address();
     auto eps = get_endpoint_state_ptr(endpoint);
     bool allowed = true;
     if (!eps) {
@@ -2620,10 +2621,12 @@ bool gossiper::is_safe_for_bootstrap(inet_address endpoint) const {
     return allowed;
 }
 
-bool gossiper::is_safe_for_restart(inet_address endpoint, locator::host_id host_id) const {
+bool gossiper::is_safe_for_restart() const {
     // Reject to restart a node in case:
     // *) if the node has been removed from the cluster by nodetool decommission or
     //    nodetool removenode
+    auto endpoint = get_broadcast_address();
+    auto host_id = my_host_id();
     std::unordered_set<std::string_view> not_allowed_statuses{
         versioned_value::STATUS_LEFT,
         versioned_value::REMOVED_TOKEN,

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2482,22 +2482,6 @@ future<> gossiper::wait_for_live_nodes_to_show_up(size_t n) {
     logger.info("Live nodes seen in gossip: {}", get_live_members());
 }
 
-const versioned_value* gossiper::get_application_state_ptr(inet_address endpoint, application_state appstate) const noexcept {
-    auto eps = get_endpoint_state_ptr(std::move(endpoint));
-    if (!eps) {
-        return nullptr;
-    }
-    return eps->get_application_state_ptr(appstate);
-}
-
-sstring gossiper::get_application_state_value(inet_address endpoint, application_state appstate) const {
-    auto v = get_application_state_ptr(endpoint, appstate);
-    if (!v) {
-        return {};
-    }
-    return v->value();
-}
-
 /**
  * This method is used to mark a node as shutdown; that is it gracefully exited on its own and told us about it
  * @param endpoint endpoint that has shut itself down

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -518,7 +518,7 @@ void gossiper::init_messaging_service_handler() {
         auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
         return handle_echo_msg(from, generation_number_opt);
     });
-    _messaging.register_gossip_shutdown([this] (inet_address from, rpc::optional<int64_t> generation_number_opt) {
+    _messaging.register_gossip_shutdown([this] (const rpc::client_info& cinfo, gms::inet_address from, rpc::optional<int64_t> generation_number_opt) {
         return background_msg("GOSSIP_SHUTDOWN", [from, generation_number_opt] (gms::gossiper& gossiper) {
             return gossiper.handle_shutdown_msg(from, generation_number_opt);
         });

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -476,7 +476,7 @@ gossiper::handle_get_endpoint_states_msg(gossip_get_endpoint_states_request requ
         auto state_wanted = endpoint_state(hbs);
         const std::map<application_state, versioned_value>& apps = state->get_application_state_map();
         for (const auto& app : apps) {
-            if (application_states_wanted.count(app.first) > 0) {
+            if (application_states_wanted.contains(app.first)) {
                 state_wanted.get_application_state_map().emplace(app);
             }
         }

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -341,6 +341,7 @@ public:
 
     int64_t get_endpoint_downtime(inet_address ep) const noexcept;
 
+private:
     /**
      * Return either: the greatest heartbeat or application state
      *
@@ -349,8 +350,6 @@ public:
      */
     version_type get_max_endpoint_state_version(const endpoint_state& state) const noexcept;
 
-
-private:
     /**
      * @param endpoint end point that is convicted.
      */

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -146,6 +146,9 @@ public:
         return _gcfg.partitioner;
     }
 
+    endpoint_id my_endpoint_id() const noexcept {
+        return endpoint_id(my_host_id(), get_broadcast_address());
+    }
     inet_address get_broadcast_address() const noexcept {
         return utils::fb_utilities::get_broadcast_address();
     }
@@ -153,6 +156,9 @@ public:
         return utils::fb_utilities::get_host_id();
     }
 
+    bool is_me(const endpoint_id& node) const noexcept {
+        return is_me(node.host_id) || is_me(node.addr);
+    }
     bool is_me(const locator::host_id& host_id) const noexcept {
         return utils::fb_utilities::is_me(host_id);
     }
@@ -187,6 +193,9 @@ public:
         const permit_id& id() const noexcept { return _permit_id; }
     };
     // Must be called on shard 0
+    future<endpoint_permit> lock_endpoint(endpoint_id node, permit_id pid, seastar::compat::source_location l = seastar::compat::source_location::current()) {
+        return lock_endpoint(node.addr, pid, std::move(l));
+    }
     future<endpoint_permit> lock_endpoint(inet_address, permit_id pid, seastar::compat::source_location l = seastar::compat::source_location::current());
 
 private:
@@ -307,6 +316,9 @@ private:
     // Replicates given endpoint_state to all other shards.
     // The state state doesn't have to be kept alive around until completes.
     // Must be called under lock_endpoint.
+    future<> replicate(endpoint_id node, endpoint_state ep_state, permit_id pid) {
+        return replicate(node.addr, std::move(ep_state), std::move(pid));
+    }
     future<> replicate(inet_address, endpoint_state, permit_id);
 public:
     explicit gossiper(abort_source& as, const locator::shared_token_metadata& stm, netw::messaging_service& ms, service::raft_address_map& address_map, const db::config& cfg, gossip_config gcfg);
@@ -367,7 +379,10 @@ public:
     /**
      * Removes the endpoint from Gossip but retains endpoint state
      */
-    future<> remove_endpoint(inet_address endpoint, permit_id);
+    future<> remove_endpoint(endpoint_id node, permit_id);
+    future<> remove_endpoint(inet_address endpoint, permit_id pid) {
+        return remove_endpoint(get_endpoint_id(endpoint), pid);
+    }
     future<> force_remove_endpoint(inet_address endpoint, permit_id);
 private:
     /**
@@ -419,7 +434,11 @@ public:
     future<generation_type> get_current_generation_number(inet_address endpoint) const;
     future<version_type> get_current_heart_beat_version(inet_address endpoint) const;
 
+    bool is_gossip_only_member(const endpoint_id& node) const {
+        return is_gossip_only_member(node.addr);
+    }
     bool is_gossip_only_member(inet_address endpoint) const;
+
     bool is_safe_for_bootstrap() const;
     bool is_safe_for_restart() const;
 private:
@@ -458,13 +477,22 @@ public:
     // The endpoint_state is immutable (except for its update_timestamp), guaranteed not to change while
     // the endpoint_state_ptr is held.
     endpoint_state_ptr get_endpoint_state_ptr(inet_address ep) const noexcept;
+    endpoint_state_ptr get_endpoint_state_ptr(endpoint_id node) const noexcept {
+        return get_endpoint_state_ptr(node.addr);
+    }
 
     const versioned_value* get_application_state_ptr(inet_address endpoint, application_state appstate) const noexcept {
         return get_application_state_ptr(get_endpoint_state_ptr(endpoint), appstate);
     }
+    const versioned_value* get_application_state_ptr(const endpoint_id& node, application_state appstate) const noexcept {
+        return get_application_state_ptr(get_endpoint_state_ptr(node), appstate);
+    }
 
     sstring get_application_state_value(inet_address endpoint, application_state appstate) const {
         return get_application_state_value(get_application_state_ptr(endpoint, appstate));
+    }
+    sstring get_application_state_value(const endpoint_id& node, application_state appstate) const {
+        return get_application_state_value(get_application_state_ptr(node, appstate));
     }
 
     // removes ALL endpoint states; should only be called after shadow gossip.
@@ -504,6 +532,13 @@ public:
     // Otherwise, retruns a null `host_id`.
     locator::host_id get_host_id(inet_address addr, throw_on_error = throw_on_error::yes) const;
 
+    // Returns the endpoint_id of a given endpoint address.
+    // Unlike get_host_id that throws a runtime_error if the host is not found,
+    // get_endpoint_id returns a null host_id for backward compatibility.
+    endpoint_id get_endpoint_id(inet_address addr) const noexcept {
+        return endpoint_id(get_host_id(addr, throw_on_error::no), addr);
+    }
+
     std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;
 
     /**
@@ -528,10 +563,17 @@ private:
     // Use with care, as the endpoint_state_ptr in the endpoint_state_map is considered
     // immutable, with one exception - the update_timestamp.
     void update_timestamp(const endpoint_state_ptr& eps) noexcept;
+
+    const endpoint_state& get_endpoint_state(endpoint_id node) const {
+        return get_endpoint_state(node.addr);
+    }
     const endpoint_state& get_endpoint_state(inet_address ep) const;
 
     void update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map);
 
+    void mark_alive(endpoint_id node) {
+        mark_alive(node.addr);
+    }
     void mark_alive(inet_address addr);
 
     future<> real_mark_alive(inet_address addr);
@@ -545,17 +587,21 @@ private:
     /**
      * This method is called whenever there is a "big" change in ep state (a generation change for a known node).
      *
-     * @param ep      endpoint
+     * @param node     endpoint
      * @param ep_state EndpointState for the endpoint
      *
      * Must be called under lock_endpoint.
      */
-    future<> handle_major_state_change(inet_address ep, endpoint_state eps, permit_id);
+    future<> handle_major_state_change(endpoint_id node, endpoint_state eps, permit_id);
 
     std::optional<endpoint_state> get_state_for_version_bigger_than(inet_address for_endpoint, const endpoint_state& ep_state, version_type version) const;
 
 public:
+    bool is_alive(const endpoint_id& node) const {
+        return is_alive(node.addr);
+    }
     bool is_alive(inet_address ep) const;
+
     bool is_dead_state(const endpoint_state& eps) const;
     // Wait for nodes to be alive on all shards
     future<> wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout);
@@ -576,19 +622,19 @@ private:
     future<> apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
     // Must be called under lock_endpoint.
-    future<> apply_new_states(inet_address addr, endpoint_state local_state, const endpoint_state& remote_state, permit_id);
+    future<> apply_new_states(endpoint_id node, endpoint_state local_state, const endpoint_state& remote_state, permit_id);
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
     // Must be called under lock_endpoint.
-    future<> do_before_change_notifications(inet_address addr, endpoint_state_ptr ep_state, const application_state& ap_state, const versioned_value& new_value) const;
+    future<> do_before_change_notifications(endpoint_id node, endpoint_state_ptr ep_state, const application_state& ap_state, const versioned_value& new_value) const;
 
     // notify that an application state has changed
     // Must be called under lock_endpoint.
-    future<> do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value, permit_id) const;
+    future<> do_on_change_notifications(endpoint_id node, const application_state& state, const versioned_value& value, permit_id) const;
 
     // notify that a node is DOWN (dead)
     // Must be called under lock_endpoint.
-    future<> do_on_dead_notifications(inet_address addr, endpoint_state_ptr state, permit_id) const;
+    future<> do_on_dead_notifications(endpoint_id node, endpoint_state_ptr state, permit_id) const;
 
     /* Request all the state for the endpoint in the g_digest */
 
@@ -692,23 +738,50 @@ public:
     void goto_shadow_round();
 
 public:
+    void add_expire_time_for_endpoint(const endpoint_id& node, clk::time_point expire_time) {
+        return add_expire_time_for_endpoint(node.addr, expire_time);
+    }
     void add_expire_time_for_endpoint(inet_address endpoint, clk::time_point expire_time);
 
     static clk::time_point compute_expire_time();
 public:
     bool is_seed(const inet_address& endpoint) const;
+
+    bool is_shutdown(const endpoint_id& node) const {
+        return is_shutdown(node.addr);
+    }
     bool is_shutdown(const inet_address& endpoint) const;
+
+    bool is_normal(const endpoint_id& node) const {
+        return is_normal(node.addr);
+    }
     bool is_normal(const inet_address& endpoint) const;
+
+    bool is_left(const endpoint_id& node) const {
+        return is_left(node.addr);
+    }
     bool is_left(const inet_address& endpoint) const;
+
     // Check if a node is in NORMAL or SHUTDOWN status which means the node is
     // part of the token ring from the gossip point of view and operates in
     // normal status or was in normal status but is shutdown.
+    bool is_normal_ring_member(const endpoint_id& node) const {
+        return is_normal_ring_member(node.addr);
+    }
     bool is_normal_ring_member(const inet_address& endpoint) const;
+
+    bool is_cql_ready(const endpoint_id& node) const {
+        return is_cql_ready(node.addr);
+    }
     bool is_cql_ready(const inet_address& endpoint) const;
+
     bool is_silent_shutdown_state(const endpoint_state& ep_state) const;
     void force_newer_generation();
 public:
     std::string_view get_gossip_status(const endpoint_state& ep_state) const noexcept;
+    std::string_view get_gossip_status(const endpoint_id& node) const noexcept {
+        return get_gossip_status(node.addr);
+    }
     std::string_view get_gossip_status(const inet_address& endpoint) const noexcept;
 public:
     future<> wait_for_gossip_to_settle() const;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -204,6 +204,26 @@ private:
 
     endpoint_id get_endpoint_id(const rpc::client_info& cinfo) noexcept;
 
+    // host_id <-> inet_address mapping;
+    inet_address host_id_address(const locator::host_id& host_id) const noexcept {
+        auto id = raft::server_id(host_id.uuid());
+        if (auto opt_addr = _address_map.find(id)) {
+            return *opt_addr;
+        }
+        return inet_address{};
+    }
+
+    locator::host_id address_host_id(const inet_address& addr) const noexcept {
+        if (auto opt_id = _address_map.find_by_addr(addr, false)) {
+            return locator::host_id(opt_id->uuid());
+        }
+        return locator::host_id();
+    }
+
+    // Update the host_id <-> address mapping on all shards
+    // host_id and addr must be valid
+    future<> update_address_map(const locator::host_id& host_id, inet_address addr, gms::generation_type generation_number = {}) noexcept;
+
 public:
     const std::vector<sstring> DEAD_STATES = {
         versioned_value::REMOVED_TOKEN,

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -650,7 +650,7 @@ public:
     /**
      * Add an endpoint we knew about previously, but whose state is unknown
      */
-    future<> add_saved_endpoint(inet_address ep);
+    future<> add_saved_endpoint(inet_address ep, locator::host_id host_id);
 
     future<> add_local_application_state(application_state state, versioned_value value);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -442,6 +442,14 @@ private:
 
     const std::unordered_map<inet_address, endpoint_state_ptr>& get_endpoint_states() const noexcept;
 
+    const versioned_value* get_application_state_ptr(endpoint_state_ptr eps, application_state appstate) const noexcept {
+        return eps ? eps->get_application_state_ptr(appstate) : nullptr;
+    }
+
+    sstring get_application_state_value(const versioned_value* v) const {
+        return v ? v->value() : "";
+    }
+
 public:
     clk::time_point get_expire_time_for_endpoint(inet_address endpoint) const noexcept;
 
@@ -451,8 +459,13 @@ public:
     // the endpoint_state_ptr is held.
     endpoint_state_ptr get_endpoint_state_ptr(inet_address ep) const noexcept;
 
-    const versioned_value* get_application_state_ptr(inet_address endpoint, application_state appstate) const noexcept;
-    sstring get_application_state_value(inet_address endpoint, application_state appstate) const;
+    const versioned_value* get_application_state_ptr(inet_address endpoint, application_state appstate) const noexcept {
+        return get_application_state_ptr(get_endpoint_state_ptr(endpoint), appstate);
+    }
+
+    sstring get_application_state_value(inet_address endpoint, application_state appstate) const {
+        return get_application_state_value(get_application_state_ptr(endpoint, appstate));
+    }
 
     // removes ALL endpoint states; should only be called after shadow gossip.
     // Must be called on shard 0

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -27,6 +27,7 @@
 #include "gms/feature.hh"
 #include "gms/gossip_digest_syn.hh"
 #include "gms/gossip_digest.hh"
+#include "gms/endpoint_id.hh"
 #include "utils/loading_shared_values.hh"
 #include "utils/updateable_value.hh"
 #include "utils/in.hh"
@@ -105,11 +106,11 @@ private:
 
     void init_messaging_service_handler();
     future<> uninit_messaging_service_handler();
-    future<> handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg);
-    future<> handle_ack_msg(msg_addr from, gossip_digest_ack ack_msg);
-    future<> handle_ack2_msg(msg_addr from, gossip_digest_ack2 msg);
-    future<> handle_echo_msg(inet_address from, std::optional<int64_t> generation_number_opt);
-    future<> handle_shutdown_msg(inet_address from, std::optional<int64_t> generation_number_opt);
+    future<> handle_syn_msg(endpoint_id node, gossip_digest_syn syn_msg);
+    future<> handle_ack_msg(endpoint_id node, gossip_digest_ack ack_msg);
+    future<> handle_ack2_msg(endpoint_id node, gossip_digest_ack2 msg);
+    future<> handle_echo_msg(endpoint_id node, std::optional<int64_t> generation_number_opt);
+    future<> handle_shutdown_msg(endpoint_id node, std::optional<int64_t> generation_number_opt);
     future<> do_send_ack_msg(msg_addr from, gossip_digest_syn syn_msg);
     future<> do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_digest> ack_msg_digest);
     future<gossip_get_endpoint_states_response> handle_get_endpoint_states_msg(gossip_get_endpoint_states_request request);
@@ -199,6 +200,8 @@ private:
     std::unordered_map<inet_address, endpoint_state_ptr> _endpoint_state_map;
     // Used for serializing changes to _endpoint_state_map and running of associated change listeners.
     endpoint_locks_map _endpoint_locks;
+
+    endpoint_id get_endpoint_id(const rpc::client_info& cinfo) noexcept;
 
 public:
     const std::vector<sstring> DEAD_STATES = {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -454,10 +454,18 @@ public:
         });
     }
 
+    future<> for_each_endpoint_state_gently(std::function<future<>(const inet_address&, const endpoint_state&)> func) const {
+        co_await for_each_endpoint_state_gently_until([func = std::move(func)] (const inet_address& node, const endpoint_state& eps) -> future<stop_iteration> {
+            co_await func(node, eps);
+            co_return stop_iteration::no;
+        });
+    }
+
     // Calls func for each endpoint_state until it returns stop_iteration::yes
     // Returns stop_iteration::yes iff `func` returns stop_iteration::yes.
     // Called function must not yield
     stop_iteration for_each_endpoint_state_until(std::function<stop_iteration(const inet_address&, const endpoint_state&)>) const;
+    future<stop_iteration> for_each_endpoint_state_gently_until(std::function<future<stop_iteration>(const inet_address&, const endpoint_state&)>) const;
 
     // Returns the `host_id` of the node with the given broadcast `addr`.
     // If not found, throws a runtime_error by default with `throw_on_error::yes`,

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -101,6 +101,7 @@ private:
     using messaging_verb = netw::messaging_verb;
     using messaging_service = netw::messaging_service;
     using msg_addr = netw::msg_addr;
+    using throw_on_error = bool_class<struct throw_on_error_tag>;
 
     void init_messaging_service_handler();
     future<> uninit_messaging_service_handler();
@@ -454,7 +455,10 @@ public:
     // Called function must not yield
     stop_iteration for_each_endpoint_state_until(std::function<stop_iteration(const inet_address&, const endpoint_state&)>) const;
 
-    locator::host_id get_host_id(inet_address endpoint) const;
+    // Returns the `host_id` of the node with the given broadcast `addr`.
+    // If not found, throws a runtime_error by default with `throw_on_error::yes`,
+    // Otherwise, retruns a null `host_id`.
+    locator::host_id get_host_id(inet_address addr, throw_on_error = throw_on_error::yes) const;
 
     std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -41,6 +41,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/scheduling.hh>
 #include "locator/token_metadata.hh"
+#include "service/raft/raft_address_map.hh"
 
 namespace db {
 class config;
@@ -288,7 +289,7 @@ private:
     // Must be called under lock_endpoint.
     future<> replicate(inet_address, endpoint_state, permit_id);
 public:
-    explicit gossiper(abort_source& as, const locator::shared_token_metadata& stm, netw::messaging_service& ms, const db::config& cfg, gossip_config gcfg);
+    explicit gossiper(abort_source& as, const locator::shared_token_metadata& stm, netw::messaging_service& ms, service::raft_address_map& address_map, const db::config& cfg, gossip_config gcfg);
 
     /**
      * Register for interesting state changes.
@@ -683,6 +684,7 @@ private:
     abort_source& _abort_source;
     const locator::shared_token_metadata& _shared_token_metadata;
     netw::messaging_service& _messaging;
+    service::raft_address_map& _address_map;
     utils::updateable_value<uint32_t> _failure_detector_timeout_ms;
     utils::updateable_value<int32_t> _force_gossip_generation;
     gossip_config _gcfg;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -420,8 +420,8 @@ public:
     future<version_type> get_current_heart_beat_version(inet_address endpoint) const;
 
     bool is_gossip_only_member(inet_address endpoint) const;
-    bool is_safe_for_bootstrap(inet_address endpoint) const;
-    bool is_safe_for_restart(inet_address endpoint, locator::host_id host_id) const;
+    bool is_safe_for_bootstrap() const;
+    bool is_safe_for_restart() const;
 private:
     /**
      * Returns true if the chosen target was also a seed. False otherwise

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -146,6 +146,17 @@ public:
     inet_address get_broadcast_address() const noexcept {
         return utils::fb_utilities::get_broadcast_address();
     }
+    const locator::host_id& my_host_id() const noexcept {
+        return utils::fb_utilities::get_host_id();
+    }
+
+    bool is_me(const locator::host_id& host_id) const noexcept {
+        return utils::fb_utilities::is_me(host_id);
+    }
+    bool is_me(const inet_address& addr) const noexcept {
+        return utils::fb_utilities::is_me(addr);
+    }
+
     const std::set<inet_address>& get_seeds() const noexcept;
 
 public:

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -537,10 +537,9 @@ public:
     locator::host_id get_host_id(inet_address addr, throw_on_error = throw_on_error::yes) const;
 
     // Returns the endpoint_id of a given endpoint address.
-    // Unlike get_host_id that throws a runtime_error if the host is not found,
-    // get_endpoint_id returns a null host_id for backward compatibility.
-    endpoint_id get_endpoint_id(inet_address addr) const noexcept {
-        return endpoint_id(get_host_id(addr, throw_on_error::no), addr);
+    // Throws a runtime_error if the host is not found,
+    endpoint_id get_endpoint_id(inet_address addr) const {
+        return endpoint_id(get_host_id(addr), addr);
     }
 
     std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -493,8 +493,6 @@ public:
 
     std::set<gms::inet_address> get_nodes_with_host_id(locator::host_id host_id) const;
 
-    std::optional<endpoint_state> get_state_for_version_bigger_than(inet_address for_endpoint, version_type version) const;
-
     /**
      * determine which endpoint started up earlier
      */
@@ -540,6 +538,8 @@ private:
      * Must be called under lock_endpoint.
      */
     future<> handle_major_state_change(inet_address ep, endpoint_state eps, permit_id);
+
+    std::optional<endpoint_state> get_state_for_version_bigger_than(inet_address for_endpoint, const endpoint_state& ep_state, version_type version) const;
 
 public:
     bool is_alive(inet_address ep) const;

--- a/gms/i_endpoint_state_change_subscriber.hh
+++ b/gms/i_endpoint_state_change_subscriber.hh
@@ -14,6 +14,7 @@
 #include "gms/endpoint_state.hh"
 #include "gms/application_state.hh"
 #include "gms/versioned_value.hh"
+#include "gms/endpoint_id.hh"
 
 namespace gms {
 
@@ -39,20 +40,20 @@ public:
      * Use to inform interested parties about the change in the state
      * for specified endpoint
      *
-     * @param endpoint endpoint for which the state change occurred.
+     * @param node endpoint for which the state change occurred.
      * @param epState  state that actually changed for the above endpoint.
      */
-    virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, permit_id) = 0;
+    virtual future<> on_join(endpoint_id node, endpoint_state_ptr ep_state, permit_id) = 0;
 
-    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
+    virtual future<> before_change(endpoint_id node, endpoint_state_ptr current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
 
-    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, permit_id) = 0;
+    virtual future<> on_change(endpoint_id node, application_state state, const versioned_value& value, permit_id) = 0;
 
-    virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
+    virtual future<> on_alive(endpoint_id node, endpoint_state_ptr state, permit_id) = 0;
 
-    virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
+    virtual future<> on_dead(endpoint_id node, endpoint_state_ptr state, permit_id) = 0;
 
-    virtual future<> on_remove(inet_address endpoint, permit_id) = 0;
+    virtual future<> on_remove(endpoint_id node, permit_id) = 0;
 
     /**
      * Called whenever a node is restarted.
@@ -60,7 +61,7 @@ public:
      * previously marked down. It will have only if {@code state.isAlive() == false}
      * as {@code state} is from before the restarted node is marked up.
      */
-    virtual future<> on_restart(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
+    virtual future<> on_restart(endpoint_id node, endpoint_state_ptr state, permit_id) = 0;
 };
 
 } // namespace gms

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -68,6 +68,10 @@ public:
     }
     friend struct std::hash<inet_address>;
 
+    explicit operator bool() const noexcept {
+        return _addr != net::inet_address();
+    }
+
     using opt_family = std::optional<net::inet_address::family>;
 
     static future<inet_address> lookup(sstring, opt_family family = {}, opt_family preferred = {});

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -62,9 +62,9 @@ public:
         return addr().as_ipv4_address().ip;
     }
     sstring to_sstring() const;
-    friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept = default;
-    friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
-        return x.bytes() < y.bytes();
+    bool operator==(const inet_address& x) const = default;
+    auto operator<=>(const inet_address& x) const noexcept {
+        return bytes() <=> x.bytes();
     }
     friend struct std::hash<inet_address>;
 

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -118,6 +118,10 @@ public:
         return _bootstrap_tokens;
     }
 
+    void update_topology(host_id id, inet_address ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count = std::nullopt) {
+        _topology.add_or_update_endpoint(id, ep, std::move(opt_dr), std::move(opt_st), std::move(shard_count));
+    }
+
     void update_topology(inet_address ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count = std::nullopt) {
         _topology.add_or_update_endpoint(ep, std::nullopt, std::move(opt_dr), std::move(opt_st), std::move(shard_count));
     }
@@ -930,6 +934,11 @@ token_metadata::get_leaving_endpoints() const {
 const std::unordered_map<token, inet_address>&
 token_metadata::get_bootstrap_tokens() const {
     return _impl->get_bootstrap_tokens();
+}
+
+void
+token_metadata::update_topology(host_id host_id, inet_address ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count) {
+    _impl->update_topology(host_id, ep, std::move(opt_dr), std::move(opt_st), std::move(shard_count));
 }
 
 void

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -31,6 +31,7 @@
 
 #include "locator/types.hh"
 #include "locator/topology.hh"
+#include "gms/endpoint_id.hh"
 
 // forward declaration since replica/database.hh includes this file
 namespace replica {
@@ -168,6 +169,9 @@ public:
      * @param endpoint
      */
     void update_host_id(const locator::host_id& host_id, inet_address endpoint);
+    void update_host_id(const gms::endpoint_id& node) {
+        update_host_id(node.host_id, node.addr);
+    }
 
     /** Return the unique host ID for an end-point. */
     host_id get_host_id(inet_address endpoint) const;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -131,6 +131,12 @@ public:
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
 
     /**
+     * Update or add endpoint given its host_id, inet_address and endpoint_dc_rack.
+     */
+    void update_topology(host_id host_id, inet_address ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st = std::nullopt,
+                         std::optional<shard_id> shard_count = std::nullopt);
+
+    /**
      * Update or add endpoint given its inet_address and endpoint_dc_rack.
      */
     void update_topology(inet_address ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st = std::nullopt,

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -63,7 +63,7 @@ struct host_id_or_endpoint {
     }
 
     bool has_endpoint() const noexcept {
-        return endpoint != gms::inet_address();
+        return bool(endpoint);
     }
 
     // Map the host_id to endpoint based on whichever of them is set,

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -317,7 +317,11 @@ void topology::index_node(const node* node) {
     if (node->endpoint()) {
         auto eit = _nodes_by_endpoint.find(node->endpoint());
         if (eit != _nodes_by_endpoint.end()) {
-            if (eit->second->is_leaving() || eit->second->left()) {
+            // When replacing a node with the same address (and different host_id),
+            // erase the existing entry before emplacing the indexed `node` below.
+            if (eit->second->host_id() != node->host_id() && eit->second->host_id() && node->host_id()) {
+                _nodes_by_endpoint.erase(eit);
+            } else if (eit->second->is_leaving() || eit->second->left()) {
                 _nodes_by_endpoint.erase(node->endpoint());
             } else if (!node->is_leaving() && !node->left()) {
                 if (node->host_id()) {
@@ -436,6 +440,29 @@ const node* topology::find_node(node::idx_type idx) const noexcept {
         return nullptr;
     }
     return _nodes.at(idx).get();
+}
+
+const node* topology::add_or_update_endpoint(host_id id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count)
+{
+    if (tlogger.is_enabled(log_level::trace)) {
+        tlogger.trace("topology[{}]: add_or_update_endpoint: host_id={} ep={} dc={} rack={} state={}, shards={}, at {}", fmt::ptr(this),
+            id, opt_ep.value_or(inet_address{}), opt_dr.value_or(endpoint_dc_rack{}).dc, opt_dr.value_or(endpoint_dc_rack{}).rack, opt_st.value_or(node::state::none), shard_count,
+            current_backtrace());
+    }
+    auto n = find_node(id);
+    if (n) {
+        return update_node(make_mutable(n), std::nullopt, std::move(opt_ep), std::move(opt_dr), std::move(opt_st), std::move(shard_count));
+    } else if (opt_ep && (n = find_node(*opt_ep)) && (n->host_id() == id || !n->host_id())) {
+        return update_node(make_mutable(n), std::move(id), std::nullopt, std::move(opt_dr), std::move(opt_st), std::move(shard_count));
+    } else {
+        if (!opt_ep) {
+            on_internal_error(tlogger, format("add_or_update_endpoint: host_id={}: opt_ep must be engaged", id));
+        }
+        return add_node(id, *opt_ep,
+                        opt_dr.value_or(endpoint_dc_rack::default_location),
+                        opt_st.value_or(node::state::normal),
+                        shard_count.value_or(0));
+    }
 }
 
 const node* topology::add_or_update_endpoint(inet_address ep, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> shard_count)

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -144,7 +144,7 @@ bool topology::is_configured_this_node(const node& n) const {
     if (_cfg.this_host_id && n.host_id()) { // Selection by host_id
         return _cfg.this_host_id == n.host_id();
     }
-    if (_cfg.this_endpoint != inet_address()) { // Selection by endpoint
+    if (_cfg.this_endpoint) { // Selection by endpoint
         return _cfg.this_endpoint == n.endpoint();
     }
     return false; // No selection;
@@ -223,7 +223,7 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
     }
     if (opt_ep) {
         if (*opt_ep != node->endpoint()) {
-            if (*opt_ep == inet_address{}) {
+            if (!*opt_ep) {
                 on_internal_error(tlogger, format("Updating node endpoint to null is disallowed: {}: new endpoint={}", debug_format(node), *opt_ep));
             }
             changed = true;
@@ -314,7 +314,7 @@ void topology::index_node(const node* node) {
             on_internal_error(tlogger, format("topology[{}]: {}: node already exists", fmt::ptr(this), debug_format(node)));
         }
     }
-    if (node->endpoint() != inet_address{}) {
+    if (node->endpoint()) {
         auto eit = _nodes_by_endpoint.find(node->endpoint());
         if (eit != _nodes_by_endpoint.end()) {
             if (eit->second->is_leaving() || eit->second->left()) {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -229,6 +229,16 @@ public:
     bool has_node(inet_address id) const noexcept;
 
     /**
+     * Stores current DC/rack assignment for host_id
+     *
+     * Adds or updates a node with given host_id and inet_address (optional when updating, mandatory for new nodes)
+     */
+    const node* add_or_update_endpoint(host_id id, std::optional<inet_address> ep,
+                                       std::optional<endpoint_dc_rack> opt_dr,
+                                       std::optional<node::state> opt_st,
+                                       std::optional<shard_id> shard_count = std::nullopt);
+
+    /**
      * Stores current DC/rack assignment for ep
      *
      * Adds or updates a node with given endpoint

--- a/main.cc
+++ b/main.cc
@@ -545,6 +545,7 @@ static locator::host_id initialize_local_info_thread(sharded<db::system_keyspace
 
     linfo.listen_address = listen_address;
     sys_ks.local().save_local_info(std::move(linfo), snitch.local()->get_location()).get();
+    utils::fb_utilities::set_host_id(linfo.host_id);
     return linfo.host_id;
 }
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1154,7 +1154,7 @@ future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_num
     return send_message_cancellable<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), as, generation_number);
 }
 
-void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func) {
+void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, inet_address from, rpc::optional<int64_t> generation_number)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(func));
 }
 future<> messaging_service::unregister_gossip_shutdown() {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -459,7 +459,7 @@ public:
     future<> send_gossip_echo(msg_addr id, int64_t generation_number, abort_source&);
 
     // Wrapper for GOSSIP_SHUTDOWN
-    void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func);
+    void register_gossip_shutdown(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, inet_address from, rpc::optional<int64_t> generation_number)>&& func);
     future<> unregister_gossip_shutdown();
     future<> send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number);
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -260,7 +260,7 @@ static std::vector<gms::inet_address> get_neighbors(
             } catch(...) {
                 throw std::runtime_error(format("Unknown host specified: {}", host));
             }
-            if (endpoint == utils::fb_utilities::get_broadcast_address()) {
+            if (utils::fb_utilities::is_me(endpoint)) {
                 found_me = true;
             } else if (neighbor_set.contains(endpoint)) {
                 ret.push_back(endpoint);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2972,11 +2972,11 @@ public:
     row_level_repair_gossip_helper(repair_service& repair_service) noexcept
         : _repair_service(repair_service)
     {}
-    future<> remove_row_level_repair(gms::inet_address node) {
+    future<> remove_row_level_repair(gms::endpoint_id node) {
         rlogger.debug("Started to remove row level repair on all shards for node {}", node);
         try {
             co_await _repair_service.container().invoke_on_all([node] (repair_service& local_repair) {
-                return local_repair.remove_repair_meta(node);
+                return local_repair.remove_repair_meta(node.addr);
             });
             rlogger.debug("Finished to remove row level repair on all shards for node {}", node);
         } catch(...) {
@@ -2984,47 +2984,47 @@ public:
         }
     }
     virtual future<> on_join(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::endpoint_state_ptr ep_state,
             gms::permit_id) override {
         return make_ready_future();
     }
     virtual future<> before_change(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::endpoint_state_ptr current_state,
             gms::application_state new_state_key,
             const gms::versioned_value& new_value) override {
         return make_ready_future();
     }
     virtual future<> on_change(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::application_state state,
             const gms::versioned_value& value,
             gms::permit_id) override {
         return make_ready_future();
     }
     virtual future<> on_alive(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::endpoint_state_ptr state,
             gms::permit_id) override {
         return make_ready_future();
     }
     virtual future<> on_dead(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::endpoint_state_ptr state,
             gms::permit_id) override {
-        return remove_row_level_repair(endpoint);
+        return remove_row_level_repair(node);
     }
     virtual future<> on_remove(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::permit_id) override {
-        return remove_row_level_repair(endpoint);
+        return remove_row_level_repair(node);
     }
     virtual future<> on_restart(
-            gms::inet_address endpoint,
+            gms::endpoint_id node,
             gms::endpoint_state_ptr ep_state,
             gms::permit_id) override {
-        return remove_row_level_repair(endpoint);
+        return remove_row_level_repair(node);
     }
 };
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2362,7 +2362,7 @@ table::cache_hit_rate table::get_my_hit_rate() const {
 }
 
 table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, gms::inet_address addr) {
-    if (utils::fb_utilities::get_broadcast_address() == addr) {
+    if (utils::fb_utilities::is_me(addr)) {
         return get_my_hit_rate();
     }
     auto it = _cluster_cache_hit_rates.find(addr);

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -35,31 +35,31 @@ public:
         assert(_stopped);
     }
 
-    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override {
+    virtual future<> on_change(gms::endpoint_id node, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override {
         if (state == gms::application_state::LOAD) {
-            _load_info[endpoint] = std::stod(value.value());
+            _load_info[node.addr] = std::stod(value.value());
         }
         return make_ready_future();
     }
 
-    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id pid) override {
+    virtual future<> on_join(gms::endpoint_id node, gms::endpoint_state_ptr ep_state, gms::permit_id pid) override {
         auto* local_value = ep_state->get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
-            return on_change(endpoint, gms::application_state::LOAD, *local_value, pid);
+            return on_change(node, gms::application_state::LOAD, *local_value, pid);
         }
         return make_ready_future();
     }
     
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
+    virtual future<> before_change(gms::endpoint_id node, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
 
-    future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_alive(gms::endpoint_id node, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_dead(gms::endpoint_id node, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    future<> on_restart(gms::endpoint_id node, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
-    virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override {
-        _load_info.erase(endpoint);
+    virtual future<> on_remove(gms::endpoint_id node, gms::permit_id) override {
+        _load_info.erase(node.addr);
         return make_ready_future();
     }
 

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -130,8 +130,8 @@ public:
         });
     }
 
-    bool should_pull_schema_from(const gms::inet_address& endpoint);
-    bool has_compatible_schema_tables_version(const gms::inet_address& endpoint);
+    bool should_pull_schema_from(const gms::endpoint_id& node);
+    bool has_compatible_schema_tables_version(const gms::endpoint_id& node);
 
     // The function needs to be called if the user wants to read most up-to-date group 0 state (including schema state)
     // (the function ensures that all previously finished group0 operations are visible on this node) or to write it.
@@ -169,9 +169,9 @@ private:
 
     future<> passive_announce();
 
-    void schedule_schema_pull(const gms::inet_address& endpoint, const gms::endpoint_state& state);
+    void schedule_schema_pull(const gms::endpoint_id& node, const gms::endpoint_state& state);
 
-    future<> maybe_schedule_schema_pull(const table_schema_version& their_version, const gms::inet_address& endpoint);
+    future<> maybe_schedule_schema_pull(const table_schema_version& their_version, const gms::endpoint_id& node);
 
     future<> announce_with_raft(std::vector<mutation> schema, group0_guard, std::string_view description);
     future<> announce_without_raft(std::vector<mutation> schema, group0_guard);
@@ -190,13 +190,13 @@ public:
     future<schema_ptr> get_schema_for_write(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source* as = nullptr);
 
 private:
-    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
-    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override;
-    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
-    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
+    virtual future<> on_join(gms::endpoint_id node, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
+    virtual future<> on_change(gms::endpoint_id node, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override;
+    virtual future<> on_alive(gms::endpoint_id node, gms::endpoint_state_ptr state, gms::permit_id) override;
+    virtual future<> on_dead(gms::endpoint_id node, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_remove(gms::endpoint_id node, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::endpoint_id node, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::endpoint_id node, gms::endpoint_state_ptr current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
 
 public:
     // For tests only.

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -266,7 +266,7 @@ future<> view_update_backlog_broker::stop() {
     });
 }
 
-future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) {
+future<> view_update_backlog_broker::on_change(gms::endpoint_id node, gms::application_state state, const gms::versioned_value& value, gms::permit_id) {
     if (state == gms::application_state::VIEW_BACKLOG) {
         size_t current;
         size_t max;
@@ -288,7 +288,7 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::
             return make_ready_future();
         }
         auto backlog = view_update_backlog_timestamped{db::view::update_backlog{current, max}, ticks};
-        auto[it, inserted] = _sp.local()._view_update_backlogs.try_emplace(endpoint, std::move(backlog));
+        auto[it, inserted] = _sp.local()._view_update_backlogs.try_emplace(node.addr, std::move(backlog));
         if (!inserted && it->second.ts < backlog.ts) {
             it->second = std::move(backlog);
         }
@@ -296,8 +296,8 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::
     return make_ready_future();
 }
 
-future<> view_update_backlog_broker::on_remove(gms::inet_address endpoint, gms::permit_id) {
-    _sp.local()._view_update_backlogs.erase(endpoint);
+future<> view_update_backlog_broker::on_remove(gms::endpoint_id node, gms::permit_id) {
+    _sp.local()._view_update_backlogs.erase(node.addr);
     return make_ready_future();
 }
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -428,7 +428,7 @@ future<> service_level_controller::do_remove_service_level(sstring name, bool re
 void service_level_controller::on_join_cluster(const gms::inet_address& endpoint) { }
 
 void service_level_controller::on_leave_cluster(const gms::inet_address& endpoint) {
-    if (this_shard_id() == global_controller && endpoint == utils::fb_utilities::get_broadcast_address()) {
+    if (this_shard_id() == global_controller && utils::fb_utilities::is_me(endpoint)) {
         _global_controller_db->dist_data_update_aborter.request_abort();
     }
 }

--- a/service/raft/discovery.cc
+++ b/service/raft/discovery.cc
@@ -10,7 +10,7 @@
 namespace service {
 
 void check_peer(const discovery_peer& peer) {
-    if (peer.ip_addr == gms::inet_address{}) {
+    if (!peer.ip_addr) {
         throw std::logic_error("Discovery requires peer internet address to be set");
     }
 }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -314,8 +314,10 @@ public:
     // --ignore-dead-nodes parameter in raft_removenode and raft_replace. As this
     // feature is deprecated, we should also remove this function when the
     // deprecation period ends.
-    std::optional<raft::server_id> find_by_addr(gms::inet_address addr) const {
-        rslog.warn("Finding Raft nodes by IP addresses is deprecated. Please use Host IDs instead.");
+    std::optional<raft::server_id> find_by_addr(gms::inet_address addr, bool warn = true) const {
+        if (warn) {
+            rslog.warn("Finding Raft nodes by IP addresses is deprecated. Please use Host IDs instead.");
+        }
         if (!addr) {
             on_internal_error(rslog, "raft_address_map::find_by_addr: called with an empty address");
         }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -311,7 +311,7 @@ public:
     // deprecation period ends.
     std::optional<raft::server_id> find_by_addr(gms::inet_address addr) const {
         rslog.warn("Finding Raft nodes by IP addresses is deprecated. Please use Host IDs instead.");
-        if (addr == gms::inet_address{}) {
+        if (!addr) {
             on_internal_error(rslog, "raft_address_map::find_by_addr: called with an empty address");
         }
         auto it = std::find_if(_map.begin(), _map.end(), [&](auto&& mapping) { return mapping.second._addr == addr; });
@@ -355,7 +355,7 @@ public:
     // arriving.
     // Used primarily from Raft RPC to speed up Raft at boot.
     void opt_add_entry(raft::server_id id, gms::inet_address addr) {
-        if (addr == gms::inet_address{}) {
+        if (!addr) {
             on_internal_error(rslog, format("IP address missing for {}", id));
         }
         handle_add_or_update_entry(id, gms::generation_type{}, addr, false);
@@ -369,7 +369,7 @@ public:
     // set_nonexpiring()) to mark the entry as non expiring.
     void add_or_update_entry(raft::server_id id, gms::inet_address addr,
             gms::generation_type generation_number = {}) {
-        if (addr == gms::inet_address{}) {
+        if (!addr) {
             on_internal_error(rslog, format("IP address missing for {}", id));
         }
         handle_add_or_update_entry(id, generation_number, addr, true);

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -685,7 +685,7 @@ future<> raft_group0::setup_group0(
 
     std::vector<gms::inet_address> seeds;
     for (auto& addr: initial_contact_nodes) {
-        if (addr != _gossiper.get_broadcast_address()) {
+        if (!_gossiper.is_me(addr)) {
             seeds.push_back(addr);
         }
     }

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -383,12 +383,12 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
     // The address map may miss our own id in case we connect
     // to an existing Raft Group 0 leader.
     auto my_id = load_my_id();
-    _raft_gr.address_map().add_or_update_entry(my_id, _gossiper.get_broadcast_address());
+    co_await _raft_gr.address_map().add_or_update_entry(my_id, _gossiper.get_broadcast_address());
     // At this time the group registry is already up and running,
     // so the address map is getting all the notifications from
     // the gossiper. By reading the application state *after* subscribing to new gossip events,
     // we ensure we haven't missed any IP update in the map.
-    load_initial_raft_address_map();
+    co_await load_initial_raft_address_map();
     group0_log.info("Server {} is starting group 0 with id {}", my_id, group0_id);
     co_await _raft_gr.start_server_for_group(create_server_for_group0(group0_id, my_id, ss, qp, mm));
     _group0.emplace<raft::group_id>(group0_id);
@@ -738,22 +738,22 @@ future<> raft_group0::setup_group0(
     co_await _client.set_group0_upgrade_state(group0_upgrade_state::use_post_raft_procedures);
 }
 
-void raft_group0::load_initial_raft_address_map() {
-    _gossiper.for_each_endpoint_state([this] (const gms::inet_address& ip_addr, const gms::endpoint_state& state) {
+future<> raft_group0::load_initial_raft_address_map() {
+    co_await _gossiper.for_each_endpoint_state_gently([this] (const gms::inet_address& ip_addr, const gms::endpoint_state& state) -> future<> {
         auto* value = state.get_application_state_ptr(gms::application_state::HOST_ID);
         if (value == nullptr) {
-            return;
+            co_return;
         }
         auto server_id = utils::UUID(value->value());
         if (server_id == utils::UUID{}) {
             upgrade_log.error("empty Host ID for host {} ", ip_addr);
-            return;
+            co_return;
         }
         // The failure detector needs the IPs on all shards. We
         // can safely overwrite existing entries since are loading
         // them directly from gossiper app state - which is most
         // recent.
-        _raft_gr.address_map().add_or_update_entry(raft::server_id{server_id}, ip_addr);
+        co_await _raft_gr.address_map().add_or_update_entry(raft::server_id{server_id}, ip_addr);
     });
 }
 
@@ -1744,7 +1744,7 @@ std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {
 
 future<> load_address_map(db::system_keyspace& sys_ks, raft_address_map& address_map) {
     for (auto [ip, host] : co_await sys_ks.load_host_ids()) {
-        address_map.add_or_update_entry(raft::server_id(host.uuid()), ip);
+        co_await address_map.add_or_update_entry(raft::server_id(host.uuid()), ip);
     }
 }
 

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -355,7 +355,7 @@ private:
 
     // Load the initial Raft <-> IP address map as seen by
     // the gossiper.
-    void load_initial_raft_address_map();
+    future<> load_initial_raft_address_map();
 
     // Returns true if raft is enabled
     future<bool> use_raft();

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -86,9 +86,8 @@ class gossiper_state_change_subscriber_proxy: public gms::i_endpoint_state_chang
         if (app_state_ptr) {
             raft::server_id id(utils::UUID(app_state_ptr->value()));
             rslog.debug("gossiper_state_change_subscriber_proxy::on_endpoint_change() {} {}", endpoint, id);
-            _address_map.add_or_update_entry(id, endpoint, ep_state->get_heart_beat_state().get_generation());
+            co_await _address_map.add_or_update_entry(id, endpoint, ep_state->get_heart_beat_state().get_generation());
         }
-        return make_ready_future<>();
     }
 
 public:

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2798,7 +2798,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         // Check if the node is already removed from the cluster
         auto local_host_id = get_token_metadata().get_my_id();
         auto my_ip = get_broadcast_address();
-        if (!_gossiper.is_safe_for_restart(my_ip, local_host_id)) {
+        if (!_gossiper.is_safe_for_restart()) {
             throw std::runtime_error(::format("The node {} with host_id {} is removed from the cluster. Can not restart the removed node to join the cluster again!",
                     my_ip, local_host_id));
         }
@@ -4094,7 +4094,7 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
             }
             _gossiper.check_snitch_name_matches(_snitch.local()->get_name());
             auto addr = get_broadcast_address();
-            if (!_gossiper.is_safe_for_bootstrap(addr)) {
+            if (!_gossiper.is_safe_for_bootstrap()) {
                 throw std::runtime_error(::format("A node with address {} already exists, cancelling join. "
                     "Use replace_address if you want to replace this node.", addr));
             }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -265,7 +265,7 @@ private:
     inet_address get_broadcast_address() const {
         return utils::fb_utilities::get_broadcast_address();
     }
-    const locator::host_id& my_host_id() const {
+    locator::host_id get_host_id() const {
         return utils::fb_utilities::get_host_id();
     }
     /* This abstraction maintains the token/endpoint metadata information */

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -265,6 +265,9 @@ private:
     inet_address get_broadcast_address() const {
         return utils::fb_utilities::get_broadcast_address();
     }
+    const locator::host_id& my_host_id() const {
+        return utils::fb_utilities::get_host_id();
+    }
     /* This abstraction maintains the token/endpoint metadata information */
     shared_token_metadata& _shared_token_metadata;
     locator::effective_replication_map_factory& _erm_factory;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -371,7 +371,7 @@ private:
     future<> join_token_ring(sharded<db::system_distributed_keyspace>& sys_dist_ks,
             sharded<service::storage_proxy>& proxy,
             std::unordered_set<gms::inet_address> initial_contact_nodes,
-            std::unordered_set<gms::inet_address> loaded_endpoints,
+            std::unordered_map<gms::inet_address, locator::host_id> loaded_endpoints,
             std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
             std::chrono::milliseconds);
     future<> start_sys_dist_ks();

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -39,15 +39,15 @@ public:
 
     seastar::future<> stop();
 
-    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
+    virtual future<> on_change(gms::endpoint_id, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
 
-    virtual future<> on_remove(gms::inet_address, gms::permit_id) override;
+    virtual future<> on_remove(gms::endpoint_id, gms::permit_id) override;
 
-    virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
-    virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_join(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::endpoint_id, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::endpoint_id, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 };
 
 }

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -299,10 +299,10 @@ stream_bytes stream_manager::get_progress_on_local_shard() const {
     return ret;
 }
 
-bool stream_manager::has_peer(inet_address endpoint) const {
+bool stream_manager::has_peer(const gms::endpoint_id& node) const {
     for (auto sr : get_all_streams()) {
         for (auto session : sr->get_coordinator()->get_all_stream_sessions()) {
-            if (session->peer == endpoint) {
+            if (session->peer == node.addr) {
                 return true;
             }
         }
@@ -310,10 +310,10 @@ bool stream_manager::has_peer(inet_address endpoint) const {
     return false;
 }
 
-void stream_manager::fail_sessions(inet_address endpoint) {
+void stream_manager::fail_sessions(const gms::endpoint_id& node) {
     for (auto sr : get_all_streams()) {
         for (auto session : sr->get_coordinator()->get_all_stream_sessions()) {
-            if (session->peer == endpoint) {
+            if (session->peer == node.addr) {
                 session->close_session(stream_session_state::FAILED);
             }
         }
@@ -328,40 +328,40 @@ void stream_manager::fail_all_sessions() {
     }
 }
 
-future<> stream_manager::on_remove(inet_address endpoint, gms::permit_id) {
-    if (has_peer(endpoint)) {
-        sslog.info("stream_manager: Close all stream_session with peer = {} in on_remove", endpoint);
+future<> stream_manager::on_remove(gms::endpoint_id node, gms::permit_id) {
+    if (has_peer(node)) {
+        sslog.info("stream_manager: Close all stream_session with peer = {} in on_remove", node);
         //FIXME: discarded future.
-        (void)container().invoke_on_all([endpoint] (auto& sm) {
-            sm.fail_sessions(endpoint);
-        }).handle_exception([endpoint] (auto ep) {
-            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_remove", endpoint);
+        (void)container().invoke_on_all([node] (auto& sm) {
+            sm.fail_sessions(node);
+        }).handle_exception([node] (auto ep) {
+            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_remove", node);
         });
     }
     return make_ready_future();
 }
 
-future<> stream_manager::on_restart(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) {
-    if (has_peer(endpoint)) {
-        sslog.info("stream_manager: Close all stream_session with peer = {} in on_restart", endpoint);
+future<> stream_manager::on_restart(gms::endpoint_id node, endpoint_state_ptr ep_state, gms::permit_id) {
+    if (has_peer(node)) {
+        sslog.info("stream_manager: Close all stream_session with peer = {} in on_restart", node);
         //FIXME: discarded future.
-        (void)container().invoke_on_all([endpoint] (auto& sm) {
-            sm.fail_sessions(endpoint);
-        }).handle_exception([endpoint] (auto ep) {
-            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_restart", endpoint);
+        (void)container().invoke_on_all([node] (auto& sm) {
+            sm.fail_sessions(node);
+        }).handle_exception([node] (auto ep) {
+            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_restart", node);
         });
     }
     return make_ready_future();
 }
 
-future<> stream_manager::on_dead(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) {
-    if (has_peer(endpoint)) {
-        sslog.info("stream_manager: Close all stream_session with peer = {} in on_dead", endpoint);
+future<> stream_manager::on_dead(gms::endpoint_id node, endpoint_state_ptr ep_state, gms::permit_id) {
+    if (has_peer(node)) {
+        sslog.info("stream_manager: Close all stream_session with peer = {} in on_dead", node);
         //FIXME: discarded future.
-        (void)container().invoke_on_all([endpoint] (auto& sm) {
-            sm.fail_sessions(endpoint);
-        }).handle_exception([endpoint] (auto ep) {
-            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_dead", endpoint);
+        (void)container().invoke_on_all([node] (auto& sm) {
+            sm.fail_sessions(node);
+        }).handle_exception([node] (auto ep) {
+            sslog.warn("stream_manager: Fail to close sessions peer = {} in on_dead", node);
         });
     }
     return make_ready_future();

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -166,18 +166,18 @@ public:
     shared_ptr<stream_session> get_session(streaming::plan_id plan_id, gms::inet_address from, const char* verb, std::optional<table_id> cf_id = {});
 
 public:
-    virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
-    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override;
-    virtual future<> on_remove(inet_address endpoint, gms::permit_id) override;
-    virtual future<> on_restart(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override;
+    virtual future<> on_join(gms::endpoint_id node, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> before_change(gms::endpoint_id node, endpoint_state_ptr current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
+    virtual future<> on_change(gms::endpoint_id node, application_state state, const versioned_value& value, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::endpoint_id node, endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::endpoint_id node, endpoint_state_ptr state, gms::permit_id) override;
+    virtual future<> on_remove(gms::endpoint_id node, gms::permit_id) override;
+    virtual future<> on_restart(gms::endpoint_id node, endpoint_state_ptr ep_state, gms::permit_id) override;
 
 private:
     void fail_all_sessions();
-    void fail_sessions(inet_address endpoint);
-    bool has_peer(inet_address endpoint) const;
+    void fail_sessions(const gms::endpoint_id& node);
+    bool has_peer(const gms::endpoint_id& node) const;
 
     void init_messaging_service_handler(abort_source& as);
     future<> uninit_messaging_service_handler();

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -34,6 +34,7 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
 
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     engine().set_strict_dma(false);
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -227,6 +227,7 @@ locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
 void simple_test() {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     // Create the RackInferringSnitch
     snitch_config cfg;
@@ -237,6 +238,7 @@ void simple_test() {
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.this_host_id = utils::fb_utilities::get_host_id();
     tm_cfg.topo_cfg.this_endpoint = utils::fb_utilities::get_broadcast_address();
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -309,6 +311,7 @@ void simple_test() {
 void heavy_origin_test() {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     // Create the RackInferringSnitch
     snitch_config cfg;
@@ -696,13 +699,15 @@ void generate_topology(topology& topo, const std::unordered_map<sstring, size_t>
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo.add_node(host_id::create_random_id(), node, {dc, to_sstring(r)}, locator::node::state::normal);
+        auto host_id = node == gms::inet_address("localhost") ? utils::fb_utilities::get_host_id() : host_id::create_random_id();
+        topo.add_node(host_id, node, {dc, to_sstring(r)}, locator::node::state::normal);
     }
 }
 
 SEASTAR_THREAD_TEST_CASE(testCalculateEndpoints) {
     utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
     utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+    utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
 
     constexpr size_t NODES = 100;
     constexpr size_t VNODES = 64;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -630,6 +630,7 @@ private:
                 host_id = linfo.host_id;
                 _sys_ks.local().save_local_info(std::move(linfo), _snitch.local()->get_location()).get();
             }
+            utils::fb_utilities::set_host_id(host_id);
             locator::shared_token_metadata::mutate_on_all_shards(_token_metadata, [hostid = host_id] (locator::token_metadata& tm) {
                 tm.get_topology().set_host_id_cfg(hostid);
                 return make_ready_future<>();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -665,20 +665,20 @@ private:
                 seeds.emplace(gms::inet_address("127.0.0.1"));
             }
 
-            gms::gossip_config gcfg;
-            gcfg.cluster_name = "Test Cluster";
-            gcfg.seeds = std::move(seeds);
-            gcfg.skip_wait_for_gossip_to_settle = 0;
-            _gossiper.start(std::ref(abort_sources), std::ref(_token_metadata), std::ref(_ms), std::ref(*cfg), std::move(gcfg)).get();
-            auto stop_ms_fd_gossiper = defer([this] {
-                _gossiper.stop().get();
-            });
-            _gossiper.invoke_on_all(&gms::gossiper::start).get();
-
             _raft_address_map.start().get();
             auto stop_address_map = defer([this] {
                 _raft_address_map.stop().get();
             });
+
+            gms::gossip_config gcfg;
+            gcfg.cluster_name = "Test Cluster";
+            gcfg.seeds = std::move(seeds);
+            gcfg.skip_wait_for_gossip_to_settle = 0;
+            _gossiper.start(std::ref(abort_sources), std::ref(_token_metadata), std::ref(_ms), std::ref(_raft_address_map), std::ref(*cfg), std::move(gcfg)).get();
+            auto stop_ms_fd_gossiper = defer([this] {
+                _gossiper.stop().get();
+            });
+            _gossiper.invoke_on_all(&gms::gossiper::start).get();
 
             _fd_pinger.start(std::ref(_ms), std::ref(_raft_address_map)).get();
             auto stop_fd_pinger = defer([this] { _fd_pinger.stop().get(); });

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -57,6 +57,7 @@ int main(int ac, char ** av) {
             const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
             utils::fb_utilities::set_broadcast_address(listen);
             utils::fb_utilities::set_broadcast_rpc_address(listen);
+            utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
             auto cfg = std::make_unique<db::config>();
 
             sharded<abort_source> abort_sources;

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -72,13 +72,17 @@ int main(int ac, char ** av) {
             messaging.start(locator::host_id{}, listen, 7000).get();
             auto stop_messaging = deferred_stop(messaging);
 
+            sharded<service::raft_address_map> address_map;
+            address_map.start().get();
+            auto stop_address_map = deferred_stop(address_map);
+
             gms::gossip_config gcfg;
             gcfg.cluster_name = "Test Cluster";
             for (auto s : config["seed"].as<std::vector<std::string>>()) {
                 gcfg.seeds.emplace(std::move(s));
             }
             sharded<gms::gossiper> gossiper;
-            gossiper.start(std::ref(abort_sources), std::ref(token_metadata), std::ref(messaging), std::ref(*cfg), std::move(gcfg)).get();
+            gossiper.start(std::ref(abort_sources), std::ref(token_metadata), std::ref(messaging), std::ref(address_map), std::ref(*cfg), std::move(gcfg)).get();
 
             auto& server = messaging.local();
             auto port = server.port();

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -172,6 +172,7 @@ int main(int ac, char ** av) {
         bool stay_alive = config["stay-alive"].as<bool>();
         const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
         utils::fb_utilities::set_broadcast_address(listen);
+        utils::fb_utilities::set_host_id(locator::host_id::create_random_id());
         seastar::sharded<netw::messaging_service> messaging;
         return messaging.start(locator::host_id{}, listen, 7000).then([config, stay_alive, &messaging] () {
             auto testers = new distributed<tester>;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -97,7 +97,8 @@ public:
             return messaging_service::no_wait();
         });
 
-        ms.register_gossip_shutdown([] (inet_address from, rpc::optional<int64_t> generation_number_opt) {
+        ms.register_gossip_shutdown([] (const rpc::client_info& cinfo, inet_address, rpc::optional<int64_t> generation_number_opt) {
+            auto from = netw::messaging_service::get_source(cinfo);
             fmt::print("Server got shutdown msg = {}\n", from);
             return messaging_service::no_wait();
         });

--- a/test/raft/raft_address_map_test.cc
+++ b/test/raft/raft_address_map_test.cc
@@ -57,7 +57,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         m.set_nonexpiring(id1);
         // Check that regular entries don't expire
         manual_clock::advance(expiration_time);
@@ -76,7 +76,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         auto found = m.find(id1);
         BOOST_CHECK(!!found && *found == addr1);
         // The entry stay in the cache for 1 hour
@@ -91,9 +91,9 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         manual_clock::advance(30min);
-        m.add_or_update_entry(id2, addr2);
+        m.add_or_update_entry(id2, addr2).get();
         // Here the expiration timer will rearm itself automatically since id2
         // hasn't expired yet and need to be collected some time later
         manual_clock::advance(30min + 1s);
@@ -111,9 +111,9 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         m.set_nonexpiring(id1);
-        BOOST_CHECK_NO_THROW(m.add_or_update_entry(id1, addr2));
+        BOOST_CHECK_NO_THROW(m.add_or_update_entry(id1, addr2).get());
         BOOST_CHECK(m.find(id1) && *m.find(id1) == addr2);
     }
     {
@@ -124,9 +124,9 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         m.set_nonexpiring(id1);
-        m.add_or_update_entry(id1, addr2);
+        m.add_or_update_entry(id1, addr2).get();
         manual_clock::advance(expiration_time);
         BOOST_CHECK(m.find(id1) && *m.find(id1) == addr2);
     }
@@ -155,7 +155,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         // inserted entry's address and advance the clock by expiration_time
         // before checking if the entry is in the address map. If set_nonexpiring()
         // didn't add the entry, add_or_update_entry() would add a new expiring entry.
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         manual_clock::advance(expiration_time);
         BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
     }
@@ -167,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto& m = m_svc.local();
 
         scoped_no_abort_on_internal_error abort_guard;
-        BOOST_CHECK_THROW(m.add_or_update_entry(id1, gms::inet_address{}), std::runtime_error);
+        BOOST_CHECK_THROW(m.add_or_update_entry(id1, gms::inet_address{}).get(), std::runtime_error);
     }
     {
         // Check that opt_add_entry() throws when called without an actual IP address
@@ -187,8 +187,8 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1, gms::generation_type(1));
-        m.add_or_update_entry(id1, addr2, gms::generation_type(0));
+        m.add_or_update_entry(id1, addr1, gms::generation_type(1)).get();
+        m.add_or_update_entry(id1, addr2, gms::generation_type(0)).get();
         BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
     }
     {
@@ -200,7 +200,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto& m = m_svc.local();
 
         m.set_nonexpiring(id1);
-        m.add_or_update_entry(id1, addr1, gms::generation_type(-1));
+        m.add_or_update_entry(id1, addr1, gms::generation_type(-1)).get();
         BOOST_CHECK(m.find(id1) && *m.find(id1) == addr1);
     }
     {
@@ -215,7 +215,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         m.set_nonexpiring(id1);
         BOOST_CHECK(!m.find_by_addr(addr1));
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         BOOST_CHECK(m.find_by_addr(addr1) && *m.find_by_addr(addr1) == id1);
     }
     {
@@ -225,7 +225,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_operations) {
         auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         manual_clock::advance(30min);
         BOOST_CHECK(m.find_by_addr(addr1) && *m.find_by_addr(addr1) == id1);
 
@@ -271,7 +271,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_replication) {
 
         // Add entry on both shards, replicate non-expiration
         // flag, ensure it doesn't expire on the other shard
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         m.set_nonexpiring(id1);
         ping_shards().get();
         m_svc.invoke_on(1, [] (raft_address_map_t<manual_clock>& m) {
@@ -293,7 +293,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_replication) {
         BOOST_CHECK(!m.find(id1));
 
         // Expiring entries are replicated
-        m.add_or_update_entry(id1, addr1);
+        m.add_or_update_entry(id1, addr1).get();
         ping_shards().get();
         m_svc.invoke_on(1, [] (raft_address_map_t<manual_clock>& m) {
             BOOST_CHECK(m.find(id1));
@@ -302,7 +302,7 @@ SEASTAR_THREAD_TEST_CASE(test_raft_address_map_replication) {
         // Can't call add_or_update_entry on shard other than 0
         m_svc.invoke_on(1, [] (raft_address_map_t<manual_clock>& m) {
             scoped_no_abort_on_internal_error abort_guard;
-            BOOST_CHECK_THROW(m.add_or_update_entry(id1, addr2), std::runtime_error);
+            BOOST_CHECK_THROW(m.add_or_update_entry(id1, addr2).get(), std::runtime_error);
         }).get();
 
         // Can add expiring entries on shard other than 0 - and they indeed expire

--- a/utils/fb_utilities.hh
+++ b/utils/fb_utilities.hh
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include "gms/inet_address.hh"
+#include "locator/host_id.hh"
 
 namespace utils {
 
@@ -29,6 +30,11 @@ private:
 
         return _broadcast_rpc_address;
     }
+    static locator::host_id& host_id() noexcept {
+        static locator::host_id _host_id;
+
+        return _host_id;
+    }
 public:
    static constexpr int32_t MAX_UNSIGNED_SHORT = 0xFFFF;
 
@@ -39,6 +45,10 @@ public:
    static void set_broadcast_rpc_address(inet_address addr) noexcept {
        broadcast_rpc_address() = addr;
    }
+
+    static void set_host_id(const locator::host_id& id) noexcept {
+        host_id() = id;
+    }
 
 
    static const inet_address get_broadcast_address() noexcept {
@@ -51,8 +61,16 @@ public:
        return *broadcast_rpc_address();
    }
 
+    static const locator::host_id& get_host_id() noexcept {
+        return host_id();
+    }
+
     static bool is_me(gms::inet_address addr) noexcept {
         return addr == get_broadcast_address();
+    }
+
+    static bool is_me(const locator::host_id id) noexcept {
+        return id == get_host_id();
     }
 };
 }


### PR DESCRIPTION
This series adds an `endpoint_id` to the gossiper interface as the first step to basing its interface solely on `host_id`.

struct `endpoint_id` describes the endpoint as a pair of `{ host_id, inet_address }`.
It allows the notification listeners to use the `host_id` when available or to to use the `inet_address` when required (until other layers in the stack, like the `token_metadata` are converted), or as a fallback.

The RPC `client_info` is used to determine the peer's host_id.
Plus, the gossiper was changed to always send the HOST_ID application state along in the endpoint_state in the ack and ack2 responses, but when talking to nodes running an older version this is not guranteed, hence the host_id cannot be mandated yet.

An address map, mutally mapping host_id to and from endpoints' inet_address on all shards, was added.
It is needed to keep the mappings learnt in the shadow round.
The raft address map was considered too, but it is insufficient for the gossiper at this point since:
a. it's available only on shard 0, and
b. the raft address map is updated by callbacks called from gossiper, while the latter needs the mapping earlier than that.

The `_endpoint_state_map` was extended by `_endpoint_state_map_by_host_id` providing fast lookup of the endpoint_state wither by the endpoint address or by its host_id.
This serves a nasty use case of replacing a node with the same ip address.
In the future it may be possible to get rid of getting the endpoint state by inet_address and
a clean api based solely on host_id could be established, once we no longer have to search for the endpoint state by its ip address.

Refs https://github.com/scylladb/scylladb/issues/12282