### PR TITLE
build: cmake: bump the minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.27)
 
 project(scylla)
 

--- a/cmake/add_whole_archive.cmake
+++ b/cmake/add_whole_archive.cmake
@@ -5,15 +5,6 @@
 # actually compiling a sample program.
 function(add_whole_archive name library)
   add_library(${name} INTERFACE)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    target_link_libraries(${name} INTERFACE
-      "$<LINK_LIBRARY:WHOLE_ARCHIVE,${library}>")
-  else()
-    add_dependencies(${name} ${library})
-    target_include_directories(${name} INTERFACE
-      ${CMAKE_SOURCE_DIR})
-    target_link_options(auth INTERFACE
-      "$<$<CXX_COMPILER_ID:Clang>:SHELL:LINKER:-force_load $<TARGET_LINKER_FILE:${library}>>"
-      "$<$<CXX_COMPILER_ID:GNU>:SHELL:LINKER:--whole-archive $<TARGET_LINKER_FILE:${library}> LINKER:--no-whole-archive>")
-  endif()
+  target_link_libraries(${name} INTERFACE
+    "$<LINK_LIBRARY:WHOLE_ARCHIVE,${library}>")
 endfunction()


### PR DESCRIPTION
because we should have a frozeon toolchain built with fedora38, and f38
provides cmake v3.27.4, we can assume the availability of cmake v3.27.4
when building scylla with the toolchain.

in this change, the minimum required CMake version is changed to
3.27.

this also allows us to simplify the implementation of
`add_whole_archive()`, and remove the buggy branch for supporting
CMake < 3.24, as we should have used `${name}` in place of `auth` there.
