### PR TITLE
build: cmake: add `tests` target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,8 @@ function(add_scylla_test name)
     set(src "${name}.cc")
   endif()
   add_executable(${name} ${src})
+  add_dependencies(tests ${name})
+
   target_include_directories(${name}
     PRIVATE
       ${CMAKE_SOURCE_DIR})
@@ -77,6 +79,9 @@ function(add_scylla_test name)
 endfunction()
 
 if(BUILD_TESTING)
+    add_custom_target(tests)
+    add_dependencies(tests scylla)
+
     add_subdirectory(boost)
     add_subdirectory(manual)
     add_subdirectory(unit)

--- a/test/resource/wasm/CMakeLists.txt
+++ b/test/resource/wasm/CMakeLists.txt
@@ -17,5 +17,6 @@ function(wasm2wat input)
 endfunction()
 
 add_custom_target(wasm)
+add_dependencies(tests wasm)
 add_subdirectory(c)
 add_subdirectory(rust)


### PR DESCRIPTION
this target mirrors the target named `{mode}e-test` in the `build.ninja` build script created by `configure.py`.