### PR TITLE
populate_keyspace: use datadir

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1393,11 +1393,11 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
 }
 
 future<> table::init_storage() {
-    co_await coroutine::parallel_for_each(_config.all_datadirs, [] (sstring cfdir) {
-        return io_check([cfdir] { return recursive_touch_directory(cfdir); });
+    co_await coroutine::parallel_for_each(_config.all_datadirs, [] (sstring cfdir) -> future<> {
+        co_await io_check([cfdir] { return recursive_touch_directory(cfdir); });
+        co_await io_check([cfdir] { return touch_directory(cfdir + "/upload"); });
+        co_await io_check([cfdir] { return touch_directory(cfdir + "/staging"); });
     });
-    co_await io_check([this] { return touch_directory(_config.datadir + "/upload"); });
-    co_await io_check([this] { return touch_directory(_config.datadir + "/staging"); });
 }
 
 future<> table::destroy_storage() {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -464,15 +464,15 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         // might have more than one dir for a keyspace iff data_file_directories is > 1 and
         // somehow someone placed sstables in more than one of them for a given ks. (import?)
         co_await coroutine::parallel_for_each(gtable->get_config().all_datadirs, [&] (const sstring& datadir) -> future<> {
-            auto cf = gtable->shared_from_this();
+            auto& cf = *gtable;
 
-            dblog.info("Keyspace {}: Reading CF {} id={} version={} storage={} datadir={}", ks_name, cfname, uuid, s->version(), cf->get_storage_options().type_string(), datadir);
+            dblog.info("Keyspace {}: Reading CF {} id={} version={} storage={} datadir={}", ks_name, cfname, uuid, s->version(), cf.get_storage_options().type_string(), datadir);
 
             auto metadata = table_populator(gtable, db, ks_name, cfname, datadir);
             std::exception_ptr ex;
 
             try {
-                co_await cf->init_storage();
+                co_await cf.init_storage();
 
                 co_await metadata.start();
             } catch (...) {

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -74,7 +74,6 @@ class distributed_loader {
             sharded<replica::database>& db, sharded<db::view::view_update_generator>& view_update_generator,
             bool needs_view_update, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<replica::database>& db, keyspace& ks, sstring ks_name);
-    static future<> populate_keyspace(distributed<replica::database>& db, keyspace& ks, sstring datadir, sstring ks_name);
 
 public:
     static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);


### PR DESCRIPTION
Currently the datadir is ignored.
Use it to construct the table's base path.

Fixes scylladb/scylladb#15418