### PR TITLE
commitlog_replayer: differentiate between truncated file and corrupt entries

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2545,6 +2545,20 @@ const db::commitlog::config& db::commitlog::active_config() const {
     return _segment_manager->cfg;
 }
 
+
+db::commitlog::segment_truncation::segment_truncation(uint64_t pos) 
+    : _msg(fmt::format("Segment truncation at {}", pos))
+    , _pos(pos)
+{}
+
+uint64_t db::commitlog::segment_truncation::position() const {
+    return _pos;
+}
+
+const char* db::commitlog::segment_truncation::what() const noexcept {
+    return _msg.c_str();
+}
+
 // No commit_io_check needed in the log reader since the database will fail
 // on error at startup if required
 future<>
@@ -2675,6 +2689,13 @@ db::commitlog::read_log_file(sstring filename, sstring pfx, commit_load_reader_f
                 // if a chunk header checksum is broken, we shall just assume that all
                 // remaining is as well. We cannot trust the "next" pointer, so...
                 clogger.debug("Checksum error in segment chunk at {}.", start);
+
+                if (corrupt_size == 0) {
+                    // if we got here and had no broken data previously, we can 
+                    // just call it truncation
+                    throw segment_truncation(pos - segment::segment_overhead_size);
+                }
+
                 corrupt_size += (file_size - pos);
                 stop();
                 co_return;

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -363,7 +363,7 @@ public:
         uint64_t bytes() const {
             return _bytes;
         }
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg.c_str();
         }
     private:
@@ -373,7 +373,7 @@ public:
     class invalid_segment_format : public segment_error {
         static constexpr const char* _msg = "Not a scylla format commitlog file";
     public:
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg;
         }
     };
@@ -381,9 +381,19 @@ public:
     class header_checksum_error : public segment_error {
         static constexpr const char* _msg = "Checksum error in file header";
     public:
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg;
         }
+    };
+
+    class segment_truncation : public segment_error {
+        std::string _msg;
+        uint64_t _pos;
+    public:
+        segment_truncation(uint64_t);
+
+        uint64_t position() const;
+        const char* what() const noexcept override;
     };
 
     static future<> read_log_file(sstring filename, sstring prefix, commit_load_reader_func, position_type = 0, const db::extensions* = nullptr);

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -494,9 +494,57 @@ SEASTAR_TEST_CASE(test_commitlog_chunk_corruption){
                         auto segments = log.get_active_segment_names();
                         BOOST_REQUIRE(!segments.empty());
                         auto seg = segments[0];
-                        return corrupt_segment(seg, rps->at(0).pos - 4, 0x451234ab).then([seg, rps] {
+                        auto cpos = rps->at(0).pos - 4;
+                        return corrupt_segment(seg, cpos, 0x451234ab).then([seg, rps, cpos] {
                             return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [rps](db::commitlog::buffer_and_replay_position buf_rp) {
                                 BOOST_FAIL("Should not reach");
+                                return make_ready_future<>();
+                            }).then_wrapped([cpos](auto&& f) {
+                                try {
+                                    f.get();
+                                    BOOST_FAIL("Expected exception");
+                                } catch (commitlog::segment_truncation& e) {
+                                    // ok. We've destroyed the first chunk of the segment. This counts as a truncation
+                                    BOOST_REQUIRE(e.position() <= cpos);
+                                }
+                            });
+                        });
+                    });
+        });
+}
+
+
+SEASTAR_TEST_CASE(test_commitlog_chunk_corruption2){
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = 1;
+    return cl_test(cfg, [](commitlog& log) {
+        auto rps = make_lw_shared<std::vector<db::replay_position>>();
+        return do_until([rps]() {return rps->size() > (128*1024/8);},
+                    [&log, rps]() {
+                        auto uuid = make_table_id();
+                        sstring tmp = "hej bubba cow";
+                        return log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [tmp](db::commitlog::output& dst) {
+                                    dst.write(tmp.data(), tmp.size());
+                                }).then([rps](rp_handle h) {
+                                    BOOST_CHECK_NE(h.rp(), db::replay_position());
+                                    rps->push_back(h.release());
+                                });
+                    }).then([&log]() {
+                        return log.sync_all_segments();
+                    }).then([&log, rps] {
+                        auto segments = log.get_active_segment_names();
+                        BOOST_REQUIRE(!segments.empty());
+                        auto seg = segments[0];
+                        auto desc = commitlog::descriptor(seg);
+                        auto e = std::find_if(rps->begin(), rps->end(), [desc](auto& rp) {
+                            return rp.id != desc.id;
+                        });
+                        auto idx = std::distance(rps->begin(), e);
+                        auto cpos = rps->at(idx/2).pos;
+
+                        return corrupt_segment(seg, cpos, 0x451234ab).then([seg, rps, cpos] {
+                            return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [rps, cpos](db::commitlog::buffer_and_replay_position buf_rp) {
+                                BOOST_CHECK_NE(buf_rp.position.pos, cpos);
                                 return make_ready_future<>();
                             }).then_wrapped([](auto&& f) {
                                 try {


### PR DESCRIPTION
Refs #11845

When replaying, differentiate between the two cases for failure we have:
 - A broken actual entry - i.e. entry header/data does not hold up to crc scrutiny
 - Truncated file - i.e. a chunk header is broken or unreadable. This can be due to either "corruption" (i.e. borked write, post-corruption, hw whatever), or simply an unterminated segment.

The difference is that the former is recoverable, the latter is not. We now signal and report the two separately. The end result for a user is not much different, in either case they imply data loss and the need for repair. But there is some value in differentiating which of the two we encountered.

Modifies and adds test cases.