### PR TITLE
storage_service: Avoid SIGSEGV when tablet cleanup is invoked on non-0 shard

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6219,7 +6219,9 @@ void storage_service::init_messaging_service(sharded<db::system_distributed_keys
         });
     });
     ser::storage_service_rpc_verbs::register_tablet_cleanup(&_messaging.local(), [this] (locator::global_tablet_id tablet) {
-        return cleanup_tablet(tablet);
+        return container().invoke_on(0, [tablet] (auto& ss) -> future<> {
+            return ss.cleanup_tablet(tablet);
+        });
     });
 }
 


### PR DESCRIPTION
We access group0, which is only set on shard 0.