### PR TITLE
cql3: fix bad optional access when executing fromJson function

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -223,7 +223,7 @@ make_from_json_function(data_dictionary::database db, const sstring& keyspace, d
     return make_native_scalar_function<true>("fromjson", t, {utf8_type},
             [keyspace, t](std::span<const bytes_opt> parameters) -> bytes_opt {
         try {
-            rjson::value json_value = rjson::parse(utf8_type->to_string(parameters[0].value()));
+            rjson::value json_value = rjson::parse(utf8_type->to_string(parameters[0].value_or("null")));
             bytes_opt parsed_json_value;
             if (!json_value.IsNull()) {
                 parsed_json_value.emplace(from_json_object(*t, json_value));

--- a/test/cql-pytest/cassandra_tests/validation/entities/json_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/json_test.py
@@ -134,7 +134,7 @@ def testSelectJsonWithPagingWithFrozenUDT(cql, test_keyspace):
                           ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 4]", "4"])
 
 # Reproduces issue #7911, #7912, #7914, #7915, #7944, #7954
-@pytest.mark.xfail(reason="issues #7912, #7914, #7915, #7944, #7954")
+@pytest.mark.xfail(reason="issues #7914, #7915, #7944, #7954")
 def testFromJsonFct(cql, test_keyspace):
     abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:

--- a/test/cql-pytest/test_json.py
+++ b/test/cql-pytest/test_json.py
@@ -225,7 +225,6 @@ def test_fromjson_boolean_string_prepared(cql, table1):
 
 # Test that null argument is allowed for fromJson(), with unprepared statement
 # Reproduces issue #7912.
-@pytest.mark.xfail(reason="issue #7912")
 def test_fromjson_null_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson(null))")
@@ -233,7 +232,6 @@ def test_fromjson_null_unprepared(cql, table1):
 
 # Test that null argument is allowed for fromJson(), with prepared statement
 # Reproduces issue #7912.
-@pytest.mark.xfail(reason="issue #7912")
 def test_fromjson_null_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")


### PR DESCRIPTION
We use "null" as the default value when unwrapping optionals to avoid bad optional access errors.

Fixes: #7912