### PR TITLE
build: cmake: use find_program(.. REQUIRED) when appropriate

### DIFF
--- a/cmake/generate_cql_grammar.cmake
+++ b/cmake/generate_cql_grammar.cmake
@@ -1,7 +1,5 @@
-find_program (ANTLR3 antlr3)
-if(NOT ANTLR3)
-  message(FATAL_ERROR "antlr3 is required")
-endif()
+find_program (ANTLR3 antlr3
+  REQUIRED)
 
 # Parse antlr3 grammar files and generate C++ sources
 function(generate_cql_grammar)

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -14,10 +14,8 @@ function(scylla_generate_thrift)
         ${args_OUT_DIR}/${args_SERVICE}.cpp
         ${args_OUT_DIR}/${args_SERVICE}.h)
 
-    find_program(THRIFT thrift)
-    if(NOT THRIFT)
-      message(FATAL_ERROR "thrift is required")
-    endif()
+    find_program(THRIFT thrift
+      REQUIRED)
     execute_process(
         COMMAND "${THRIFT}" -version
         OUTPUT_VARIABLE thrift_version_output

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,7 +1,5 @@
-find_program(CARGO cargo)
-if(NOT CARGO)
-  message(FATAL_ERROR "cargo is required")
-endif()
+find_program(CARGO cargo
+  REQUIRED)
 
 function(add_rust_library name)
   # use for profiles defined in Cargo.toml
@@ -24,10 +22,8 @@ function(add_rust_library name)
     IMPORTED_LOCATION "${library}")
 endfunction(add_rust_library)
 
-find_program(CXXBRIDGE cxxbridge)
-if(NOT CXXBRIDGE)
-  message(FATAL_ERROR "cxxbridge is required")
-endif()
+find_program(CXXBRIDGE cxxbridge
+  REQUIRED)
 # Generate cxxbridge header and source
 function(generate_cxxbridge name)
   cmake_parse_arguments(parsed_args

--- a/test/resource/wasm/CMakeLists.txt
+++ b/test/resource/wasm/CMakeLists.txt
@@ -1,7 +1,5 @@
-find_program(WASM2WAT wasm2wat)
-if(NOT WASM2WAT)
-  message(FATAL_ERROR "wasm2wat is required")
-endif()
+find_program(WASM2WAT wasm2wat
+  REQUIRED)
 
 function(wasm2wat input)
   cmake_parse_arguments(parsed_args "" "WAT;OUT_DIR" "" ${ARGN})

--- a/test/resource/wasm/c/CMakeLists.txt
+++ b/test/resource/wasm/c/CMakeLists.txt
@@ -1,7 +1,5 @@
-find_program(CLANG clang)
-if(NOT CLANG)
-  message(FATAL_ERROR "clang is required")
-endif()
+find_program(CLANG clang
+  REQUIRED)
 
 function(compile_c_to_wasm input)
   cmake_parse_arguments(parsed_args "" "WASM;OUT_DIR" "" ${ARGN})

--- a/test/resource/wasm/rust/CMakeLists.txt
+++ b/test/resource/wasm/rust/CMakeLists.txt
@@ -1,7 +1,6 @@
-find_program(CARGO cargo)
-if(NOT CARGO)
-  message(FATAL_ERROR "cargo is required")
-endif()
+find_program(CARGO cargo
+  REQUIRED)
+
 
 function(compile_rust_to_wasm input)
   cmake_parse_arguments(parsed_args "" "WASM;OUT_DIR" "" ${ARGN})


### PR DESCRIPTION
instead of checking the availability of a required program, let's use the `REQUIRED` argument introduced by CMake 3.18, simpler this way.