### PR TITLE
New commitlog file format using tagged pages

### DIFF
--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -373,7 +373,7 @@ public:
         uint64_t bytes() const {
             return _bytes;
         }
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg.c_str();
         }
     private:
@@ -383,7 +383,7 @@ public:
     class invalid_segment_format : public segment_error {
         static constexpr const char* _msg = "Not a scylla format commitlog file";
     public:
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg;
         }
     };
@@ -391,9 +391,19 @@ public:
     class header_checksum_error : public segment_error {
         static constexpr const char* _msg = "Checksum error in file header";
     public:
-        virtual const char* what() const noexcept {
+        const char* what() const noexcept override {
             return _msg;
         }
+    };
+
+    class segment_truncation : public segment_error {
+        std::string _msg;
+        uint64_t _pos;
+    public:
+        segment_truncation(uint64_t);
+
+        uint64_t position() const;
+        const char* what() const noexcept override;
     };
 
     static future<> read_log_file(sstring filename, sstring prefix, commit_load_reader_func, position_type = 0, const db::extensions* = nullptr);

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -134,10 +134,12 @@ public:
 
         static inline constexpr uint32_t segment_version_1 = 1u;
         static inline constexpr uint32_t segment_version_2 = 2u;
+        static inline constexpr uint32_t segment_version_3 = 4u;
+        static inline constexpr uint32_t current_version = segment_version_3;
 
         descriptor(descriptor&&) noexcept = default;
         descriptor(const descriptor&) = default;
-        descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v = segment_version_2, sstring = {});
+        descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v = current_version, sstring = {});
         descriptor(replay_position p, const std::string& fname_prefix = FILENAME_PREFIX);
         descriptor(const std::string& filename, const std::string& fname_prefix = FILENAME_PREFIX);
 
@@ -171,7 +173,7 @@ public:
      * of data to be written. (See add).
      * Don't write less, absolutely don't write more...
      */
