### PR TITLE
install-dependencies.sh: drop java deps

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -70,11 +70,6 @@ fedora_packages=(
     git
     python
     sudo
-    java-1.8.0-openjdk-headless
-    java-1.8.0-openjdk-devel
-    ant
-    ant-junit
-    maven
     patchelf
     python3
     python3-aiohttp


### PR DESCRIPTION
the java related build dependencies are installed by

* tools/java/install-dependencies.sh
* tools/jmx/install-dependencies.sh

respectively. and the parent `install-dependencies.sh` always invoke these scripts, so there is no need to repeat them in the parent `install-dependenceies.sh` anymore.

in addition to dedup the build deps, this change also helps to reduce the size of build dependencies. as by default, `dnf` install the weak deps, unless `-setopt=install_weak_deps=False` is passed to it, so this change also helps to reduce the traffic and foot print of the installed packages for building scylla.

see also https://github.com/scylladb/scylla-tools-java/commit/9dddad27bfd9f2f93c712821087cba6d0c7fae69