### PR TITLE
Gossiper: get_or_create_endpoint_state update this node RPC_ADDRESS and HOST_ID

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1431,6 +1431,10 @@ endpoint_state& gossiper::get_or_create_endpoint_state(inet_address ep) {
         if (utils::fb_utilities::is_me(ep)) {
             auto rpc_addr = utils::fb_utilities::get_broadcast_rpc_address();
             eps.add_application_state(application_state::RPC_ADDRESS, versioned_value::rpcaddress(rpc_addr));
+            auto node = get_token_metadata_ptr()->get_topology().this_node();
+            if (node && node->host_id()) {
+                eps.add_application_state(application_state::HOST_ID, versioned_value::host_id(node->host_id()));
+            }
         }
         it = _endpoint_state_map.emplace(ep, make_endpoint_state_ptr(std::move(eps))).first;
     }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1428,7 +1428,10 @@ endpoint_state& gossiper::get_or_create_endpoint_state(inet_address ep) {
     auto it = _endpoint_state_map.find(ep);
     if (it == _endpoint_state_map.end()) {
         auto eps = endpoint_state();
-        eps.add_application_state(application_state::RPC_ADDRESS, versioned_value::rpcaddress(ep));
+        if (utils::fb_utilities::is_me(ep)) {
+            auto rpc_addr = utils::fb_utilities::get_broadcast_rpc_address();
+            eps.add_application_state(application_state::RPC_ADDRESS, versioned_value::rpcaddress(rpc_addr));
+        }
         it = _endpoint_state_map.emplace(ep, make_endpoint_state_ptr(std::move(eps))).first;
     }
     return const_cast<endpoint_state&>(*it->second);


### PR DESCRIPTION
When setting this node's RPC_ADDRESS application state,
use the `broadcast_rpc_address` rather than `broadcast_address`
as this is the one that should be exposed to the client.
See also `storage_service::join_token_ring()`.

Also, set the endpoint_state HOST_ID if available.

Fixes scylladb/scylladb#15458