### PR TITLE
utils/s3: auth using AWS_SESSION_TOKEN

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -170,6 +170,7 @@ struct convert<::object_storage_endpoint_param> {
             ep.config.aws->region = node["aws_region"].as<std::string>();
             ep.config.aws->key = node["aws_key"].as<std::string>();
             ep.config.aws->secret = node["aws_secret"].as<std::string>();
+            ep.config.aws->token = node["aws_token"].as<std::string>("");
         }
         return true;
     }

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -33,6 +33,7 @@
 //   export S3_BUCKET_FOR_TEST=xemul
 //   export AWS_ACCESS_KEY_ID=${aws_key}
 //   export AWS_SECRET_ACCESS_KEY=${aws_secret}
+//   export AWS_SESSION_TOKEN=${aws_token}
 //   export AWS_DEFAULT_REGION="us-east-2"
 
 s3::endpoint_config_ptr make_minio_config() {
@@ -42,6 +43,7 @@ s3::endpoint_config_ptr make_minio_config() {
         .aws = {{
             .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
             .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+            .token = ::getenv("AWS_SESSION_TOKEN") ? : "",
             .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
         }},
     };

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -178,6 +178,7 @@ std::unordered_map<sstring, s3::endpoint_config> make_storage_options_config(con
                 .aws = {{
                     .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
                     .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+                    .token = ::getenv("AWS_SESSION_TOKEN") ? : "",
                     .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
                 }},
             };

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -33,6 +33,9 @@ class tester {
         cfg.aws.emplace();
         cfg.aws->key = tests::getenv_safe("AWS_ACCESS_KEY_ID");
         cfg.aws->secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY");
+        if (auto token = ::getenv("AWS_SESSION_TOKEN"); token) {
+            cfg.aws->token = token;
+        }
         cfg.aws->region = tests::getenv_safe("AWS_DEFAULT_REGION");
 
         return make_lw_shared<s3::endpoint_config>(std::move(cfg));

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -84,6 +84,9 @@ void client::authorize(http::request& req) {
     auto time_point_st = time_point_str.substr(0, 8);
     req._headers["x-amz-date"] = time_point_str;
     req._headers["x-amz-content-sha256"] = "UNSIGNED-PAYLOAD";
+    if (!_cfg->aws->token.empty()) {
+        req._headers["x-amz-security-token"] = _cfg->aws->token;
+    }
     std::map<std::string_view, std::string_view> signed_headers;
     sstring signed_headers_list = "";
     // AWS requires all x-... and Host: headers to be signed

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -18,8 +18,12 @@ struct endpoint_config {
     bool use_https;
 
     struct aws_config {
+        // the access key of the credentials
         std::string key;
+        // the secret key of the credentials
         std::string secret;
+        // the security token, only for session credentials
+        std::string token;
         std::string region;
     };
 


### PR DESCRIPTION
when accessing AWS resources, uses are allowed to long-term security credentials, they can also the temporary credentials. but if the latter are used, we have to pass a session token along with the keys. see also https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html so, if we want to programatically get authenticated, we need to set the "x-amz-security-token" header,
see
https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#UsingTemporarySecurityCredentials

so, in this change, we

1. add another member named `token` in `s3::endpoint_config::aws_config` for storing "AWS_SESSION_TOKEN".
2. populate the setting from "object_storage.yaml" and "$AWS_SESSION_TOKEN" environment variable.
3. set "x-amz-security-token" header if `s3::endpoint_config::aws_config::token` is not empty.

this should allow us to test s3 client and s3 object store backend with S3 bucket, with the temporary credentials.