### PR TITLE
test/boost/s3_test: enable debugging message from http and s3

### DIFF
--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -42,5 +42,7 @@ custom_args:
         - '-c2 -m3G'
     cache_algorithm_test:
         - '-c1 -m256M'
+    s3_test:
+        - '--logger-log-level http=debug --logger-log-level s3=debug'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test


### PR DESCRIPTION
so that these subsystems can print more verbose error message, for
instance the HTTP response from server, when the test fails. this
would be helpful for postmortem debugging.