-    using output = fragmented_temporary_buffer::ostream;
+    using output = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     using serializer_func = std::function<void(output&)>;
 
     /**

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -30,7 +30,7 @@ void commitlog_entry_writer::compute_size() {
     _size = ms.size();
 }
 
-void commitlog_entry_writer::write(typename seastar::memory_output_stream<std::vector<temporary_buffer<char>>::iterator>& out) const {
+void commitlog_entry_writer::write(ostream& out) const {
     serialize(out);
 }
 

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -121,7 +121,10 @@ public:
     force_sync sync() const {
         return _sync;
     }
-    void write(typename seastar::memory_output_stream<std::vector<temporary_buffer<char>>::iterator>& out) const;
+
+    using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
+
+    void write(ostream& out) const;
 };
 
 class commitlog_entry_reader {

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -13,6 +13,62 @@
 #include "commitlog_types.hh"
 #include "mutation/frozen_mutation.hh"
 #include "schema/schema_fwd.hh"
+#include "replay_position.hh"
+
+namespace detail {
+
+    using buffer_type = fragmented_temporary_buffer;
+    using base_iterator = typename std::vector<temporary_buffer<char>>::const_iterator;
+
+    static constexpr auto sector_overhead_size = sizeof(uint32_t) + sizeof(db::segment_id_type);
+
+    // iterator adaptor to enable splitting normal
+    // frag-buffer temporary buffer objects into 
+    // sub-disk-page sized chunks.
+    class sector_split_iterator {
+        base_iterator _iter, _end;
+        char* _ptr;
+        size_t _size;
+        size_t _sector_size;
+    public:
+        sector_split_iterator(const sector_split_iterator&) noexcept;
+        sector_split_iterator(base_iterator i, base_iterator e, size_t sector_size);
+        sector_split_iterator();
+
+        char* get_write() const {
+            return _ptr;
+        }
+        size_t size() const {
+            return _size;
+        }
+        char* begin() {
+            return _ptr;
+        }
+        char* end() {
+            return _ptr + _size;
+        }
+        const char* begin() const {
+            return _ptr;
+        }
+        const char* end() const {
+            return _ptr + _size;
+        }
+
+        bool operator==(const sector_split_iterator& rhs) const {
+            return _iter == rhs._iter && _ptr == rhs._ptr;
+        }
+
+        auto& operator*() const {
+            return *this;
+        }
+        auto* operator->() const {
+            return this;
+        }
+
+        sector_split_iterator& operator++();
+        sector_split_iterator operator++(int);
+    };
+}
 
 class commitlog_entry {
     std::optional<column_mapping> _mapping;

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -56,6 +56,7 @@ public:
         uint64_t skipped_mutations = 0;
         uint64_t applied_mutations = 0;
         uint64_t corrupt_bytes = 0;
+        uint64_t truncated_at = 0;
 
         stats& operator+=(const stats& s) {
             invalid_mutations += s.invalid_mutations;
@@ -180,6 +181,8 @@ db::commitlog_replayer::impl::recover(sstring file, const sstring& fname_prefix)
             f.get();
         } catch (commitlog::segment_data_corruption_error& e) {
             s->corrupt_bytes += e.bytes();
+        } catch (commitlog::segment_truncation& e) {
+            s->truncated_at = e.position();
         } catch (...) {
             throw;
         }
@@ -329,6 +332,9 @@ future<> db::commitlog_replayer::recover(std::vector<sstring> files, sstring fna
                         return _impl->recover(f, fname_prefix).then([f, total](impl::stats stats) {
                             if (stats.corrupt_bytes != 0) {
                                 rlogger.warn("Corrupted file: {}. {} bytes skipped.", f, stats.corrupt_bytes);
+                            }
+                            if (stats.truncated_at != 0) {
+                                rlogger.warn("Truncated file: {} at position {}.", f, stats.truncated_at);
                             }
                             rlogger.debug("Log replay of {} complete, {} replayed mutations ({} invalid, {} skipped)"
                                             , f

--- a/docs/dev/commitlog-file-format.md
+++ b/docs/dev/commitlog-file-format.md
@@ -62,4 +62,55 @@ Version 2
         size            : size of all entries in this multi-entry + headers
         crc             : CRC32 of magic, size
         <entries> * N
+        crc2            : CRC32 of magic, size and data in each entry
+```
+
+Version 3
+---------
+
+Modified from v2 to improve error detection/false positive elimination.
+This version does CRC per written disk block instead of actual entry.
+Every block is also tagged with which file is being written, this to
+be able to better distinguish new data from that left over from recycling
+(reusing old files) and actual disk/file corruption.
+
+```
+
+        Segment file header
+
+        magic           : uint32_t - ('S'<<24) |('C'<< 16) | ('L' << 8) | 'C';
+        version         : uint32_t - same as descriptor
+        id              : uint64_t - same as descriptor
+        alignment       : uint32_t - disk block size
+        crc             : uint32_t - CRC32 of version, low 32 of id, high 32 of id, alignment. 
+
+        Chunk header
+
+        file_pos        : uint32_t - the file position of next chunk
+        crc             : uint32_t - CRC32 of low 32 of segment id, high 32 of id and file offset of end of this header.
+
+        Entry
+
+        size            : uint32_t - size of entry (data + full headers). Must be smaller than MAX_UINT32.
+        crc             : uint32_t - CRC32 of size
+        data            : bytes - actual entry data
+
+        Multi-entry
+
+        magic           : multi marker - 0xffffffff (MAX_UINT32)
+        size            : size of all entries in this multi-entry + headers
+        crc             : CRC32 of magic, size
+        <entries> * N
+
+        Disk block (block size = `alignment`)
+
+        0 - <bs - 12>   : Interleaved file data, i.e. the content above
+        <bs - 12>       : uint64_t - same as descriptor.
+        <bs - 4>        : uint32_t - CRC32 of block data up until crc (bs - 4), including segment id
+
+The main benefit of the tagged and CRC:ed block is that if the CRC is broken, we know the part
+of this file is corrupt. If the CRC is correct, but segment ID does not match, we can assume
+the file is not fully written/prematurely ended. Both cases can mean data loss, depending on 
+how writing is done as well as OS and hardware.
+
 ```

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -60,6 +60,15 @@ public:
         return ostream::simple(reinterpret_cast<char*>(current.get_write()), current.size());
     }
 
+    using const_fragment_iterator = typename vector_type::const_iterator;
+
+    const_fragment_iterator begin() const {
+        return _fragments.begin();
+    }
+    const_fragment_iterator end() const {
+        return _fragments.end();
+    }
+
     size_t size_bytes() const { return _size_bytes; }
     bool empty() const { return !_size_bytes; }
 


### PR DESCRIPTION
Prototype implementation of format suggested/requested by @avikivity:

Divides segments into disk-write-alignment sized pages, each tagged with segment ID + CRC of data content. 
When read, we both verify sector integrity (CRC) to detect corruption, as well as matching ID read with expected one.

If the latter mismatches we have a prematurely terminated segment (read truncation), which, depending on whether the CL is
written in batch or periodic mode, as well as explicit sync, can mean data loss.

Note: all-zero pages are treated as kosher, both to align with newly allocated segments, as well as fully terminated (zero-page) ones.

Note: This is a preview/RFC - the rest of the file format is not modified. At least parts of entry CRC could probably be removed, but I have not done so yet (needs some thinking). 

Note: Some slight abstraction breaks in impl. and probably less than maximal efficiency.

v2:
* Removed entry CRC:s in file format. 
* Added docs on format v3
* Added one more test for recycling-truncation

v3: 
* Fixed typos in size calc and docs
* Changed sect metadata order
* Explicit iter type