### PR TITLE
gossiper: get_or_create_endpoint_state: create empty endpoint_state

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1427,9 +1427,7 @@ const endpoint_state& gossiper::get_endpoint_state(inet_address ep) const {
 endpoint_state& gossiper::get_or_create_endpoint_state(inet_address ep) {
     auto it = _endpoint_state_map.find(ep);
     if (it == _endpoint_state_map.end()) {
-        auto eps = endpoint_state();
-        eps.add_application_state(application_state::RPC_ADDRESS, versioned_value::rpcaddress(ep));
-        it = _endpoint_state_map.emplace(ep, make_endpoint_state_ptr(std::move(eps))).first;
+        it = _endpoint_state_map.emplace(ep, make_endpoint_state_ptr({})).first;
     }
     return const_cast<endpoint_state&>(*it->second);
 }


### PR DESCRIPTION
Currently, the endpoint address is set as the new
endpoint_state RPC_ADDRESS.  This is wrong since
it should be assigned with the `broadcast_rpc_address` rather than `broadcast_address`.
This was introduced in b82c77ed9c8ce683daa6ff32396acb6d72c42c1c

Instead just create an empty endpoint_state.
The RPC_ADDRESS (as well as HOST_ID) application states are set later.

Fixes scylladb/scylladb#15458