### PR TITLE
doc: add a note that counters do not support TTL

### DIFF
--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -116,7 +116,7 @@ Counters have a number of important limitations:
 - They cannot be used for columns part of the ``PRIMARY KEY`` of a table.
 - A table that contains a counter can only contain counters. In other words, either all the columns of a table outside
   the ``PRIMARY KEY`` have the ``counter`` type, or none of them have it.
-- Counters do not support expiration.
+- Counters do not support expiring data with :doc:`Time to Live (TTL) </cql/time-to-live>`.
 - The deletion of counters is supported but is only guaranteed to work the first time you delete a counter. In other
   words, you should not re-update a counter that you have deleted (if you do, proper behavior is not guaranteed).
 - Counter updates are, by nature, **not** `idempotent <https://en.wikipedia.org/wiki/Idempotence>`__. An important

--- a/docs/using-scylla/counters.rst
+++ b/docs/using-scylla/counters.rst
@@ -47,7 +47,7 @@ However, counters have limitations not present in other column types:
 * Counter columns, on the other hand, may not be part of the primary key.
 * Counters may not be indexed.
 * Counters may not be part of a materialized view.
-* You cannot use TIMESTAMP or set a TTL (time to live) when updating a counter.
+* ScyllaDB does not support USING TIMESTAMP or USING TTL in the command to update a counter column.
 * Once deleted, counter column values **should** not be used again. If you reuse them, proper behavior is not guaranteed.
 * Counters cannot be set to a specific value other than when incrementing from 0 using the UPDATE command at initialization.
 * Updates are **not** :term:`idempotent <Idempotent>`. In the case of a write failure, the client cannot safely retry the request. 


### PR DESCRIPTION
This PR adds the information that counters do not support data expiration with TTL, plus the link to the TTL page.

Fixes https://github.com/scylladb/scylladb/issues/15479