### PR TITLE
Update seastar submodule

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1698,7 +1698,7 @@ def configure_seastar(build_dir, mode, mode_config):
     if dpdk is None:
         dpdk = platform.machine() == 'x86_64' and mode == 'release'
     if dpdk:
-        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=wsm']
+        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=westmere']
     if args.split_dwarf:
         seastar_cmake_args += ['-DSeastar_SPLIT_DWARF=ON']
     if args.alloc_failure_injector:

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20230913
+docker.io/scylladb/scylla-toolchain:fedora-38-20230919


### PR DESCRIPTION
* seastar 576ee47d...bab1625c (13):
  > build: s/{dpdk_libs}/${dpdk_libs}/
  > build: build with dpdk v23.07
  > scripts: Fix escaping of regexes in addr2line
  > linux-aio: print more specific error when setup_aio fails
  > linux-aio: correct the error message raised when io_setup() fails
  > build: reenable -Warray-bound compiling option
  > build: error out if find_program() fails
  > build: enable systemtap only if it is available
  > build: check if libucontext is necessary for using ucontext functions
  > smp: reference correct variable when fetch_or()
  > build: use target_compile_definitions() for adding -D...
  > http/client: pass tls_options to tls::connect()
  > Merge 'build, process: avoid using stdout or stderr as C++ identifiers' from Kefu Chai

Frozen toolchain regenerated for new Seastar depdendencies.

configure.py adjusted for new Seastar arch names.