### PR TITLE
compaction_backlog_tracker: do not allow moving registered trackers

### DIFF
--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -67,7 +67,7 @@ public:
 
     compaction_backlog_tracker(std::unique_ptr<impl> impl) : _impl(std::move(impl)) {}
     compaction_backlog_tracker(compaction_backlog_tracker&&);
-    compaction_backlog_tracker& operator=(compaction_backlog_tracker&&) noexcept;
+    compaction_backlog_tracker& operator=(compaction_backlog_tracker&&) = delete;
     compaction_backlog_tracker(const compaction_backlog_tracker&) = delete;
     ~compaction_backlog_tracker();
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2153,14 +2153,17 @@ compaction_backlog_tracker::compaction_backlog_tracker(compaction_backlog_tracke
         : _impl(std::move(other._impl))
         , _ongoing_writes(std::move(other._ongoing_writes))
         , _ongoing_compactions(std::move(other._ongoing_compactions))
-        , _manager(std::exchange(other._manager, nullptr)) {
+{
+    if (other._manager) {
+        on_internal_error(cmlog, "compaction_backlog_tracker is moved while registered");
+    }
 }
 
 compaction_backlog_tracker&
 compaction_backlog_tracker::operator=(compaction_backlog_tracker&& x) noexcept {
     if (this != &x) {
-        if (auto manager = std::exchange(_manager, x._manager)) {
-            manager->remove_backlog_tracker(this);
+        if (x._manager) {
+            on_internal_error(cmlog, "compaction_backlog_tracker is moved while registered");
         }
         _impl = std::move(x._impl);
         _ongoing_writes = std::move(x._ongoing_writes);

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -32,7 +32,7 @@ struct compaction_state {
     // Signaled whenever a compaction task completes.
     condition_variable compaction_done;
 
-    compaction_backlog_tracker backlog_tracker;
+    std::optional<compaction_backlog_tracker> backlog_tracker;
 
     std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
     compaction::owned_ranges_ptr owned_ranges_ptr;


### PR DESCRIPTION
Currently, the moved-object's manager pointer is moved into the
constructed object, but without fixing the registration to
point to the moved-to object, causing #15248.

Although we could properly move the registration from
the moved-from object to the moved-to one, it is simpler
to just disallow moving a registered tracker, since it's
not needed anywhere. This way we just don't need to mess
with the trackers' registration.

The move-assignment operator has a similar problem,
therefore it is deleted in this series, and the function is
renamed to `transfer_backlog` that just doesn't deal with the
moved-from registration.  This is safe since it's only used internally
by the compaction manager.

Fixes #15248