### PR TITLE
cql.g: always initialize returned values

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1012,14 +1012,8 @@ alterTableStatement returns [std::unique_ptr<alter_table_statement> expr]
     }
     ;
 
-cfisStatic returns [bool isStaticColumn]
-    @init{
-        bool isStatic = false;
-    }
-    : (K_STATIC { isStatic=true; })?
-    {
-        $isStaticColumn = isStatic;
-    }
+cfisStatic returns [bool isStaticColumn=false]
+    : (K_STATIC { $isStaticColumn=true; })?
     ;
 
 /**
@@ -1168,7 +1162,7 @@ listPermissionsStatement returns [std::unique_ptr<list_permissions_statement> st
       { $stmt = std::make_unique<list_permissions_statement>($permissionOrAll.perms, std::move(r), std::move(role), recursive); }
     ;
 
-permission returns [auth::permission perm]
+permission returns [auth::permission perm = auth::permission{}]
     : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE)
     { $perm = auth::permissions::from_string($p.text); }
     ;
@@ -1773,7 +1767,7 @@ propertyValue returns [sstring str]
     | K_NULL { $str = "null"; }
     ;
 
-relationType returns [oper_t op]
+relationType returns [oper_t op = oper_t{}]
     : '='  { $op = oper_t::EQ; }
     | '<'  { $op = oper_t::LT; }
     | '<=' { $op = oper_t::LTE; }


### PR DESCRIPTION
cql.g: always initialize returned values

always initialize returned values. the branches which
return these unitiailized returned values handles the
unmatched cases, so this change should not have any
impact on the behavior.

ANTLR3's C++ code generator does not assign any value
to the value, if it runs into failure or encounter
exceptions. for instance, following rule assigns the
value of `isStatic` to `isStaticColumn` only if
nothing goes wrong.

```antlr
cfisStatic returns [bool isStaticColumn]
    @init{
        bool isStatic = false;
    }
    : (K_STATIC { isStatic=true; })?
    {
        $isStaticColumn = isStatic;
    }
    ;
```

as shown in the generated C++ code:
```c++
                switch (alt118)
                {
            	case 1:
            	    // build/debug/gen/cql3/Cql.g:989:8: K_STATIC
            	    {
            	         this->matchToken(K_STATIC, &FOLLOW_K_STATIC_in_cfisStatic5870);
            	        if  (this->hasException())
            	        {
            	            goto rulecfisStaticEx;
            	        }
            	        if (this->hasFailed())
            	        {
            	            return isStaticColumn;
            	        }

            	        if ( this->get_backtracking()==0 )
            	        {
            	             isStaticColumn=isStatic;

            	        }

            	    }
            	    break;

                }
```

when `this->hasException()` or `this->hasFailed()`,
`isStaticColumn` is returned right away without being
initialized, because we don't assign any initial value
to it, neither do we customize the exception handling
for this rule.

and, the parser bails out when its smells something bad
after it tries to match the specified rule. also, the
parser is a stateful tokenizer, its failure state is
carried by the parser itself. also, the matchToken()
*could* fail when trying to find the matched token,
this is the runtime behavior of parser, that's why the
compiler cannot be certain that the error path won't
be taken.

anyway, let's always initialize the values without
default constructor. the return values whose type
is of scoped enum are initialized with zero
initialization, because their types don't provide an
"invalid" value.

this change should silence warnings like:

```
clang++ -MD -MT build/debug/gen/cql3/CqlParser.o -MF build/debug/gen/cql3/CqlParser.o.d -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/debug/seastar/gen/include -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_DEBUG -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_TYPE_ERASE_MORE -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -I/usr/include/p11-kit-1   -ffile-prefix-map=/home/kefu/dev/scylladb=. -march=westmere -DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION -Og -DSCYLLA_BUILD_MODE=debug -g -gz -iquote. -iquote build/debug/gen --std=gnu++20  -ffile-prefix-map=/home/kefu/dev/scylladb=. -march=westmere  -DBOOST_TEST_DYN_LINK   -DNOMINMAX -DNOMINMAX -fvisibility=hidden  -Wall -Werror -Wextra -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-c++11-narrowing -Wno-ignored-qualifiers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -Wno-implicit-int-float-conversion -Wno-error=deprecated-declarations -DXXH_PRIVATE_API -DSEASTAR_TESTING_MAIN -DFMT_DEPRECATED_OSTREAM -Wno-parentheses-equality -O1 -fno-sanitize-address-use-after-scope -c -o build/debug/gen/cql3/CqlParser.o build/debug/gen/cql3/CqlParser.cpp
build/debug/gen/cql3/CqlParser.cpp:26645:28: error: variable 'perm' is uninitialized when used here [-Werror,-Wuninitialized]
                    return perm;
                           ^~~~
build/debug/gen/cql3/CqlParser.cpp:26616:5: note: variable 'perm' is declared here
    auth::permission perm;
    ^
build/debug/gen/cql3/CqlParser.cpp:52577:28: error: variable 'op' is uninitialized when used here [-Werror,-Wuninitialized]
                    return op;
                           ^~
build/debug/gen/cql3/CqlParser.cpp:52518:5: note: variable 'op' is declared here
    oper_t op;
    ^
```
