### PR TITLE
cql3: expr: do not use multi-line comment

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -487,7 +487,7 @@ data_type type_of(const expression& e);
 
 } // namespace cql3
 
-/// Custom formatter for an expression.  Supports multiple modes:\
+/// Custom formatter for an expression.  Supports multiple modes:
 ///     {:user} for user-oriented output, suitable for error messages (default)
 ///     {:debug} for debug-oriented output
 ///     {:result_set_metadata} for stable output suitable for result set metadata (column headings)


### PR DESCRIPTION
do not use muti-line comment. this silences the warning from GCC:
```
In file included from ./cql3/prepare_context.hh:19,
                 from ./cql3/statements/raw/parsed_statement.hh:14,
                 from build/debug/gen/cql3/CqlParser.hpp:62,
                 from build/debug/gen/cql3/CqlParser.cpp:44:
./cql3/expr/expression.hh:490:1: error: multi-line comment [-Werror=comment]
  490 | /// Custom formatter for an expression.  Supports multiple modes:\
      | ^
```